### PR TITLE
YTMusic: Fix missing metadata for Artists on library sync

### DIFF
--- a/music_assistant/server/providers/ytmusic/__init__.py
+++ b/music_assistant/server/providers/ytmusic/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from time import time
+from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 
@@ -778,10 +779,16 @@ class YoutubeMusicProvider(MusicProvider):
                 "quiet": self.logger.level > logging.DEBUG,
                 "username": "oauth2",
                 "password": "",
+                "extractor_args": {
+                    "youtube": {"skip": ["translated_subs", "dash"], "player_client": ["ios"]}
+                },
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 try:
+                    start = timer()
                     info = ydl.extract_info(url, download=False)
+                    end = timer()
+                    self.logger.debug("YTMusic extract stream info took %s seconds", end - start)
                 except yt_dlp.utils.DownloadError as err:
                     raise UnplayableMediaError(err) from err
                 format_selector = ydl.build_format_selector("m4a/bestaudio")

--- a/music_assistant/server/providers/ytmusic/helpers.py
+++ b/music_assistant/server/providers/ytmusic/helpers.py
@@ -94,7 +94,6 @@ async def get_track(
             "thumbnails"
         ]
         track["isAvailable"] = track_obj["playabilityStatus"]["status"] == "OK"
-        track["streamingData"] = track_obj["streamingData"]
         return track
 
     return await asyncio.to_thread(_get_song)


### PR DESCRIPTION
Fixes missing thumbs and descriptions during initial library sync. Previously, Artists were added as ItemMappings because of the missing info. However, those were never refreshed unless the were actively clicked on by the user. With this change, full artist details will be fetched during the library sync from YT Music, also relieving some stress on MusicBrainz.