### PR TITLE
Jellyfin: Don't adjust logging level of unrelated providers dependencies

### DIFF
--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -155,8 +155,6 @@ class JellyfinProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Initialize provider(instance) with given configuration."""
-        logging.getLogger("pytube").setLevel(self.logger.level + 10)
-        logging.getLogger("ytmusicapi").setLevel(self.logger.level + 10)
 
         def connect() -> JellyfinClient:
             try:


### PR DESCRIPTION
Just a tiny code cleanup I noticed.