### PR TITLE
Do not load any providers by default (except builtin)

### DIFF
--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -468,15 +468,15 @@ class ConfigController:
             default_conf_raw,
         )
 
-    async def create_default_provider_config(self, provider_domain: str) -> None:
+    async def create_builtin_provider_config(self, provider_domain: str) -> None:
         """
-        Create default ProviderConfig.
+        Create builtin ProviderConfig.
 
-        This is meant as helper to create default configs for default enabled providers.
+        This is meant as helper to create default configs for builtin providers.
         Called by the server initialization code which load all providers at startup.
         """
-        for _conf in await self.get_provider_configs(provider_domain=provider_domain):
-            # return if there is already a config
+        for _ in await self.get_provider_configs(provider_domain=provider_domain):
+            # return if there is already any config
             return
         for prov in self.mass.get_provider_manifests():
             if prov.domain == provider_domain:

--- a/music_assistant/server/providers/airplay/manifest.json
+++ b/music_assistant/server/providers/airplay/manifest.json
@@ -10,7 +10,6 @@
   "documentation": "https://music-assistant.io/player-support/airplay/",
   "multi_instance": false,
   "builtin": false,
-  "load_by_default": true,
   "icon": "cast-variant",
   "mdns_discovery": [
     "_raop._tcp.local."

--- a/music_assistant/server/providers/builtin/manifest.json
+++ b/music_assistant/server/providers/builtin/manifest.json
@@ -10,6 +10,5 @@
   "documentation": "https://music-assistant.io/music-providers/builtin/",
   "multi_instance": false,
   "builtin": true,
-  "hidden": true,
-  "load_by_default": true
+  "hidden": true
 }

--- a/music_assistant/server/providers/chromecast/manifest.json
+++ b/music_assistant/server/providers/chromecast/manifest.json
@@ -12,7 +12,6 @@
   "documentation": "https://music-assistant.io/player-support/google-cast/",
   "multi_instance": false,
   "builtin": false,
-  "load_by_default": true,
   "icon": "cast",
   "mdns_discovery": [
     "_googlecast._tcp.local."

--- a/music_assistant/server/providers/dlna/manifest.json
+++ b/music_assistant/server/providers/dlna/manifest.json
@@ -3,11 +3,14 @@
   "domain": "dlna",
   "name": "UPnP/DLNA Player provider",
   "description": "Support for players that are compatible with the UPnP/DLNA (DMR) standard.",
-  "codeowners": ["@music-assistant"],
-  "requirements": ["async-upnp-client==0.38.3"],
+  "codeowners": [
+    "@music-assistant"
+  ],
+  "requirements": [
+    "async-upnp-client==0.38.3"
+  ],
   "documentation": "https://music-assistant.io/player-support/dlna/",
   "multi_instance": false,
   "builtin": false,
-  "load_by_default": true,
   "icon": "dlna"
 }

--- a/music_assistant/server/providers/fanarttv/manifest.json
+++ b/music_assistant/server/providers/fanarttv/manifest.json
@@ -3,11 +3,12 @@
   "domain": "fanarttv",
   "name": "fanart.tv Metadata provider",
   "description": "fanart.tv is a community database of artwork for movies, tv series and music.",
-  "codeowners": ["@music-assistant"],
+  "codeowners": [
+    "@music-assistant"
+  ],
   "requirements": [],
   "documentation": "",
   "multi_instance": false,
   "builtin": true,
-  "load_by_default": true,
   "icon": "folder-information"
 }

--- a/music_assistant/server/providers/musicbrainz/manifest.json
+++ b/music_assistant/server/providers/musicbrainz/manifest.json
@@ -3,11 +3,12 @@
   "domain": "musicbrainz",
   "name": "MusicBrainz Metadata provider",
   "description": "MusicBrainz is an open music encyclopedia that collects music metadata and makes it available to the public.",
-  "codeowners": ["@music-assistant"],
+  "codeowners": [
+    "@music-assistant"
+  ],
   "requirements": [],
   "documentation": "",
   "multi_instance": false,
   "builtin": true,
-  "load_by_default": true,
   "icon": "mdi-folder-information"
 }

--- a/music_assistant/server/providers/sonos/manifest.json
+++ b/music_assistant/server/providers/sonos/manifest.json
@@ -13,6 +13,5 @@
   ],
   "documentation": "https://music-assistant.io/player-support/sonos/",
   "multi_instance": false,
-  "builtin": false,
-  "load_by_default": true
+  "builtin": false
 }

--- a/music_assistant/server/providers/theaudiodb/manifest.json
+++ b/music_assistant/server/providers/theaudiodb/manifest.json
@@ -3,11 +3,12 @@
   "domain": "theaudiodb",
   "name": "TheAudioDB Metadata provider",
   "description": "TheAudioDB is a community Database of audio artwork and metadata with a JSON API.",
-  "codeowners": ["@music-assistant"],
+  "codeowners": [
+    "@music-assistant"
+  ],
   "requirements": [],
   "documentation": "",
   "multi_instance": false,
   "builtin": true,
-  "load_by_default": true,
   "icon": "folder-information"
 }

--- a/music_assistant/server/providers/ugp/manifest.json
+++ b/music_assistant/server/providers/ugp/manifest.json
@@ -3,11 +3,12 @@
   "domain": "ugp",
   "name": "Universal Group Player",
   "description": "Create Player Groups with your favorite players, regardless of type and model.",
-  "codeowners": ["@music-assistant"],
+  "codeowners": [
+    "@music-assistant"
+  ],
   "requirements": [],
   "documentation": "https://music-assistant.io/player-support/universal/",
   "multi_instance": false,
   "builtin": false,
-  "load_by_default": true,
   "icon": "speaker-multiple"
 }

--- a/music_assistant/server/server.py
+++ b/music_assistant/server/server.py
@@ -530,11 +530,11 @@ class MusicAssistant:
 
     async def _load_providers(self) -> None:
         """Load providers from config."""
-        # create default config for any 'load_by_default' providers (e.g. URL provider)
+        # create default config for any 'builtin' providers (e.g. URL provider)
         for prov_manifest in self._provider_manifests.values():
-            if not prov_manifest.load_by_default:
+            if not prov_manifest.builtin:
                 continue
-            await self.config.create_default_provider_config(prov_manifest.domain)
+            await self.config.create_builtin_provider_config(prov_manifest.domain)
 
         async def load_provider(prov_conf: ProviderConfig) -> None:
             """Try to load a provider and catch errors."""


### PR DESCRIPTION
Partial fix for the fact that the Sonos provider makes the whole MA container crash on older systems.

With this PR we no longer load any provider by default anymore (except the builtin ones offcourse). 
Instead we are going to propose providers based on discovery and hints/getting started in the UI.

