### PR TITLE
lower throttler log level to info

### DIFF
--- a/music_assistant/server/helpers/throttle_retry.py
+++ b/music_assistant/server/helpers/throttle_retry.py
@@ -44,9 +44,9 @@ class ThrottlerManager(Throttler):
             except ResourceTemporarilyUnavailable as e:
                 if e.backoff_time:
                     backoff_time = e.backoff_time
-                LOGGER.warning(f"Attempt {attempt + 1}/{self.retry_attempts} failed: {e}")
+                LOGGER.info(f"Attempt {attempt + 1}/{self.retry_attempts} failed: {e}")
                 if attempt < self.retry_attempts - 1:
-                    LOGGER.warning(f"Retrying in {backoff_time} seconds...")
+                    LOGGER.info(f"Retrying in {backoff_time} seconds...")
                     await asyncio.sleep(backoff_time)
                     backoff_time *= 2
         else:  # noqa: PLW0120
@@ -71,11 +71,11 @@ def throttle_with_retries(
                     return await func(self, *args, **kwargs)
                 except ResourceTemporarilyUnavailable as e:
                     backoff_time += e.backoff_time
-                    self.logger.warning(
+                    self.logger.info(
                         f"Attempt {attempt + 1}/{throttler.retry_attempts} failed: {e}"
                     )
                     if attempt < throttler.retry_attempts - 1:
-                        self.logger.warning(f"Retrying in {backoff_time} seconds...")
+                        self.logger.info(f"Retrying in {backoff_time} seconds...")
                         await asyncio.sleep(backoff_time)
                         backoff_time *= 2
             else:  # noqa: PLW0120


### PR DESCRIPTION
As a suggestion I am thinking that just doing a retry doesn't need to be a warning. A warning is something that I think should be investigated. So lower that to an info and users will still be alerted if the retries are exhausted.