### PR TITLE
Jellyfin: Faster track fetching

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -10,6 +10,7 @@ DB_SCHEMA_VERSION: Final[int] = 1
 MASS_LOGGER_NAME: Final[str] = "music_assistant"
 
 UNKNOWN_ARTIST: Final[str] = "Unknown Artist"
+UNKNOWN_ARTIST_ID_MBID: Final[str] = "125ec42a-7229-4250-afc5-e057484327fe"
 VARIOUS_ARTISTS_NAME: Final[str] = "Various Artists"
 VARIOUS_ARTISTS_ID_MBID: Final[str] = "89ad4ac3-39f7-470e-963a-56509c546377"
 

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -9,7 +9,7 @@ DB_SCHEMA_VERSION: Final[int] = 1
 
 MASS_LOGGER_NAME: Final[str] = "music_assistant"
 
-UNKNOWN_ARTIST: Final[str] = "Unknown Artist"
+UNKNOWN_ARTIST: Final[str] = "[unknown]"
 UNKNOWN_ARTIST_ID_MBID: Final[str] = "125ec42a-7229-4250-afc5-e057484327fe"
 VARIOUS_ARTISTS_NAME: Final[str] = "Various Artists"
 VARIOUS_ARTISTS_ID_MBID: Final[str] = "89ad4ac3-39f7-470e-963a-56509c546377"

--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -719,7 +719,7 @@ class JellyfinProvider(MusicProvider):
         """Get a list of albums for the given artist."""
         if not prov_artist_id.startswith(FAKE_ARTIST_PREFIX):
             return []
-        albums = await self._client.album(
+        albums = await self._client.albums(
             prov_artist_id, fields=ALBUM_FIELDS, enable_user_data=True
         )
         return [self._parse_album(album) for album in albums["Items"]]
@@ -773,7 +773,7 @@ class JellyfinProvider(MusicProvider):
         else:
             params["IncludeItemTypes"] = item_type
         if item_type in ITEM_TYPE_AUDIO:
-            params["Fields"] = TRACK_FIELDS
+            params["Fields"] = ",".join(TRACK_FIELDS)
 
         result = await self._client.user_items("", params)
         return result["Items"]

--- a/music_assistant/server/providers/jellyfin/const.py
+++ b/music_assistant/server/providers/jellyfin/const.py
@@ -2,6 +2,9 @@
 
 from typing import Final
 
+from music_assistant.common.models.enums import MediaType
+from music_assistant.common.models.media_items import ItemMapping
+
 DOMAIN: Final = "jellyfin"
 
 CLIENT_VERSION: Final = "0.1"
@@ -70,3 +73,7 @@ TRACK_FIELDS = ["ProviderIds", "CanDownload", "SortName", "MediaSources", "Media
 
 USER_APP_NAME: Final = "Music Assistant"
 USER_AGENT: Final = "Music-Assistant-1.0"
+
+UNKNOWN_ARTIST_MAPPING = ItemMapping(
+    media_type=MediaType.ARTIST, item_id="[unknown]", provider=DOMAIN, name="[unknown]"
+)

--- a/music_assistant/server/providers/jellyfin/const.py
+++ b/music_assistant/server/providers/jellyfin/const.py
@@ -4,6 +4,7 @@ from typing import Final
 
 from music_assistant.common.models.enums import MediaType
 from music_assistant.common.models.media_items import ItemMapping
+from music_assistant.constants import UNKNOWN_ARTIST
 
 DOMAIN: Final = "jellyfin"
 
@@ -75,5 +76,5 @@ USER_APP_NAME: Final = "Music Assistant"
 USER_AGENT: Final = "Music-Assistant-1.0"
 
 UNKNOWN_ARTIST_MAPPING = ItemMapping(
-    media_type=MediaType.ARTIST, item_id="[unknown]", provider=DOMAIN, name="[unknown]"
+    media_type=MediaType.ARTIST, item_id=UNKNOWN_ARTIST, provider=DOMAIN, name=UNKNOWN_ARTIST
 )


### PR DESCRIPTION
This:

* Fixes a case where the same _parse_track call might call out to get the same album twice
* Fetches all tracks, even if they don't have an album

It also means instead of making a HTTP request for evey album its making one for every 4 or so albums (paginating over the whole library, rather than fetching each albums tracks).

Ideally i'd like to not query the album API at all when parsing the track. But:

* Right now we use the album to find the artist if the track doesn't have an artist directly. This feels weird and edge casey, but it does happen in my library.
* Apparently there might be edge cases where we have an album id but not name. Can I have an item mapping that has an id but not a name?