### PR TITLE
Add default enqueue options

### DIFF
--- a/music_assistant/client/players.py
+++ b/music_assistant/client/players.py
@@ -264,7 +264,7 @@ class Players:
         self,
         queue_id: str,
         media: MediaItemType | list[MediaItemType] | str | list[str],
-        option: QueueOption = QueueOption.PLAY,
+        option: QueueOption | None = None,
         radio_mode: bool = False,
     ) -> None:
         """

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -298,7 +298,7 @@ class PlayerQueuesController(CoreController):
             # handle default enqueue option if needed
             if option is None:
                 option = QueueOption(
-                    self.mass.config.get_core_config_value(
+                    await self.mass.config.get_core_config_value(
                         self.domain, f"default_enqueue_action_{media_item.media_type.value}"
                     )
                 )

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -1038,6 +1038,7 @@ class PlayerQueuesController(CoreController):
                 ):
                     if album_track not in all_items:
                         all_items.append(album_track)
+            random.shuffle(all_items)
             return all_items
         if artist_items_conf == "all_tracks":
             artist = await self.mass.music.artists.get(
@@ -1046,16 +1047,17 @@ class PlayerQueuesController(CoreController):
             all_items: list[Track] = []
             unique_tracks = set()
             for provider in artist.provider_mappings:
-                for album_track in await self.mass.music.albums.tracks(
+                for artist_track in await self.mass.music.artists.tracks(
                     provider.item_id, provider.provider_instance
                 ):
-                    if album_track in all_items:
+                    if artist_track in all_items:
                         continue
-                    unique_key = f"{album_track.name}.{album_track.version}.{album_track.duration}"
+                    unique_key = f"{artist_track.name.lower()}.{artist_track.version.lower()}"
                     if unique_key in unique_tracks:
                         continue
-                    all_items.append(album_track)
+                    all_items.append(artist_track)
                     unique_tracks.add(unique_key)
+            random.shuffle(all_items)
             return all_items
         if artist_items_conf == "all_album_tracks":
             artist = await self.mass.music.artists.get(
@@ -1072,13 +1074,12 @@ class PlayerQueuesController(CoreController):
                     ):
                         if album_track in all_items:
                             continue
-                        unique_key = (
-                            f"{album_track.name}.{album_track.version}.{album_track.duration}"
-                        )
+                        unique_key = f"{album_track.name.lower()}.{album_track.version.lower()}.{album_track.duration}"  # noqa: E501
                         if unique_key in unique_tracks:
                             continue
                         all_items.append(album_track)
                         unique_tracks.add(unique_key)
+            random.shuffle(all_items)
             return all_items
         return []
 


### PR DESCRIPTION
Add some config options to specify fallback/defaults to enqueue items.

![Scherm­afbeelding 2024-01-27 om 15 33 15](https://github.com/music-assistant/server/assets/6389780/b625a518-4b67-4e7a-9cd8-b754f48ce45f)
