### PR TITLE
Jellyfin Transcoding Fix

### DIFF
--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -812,7 +812,7 @@ class JellyfinProvider(MusicProvider):
         self, streamdetails: StreamDetails, seek_position: int = 0
     ) -> AsyncGenerator[bytes, None]:
         """Return the audio stream for the provider item."""
-        url = API.audio_url(self._jellyfin_server.jellyfin, streamdetails.item_id, "ogg,flac,mp3,aac,mpeg,alac,wav,aiff,wma,m4a,m4b,dsf,opus,wv")
+        url = API.audio_url(self._jellyfin_server.jellyfin, streamdetails.item_id, SUPPORTED_CONTAINER_FORMATS)
 
         async for chunk in get_http_stream(self.mass, url, streamdetails, seek_position):
             yield chunk

--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -812,7 +812,7 @@ class JellyfinProvider(MusicProvider):
         self, streamdetails: StreamDetails, seek_position: int = 0
     ) -> AsyncGenerator[bytes, None]:
         """Return the audio stream for the provider item."""
-        url = API.audio_url(self._jellyfin_server.jellyfin, streamdetails.item_id, "", streamdetails.audio_format.content_type)
+        url = API.audio_url(self._jellyfin_server.jellyfin, streamdetails.item_id, "ogg,flac,mp3,aac,mpeg,alac,wav,aiff,wma,m4a,m4b,dsf,opus,wv")
 
         async for chunk in get_http_stream(self.mass, url, streamdetails, seek_position):
             yield chunk

--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -95,6 +95,7 @@ from .const import (
     ITEM_TYPE_ARTIST,
     ITEM_TYPE_AUDIO,
     MAX_IMAGE_WIDTH,
+    SUPPORTED_CONTAINER_FORMATS,
     USER_APP_NAME,
 )
 
@@ -812,7 +813,9 @@ class JellyfinProvider(MusicProvider):
         self, streamdetails: StreamDetails, seek_position: int = 0
     ) -> AsyncGenerator[bytes, None]:
         """Return the audio stream for the provider item."""
-        url = API.audio_url(self._jellyfin_server.jellyfin, streamdetails.item_id, SUPPORTED_CONTAINER_FORMATS)
+        url = API.audio_url(
+            self._jellyfin_server.jellyfin, streamdetails.item_id, SUPPORTED_CONTAINER_FORMATS
+        )
 
         async for chunk in get_http_stream(self.mass, url, streamdetails, seek_position):
             yield chunk

--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -812,7 +812,7 @@ class JellyfinProvider(MusicProvider):
         self, streamdetails: StreamDetails, seek_position: int = 0
     ) -> AsyncGenerator[bytes, None]:
         """Return the audio stream for the provider item."""
-        url = API.audio_url(self._jellyfin_server.jellyfin, streamdetails.item_id)
+        url = API.audio_url(self._jellyfin_server.jellyfin, streamdetails.item_id, "", streamdetails.audio_format.content_type)
 
         async for chunk in get_http_stream(self.mass, url, streamdetails, seek_position):
             yield chunk

--- a/music_assistant/server/providers/jellyfin/const.py
+++ b/music_assistant/server/providers/jellyfin/const.py
@@ -54,6 +54,8 @@ MEDIA_TYPE_NONE: Final = ""
 
 SUPPORTED_COLLECTION_TYPES: Final = [COLLECTION_TYPE_MUSIC]
 
+SUPPORTED_CONTAINER_FORMATS: Final = "ogg,flac,mp3,aac,mpeg,alac,wav,aiff,wma,m4a,m4b,dsf,opus,wv"
+
 PLAYABLE_ITEM_TYPES: Final = [ITEM_TYPE_AUDIO]
 
 


### PR DESCRIPTION
Jellyfin's universal audio stream API will attempt to transcode any media to mp3 if the application does not specify what containers it supports [1].  If Music Assistant knows that the file in Jellyfin is of a certain container type, and thus expects an audio stream of that type, there may be a playback error when Jellyfin delivers the data in mp3 format instead.  This PR adds information about the containers supported by FFmpeg to the universal audio stream API call so that Jellyfin does not attempt to transcode unnecessarily.

[1] https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Api/Controllers/UniversalAudioController.cs/#L269