### PR TITLE
Revert "Fix snapcast player unsync when master off"

### DIFF
--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -342,9 +342,6 @@ class SnapCastProvider(PlayerProvider):
         """Sync Snapcast player."""
         group = self._get_snapgroup(target_player)
         await group.add_client(self._get_snapclient_id(player_id))
-        target = self.mass.players.get(target_player)
-        target.synced_to = self._synced_to(target_player)
-        self.mass.players.update(target_player)
 
     async def cmd_unsync(self, player_id: str) -> None:
         """Unsync Snapcast player."""


### PR DESCRIPTION
 Introduces another bug, where only two clients can be synchronised.