### PR TITLE
fix: Several minor fixes for deezer

### DIFF
--- a/music_assistant/server/providers/deezer/__init__.py
+++ b/music_assistant/server/providers/deezer/__init__.py
@@ -1,6 +1,5 @@
 """Deezer music provider support for MusicAssistant."""
 
-import datetime
 import hashlib
 import uuid
 from asyncio import TaskGroup
@@ -14,6 +13,7 @@ from aiohttp import ClientSession, ClientTimeout
 from Crypto.Cipher import Blowfish
 from deezer import exceptions as deezer_exceptions
 
+from music_assistant.common.helpers.datetime import utc_timestamp
 from music_assistant.common.models.config_entries import (
     ConfigEntry,
     ConfigValueType,
@@ -474,7 +474,7 @@ class DeezerProvider(MusicProvider):  # pylint: disable=W0223
             headers["Range"] = f"bytes={skip_bytes}-"
 
         buffer = bytearray()
-        streamdetails.data["start_ts"] = datetime.datetime.now().timestamp()
+        streamdetails.data["start_ts"] = utc_timestamp()
         streamdetails.data["stream_id"] = uuid.uuid1()
         self.mass.create_task(self.gw_client.log_listen(next_track=streamdetails.item_id))
         async with self.mass.http_session.get(

--- a/music_assistant/server/providers/deezer/gw_client.py
+++ b/music_assistant/server/providers/deezer/gw_client.py
@@ -10,6 +10,7 @@ from http.cookies import BaseCookie, Morsel
 from aiohttp import ClientSession
 from yarl import URL
 
+from music_assistant.common.helpers.datetime import utc_timestamp
 from music_assistant.common.models.streamdetails import StreamDetails
 
 USER_AGENT_HEADER = (
@@ -167,7 +168,7 @@ class GWClient:
 
         if last_track:
             seconds_streamed = min(
-                datetime.datetime.now().timestamp() - last_track.data["start_ts"],
+                utc_timestamp() - last_track.data["start_ts"],
                 last_track.seconds_streamed,
             )
 

--- a/music_assistant/server/providers/deezer/gw_client.py
+++ b/music_assistant/server/providers/deezer/gw_client.py
@@ -57,11 +57,11 @@ class GWClient:
     async def _update_user_data(self) -> None:
         user_data = await self._gw_api_call("deezer.getUserData", False)
         if not user_data["results"]["USER"]["USER_ID"]:
-            await self._get_cookie()
+            await self._set_cookie()
             user_data = await self._gw_api_call("deezer.getUserData", False)
 
         if not user_data["results"]["OFFER_ID"]:
-            msg = "Free subscriptions cannot be used in MA."
+            msg = "Free subscriptions cannot be used in MA. Make sure you set a valid ARL."
             raise DeezerGWError(msg)
 
         self._gw_csrf_token = user_data["results"]["checkForm"]
@@ -167,7 +167,7 @@ class GWClient:
 
         if last_track:
             seconds_streamed = min(
-                datetime.datetime.utcnow().timestamp() - last_track.data["start_ts"],
+                datetime.datetime.now().timestamp() - last_track.data["start_ts"],
                 last_track.seconds_streamed,
             )
 
@@ -179,7 +179,7 @@ class GWClient:
                 },
                 "type": 1,
                 "stat": {
-                    "seek": 1 if last_track.seconds_skipped else 0,
+                    "seek": 1 if seconds_streamed < last_track.duration else 0,
                     "pause": 0,
                     "sync": 0,
                     "next": bool(next_track),


### PR DESCRIPTION
* don't use `seconds_skipped` from StreamDetails anymore
* avoid using `utc_now`
* use `cache_checksum` instead of `checksum` on MediaItemMetadata