### PR TITLE
Jellyfin: Fix regression importing track artist mapping

### DIFF
--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -446,14 +446,15 @@ class JellyfinProvider(MusicProvider):
             parent_album = API.get_item(
                 self._jellyfin_server.jellyfin, current_jellyfin_track[ITEM_KEY_ALBUM_ID]
             )
-            if ITEM_KEY_ALBUM_ID in parent_album and ITEM_KEY_ALBUM_ARTIST in parent_album:
-                track.artists.append(
-                    self._get_item_mapping(
-                        MediaType.ARTIST,
-                        parent_album[ITEM_KEY_ALBUM_ID],
-                        parent_album[ITEM_KEY_ALBUM_ARTIST],
+            if ITEM_KEY_ALBUM_ARTISTS in parent_album:
+                for artist_item in parent_album[ITEM_KEY_ALBUM_ARTISTS]:
+                    track.artists.append(
+                        self._get_item_mapping(
+                            MediaType.ARTIST,
+                            artist_item[ITEM_KEY_ID],
+                            artist_item[ITEM_KEY_NAME],
+                        )
                     )
-                )
             else:
                 track.artists.append(await self._parse_artist(name=VARIOUS_ARTISTS_NAME))
         else:


### PR DESCRIPTION
AFAICT, https://github.com/music-assistant/server/pull/1325 introduced a regression in syncing Jellyfin tracks. After that merge the code started looking for ITEM_KEY_ALBUM_ID in the album metadata. It then tries to create an artist mapping with the ID of the album (rather than an artist id) and the "album artist" text from the album. This creates invalid data. Or it would, but an album doesn't actually have an AlbumId field at all.

This PR allows syncing to complete without exceptions again by using the "AlbumArtists" list from the album object:

```
    "AlbumArtists": [
        {
            "Name": "Papa Roach",
            "Id": "e439648e08ade14e27d5de48fa97c88e"
        }
    ],
```
