### PR TITLE
Open Subsonic: Fix MediaImageItem constructor call

### DIFF
--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -328,7 +328,10 @@ class OpenSonicProvider(MusicProvider):
             if sonic_info.small_url:
                 album.metadata.images.append(
                     MediaItemImage(
-                        type=ImageType.THUMB, path=sonic_info.small_url, remotely_accessible=False
+                        type=ImageType.THUMB,
+                        path=sonic_info.small_url,
+                        remotely_accessible=False,
+                        provider=self.instance_id,
                     )
                 )
             if sonic_info.notes:


### PR DESCRIPTION
The MediaImageItem construtor now requires a provider key word argument.

Previous versions of MA would avoid calling resolve_image if the path was None or empty. This seems to have changed and is causing errors in library syncing. The function now checks if path is empty and returns an empty list if so.