### PR TITLE
Correctly select a free port

### DIFF
--- a/music_assistant/common/helpers/util.py
+++ b/music_assistant/common/helpers/util.py
@@ -158,7 +158,7 @@ async def select_free_port(range_start: int, range_end: int) -> int:
         """Check if port is in use."""
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _sock:
             try:
-                _sock.bind(("127.0.0.1", port))
+                _sock.bind(("0.0.0.0", port))
             except OSError:
                 return True
         return False


### PR DESCRIPTION
Looking up of free ports should be done on the global interface (0.0.0.0) for best compatibility. For example the stream server binds to a public interface, not 127.0.0.1, yet the port check is currently using 127.0.0.1.

This gives incorrect results in some cases. For example I have a thing bound to a specific interface on port 8096, but not on 127.0.0.1, so the current implementation thinks that 8096 is free, while in reality it is not.

I suggest using 0.0.0.0 instead of the default ip, because this port is dynamic anyway and we better find one that is not used on any other interface. This will mean no other service on the system needs this port. Otherwise collisions might happen in the future if another service tries to switch interfaces and ends up trying the one MA is bound to.