### PR TITLE
Check for transcodeOffset support on startup

### DIFF
--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -65,6 +65,7 @@ class OpenSonicProvider(MusicProvider):
 
     _conn: SonicConnection = None
     _enable_podcasts: bool = True
+    _seek_support: bool = False
 
     async def handle_async_init(self) -> None:
         """Set up the music provider and test the connection."""
@@ -97,6 +98,16 @@ class OpenSonicProvider(MusicProvider):
             )
             raise LoginFailed(msg) from e
         self._enable_podcasts = self.config.get_value(CONF_ENABLE_PODCASTS)
+        try:
+            ret = self._conn.getOpenSubsonicExtensions()
+            extensions = ret["openSubsonicExtensions"]
+            for entry in extensions:
+                if entry["name"] == "transcodeOffset":
+                    self._seek_support = True
+        except OSError:
+            logging.getLogger().debug(
+                "Server does not support transcodeOffset, seeking in player provider"
+            )
 
     @property
     def supported_features(self) -> tuple[ProviderFeature, ...]:
@@ -656,6 +667,7 @@ class OpenSonicProvider(MusicProvider):
         return StreamDetails(
             item_id=sonic_song.id,
             provider=self.instance_id,
+            can_seek=self._seek_support,
             audio_format=AudioFormat(content_type=ContentType.try_parse(mime_type)),
             duration=sonic_song.duration if sonic_song.duration is not None else 0,
             callback=self._report_playback_stopped,


### PR DESCRIPTION
If this support is present, then we can seek using the stream endpoint timeOffset argument. If not we need to fall back to having the player provider do it.