### PR TITLE
Add debug logging to audio.py

### DIFF
--- a/music_assistant/server/helpers/audio.py
+++ b/music_assistant/server/helpers/audio.py
@@ -238,7 +238,7 @@ async def get_stream_details(mass: MusicAssistant, queue_item: QueueItem) -> Str
     """
     streamdetails = None
     if queue_item.streamdetails and (time() < (queue_item.streamdetails.expires - 360)):
-        LOGGER.debug(f"Using cached streamdetails for {queue_item}")
+        LOGGER.debug(f"Using cached streamdetails for {queue_item.uri}")
         # we already have fresh streamdetails, use these
         queue_item.streamdetails.seconds_skipped = None
         queue_item.streamdetails.seconds_streamed = None

--- a/music_assistant/server/helpers/audio.py
+++ b/music_assistant/server/helpers/audio.py
@@ -263,7 +263,6 @@ async def get_stream_details(mass: MusicAssistant, queue_item: QueueItem) -> Str
                 streamdetails: StreamDetails = await music_prov.get_stream_details(
                     prov_media.item_id
                 )
-                LOGGER.debug(f"Got streamdetails from music provider: {streamdetails}")
                 streamdetails.content_type = ContentType(streamdetails.content_type)
             except MusicAssistantError as err:
                 LOGGER.warning(str(err))


### PR DESCRIPTION
This PR adds some more debug logging to `audio.py` so we can catch that weird `MediaNotFoundError`.