### PR TITLE
Refactor image handling a bit

### DIFF
--- a/music_assistant/common/models/media_items.py
+++ b/music_assistant/common/models/media_items.py
@@ -77,12 +77,14 @@ class MediaItemImage(DataClassDictMixin):
     """Model for a image."""
 
     type: ImageType
-    url: str
-    source: str = "http"  # set to instance_id of file provider if path is local
+    path: str
+    # set to instance_id of provider if the path needs to be resolved
+    # if the path is just a plain (remotely accessible) URL, set it to 'url'
+    provider: str = "url"
 
     def __hash__(self):
         """Return custom hash."""
-        return hash(self.url)
+        return hash(self.type.value, self.path)
 
 
 @dataclass(frozen=True)
@@ -96,7 +98,7 @@ class MediaItemChapter(DataClassDictMixin):
 
     def __hash__(self):
         """Return custom hash."""
-        return hash(self.number)
+        return hash(self.chapter_id)
 
 
 @dataclass

--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -263,9 +263,7 @@ class ConfigController:
         """Return single configentry value for a player."""
         conf = self.get(f"{CONF_PLAYERS}/{player_id}")
         if not conf:
-            player = self.mass.players.get(player_id)
-            if not player:
-                raise PlayerUnavailableError(f"Player {player_id} is not available")
+            player = self.mass.players.get(player_id, True)
             conf = {"provider": player.provider, "player_id": player_id, "values": {}}
         prov = self.mass.get_provider(conf["provider"])
         entries = DEFAULT_PLAYER_CONFIG_ENTRIES + prov.get_player_config_entries(player_id)

--- a/music_assistant/server/models/music_provider.py
+++ b/music_assistant/server/models/music_provider.py
@@ -228,8 +228,8 @@ class MusicProvider(Provider):
         """
         Resolve an image from an image path.
 
-        This either returns the raw bytes of the image directly or a http(s) URL
-        or local path that is accessible from the server.
+        This either returns (a generator to get) raw bytes of the image or
+        a string with an http(s) URL or local path that is accessible from the server.
         """
         raise NotImplementedError
 

--- a/music_assistant/server/models/music_provider.py
+++ b/music_assistant/server/models/music_provider.py
@@ -224,6 +224,15 @@ class MusicProvider(Provider):
         if streamdetails.direct is None:
             raise NotImplementedError
 
+    async def resolve_image(self, path: str) -> str | bytes | AsyncGenerator[bytes, None]:
+        """
+        Resolve an image from an image path.
+
+        This either returns the raw bytes of the image directly or a http(s) URL
+        or local path that is accessible from the server.
+        """
+        raise NotImplementedError
+
     async def get_item(self, media_type: MediaType, prov_item_id: str) -> MediaItemType:
         """Get single MediaItem from provider."""
         if media_type == MediaType.ARTIST:

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -561,6 +561,16 @@ class FileSystemProviderBase(MusicProvider):
         async for chunk in self.read_file_content(streamdetails.item_id, seek_bytes):
             yield chunk
 
+    async def resolve_image(self, path: str) -> str | bytes | AsyncGenerator[bytes, None]:
+        """
+        Resolve an image from an image path.
+
+        This either returns (a generator to get) raw bytes of the image or a http(s) URL
+        or local path that is accessible from the server.
+        """
+        file_item = await self.resolve(path)
+        return file_item.local_path or self.read_file_content(file_item.absolute_path)
+
     async def _parse_track(self, file_item: FileSystemItem) -> Track:
         """Get full track details by id."""
         # ruff: noqa: PLR0915, PLR0912

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -565,8 +565,8 @@ class FileSystemProviderBase(MusicProvider):
         """
         Resolve an image from an image path.
 
-        This either returns (a generator to get) raw bytes of the image or a http(s) URL
-        or local path that is accessible from the server.
+        This either returns (a generator to get) raw bytes of the image or
+        a string with an http(s) URL or local path that is accessible from the server.
         """
         file_item = await self.resolve(path)
         return file_item.local_path or self.read_file_content(file_item.absolute_path)


### PR DESCRIPTION
Refactors the logic to resolve images that are not (or may be not) remotely accessible. Instead of limiting that functionality to the file providers, this is now useable for other providers too (e.g. Plex)

