### PR TITLE
Fix mass user playlists (and queue items) limited to 50 items

### DIFF
--- a/music_assistant/common/models/media_items.py
+++ b/music_assistant/common/models/media_items.py
@@ -577,7 +577,7 @@ class PagedItems(Generic[_T]):
         self.limit = limit
         self.offset = offset
         self.total = total
-        if total is None and offset == 0 and count != limit:
+        if total is None and offset == 0 and count > limit:
             self.total = count
         if total is None and offset and count < limit:
             self.total = offset + count

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -212,7 +212,7 @@ class PlayerQueuesController(CoreController):
             return PagedItems(items=[], limit=limit, offset=offset)
 
         return PagedItems(
-            items=self._queue_items[queue_id][offset:limit],
+            items=self._queue_items[queue_id][offset : offset + limit],
             limit=limit,
             offset=offset,
             total=len(self._queue_items[queue_id]),

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -540,7 +540,7 @@ class FileSystemProviderBase(MusicProvider):
             else:
                 playlist_lines = parse_pls(playlist_data)
 
-            playlist_lines = playlist_lines[offset:limit]
+            playlist_lines = playlist_lines[offset : offset + limit]
 
             for line_no, playlist_line in enumerate(playlist_lines):
                 if track := await self._parse_playlist_line(


### PR DESCRIPTION
Turned out to be a stupid typo actually but well hidden ;-)

Fixes playlist items listings for user created playlists (on the mass provider) limited to 50 items.