### PR TITLE
Add index on timestamp_added

### DIFF
--- a/music_assistant/server/controllers/music.py
+++ b/music_assistant/server/controllers/music.py
@@ -1110,7 +1110,8 @@ class MusicController(CoreController):
             )
             # index on timestamp_added
             await self.database.execute(
-                f"CREATE INDEX IF NOT EXISTS {db_table}_timestamp_added_idx on {db_table}(timestamp_added);"
+                f"CREATE INDEX IF NOT EXISTS {db_table}_timestamp_added_idx "
+                f"on {db_table}(timestamp_added);"
             )
 
         # indexes on provider_mappings table

--- a/music_assistant/server/controllers/music.py
+++ b/music_assistant/server/controllers/music.py
@@ -1108,6 +1108,10 @@ class MusicController(CoreController):
             await self.database.execute(
                 f"CREATE INDEX IF NOT EXISTS {db_table}_external_ids_idx on {db_table}(external_ids);"  # noqa: E501
             )
+            # index on timestamp_added
+            await self.database.execute(
+                f"CREATE INDEX IF NOT EXISTS {db_table}_timestamp_added_idx on {db_table}(timestamp_added);"
+            )
 
         # indexes on provider_mappings table
         await self.database.execute(


### PR DESCRIPTION
The home screen of MA includes a 'recently added' row:

https://github.com/music-assistant/frontend/blob/7553714d748b53ba29b52671586ab38108fa18be/src/components/HomeWidgetRows.vue#L112

My library has ca. 8000s tracks and it takes a fair amount of time to fetch just that row (7-8s I think). This should speed up the fetch and hence the display of the home screen.