### PR TITLE
Plex provider: Ensure that we only connect to servers

### DIFF
--- a/music_assistant/server/providers/plex/helpers.py
+++ b/music_assistant/server/providers/plex/helpers.py
@@ -27,7 +27,8 @@ async def get_libraries(mass: MusicAssistant, auth_token: str) -> set[str]:
         all_libraries: list[str] = []
         plex_account = MyPlexAccount(token=auth_token)
         for resource in plex_account.resources():
-            if "server" in resource.provides:
+            if "server" not in resource.provides:
+                continue
                 try:
                     plex_server: PlexServer = resource.connect(None, 10)
                 except plexapi.exceptions.NotFound:

--- a/music_assistant/server/providers/plex/helpers.py
+++ b/music_assistant/server/providers/plex/helpers.py
@@ -26,17 +26,18 @@ async def get_libraries(mass: MusicAssistant, auth_token: str) -> set[str]:
         # create a listing of available music libraries on all servers
         all_libraries: list[str] = []
         plex_account = MyPlexAccount(token=auth_token)
-        for server_resource in plex_account.resources():
-            try:
-                plex_server: PlexServer = server_resource.connect(None, 10)
-            except plexapi.exceptions.NotFound:
-                continue
-            for media_section in plex_server.library.sections():
-                media_section: PlexLibrarySection  # noqa: PLW2901
-                if media_section.type != PlexMusicSection.TYPE:
+        for resource in plex_account.resources():
+            if "server" in resource.provides:
+                try:
+                    plex_server: PlexServer = resource.connect(None, 10)
+                except plexapi.exceptions.NotFound:
                     continue
-                # TODO: figure out what plex uses as stable id and use that instead of names
-                all_libraries.append(f"{server_resource.name} / {media_section.title}")
+                for media_section in plex_server.library.sections():
+                    media_section: PlexLibrarySection  # noqa: PLW2901
+                    if media_section.type != PlexMusicSection.TYPE:
+                        continue
+                    # TODO: figure out what plex uses as stable id and use that instead of names
+                    all_libraries.append(f"{resource.name} / {media_section.title}")
         return all_libraries
 
     if cache := await mass.cache.get(cache_key, checksum=auth_token):

--- a/music_assistant/server/providers/plex/helpers.py
+++ b/music_assistant/server/providers/plex/helpers.py
@@ -29,16 +29,16 @@ async def get_libraries(mass: MusicAssistant, auth_token: str) -> set[str]:
         for resource in plex_account.resources():
             if "server" not in resource.provides:
                 continue
-                try:
-                    plex_server: PlexServer = resource.connect(None, 10)
-                except plexapi.exceptions.NotFound:
+            try:
+                plex_server: PlexServer = resource.connect(None, 10)
+            except plexapi.exceptions.NotFound:
+                continue
+            for media_section in plex_server.library.sections():
+                media_section: PlexLibrarySection  # noqa: PLW2901
+                if media_section.type != PlexMusicSection.TYPE:
                     continue
-                for media_section in plex_server.library.sections():
-                    media_section: PlexLibrarySection  # noqa: PLW2901
-                    if media_section.type != PlexMusicSection.TYPE:
-                        continue
-                    # TODO: figure out what plex uses as stable id and use that instead of names
-                    all_libraries.append(f"{resource.name} / {media_section.title}")
+                # TODO: figure out what plex uses as stable id and use that instead of names
+                all_libraries.append(f"{resource.name} / {media_section.title}")
         return all_libraries
 
     if cache := await mass.cache.get(cache_key, checksum=auth_token):


### PR DESCRIPTION
By now we tried to connect to any resource. A resource can also be a PlexClient (e.g. a player/app etc.), so this can lead to multiple different problems and errors, as these devices do not have any libraries or something like that.