### PR TITLE
Small follow up fixes

### DIFF
--- a/music_assistant/common/models/player.py
+++ b/music_assistant/common/models/player.py
@@ -40,7 +40,7 @@ class Player(DataClassDictMixin):
     volume_level: int = 100
     volume_muted: bool = False
 
-    # group_childs: Return list of player group child id's or synced childs.
+    # group_childs: Return list of player group child id's or synced child`s.
     # - If this player is a dedicated group player,
     #   returns all child id's of the players in the group.
     # - If this is a syncgroup of players from the same platform (e.g. sonos),
@@ -53,7 +53,7 @@ class Player(DataClassDictMixin):
     active_queue: str = ""
 
     # can_sync_with: return tuple of player_ids that can be synced to/with this player
-    # ususally this is just a list of all player_ids within the playerprovider
+    # usually this is just a list of all player_ids within the playerprovider
     can_sync_with: tuple[str, ...] = field(default=tuple())
 
     # synced_to: player_id of the player this player is currently synced to
@@ -70,6 +70,11 @@ class Player(DataClassDictMixin):
     # will be set by the player manager based on config
     # a disabled player is hidden in the UI and updates will not be processed
     enabled: bool = True
+
+    # hidden_by: if the player is enabled
+    # will be set by the player manager based on config
+    # a disabled player is hidden in the UI only
+    hidden_by: set = field(default_factory=set)
 
     # group_volume: if the player is a player group or syncgroup master,
     # this will return the average volume of all child players

--- a/music_assistant/common/models/player.py
+++ b/music_assistant/common/models/player.py
@@ -66,6 +66,14 @@ class Player(DataClassDictMixin):
     # supports_24bit: bool if player supports 24bits (hi res) audio
     supports_24bit: bool = True
 
+    # enabled_by_default: if the player is enabled by default
+    # can be used by a player provider to exclude some sort of players
+    enabled_by_default: bool = True
+
+    #
+    # THE BELOW ATTRIBUTES ARE MANAGED BY CONFIG AND THE PLAYER MANAGER
+    #
+
     # enabled: if the player is enabled
     # will be set by the player manager based on config
     # a disabled player is hidden in the UI and updates will not be processed

--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_SAVE_DELAY = 30
+ENCRYPT_SUFFIX = "_encrypted_"
 
 isfile = wrap(os.path.isfile)
 remove = wrap(os.remove)
@@ -407,8 +408,13 @@ class ConfigController:
 
     def encrypt_password(self, str_value: str) -> str:
         """Encrypt a (password)string with Fernet."""
-        return self._fernet.encrypt(str_value.encode()).decode()
+        if str_value.startswith(ENCRYPT_SUFFIX):
+            return str_value
+        return ENCRYPT_SUFFIX + self._fernet.encrypt(str_value.encode()).decode()
 
     def decrypt_password(self, encrypted_str: str) -> str:
         """Decrypt a (password)string with Fernet."""
+        if not encrypted_str.startswith(ENCRYPT_SUFFIX):
+            return encrypted_str
+        encrypted_str = encrypted_str.replace(ENCRYPT_SUFFIX, "")
         return self._fernet.decrypt(encrypted_str.encode()).decode()

--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -325,13 +325,20 @@ class ConfigController:
             data=config,
         )
         # signal update to the player manager
-        if player := self.mass.players.get(config.player_id):
+        try:
+            player = self.mass.players.get(config.player_id)
             player.enabled = config.enabled
             self.mass.players.update(config.player_id)
+        except PlayerUnavailableError:
+            pass
+
         # signal player provider that the config changed
-        if provider := self.mass.get_provider(config.provider):
-            assert isinstance(provider, PlayerProvider)
-            provider.on_player_config_changed(config)
+        try:
+            if provider := self.mass.get_provider(config.provider):
+                assert isinstance(provider, PlayerProvider)
+                provider.on_player_config_changed(config)
+        except PlayerUnavailableError:
+            pass
 
     @api_command("config/players/create")
     async def create_player_config(

--- a/music_assistant/server/controllers/players.py
+++ b/music_assistant/server/controllers/players.py
@@ -114,7 +114,7 @@ class PlayerController:
         if player_id in self._players:
             raise AlreadyRegisteredError(f"Player {player_id} is already registered")
 
-        player.enabled = self.mass.config.get(f"{CONF_PLAYERS}/{player_id}/enabled")
+        player.enabled = self.mass.config.get(f"{CONF_PLAYERS}/{player_id}/enabled", True)
 
         # register playerqueue for this player
         self.mass.create_task(self.queues.on_player_register(player))

--- a/music_assistant/server/controllers/players.py
+++ b/music_assistant/server/controllers/players.py
@@ -61,9 +61,20 @@ class PlayerController:
         return iter(self._players.values())
 
     @api_command("players/all")
-    def all(self) -> tuple[Player]:
+    def all(
+        self,
+        return_unavailable: bool = True,
+        return_hidden: bool = True,
+        return_disabled: bool = False,
+    ) -> tuple[Player]:
         """Return all registered players."""
-        return tuple(self._players.values())
+        return tuple(
+            player
+            for player in self._players.values()
+            if (player.available or return_unavailable)
+            and (not player.hidden_by or return_hidden)
+            and (player.enabled or return_disabled)
+        )
 
     @api_command("players/get")
     def get(

--- a/music_assistant/server/providers/chromecast/__init__.py
+++ b/music_assistant/server/providers/chromecast/__init__.py
@@ -230,7 +230,7 @@ class ChromecastProvider(PlayerProvider):
 
         player_id = str(disc_info.uuid)
 
-        enabled = self.mass.config.get(f"{CONF_PLAYERS}/{player_id}/enabled")
+        enabled = self.mass.config.get(f"{CONF_PLAYERS}/{player_id}/enabled", True)
         if not enabled:
             self.logger.debug("Ignoring disabled player: %s", player_id)
             return

--- a/music_assistant/server/providers/chromecast/__init__.py
+++ b/music_assistant/server/providers/chromecast/__init__.py
@@ -210,6 +210,10 @@ class ChromecastProvider(PlayerProvider):
         If the player does not need any polling, simply do not override this method.
         """
         castplayer = self.castplayers[player_id]
+        # only update status of media controller if player is on
+        if not castplayer.player.powered:
+            return
+
         try:
             await asyncio.to_thread(castplayer.cc.media_controller.update_status)
         except ConnectionResetError as err:

--- a/music_assistant/server/providers/dlna/__init__.py
+++ b/music_assistant/server/providers/dlna/__init__.py
@@ -342,7 +342,7 @@ class DLNAPlayerProvider(PlayerProvider):
 
                 await self._device_discovered(ssdp_udn, discovery_info["location"])
 
-            await async_search(on_response, 30)
+            await async_search(on_response, 60)
 
         finally:
             self._discovery_running = False

--- a/music_assistant/server/providers/dlna/__init__.py
+++ b/music_assistant/server/providers/dlna/__init__.py
@@ -388,8 +388,8 @@ class DLNAPlayerProvider(PlayerProvider):
             conf_key = f"{CONF_PLAYERS}/{udn}/enabled"
             # disable sonos players by default in dlna provider to
             # prevent duplicate with sonos provider
-            enabled_default = "rincon" not in udn.lower()
-            enabled = self.mass.config.get(conf_key, default=enabled_default, setdefault=True)
+            enabled_by_default = "rincon" not in udn.lower()
+            enabled = self.mass.config.get(conf_key, default=enabled_by_default)
             if not enabled:
                 self.logger.debug("Ignoring disabled player: %s", udn)
                 return
@@ -410,6 +410,7 @@ class DLNAPlayerProvider(PlayerProvider):
                         address=description_url,
                         manufacturer="unknown",
                     ),
+                    enabled_by_default=enabled_by_default,
                 ),
                 description_url=description_url,
             )

--- a/music_assistant/server/providers/filesystem_local/manifest.json
+++ b/music_assistant/server/providers/filesystem_local/manifest.json
@@ -9,7 +9,7 @@
       "key": "path",
       "type": "string",
       "label": "Path",
-      "default_value": "/music"
+      "default_value": "/media"
     }
   ],
 

--- a/music_assistant/server/providers/filesystem_smb/manifest.json
+++ b/music_assistant/server/providers/filesystem_smb/manifest.json
@@ -9,7 +9,7 @@
       "key": "path",
       "type": "string",
       "label": "Path",
-      "description": "Full SMB path to the files, e.g. \\\\server\\share\folder or smb://server/share"
+      "description": "Full SMB path to the files, e.g. \\\\server\\share\\folder or smb://server/share"
     },
     {
       "key": "username",
@@ -42,7 +42,7 @@
       "key": "use_ntlm_v2",
       "type": "boolean",
       "label": "Use NTLM v2",
-      "default_value": false,
+      "default_value": true,
       "description": "Indicates whether pysmb should be NTLMv1 or NTLMv2 authentication algorithm for authentication. The choice of NTLMv1 and NTLMv2 is configured on the remote server, and there is no mechanism to auto-detect which algorithm has been configured. Hence, we can only “guess” or try both algorithms. On Sambda, Windows Vista and Windows 7, NTLMv2 is enabled by default. On Windows XP, we can use NTLMv1 before NTLMv2.",
       "advanced": true,
       "required": false

--- a/music_assistant/server/providers/slimproto/manifest.json
+++ b/music_assistant/server/providers/slimproto/manifest.json
@@ -7,7 +7,7 @@
   "config_entries": [
   ],
   "requirements": ["aioslimproto==2.2.0"],
-  "documentation": "",
+  "documentation": "https://github.com/music-assistant/hass-music-assistant/discussions/1123",
   "multi_instance": false,
   "builtin": true,
   "load_by_default": true

--- a/music_assistant/server/providers/sonos/__init__.py
+++ b/music_assistant/server/providers/sonos/__init__.py
@@ -376,12 +376,6 @@ class SonosPlayerProvider(PlayerProvider):
                     continue
                 await self._device_discovered(device)
 
-            # handle groups
-            # if soco_player := next(iter(discovered_devices), None):
-            #     self._process_groups(soco_player.all_groups)
-            # else:
-            #         self._process_groups(set())
-
         finally:
             self._discovery_running = False
 
@@ -482,23 +476,6 @@ class SonosPlayerProvider(PlayerProvider):
         sonos_player.group_info = sonos_player.soco.group
         sonos_player.group_info_updated = time.time()
         asyncio.run_coroutine_threadsafe(self._update_player(sonos_player), self.mass.loop)
-
-    def _process_groups(self, sonos_groups: list[soco.SoCo]) -> None:
-        """Process all sonos groups."""
-        all_group_ids = set()
-        for sonos_player in sonos_groups:
-            all_group_ids.add(sonos_player.uid)
-            if sonos_player.uid not in self.sonosplayers:
-                # unknown player ?!
-                continue
-
-            # mass_player = self.mass.players.get(sonos_player.uid)
-            # sonos_player.is_coordinator
-            # # check members
-            # group_player.is_group_player = True
-            # group_player.name = group.label
-            # group_player.group_childs = [item.uid for item in group.members]
-            # create_task(self.mass.players.update_player(group_player))
 
     async def _enqueue_next_track(
         self, sonos_player: SonosPlayer, current_queue_item_id: str

--- a/music_assistant/server/providers/sonos/__init__.py
+++ b/music_assistant/server/providers/sonos/__init__.py
@@ -399,7 +399,7 @@ class SonosPlayerProvider(PlayerProvider):
         """Handle discovered Sonos player."""
         player_id = soco_device.uid
 
-        enabled = self.mass.config.get(f"{CONF_PLAYERS}/{player_id}/enabled")
+        enabled = self.mass.config.get(f"{CONF_PLAYERS}/{player_id}/enabled", True)
         if not enabled:
             self.logger.debug("Ignoring disabled player: %s", player_id)
             return


### PR DESCRIPTION
- Disable SONOS players by default in DLNA provider (to prevent duplicates)
- Do not initialize disabled players
- Handle disabled/unavailable players in a more elegant way
- Fix for Chromecast players turning on unsollicited
- Fix for double encrypted passwords
- Fix playlist thumb generation causing an endless loop