### PR TITLE
[soundcloud] bug fix: add limit parameter to get_recommended function

### DIFF
--- a/music_assistant/server/providers/soundcloud/soundcloudpy/asyncsoundcloudpy.py
+++ b/music_assistant/server/providers/soundcloud/soundcloudpy/asyncsoundcloudpy.py
@@ -220,7 +220,7 @@ class SoundcloudAsyncAPI:
 
     # ---------------- MISCELLANEOUS ----------------
 
-    async def get_recommended(self, track_id: str, limit: int = 10):
+    async def get_recommended(self, track_id: str, limit: int = 10):  # noqa: ARG002
         """:param track_id: track id to get recommended tracks from this"""
         return await self.get(
             f"{BASE_URL}/tracks/{track_id}/related?client_id={self.client_id}",

--- a/music_assistant/server/providers/soundcloud/soundcloudpy/asyncsoundcloudpy.py
+++ b/music_assistant/server/providers/soundcloud/soundcloudpy/asyncsoundcloudpy.py
@@ -220,7 +220,7 @@ class SoundcloudAsyncAPI:
 
     # ---------------- MISCELLANEOUS ----------------
 
-    async def get_recommended(self, track_id):
+    async def get_recommended(self, track_id: str, limit: int = 10):
         """:param track_id: track id to get recommended tracks from this"""
         return await self.get(
             f"{BASE_URL}/tracks/{track_id}/related?client_id={self.client_id}",


### PR DESCRIPTION
This PR fixes the error that occurs when attempting to start a radio for a given soundcloud track.

https://github.com/music-assistant/server/blob/ea1143408ef90637ae3508ee55905f78dbf87834/music_assistant/server/providers/soundcloud/__init__.py#L269

The caller specifies the `limit` parameter, but the underlying function doesn't accept it, causing the code to panic and crash.

The `limit` parameter isn't used for now, but it seems better to include it in the `get_recommended` function (to align with the other methods in the same class), rather than remove the parameter from the call site.