### PR TITLE
Deezer: Fix Playback

### DIFF
--- a/music_assistant/server/providers/deezer/__init__.py
+++ b/music_assistant/server/providers/deezer/__init__.py
@@ -488,12 +488,12 @@ class DeezerProvider(MusicProvider):  # pylint: disable=W0223
             async for chunk in resp.content.iter_chunked(2048):
                 buffer += chunk
                 if len(buffer) >= 2048:
-                    if chunk_index >= skip_chunks:
-                        continue
-                    if chunk_index % 3 > 0:
-                        yield bytes(buffer[:2048])
-                    else:
-                        yield self.decrypt_chunk(bytes(buffer[:2048]), blowfish_key)
+                    if chunk_index >= skip_chunks or chunk_index == 0:
+                        if chunk_index % 3 > 0:
+                            yield bytes(buffer[:2048])
+                        else:
+                            yield self.decrypt_chunk(bytes(buffer[:2048]), blowfish_key)
+
                     chunk_index += 1
                     del buffer[:2048]
         yield bytes(buffer)


### PR DESCRIPTION
Playback from deezer gets possible again with this fix. Unfortunately the `skip_chunk` implementation caused that no chunks were decrypted anymore. The new logic is as follows:
If the current `chunk_index` is greater or equal to the `skip_chunk` value, we will yield the chunk. As we start with an index of 0 this should be the correct behavior - correct me if I am wrong, it has been a long week 😆 
Even if this is not the case, we increase the `chunk_index` and delete its bytes from the buffer. There is one exception from this rule: The first chunk is always used as it contains the audio file header. This is for sure no good solution, but at least for FLAC it's strictly necessary to have this header as ffmpeg won't play the content, if we don't provide it. I was also considering to extract the header only instead of returning the whole first chunk, but I think this is something to be discussed first. It could be better to use the seeking of ffmpeg instead.