### PR TITLE
Add videos to YTM search results

### DIFF
--- a/music_assistant/server/providers/ytmusic/__init__.py
+++ b/music_assistant/server/providers/ytmusic/__init__.py
@@ -234,7 +234,9 @@ class YoutubeMusicProvider(MusicProvider):
                     parsed_results.albums.append(await self._parse_album(result))
                 elif result["resultType"] == "playlist":
                     parsed_results.playlists.append(await self._parse_playlist(result))
-                elif result["resultType"] in ("song", "video") and (track := await self._parse_track(result)):
+                elif result["resultType"] in ("song", "video") and (
+                    track := await self._parse_track(result)
+                ):
                     parsed_results.tracks.append(track)
             except InvalidDataError:
                 pass  # ignore invalid item

--- a/music_assistant/server/providers/ytmusic/__init__.py
+++ b/music_assistant/server/providers/ytmusic/__init__.py
@@ -234,7 +234,7 @@ class YoutubeMusicProvider(MusicProvider):
                     parsed_results.albums.append(await self._parse_album(result))
                 elif result["resultType"] == "playlist":
                     parsed_results.playlists.append(await self._parse_playlist(result))
-                elif result["resultType"] == "song" and (track := await self._parse_track(result)):
+                elif result["resultType"] in ("song", "video") and (track := await self._parse_track(result)):
                     parsed_results.tracks.append(track)
             except InvalidDataError:
                 pass  # ignore invalid item


### PR DESCRIPTION
Make sure to include videos in the search results as 'tracks'. This allows people to search for non-music content like desk concerts, kids music etc.