### PR TITLE
Allow aarch64 architecture

### DIFF
--- a/music_assistant/server/providers/airplay/__init__.py
+++ b/music_assistant/server/providers/airplay/__init__.py
@@ -277,7 +277,7 @@ class AirplayProvider(PlayerProvider):
                     return bridge_binary
 
             # other linux architecture... try all options one by one...
-            for arch in ["arm64", "aarch64", "arm", "armv6", "mips", "sparc64", "x86"]:
+            for arch in ["aarch64", "arm", "armv6", "mips", "sparc64", "x86"]:
                 if bridge_binary := await check_bridge_binary(
                     os.path.join(base_path, f"squeeze2raop-linux-{arch}-static")
                 ):

--- a/music_assistant/server/providers/airplay/__init__.py
+++ b/music_assistant/server/providers/airplay/__init__.py
@@ -277,7 +277,7 @@ class AirplayProvider(PlayerProvider):
                     return bridge_binary
 
             # other linux architecture... try all options one by one...
-            for arch in ["arm64", "arm", "armv6", "mips", "sparc64", "x86"]:
+            for arch in ["arm64", "aarch64", "arm", "armv6", "mips", "sparc64", "x86"]:
                 if bridge_binary := await check_bridge_binary(
                     os.path.join(base_path, f"squeeze2raop-linux-{arch}-static")
                 ):


### PR DESCRIPTION
There is a RaopBridge binary for aarch64 but aarch64 was not an accepted architecture.