### PR TITLE
Fix cleanup on removal of a provider

### DIFF
--- a/music_assistant/common/helpers/uri.py
+++ b/music_assistant/common/helpers/uri.py
@@ -47,7 +47,7 @@ async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str
             provider_instance_id_or_domain, rest = uri.split("://", 1)
             media_type_str, item_id = rest.split("/", 1)
             media_type = MediaType(media_type_str)
-        elif ":" in uri:
+        elif ":" in uri and len(uri.split(":")) == 3:
             # spotify new-style uri
             provider_instance_id_or_domain, media_type_str, item_id = uri.split(":")
             media_type = MediaType(media_type_str)

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -393,12 +393,12 @@ class FileSystemProviderBase(MusicProvider):
                 await controller.remove_item_from_library(library_item.item_id)
         # check if any albums need to be cleaned up
         for album_id in album_ids:
-            if not self.mass.music.albums.tracks(album_id, "library"):
+            if not await self.mass.music.albums.tracks(album_id, "library"):
                 await self.mass.music.albums.remove_item_from_library(album_id)
         # check if any artists need to be cleaned up
         for artist_id in artist_ids:
             artist_albums = await self.mass.music.artists.albums(artist_id, "library")
-            artist_tracks = self.mass.music.artists.tracks(artist_id, "library")
+            artist_tracks = await self.mass.music.artists.tracks(artist_id, "library")
             if not (artist_albums or artist_tracks):
                 await self.mass.music.artists.remove_item_from_library(album_id)
 
@@ -672,6 +672,7 @@ class FileSystemProviderBase(MusicProvider):
                         content_type=ContentType.try_parse(tags.format),
                         sample_rate=tags.sample_rate,
                         bit_depth=tags.bits_per_sample,
+                        channels=tags.channels,
                         bit_rate=tags.bit_rate,
                     ),
                 )

--- a/music_assistant/server/server.py
+++ b/music_assistant/server/server.py
@@ -493,7 +493,6 @@ class MusicAssistant:
             for sync_task in self.music.in_progress_syncs:
                 if sync_task.provider_instance == instance_id:
                     sync_task.task.cancel()
-                    await sync_task.task
             # check if there are no other providers dependent of this provider
             for dep_prov in self.providers:
                 if dep_prov.manifest.depends_on == provider.domain:


### PR DESCRIPTION
Make sure that all entries get cleaned up when removing a provider, even when the user decides to restart while a removal is in progress.