### PR TITLE
Readme: Add data directory mount to docker run command and explanatory note

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ By far the most convenient way to run the Music Assistant Server is to install t
 An alternative way to run the Music Assistant server is by running the docker image:
 
 ```
-docker run --network host --privileged ghcr.io/music-assistant/server
+docker run --network host --privileged -v <dir>:/data ghcr.io/music-assistant/server
 ```
 
-You must run the docker container with host network mode and the data volume is `/data`.
+You must run the docker container with host network mode. The data volume is `/data` - replace `<dir>` with a writeable directory to ensure the data volume persists between updates.
 If you want access to your local music files from within MA, make sure to also mount that, e.g. /media.
 Note that accessing remote (SMB) shares can be done from within MA itself using the SMB File provider (but requires the privileged flag).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ An alternative way to run the Music Assistant server is by running the docker im
 docker run --network host --privileged -v <dir>:/data ghcr.io/music-assistant/server
 ```
 
-You must run the docker container with host network mode. The data volume is `/data` - replace `<dir>` with a writeable directory to ensure the data volume persists between updates.
+You must run the docker container with host network mode. The data volume is `/data` - replace `<dir>` with a writable directory to ensure the data volume persists between updates.
 If you want access to your local music files from within MA, make sure to also mount that, e.g. /media.
 Note that accessing remote (SMB) shares can be done from within MA itself using the SMB File provider (but requires the privileged flag).
 


### PR DESCRIPTION
Include a mount for the data store in the `docker run` command so that data persists between updates, and an explanatory note below. 

Could also just have the note and not include the `-v ...` but I feel this is an important thing to include since missing it out means data loss - potentially a lot of time wasted and users lost if someone sets up their entire library, setup etc first time, then updates and loses everything. 