### PR TITLE
Fix for adding new provider

### DIFF
--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -397,7 +397,7 @@ class ConfigController:
 
         # all checks passed, return a default config
         return ProviderConfig.parse(
-            prov.config_entries,
+            DEFAULT_PROVIDER_CONFIG_ENTRIES + tuple(prov.config_entries),
             {
                 "type": manifest.type.value,
                 "domain": manifest.domain,


### PR DESCRIPTION
Adding a new provider caused a keyerror on fresh installs