### PR TITLE
Fix issues with streaming YTM and some radio stations

### DIFF
--- a/music_assistant/common/models/enums.py
+++ b/music_assistant/common/models/enums.py
@@ -397,3 +397,11 @@ class ConfigEntryType(StrEnum):
     def _missing_(cls: Self, value: object) -> Self:  # noqa: ARG003
         """Set default enum member if an unknown value is provided."""
         return cls.UNKNOWN
+
+
+class StreamType(StrEnum):
+    """Enum for the type of streamdetails."""
+
+    HTTP = "http"
+    LOCAL_FILE = "local_file"
+    CUSTOM = "custom"

--- a/music_assistant/common/models/streamdetails.py
+++ b/music_assistant/common/models/streamdetails.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from time import time
 from typing import Any
 
 from mashumaro import DataClassDictMixin
 
-from music_assistant.common.models.enums import MediaType
+from music_assistant.common.models.enums import MediaType, StreamType
 from music_assistant.common.models.media_items import AudioFormat
 
 
@@ -36,6 +35,8 @@ class StreamDetails(DataClassDictMixin):
     item_id: str
     audio_format: AudioFormat
     media_type: MediaType = MediaType.TRACK
+    stream_type: StreamType = StreamType.CUSTOM
+    path: str | None = None
 
     # stream_title: radio streams can optionally set this field
     stream_title: str | None = None
@@ -43,13 +44,13 @@ class StreamDetails(DataClassDictMixin):
     duration: int | None = None
     # total size in bytes of the item, calculated at eof when omitted
     size: int | None = None
-    # expires: timestamp this streamdetails expire
-    expires: float = time() + 3600
     # data: provider specific data (not exposed externally)
     # this info is for example used to pass details to the get_audio_stream
     data: Any = None
     # can_seek: bool to indicate that the providers 'get_audio_stream' supports seeking of the item
     can_seek: bool = True
+
+    # stream_type:
 
     # the fields below will be set/controlled by the streamcontroller
     seek_position: int = 0

--- a/music_assistant/server/controllers/players.py
+++ b/music_assistant/server/controllers/players.py
@@ -28,6 +28,7 @@ from music_assistant.common.models.enums import (
     PlayerType,
     ProviderFeature,
     ProviderType,
+    StreamType,
 )
 from music_assistant.common.models.errors import (
     AlreadyRegisteredError,
@@ -1183,8 +1184,10 @@ class PlayerController(CoreController):
                 audio_format=AudioFormat(
                     content_type=ContentType.try_parse(url),
                 ),
+                stream_type=StreamType.HTTP,
                 media_type=MediaType.ANNOUNCEMENT,
                 data={"url": url, "use_pre_announce": use_pre_announce},
+                path=url,
                 target_loudness=-10,
             ),
         )

--- a/music_assistant/server/models/music_provider.py
+++ b/music_assistant/server/models/music_provider.py
@@ -251,7 +251,11 @@ class MusicProvider(Provider):
     async def get_audio_stream(  # type: ignore[return]
         self, streamdetails: StreamDetails, seek_position: int = 0
     ) -> AsyncGenerator[bytes, None]:
-        """Return the audio stream for the provider item."""
+        """
+        Return the (custom) audio stream for the provider item.
+
+        Will only be called when the stream_type is set to CUSTOM.
+        """
         raise NotImplementedError
 
     async def on_streamed(self, streamdetails: StreamDetails, seconds_streamed: int) -> None:

--- a/music_assistant/server/providers/airplay/__init__.py
+++ b/music_assistant/server/providers/airplay/__init__.py
@@ -265,7 +265,6 @@ class AirplayStream:
             input_format=self.input_format,
             output_format=AIRPLAY_PCM_FORMAT,
             filter_params=get_player_filter_params(self.mass, player_id),
-            loglevel="fatal",
         )
         self._ffmpeg_proc = AsyncProcess(
             ffmpeg_args,

--- a/music_assistant/server/providers/deezer/__init__.py
+++ b/music_assistant/server/providers/deezer/__init__.py
@@ -26,6 +26,7 @@ from music_assistant.common.models.enums import (
     ImageType,
     MediaType,
     ProviderFeature,
+    StreamType,
 )
 from music_assistant.common.models.errors import LoginFailed
 from music_assistant.common.models.media_items import (
@@ -450,9 +451,9 @@ class DeezerProvider(MusicProvider):  # pylint: disable=W0223
             audio_format=AudioFormat(
                 content_type=ContentType.try_parse(url_details["format"].split("_")[0])
             ),
+            stream_type=StreamType.CUSTOM,
             duration=int(song_data["DURATION"]),
             data={"url": url, "format": url_details["format"]},
-            expires=url_details["exp"],
             size=int(song_data[f"FILESIZE_{url_details['format']}"]),
         )
 

--- a/music_assistant/server/providers/filesystem_local/__init__.py
+++ b/music_assistant/server/providers/filesystem_local/__init__.py
@@ -13,9 +13,7 @@ from aiofiles.os import wrap
 from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType
 from music_assistant.common.models.errors import SetupFailedError
-from music_assistant.common.models.streamdetails import StreamDetails
 from music_assistant.constants import CONF_PATH
-from music_assistant.server.helpers.audio import get_file_stream
 
 from .base import (
     CONF_ENTRY_MISSING_ALBUM_ARTIST,
@@ -168,14 +166,6 @@ class LocalFileSystemProvider(FileSystemProviderBase):
             return False  # guard
         abs_path = get_absolute_path(self.base_path, file_path)
         return await exists(abs_path)
-
-    async def get_audio_stream(
-        self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
-        """Return the audio stream for the provider item."""
-        abs_path = get_absolute_path(self.base_path, streamdetails.item_id)
-        async for chunk in get_file_stream(self.mass, abs_path, streamdetails, seek_position):
-            yield chunk
 
     async def read_file_content(self, file_path: str, seek: int = 0) -> AsyncGenerator[bytes, None]:
         """Yield (binary) contents of file in chunks of bytes."""

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -18,7 +18,7 @@ from music_assistant.common.models.config_entries import (
     ConfigEntryType,
     ConfigValueOption,
 )
-from music_assistant.common.models.enums import ExternalID, ProviderFeature
+from music_assistant.common.models.enums import ExternalID, ProviderFeature, StreamType
 from music_assistant.common.models.errors import (
     InvalidDataError,
     MediaNotFoundError,
@@ -613,9 +613,11 @@ class FileSystemProviderBase(MusicProvider):
             item_id=item_id,
             audio_format=prov_mapping.audio_format,
             media_type=MediaType.TRACK,
+            stream_type=StreamType.LOCAL_FILE if file_item.local_path else StreamType.CUSTOM,
             duration=library_item.duration,
             size=file_item.file_size,
-            data=file_item.local_path,
+            data=file_item,
+            path=file_item.local_path,
             can_seek=prov_mapping.audio_format.content_type in SEEKABLE_FILES,
         )
 

--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -15,7 +15,13 @@ from libopensonic.errors import (
     SonicError,
 )
 
-from music_assistant.common.models.enums import ContentType, ImageType, MediaType, ProviderFeature
+from music_assistant.common.models.enums import (
+    ContentType,
+    ImageType,
+    MediaType,
+    ProviderFeature,
+    StreamType,
+)
 from music_assistant.common.models.errors import LoginFailed, MediaNotFoundError
 from music_assistant.common.models.media_items import (
     Album,
@@ -671,6 +677,7 @@ class OpenSonicProvider(MusicProvider):
             provider=self.instance_id,
             can_seek=self._seek_support,
             audio_format=AudioFormat(content_type=ContentType.try_parse(mime_type)),
+            stream_type=StreamType.CUSTOM,
             duration=sonic_song.duration if sonic_song.duration is not None else 0,
         )
 

--- a/music_assistant/server/providers/radiobrowser/__init__.py
+++ b/music_assistant/server/providers/radiobrowser/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from radios import FilterBy, Order, RadioBrowser, RadioBrowserError
 
-from music_assistant.common.models.enums import LinkType, ProviderFeature
+from music_assistant.common.models.enums import LinkType, ProviderFeature, StreamType
 from music_assistant.common.models.media_items import (
     AudioFormat,
     BrowseFolder,
@@ -22,7 +22,6 @@ from music_assistant.common.models.media_items import (
     SearchResults,
 )
 from music_assistant.common.models.streamdetails import StreamDetails
-from music_assistant.server.helpers.audio import get_radio_stream
 from music_assistant.server.models.music_provider import MusicProvider
 
 SUPPORTED_FEATURES = (ProviderFeature.SEARCH, ProviderFeature.BROWSE)
@@ -290,14 +289,7 @@ class RadioBrowserProvider(MusicProvider):
                 content_type=ContentType.try_parse(stream.codec),
             ),
             media_type=MediaType.RADIO,
-            data=stream.url_resolved,
-            expires=time() + 3600,
+            stream_type=StreamType.HTTP,
+            path=stream.url_resolved,
+            can_seek=False,
         )
-
-    async def get_audio_stream(
-        self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
-        """Return the audio stream for the provider item."""
-        # report playback started as soon as we start streaming
-        async for chunk in get_radio_stream(self.mass, streamdetails.data, streamdetails):
-            yield chunk

--- a/music_assistant/server/providers/sonos/player.py
+++ b/music_assistant/server/providers/sonos/player.py
@@ -535,7 +535,8 @@ class SonosPlayer:
         """Handle callback for topology change event."""
         if xml := event.variables.get("zone_group_state"):
             zgs = ET.fromstring(xml)
-            for vanished_device in zgs.find("VanishedDevices") or []:
+            vanished_devices = zgs.find("VanishedDevices") or []
+            for vanished_device in vanished_devices:
                 if (reason := vanished_device.get("Reason")) not in SUPPORTED_VANISH_REASONS:
                     self.logger.debug(
                         "Ignoring %s marked %s as vanished with reason: %s",

--- a/music_assistant/server/providers/soundcloud/__init__.py
+++ b/music_assistant/server/providers/soundcloud/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from music_assistant.common.helpers.util import parse_title_and_version
 from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
-from music_assistant.common.models.enums import ConfigEntryType, ProviderFeature
+from music_assistant.common.models.enums import ConfigEntryType, ProviderFeature, StreamType
 from music_assistant.common.models.errors import InvalidDataError, LoginFailed
 from music_assistant.common.models.media_items import (
     Artist,
@@ -24,11 +24,6 @@ from music_assistant.common.models.media_items import (
     Track,
 )
 from music_assistant.common.models.streamdetails import StreamDetails
-from music_assistant.server.helpers.audio import (
-    get_hls_stream,
-    get_http_stream,
-    resolve_radio_stream,
-)
 from music_assistant.server.models.music_provider import MusicProvider
 
 from .soundcloudpy.asyncsoundcloudpy import SoundcloudAsyncAPI
@@ -315,24 +310,9 @@ class SoundcloudMusicProvider(MusicProvider):
             audio_format=AudioFormat(
                 content_type=ContentType.try_parse(stream_format),
             ),
+            stream_type=StreamType.HTTP,
             data=url,
         )
-
-    async def get_audio_stream(
-        self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
-        """Return the audio stream for the provider item."""
-        _, _, is_hls = await resolve_radio_stream(self.mass, streamdetails.data)
-        if is_hls:
-            # some soundcloud streams are HLS, prefer the radio streamer
-            async for chunk in get_hls_stream(self.mass, streamdetails.data, streamdetails):
-                yield chunk
-            return
-        # regular stream from http
-        async for chunk in get_http_stream(
-            self.mass, streamdetails.data, streamdetails, seek_position
-        ):
-            yield chunk
 
     async def _parse_artist(self, artist_obj: dict) -> Artist:
         """Parse a Soundcloud user response to Artist model object."""

--- a/music_assistant/server/providers/tidal/__init__.py
+++ b/music_assistant/server/providers/tidal/__init__.py
@@ -27,6 +27,7 @@ from music_assistant.common.models.enums import (
     ImageType,
     MediaType,
     ProviderFeature,
+    StreamType,
 )
 from music_assistant.common.models.errors import LoginFailed, MediaNotFoundError
 from music_assistant.common.models.media_items import (
@@ -44,7 +45,6 @@ from music_assistant.common.models.media_items import (
     Track,
 )
 from music_assistant.common.models.streamdetails import StreamDetails
-from music_assistant.server.helpers.audio import get_http_stream
 from music_assistant.server.helpers.auth import AuthenticationHelper
 from music_assistant.server.helpers.tags import AudioTags, parse_tags
 from music_assistant.server.models.music_provider import MusicProvider
@@ -439,19 +439,10 @@ class TidalProvider(MusicProvider):
                 bit_depth=media_info.bits_per_sample,
                 channels=media_info.channels,
             ),
+            stream_type=StreamType.HTTP,
             duration=track.duration,
-            data=url,
+            path=url,
         )
-
-    async def get_audio_stream(
-        self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
-        """Return the audio stream for the provider item."""
-        # report playback started as soon as we start streaming
-        async for chunk in get_http_stream(
-            self.mass, streamdetails.data, streamdetails, seek_position
-        ):
-            yield chunk
 
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """Get artist details for given artist id."""


### PR DESCRIPTION
Again a bit of refactoring involved which even reverts some earlier changes.
Introduced a stream type property to the stream details to split up between custom streaming (using get_audio_stream) and leave all/most http and local file streaming to ffmpeg directly.

Also catch and log all errors while streaming so we can better track what's going on.