### PR TITLE
[soundcloud] improved track iteration

### DIFF
--- a/music_assistant/server/providers/soundcloud/__init__.py
+++ b/music_assistant/server/providers/soundcloud/__init__.py
@@ -192,12 +192,7 @@ class SoundcloudMusicProvider(MusicProvider):
     async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
         """Retrieve library tracks from Soundcloud."""
         time_start = time.time()
-        tracks = await self._soundcloud.get_tracks_liked()
-        self.logger.debug(
-            "Processing Soundcloud library tracks took %s seconds",
-            round(time.time() - time_start, 2),
-        )
-        for item in tracks["collection"]:
+        async for item in self._soundcloud.get_tracks_liked():
             track = await self._soundcloud.get_track_details(item)
             try:
                 yield await self._parse_track(track[0])
@@ -206,6 +201,11 @@ class SoundcloudMusicProvider(MusicProvider):
             except (KeyError, TypeError, InvalidDataError) as error:
                 self.logger.debug("Parse track failed: %s", track, exc_info=error)
                 continue
+
+        self.logger.debug(
+            "Processing Soundcloud library tracks took %s seconds",
+            round(time.time() - time_start, 2),
+        )
 
     async def get_artist(self, prov_artist_id) -> Artist:
         """Get full artist details by id."""


### PR DESCRIPTION
### Summary

#### Problem

The soundcloud integration only loads the first 50 tracks from the user's list after setup. This is primarily due to the default limit imposed on the underlying API functionality:

https://github.com/music-assistant/server/blob/7b08dcf9e5d82884ee4500b6e4b8056d00c19229/music_assistant/server/providers/soundcloud/soundcloudpy/asyncsoundcloudpy.py#L121

For users with more than 50 liked tracks, this results in an incomplete import of such tracks into the Music Assistant.

#### Solution

We convert the soundcloud API library into an async generator, rather than a standard API fetcher. Pagination is implemented, and the `limit` parameter is made optional so that all tracks can be fetched if no limit is specified.

### Testing Done

This was manually tested with an explicit limit, as well as without.