### PR TITLE
Increase chunksize for audio streams

### DIFF
--- a/music_assistant/server/controllers/streams.py
+++ b/music_assistant/server/controllers/streams.py
@@ -533,7 +533,7 @@ class StreamsController(CoreController):
             ffmpeg_proc.attach_task(read_audio())
 
             # read final chunks from stdout
-            async for chunk in ffmpeg_proc.iter_any():
+            async for chunk in ffmpeg_proc.iter_chunked():
                 try:
                     await resp.write(chunk)
                 except (BrokenPipeError, ConnectionResetError):
@@ -736,7 +736,7 @@ class StreamsController(CoreController):
             ffmpeg_proc.attach_task(read_audio())
 
             # read final chunks from stdout
-            async for chunk in ffmpeg_proc.iter_any():
+            async for chunk in ffmpeg_proc.iter_chunked():
                 try:
                     await resp.write(chunk)
                 except (BrokenPipeError, ConnectionResetError):


### PR DESCRIPTION
Send larger chunks by default should solve some buffering issues on some playertypes.