### PR TITLE
Add support for Config entries actions

### DIFF
--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from types import NoneType
-from typing import Any
+from typing import Any, Self
 
 from mashumaro import DataClassDictMixin
 
@@ -39,7 +39,11 @@ ConfigEntryTypeMap = {
     ConfigEntryType.INTEGER: int,
     ConfigEntryType.FLOAT: float,
     ConfigEntryType.LABEL: str,
+    ConfigEntryType.DIVIDER: str,
+    ConfigEntryType.ACTION: str,
 }
+
+UI_ONLY = (ConfigEntryType.LABEL, ConfigEntryType.DIVIDER, ConfigEntryType.ACTION)
 
 
 @dataclass
@@ -54,8 +58,9 @@ class ConfigValueOption(DataClassDictMixin):
 class ConfigEntry(DataClassDictMixin):
     """Model for a Config Entry.
 
-    The definition of something that can be configured for an object (e.g. provider or player)
-    within Music Assistant (without the value).
+    The definition of something that can be configured
+    for an object (e.g. provider or player)
+    within Music Assistant.
     """
 
     # key: used as identifier for the entry, also for localization
@@ -81,73 +86,58 @@ class ConfigEntry(DataClassDictMixin):
     hidden: bool = False
     # advanced: this is an advanced setting (frontend hides it in some corner)
     advanced: bool = False
-    # encrypt: store string value encrypted and do not send its value in the api
-    encrypt: bool = False
-
-
-@dataclass
-class ConfigEntryValue(ConfigEntry):
-    """Config Entry with its value parsed."""
-
+    # value: set by the config manager/flow (or in rare cases by the provider itself)
     value: ConfigValueType = None
 
-    @classmethod
-    def parse(
-        cls,
-        entry: ConfigEntry,
+    def parse_value(
+        self,
         value: ConfigValueType,
-        allow_none: bool = True,
-    ) -> ConfigEntryValue:
-        """Parse ConfigEntryValue from the config entry and plain value."""
-        result = ConfigEntryValue.from_dict(entry.to_dict())
-        result.value = value
-        expected_type = ConfigEntryTypeMap.get(result.type, NoneType)
-        if result.value is None:
-            result.value = entry.default_value
-        if result.value is None and not entry.required:
+        allow_none: bool = False,
+    ) -> ConfigValueType:
+        """Parse value from the config entry details and plain value."""
+        expected_type = ConfigEntryTypeMap.get(self.type, NoneType)
+        if value is None:
+            value = self.default_value
+        if value is None and (not self.required or allow_none):
             expected_type = NoneType
-        if entry.type == ConfigEntryType.LABEL:
-            result.value = result.label
-        if not isinstance(result.value, expected_type):
+        if self.type == ConfigEntryType.LABEL:
+            value = self.label
+        if not isinstance(value, expected_type):
             # handle common conversions/mistakes
-            if expected_type == float and isinstance(result.value, int):
-                result.value = float(result.value)
-                return result
-            if expected_type == int and isinstance(result.value, float):
-                result.value = int(result.value)
-                return result
-            if expected_type == int and isinstance(result.value, str) and result.value.isnumeric():
-                result.value = int(result.value)
-                return result
-            if (
-                expected_type == float
-                and isinstance(result.value, str)
-                and result.value.isnumeric()
-            ):
-                result.value = float(result.value)
-                return result
+            if expected_type == float and isinstance(value, int):
+                self.value = float(value)
+                return self.value
+            if expected_type == int and isinstance(value, float):
+                self.value = int(value)
+                return self.value
+            if expected_type == int and isinstance(value, str) and value.isnumeric():
+                self.value = int(value)
+                return self.value
+            if expected_type == float and isinstance(value, str) and value.isnumeric():
+                self.value = float(value)
+                return self.value
+            if self.type in UI_ONLY:
+                self.value = self.default_value
+                return self.value
             # fallback to default
-            if result.value is None and allow_none:
-                # In some cases we allow this (e.g. create default config)
-                result.value = None
-                return result
-            if entry.default_value:
+            if self.default_value is not None:
                 LOGGER.warning(
                     "%s has unexpected type: %s, fallback to default",
-                    result.key,
-                    type(result.value),
+                    self.key,
+                    type(self.value),
                 )
-                result.value = entry.default_value
-                return result
-            raise ValueError(f"{result.key} has unexpected type: {type(result.value)}")
-        return result
+                self.value = self.default_value
+                return self.value
+            raise ValueError(f"{self.key} has unexpected type: {type(value)}")
+        self.value = value
+        return self.value
 
 
 @dataclass
 class Config(DataClassDictMixin):
     """Base Configuration object."""
 
-    values: dict[str, ConfigEntryValue]
+    values: dict[str, ConfigEntry]
 
     def get_value(self, key: str) -> ConfigValueType:
         """Return config value for given key."""
@@ -159,22 +149,22 @@ class Config(DataClassDictMixin):
 
     @classmethod
     def parse(
-        cls,
+        cls: Self,
         config_entries: Iterable[ConfigEntry],
         raw: dict[str, Any],
-    ) -> Config:
+    ) -> Self:
         """Parse Config from the raw values (as stored in persistent storage)."""
-        values = {
-            x.key: ConfigEntryValue.parse(x, raw.get("values", {}).get(x.key)).to_dict()
-            for x in config_entries
-        }
-        conf = cls.from_dict({**raw, "values": values})
+        conf = cls.from_dict({**raw, "values": {}})
+        for entry in config_entries:
+            # create a copy of the entry
+            conf.values[entry.key] = ConfigEntry.from_dict(entry.to_dict())
+            conf.values[entry.key].parse_value(raw["values"].get(entry.key))
         return conf
 
     def to_raw(self) -> dict[str, Any]:
         """Return minimized/raw dict to store in persistent storage."""
 
-        def _handle_value(value: ConfigEntryValue):
+        def _handle_value(value: ConfigEntry):
             if value.type == ConfigEntryType.SECURE_STRING:
                 assert ENCRYPT_CALLBACK is not None
                 return ENCRYPT_CALLBACK(value.value)
@@ -183,7 +173,9 @@ class Config(DataClassDictMixin):
         return {
             **self.to_dict(),
             "values": {
-                x.key: _handle_value(x) for x in self.values.values() if x.value != x.default_value
+                x.key: _handle_value(x)
+                for x in self.values.values()
+                if (x.value != x.default_value and x.type not in UI_ONLY)
             },
         }
 
@@ -197,33 +189,30 @@ class Config(DataClassDictMixin):
                 d["values"][key]["value"] = SECURE_STRING_SUBSTITUTE
         return d
 
-    def update(self, update: ConfigUpdate) -> set[str]:
+    def update(self, update: dict[str, ConfigValueType]) -> set[str]:
         """Update Config with updated values."""
         changed_keys: set[str] = set()
 
         # root values (enabled, name)
-        for key in ("enabled", "name"):
-            cur_val = getattr(self, key, None)
-            new_val = getattr(update, key, None)
-            if new_val is None:
+        root_values = ("enabled", "name")
+        for key in root_values:
+            cur_val = getattr(self, key)
+            if key not in update:
                 continue
+            new_val = update[key]
             if new_val == cur_val:
                 continue
             setattr(self, key, new_val)
             changed_keys.add(key)
 
-        # update values
-        if update.values is not None:
-            for key, new_val in update.values.items():
-                cur_val = self.values[key].value
-                # parse entry to do type validation
-                parsed_val = ConfigEntryValue.parse(self.values[key], new_val)
-                if cur_val == parsed_val.value:
-                    continue
-                if parsed_val.value is None:
-                    self.values[key].value = parsed_val.default_value
-                else:
-                    self.values[key].value = parsed_val.value
+        # config entry values
+        for key, new_val in update.items():
+            if key in root_values:
+                continue
+            cur_val = self.values[key].value
+            # parse entry to do type validation
+            parsed_val = self.values[key].parse_value(new_val)
+            if cur_val != parsed_val:
                 changed_keys.add(f"values/{key}")
 
         return changed_keys
@@ -233,7 +222,7 @@ class Config(DataClassDictMixin):
         # For now we just use the parse method to check for not allowed None values
         # this can be extended later
         for value in self.values.values():
-            value.parse(value, value.value, allow_none=False)
+            value.parse_value(value.value, allow_none=False)
 
 
 @dataclass
@@ -263,17 +252,8 @@ class PlayerConfig(Config):
     name: str | None = None
     # available: boolean to indicate if the player is available
     available: bool = True
-    # default_name: default name to use when there is name available
+    # default_name: default name to use when there is no name available
     default_name: str | None = None
-
-
-@dataclass
-class ConfigUpdate(DataClassDictMixin):
-    """Config object to send when updating some/all values through the API."""
-
-    enabled: bool | None = None
-    name: str | None = None
-    values: dict[str, ConfigValueType] | None = None
 
 
 DEFAULT_PROVIDER_CONFIG_ENTRIES = (
@@ -375,7 +355,7 @@ CONF_ENTRY_OUTPUT_CODEC = ConfigEntry(
     label="Output codec",
     options=[
         ConfigValueOption("FLAC (lossless, compact file size)", "flac"),
-        ConfigValueOption("M4A AAC (lossy, superior quality)", "aac"),
+        ConfigValueOption("AAC (lossy, superior quality)", "aac"),
         ConfigValueOption("MP3 (lossy, average quality)", "mp3"),
         ConfigValueOption("WAV (lossless, huge file size)", "wav"),
     ],

--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -86,13 +86,17 @@ class ConfigEntry(DataClassDictMixin):
     hidden: bool = False
     # advanced: this is an advanced setting (frontend hides it in some corner)
     advanced: bool = False
+    # action: (configentry)action that is needed to get the value for this entry
+    action: str | None = None
+    # action_label: default label for the action when no translation for the action is present
+    action_label: str | None = None
     # value: set by the config manager/flow (or in rare cases by the provider itself)
     value: ConfigValueType = None
 
     def parse_value(
         self,
         value: ConfigValueType,
-        allow_none: bool = False,
+        allow_none: bool = True,
     ) -> ConfigValueType:
         """Parse value from the config entry details and plain value."""
         expected_type = ConfigEntryTypeMap.get(self.type, NoneType)
@@ -158,7 +162,7 @@ class Config(DataClassDictMixin):
         for entry in config_entries:
             # create a copy of the entry
             conf.values[entry.key] = ConfigEntry.from_dict(entry.to_dict())
-            conf.values[entry.key].parse_value(raw["values"].get(entry.key))
+            conf.values[entry.key].parse_value(raw["values"].get(entry.key), allow_none=True)
         return conf
 
     def to_raw(self) -> dict[str, Any]:

--- a/music_assistant/common/models/enums.py
+++ b/music_assistant/common/models/enums.py
@@ -315,7 +315,7 @@ class ProviderFeature(StrEnum):
     #
     # PLAYERPROVIDER FEATURES
     #
-    CREATE_PLAYER_CONFIG = "create_player_config"
+    # we currently have none ;-)
 
     #
     # METADATAPROVIDER FEATURES
@@ -348,3 +348,5 @@ class ConfigEntryType(StrEnum):
     INTEGER = "integer"
     FLOAT = "float"
     LABEL = "label"
+    DIVIDER = "divider"
+    ACTION = "action"

--- a/music_assistant/common/models/enums.py
+++ b/music_assistant/common/models/enums.py
@@ -272,6 +272,7 @@ class EventType(StrEnum):
     PROVIDERS_UPDATED = "providers_updated"
     PLAYER_CONFIG_UPDATED = "player_config_updated"
     SYNC_TASKS_UPDATED = "sync_tasks_updated"
+    AUTH_SESSION = "auth_session"
 
 
 class ProviderFeature(StrEnum):

--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -239,6 +239,14 @@ class ConfigController:
             # cleanup entries in library
             await self.mass.music.cleanup_provider(instance_id)
 
+    async def remove_provider_config_value(self, instance_id: str, key: str) -> None:
+        """Remove/reset single Provider config value."""
+        conf_key = f"{CONF_PROVIDERS}/{instance_id}/values/{key}"
+        existing = self.get(conf_key)
+        if not existing:
+            return
+        self.remove(conf_key)
+
     @api_command("config/providers/reload")
     async def reload_provider(self, instance_id: str) -> None:
         """Reload provider."""
@@ -460,7 +468,7 @@ class ConfigController:
         available = prov.available if (prov := self.mass.get_provider(instance_id)) else False
         if not changed_keys and (config.enabled == available):
             # no changes
-            return
+            return config
         # try to load the provider first to catch errors before we save it.
         if config.enabled:
             await self.mass.load_provider(config)

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -480,13 +480,13 @@ class PlayerQueuesController:
         # execute the play_media command on the player(s)
         player_prov = self.mass.players.get_player_provider(queue_id)
         flow_mode = self.mass.config.get_player_config_value(queue.queue_id, CONF_FLOW_MODE)
-        queue.flow_mode = flow_mode.value
+        queue.flow_mode = flow_mode
         await player_prov.cmd_play_media(
             queue_id,
             queue_item=queue_item,
             seek_position=seek_position,
             fade_in=fade_in,
-            flow_mode=flow_mode.value,
+            flow_mode=flow_mode,
         )
 
     # Interaction with player

--- a/music_assistant/server/controllers/players.py
+++ b/music_assistant/server/controllers/players.py
@@ -189,7 +189,7 @@ class PlayerController:
             try:
                 hide_group_childs = self.mass.config.get_player_config_value(
                     group_player.player_id, CONF_HIDE_GROUP_CHILDS
-                ).value
+                )
             except KeyError:
                 continue
             if hide_group_childs == "always":

--- a/music_assistant/server/controllers/streams.py
+++ b/music_assistant/server/controllers/streams.py
@@ -331,7 +331,7 @@ class StreamsController:
         if output_format.is_pcm() or output_format == ContentType.WAV:
             output_channels = self.mass.config.get_player_config_value(
                 player_id, CONF_OUTPUT_CHANNELS
-            ).value
+            )
             channels = 1 if output_channels != "stereo" else 2
             output_format_str = (
                 f"x-wav;codec=pcm;rate={output_sample_rate};"

--- a/music_assistant/server/helpers/auth.py
+++ b/music_assistant/server/helpers/auth.py
@@ -1,0 +1,64 @@
+"""Helper(s) to deal with authentication for (music) providers."""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from aiohttp.web import Request, Response
+
+from music_assistant.common.models.enums import EventType
+
+if TYPE_CHECKING:
+    from music_assistant.server import MusicAssistant
+
+
+class AuthenticationHelper:
+    """Context manager helper class for authentication with a forward and redirect URL."""
+
+    def __init__(self, mass: MusicAssistant, session_id: str):
+        """
+        Initialize the Authentication Helper.
+
+        Params:
+        - url: The URL the user needs to open for authentication.
+        - session_id: a unique id for this auth session.
+        """
+        self.mass = mass
+        self.session_id = session_id
+        self._callback_response: asyncio.Queue[dict[str, str]] = asyncio.Queue(1)
+
+    @property
+    def callback_url(self) -> str:
+        """Return the callback URL."""
+        return f"{self.mass.webserver.base_url}/callback/{self.session_id}"
+
+    async def __aenter__(self) -> AuthenticationHelper:
+        """Enter context manager."""
+        self.mass.webserver.register_route(
+            f"/callback/{self.session_id}", self._handle_callback, "GET"
+        )
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> bool:
+        """Exit context manager."""
+        self.mass.webserver.unregister_route(f"/callback/{self.session_id}", "GET")
+
+    async def authenticate(self, auth_url: str, timeout: int = 60) -> dict[str, str]:
+        """Start the auth process and return any query params if received on the callback."""
+        # redirect the user in the frontend to the auth url
+        self.mass.signal_event(EventType.AUTH_SESSION, self.session_id, auth_url)
+        async with asyncio.timeout(timeout):
+            return await self._callback_response.get()
+
+    async def _handle_callback(self, request: Request) -> Response:
+        """Handle callback response."""
+        params = dict(request.query)
+        await self._callback_response.put(params)
+        return_html = """
+        <html>
+        <body onload="window.close();">
+            Authentication completed, you may now close this window.
+        </body>
+        </html>
+        """
+        return Response(body=return_html, headers={"content-type": "text/html"})

--- a/music_assistant/server/models/__init__.py
+++ b/music_assistant/server/models/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
+from music_assistant.common.models.config_entries import ConfigValueType
+
 from .metadata_provider import MetadataProvider
 from .music_provider import MusicProvider
 from .player_provider import PlayerProvider
@@ -28,6 +30,15 @@ class ProviderModuleType(Protocol):
 
     @staticmethod
     async def get_config_entries(
-        mass: MusicAssistant, manifest: ProviderManifest
+        mass: MusicAssistant,
+        instance_id: str | None = None,
+        action: str | None = None,
+        values: dict[str, ConfigValueType] | None = None,
     ) -> tuple[ConfigEntry, ...]:
-        """Return Config entries to setup this provider."""
+        """
+        Return Config entries to setup this provider.
+
+        instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+        """

--- a/music_assistant/server/models/player_provider.py
+++ b/music_assistant/server/models/player_provider.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from music_assistant.common.models.enums import ProviderFeature
 from music_assistant.common.models.player import Player
 from music_assistant.common.models.queue_item import QueueItem
 
@@ -31,19 +30,6 @@ class PlayerProvider(Provider):
 
     def on_player_config_removed(self, player_id: str) -> None:
         """Call (by config manager) when the configuration of a player is removed."""
-
-    async def create_player_config(self, config: PlayerConfig | None = None) -> PlayerConfig:
-        """Handle CREATE_PLAYER flow for this player provider.
-
-        Allows manually registering/creating a player,
-        for example by manually entering an IP address etc.
-
-        Called by the Config manager without a value to get the PlayerConfig to show in the UI.
-        Called with PlayerConfig value with the submitted values.
-        """
-        # will only be called if the provider has the ADD_PLAYER feature set.
-        if ProviderFeature.CREATE_PLAYER_CONFIG in self.supported_features:
-            raise NotImplementedError
 
     @abstractmethod
     async def cmd_stop(self, player_id: str) -> None:

--- a/music_assistant/server/providers/airplay/__init__.py
+++ b/music_assistant/server/providers/airplay/__init__.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 import aiofiles
 
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType
 from music_assistant.common.models.player import DeviceInfo, Player
 from music_assistant.common.models.queue_item import QueueItem
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
 
 PLAYER_CONFIG_ENTRIES = (
     ConfigEntry(
-        key="airplay_label",
-        type=ConfigEntryType.LABEL,
+        key="airplay_header",
+        type=ConfigEntryType.DIVIDER,
         label="Airplay specific settings",
         description="Configure Airplay specific settings. "
         "Note that changing any airplay specific setting, will reconnect all players.",
@@ -83,9 +83,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 

--- a/music_assistant/server/providers/airplay/__init__.py
+++ b/music_assistant/server/providers/airplay/__init__.py
@@ -92,8 +92,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/chromecast/__init__.py
+++ b/music_assistant/server/providers/chromecast/__init__.py
@@ -93,8 +93,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/chromecast/__init__.py
+++ b/music_assistant/server/providers/chromecast/__init__.py
@@ -23,6 +23,7 @@ from music_assistant.common.models.config_entries import (
     CONF_ENTRY_OUTPUT_CODEC,
     ConfigEntry,
     ConfigValueOption,
+    ConfigValueType,
 )
 from music_assistant.common.models.enums import (
     ConfigEntryType,
@@ -83,9 +84,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 
@@ -207,7 +218,7 @@ class ChromecastProvider(PlayerProvider):
     ) -> None:
         """Send PLAY MEDIA command to given player."""
         castplayer = self.castplayers[player_id]
-        output_codec = self.mass.config.get_player_config_value(player_id, CONF_OUTPUT_CODEC).value
+        output_codec = self.mass.config.get_player_config_value(player_id, CONF_OUTPUT_CODEC)
         url = await self.mass.streams.resolve_stream_url(
             queue_item=queue_item,
             player_id=player_id,
@@ -548,7 +559,7 @@ class ChromecastProvider(PlayerProvider):
         event = asyncio.Event()
         if use_alt_app := self.mass.config.get_player_config_value(
             castplayer.player_id, CONF_ALT_APP
-        ).value:
+        ):
             app_id = pychromecast.config.APP_BUBBLEUPNP
         else:
             app_id = pychromecast.config.APP_MEDIA_RECEIVER

--- a/music_assistant/server/providers/dlna/__init__.py
+++ b/music_assistant/server/providers/dlna/__init__.py
@@ -23,7 +23,11 @@ from async_upnp_client.profiles.dlna import DmrDevice, TransportState
 from async_upnp_client.search import async_search
 from async_upnp_client.utils import CaseInsensitiveDict
 
-from music_assistant.common.models.config_entries import CONF_ENTRY_OUTPUT_CODEC, ConfigEntry
+from music_assistant.common.models.config_entries import (
+    CONF_ENTRY_OUTPUT_CODEC,
+    ConfigEntry,
+    ConfigValueType,
+)
 from music_assistant.common.models.enums import ContentType, PlayerFeature, PlayerState, PlayerType
 from music_assistant.common.models.errors import PlayerUnavailableError, QueueEmpty
 from music_assistant.common.models.player import DeviceInfo, Player
@@ -63,9 +67,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 
@@ -262,7 +276,7 @@ class DLNAPlayerProvider(PlayerProvider):
         # always clear queue (by sending stop) first
         if dlna_player.device.can_stop:
             await self.cmd_stop(player_id)
-        output_codec = self.mass.config.get_player_config_value(player_id, CONF_OUTPUT_CODEC).value
+        output_codec = self.mass.config.get_player_config_value(player_id, CONF_OUTPUT_CODEC)
         url = await self.mass.streams.resolve_stream_url(
             queue_item=queue_item,
             player_id=dlna_player.udn,
@@ -554,7 +568,7 @@ class DLNAPlayerProvider(PlayerProvider):
         # send queue item to dlna queue
         output_codec = self.mass.config.get_player_config_value(
             dlna_player.player.player_id, CONF_OUTPUT_CODEC
-        ).value
+        )
         url = await self.mass.streams.resolve_stream_url(
             queue_item=next_item,
             player_id=dlna_player.udn,

--- a/music_assistant/server/providers/dlna/__init__.py
+++ b/music_assistant/server/providers/dlna/__init__.py
@@ -76,8 +76,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/fanarttv/__init__.py
+++ b/music_assistant/server/providers/fanarttv/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import aiohttp.client_exceptions
 from asyncio_throttle import Throttler
 
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ProviderFeature
 from music_assistant.common.models.media_items import ImageType, MediaItemImage, MediaItemMetadata
 from music_assistant.server.controllers.cache import use_cache
@@ -47,9 +47,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 

--- a/music_assistant/server/providers/fanarttv/__init__.py
+++ b/music_assistant/server/providers/fanarttv/__init__.py
@@ -56,8 +56,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/filesystem_local/__init__.py
+++ b/music_assistant/server/providers/filesystem_local/__init__.py
@@ -59,8 +59,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return (

--- a/music_assistant/server/providers/filesystem_local/__init__.py
+++ b/music_assistant/server/providers/filesystem_local/__init__.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import aiofiles
 from aiofiles.os import wrap
 
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType
 from music_assistant.common.models.errors import SetupFailedError
 from music_assistant.constants import CONF_PATH
@@ -50,9 +50,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return (
         ConfigEntry(key="path", type=ConfigEntryType.STRING, label="Path", default_value="/media"),
         CONF_ENTRY_MISSING_ALBUM_ARTIST,

--- a/music_assistant/server/providers/filesystem_smb/__init__.py
+++ b/music_assistant/server/providers/filesystem_smb/__init__.py
@@ -6,7 +6,7 @@ import platform
 from typing import TYPE_CHECKING
 
 from music_assistant.common.helpers.util import get_ip_from_host
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType
 from music_assistant.common.models.errors import LoginFailed
 from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
@@ -47,9 +47,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return (
         ConfigEntry(
             key=CONF_HOST,
@@ -100,7 +110,7 @@ async def get_config_entries(
             label="Mount options",
             required=False,
             advanced=True,
-            default_value="file_mode=0775,dir_mode=0775,uid=0,gid=0",
+            default_value="noserverino,file_mode=0775,dir_mode=0775,uid=0,gid=0",
             description="[optional] Any additional mount options you "
             "want to pass to the mount command if needed for your particular setup.",
         ),

--- a/music_assistant/server/providers/filesystem_smb/__init__.py
+++ b/music_assistant/server/providers/filesystem_smb/__init__.py
@@ -56,8 +56,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return (

--- a/music_assistant/server/providers/lms_cli/__init__.py
+++ b/music_assistant/server/providers/lms_cli/__init__.py
@@ -9,7 +9,7 @@ from aiohttp import web
 
 from music_assistant.common.helpers.json import json_dumps, json_loads
 from music_assistant.common.helpers.util import select_free_port
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import PlayerState
 from music_assistant.server.models.plugin import PluginProvider
 
@@ -47,9 +47,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 

--- a/music_assistant/server/providers/lms_cli/__init__.py
+++ b/music_assistant/server/providers/lms_cli/__init__.py
@@ -56,8 +56,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/musicbrainz/__init__.py
+++ b/music_assistant/server/providers/musicbrainz/__init__.py
@@ -51,8 +51,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/musicbrainz/__init__.py
+++ b/music_assistant/server/providers/musicbrainz/__init__.py
@@ -13,7 +13,7 @@ import aiohttp.client_exceptions
 from asyncio_throttle import Throttler
 
 from music_assistant.common.helpers.util import create_sort_name
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ProviderFeature
 from music_assistant.server.controllers.cache import use_cache
 from music_assistant.server.helpers.compare import compare_strings
@@ -42,9 +42,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 

--- a/music_assistant/server/providers/plex/__init__.py
+++ b/music_assistant/server/providers/plex/__init__.py
@@ -1,8 +1,11 @@
 """Plex musicprovider support for MusicAssistant."""
+from __future__ import annotations
+
 import logging
 from asyncio import TaskGroup
 from collections.abc import AsyncGenerator, Callable, Coroutine
 
+import plexapi.exceptions
 from aiohttp import ClientTimeout
 from plexapi.audio import Album as PlexAlbum
 from plexapi.audio import Artist as PlexArtist
@@ -12,10 +15,15 @@ from plexapi.library import MusicSection as PlexMusicSection
 from plexapi.media import AudioStream as PlexAudioStream
 from plexapi.media import Media as PlexMedia
 from plexapi.media import MediaPart as PlexMediaPart
-from plexapi.myplex import MyPlexAccount
+from plexapi.myplex import MyPlexAccount, MyPlexPinLogin
 from plexapi.server import PlexServer
 
-from music_assistant.common.models.config_entries import ConfigEntry, ProviderConfig
+from music_assistant.common.models.config_entries import (
+    ConfigEntry,
+    ConfigValueOption,
+    ConfigValueType,
+    ProviderConfig,
+)
 from music_assistant.common.models.enums import (
     ConfigEntryType,
     ContentType,
@@ -38,13 +46,16 @@ from music_assistant.common.models.media_items import (
 )
 from music_assistant.common.models.provider import ProviderManifest
 from music_assistant.server import MusicAssistant
+from music_assistant.server.helpers.auth import AuthenticationHelper
 from music_assistant.server.helpers.tags import parse_tags
 from music_assistant.server.models import ProviderInstanceType
 from music_assistant.server.models.music_provider import MusicProvider
+from music_assistant.server.providers.plex.helpers import get_libraries
 
+CONF_ACTION_AUTH = "auth"
+CONF_ACTION_LIBRARY = "library"
 CONF_AUTH_TOKEN = "token"
-CONF_SERVER_NAME = "server"
-CONF_LIBRARY_NAME = "library"
+CONF_LIBRARY_ID = "library_id"
 
 
 async def setup(
@@ -60,32 +71,70 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,  # noqa: ARG001
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # config flow auth action/step (authenticate button clicked)
+    if action == CONF_ACTION_AUTH:
+        async with AuthenticationHelper(mass, values["session_id"]) as auth_helper:
+            plex_auth = MyPlexPinLogin(headers={"X-Plex-Product": "Music Assistant"}, oauth=True)
+            auth_url = plex_auth.oauthUrl(auth_helper.callback_url)
+            await auth_helper.authenticate(auth_url)
+            if not plex_auth.checkLogin():
+                raise LoginFailed("Authentication to MyPlex failed")
+            # set the retrieved token on the values object to pass along
+            values[CONF_AUTH_TOKEN] = plex_auth.token
+
+    # config flow auth action/step to pick the library to use
+    # because this call is very slow, we only show/calculate the dropdown if we do
+    # not yet have this info or we/user invalidated it.
+    conf_libraries = ConfigEntry(
+        key=CONF_LIBRARY_ID,
+        type=ConfigEntryType.STRING,
+        label="Library",
+        required=True,
+        description="The library to connect to (e.g. Music)",
+        depends_on=CONF_AUTH_TOKEN,
+        action=CONF_ACTION_LIBRARY,
+        action_label="Select Plex Music Library",
+    )
+    if action in (CONF_ACTION_LIBRARY, CONF_ACTION_AUTH):
+        token = mass.config.decrypt_string(values.get(CONF_AUTH_TOKEN))
+        if not (libraries := await get_libraries(mass, token)):
+            raise LoginFailed("Unable to retrieve Servers and/or Music Libraries")
+        conf_libraries.options = tuple(
+            # use the same value for both the value and the title
+            # until we find out what plex uses as stable identifiers
+            ConfigValueOption(
+                title=x,
+                value=x,
+            )
+            for x in libraries
+        )
+        # select first library as (default) value
+        conf_libraries.default_value = libraries[0]
+        conf_libraries.value = libraries[0]
+    # return the collected config entries
     return (
-        ConfigEntry(
-            key=CONF_SERVER_NAME,
-            type=ConfigEntryType.STRING,
-            label="Server",
-            required=True,
-            description="The name of the server (as shown in the interface)",
-        ),
-        ConfigEntry(
-            key=CONF_LIBRARY_NAME,
-            type=ConfigEntryType.STRING,
-            label="Library",
-            required=True,
-            description="The name of the library to connect to (e.g. Music)",
-        ),
         ConfigEntry(
             key=CONF_AUTH_TOKEN,
             type=ConfigEntryType.SECURE_STRING,
-            label="Token",
-            required=True,
-            description="A token to connect to your plex.tv account.",
-            help_link="https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/",
+            label="Authentication token for MyPlex.tv",
+            description="You need to link Music Assistant to your MyPlex account.",
+            action=CONF_ACTION_AUTH,
+            action_label="Authenticate on MyPlex.tv",
+            value=values.get(CONF_AUTH_TOKEN) if values else None,
         ),
+        conf_libraries,
     )
 
 
@@ -99,15 +148,21 @@ class PlexProvider(MusicProvider):
         """Set up the music provider by connecting to the server."""
         # silence urllib logger
         logging.getLogger("urllib3.connectionpool").setLevel(logging.INFO)
+        server_name, library_name = self.config.get_value(CONF_LIBRARY_ID).split(" / ", 1)
 
-        def connect():
-            plex_account = MyPlexAccount(token=self.config.get_value(CONF_AUTH_TOKEN))
-            return plex_account.resource(self.config.get_value(CONF_SERVER_NAME)).connect(None, 10)
+        def connect() -> PlexServer:
+            try:
+                plex_account = MyPlexAccount(token=self.config.get_value(CONF_AUTH_TOKEN))
+            except plexapi.exceptions.BadRequest as err:
+                if "Invalid token" in str(err):
+                    # token invalid, invaidate the config
+                    self.mass.config.remove_provider_config_value(self.instance_id, CONF_AUTH_TOKEN)
+                    raise LoginFailed("Authentication failed")
+                raise LoginFailed() from err
+            return plex_account.resource(server_name).connect(None, 10)
 
         self._plex_server = await self._run_async(connect)
-        self._plex_library = await self._run_async(
-            self._plex_server.library.section, self.config.get_value(CONF_LIBRARY_NAME)
-        )
+        self._plex_library = await self._run_async(self._plex_server.library.section, library_name)
 
     @property
     def supported_features(self) -> tuple[ProviderFeature, ...]:

--- a/music_assistant/server/providers/plex/helpers.py
+++ b/music_assistant/server/providers/plex/helpers.py
@@ -1,0 +1,48 @@
+"""Several helpers/utils for the Plex Music Provider."""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import plexapi.exceptions
+from plexapi.library import LibrarySection as PlexLibrarySection
+from plexapi.library import MusicSection as PlexMusicSection
+from plexapi.myplex import MyPlexAccount
+from plexapi.server import PlexServer
+
+if TYPE_CHECKING:
+    from music_assistant.server import MusicAssistant
+
+
+async def get_libraries(mass: MusicAssistant, auth_token: str) -> set[str]:
+    """
+    Get all music libraries for all plex servers.
+
+    Returns a set of Library names in format 'servername / library name'
+    """
+    cache_key = "plex_libraries"
+
+    def _get_libraries():
+        # create a listing of available music libraries on all servers
+        all_libraries: list[str] = []
+        plex_account = MyPlexAccount(token=auth_token)
+        for server_resource in plex_account.resources():
+            try:
+                plex_server: PlexServer = server_resource.connect(None, 10)
+            except plexapi.exceptions.NotFound:
+                continue
+            for media_section in plex_server.library.sections():
+                media_section: PlexLibrarySection  # noqa: PLW2901
+                if media_section.type != PlexMusicSection.TYPE:
+                    continue
+                # TODO: figure out what plex uses as stable id and use that instead of names
+                all_libraries.append(f"{server_resource.name} / {media_section.title}")
+        return all_libraries
+
+    if cache := await mass.cache.get(cache_key, checksum=auth_token):
+        return cache
+
+    result = await asyncio.to_thread(_get_libraries)
+    # use short expiration for in-memory cache
+    await mass.cache.set(cache_key, result, checksum=auth_token, expiration=3600)
+    return result

--- a/music_assistant/server/providers/qobuz/__init__.py
+++ b/music_assistant/server/providers/qobuz/__init__.py
@@ -12,7 +12,7 @@ import aiohttp
 from asyncio_throttle import Throttler
 
 from music_assistant.common.helpers.util import parse_title_and_version, try_parse_int
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType, ProviderFeature
 from music_assistant.common.models.errors import LoginFailed, MediaNotFoundError
 from music_assistant.common.models.media_items import (
@@ -67,9 +67,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return (
         ConfigEntry(
             key=CONF_USERNAME, type=ConfigEntryType.STRING, label="Username", required=True

--- a/music_assistant/server/providers/qobuz/__init__.py
+++ b/music_assistant/server/providers/qobuz/__init__.py
@@ -76,8 +76,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return (

--- a/music_assistant/server/providers/slimproto/__init__.py
+++ b/music_assistant/server/providers/slimproto/__init__.py
@@ -14,7 +14,7 @@ from aioslimproto.client import TransitionType as SlimTransition
 from aioslimproto.const import EventType as SlimEventType
 from aioslimproto.discovery import start_discovery
 
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import (
     ConfigEntryType,
     ContentType,
@@ -94,9 +94,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 

--- a/music_assistant/server/providers/slimproto/__init__.py
+++ b/music_assistant/server/providers/slimproto/__init__.py
@@ -103,8 +103,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/sonos/__init__.py
+++ b/music_assistant/server/providers/sonos/__init__.py
@@ -68,8 +68,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/sonos/__init__.py
+++ b/music_assistant/server/providers/sonos/__init__.py
@@ -14,7 +14,11 @@ from soco.events_base import Event as SonosEvent
 from soco.events_base import SubscriptionBase
 from soco.groups import ZoneGroup
 
-from music_assistant.common.models.config_entries import CONF_ENTRY_OUTPUT_CODEC, ConfigEntry
+from music_assistant.common.models.config_entries import (
+    CONF_ENTRY_OUTPUT_CODEC,
+    ConfigEntry,
+    ConfigValueType,
+)
 from music_assistant.common.models.enums import (
     ContentType,
     MediaType,
@@ -55,9 +59,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 
@@ -282,7 +296,7 @@ class SonosPlayerProvider(PlayerProvider):
         await asyncio.to_thread(sonos_player.soco.stop)
         await asyncio.to_thread(sonos_player.soco.clear_queue)
 
-        output_codec = self.mass.config.get_player_config_value(player_id, CONF_OUTPUT_CODEC).value
+        output_codec = self.mass.config.get_player_config_value(player_id, CONF_OUTPUT_CODEC)
         radio_mode = (
             flow_mode or not queue_item.duration or queue_item.media_type == MediaType.RADIO
         )
@@ -552,7 +566,7 @@ class SonosPlayerProvider(PlayerProvider):
         # send queue item to sonos queue
         output_codec = self.mass.config.get_player_config_value(
             sonos_player.player_id, CONF_OUTPUT_CODEC
-        ).value
+        )
         is_radio = next_item.media_type != MediaType.TRACK
         url = await self.mass.streams.resolve_stream_url(
             queue_item=next_item,

--- a/music_assistant/server/providers/soundcloud/__init__.py
+++ b/music_assistant/server/providers/soundcloud/__init__.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING
 
 from music_assistant.common.helpers.util import parse_title_and_version
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType, ProviderFeature
 from music_assistant.common.models.errors import InvalidDataError, LoginFailed
 from music_assistant.common.models.media_items import (
@@ -59,9 +59,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return (
         ConfigEntry(
             key=CONF_CLIENT_ID, type=ConfigEntryType.SECURE_STRING, label="Client ID", required=True

--- a/music_assistant/server/providers/soundcloud/__init__.py
+++ b/music_assistant/server/providers/soundcloud/__init__.py
@@ -68,8 +68,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return (

--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -16,7 +16,7 @@ import aiohttp
 from asyncio_throttle import Throttler
 
 from music_assistant.common.helpers.util import parse_title_and_version
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType, ProviderFeature
 from music_assistant.common.models.errors import LoginFailed, MediaNotFoundError
 from music_assistant.common.models.media_items import (
@@ -74,9 +74,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return (
         ConfigEntry(
             key=CONF_USERNAME, type=ConfigEntryType.STRING, label="Username", required=True
@@ -539,9 +549,11 @@ class SpotifyProvider(MusicProvider):
             try:
                 retries += 1
                 if not tokeninfo:
-                    tokeninfo = await asyncio.wait_for(self._get_token(), 5)
+                    async with asyncio.timeout(5):
+                        tokeninfo = await self._get_token()
                 if tokeninfo and not userinfo:
-                    userinfo = await asyncio.wait_for(self._get_data("me", tokeninfo=tokeninfo), 5)
+                    async with asyncio.timeout(5):
+                        userinfo = await self._get_data("me", tokeninfo=tokeninfo)
                 if tokeninfo and userinfo:
                     # we have all info we need!
                     break

--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -83,8 +83,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return (

--- a/music_assistant/server/providers/theaudiodb/__init__.py
+++ b/music_assistant/server/providers/theaudiodb/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import aiohttp.client_exceptions
 from asyncio_throttle import Throttler
 
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ProviderFeature
 from music_assistant.common.models.media_items import (
     Album,
@@ -84,9 +84,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 

--- a/music_assistant/server/providers/theaudiodb/__init__.py
+++ b/music_assistant/server/providers/theaudiodb/__init__.py
@@ -93,8 +93,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/tunein/__init__.py
+++ b/music_assistant/server/providers/tunein/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from asyncio_throttle import Throttler
 
 from music_assistant.common.helpers.util import create_sort_name
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType, ProviderFeature
 from music_assistant.common.models.errors import LoginFailed, MediaNotFoundError
 from music_assistant.common.models.media_items import (
@@ -56,9 +56,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return (
         ConfigEntry(
             key=CONF_USERNAME, type=ConfigEntryType.STRING, label="Username", required=True

--- a/music_assistant/server/providers/tunein/__init__.py
+++ b/music_assistant/server/providers/tunein/__init__.py
@@ -65,8 +65,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return (

--- a/music_assistant/server/providers/url/__init__.py
+++ b/music_assistant/server/providers/url/__init__.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ContentType, ImageType, MediaType
 from music_assistant.common.models.media_items import (
     Artist,
@@ -38,9 +38,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 

--- a/music_assistant/server/providers/url/__init__.py
+++ b/music_assistant/server/providers/url/__init__.py
@@ -47,8 +47,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/websocket_api/__init__.py
+++ b/music_assistant/server/providers/websocket_api/__init__.py
@@ -19,7 +19,7 @@ from music_assistant.common.models.api import (
     ServerInfoMessage,
     SuccessResultMessage,
 )
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.errors import InvalidCommand
 from music_assistant.common.models.event import MassEvent
 from music_assistant.constants import ROOT_LOGGER_NAME, __version__
@@ -53,9 +53,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)
 
 

--- a/music_assistant/server/providers/websocket_api/__init__.py
+++ b/music_assistant/server/providers/websocket_api/__init__.py
@@ -62,8 +62,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return tuple()  # we do not have any config entries (yet)

--- a/music_assistant/server/providers/ytmusic/__init__.py
+++ b/music_assistant/server/providers/ytmusic/__init__.py
@@ -13,7 +13,7 @@ import ytmusicapi
 
 from music_assistant.common.helpers.uri import create_uri
 from music_assistant.common.helpers.util import create_sort_name
-from music_assistant.common.models.config_entries import ConfigEntry
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType, ProviderFeature
 from music_assistant.common.models.errors import (
     InvalidDataError,
@@ -96,9 +96,19 @@ async def setup(
 
 
 async def get_config_entries(
-    mass: MusicAssistant, manifest: ProviderManifest  # noqa: ARG001
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """Return Config entries to setup this provider."""
+    """
+    Return Config entries to setup this provider.
+
+    instance_id: id of an existing provider instance (None if new instance setup).
+        action: [optional] action key called from config entries UI.
+        values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
     return (
         ConfigEntry(
             key=CONF_USERNAME, type=ConfigEntryType.STRING, label="Username", required=True

--- a/music_assistant/server/providers/ytmusic/__init__.py
+++ b/music_assistant/server/providers/ytmusic/__init__.py
@@ -105,8 +105,8 @@ async def get_config_entries(
     Return Config entries to setup this provider.
 
     instance_id: id of an existing provider instance (None if new instance setup).
-        action: [optional] action key called from config entries UI.
-        values: the (intermediate) raw values for config entries sent with the action.
+    action: [optional] action key called from config entries UI.
+    values: the (intermediate) raw values for config entries sent with the action.
     """
     # ruff: noqa: ARG001
     return (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ server = [
   "python-slugify==8.0.1",
   "mashumaro==3.5.0",
   "memory-tempfile==2.2.3",
-  "music-assistant-frontend==20230404.0",
+  "music-assistant-frontend==20230414.0",
   "pillow==9.5.0",
   "unidecode==1.3.6",
   "xmltodict==0.13.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ databases==0.7.0
 git+https://github.com/pytube/pytube.git@refs/pull/1501/head
 mashumaro==3.5.0
 memory-tempfile==2.2.3
-music-assistant-frontend==20230404.0
+music-assistant-frontend==20230414.0
 orjson==3.8.9
 pillow==9.5.0
 plexapi==4.13.4


### PR DESCRIPTION
- Adds support for executing actions within config entries
- Supports action as plain config entry type
- Supports action as a way to fetch a value
- Implement oAuth flow helper ready to use as config entry action
- Implemented action support for oAuth login of Plex provider (as example)
- Some more tweaks to config entries in general
- Requires frontend version 20230414.0 (bumped in this PR)
