### PR TITLE
Plex - Set a timeout of 10 seconds to connect to the server

### DIFF
--- a/music_assistant/server/providers/plex/__init__.py
+++ b/music_assistant/server/providers/plex/__init__.py
@@ -101,7 +101,7 @@ class PlexProvider(MusicProvider):
 
         def connect():
             plex_account = MyPlexAccount(token=self.config.get_value(CONF_AUTH_TOKEN))
-            return plex_account.resource(self.config.get_value(CONF_SERVER_NAME)).connect(None)
+            return plex_account.resource(self.config.get_value(CONF_SERVER_NAME)).connect(None, 10)
 
         self._plex_server = await self._run_async(connect)
         self._plex_library = await self._run_async(


### PR DESCRIPTION
On connect all known addresses of the server are tried out and afterwards the best one (SSL over non SSL and local over remote) is used. The current timeout sometimes takes longer than the MA timeout of 30 seconds for the setup of a provider