### PR TITLE
Force comparison of MBID

### DIFF
--- a/music_assistant/server/helpers/compare.py
+++ b/music_assistant/server/helpers/compare.py
@@ -112,6 +112,9 @@ def compare_track(
     # return early on exact item_id match
     if compare_item_ids(base_item, compare_item):
         return True
+    # return early on MBID match
+    if base_item.mbid and compare_item.mbid:
+        return base_item.mbid == compare_item.mbid
     # return early on (un)matched external id
     external_id_match = compare_external_ids(base_item.external_ids, compare_item.external_ids)
     if external_id_match is not None:


### PR DESCRIPTION
ISRC turns out to be a minefield of inconsistency. MBID is generally a good indicator for tracks, so if that's present on both tracks, default to using that.