### PR TITLE
Fix tidal image retrieval

### DIFF
--- a/music_assistant/server/providers/tidal/__init__.py
+++ b/music_assistant/server/providers/tidal/__init__.py
@@ -649,8 +649,8 @@ class TidalProvider(MusicProvider):
                         image_url,
                     )
                 ]
-            except Exception as err:
-                self.logger.info(f"x {playlist_obj.id} has no available picture", err)
+            except Exception:
+                self.logger.info(f"Playlist {playlist_obj.id} has no available picture")
 
         return playlist
 


### PR DESCRIPTION
The image retrieval was not resolving the urls correctly, and was causing exceptions even when an image was available.
This was somehow caused by the asyncio.to_thread() raising the error "TypeError: 'str' object is not callable"
The other issue was that the I was initialisng a url with "None" and setting this onto an image metadata object as the url, when none was available, which due to the above error was always 