### PR TITLE
Subsonic: Set Track.disc_number to 0 for now

### DIFF
--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -350,6 +350,10 @@ class OpenSonicProvider(MusicProvider):
             name=sonic_song.title,
             album=mapping,
             duration=sonic_song.duration if sonic_song.duration is not None else 0,
+            # We are setting disc number to 0 because the standard for what is part of
+            # a Open Subsonic Song is not yet set and the implementations I have checked
+            # do not contain this field. We should revisit this when the spec is finished
+            disc_number=0,
             provider_mappings={
                 ProviderMapping(
                     item_id=sonic_song.id,


### PR DESCRIPTION
The standard for Open Subsonic is not complete for Songs so we don't know if this field will be supported. Once the standard is ready we can readress this.

Fixes: https://github.com/music-assistant/hass-music-assistant/issues/2247
