### PR TITLE
Prevent overwriting album_tracks table

### DIFF
--- a/music_assistant/server/controllers/media/tracks.py
+++ b/music_assistant/server/controllers/media/tracks.py
@@ -410,7 +410,6 @@ class TracksController(MediaControllerBase[Track]):
         For digital releases, the discnumber will be just 0 or 1.
         Track number should start counting at 1.
         """
-        
         db_album: Album | ItemMapping = None
         if album.provider == "library":
             db_album = album

--- a/music_assistant/server/controllers/media/tracks.py
+++ b/music_assistant/server/controllers/media/tracks.py
@@ -410,16 +410,7 @@ class TracksController(MediaControllerBase[Track]):
         For digital releases, the discnumber will be just 0 or 1.
         Track number should start counting at 1.
         """
-        if overwrite and album.provider.startswith("filesystem"):
-            # on overwrite, clear the album_tracks table first
-            # this is done for filesystem providers only (to account for changing ID3 tags)
-            # TODO: find a better way to deal with this as this doesn't cover all (edge) cases
-            await self.mass.music.database.delete(
-                DB_TABLE_ALBUM_TRACKS,
-                {
-                    "track_id": db_id,
-                },
-            )
+        
         db_album: Album | ItemMapping = None
         if album.provider == "library":
             db_album = album


### PR DESCRIPTION
If you have the same track on two different albums via the filesystem provider, this code will force an overwrite of the album_tracks table, meaning it only gets shown on a single album, rather than (correctly) in both places.

AIUI the intention of the overwrite is to force rewriting in the case of modified ID3 tags, but the only tags that would be relevant in this case would be disc number and track number, and those should already be taken care of by this line:

https://github.com/music-assistant/server/blob/642ccbef85bd5a190078563e8572a5aa0dbc0e89/music_assistant/server/controllers/media/tracks.py#L453

Which does an insert or update as required.

See https://github.com/music-assistant/hass-music-assistant/issues/2506 for reporting of the issue.