### PR TITLE
Do not load uvloop by default

### DIFF
--- a/music_assistant/__main__.py
+++ b/music_assistant/__main__.py
@@ -48,6 +48,7 @@ def get_arguments():
         help="Provide logging level. Example --log-level debug, "
         "default=info, possible=(critical, error, warning, info, debug)",
     )
+    parser.add_argument("-u", "--enable-uvloop", action="store_true")
     arguments = parser.parse_args()
     return arguments
 
@@ -151,6 +152,7 @@ def main():
         hass_options = {}
 
     log_level = hass_options.get("log_level", args.log_level).upper()
+    enable_uvloop = bool(hass_options.get("enable_uvloop", args.enable_uvloop))
     dev_mode = os.environ.get("PYTHONDEVMODE", "0") == "1"
 
     # setup logger
@@ -173,7 +175,7 @@ def main():
 
     run(
         start_mass(),
-        use_uvloop=True,
+        use_uvloop=enable_uvloop,
         shutdown_callback=on_shutdown,
         executor_workers=64,
     )

--- a/music_assistant/server/server.py
+++ b/music_assistant/server/server.py
@@ -116,7 +116,12 @@ class MusicAssistant:
         # setup config controller first and fetch important config values
         self.config = ConfigController(self)
         await self.config.setup()
-        LOGGER.info("Starting Music Assistant Server (%s) version %s", self.server_id, self.version)
+        LOGGER.info(
+            "Starting Music Assistant Server (%s) version %s - uvloop: %s",
+            self.server_id,
+            self.version,
+            "uvloop" in str(self.loop),
+        )
         # setup other core controllers
         self.cache = CacheController(self)
         self.webserver = WebserverController(self)


### PR DESCRIPTION
Some mysterious issues we have atm might be caused by uvloop.
Disable it by default for now and make it a startup/config option to enable it.