### PR TITLE
Jellyfin: Make less http requests

### DIFF
--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -426,6 +426,13 @@ class JellyfinProvider(MusicProvider):
                 jellyfin_track[ITEM_KEY_ALBUM_ID],
                 jellyfin_track[ITEM_KEY_ALBUM],
             )
+        elif ITEM_KEY_ALBUM_ID in jellyfin_track:
+            parent_album = await self._client.get_item(jellyfin_track[ITEM_KEY_ALBUM_ID])
+            track.album = self._get_item_mapping(
+                MediaType.ALBUM,
+                parent_album[ITEM_KEY_ID],
+                parent_album[ITEM_KEY_NAME],
+            )
 
         if ITEM_KEY_RUNTIME_TICKS in jellyfin_track:
             track.duration = int(

--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -235,7 +235,7 @@ class JellyfinProvider(MusicProvider):
         )
         playlists = []
         for item in resultset["Items"]:
-            playlists.append(await self._parse_playlist(item))
+            playlists.append(self._parse_playlist(item))
         return playlists
 
     async def _parse_album(self, jellyfin_album: JellyMediaItem) -> Album:
@@ -452,7 +452,7 @@ class JellyfinProvider(MusicProvider):
         track.favorite = user_data.get(USER_DATA_KEY_IS_FAVORITE, False)
         return track
 
-    async def _parse_playlist(self, jellyfin_playlist: JellyMediaItem) -> Playlist:
+    def _parse_playlist(self, jellyfin_playlist: JellyMediaItem) -> Playlist:
         """Parse a Jellyfin Playlist response to a Playlist object."""
         playlistid = jellyfin_playlist[ITEM_KEY_ID]
         playlist = Playlist(
@@ -564,9 +564,9 @@ class JellyfinProvider(MusicProvider):
             for playlist in playlists_obj:
                 if "MediaType" in playlist:  # Only jellyfin has this property
                     if playlist["MediaType"] == "Audio":
-                        yield await self._parse_playlist(playlist)
+                        yield self._parse_playlist(playlist)
                 else:  # emby playlists are only audio type
-                    yield await self._parse_playlist(playlist)
+                    yield self._parse_playlist(playlist)
 
     async def get_album(self, prov_album_id: str) -> Album:
         """Get full album details by id."""
@@ -610,7 +610,7 @@ class JellyfinProvider(MusicProvider):
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
         """Get full playlist details by id."""
         if jellyfin_playlist := await self._client.get_item(prov_playlist_id):
-            return await self._parse_playlist(jellyfin_playlist)
+            return self._parse_playlist(jellyfin_playlist)
         msg = f"Item {prov_playlist_id} not found"
         raise MediaNotFoundError(msg)
 

--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -380,7 +380,8 @@ class JellyfinProvider(MusicProvider):
             },
         )
 
-        track.disc_number = jellyfin_track.get(ITEM_KEY_PARENT_INDEX_NUM, 1)
+        if disc_number := jellyfin_track.get(ITEM_KEY_PARENT_INDEX_NUM):
+            track.disc_number = disc_number
         if "IndexNumber" in jellyfin_track:
             if jellyfin_track["IndexNumber"] >= 1:
                 track_idx = jellyfin_track["IndexNumber"]

--- a/music_assistant/server/providers/jellyfin/const.py
+++ b/music_assistant/server/providers/jellyfin/const.py
@@ -66,6 +66,7 @@ PLAYABLE_ITEM_TYPES: Final = [ITEM_TYPE_AUDIO]
 
 ARTIST_FIELDS = ["Overview", "ProviderIds", "SortName"]
 ALBUM_FIELDS = ["ProductionYear", "Overview", "ProviderIds", "SortName"]
+TRACK_FIELDS = ["ProviderIds", "CanDownload", "SortName", "MediaSources", "MediaStreams"]
 
 USER_APP_NAME: Final = "Music Assistant"
 USER_AGENT: Final = "Music-Assistant-1.0"

--- a/music_assistant/server/providers/jellyfin/const.py
+++ b/music_assistant/server/providers/jellyfin/const.py
@@ -65,6 +65,7 @@ SUPPORTED_CONTAINER_FORMATS: Final = "ogg,flac,mp3,aac,mpeg,alac,wav,aiff,wma,m4
 PLAYABLE_ITEM_TYPES: Final = [ITEM_TYPE_AUDIO]
 
 ARTIST_FIELDS = ["Overview", "ProviderIds", "SortName"]
+ALBUM_FIELDS = ["ProductionYear", "Overview", "ProviderIds", "SortName"]
 
 USER_APP_NAME: Final = "Music Assistant"
 USER_AGENT: Final = "Music-Assistant-1.0"

--- a/music_assistant/server/providers/jellyfin/const.py
+++ b/music_assistant/server/providers/jellyfin/const.py
@@ -64,6 +64,7 @@ SUPPORTED_CONTAINER_FORMATS: Final = "ogg,flac,mp3,aac,mpeg,alac,wav,aiff,wma,m4
 
 PLAYABLE_ITEM_TYPES: Final = [ITEM_TYPE_AUDIO]
 
+ARTIST_FIELDS = ["Overview", "ProviderIds", "SortName"]
 
 USER_APP_NAME: Final = "Music Assistant"
 USER_AGENT: Final = "Music-Assistant-1.0"

--- a/music_assistant/server/providers/jellyfin/manifest.json
+++ b/music_assistant/server/providers/jellyfin/manifest.json
@@ -4,7 +4,7 @@
   "name": "Jellyfin Media Server Library",
   "description": "Support for the Jellyfin streaming provider in Music Assistant.",
   "codeowners": ["@lokiberra", "@Jc2k"],
-  "requirements": ["aiojellyfin==0.0.6"],
+  "requirements": ["aiojellyfin==0.1.0"],
   "documentation": "https://music-assistant.io/music-providers/jellyfin/",
   "multi_instance": true
 }

--- a/music_assistant/server/providers/jellyfin/manifest.json
+++ b/music_assistant/server/providers/jellyfin/manifest.json
@@ -4,7 +4,7 @@
   "name": "Jellyfin Media Server Library",
   "description": "Support for the Jellyfin streaming provider in Music Assistant.",
   "codeowners": ["@lokiberra", "@Jc2k"],
-  "requirements": ["aiojellyfin==0.1.0"],
+  "requirements": ["aiojellyfin==0.2.0"],
   "documentation": "https://music-assistant.io/music-providers/jellyfin/",
   "multi_instance": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ Brotli>=1.0.9
 aiodns>=3.0.0
 aiofiles==23.2.1
 aiohttp==3.9.5
-aiojellyfin==0.0.6
+aiojellyfin==0.1.0
 aiorun==2024.5.1
 aioslimproto==3.0.1
 aiosqlite==0.20.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ Brotli>=1.0.9
 aiodns>=3.0.0
 aiofiles==23.2.1
 aiohttp==3.9.5
-aiojellyfin==0.1.0
+aiojellyfin==0.2.0
 aiorun==2024.5.1
 aioslimproto==3.0.1
 aiosqlite==0.20.0


### PR DESCRIPTION
By passing `enableUserData` and `fields` to more requests we can get all the data we need from the `_search` methods without `_parse` methods needing to make additional HTTP requests. This can save hundreds if not thousands of HTTP requests on moderate libraries.

We are able to make _parse_playlist non-async as it already does no I/O, and _parse_album and _parse_artist are (after the change above) also I/O free. 

This just leaves _parse_track. I can easily get rid of 1 extra http request per track. However in the worst case, this function will still make 2 HTTP requests:

* If a track has `AlbumId` but not `Album` (the human readable album name) it does a HTTP request to get it for the ItemMapping
* If a track doesn't have `ArtistItems` but does have `AlbumId` it does a HTTP request to see if the artist data is on the album object.

Both of these are for the same album, so worst case we can get this down to 1 additional HTTP request, but i'lll probably look at that separately.