### PR TITLE
Subsonic: Support track enumeration on older Navidrome servers

### DIFF
--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -453,23 +453,36 @@ class OpenSonicProvider(MusicProvider):
 
         Note the lack of item count on this method.
         """
+        query = ""
         offset = 0
         count = 500
-        results = await self._run_async(
-            self._conn.search3,
-            query="",
-            artistCount=0,
-            albumCount=0,
-            songOffset=offset,
-            songCount=count,
-        )
+        try:
+            results = await self._run_async(
+                self._conn.search3,
+                query=query,
+                artistCount=0,
+                albumCount=0,
+                songOffset=offset,
+                songCount=count,
+            )
+        except ParameterError:
+            # Older Navidrome does not accept an empty string and requires the empty quotes
+            query = '""'
+            results = await self._run_async(
+                self._conn.search3,
+                query=query,
+                artistCount=0,
+                albumCount=0,
+                songOffset=offset,
+                songCount=count,
+            )
         while results["songs"]:
             for entry in results["songs"]:
                 yield self._parse_track(entry)
             offset += count
             results = await self._run_async(
                 self._conn.search3,
-                query="",
+                query=query,
                 artistCount=0,
                 albumCount=0,
                 songOffset=offset,


### PR DESCRIPTION
Older Navidrome servers do not handle an empty query string and require the query to be "" when we want to enumerate all entries in a category. If the first try to query with an empty string fails, change to "".