### PR TITLE
Use Deezer artist name instead of ID when ID isn't present

### DIFF
--- a/music_assistant/server/providers/deezer/__init__.py
+++ b/music_assistant/server/providers/deezer/__init__.py
@@ -615,7 +615,7 @@ class DeezerProvider(MusicProvider):  # pylint: disable=W0223
         if hasattr(track, "artist"):
             artist = ItemMapping(
                 media_type=MediaType.ARTIST,
-                item_id=str(track.artist.id),
+                item_id=str(getattr(track.artist, 'id', track.artist.name)),
                 provider=self.instance_id,
                 name=track.artist.name,
             )

--- a/music_assistant/server/providers/deezer/__init__.py
+++ b/music_assistant/server/providers/deezer/__init__.py
@@ -615,7 +615,7 @@ class DeezerProvider(MusicProvider):  # pylint: disable=W0223
         if hasattr(track, "artist"):
             artist = ItemMapping(
                 media_type=MediaType.ARTIST,
-                item_id=str(getattr(track.artist, "id", track.artist.name)),
+                item_id=str(getattr(track.artist, "id", f"deezer-{track.artist.name}")),
                 provider=self.instance_id,
                 name=track.artist.name,
             )

--- a/music_assistant/server/providers/deezer/__init__.py
+++ b/music_assistant/server/providers/deezer/__init__.py
@@ -615,7 +615,7 @@ class DeezerProvider(MusicProvider):  # pylint: disable=W0223
         if hasattr(track, "artist"):
             artist = ItemMapping(
                 media_type=MediaType.ARTIST,
-                item_id=str(getattr(track.artist, 'id', track.artist.name)),
+                item_id=str(getattr(track.artist, "id", track.artist.name)),
                 provider=self.instance_id,
                 name=track.artist.name,
             )


### PR DESCRIPTION
Fixes [this](https://github.com/music-assistant/hass-music-assistant/issues/1777) (maybe not in the best way - open to ideas).

Basically some Deezer tracks (I think the user-uploaded ones) don't have an `id` field in `artist`, e.g.:
```json
{
  "id": -3092972371,
  "readable": false,
  "title": "1983 (Eric Prydz remix)",
  "title_short": "1983 (Eric Prydz remix)",
  "isrc": "",
  "link": "https://www.deezer.com/track/-3092972371",
  "duration": 720,
  "rank": 0,
  "explicit_lyrics": false,
  "explicit_content_lyrics": 0,
  "explicit_content_cover": 0,
  "md5_image": "",
  "time_add": 1706669513,
  "artist": { "name": "Paolo Mojo", "tracklist": "", "type": "artist" },
  "album": { "id": 0, "title": "1983", "md5_image": "", "tracklist": "", "type": "album" },
  "type": "track"
}
```

There's a few options:

- Use the artist name (what I've done here, although not sure of the suitability of name as an ID - might work with a prefix? see below)
- Use null (can we do that?) or empty string
- Omit the artist entirely with another `hasattr` in the containing `if`
- Use a generated ID (random) if that's better

I'm wondering if the best answer is the artist name prepended with "Deezer-User:" or similar to disambiguate from "true" Deezer IDs but still link uploaded artists of the same name.