### PR TITLE
Fix SMB Music provider

### DIFF
--- a/music_assistant/common/helpers/util.py
+++ b/music_assistant/common/helpers/util.py
@@ -178,7 +178,7 @@ async def select_free_port(range_start: int, range_end: int) -> int:
     return await asyncio.to_thread(_select_free_port)
 
 
-async def get_ip_from_host(dns_name: str) -> str:
+async def get_ip_from_host(dns_name: str) -> str | None:
     """Resolve (first) IP-address for given dns name."""
 
     def _resolve():
@@ -186,7 +186,7 @@ async def get_ip_from_host(dns_name: str) -> str:
             return socket.gethostbyname(dns_name)
         except Exception:  # pylint: disable=broad-except
             # fail gracefully!
-            return dns_name
+            return None
 
     return await asyncio.to_thread(_resolve)
 

--- a/music_assistant/common/models/media_items.py
+++ b/music_assistant/common/models/media_items.py
@@ -462,6 +462,8 @@ class StreamDetails(DataClassDictMixin):
     data: Any = None
     # if the url/file is supported by ffmpeg directly, use direct stream
     direct: str | None = None
+    # bool to indicate that the providers 'get_audio_stream' supports seeking of the item
+    can_seek: bool = True
     # callback: optional callback function (or coroutine) to call when the stream completes.
     # needed for streaming provivders to report what is playing
     # receives the streamdetails as only argument from which to grab

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -253,7 +253,6 @@ class FileSystemProviderBase(MusicProvider):
                 continue
 
             try:
-                cur_checksums[item.path] = item.checksum
                 if item.checksum == prev_checksums.get(item.path):
                     continue
 
@@ -275,6 +274,9 @@ class FileSystemProviderBase(MusicProvider):
             except Exception as err:  # pylint: disable=broad-except
                 # we don't want the whole sync to crash on one file so we catch all exceptions here
                 self.logger.exception("Error processing %s - %s", item.path, str(err))
+            else:
+                # save item's checksum only if the parse succeeded
+                cur_checksums[item.path] = item.checksum
 
             # save checksums every 100 processed items
             # this allows us to pickup where we leftoff when initial scan gets interrupted

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -42,6 +42,7 @@ TRACK_EXTENSIONS = ("mp3", "m4a", "mp4", "flac", "wav", "ogg", "aiff", "wma", "d
 PLAYLIST_EXTENSIONS = ("m3u", "pls")
 SUPPORTED_EXTENSIONS = TRACK_EXTENSIONS + PLAYLIST_EXTENSIONS
 IMAGE_EXTENSIONS = ("jpg", "jpeg", "JPG", "JPEG", "png", "PNG", "gif", "GIF")
+SEEKABLE_FILES = (ContentType.MP3, ContentType.WAV, ContentType.FLAC)
 
 SUPPORTED_FEATURES = (
     ProviderFeature.LIBRARY_ARTISTS,
@@ -626,6 +627,7 @@ class FileSystemProviderBase(MusicProvider):
             sample_rate=prov_mapping.sample_rate,
             bit_depth=prov_mapping.bit_depth,
             direct=file_item.local_path,
+            can_seek=prov_mapping.content_type in SEEKABLE_FILES,
         )
 
     async def get_audio_stream(

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -254,7 +254,9 @@ class FileSystemProviderBase(MusicProvider):
                 continue
 
             try:
+                # continue if the item did not change (checksum still the same)
                 if item.checksum == prev_checksums.get(item.path):
+                    cur_checksums[item.path] = item.checksum
                     continue
 
                 if item.ext in TRACK_EXTENSIONS:

--- a/music_assistant/server/providers/filesystem_smb/helpers.py
+++ b/music_assistant/server/providers/filesystem_smb/helpers.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 from io import BytesIO
-from uuid import uuid4
 
-from smb.base import SharedFile, SMBTimeout
-from smb.smb_structs import OperationFailure
+from smb.base import OperationFailure, SharedFile
 from smb.SMBConnection import SMBConnection
 
 from music_assistant.common.models.errors import LoginFailed
@@ -30,7 +28,6 @@ class AsyncSMB:
         is_direct_tcp: bool = False,
     ) -> None:
         """Initialize instance."""
-        self.session_id = uuid4().hex
         self._service_name = service_name
         self._remote_name = remote_name
         self._target_ip = target_ip
@@ -45,63 +42,73 @@ class AsyncSMB:
             sign_options=sign_options,
             is_direct_tcp=is_direct_tcp,
         )
+        # the smb connection may not be used asynchronously and
+        # each operation should take sequentially.
+        # to support this, we use a Lock and we create a new.
+        self._lock = asyncio.Lock()
 
     async def list_path(self, path: str) -> list[SharedFile]:
         """Retrieve a directory listing of files/folders at *path*."""
-        return await asyncio.to_thread(self._conn.listPath, self._service_name, path)
+        async with self._lock:
+            return await asyncio.to_thread(self._conn.listPath, self._service_name, path)
 
     async def get_attributes(self, path: str) -> SharedFile:
         """Retrieve information about the file at *path* on the *service_name*."""
-        return await asyncio.to_thread(self._conn.getAttributes, self._service_name, path)
+        async with self._lock:
+            return await asyncio.to_thread(self._conn.getAttributes, self._service_name, path)
 
     async def retrieve_file(self, path: str, offset: int = 0) -> AsyncGenerator[bytes, None]:
         """Retrieve file contents."""
         chunk_size = 256000
         while True:
-            with BytesIO() as file_obj:
-                await asyncio.to_thread(
-                    self._conn.retrieveFileFromOffset,
-                    self._service_name,
-                    path,
-                    file_obj,
-                    offset,
-                    chunk_size,
-                )
-                file_obj.seek(0)
-                chunk = file_obj.read()
-                yield chunk
-                offset += len(chunk)
-                if len(chunk) < chunk_size:
-                    break
+            async with self._lock:
+                with BytesIO() as file_obj:
+                    await asyncio.to_thread(
+                        self._conn.retrieveFileFromOffset,
+                        self._service_name,
+                        path,
+                        file_obj,
+                        offset,
+                        chunk_size,
+                    )
+                    file_obj.seek(0)
+                    chunk = file_obj.read()
+                    yield chunk
+                    offset += len(chunk)
+                    if len(chunk) < chunk_size:
+                        break
 
     async def write_file(self, path: str, data: bytes) -> SharedFile:
         """Store the contents to the file at *path*."""
         with BytesIO() as file_obj:
             file_obj.write(data)
             file_obj.seek(0)
-            await asyncio.to_thread(
-                self._conn.storeFile,
-                self._service_name,
-                path,
-                file_obj,
-            )
+            async with self._lock:
+                await asyncio.to_thread(
+                    self._conn.storeFile,
+                    self._service_name,
+                    path,
+                    file_obj,
+                )
 
     async def path_exists(self, path: str) -> bool:
         """Return bool is this FileSystem musicprovider has given file/dir."""
-        try:
-            await asyncio.to_thread(self._conn.getAttributes, self._service_name, path)
-        except (OperationFailure, SMBTimeout, TimeoutError):
-            return False
-        except IndexError:
-            return False
-        return True
+        async with self._lock:
+            try:
+                await asyncio.to_thread(self._conn.getAttributes, self._service_name, path)
+            except (OperationFailure,):
+                return False
+            except IndexError:
+                return False
+            return True
 
     async def connect(self) -> None:
         """Connect to the SMB server."""
-        try:
-            assert await asyncio.to_thread(self._conn.connect, self._target_ip) is True
-        except Exception as exc:
-            raise LoginFailed(f"SMB Connect failed to {self._remote_name}") from exc
+        async with self._lock:
+            try:
+                assert await asyncio.to_thread(self._conn.connect, self._target_ip) is True
+            except Exception as exc:
+                raise LoginFailed(f"SMB Connect failed to {self._remote_name}") from exc
 
     async def __aenter__(self) -> AsyncSMB:
         """Enter context manager."""

--- a/music_assistant/server/providers/filesystem_smb/helpers.py
+++ b/music_assistant/server/providers/filesystem_smb/helpers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 from io import BytesIO
-from typing import Any
 
 from smb.base import SharedFile, SMBTimeout
 from smb.smb_structs import OperationFailure
@@ -25,7 +24,9 @@ class AsyncSMB:
         username: str,
         password: str,
         target_ip: str,
-        options: dict[str, Any],
+        use_ntlm_v2: bool = True,
+        sign_options: int = 2,
+        is_direct_tcp: bool = False,
     ) -> None:
         """Initialize instance."""
         self._service_name = service_name
@@ -38,11 +39,9 @@ class AsyncSMB:
             password=self._password,
             my_name=SERVICE_NAME,
             remote_name=self._remote_name,
-            # choose sane default options but allow user to override them via the options dict
-            domain=options.get("domain", ""),
-            use_ntlm_v2=options.get("use_ntlm_v2", False),
-            sign_options=options.get("sign_options", 2),
-            is_direct_tcp=options.get("is_direct_tcp", False),
+            use_ntlm_v2=use_ntlm_v2,
+            sign_options=sign_options,
+            is_direct_tcp=is_direct_tcp,
         )
 
     async def list_path(self, path: str) -> list[SharedFile]:

--- a/music_assistant/server/providers/filesystem_smb/helpers.py
+++ b/music_assistant/server/providers/filesystem_smb/helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 from io import BytesIO
+from uuid import uuid4
 
 from smb.base import SharedFile, SMBTimeout
 from smb.smb_structs import OperationFailure
@@ -29,6 +30,7 @@ class AsyncSMB:
         is_direct_tcp: bool = False,
     ) -> None:
         """Initialize instance."""
+        self.session_id = uuid4().hex
         self._service_name = service_name
         self._remote_name = remote_name
         self._target_ip = target_ip
@@ -88,7 +90,9 @@ class AsyncSMB:
         """Return bool is this FileSystem musicprovider has given file/dir."""
         try:
             await asyncio.to_thread(self._conn.getAttributes, self._service_name, path)
-        except (OperationFailure, SMBTimeout):
+        except (OperationFailure, SMBTimeout, TimeoutError):
+            return False
+        except IndexError:
             return False
         return True
 

--- a/music_assistant/server/providers/filesystem_smb/manifest.json
+++ b/music_assistant/server/providers/filesystem_smb/manifest.json
@@ -20,12 +20,12 @@
       "required": true
     },
     {
-      "key": "root_path",
+      "key": "subfolder",
       "type": "string",
-      "label": "Root path",
-      "description": "Use if your music is stored in a sublevel of the share. Defaults to the root '/' but you can use any sublevel here, like '/awesome/collection'",
-      "default_value": "/",
-      "required": true
+      "label": "Subfolder",
+      "description": "[optional] Use if your music is stored in a sublevel of the share. E.g. 'music' or 'music/collection'.",
+      "default_value": "",
+      "required": false
     },
     {
       "key": "username",

--- a/music_assistant/server/providers/filesystem_smb/manifest.json
+++ b/music_assistant/server/providers/filesystem_smb/manifest.json
@@ -6,28 +6,38 @@
   "codeowners": ["@MarvinSchenkel", "@marcelveldt"],
   "config_entries": [
     {
-      "key": "path",
+      "key": "host",
       "type": "string",
-      "label": "Path",
-      "description": "Full SMB path to the files, e.g. \\\\server\\share\\folder or smb://server/share"
+      "label": "Remote host",
+      "description": "The hostname of the SMB/CIFS server to connect to. For example mynas.local. You may need to use the IP address instead of DNS name.",
+      "required": true
+    },
+    {
+      "key": "share",
+      "type": "string",
+      "label": "Share",
+      "description": "The name of the share/service you'd like to connect to on the remote host, For example 'media'.",
+      "required": true
+    },
+    {
+      "key": "root_path",
+      "type": "string",
+      "label": "Root path",
+      "description": "Use if your music is stored in a sublevel of the share. Defaults to the root '/' but you can use any sublevel here, like '/awesome/collection'",
+      "default_value": "/",
+      "required": true
     },
     {
       "key": "username",
       "type": "string",
-      "label": "Username"
+      "label": "Username",
+      "default_value": "anonymous",
+      "required": true
     },
     {
       "key": "password",
       "type": "secure_string",
       "label": "Password"
-    },
-    {
-      "key": "target_ip",
-      "type": "string",
-      "label": "Target IP",
-      "description": "Use in case of DNS resolve issues. Connect to this IP instead of the DNS name.",
-      "advanced": true,
-      "required": false
     },
     {
       "key": "domain",
@@ -43,7 +53,7 @@
       "type": "boolean",
       "label": "Use NTLM v2",
       "default_value": true,
-      "description": "Indicates whether pysmb should be NTLMv1 or NTLMv2 authentication algorithm for authentication. The choice of NTLMv1 and NTLMv2 is configured on the remote server, and there is no mechanism to auto-detect which algorithm has been configured. Hence, we can only “guess” or try both algorithms. On Sambda, Windows Vista and Windows 7, NTLMv2 is enabled by default. On Windows XP, we can use NTLMv1 before NTLMv2.",
+      "description": "Indicates whether NTLMv1 or NTLMv2 authentication algorithm should be used for authentication. The choice of NTLMv1 and NTLMv2 is configured on the remote server, and there is no mechanism to auto-detect which algorithm has been configured. Hence, we can only “guess” or try both algorithms. On Sambda, Windows Vista and Windows 7, NTLMv2 is enabled by default. On Windows XP, we can use NTLMv1 before NTLMv2.",
       "advanced": true,
       "required": false
     },
@@ -65,7 +75,7 @@
       "key": "is_direct_tcp",
       "type": "boolean",
       "label": "Use Direct TCP",
-      "default_value": true,
+      "default_value": false,
       "description": "Controls whether the NetBIOS over TCP/IP (is_direct_tcp=False) or the newer Direct hosting of SMB over TCP/IP (is_direct_tcp=True) will be used for the communication. The default parameter is False which will use NetBIOS over TCP/IP for wider compatibility (TCP port: 139).",
       "advanced": true,
       "required": false


### PR DESCRIPTION
Create a single connection per action. This a bit slower but much more reliable.
Now it seems to handle all test cases I throw at it just fine.

Also adjust the configuration a bit and split out the path into server/host, share and subfolder