### PR TITLE
Subsonic: Better scrobbling and track enumeration

### DIFF
--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -572,15 +572,27 @@ class OpenSonicProvider(MusicProvider):
             sonic_song: SonicSong = await self._run_async(self._conn.getSong, item_id)
         except (ParameterError, DataNotFoundError) as e:
             raise MediaNotFoundError(f"Item {item_id} not found") from e
+
+        self.mass.create_task(self._report_playback_started(item_id))
+
         mime_type = sonic_song.content_type
         if mime_type.endswith("mpeg"):
             mime_type = sonic_song.suffix
+
         return StreamDetails(
             item_id=sonic_song.id,
             provider=self.instance_id,
             audio_format=AudioFormat(content_type=ContentType.try_parse(mime_type)),
             duration=sonic_song.duration if sonic_song.duration is not None else 0,
+            callback=self._report_playback_stopped,
         )
+
+    async def _report_playback_started(self, item_id: str) -> None:
+        await self._run_async(self._conn.scrobble, sid=item_id, submission=False)
+
+    async def _report_playback_stopped(self, streamdetails: StreamDetails) -> None:
+        if streamdetails.seconds_streamed >= streamdetails.duration / 2:
+            await self._run_async(self._conn.scrobble, sid=streamdetails.item_id, submission=True)
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
@@ -606,7 +618,6 @@ class OpenSonicProvider(MusicProvider):
                 # keep reading from the audio buffer until there is no more data
                 chunk = await audio_buffer.get()
                 if chunk == b"":
-                    await self._run_async(self._conn.scrobble, streamdetails.item_id)
                     break
                 yield chunk
         finally:

--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -453,11 +453,28 @@ class OpenSonicProvider(MusicProvider):
 
         Note the lack of item count on this method.
         """
+        offset = 0
+        count = 500
         results = await self._run_async(
-            self._conn.search3, query="", artistCount=0, albumCount=0, songCount=999999
+            self._conn.search3,
+            query="",
+            artistCount=0,
+            albumCount=0,
+            songOffset=offset,
+            songCount=count,
         )
-        for entry in results["songs"]:
-            yield self._parse_track(entry)
+        while results["songs"]:
+            for entry in results["songs"]:
+                yield self._parse_track(entry)
+            offset += count
+            results = await self._run_async(
+                self._conn.search3,
+                query="",
+                artistCount=0,
+                albumCount=0,
+                songOffset=offset,
+                songCount=count,
+            )
 
     async def get_album(self, prov_album_id: str) -> Album:
         """Return the requested Album."""


### PR DESCRIPTION
The first commit should fix the multiple scrobble issue we were seeing by using the StreamDetails object callback to report playback completion instead of scrobbling in get_audio_stream.

The second commit handles track enumeration more intelligently by paginating the requests instead of making one giant call.