### PR TITLE
Snapcast fix sync and unsync many

### DIFF
--- a/music_assistant/server/models/player_provider.py
+++ b/music_assistant/server/models/player_provider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from abc import abstractmethod
 from collections.abc import Iterable
 
@@ -227,10 +226,9 @@ class PlayerProvider(Provider):
 
     async def cmd_sync_many(self, target_player: str, child_player_ids: list[str]) -> None:
         """Create temporary sync group by joining given players to target player."""
-        # default implementation, simply call the cmd_sync for all child players
-        async with asyncio.TaskGroup() as tg:
-            for child_player_id in child_player_ids:
-                tg.create_task(self.cmd_sync(child_player_id, target_player))
+        for child_id in child_player_ids:
+            # default implementation, simply call the cmd_sync for all child players
+            await self.cmd_sync(child_id, target_player)
 
     async def cmd_unsync_many(self, player_ids: str) -> None:
         """Handle UNSYNC command for all the given players.
@@ -239,10 +237,9 @@ class PlayerProvider(Provider):
 
             - player_id: player_id of the player to handle the command.
         """
-        # default implementation, simply call the cmd_sync for all player_ids
-        async with asyncio.TaskGroup() as tg:
-            for player_id in player_ids:
-                tg.create_task(self.cmd_unsync(player_id))
+        for player_id in player_ids:
+            # default implementation, simply call the cmd_sync for all player_ids
+            await self.cmd_unsync(player_id)
 
     async def create_group(self, name: str, members: list[str]) -> Player:
         """Create new PlayerGroup on this provider.

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -347,6 +347,21 @@ class SnapCastProvider(PlayerProvider):
             player.synced_to = self._synced_to(player_id)
             self.mass.players.update(target_player)
 
+    async def cmd_sync_many(self, target_player: str, child_player_ids: list[str]) -> None:
+        """Create temporary sync group by joining given players to target player."""
+        for child_id in child_player_ids:
+            await self.cmd_sync(child_id, target_player)
+
+    async def cmd_unsync_many(self, player_ids: str) -> None:
+        """Handle UNSYNC command for all the given players.
+
+        Remove the given player from any syncgroups it currently is synced to.
+
+            - player_id: player_id of the player to handle the command.
+        """
+        for player_id in player_ids:
+            await self.cmd_unsync(player_id)
+
     async def cmd_unsync(self, player_id: str) -> None:
         """Unsync Snapcast player."""
         snap_client_id = self._get_snapclient_id(player_id)

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -347,21 +347,6 @@ class SnapCastProvider(PlayerProvider):
             player.synced_to = self._synced_to(player_id)
             self.mass.players.update(target_player)
 
-    async def cmd_sync_many(self, target_player: str, child_player_ids: list[str]) -> None:
-        """Create temporary sync group by joining given players to target player."""
-        for child_id in child_player_ids:
-            await self.cmd_sync(child_id, target_player)
-
-    async def cmd_unsync_many(self, player_ids: str) -> None:
-        """Handle UNSYNC command for all the given players.
-
-        Remove the given player from any syncgroups it currently is synced to.
-
-            - player_id: player_id of the player to handle the command.
-        """
-        for player_id in player_ids:
-            await self.cmd_unsync(player_id)
-
     async def cmd_unsync(self, player_id: str) -> None:
         """Unsync Snapcast player."""
         snap_client_id = self._get_snapclient_id(player_id)


### PR DESCRIPTION
The method in the python-snapcast library requires that the sync and unsync be done in series and not in parallel.

Soon I will try to add a method that supports this option since the snapcast api allows these operations in a single call. 