### PR TITLE
Jellyfin: Don't fail entire sync if artist mbid is corrupt

### DIFF
--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -365,7 +365,14 @@ class JellyfinProvider(MusicProvider):
         if ITEM_KEY_OVERVIEW in current_artist:
             artist.metadata.description = current_artist[ITEM_KEY_OVERVIEW]
         if ITEM_KEY_MUSICBRAINZ_ARTIST in current_artist[ITEM_KEY_PROVIDER_IDS]:
-            artist.mbid = current_artist[ITEM_KEY_PROVIDER_IDS][ITEM_KEY_MUSICBRAINZ_ARTIST]
+            try:
+                artist.mbid = current_artist[ITEM_KEY_PROVIDER_IDS][ITEM_KEY_MUSICBRAINZ_ARTIST]
+            except InvalidDataError as error:
+                self.logger.warning(
+                    "Jellyfin reports an invalid id for artist_id: %s",
+                    artist_id,
+                    exc_info=error if self.logger.isEnabledFor(10) else None,
+                )
         if ITEM_KEY_SORT_NAME in current_artist:
             artist.sort_name = current_artist[ITEM_KEY_SORT_NAME]
         if thumb := self._get_thumbnail_url(self._jellyfin_server, jellyfin_artist):

--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -369,8 +369,8 @@ class JellyfinProvider(MusicProvider):
                 artist.mbid = current_artist[ITEM_KEY_PROVIDER_IDS][ITEM_KEY_MUSICBRAINZ_ARTIST]
             except InvalidDataError as error:
                 self.logger.warning(
-                    "Jellyfin reports an invalid id for artist_id: %s",
-                    artist_id,
+                    "Jellyfin has an invalid musicbrainz id for artist %r",
+                    artist.name,
                     exc_info=error if self.logger.isEnabledFor(10) else None,
                 )
         if ITEM_KEY_SORT_NAME in current_artist:


### PR DESCRIPTION
Jellyfin does not seem to validate musicbrainz ids. It's basically a free text field in the Jellyfin UI, accepting even daft strings like "FEEDME". MA does validate them though, raising InvalidDataError if basic checks fail when setting the value on a model object. If that InvalidDataError exception is raised during a library sync then the sync will stop. This leads to a library with some artists, no albums and no tracks. This happened to my library after running Picard over it.

I would like to handle the exception, log a message the user can action, and then continue without bringing the MBID into MA. The rest of the users library is imported. And the user can see which track is broken, fix it, and then on the next sync it can be pulled in.

If you are happy with this change, I'd like to do a follow up PR to cover the other unprotected mbid cases in the sync process.

(In my case the field is "corrupt" because Jellyfin can't handle albums with multiple artists very well and has decided to put multiple artist mbid's against a single artist. This is so broken even parts of the Jellyfin UI can't handle it).