### PR TITLE
Subsonic: Moving blocking IO to task

### DIFF
--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -86,7 +86,8 @@ class OpenSonicProvider(MusicProvider):
             appName="Music Assistant",
         )
         try:
-            if not self._conn.ping():
+            success = await self._run_async(self._conn.ping)
+            if not success:
                 msg = (
                     f"Failed to connect to {self.config.get_value(CONF_BASE_URL)}, "
                     "check your settings."


### PR DESCRIPTION
We were using blocking IO directly in handle_async_init(), make this call use a task instead.