### PR TITLE
Ensure favorited item is added to provider library

### DIFF
--- a/music_assistant/server/controllers/music.py
+++ b/music_assistant/server/controllers/music.py
@@ -346,13 +346,12 @@ class MusicController(CoreController):
         if isinstance(item, str):
             item = await self.get_item_by_uri(item)
         # ensure item is added to streaming provider library
-        prov_controller = self.mass.get_provider(item.provider)
         if (
-            prov_controller
-            and prov_controller.is_streaming_provider
-            and prov_controller.library_edit_supported(item.media_type)
+            (provider := self.mass.get_provider(item.provider))
+            and provider.is_streaming_provider
+            and provider.library_edit_supported(item.media_type)
         ):
-            await prov_controller.library_add(item.item_id, item.media_type)
+            await provider.library_add(item.item_id, item.media_type)
         # make sure we have a full library item
         # a favorite must always be in the library
         full_item = await self.get_item(

--- a/music_assistant/server/controllers/music.py
+++ b/music_assistant/server/controllers/music.py
@@ -360,6 +360,14 @@ class MusicController(CoreController):
             full_item.item_id,
             True,
         )
+        # ensure item is added to provider library
+        for provider_mapping in full_item.provider_mappings:
+            prov_controller = self.mass.get_provider(provider_mapping.provider_instance)
+            if prov_controller and prov_controller.library_edit_supported(full_item.media_type):
+                with suppress(NotImplementedError):
+                    await prov_controller.library_add(
+                        provider_mapping.item_id, full_item.media_type
+                    )
 
     @api_command("music/favorites/remove_item")
     async def remove_item_from_favorites(


### PR DESCRIPTION
Hey @marcelveldt , adding an item to favourites in MA is adding it to local library, but not to the Spotify library so I've taken a stab at a fix here - is this an acceptable fix?

I've seen bug reports and mentions of this from Spotify users, but from what I can tell this can't have worked for any provider, yet where are the bug reports?  So maybe I'm missing something...  