### PR TITLE
Avoid subshells when using check_output

### DIFF
--- a/music_assistant/server/helpers/audio.py
+++ b/music_assistant/server/helpers/audio.py
@@ -819,7 +819,7 @@ async def get_ffmpeg_stream(
 async def check_audio_support() -> tuple[bool, bool, str]:
     """Check if ffmpeg is present (with/without libsoxr support)."""
     # check for FFmpeg presence
-    returncode, output = await check_output("ffmpeg -version")
+    returncode, output = await check_output(["ffmpeg", "-version"])
     ffmpeg_present = returncode == 0 and "FFmpeg" in output.decode()
 
     # use globals as in-memory cache

--- a/music_assistant/server/providers/airplay/__init__.py
+++ b/music_assistant/server/providers/airplay/__init__.py
@@ -723,7 +723,7 @@ class AirplayProvider(PlayerProvider):
                 empty_queue(buffer)
 
         # get current ntp and start cliraop
-        _, stdout = await check_output(f"{self.cliraop_bin} -ntp")
+        _, stdout = await check_output(self.cliraop_bin, "-ntp")
         start_ntp = int(stdout.strip())
         wait_start = 1250 + (250 * len(sync_clients))
         await asyncio.gather(

--- a/music_assistant/server/providers/filesystem_smb/__init__.py
+++ b/music_assistant/server/providers/filesystem_smb/__init__.py
@@ -220,7 +220,10 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
             raise LoginFailed(msg)
 
         self.logger.info("Mounting //%s/%s%s to %s", server, share, subfolder, self.base_path)
-        self.logger.debug("Using mount command: %s", mount_cmd.replace(password, "########"))
+        self.logger.debug(
+            "Using mount command: %s",
+            [m.replace(password, "########") if password else m for m in mount_cmd],
+        )
 
         returncode, output = await check_output(mount_cmd)
         if returncode != 0:

--- a/music_assistant/server/providers/filesystem_smb/__init__.py
+++ b/music_assistant/server/providers/filesystem_smb/__init__.py
@@ -186,7 +186,13 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
 
         if platform.system() == "Darwin":
             password_str = f":{password}" if password else ""
-            mount_cmd = f'mount -t smbfs "//{username}:{password_str}@{server}/{share}{subfolder}" "{self.base_path}"'  # noqa: E501
+            mount_cmd = [
+                "mount",
+                "-t",
+                "smbfs",
+                f"//{username}:{password_str}@{server}/{share}{subfolder}",
+                self.base_path,
+            ]
 
         elif platform.system() == "Linux":
             options = [
@@ -199,10 +205,15 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
                 options += mount_options.split(",")
 
             options_str = ",".join(options)
-            mount_cmd = (
-                f"mount -t cifs -o {options_str} "
-                f'"//{server}/{share}{subfolder}" "{self.base_path}"'
-            )
+            mount_cmd = [
+                "mount",
+                "-t",
+                "cifs",
+                "-o",
+                options_str,
+                f"//{server}/{share}{subfolder}",
+                self.base_path,
+            ]
 
         else:
             msg = f"SMB provider is not supported on {platform.system()}"
@@ -218,6 +229,6 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
 
     async def unmount(self, ignore_error: bool = False) -> None:
         """Unmount the remote share."""
-        returncode, output = await check_output(f"umount {self.base_path}")
+        returncode, output = await check_output(["umount", self.base_path])
         if returncode != 0 and not ignore_error:
             self.logger.warning("SMB unmount failed with error: %s", output.decode())

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -108,7 +108,7 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
-    returncode, output = await check_output("snapserver -v")
+    returncode, output = await check_output(["snapserver", "-v"])
     snapserver_present = returncode == 0 and "snapserver v0.27.0" in output.decode()
     return (
         ConfigEntry(


### PR DESCRIPTION
A few places were passing `str` to check_output rather then `list[str]`. The list is better - avoids needing to worry about escaping (for security), avoids a few fstrings, and avoids creating /bin/sh instances we don't need.

Hopefully fixes: https://github.com/music-assistant/hass-music-assistant/issues/2234 https://github.com/music-assistant/hass-music-assistant/issues/2266