### PR TITLE
Auto retry provider load if its unavailable or the connection gets lost

### DIFF
--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -803,7 +803,7 @@ class ConfigController:
         # validate the new config
         config.validate()
         # try to load the provider first to catch errors before we save it.
-        await self.mass.load_provider(config)
+        await self.mass.load_provider(config, raise_on_error=True)
         # the load was a success, store this config
         conf_key = f"{CONF_PROVIDERS}/{config.instance_id}"
         self.set(conf_key, config.to_raw())

--- a/music_assistant/server/providers/hass/manifest.json
+++ b/music_assistant/server/providers/hass/manifest.json
@@ -12,6 +12,6 @@
   "load_by_default": false,
   "icon": "md:webhook",
   "requirements": [
-    "hass-client==1.0.1"
+    "hass-client==1.1.0"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -17,7 +17,7 @@ deezer-python-async==0.3.0
 defusedxml==0.7.1
 faust-cchardet>=2.1.18
 git+https://github.com/MarvinSchenkel/pytube.git
-hass-client==1.0.1
+hass-client==1.1.0
 ifaddr==0.2.0
 jellyfin_apiclient_python==1.9.2
 mashumaro==3.13


### PR DESCRIPTION
Currently, if a provider is unavailable at startup, it will never be retried. Also when the connection gets lost, there is no way to tell the server to retry later.

This PR addresses that:

- Implement auto retry logic if the initial load of a provider(instance) failed.
- Allow provider to reload itself (which is then also retried if that fails)
- Fix Home Assistant provider to reload when the connection was lost
- Fix Home Assistant provider for a player that is unavailable at startup but available later
