### PR TITLE
Downgrade orjson to 3.9.15 due to segmentation faults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ server = [
   "soundcloudpy==0.1.0",
   "unidecode==1.3.8",
   "xmltodict==0.13.0",
-  "orjson==3.10.1",
+  "orjson==3.9.15",
   "shortuuid==1.0.13",
   "zeroconf==0.132.2",
   "cryptography==42.0.5",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -21,7 +21,7 @@ jellyfin_apiclient_python==1.9.2
 mashumaro==3.12
 memory-tempfile==2.2.3
 music-assistant-frontend==2.4.6
-orjson==3.10.1
+orjson==3.9.15
 pillow==10.3.0
 plexapi==4.15.12
 py-opensonic==5.0.5


### PR DESCRIPTION
We got some reports of a crashing container and this seems to lead to the recent orjson version bump.
Revert for the time being while the issue is being investigated.

Upstream issue:
https://github.com/ijl/orjson/issues/479

Related issue reports:
https://github.com/music-assistant/hass-music-assistant/issues/2142
https://github.com/music-assistant/hass-music-assistant/issues/2110