### PR TITLE
fix: handle invalid start_index when receiving command player status

### DIFF
--- a/music_assistant/server/providers/slimproto/cli.py
+++ b/music_assistant/server/providers/slimproto/cli.py
@@ -591,6 +591,8 @@ class LmsCli:
         """Handle players command."""
         players: list[PlayerItem] = []
         for index, mass_player in enumerate(self.mass.players.all()):
+            if not isinstance(start_index, int):
+                start_index = 0
             if isinstance(start_index, int) and index < start_index:
                 continue
             if len(players) > limit:


### PR DESCRIPTION
This PR fix the Home Assistant squeezebox integration players discovery, by providing a valid start_index when receiving the command "player: status".
In this case, start_index was set to "status".
