### PR TITLE
Announce support (TTS with automatic resume)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv/
 *.spec
 .history
 .idea
+.coverage

--- a/music_assistant/client/players.py
+++ b/music_assistant/client/players.py
@@ -121,6 +121,16 @@ class Players:
         """
         await self.client.send_command("players/cmd/unsync", player_id=player_id)
 
+    async def play_announcement(
+        self,
+        player_id: str,
+        url: str,
+    ) -> None:
+        """Handle playback of an announcement (url) on given player."""
+        await self.client.send_command(
+            "players/cmd/play_announcement", player_id=player_id, url=url
+        )
+
     #  PlayerGroup related endpoints/commands
 
     async def set_player_group_volume(self, player_id: str, volume_level: int) -> None:

--- a/music_assistant/client/players.py
+++ b/music_assistant/client/players.py
@@ -125,10 +125,14 @@ class Players:
         self,
         player_id: str,
         url: str,
+        use_pre_announce: bool = False,
     ) -> None:
         """Handle playback of an announcement (url) on given player."""
         await self.client.send_command(
-            "players/cmd/play_announcement", player_id=player_id, url=url
+            "players/cmd/play_announcement",
+            player_id=player_id,
+            url=url,
+            use_pre_announce=use_pre_announce,
         )
 
     #  PlayerGroup related endpoints/commands

--- a/music_assistant/common/helpers/global_cache.py
+++ b/music_assistant/common/helpers/global_cache.py
@@ -1,6 +1,5 @@
 """Provides a simple global memory cache."""
 
-
 from __future__ import annotations
 
 import asyncio

--- a/music_assistant/common/helpers/uri.py
+++ b/music_assistant/common/helpers/uri.py
@@ -24,7 +24,7 @@ def parse_uri(uri: str) -> tuple[MediaType, str, str]:
             provider_instance_id_or_domain = "url"
             media_type = MediaType.UNKNOWN
             item_id = uri
-        elif "://" in uri:
+        elif "://" in uri and len(uri.split("/")) >= 4:
             # music assistant-style uri
             # provider://media_type/item_id
             provider_instance_id_or_domain = uri.split("://")[0]

--- a/music_assistant/common/helpers/util.py
+++ b/music_assistant/common/helpers/util.py
@@ -289,3 +289,10 @@ def is_valid_uuid(uuid_to_test: str) -> bool:
     except ValueError:
         return False
     return str(uuid_obj) == uuid_to_test
+
+
+class classproperty(property):  # noqa: N801
+    """Implement class property for python3.11+."""
+
+    def __get__(self, cls, owner):  # noqa: D105
+        return classmethod(self.fget).__get__(None, owner)()

--- a/music_assistant/common/models/enums.py
+++ b/music_assistant/common/models/enums.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Self
+
+from music_assistant.common.helpers.util import classproperty
 
 
 class MediaType(StrEnum):
@@ -14,11 +17,16 @@ class MediaType(StrEnum):
     PLAYLIST = "playlist"
     RADIO = "radio"
     FOLDER = "folder"
+    ANNOUNCEMENT = "announcement"
     UNKNOWN = "unknown"
 
     @classmethod
-    @property
-    def ALL(cls) -> tuple[MediaType, ...]:  # noqa: N802
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
+
+    @classproperty
+    def ALL(self) -> tuple[MediaType, ...]:  # noqa: N802
         """Return all (default) MediaTypes as tuple."""
         return (
             MediaType.ARTIST,
@@ -26,6 +34,7 @@ class MediaType(StrEnum):
             MediaType.TRACK,
             MediaType.PLAYLIST,
             MediaType.RADIO,
+            MediaType.ANNOUNCEMENT,
         )
 
 
@@ -43,6 +52,12 @@ class ExternalID(StrEnum):
     ASIN = "asin"  # amazon unique number to identify albums
     DISCOGS = "discogs"  # id for media item on discogs
     TADB = "tadb"  # the audio db id
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
 
 
 class LinkType(StrEnum):
@@ -59,6 +74,12 @@ class LinkType(StrEnum):
     DISCOGS = "discogs"
     WIKIPEDIA = "wikipedia"
     ALLMUSIC = "allmusic"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
 
 
 class ImageType(StrEnum):
@@ -74,6 +95,11 @@ class ImageType(StrEnum):
     BACK = "back"
     DISCART = "discart"
     OTHER = "other"
+
+    @classmethod
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.OTHER
 
 
 class AlbumType(StrEnum):
@@ -113,6 +139,11 @@ class ContentType(StrEnum):
     PCM = "pcm"  # PCM generic (details determined later)
     MPEG_DASH = "dash"
     UNKNOWN = "?"
+
+    @classmethod
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
 
     @classmethod
     def try_parse(cls: ContentType, string: str) -> ContentType:
@@ -211,6 +242,12 @@ class PlayerType(StrEnum):
     STEREO_PAIR = "stereo_pair"
     GROUP = "group"
     SYNC_GROUP = "sync_group"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
 
 
 class PlayerFeature(StrEnum):
@@ -232,6 +269,13 @@ class PlayerFeature(StrEnum):
     SYNC = "sync"
     SEEK = "seek"
     ENQUEUE_NEXT = "enqueue_next"
+    PLAY_ANNOUNCEMENT = "play_announcement"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
 
 
 class EventType(StrEnum):
@@ -254,6 +298,12 @@ class EventType(StrEnum):
     PLAYER_CONFIG_UPDATED = "player_config_updated"
     SYNC_TASKS_UPDATED = "sync_tasks_updated"
     AUTH_SESSION = "auth_session"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
 
 
 class ProviderFeature(StrEnum):
@@ -310,6 +360,12 @@ class ProviderFeature(StrEnum):
     #
     # PLUGIN FEATURES
     #
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN
 
 
 class ProviderType(StrEnum):
@@ -333,3 +389,9 @@ class ConfigEntryType(StrEnum):
     LABEL = "label"
     DIVIDER = "divider"
     ACTION = "action"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
+        """Set default enum member if an unknown value is provided."""
+        return cls.UNKNOWN

--- a/music_assistant/common/models/player.py
+++ b/music_assistant/common/models/player.py
@@ -104,6 +104,9 @@ class Player(DataClassDictMixin):
     # and pass along freely
     extra_data: dict[str, Any] = field(default_factory=dict)
 
+    # announcement_in_progress boolean to indicate there's an announcement in progress.
+    announcement_in_progress: bool = False
+
     @property
     def corrected_elapsed_time(self) -> float:
         """Return the corrected/realtime elapsed time."""

--- a/music_assistant/common/models/player_queue.py
+++ b/music_assistant/common/models/player_queue.py
@@ -36,7 +36,6 @@ class PlayerQueue(DataClassDictMixin):
     current_item: QueueItem | None = None
     next_item: QueueItem | None = None
     radio_source: list[MediaItemType] = field(default_factory=list)
-    announcement_in_progress: bool = False
     flow_mode: bool = False
     # flow_mode_start_index: index of the first item of the flow stream
     flow_mode_start_index: int = 0

--- a/music_assistant/common/models/queue_item.py
+++ b/music_assistant/common/models/queue_item.py
@@ -56,6 +56,8 @@ class QueueItem(DataClassDictMixin):
         """Return MediaType for this QueueItem (for convenience purposes)."""
         if self.media_item:
             return self.media_item.media_type
+        if self.streamdetails:
+            return self.streamdetails.media_type
         return MediaType.UNKNOWN
 
     @classmethod

--- a/music_assistant/common/models/streamdetails.py
+++ b/music_assistant/common/models/streamdetails.py
@@ -58,7 +58,6 @@ class StreamDetails(DataClassDictMixin):
     loudness: LoudnessMeasurement | None = None
     queue_id: str | None = None
     seconds_streamed: float | None = None
-    seconds_skipped: int = 0
     target_loudness: float | None = None
 
     def __str__(self) -> str:
@@ -69,7 +68,6 @@ class StreamDetails(DataClassDictMixin):
         """Execute action(s) on serialization."""
         d.pop("queue_id", None)
         d.pop("seconds_streamed", None)
-        d.pop("seconds_skipped", None)
         d.pop("seek_position", None)
         d.pop("fade_in", None)
         d.pop("target_loudness", None)

--- a/music_assistant/common/models/streamdetails.py
+++ b/music_assistant/common/models/streamdetails.py
@@ -53,10 +53,12 @@ class StreamDetails(DataClassDictMixin):
     can_seek: bool = True
 
     # the fields below will be set/controlled by the streamcontroller
+    seek_position: int = 0
+    fade_in: bool = False
     loudness: LoudnessMeasurement | None = None
     queue_id: str | None = None
     seconds_streamed: float | None = None
-    seconds_skipped: float | None = None
+    seconds_skipped: int = 0
     target_loudness: float | None = None
 
     def __str__(self) -> str:
@@ -68,6 +70,8 @@ class StreamDetails(DataClassDictMixin):
         d.pop("queue_id", None)
         d.pop("seconds_streamed", None)
         d.pop("seconds_skipped", None)
+        d.pop("seek_position", None)
+        d.pop("fade_in", None)
         d.pop("target_loudness", None)
         return d
 

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -3,8 +3,8 @@
 import pathlib
 from typing import Final
 
-API_SCHEMA_VERSION: Final[int] = 23
-MIN_SCHEMA_VERSION: Final[int] = 23
+API_SCHEMA_VERSION: Final[int] = 24
+MIN_SCHEMA_VERSION: Final[int] = 24
 DB_SCHEMA_VERSION: Final[int] = 28
 
 ROOT_LOGGER_NAME: Final[str] = "music_assistant"

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -1201,8 +1201,8 @@ class PlayerQueuesController(CoreController):
                     queue_index += 1
                 else:
                     # no more seconds left to divide, this is our track
-                    # account for any seeking by adding the skipped seconds
-                    track_sec_skipped = queue_track.streamdetails.seconds_skipped or 0
+                    # account for any seeking by adding the skipped/seeked seconds
+                    track_sec_skipped = queue_track.streamdetails.seek_position
                     track_time = elapsed_time_queue + track_sec_skipped - total_time
                     break
         return queue_index, track_time

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -215,6 +215,9 @@ class PlayerQueuesController(CoreController):
     @api_command("players/queue/shuffle")
     def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
         """Configure shuffle setting on the the queue."""
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         queue = self._queues[queue_id]
         if queue.shuffle_enabled == shuffle_enabled:
             return  # no change
@@ -243,6 +246,9 @@ class PlayerQueuesController(CoreController):
     @api_command("players/queue/repeat")
     def set_repeat(self, queue_id: str, repeat_mode: RepeatMode) -> None:
         """Configure repeat setting on the the queue."""
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         queue = self._queues[queue_id]
         if queue.repeat_mode == repeat_mode:
             return  # no change
@@ -267,7 +273,7 @@ class PlayerQueuesController(CoreController):
         """
         # ruff: noqa: PLR0915,PLR0912
         queue = self._queues[queue_id]
-        if queue.announcement_in_progress:
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
             LOGGER.warning("Ignore queue command: An announcement is in progress")
             return
 
@@ -434,6 +440,9 @@ class PlayerQueuesController(CoreController):
         - pos_shift: move item x positions up if negative value
         - pos_shift:  move item to top of queue as next item if 0.
         """
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         queue = self._queues[queue_id]
         item_index = self.index_by_id(queue_id, queue_item_id)
         if item_index <= queue.index_in_buffer:
@@ -458,6 +467,9 @@ class PlayerQueuesController(CoreController):
     @api_command("players/queue/delete_item")
     def delete_item(self, queue_id: str, item_id_or_index: int | str) -> None:
         """Delete item (by id or index) from the queue."""
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         if isinstance(item_id_or_index, str):
             item_index = self.index_by_id(queue_id, item_id_or_index)
         else:
@@ -475,6 +487,9 @@ class PlayerQueuesController(CoreController):
     @api_command("players/queue/clear")
     def clear(self, queue_id: str) -> None:
         """Clear all items in the queue."""
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         queue = self._queues[queue_id]
         queue.radio_source = []
         if queue.state != PlayerState.IDLE:
@@ -492,8 +507,8 @@ class PlayerQueuesController(CoreController):
 
         - queue_id: queue_id of the playerqueue to handle the command.
         """
-        if self._queues[queue_id].announcement_in_progress:
-            LOGGER.warning("Ignore queue command for %s because an announcement is in progress.")
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
             return
         # simply forward the command to underlying player
         await self.mass.players.cmd_stop(queue_id)
@@ -505,8 +520,8 @@ class PlayerQueuesController(CoreController):
 
         - queue_id: queue_id of the playerqueue to handle the command.
         """
-        if self._queues[queue_id].announcement_in_progress:
-            LOGGER.warning("Ignore queue command for %s because an announcement is in progress.")
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
             return
         if self._queues[queue_id].state == PlayerState.PAUSED:
             # simply forward the command to underlying player
@@ -520,8 +535,8 @@ class PlayerQueuesController(CoreController):
 
         - queue_id: queue_id of the playerqueue to handle the command.
         """
-        if self._queues[queue_id].announcement_in_progress:
-            LOGGER.warning("Ignore queue command for %s because an announcement is in progress.")
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
             return
         player = self.mass.players.get(queue_id, True)
         if PlayerFeature.PAUSE not in player.supported_features:
@@ -548,6 +563,9 @@ class PlayerQueuesController(CoreController):
 
         - queue_id: queue_id of the queue to handle the command.
         """
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         current_index = self._queues[queue_id].current_index
         next_index = self._get_next_index(queue_id, current_index, True)
         if next_index is None:
@@ -560,6 +578,9 @@ class PlayerQueuesController(CoreController):
 
         - queue_id: queue_id of the queue to handle the command.
         """
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         current_index = self._queues[queue_id].current_index
         if current_index is None:
             return
@@ -572,6 +593,9 @@ class PlayerQueuesController(CoreController):
         - queue_id: queue_id of the queue to handle the command.
         - seconds: number of seconds to skip in track. Use negative value to skip back.
         """
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         await self.seek(queue_id, self._queues[queue_id].elapsed_time + seconds)
 
     @api_command("players/queue/seek")
@@ -581,6 +605,9 @@ class PlayerQueuesController(CoreController):
         - queue_id: queue_id of the queue to handle the command.
         - position: position in seconds to seek to in the current playing item.
         """
+        if (player := self.mass.players.get(queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         queue = self._queues[queue_id]
         assert queue.current_item, "No item loaded"
         assert queue.current_item.media_item.media_type == MediaType.TRACK
@@ -637,9 +664,6 @@ class PlayerQueuesController(CoreController):
     ) -> None:
         """Play item at index (or item_id) X in queue."""
         queue = self._queues[queue_id]
-        if queue.announcement_in_progress:
-            LOGGER.warning("Ignore queue command for %s because an announcement is in progress.")
-            return
         if isinstance(index, str):
             index = self.index_by_id(queue_id, index)
         queue_item = self.get_item(queue_id, index)
@@ -650,11 +674,13 @@ class PlayerQueuesController(CoreController):
         queue.index_in_buffer = index
         queue.flow_mode_start_index = index
         queue.flow_mode = False  # reset
+        # get streamdetails - do this here to catch unavailable items early
+        queue_item.streamdetails = await get_stream_details(
+            self.mass, queue_item, seek_position=seek_position, fade_in=fade_in
+        )
         await self.mass.players.play_media(
             player_id=queue_id,
             queue_item=queue_item,
-            seek_position=int(seek_position),
-            fade_in=fade_in,
         )
 
     # Interaction with player
@@ -703,6 +729,9 @@ class PlayerQueuesController(CoreController):
         if player.player_id not in self._queues:
             # race condition
             return
+        if player.announcement_in_progress:
+            # do nothing while the announcement is in progress
+            return
         queue_id = player.player_id
         player = self.mass.players.get(queue_id)
         queue = self._queues[queue_id]
@@ -721,26 +750,28 @@ class PlayerQueuesController(CoreController):
         if queue.flow_mode:
             # flow mode active, calculate current item
             queue.current_index, queue.elapsed_time = self.__get_queue_stream_index(queue, player)
+            queue.elapsed_time_last_updated = time.time()
         else:
             # queue is active and player has one of our tracks loaded, update state
             if item_id := self._parse_player_current_item_id(queue_id, player.current_item_id):
                 queue.current_index = self.index_by_id(queue_id, item_id)
-            queue.elapsed_time = int(player.corrected_elapsed_time)
+            if player.state == PlayerState.PLAYING:
+                queue.elapsed_time = int(player.corrected_elapsed_time)
+                queue.elapsed_time_last_updated = player.elapsed_time_last_updated
 
         # only update these attributes if the queue is active
         # and has an item loaded so we are able to resume it
         queue.state = player.state
-        queue.elapsed_time_last_updated = time.time()
         queue.current_item = self.get_item(queue_id, queue.current_index)
         queue.next_item = self._get_next_item(queue_id)
         # correct elapsed time when seeking
         if (
             queue.current_item
             and queue.current_item.streamdetails
-            and queue.current_item.streamdetails.seconds_skipped
+            and queue.current_item.streamdetails.seek_position
             and not queue.flow_mode
         ):
-            queue.elapsed_time += queue.current_item.streamdetails.seconds_skipped
+            queue.elapsed_time += queue.current_item.streamdetails.seek_position
 
         # basic throttle: do not send state changed events if queue did not actually change
         prev_state = self._prev_states.get(queue_id, {})
@@ -972,6 +1003,9 @@ class PlayerQueuesController(CoreController):
             return
         if prev_state.get("state") != PlayerState.PLAYING:
             return
+        if (player := self.mass.players.get(queue.queue_id)) and player.announcement_in_progress:
+            LOGGER.warning("Ignore queue command: An announcement is in progress")
+            return
         current_item = self.get_item(queue.queue_id, queue.current_index)
         if not current_item:
             return  # guard, just in case something bad happened
@@ -985,6 +1019,11 @@ class PlayerQueuesController(CoreController):
         seconds_remaining = int(duration - player.corrected_elapsed_time)
 
         async def _enqueue_next(index: int, supports_enqueue: bool = False) -> None:
+            if (
+                player := self.mass.players.get(queue.queue_id)
+            ) and player.announcement_in_progress:
+                LOGGER.warning("Ignore queue command: An announcement is in progress")
+                return
             with suppress(QueueEmpty):
                 next_item = await self.preload_next_item(queue.queue_id, index)
                 if supports_enqueue:

--- a/music_assistant/server/controllers/players.py
+++ b/music_assistant/server/controllers/players.py
@@ -1134,7 +1134,7 @@ class PlayerController(CoreController):
         prev_item_id = player.current_item_id
         # stop player if its currently playing
         if prev_state in (PlayerState.PLAYING, PlayerState.PAUSED):
-            self.logger.info(
+            self.logger.debug(
                 "Announcement to player %s - stop existing content (%s)...",
                 player.display_name,
                 prev_item_id,
@@ -1146,14 +1146,14 @@ class PlayerController(CoreController):
         # increase volume a bit
         temp_volume = int(min(75, prev_volume * 1.5))
         if temp_volume > prev_volume:
-            self.logger.info(
+            self.logger.debug(
                 "Announcement to player %s - setting temporary volume (%s)...",
                 player.display_name,
                 temp_volume,
             )
             await self.cmd_volume_set(player.player_id, temp_volume)
             # play the announcement
-            self.logger.info(
+            self.logger.debug(
                 "Announcement to player %s - playing the announcement on the player...",
                 player.display_name,
             )
@@ -1161,14 +1161,14 @@ class PlayerController(CoreController):
         # wait for the player to play
         with suppress(TimeoutError):
             await self.wait_for_state(player, PlayerState.PLAYING, 5)
-        self.logger.info(
+        self.logger.debug(
             "Announcement to player %s - waiting on the player to stop playing...",
             player.display_name,
         )
         # wait for the player to stop playing
         with suppress(TimeoutError):
             await self.wait_for_state(player, PlayerState.IDLE, 30)
-        self.logger.info(
+        self.logger.debug(
             "Announcement to player %s - restore previous state...", player.display_name
         )
         # restore volume
@@ -1183,7 +1183,7 @@ class PlayerController(CoreController):
             await self.mass.player_queues.resume(queue.queue_id, True)
         elif prev_state == PlayerState.PLAYING:
             # player was playing something else - try to resume that here
-            self.logger.info("Can not resume %s on %s", prev_item_id, player.display_name)
+            self.logger.warning("Can not resume %s on %s", prev_item_id, player.display_name)
             # TODO !!
 
     async def wait_for_state(

--- a/music_assistant/server/controllers/players.py
+++ b/music_assistant/server/controllers/players.py
@@ -597,15 +597,12 @@ class PlayerController(CoreController):
         self,
         player_id: str,
         url: str,
-        use_pre_announce: bool | None = None,
+        use_pre_announce: bool = False,
     ) -> None:
         """Handle playback of an announcement (url) on given player."""
         player = self.get(player_id, True)
         if player.announcement_in_progress:
             return
-        if use_pre_announce is None and "tts" in url:
-            # TODO: handle this in an HA or player setting
-            use_pre_announce = True
         try:
             # mark announcement_in_progress on player
             player.announcement_in_progress = True

--- a/music_assistant/server/helpers/audio.py
+++ b/music_assistant/server/helpers/audio.py
@@ -237,8 +237,8 @@ async def analyze_loudness(mass: MusicAssistant, streamdetails: StreamDetails) -
 async def get_stream_details(
     mass: MusicAssistant,
     queue_item: QueueItem,
-    seek_position: int | None = None,
-    fade_in: bool | None = None,
+    seek_position: int = 0,
+    fade_in: bool = False,
 ) -> StreamDetails:
     """Get streamdetails for the given QueueItem.
 

--- a/music_assistant/server/models/player_provider.py
+++ b/music_assistant/server/models/player_provider.py
@@ -107,8 +107,6 @@ class PlayerProvider(Provider):
         self,
         player_id: str,
         queue_item: QueueItem,
-        seek_position: int,
-        fade_in: bool,
     ) -> None:
         """Handle PLAY MEDIA on given player.
 
@@ -117,8 +115,6 @@ class PlayerProvider(Provider):
 
             - player_id: player_id of the player to handle the command.
             - queue_item: The QueueItem that needs to be played on the player.
-            - seek_position: Optional seek to this position.
-            - fade_in: Optionally fade in the item at playback start.
         """
         raise NotImplementedError
 
@@ -136,6 +132,13 @@ class PlayerProvider(Provider):
         This will NOT be called if the end of the queue is reached (and repeat disabled).
         This will NOT be called if the player is using flow mode to playback the queue.
         """
+
+    async def play_announcement(
+        self, player_id: str, announcement_url: str, use_pre_announce: bool = False
+    ) -> None:
+        """Handle (provider native) playback of an announcement on given player."""
+        # will only be called for players with PLAY_ANNOUNCEMENT feature set.
+        raise NotImplementedError
 
     async def cmd_power(self, player_id: str, powered: bool) -> None:
         """Send POWER command to given player.

--- a/music_assistant/server/providers/chromecast/__init__.py
+++ b/music_assistant/server/providers/chromecast/__init__.py
@@ -238,19 +238,8 @@ class ChromecastProvider(PlayerProvider):
         self,
         player_id: str,
         queue_item: QueueItem,
-        seek_position: int,
-        fade_in: bool,
     ) -> None:
-        """Handle PLAY MEDIA on given player.
-
-        This is called by the Queue controller to start playing a queue item on the given player.
-        The provider's own implementation should work out how to handle this request.
-
-            - player_id: player_id of the player to handle the command.
-            - queue_item: The QueueItem that needs to be played on the player.
-            - seek_position: Optional seek to this position.
-            - fade_in: Optionally fade in the item at playback start.
-        """
+        """Handle PLAY MEDIA on given player."""
         castplayer = self.castplayers[player_id]
         use_flow_mode = await self.mass.config.get_player_config_value(
             player_id, CONF_FLOW_MODE
@@ -259,8 +248,6 @@ class ChromecastProvider(PlayerProvider):
             player_id,
             queue_item=queue_item,
             output_codec=ContentType.FLAC,
-            seek_position=seek_position,
-            fade_in=fade_in,
             flow_mode=use_flow_mode,
         )
         queuedata = {

--- a/music_assistant/server/providers/dlna/__init__.py
+++ b/music_assistant/server/providers/dlna/__init__.py
@@ -346,27 +346,14 @@ class DLNAPlayerProvider(PlayerProvider):
         self,
         player_id: str,
         queue_item: QueueItem,
-        seek_position: int,
-        fade_in: bool,
     ) -> None:
-        """Handle PLAY MEDIA on given player.
-
-        This is called by the Queue controller to start playing a queue item on the given player.
-        The provider's own implementation should work out how to handle this request.
-
-            - player_id: player_id of the player to handle the command.
-            - queue_item: The QueueItem that needs to be played on the player.
-            - seek_position: Optional seek to this position.
-            - fade_in: Optionally fade in the item at playback start.
-        """
+        """Handle PLAY MEDIA on given player."""
         use_flow_mode = await self.mass.config.get_player_config_value(player_id, CONF_FLOW_MODE)
         enforce_mp3 = await self.mass.config.get_player_config_value(player_id, CONF_ENFORCE_MP3)
         url = await self.mass.streams.resolve_stream_url(
             player_id,
             queue_item=queue_item,
             output_codec=ContentType.MP3 if enforce_mp3 else ContentType.FLAC,
-            seek_position=seek_position,
-            fade_in=fade_in,
             flow_mode=use_flow_mode,
         )
         dlna_player = self.dlnaplayers[player_id]

--- a/music_assistant/server/providers/fully_kiosk/__init__.py
+++ b/music_assistant/server/providers/fully_kiosk/__init__.py
@@ -182,27 +182,14 @@ class FullyKioskProvider(PlayerProvider):
         self,
         player_id: str,
         queue_item: QueueItem,
-        seek_position: int,
-        fade_in: bool,
     ) -> None:
-        """Handle PLAY MEDIA on given player.
-
-        This is called by the Queue controller to start playing a queue item on the given player.
-        The provider's own implementation should work out how to handle this request.
-
-            - player_id: player_id of the player to handle the command.
-            - queue_item: The QueueItem that needs to be played on the player.
-            - seek_position: Optional seek to this position.
-            - fade_in: Optionally fade in the item at playback start.
-        """
+        """Handle PLAY MEDIA on given player."""
         player = self.mass.players.get(player_id)
         enforce_mp3 = await self.mass.config.get_player_config_value(player_id, CONF_ENFORCE_MP3)
         url = await self.mass.streams.resolve_stream_url(
             player_id,
             queue_item=queue_item,
             output_codec=ContentType.MP3 if enforce_mp3 else ContentType.FLAC,
-            seek_position=seek_position,
-            fade_in=fade_in,
             flow_mode=True,
         )
         await self._fully.playSound(url, AUDIOMANAGER_STREAM_MUSIC)

--- a/music_assistant/server/providers/hass_players/__init__.py
+++ b/music_assistant/server/providers/hass_players/__init__.py
@@ -249,27 +249,14 @@ class HomeAssistantPlayers(PlayerProvider):
         self,
         player_id: str,
         queue_item: QueueItem,
-        seek_position: int,
-        fade_in: bool,
     ) -> None:
-        """Handle PLAY MEDIA on given player.
-
-        This is called by the Queue controller to start playing a queue item on the given player.
-        The provider's own implementation should work out how to handle this request.
-
-            - player_id: player_id of the player to handle the command.
-            - queue_item: The QueueItem that needs to be played on the player.
-            - seek_position: Optional seek to this position.
-            - fade_in: Optionally fade in the item at playback start.
-        """
+        """Handle PLAY MEDIA on given player."""
         use_flow_mode = await self.mass.config.get_player_config_value(player_id, CONF_FLOW_MODE)
         enforce_mp3 = await self.mass.config.get_player_config_value(player_id, CONF_ENFORCE_MP3)
         url = await self.mass.streams.resolve_stream_url(
             player_id,
             queue_item=queue_item,
             output_codec=ContentType.MP3 if enforce_mp3 else ContentType.FLAC,
-            seek_position=seek_position,
-            fade_in=fade_in,
             flow_mode=use_flow_mode,
         )
         await self.hass_prov.hass.call_service(

--- a/music_assistant/server/providers/plex/__init__.py
+++ b/music_assistant/server/providers/plex/__init__.py
@@ -760,9 +760,6 @@ class PlexProvider(MusicProvider):
             data=plex_track,
         )
 
-        if audio_stream.loudness:
-            stream_details.loudness = audio_stream.loudness
-
         if media_type != ContentType.M4A:
             stream_details.direct = self._plex_server.url(media_part.key, True)
             if audio_stream.samplingRate:

--- a/music_assistant/server/providers/slimproto/__init__.py
+++ b/music_assistant/server/providers/slimproto/__init__.py
@@ -325,19 +325,8 @@ class SlimprotoProvider(PlayerProvider):
         self,
         player_id: str,
         queue_item: QueueItem,
-        seek_position: int,
-        fade_in: bool,
     ) -> None:
-        """Handle PLAY MEDIA on given player.
-
-        This is called by the Queue controller to start playing a queue item on the given player.
-        The provider's own implementation should work out how to handle this request.
-
-            - player_id: player_id of the player to handle the command.
-            - queue_item: The QueueItem that needs to be played on the player.
-            - seek_position: Optional seek to this position.
-            - fade_in: Optionally fade in the item at playback start.
-        """
+        """Handle PLAY MEDIA on given player."""
         # fix race condition where resync and play media are called at more or less the same time
         if self._resync_handle:
             self._resync_handle.cancel()
@@ -352,8 +341,6 @@ class SlimprotoProvider(PlayerProvider):
             stream_job = await self.mass.streams.create_multi_client_stream_job(
                 queue_id=queue_item.queue_id,
                 start_queue_item=queue_item,
-                seek_position=int(seek_position),
-                fade_in=fade_in,
             )
             # forward command to player and any connected sync members
             sync_clients = self._get_sync_clients(player_id)
@@ -384,8 +371,6 @@ class SlimprotoProvider(PlayerProvider):
                 # for now just hardcode flac as we assume that every (modern)
                 # slimproto based player can handle that just fine
                 output_codec=ContentType.MP3 if enforce_mp3 else ContentType.FLAC,
-                seek_position=seek_position,
-                fade_in=fade_in,
                 flow_mode=False,
             )
             await self._handle_play_url(


### PR DESCRIPTION
Full support of the announce feature:

- If music playing it will be temporary interrupted and restored after the announcement
- will power on the player if needed and off if needed afterwards
- increases the volume slightly while playing the announcement
- prefers native approaches where possible (for example on sonos)
- works with all players
- For TTS announcements, supports prepending it with a "pre announcement sound"

Requires new HA integration as well - breaking changes!