### PR TITLE
Fix shuffle not shuffling entire queue

### DIFF
--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -651,7 +651,7 @@ class PlayerQueuesController:
 
         # if keep_remaining, append the old previous items
         if keep_remaining:
-            next_items += prev_items[insert_at_index:]
+            next_items += self._queue_items[queue_id][insert_at_index:]
 
         # we set the original insert order as attribute so we can un-shuffle
         for index, item in enumerate(next_items):


### PR DESCRIPTION
This PR ensures that the entire queue is shuffled when e.g. a new album is added to the queue and shuffle is enabled.

[Related backlog item](https://github.com/orgs/music-assistant/projects/2/views/1?pane=issue&itemId=24094419)