### PR TITLE
Refactor SnapCastProvider cmd_volume_set method

### DIFF
--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -318,7 +318,7 @@ class SnapCastProvider(PlayerProvider):
     async def cmd_volume_set(self, player_id: str, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""
         snap_client_id = self._get_snapclient_id(player_id)
-        self._snapserver.client(snap_client_id).update_volume({"volume": {"percent": volume_level}})
+        await self._snapserver.client(snap_client_id).set_volume(volume_level)
 
     async def cmd_stop(self, player_id: str) -> None:
         """Send STOP command to given player."""

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -318,9 +318,7 @@ class SnapCastProvider(PlayerProvider):
     async def cmd_volume_set(self, player_id: str, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""
         snap_client_id = self._get_snapclient_id(player_id)
-        await self._snapserver.client_volume(
-            snap_client_id, {"percent": volume_level, "muted": volume_level == 0}
-        )
+        self._snapserver.client(snap_client_id).update_volume({"volume": {"percent": volume_level}})
 
     async def cmd_stop(self, player_id: str) -> None:
         """Send STOP command to given player."""

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -319,6 +319,7 @@ class SnapCastProvider(PlayerProvider):
         """Send VOLUME_SET command to given player."""
         snap_client_id = self._get_snapclient_id(player_id)
         await self._snapserver.client(snap_client_id).set_volume(volume_level)
+        self.mass.players.update(snap_client_id)
 
     async def cmd_stop(self, player_id: str) -> None:
         """Send STOP command to given player."""


### PR DESCRIPTION
The method in the snapserver class does not call the callback, so the volume was not updated correctly. 
Also the muting logic is eliminated because it is not correct that if the volume of a group is changed, a muted client will sound again.