### PR TITLE
Subsonic: fix cover art resolution

### DIFF
--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -404,7 +404,7 @@ class OpenSonicProvider(MusicProvider):
             with self._conn.getCoverArt(path) as art:
                 return art.content
 
-        await asyncio.to_thread(_get_cover_art)
+        return await asyncio.to_thread(_get_cover_art)
 
     async def search(
         self, search_query: str, media_types: list[MediaType] | None = None, limit: int = 20


### PR DESCRIPTION
We had all the code inplace except for a return statement. Make resolve_image() actually return the image bytes.