### PR TITLE
Don't load_provider if provider already deleted

### DIFF
--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -802,11 +802,12 @@ class ConfigController:
         )
         # validate the new config
         config.validate()
-        # try to load the provider first to catch errors before we save it.
-        await self.mass.load_provider(config, raise_on_error=True)
-        # the load was a success, store this config
+
         conf_key = f"{CONF_PROVIDERS}/{config.instance_id}"
         self.set(conf_key, config.to_raw())
+
+        await self.mass.load_provider(instance_id, raise_on_error=True)
+
         return config
 
     async def _load_provider_config(self, config: ProviderConfig) -> None:
@@ -818,8 +819,8 @@ class ConfigController:
                 deps.add(dep_prov.instance_id)
                 await self.mass.unload_provider(dep_prov.instance_id)
         # (re)load the provider
-        await self.mass.load_provider(config)
+        await self.mass.load_provider(config.instance_id)
         # reload any dependants
         for dep in deps:
             conf = await self.get_provider_config(dep)
-            await self.mass.load_provider(conf)
+            await self.mass.load_provider(conf.instance_id)

--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -802,12 +802,11 @@ class ConfigController:
         )
         # validate the new config
         config.validate()
-
+        # try to load the provider first to catch errors before we save it.
+        await self.mass.load_provider_config(config)
+        # the load was a success, store this config
         conf_key = f"{CONF_PROVIDERS}/{config.instance_id}"
         self.set(conf_key, config.to_raw())
-
-        await self.mass.load_provider(instance_id, raise_on_error=True)
-
         return config
 
     async def _load_provider_config(self, config: ProviderConfig) -> None:

--- a/music_assistant/server/server.py
+++ b/music_assistant/server/server.py
@@ -417,11 +417,21 @@ class MusicAssistant:
 
     async def load_provider(
         self,
-        prov_conf: ProviderConfig,
+        instance_id: str,
         raise_on_error: bool = False,
         schedule_retry: int | None = 10,
     ) -> None:
         """Try to load a provider and catch errors."""
+        try:
+            prov_conf = await self.config.get_provider_config(instance_id)
+        except KeyError:
+            # Was deleted before we could run
+            return
+
+        if not prov_conf.enabled:
+            # Was disabled before we could run
+            return
+
         try:
             await self._load_provider(prov_conf)
         # pylint: disable=broad-except
@@ -443,13 +453,13 @@ class MusicAssistant:
             # if loading failed, we store the error in the config object
             # so we can show something useful to the user
             prov_conf.last_error = str(exc)
-            self.config.set(f"{CONF_PROVIDERS}/{prov_conf.instance_id}/last_error", str(exc))
+            self.config.set(f"{CONF_PROVIDERS}/{instance_id}/last_error", str(exc))
             # auto schedule a retry if the (re)load failed
             if schedule_retry:
                 self.call_later(
                     schedule_retry,
                     self.load_provider,
-                    prov_conf,
+                    instance_id,
                     raise_on_error,
                     min(schedule_retry + 10, 600),
                 )
@@ -515,7 +525,7 @@ class MusicAssistant:
             for prov_conf in prov_configs:
                 if not prov_conf.enabled:
                     continue
-                tg.create_task(self.load_provider(prov_conf))
+                tg.create_task(self.load_provider(prov_conf.instance_id))
 
     async def _load_provider(self, conf: ProviderConfig) -> None:
         """Load (or reload) a provider."""


### PR DESCRIPTION
Our retry logic never stops trying to load a provider until it works. Even after a provider is removed.

Because failures are captured with `self.config.set`, this causes corruption where we re-insert a nearly empty dict for an instance id:

```
  "providers": {
    "snapcast--e8gUtVPG": {
      "last_error": "Unable to start the Snapserver connection ?"
    }
  }
```

This PR changes things to make sure a provider still exists in the config system before trying to load_provider. The corruption never happens, and the looping stops.

The problem with this approach is that it requires a ProviderConfig to be stored *before* we can call load_provider. This is a change in behaviour.