### PR TITLE
Add support for using streamer provider publicly shareable URLs in search query

### DIFF
--- a/music_assistant/common/helpers/uri.py
+++ b/music_assistant/common/helpers/uri.py
@@ -4,7 +4,7 @@ import os
 import re
 
 from music_assistant.common.models.enums import MediaType
-from music_assistant.common.models.errors import InvalidProviderURI, MusicAssistantError
+from music_assistant.common.models.errors import InvalidProviderID, InvalidProviderURI
 
 base62_length22_id_pattern = re.compile(r"^[a-zA-Z0-9]{22}$")
 
@@ -60,11 +60,10 @@ def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str, str]
             raise KeyError
     except (TypeError, AttributeError, ValueError, KeyError) as err:
         msg = f"Not a valid Music Assistant uri: {uri}"
-        raise MusicAssistantError(msg) from err
-    if validate_id:
-        if not valid_id(provider_instance_id_or_domain, item_id):
-            msg = f"Invalid {provider_instance_id_or_domain} ID: {item_id}"
-            raise InvalidProviderURI(msg)
+        raise InvalidProviderURI(msg) from err
+    if validate_id and not valid_id(provider_instance_id_or_domain, item_id):
+        msg = f"Invalid {provider_instance_id_or_domain} ID: {item_id} found in URI: {uri}"
+        raise InvalidProviderID(msg)
     return (media_type, provider_instance_id_or_domain, item_id)
 
 

--- a/music_assistant/common/models/errors.py
+++ b/music_assistant/common/models/errors.py
@@ -98,3 +98,9 @@ class InvalidProviderURI(MusicAssistantError):
     """Error thrown when a provider URI does not match a known format."""
 
     error_code = 14
+
+
+class InvalidProviderID(MusicAssistantError):
+    """Error thrown when a provider media item identifier does not match a known format."""
+
+    error_code = 15

--- a/music_assistant/common/models/errors.py
+++ b/music_assistant/common/models/errors.py
@@ -92,3 +92,9 @@ class UnplayableMediaError(MusicAssistantError):
     """Error thrown when a MediaItem cannot be played properly."""
 
     error_code = 13
+
+
+class InvalidProviderURI(MusicAssistantError):
+    """Error thrown when a provider URI does not match a known format."""
+
+    error_code = 14

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -97,3 +97,4 @@ CONFIGURABLE_CORE_CONTROLLERS = (
 )
 SYNCGROUP_PREFIX: Final[str] = "syncgroup_"
 VERBOSE_LOG_LEVEL: Final[int] = 5
+PROVIDERS_WITH_SHAREABLE_URLS = ("spotify", "qobuz")

--- a/music_assistant/server/controllers/music.py
+++ b/music_assistant/server/controllers/music.py
@@ -21,6 +21,7 @@ from music_assistant.common.models.enums import (
     ProviderType,
 )
 from music_assistant.common.models.errors import (
+    InvalidProviderID,
     InvalidProviderURI,
     MediaNotFoundError,
     MusicAssistantError,
@@ -167,11 +168,11 @@ class MusicController(CoreController):
             media_type, provider_instance_id_or_domain, item_id = parse_uri(
                 search_query, validate_id=True
             )
-        except InvalidProviderURI as err:
+        except InvalidProviderURI:
+            pass
+        except InvalidProviderID as err:
             self.logger.warning("%s", str(err))
             return SearchResults()
-        except MusicAssistantError:
-            pass
         else:
             if provider_instance_id_or_domain in PROVIDERS_WITH_SHAREABLE_URLS:
                 try:


### PR DESCRIPTION
I often get Spotify URLs sent to me which I'd like to open directly in MA.  Right now I have to go into the Spotify app first to find out what it is, then search for the track in MA for playing.  It would be nice to use these URLs as is, so I've added support for using them in the MA global search.

Conversely I'd like to be able to copy the provider URL in MA so I can share it, but there's some CSS property making it unselectable and on a phone in portrait mode, the provider box contents wrap so the URL disappears, making it unclickable to go to Spotify app.  A button next to the URL to copy it to clipboard would be very nice!   Anyway that's a front end issue, so wrong place to put this I know ☺️ I'll put a feature request in for the new front end design.

Oh I've enabled the use of Qobuz URLs as they seem to use the same format as Spotify, but I'm not able to test Qobuz,

