### PR TITLE
Optimize playlist tracks listings

### DIFF
--- a/music_assistant/common/models/api.py
+++ b/music_assistant/common/models/api.py
@@ -35,6 +35,14 @@ class SuccessResultMessage(ResultMessageBase):
 
 
 @dataclass
+class ChunkedResultMessage(ResultMessageBase):
+    """Message sent when the result of a command is sent in multiple chunks."""
+
+    result: Any = field(default=None, metadata={"serialize": lambda v: get_serializable_value(v)})
+    is_last_chunk: bool = False
+
+
+@dataclass
 class ErrorResultMessage(ResultMessageBase):
     """Message sent when a command did not execute successfully."""
 

--- a/music_assistant/server/controllers/media/playlists.py
+++ b/music_assistant/server/controllers/media/playlists.py
@@ -51,7 +51,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         """Return playlist tracks for the given provider playlist id."""
         playlist = await self.get(item_id, provider_domain, provider_instance)
         prov = next(x for x in playlist.provider_mappings)
-        async for track in await self._get_provider_playlist_tracks(
+        async for track in self._get_provider_playlist_tracks(
             prov.item_id,
             provider_domain=prov.provider_domain,
             provider_instance=prov.provider_instance,
@@ -251,6 +251,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         if cache := await self.mass.cache.get(cache_key, checksum=cache_checksum):
             for track_dict in cache:
                 yield Track.from_dict(track_dict)
+            return
         # no items in cache - get listing from provider
         all_items = []
         async for item in provider.get_playlist_tracks(item_id):

--- a/music_assistant/server/controllers/metadata.py
+++ b/music_assistant/server/controllers/metadata.py
@@ -174,7 +174,7 @@ class MetaDataController:
         playlist.metadata.genres = set()
         image_urls = set()
         try:
-            for track in await self.mass.music.playlists.tracks(
+            async for track in self.mass.music.playlists.tracks(
                 playlist.item_id, playlist.provider
             ):
                 if not playlist.image and track.image:

--- a/music_assistant/server/controllers/metadata.py
+++ b/music_assistant/server/controllers/metadata.py
@@ -182,11 +182,11 @@ class MetaDataController:
                 if track.media_type != MediaType.TRACK:
                     # filter out radio items
                     continue
-                assert isinstance(track, Track)
-                assert isinstance(track.album, Album)
+                if not isinstance(track, Track):
+                    continue
                 if track.metadata.genres:
                     playlist.metadata.genres.update(track.metadata.genres)
-                elif track.album and track.album.metadata.genres:
+                elif track.album and isinstance(track.album, Album) and track.album.metadata.genres:
                     playlist.metadata.genres.update(track.album.metadata.genres)
             # create collage thumb/fanart from playlist tracks
             if image_urls:

--- a/music_assistant/server/controllers/metadata.py
+++ b/music_assistant/server/controllers/metadata.py
@@ -197,7 +197,7 @@ class MetaDataController:
                     playlist_genres[genre] += 1
 
             playlist_genres_filtered = {
-                genre for genre, count in playlist_genres.items() if count > 2
+                genre for genre, count in playlist_genres.items() if count > 5
             }
             playlist.metadata.genres.update(playlist_genres_filtered)
 

--- a/music_assistant/server/models/music_provider.py
+++ b/music_assistant/server/models/music_provider.py
@@ -116,10 +116,11 @@ class MusicProvider(Provider):
 
     async def get_playlist_tracks(  # type: ignore[return]
         self, prov_playlist_id: str
-    ) -> list[Track]:
+    ) -> AsyncGenerator[Track, None]:
         """Get all playlist tracks for given playlist id."""
         if ProviderFeature.LIBRARY_PLAYLISTS in self.supported_features:
             raise NotImplementedError
+        yield  # type: ignore
 
     async def library_add(self, prov_item_id: str, media_type: MediaType) -> bool:
         """Add item to provider's library. Return true on success."""

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -424,9 +424,8 @@ class FileSystemProviderBase(MusicProvider):
                 result.append(track)
         return sorted(result, key=lambda x: (x.disc_number or 0, x.track_number or 0))
 
-    async def get_playlist_tracks(self, prov_playlist_id: str) -> list[Track]:
+    async def get_playlist_tracks(self, prov_playlist_id: str) -> AsyncGenerator[Track, None]:
         """Get playlist tracks for given playlist id."""
-        result = []
         if not await self.exists(prov_playlist_id):
             raise MediaNotFoundError(f"Playlist path does not exist: {prov_playlist_id}")
 
@@ -449,11 +448,10 @@ class FileSystemProviderBase(MusicProvider):
                 ):
                     # use the linenumber as position for easier deletions
                     media_item.position = line_no
-                    result.append(media_item)
+                    yield media_item
 
         except Exception as err:  # pylint: disable=broad-except
             self.logger.warning("Error while parsing playlist %s", prov_playlist_id, exc_info=err)
-        return result
 
     async def _parse_playlist_line(self, line: str, playlist_path: str) -> Track | Radio | None:
         """Try to parse a track from a playlist line."""

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -447,7 +447,7 @@ class FileSystemProviderBase(MusicProvider):
                     playlist_line, os.path.dirname(prov_playlist_id)
                 ):
                     # use the linenumber as position for easier deletions
-                    media_item.position = line_no
+                    media_item.position = line_no + 1
                     yield media_item
 
         except Exception as err:  # pylint: disable=broad-except

--- a/music_assistant/server/providers/qobuz/__init__.py
+++ b/music_assistant/server/providers/qobuz/__init__.py
@@ -215,10 +215,9 @@ class QobuzProvider(MusicProvider):
             if (item and item["id"])
         ]
 
-    async def get_playlist_tracks(self, prov_playlist_id) -> list[Track]:
+    async def get_playlist_tracks(self, prov_playlist_id) -> AsyncGenerator[Track, None]:
         """Get all playlist tracks for given playlist id."""
         count = 0
-        result = []
         for item in await self._get_all_items(
             "playlist/get",
             key="tracks",
@@ -230,9 +229,8 @@ class QobuzProvider(MusicProvider):
             track = await self._parse_track(item)
             # use count as position
             track.position = count
-            result.append(track)
+            yield track
             count += 1
-        return result
 
     async def get_artist_albums(self, prov_artist_id) -> list[Album]:
         """Get a list of albums for the given artist."""

--- a/music_assistant/server/providers/qobuz/__init__.py
+++ b/music_assistant/server/providers/qobuz/__init__.py
@@ -217,7 +217,7 @@ class QobuzProvider(MusicProvider):
 
     async def get_playlist_tracks(self, prov_playlist_id) -> AsyncGenerator[Track, None]:
         """Get all playlist tracks for given playlist id."""
-        count = 0
+        count = 1
         for item in await self._get_all_items(
             "playlist/get",
             key="tracks",
@@ -322,7 +322,7 @@ class QobuzProvider(MusicProvider):
     ) -> None:
         """Remove track(s) from playlist."""
         playlist_track_ids = set()
-        for track in await self.get_playlist_tracks(prov_playlist_id):
+        async for track in self.get_playlist_tracks(prov_playlist_id):
             if track.position in positions_to_remove:
                 playlist_track_ids.add(str(track["playlist_track_id"]))
             if len(playlist_track_ids) == positions_to_remove:

--- a/music_assistant/server/providers/soundcloud/__init__.py
+++ b/music_assistant/server/providers/soundcloud/__init__.py
@@ -206,7 +206,7 @@ class SoundcloudMusicProvider(MusicProvider):
             try:
                 track = await self._parse_track(song[0])
                 if track:
-                    track.position = index
+                    track.position = index + 1
                     yield track
             except (KeyError, TypeError, InvalidDataError, IndexError) as error:
                 self.logger.debug("Parse track failed: %s", song, exc_info=error)

--- a/music_assistant/server/providers/soundcloud/__init__.py
+++ b/music_assistant/server/providers/soundcloud/__init__.py
@@ -196,23 +196,21 @@ class SoundcloudMusicProvider(MusicProvider):
             self.logger.debug("Parse playlist failed: %s", playlist_obj, exc_info=error)
         return playlist
 
-    async def get_playlist_tracks(self, prov_playlist_id) -> list[Track]:
+    async def get_playlist_tracks(self, prov_playlist_id) -> AsyncGenerator[Track, None]:
         """Get all playlist tracks for given playlist id."""
         playlist_obj = await self._soundcloud.get_playlist_details(playlist_id=prov_playlist_id)
         if "tracks" not in playlist_obj:
-            return []
-        tracks = []
+            return
         for index, item in enumerate(playlist_obj["tracks"]):
             song = await self._soundcloud.get_track_details(item["id"])
             try:
                 track = await self._parse_track(song[0])
                 if track:
                     track.position = index
-                    tracks.append(track)
+                    yield track
             except (KeyError, TypeError, InvalidDataError, IndexError) as error:
                 self.logger.debug("Parse track failed: %s", song, exc_info=error)
                 continue
-        return tracks
 
     async def get_artist_toptracks(self, prov_artist_id) -> list[Track]:
         """Get a list of 25 most popular tracks for the given artist."""

--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -239,10 +239,9 @@ class SpotifyProvider(MusicProvider):
             if (item and item["id"])
         ]
 
-    async def get_playlist_tracks(self, prov_playlist_id) -> list[Track]:
+    async def get_playlist_tracks(self, prov_playlist_id) -> AsyncGenerator[Track, None]:
         """Get all playlist tracks for given playlist id."""
         count = 0
-        result = []
         for item in await self._get_all_items(
             f"playlists/{prov_playlist_id}/tracks",
         ):
@@ -251,9 +250,8 @@ class SpotifyProvider(MusicProvider):
             track = await self._parse_track(item["track"])
             # use count as position
             track.position = count
-            result.append(track)
+            yield track
             count += 1
-        return result
 
     async def get_artist_albums(self, prov_artist_id) -> list[Album]:
         """Get a list of all albums for the given artist."""
@@ -319,7 +317,7 @@ class SpotifyProvider(MusicProvider):
     ) -> None:
         """Remove track(s) from playlist."""
         track_uris = []
-        for track in await self.get_playlist_tracks(prov_playlist_id):
+        async for track in self.get_playlist_tracks(prov_playlist_id):
             if track.position in positions_to_remove:
                 track_uris.append({"uri": f"spotify:track:{track.item_id}"})
             if len(track_uris) == positions_to_remove:

--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -241,7 +241,7 @@ class SpotifyProvider(MusicProvider):
 
     async def get_playlist_tracks(self, prov_playlist_id) -> AsyncGenerator[Track, None]:
         """Get all playlist tracks for given playlist id."""
-        count = 0
+        count = 1
         for item in await self._get_all_items(
             f"playlists/{prov_playlist_id}/tracks",
         ):

--- a/music_assistant/server/providers/websocket_api/__init__.py
+++ b/music_assistant/server/providers/websocket_api/__init__.py
@@ -217,7 +217,7 @@ class WebsocketClientHandler:
         try:
             args = parse_arguments(handler.signature, handler.type_hints, msg.args)
             result = handler.target(**args)
-            if inspect.isasyncgenfunction(result):
+            if inspect.isasyncgen(result):
                 # async generator = send chunked response
                 chunk_size = 100
                 batch: list[Any] = []

--- a/music_assistant/server/providers/websocket_api/__init__.py
+++ b/music_assistant/server/providers/websocket_api/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import weakref
 from concurrent import futures
@@ -11,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Final
 from aiohttp import WSMsgType, web
 
 from music_assistant.common.models.api import (
+    ChunkedResultMessage,
     CommandMessage,
     ErrorResultMessage,
     MessageType,
@@ -215,6 +217,19 @@ class WebsocketClientHandler:
         try:
             args = parse_arguments(handler.signature, handler.type_hints, msg.args)
             result = handler.target(**args)
+            if inspect.isasyncgenfunction(result):
+                # async generator = send chunked response
+                chunk_size = 100
+                batch: list[Any] = []
+                async for item in result:
+                    batch.append(item)
+                    if len(batch) == chunk_size:
+                        self._send_message(ChunkedResultMessage(msg.message_id, batch))
+                        batch = []
+                # send last chunk
+                self._send_message(ChunkedResultMessage(msg.message_id, batch, True))
+                del batch
+                return
             if asyncio.iscoroutine(result):
                 result = await result
             self._send_message(SuccessResultMessage(msg.message_id, result))

--- a/music_assistant/server/providers/ytmusic/__init__.py
+++ b/music_assistant/server/providers/ytmusic/__init__.py
@@ -264,12 +264,12 @@ class YoutubeMusicProvider(MusicProvider):
                 try:
                     track = await self._parse_track(track)
                     if track:
-                        track.position = index
+                        track.position = index + 1
                         yield track
                 except InvalidDataError:
                     track = await self.get_track(track["videoId"])
                     if track:
-                        track.position = index
+                        track.position = index + 1
                         yield track
 
     async def get_artist_albums(self, prov_artist_id) -> list[Album]:


### PR DESCRIPTION
Playlist tracks listings can be pretty big.
Ideal solution should have been a PagedListing but because every provider has a different implementation this was not easy to implement in a universal way so solved it by converting the playlist tracks to asyncgenerators.

The API is extended with a ChunkedResult object to send the data in bursts.

Fixes https://github.com/orgs/music-assistant/projects/2/views/1#