### PR TITLE
Add support to specify the Metadata language

### DIFF
--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -28,6 +28,7 @@ from music_assistant.constants import (
     CONF_ICON,
     CONF_LOG_LEVEL,
     CONF_OUTPUT_CHANNELS,
+    CONF_PROVIDER_LANGUAGE,
     CONF_SYNC_ADJUST,
     CONF_TTS_PRE_ANNOUNCE,
     CONF_VOLUME_NORMALIZATION,
@@ -527,4 +528,16 @@ CONF_ENTRY_PLAYER_ICON = ConfigEntry(
 
 CONF_ENTRY_PLAYER_ICON_GROUP = ConfigEntry.from_dict(
     {**CONF_ENTRY_PLAYER_ICON.to_dict(), "default_value": "mdi-speaker-multiple"}
+)
+
+CONF_ENTRY_PROVIDER_LANGUAGE = ConfigEntry(
+    key=CONF_PROVIDER_LANGUAGE,
+    type=ConfigEntryType.STRING,
+    label="Override language",
+    required=False,
+    default_value="",
+    description="Override the default language to use for this provider, "
+    "impacting metadata and/or default playlists such as daily mixes etc. \n\n"
+    "Leave blank for auto select (based on your account).",
+    category="advanced",
 )

--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -28,7 +28,6 @@ from music_assistant.constants import (
     CONF_ICON,
     CONF_LOG_LEVEL,
     CONF_OUTPUT_CHANNELS,
-    CONF_PROVIDER_LANGUAGE,
     CONF_SYNC_ADJUST,
     CONF_TTS_PRE_ANNOUNCE,
     CONF_VOLUME_NORMALIZATION,
@@ -528,16 +527,4 @@ CONF_ENTRY_PLAYER_ICON = ConfigEntry(
 
 CONF_ENTRY_PLAYER_ICON_GROUP = ConfigEntry.from_dict(
     {**CONF_ENTRY_PLAYER_ICON.to_dict(), "default_value": "mdi-speaker-multiple"}
-)
-
-CONF_ENTRY_PROVIDER_LANGUAGE = ConfigEntry(
-    key=CONF_PROVIDER_LANGUAGE,
-    type=ConfigEntryType.STRING,
-    label="Override language",
-    required=False,
-    default_value="",
-    description="Override the default language to use for this provider, "
-    "impacting metadata and/or default playlists such as daily mixes etc. \n\n"
-    "Leave blank for auto select (based on your account).",
-    category="advanced",
 )

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -61,6 +61,8 @@ CONF_ANNOUNCE_VOLUME: Final[str] = "announce_volume"
 CONF_ANNOUNCE_VOLUME_MIN: Final[str] = "announce_volume_min"
 CONF_ANNOUNCE_VOLUME_MAX: Final[str] = "announce_volume_max"
 CONF_ICON: Final[str] = "icon"
+CONF_PROVIDER_LANGUAGE: Final[str] = "provider_language"
+
 
 # config default values
 DEFAULT_HOST: Final[str] = "0.0.0.0"

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -61,8 +61,7 @@ CONF_ANNOUNCE_VOLUME: Final[str] = "announce_volume"
 CONF_ANNOUNCE_VOLUME_MIN: Final[str] = "announce_volume_min"
 CONF_ANNOUNCE_VOLUME_MAX: Final[str] = "announce_volume_max"
 CONF_ICON: Final[str] = "icon"
-CONF_PROVIDER_LANGUAGE: Final[str] = "provider_language"
-
+CONF_LANGUAGE: Final[str] = "language"
 
 # config default values
 DEFAULT_HOST: Final[str] = "0.0.0.0"

--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -620,7 +620,18 @@ class ConfigController:
             # only allow setting raw values if main entry exists
             msg = f"Invalid provider_instance: {provider_instance}"
             raise KeyError(msg)
-        self.set(f"{CONF_PROVIDERS}/{provider_instance}/{key}", value)
+        self.set(f"{CONF_PROVIDERS}/{provider_instance}/values/{key}", value)
+
+    def set_raw_core_config_value(self, core_module: str, key: str, value: ConfigValueType) -> None:
+        """
+        Set (raw) single config(entry) value for a core controller.
+
+        Note that this only stores the (raw) value without any validation or default.
+        """
+        if not self.get(f"{CONF_CORE}/{core_module}"):
+            # create base object first if needed
+            self.set(f"{CONF_CORE}/{core_module}", CoreConfig({}, core_module).to_raw())
+        self.set(f"{CONF_CORE}/{core_module}/values/{key}", value)
 
     def set_raw_player_config_value(self, player_id: str, key: str, value: ConfigValueType) -> None:
         """

--- a/music_assistant/server/controllers/music.py
+++ b/music_assistant/server/controllers/music.py
@@ -272,6 +272,8 @@ class MusicController(CoreController):
         # handle regular provider listing, always add back folder first
         if not prov or not sub_path:
             yield BrowseFolder(item_id="root", provider="library", path="root", name="..")
+            if not prov:
+                return
         else:
             back_path = f"{provider_instance}://" + "/".join(sub_path.split("/")[:-1])
             yield BrowseFolder(

--- a/music_assistant/server/controllers/webserver.py
+++ b/music_assistant/server/controllers/webserver.py
@@ -216,6 +216,8 @@ class WebserverController(CoreController):
 
     async def _handle_ws_client(self, request: web.Request) -> web.WebSocketResponse:
         connection = WebsocketClientHandler(self, request)
+        if lang := request.headers.get("Accept-Language"):
+            self.mass.metadata.set_default_preferred_language(lang.split(",")[0])
         try:
             self.clients.add(connection)
             return await connection.handle_client()

--- a/music_assistant/server/helpers/webserver.py
+++ b/music_assistant/server/helpers/webserver.py
@@ -113,7 +113,7 @@ class Webserver:
         key = f"{method}.{path}"
         self._dynamic_routes.pop(key)
 
-    async def serve_static(self, file_path: str, _request: web.Request) -> web.FileResponse:
+    async def serve_static(self, file_path: str, request: web.Request) -> web.FileResponse:
         """Serve file response."""
         headers = {"Cache-Control": "no-cache"}
         return web.FileResponse(file_path, headers=headers)

--- a/music_assistant/server/providers/qobuz/__init__.py
+++ b/music_assistant/server/providers/qobuz/__init__.py
@@ -669,7 +669,7 @@ class QobuzProvider(MusicProvider):
             self.logger.info(
                 "Successfully logged in to Qobuz as %s", details["user"]["display_name"]
             )
-            self.mass.metadata.preferred_language = details["user"]["country_code"]
+            self.mass.metadata.set_default_preferred_language(details["user"]["country_code"])
             return details["user_auth_token"]
         return None
 

--- a/music_assistant/server/providers/qobuz/__init__.py
+++ b/music_assistant/server/providers/qobuz/__init__.py
@@ -698,6 +698,9 @@ class QobuzProvider(MusicProvider):
         # pylint: disable=too-many-branches
         url = f"http://www.qobuz.com/api.json/0.2/{endpoint}"
         headers = {"X-App-Id": app_var(0)}
+        locale = self.mass.metadata.locale.replace("_", "-")
+        language = locale.split("-")[0]
+        headers["Accept-Language"] = f"{locale}, {language};q=0.9, *;q=0.5"
         if endpoint != "user/login":
             auth_token = await self._auth_token()
             if not auth_token:

--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -16,11 +16,7 @@ from asyncio_throttle import Throttler
 
 from music_assistant.common.helpers.json import json_loads
 from music_assistant.common.helpers.util import parse_title_and_version
-from music_assistant.common.models.config_entries import (
-    CONF_ENTRY_PROVIDER_LANGUAGE,
-    ConfigEntry,
-    ConfigValueType,
-)
+from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import (
     ConfigEntryType,
     ExternalID,
@@ -45,7 +41,7 @@ from music_assistant.common.models.media_items import (
     Track,
 )
 from music_assistant.common.models.streamdetails import StreamDetails
-from music_assistant.constants import CONF_PASSWORD, CONF_PROVIDER_LANGUAGE, CONF_USERNAME
+from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
 
 # pylint: disable=no-name-in-module
 from music_assistant.server.helpers.app_vars import app_var
@@ -119,7 +115,6 @@ async def get_config_entries(
             label="Password",
             required=True,
         ),
-        CONF_ENTRY_PROVIDER_LANGUAGE,
     )
 
 
@@ -614,7 +609,7 @@ class SpotifyProvider(MusicProvider):
         # return existing token if we have one in memory
         if (
             self._auth_token
-            and asyncio.to_thread(os.path.isdir, self._cache_dir)
+            and await asyncio.to_thread(os.path.isdir, self._cache_dir)
             and (self._auth_token["expiresAt"] > int(time.time()) + 600)
         ):
             return self._auth_token
@@ -644,7 +639,7 @@ class SpotifyProvider(MusicProvider):
         if tokeninfo and userinfo:
             self._auth_token = tokeninfo
             self._sp_user = userinfo
-            self.mass.metadata.preferred_language = userinfo["country"]
+            self.mass.metadata.set_default_preferred_language(userinfo["country"])
             self.logger.info("Successfully logged in to Spotify as %s", userinfo["id"])
             self._auth_token = tokeninfo
             return tokeninfo
@@ -763,10 +758,9 @@ class SpotifyProvider(MusicProvider):
         if tokeninfo is None:
             tokeninfo = await self.login()
         headers = {"Authorization": f'Bearer {tokeninfo["accessToken"]}'}
-        if language := self.mass.config.get_raw_provider_config_value(
-            self.instance_id, CONF_PROVIDER_LANGUAGE
-        ):
-            headers["Accept-Language"] = language
+        locale = self.mass.metadata.locale.replace("_", "-")
+        language = locale.split("-")[0]
+        headers["Accept-Language"] = f"{locale}, {language};q=0.9, *;q=0.5"
         async with (
             self._throttler,
             self.mass.http_session.get(

--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -16,7 +16,11 @@ from asyncio_throttle import Throttler
 
 from music_assistant.common.helpers.json import json_loads
 from music_assistant.common.helpers.util import parse_title_and_version
-from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
+from music_assistant.common.models.config_entries import (
+    CONF_ENTRY_PROVIDER_LANGUAGE,
+    ConfigEntry,
+    ConfigValueType,
+)
 from music_assistant.common.models.enums import (
     ConfigEntryType,
     ExternalID,
@@ -41,7 +45,7 @@ from music_assistant.common.models.media_items import (
     Track,
 )
 from music_assistant.common.models.streamdetails import StreamDetails
-from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.constants import CONF_PASSWORD, CONF_PROVIDER_LANGUAGE, CONF_USERNAME
 
 # pylint: disable=no-name-in-module
 from music_assistant.server.helpers.app_vars import app_var
@@ -115,6 +119,7 @@ async def get_config_entries(
             label="Password",
             required=True,
         ),
+        CONF_ENTRY_PROVIDER_LANGUAGE,
     )
 
 
@@ -760,6 +765,10 @@ class SpotifyProvider(MusicProvider):
         if tokeninfo is None:
             tokeninfo = await self.login()
         headers = {"Authorization": f'Bearer {tokeninfo["accessToken"]}'}
+        if language := self.mass.config.get_raw_provider_config_value(
+            self.instance_id, CONF_PROVIDER_LANGUAGE
+        ):
+            headers["Accept-Language"] = language
         async with (
             self._throttler,
             self.mass.http_session.get(

--- a/music_assistant/server/providers/theaudiodb/__init__.py
+++ b/music_assistant/server/providers/theaudiodb/__init__.py
@@ -191,7 +191,10 @@ class AudioDbMetadataProvider(MetadataProvider):
             if link := artist_obj.get(key):
                 metadata.links.add(MediaItemLink(type=link_type, url=link))
         # description/biography
-        if desc := artist_obj.get(f"strBiography{self.mass.metadata.preferred_language}"):
+        lang_code, lang_country = self.mass.metadata.locale.split("_")
+        if desc := artist_obj.get(f"strBiography{lang_country}") or (
+            desc := artist_obj.get(f"strBiography{lang_code.upper()}")
+        ):
             metadata.description = desc
         else:
             metadata.description = artist_obj.get("strBiographyEN")
@@ -226,7 +229,10 @@ class AudioDbMetadataProvider(MetadataProvider):
             )
 
         # description
-        if desc := album_obj.get(f"strDescription{self.mass.metadata.preferred_language}"):
+        lang_code, lang_country = self.mass.metadata.locale.split("_")
+        if desc := album_obj.get(f"strDescription{lang_country}") or (
+            desc := album_obj.get(f"strDescription{lang_code.upper()}")
+        ):
             metadata.description = desc
         else:
             metadata.description = album_obj.get("strDescriptionEN")
@@ -251,7 +257,10 @@ class AudioDbMetadataProvider(MetadataProvider):
             metadata.genres = {genre}
         metadata.mood = track_obj.get("strMood")
         # description
-        if desc := track_obj.get(f"strDescription{self.mass.metadata.preferred_language}"):
+        lang_code, lang_country = self.mass.metadata.locale.split("_")
+        if desc := track_obj.get(f"strDescription{lang_country}") or (
+            desc := track_obj.get(f"strDescription{lang_code.upper()}")
+        ):
             metadata.description = desc
         else:
             metadata.description = track_obj.get("strDescriptionEN")

--- a/music_assistant/server/providers/tunein/__init__.py
+++ b/music_assistant/server/providers/tunein/__init__.py
@@ -258,9 +258,12 @@ class TuneInProvider(MusicProvider):
             kwargs["username"] = self.config.get_value(CONF_USERNAME)
             kwargs["partnerId"] = "1"
             kwargs["render"] = "json"
+        locale = self.mass.metadata.locale.replace("_", "-")
+        language = locale.split("-")[0]
+        headers = {"Accept-Language": f"{locale}, {language};q=0.9, *;q=0.5"}
         async with (
             self._throttler,
-            self.mass.http_session.get(url, params=kwargs, ssl=False) as response,
+            self.mass.http_session.get(url, params=kwargs, headers=headers, ssl=False) as response,
         ):
             result = await response.json()
             if not result or "error" in result:

--- a/music_assistant/server/providers/ytmusic/helpers.py
+++ b/music_assistant/server/providers/ytmusic/helpers.py
@@ -23,11 +23,13 @@ from ytmusicapi.constants import (
 from music_assistant.server.helpers.auth import AuthenticationHelper
 
 
-async def get_artist(prov_artist_id: str, headers: dict[str, str]) -> dict[str, str]:
+async def get_artist(
+    prov_artist_id: str, headers: dict[str, str], language: str = "en"
+) -> dict[str, str]:
     """Async wrapper around the ytmusicapi get_artist function."""
 
     def _get_artist():
-        ytm = ytmusicapi.YTMusic(auth=headers)
+        ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         try:
             artist = ytm.get_artist(channelId=prov_artist_id)
             # ChannelId can sometimes be different and original ID is not part of the response
@@ -40,21 +42,23 @@ async def get_artist(prov_artist_id: str, headers: dict[str, str]) -> dict[str, 
     return await asyncio.to_thread(_get_artist)
 
 
-async def get_album(prov_album_id: str) -> dict[str, str]:
+async def get_album(prov_album_id: str, language: str = "en") -> dict[str, str]:
     """Async wrapper around the ytmusicapi get_album function."""
 
     def _get_album():
-        ytm = ytmusicapi.YTMusic()
+        ytm = ytmusicapi.YTMusic(language=language)
         return ytm.get_album(browseId=prov_album_id)
 
     return await asyncio.to_thread(_get_album)
 
 
-async def get_playlist(prov_playlist_id: str, headers: dict[str, str]) -> dict[str, str]:
+async def get_playlist(
+    prov_playlist_id: str, headers: dict[str, str], language: str = "en"
+) -> dict[str, str]:
     """Async wrapper around the ytmusicapi get_playlist function."""
 
     def _get_playlist():
-        ytm = ytmusicapi.YTMusic(auth=headers)
+        ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         playlist = ytm.get_playlist(playlistId=prov_playlist_id, limit=None)
         playlist["checksum"] = get_playlist_checksum(playlist)
         return playlist
@@ -63,12 +67,12 @@ async def get_playlist(prov_playlist_id: str, headers: dict[str, str]) -> dict[s
 
 
 async def get_track(
-    prov_track_id: str, headers: dict[str, str], signature_timestamp: str
+    prov_track_id: str, headers: dict[str, str], signature_timestamp: str, language: str = "en"
 ) -> dict[str, str] | None:
     """Async wrapper around the ytmusicapi get_playlist function."""
 
     def _get_song():
-        ytm = ytmusicapi.YTMusic(auth=headers)
+        ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         track_obj = ytm.get_song(videoId=prov_track_id, signatureTimestamp=signature_timestamp)
         track = {}
         if "videoDetails" not in track_obj:
@@ -93,11 +97,11 @@ async def get_track(
     return await asyncio.to_thread(_get_song)
 
 
-async def get_library_artists(headers: dict[str, str]) -> dict[str, str]:
+async def get_library_artists(headers: dict[str, str], language: str = "en") -> dict[str, str]:
     """Async wrapper around the ytmusicapi get_library_artists function."""
 
     def _get_library_artists():
-        ytm = ytmusicapi.YTMusic(auth=headers)
+        ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         artists = ytm.get_library_subscriptions(limit=9999)
         # Sync properties with uniformal artist object
         for artist in artists:
@@ -110,21 +114,21 @@ async def get_library_artists(headers: dict[str, str]) -> dict[str, str]:
     return await asyncio.to_thread(_get_library_artists)
 
 
-async def get_library_albums(headers: dict[str, str]) -> dict[str, str]:
+async def get_library_albums(headers: dict[str, str], language: str = "en") -> dict[str, str]:
     """Async wrapper around the ytmusicapi get_library_albums function."""
 
     def _get_library_albums():
-        ytm = ytmusicapi.YTMusic(auth=headers)
+        ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         return ytm.get_library_albums(limit=9999)
 
     return await asyncio.to_thread(_get_library_albums)
 
 
-async def get_library_playlists(headers: dict[str, str]) -> dict[str, str]:
+async def get_library_playlists(headers: dict[str, str], language: str = "en") -> dict[str, str]:
     """Async wrapper around the ytmusicapi get_library_playlists function."""
 
     def _get_library_playlists():
-        ytm = ytmusicapi.YTMusic(auth=headers)
+        ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         playlists = ytm.get_library_playlists(limit=9999)
         # Sync properties with uniformal playlist object
         for playlist in playlists:
@@ -136,11 +140,11 @@ async def get_library_playlists(headers: dict[str, str]) -> dict[str, str]:
     return await asyncio.to_thread(_get_library_playlists)
 
 
-async def get_library_tracks(headers: dict[str, str]) -> dict[str, str]:
+async def get_library_tracks(headers: dict[str, str], language: str = "en") -> dict[str, str]:
     """Async wrapper around the ytmusicapi get_library_tracks function."""
 
     def _get_library_tracks():
-        ytm = ytmusicapi.YTMusic(auth=headers)
+        ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         return ytm.get_library_songs(limit=9999)
 
     return await asyncio.to_thread(_get_library_tracks)
@@ -235,11 +239,13 @@ async def get_song_radio_tracks(
     return await asyncio.to_thread(_get_song_radio_tracks)
 
 
-async def search(query: str, ytm_filter: str | None = None, limit: int = 20) -> list[dict]:
+async def search(
+    query: str, ytm_filter: str | None = None, limit: int = 20, language: str = "en"
+) -> list[dict]:
     """Async wrapper around the ytmusicapi search function."""
 
     def _search():
-        ytm = ytmusicapi.YTMusic()
+        ytm = ytmusicapi.YTMusic(language=language)
         results = ytm.search(query=query, filter=ytm_filter, limit=limit)
         # Sync result properties with uniformal objects
         for result in results:


### PR DESCRIPTION
- specify preferred metadata language on the metadata controller
- try to get the default setting (once) for the language from either the user's browser or a logged in streaming provider
- use the language on providers that support it (spotify and YTM)

Fixes https://github.com/music-assistant/hass-music-assistant/issues/751