### PR TITLE
Double check external ID comparison

### DIFF
--- a/music_assistant/server/controllers/media/base.py
+++ b/music_assistant/server/controllers/media/base.py
@@ -126,7 +126,6 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
             # existing item match by provider id
             await self._update_library_item(cur_item.item_id, item, overwrite=overwrite_existing)
             return cur_item.item_id
-
         if cur_item := await self.get_library_item_by_external_ids(item.external_ids):
             # existing item match by external id
             # Double check external IDs - if MBID exists, regards that as overriding
@@ -135,7 +134,6 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
                     cur_item.item_id, item, overwrite=overwrite_existing
                 )
                 return cur_item.item_id
-
         # search by (exact) name match
         query = f"WHERE {self.db_table}.name = :name OR {self.db_table}.sort_name = :sort_name"
         query_params = {"name": item.name, "sort_name": item.sort_name}

--- a/music_assistant/server/controllers/media/base.py
+++ b/music_assistant/server/controllers/media/base.py
@@ -121,7 +121,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
 
     async def _get_library_item_by_match(
         self, item: Track, overwrite_existing: bool = False
-    ) -> int:
+    ) -> int | None:
         if cur_item := await self.get_library_item_by_prov_id(item.item_id, item.provider):
             # existing item match by provider id
             await self._update_library_item(cur_item.item_id, item, overwrite=overwrite_existing)
@@ -142,9 +142,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         ):
             if compare_media_item(db_item, item, True):
                 # existing item found: update it
-                await self._update_library_item(
-                    db_item.item_id, item, overwrite=overwrite_existing
-                )
+                await self._update_library_item(db_item.item_id, item, overwrite=overwrite_existing)
                 return db_item.item_id
         return None
 

--- a/music_assistant/server/controllers/media/base.py
+++ b/music_assistant/server/controllers/media/base.py
@@ -108,7 +108,9 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
             # existing item match by external id
             # Double check external IDs - if MBID exists, regards that as overriding
             if compare_media_item(item, cur_item):
-                await self._update_library_item(cur_item.item_id, item, overwrite=overwrite_existing)
+                await self._update_library_item(
+                    cur_item.item_id, item, overwrite=overwrite_existing
+                )
                 library_id = cur_item.item_id
         else:
             # search by (exact) name match

--- a/music_assistant/server/controllers/media/base.py
+++ b/music_assistant/server/controllers/media/base.py
@@ -106,8 +106,10 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
             library_id = cur_item.item_id
         elif cur_item := await self.get_library_item_by_external_ids(item.external_ids):
             # existing item match by external id
-            await self._update_library_item(cur_item.item_id, item, overwrite=overwrite_existing)
-            library_id = cur_item.item_id
+            # Double check external IDs - if MBID exists, regards that as overriding
+            if compare_media_item(item, cur_item):
+                await self._update_library_item(cur_item.item_id, item, overwrite=overwrite_existing)
+                library_id = cur_item.item_id
         else:
             # search by (exact) name match
             query = f"WHERE {self.db_table}.name = :name OR {self.db_table}.sort_name = :sort_name"

--- a/music_assistant/server/controllers/media/base.py
+++ b/music_assistant/server/controllers/media/base.py
@@ -100,7 +100,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
             await self.mass.metadata.get_metadata(item)
         # check for existing item first
         library_id = await self._get_library_item_by_match(item, overwrite_existing)
-        
+
         if library_id is None:
             # actually add a new item in the library db
             async with self._db_add_lock:
@@ -135,7 +135,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
                     cur_item.item_id, item, overwrite=overwrite_existing
                 )
                 return cur_item.item_id
-        
+
         # search by (exact) name match
         query = f"WHERE {self.db_table}.name = :name OR {self.db_table}.sort_name = :sort_name"
         query_params = {"name": item.name, "sort_name": item.sort_name}

--- a/music_assistant/server/controllers/media/base.py
+++ b/music_assistant/server/controllers/media/base.py
@@ -99,33 +99,8 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         if metadata_lookup:
             await self.mass.metadata.get_metadata(item)
         # check for existing item first
-        library_id = None
-        if cur_item := await self.get_library_item_by_prov_id(item.item_id, item.provider):
-            # existing item match by provider id
-            await self._update_library_item(cur_item.item_id, item, overwrite=overwrite_existing)
-            library_id = cur_item.item_id
-        elif cur_item := await self.get_library_item_by_external_ids(item.external_ids):
-            # existing item match by external id
-            # Double check external IDs - if MBID exists, regards that as overriding
-            if compare_media_item(item, cur_item):
-                await self._update_library_item(
-                    cur_item.item_id, item, overwrite=overwrite_existing
-                )
-                library_id = cur_item.item_id
-        else:
-            # search by (exact) name match
-            query = f"WHERE {self.db_table}.name = :name OR {self.db_table}.sort_name = :sort_name"
-            query_params = {"name": item.name, "sort_name": item.sort_name}
-            async for db_item in self.iter_library_items(
-                extra_query=query, extra_query_params=query_params
-            ):
-                if compare_media_item(db_item, item, True):
-                    # existing item found: update it
-                    await self._update_library_item(
-                        db_item.item_id, item, overwrite=overwrite_existing
-                    )
-                    library_id = db_item.item_id
-                    break
+        library_id = await self._get_library_item_by_match(item, overwrite_existing)
+        
         if library_id is None:
             # actually add a new item in the library db
             async with self._db_add_lock:
@@ -143,6 +118,37 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
             library_item,
         )
         return library_item
+
+    async def _get_library_item_by_match(
+        self, item: Track, overwrite_existing: bool = False
+    ) -> int:
+        if cur_item := await self.get_library_item_by_prov_id(item.item_id, item.provider):
+            # existing item match by provider id
+            await self._update_library_item(cur_item.item_id, item, overwrite=overwrite_existing)
+            return cur_item.item_id
+
+        if cur_item := await self.get_library_item_by_external_ids(item.external_ids):
+            # existing item match by external id
+            # Double check external IDs - if MBID exists, regards that as overriding
+            if compare_media_item(item, cur_item):
+                await self._update_library_item(
+                    cur_item.item_id, item, overwrite=overwrite_existing
+                )
+                return cur_item.item_id
+        
+        # search by (exact) name match
+        query = f"WHERE {self.db_table}.name = :name OR {self.db_table}.sort_name = :sort_name"
+        query_params = {"name": item.name, "sort_name": item.sort_name}
+        async for db_item in self.iter_library_items(
+            extra_query=query, extra_query_params=query_params
+        ):
+            if compare_media_item(db_item, item, True):
+                # existing item found: update it
+                await self._update_library_item(
+                    db_item.item_id, item, overwrite=overwrite_existing
+                )
+                return db_item.item_id
+        return None
 
     async def update_item_in_library(
         self, item_id: str | int, update: ItemCls, overwrite: bool = False


### PR DESCRIPTION
Additional logic got added to the compare_track function that accounts for ISRCs. When importing, it doesn't make it that far though. This is slightly clunky, but adding in an extra double check should handle it.