### PR TITLE
[Deezer]: Update deezer-python-async to use pypi version

### DIFF
--- a/music_assistant/server/providers/deezer/manifest.json
+++ b/music_assistant/server/providers/deezer/manifest.json
@@ -5,6 +5,6 @@
   "description": "Support for the Deezer streaming provider in Music Assistant.",
   "codeowners": ["@arctixdev",  "@micha91"],
   "documentation": "https://music-assistant.io/music-providers/deezer/",
-  "requirements": ["git+https://github.com/music-assistant/deezer-python-async@v0.1.3", "pycryptodome==3.20.0"],
+  "requirements": ["deezer-python-async==0.3.0", "pycryptodome==3.20.0"],
   "multi_instance": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,10 +11,10 @@ async-upnp-client==0.38.2
 asyncio-throttle==1.0.2
 colorlog==6.8.2
 cryptography==42.0.5
+deezer-python-async==0.3.0
 defusedxml==0.7.1
 faust-cchardet>=2.1.18
 git+https://github.com/MarvinSchenkel/pytube.git
-git+https://github.com/music-assistant/deezer-python-async@v0.1.3
 hass-client==1.0.1
 ifaddr==0.2.0
 jellyfin_apiclient_python==1.9.2


### PR DESCRIPTION
I published deezer-python-async to pypi and switched the requirement to use that version instead.
