### PR TITLE
Re-add addon update action to ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,12 +101,12 @@ jobs:
           build-args: |
             "MASS_VERSION=${{ needs.build-and-publish-pypi.outputs.version }}"
 
-  #addon-version-update:
-  #  name: Server repo PR
-  #  needs: build-and-publish-pypi
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: music-assistant/addon-update-action@main
-  #      with:
-  #        github_token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
-  #        new_release_version: ${{ needs.build-and-publish-pypi.outputs.version }}
+  addon-version-update:
+    name: Server repo PR
+    needs: [ build-and-publish-pypi, build-and-push-container-image ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: music-assistant/addon-update-action@main
+        with:
+          github_token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          new_release_version: ${{ needs.build-and-publish-pypi.outputs.version }}


### PR DESCRIPTION
Re-added the addon upadte action, this time with a depdencey to both prior jobs. The addon update action no longer sorts the yaml keys incorrectly and the mismatch of version/tag has been corrected here:
https://github.com/music-assistant/addon-update-action/commit/e9441782b6a4f929c6dd797ec72923919d6d1524