### PR TITLE
Fix: prevent enqueuing of next queue item if current item is a radio stream

### DIFF
--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -821,7 +821,9 @@ class PlayerQueuesController(CoreController):
         if len(changed_keys) == 0:
             return
         # handle enqueuing of next item to play
-        if not queue.flow_mode or queue.stream_finished:
+        if (not queue.flow_mode or queue.stream_finished) and (
+            not queue.current_item or queue.current_item.media_type != MediaType.RADIO
+        ):
             self._check_enqueue_next(player, queue, prev_state, new_state)
         # do not send full updates if only time was updated
         if changed_keys == {"elapsed_time"}:


### PR DESCRIPTION
I'm trying to work out why in the frontend the radio stream_title is either:
1: Missing completely or
2: Present, but doesn't update on metadata change.  

Been down a few rabbit holes but I think this is a first step, but not complete solution to solving 1 at least.  

The current queue item's `streamdetails` can be found at `queue.current_item.streamdetails` 
If enqueuing is enabled a new `streamdetails` object for next item replaces the current stream's `streamdetails` shortly after playing begins.  This even happens for a queue with only one radio stream in it, if Repeat is enabled.

But `get_hls_stream` and `get_icy_stream` have a reference to the original current item's `streamdetails` object and update the `stream_title` property on metadata change.

So preventing enqueing when current item is a radio stream prevents the original `streamdetails` being lost.  It only partially solves 1. as there's a timing issue - if the frontend starts the stream and receives `streamdetails` before the metadata is found, the `stream_title`is blank.

To solve this and 2. there needs to be a mechanism to watch changes to `stream_title` on metadata changes and send a WS notification msg to the frontend. `on_player_update` handles this for some queue item changes like elapsed time.  I'm thinking this needs extended to watch the `stream_title` changes and send out a `queue_updated` msg so the player templates rerender.