### PR TITLE
Prefer instance id over domain

### DIFF
--- a/music_assistant/server/controllers/media/albums.py
+++ b/music_assistant/server/controllers/media/albums.py
@@ -69,9 +69,9 @@ class AlbumsController(MediaControllerBase[Album]):
         if album.artist:
             album.artist = await self.mass.music.artists.get(
                 album.artist.item_id,
-                album.artist.provider,
+                provider_instance=album.artist.provider,
                 lazy=True,
-                details=album.artist,
+                details=None if isinstance(album.artist, ItemMapping) else album.artist,
                 add_to_db=add_to_db,
             )
         return album
@@ -133,7 +133,7 @@ class AlbumsController(MediaControllerBase[Album]):
         """Add album to local db and return the database item."""
         # grab additional metadata
         await self.mass.metadata.get_album_metadata(item)
-        existing = await self.get_db_item_by_prov_id(item.item_id, item.provider)
+        existing = await self.get_db_item_by_prov_id(item.item_id, provider_instance=item.provider)
         if existing:
             db_item = await self.update_db_item(existing.item_id, item)
         else:
@@ -148,7 +148,7 @@ class AlbumsController(MediaControllerBase[Album]):
                 prov_mapping.item_id, prov_mapping.provider_instance
             ):
                 await self.mass.music.tracks.get(
-                    track.item_id, track.provider, details=track, add_to_db=True
+                    track.item_id, provider_instance=track.provider, details=track, add_to_db=True
                 )
         self.mass.signal_event(
             EventType.MEDIA_ITEM_UPDATED if existing else EventType.MEDIA_ITEM_ADDED,
@@ -446,7 +446,7 @@ class AlbumsController(MediaControllerBase[Album]):
             return ItemMapping.from_item(artist)
 
         if db_artist := await self.mass.music.artists.get_db_item_by_prov_id(
-            artist.item_id, provider_domain=artist.provider
+            artist.item_id, provider_instance=artist.provider
         ):
             return ItemMapping.from_item(db_artist)
 

--- a/music_assistant/server/controllers/media/playlists.py
+++ b/music_assistant/server/controllers/media/playlists.py
@@ -63,7 +63,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         """Add playlist to local db and return the new database item."""
         item.metadata.last_refresh = int(time())
         await self.mass.metadata.get_playlist_metadata(item)
-        existing = await self.get_db_item_by_prov_id(item.item_id, item.provider)
+        existing = await self.get_db_item_by_prov_id(item.item_id, provider_instance=item.provider)
         if existing:
             db_item = await self.update_db_item(existing.item_id, item)
         else:

--- a/music_assistant/server/controllers/media/radio.py
+++ b/music_assistant/server/controllers/media/radio.py
@@ -61,7 +61,7 @@ class RadioController(MediaControllerBase[Radio]):
         """Add radio to local db and return the new database item."""
         item.metadata.last_refresh = int(time())
         await self.mass.metadata.get_radio_metadata(item)
-        existing = await self.get_db_item_by_prov_id(item.item_id, item.provider)
+        existing = await self.get_db_item_by_prov_id(item.item_id, provider_instance=item.provider)
         if existing:
             db_item = await self.update_db_item(existing.item_id, item)
         else:

--- a/music_assistant/server/controllers/music.py
+++ b/music_assistant/server/controllers/music.py
@@ -11,7 +11,11 @@ from music_assistant.common.helpers.datetime import utc_timestamp
 from music_assistant.common.helpers.uri import parse_uri
 from music_assistant.common.models.enums import EventType, MediaType, ProviderFeature, ProviderType
 from music_assistant.common.models.errors import MusicAssistantError
-from music_assistant.common.models.media_items import BrowseFolder, MediaItemType, SearchResults
+from music_assistant.common.models.media_items import (
+    BrowseFolder,
+    MediaItemType,
+    SearchResults,
+)
 from music_assistant.common.models.provider import SyncTask
 from music_assistant.constants import (
     CONF_DB_LIBRARY,
@@ -124,16 +128,15 @@ class MusicController:
         :param limit: number of items to return in the search (per type).
         """
         # include results from all (unique) music providers
-        provider_domains = {item.domain for item in self.providers}
         results_per_provider: list[SearchResults] = await asyncio.gather(
             *[
                 self.search_provider(
                     search_query,
                     media_types,
-                    provider_domain=provider_domain,
+                    provider_instance=provider_instance,
                     limit=limit,
                 )
-                for provider_domain in provider_domains
+                for provider_instance in self.get_unique_providers()
             ]
         )
         # return result from all providers while keeping index
@@ -253,7 +256,7 @@ class MusicController:
         for prov in self.providers:
             if prov.instance_id == provider_domain_or_instance_id:
                 provider_instance = prov.instance_id
-                provider_domain = None
+                provider_domain = prov.domain
                 break
         else:
             provider_instance = None
@@ -332,7 +335,7 @@ class MusicController:
                     self.add_to_library(
                         media_type=item.media_type,
                         item_id=item.item_id,
-                        provider_domain=item.provider,
+                        provider_instance=item.provider,
                     )
                 )
             )
@@ -367,6 +370,7 @@ class MusicController:
                         media_type=item.media_type,
                         item_id=item.item_id,
                         provider_domain=item.provider,
+                        provider_instance=item.provider,
                     )
                 )
             )
@@ -398,7 +402,7 @@ class MusicController:
             return await self.get_item(
                 media_item.media_type,
                 media_item.item_id,
-                provider_domain=media_item.provider,
+                provider_instance=media_item.provider,
                 force_refresh=True,
                 lazy=False,
                 add_to_db=True,
@@ -479,7 +483,11 @@ class MusicController:
         """
         for media_item in items:
             self.mass.create_task(
-                self.add_to_library(media_item.media_type, media_item.item_id, media_item.provider)
+                self.add_to_library(
+                    media_item.media_type,
+                    media_item.item_id,
+                    provider_instance=media_item.provider,
+                )
             )
 
     async def library_remove_items(self, items: list[MediaItemType]) -> None:
@@ -490,7 +498,9 @@ class MusicController:
         for media_item in items:
             self.mass.create_task(
                 self.remove_from_library(
-                    media_item.media_type, media_item.item_id, media_item.provider
+                    media_item.media_type,
+                    media_item.item_id,
+                    provider_instance=media_item.provider,
                 )
             )
 
@@ -526,7 +536,7 @@ class MusicController:
         instances = set()
         domains = set()
         for provider in self.providers:
-            if provider.domain not in domains or provider.is_file():
+            if provider.domain not in domains or provider.is_unique():
                 instances.add(provider.instance_id)
                 domains.add(provider.domain)
         return instances

--- a/music_assistant/server/models/music_provider.py
+++ b/music_assistant/server/models/music_provider.py
@@ -424,10 +424,15 @@ class MusicProvider(Provider):
                     # only mark the item as not in library and leave the metadata in db
                     await controller.set_db_library(db_item.item_id, False)
 
-    def is_file(self) -> bool:
-        """Return if this is a FileSystem based provider."""
-        # override this is needed
-        return self.domain.startswith("filesystem")
+    def is_unique(self) -> bool:
+        """
+        Return if the (non user related) data in this providerinstance is unique.
+
+        For example on a streaming provider (like Spotify) the data on all instances is the same.
+        For a file provider each instance has other items.
+        Setting this to True will only query one instance of the provider for search and lookups.
+        """
+        return False
 
     # DO NOT OVERRIDE BELOW
 

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -173,6 +173,16 @@ class FileSystemProviderBase(MusicProvider):
     # DEFAULT/GENERIC IMPLEMENTATION BELOW
     # should normally not be needed to override
 
+    def is_unique(self) -> bool:
+        """
+        Return if the (non user related) data in this providerinstance is unique.
+
+        For example on a streaming provider (like Spotify) the data on all instances is the same.
+        For a file provider each instance has other items.
+        Setting this to True will only query one instance of the provider for search and lookups.
+        """
+        return True
+
     async def search(
         self, search_query: str, media_types=list[MediaType] | None, limit: int = 5  # noqa: ARG002
     ) -> SearchResults:
@@ -213,7 +223,7 @@ class FileSystemProviderBase(MusicProvider):
                 subitems.append(
                     BrowseFolder(
                         item_id=item.path,
-                        provider=self.domain,
+                        provider=self.instance_id,
                         path=f"{self.instance_id}://{item.path}",
                         name=item.name,
                     )
@@ -249,7 +259,7 @@ class FileSystemProviderBase(MusicProvider):
 
         return BrowseFolder(
             item_id=item_path,
-            provider=self.domain,
+            provider=self.instance_id,
             path=path,
             name=item_path or self.name,
             # make sure to sort the resulting listing
@@ -386,7 +396,7 @@ class FileSystemProviderBase(MusicProvider):
         file_item = await self.resolve(prov_playlist_id)
         playlist = Playlist(
             file_item.path,
-            provider=self.domain,
+            provider=self.instance_id,
             name=file_item.name.replace(f".{file_item.ext}", ""),
         )
         playlist.is_editable = file_item.ext != "pls"  # can only edit m3u playlists
@@ -581,7 +591,7 @@ class FileSystemProviderBase(MusicProvider):
         name, version = parse_title_and_version(tags.title, tags.version)
         track = Track(
             item_id=file_item.path,
-            provider=self.domain,
+            provider=self.instance_id,
             name=name,
             version=version,
         )
@@ -724,10 +734,10 @@ class FileSystemProviderBase(MusicProvider):
 
         artist = Artist(
             artist_path,
-            self.domain,
+            self.instance_id,
             name,
             provider_mappings={
-                ProviderMapping(artist_path, self.domain, self.instance_id, url=artist_path)
+                ProviderMapping(artist_path, self.instance_id, self.instance_id, url=artist_path)
             },
             musicbrainz_id=VARIOUS_ARTISTS_ID if compare_strings(name, VARIOUS_ARTISTS) else None,
         )
@@ -774,11 +784,11 @@ class FileSystemProviderBase(MusicProvider):
 
         album = Album(
             album_path,
-            self.domain,
+            self.instance_id,
             name,
             artists=artists,
             provider_mappings={
-                ProviderMapping(album_path, self.domain, self.instance_id, url=album_path)
+                ProviderMapping(album_path, self.instance_id, self.instance_id, url=album_path)
             },
         )
 

--- a/music_assistant/server/providers/plex/__init__.py
+++ b/music_assistant/server/providers/plex/__init__.py
@@ -125,6 +125,16 @@ class PlexProvider(MusicProvider):
             ProviderFeature.ARTIST_ALBUMS,
         )
 
+    def is_unique(self) -> bool:
+        """
+        Return if the (non user related) data in this providerinstance is unique.
+
+        For example on a streaming provider (like Spotify) the data on all instances is the same.
+        For a file provider each instance has other items.
+        Setting this to True will only query one instance of the provider for search and lookups.
+        """
+        return True
+
     async def _run_async(self, call: Callable, *args, **kwargs):
         return await self.mass.create_task(call, *args, **kwargs)
 
@@ -201,7 +211,7 @@ class PlexProvider(MusicProvider):
         album_id = plex_album.key
         album = Album(
             item_id=album_id,
-            provider=self.instance_id,
+            provider=self.domain,
             name=plex_album.title,
         )
         if plex_album.year:
@@ -230,7 +240,7 @@ class PlexProvider(MusicProvider):
         artist_id = plex_artist.key
         if not artist_id:
             raise InvalidDataError("Artist does not have a valid ID")
-        artist = Artist(item_id=artist_id, name=plex_artist.title, provider=self.instance_id)
+        artist = Artist(item_id=artist_id, name=plex_artist.title, provider=self.domain)
         if plex_artist.summary:
             artist.metadata.description = plex_artist.summary
         if thumb := plex_artist.firstAttr("thumb", "parentThumb", "grandparentThumb"):
@@ -248,7 +258,7 @@ class PlexProvider(MusicProvider):
     async def _parse_playlist(self, plex_playlist: PlexPlaylist) -> Playlist:
         """Parse a Plex Playlist response to a Playlist object."""
         playlist = Playlist(
-            item_id=plex_playlist.key, provider=self.instance_id, name=plex_playlist.title
+            item_id=plex_playlist.key, provider=self.domain, name=plex_playlist.title
         )
         if plex_playlist.summary:
             playlist.metadata.description = plex_playlist.summary


### PR DESCRIPTION
Preparation of https://github.com/orgs/music-assistant/projects/2/views/1?pane=issue&itemId=24283728

This makes sure that we do lookups all on provider instance first and only fallback to domain.
Allows setting the provider attribute on the media item to the provider instance.