### PR TITLE
Bump py-opensonic to 5.1.1

### DIFF
--- a/music_assistant/server/providers/opensubsonic/manifest.json
+++ b/music_assistant/server/providers/opensubsonic/manifest.json
@@ -7,7 +7,7 @@
     "@khers"
   ],
   "requirements": [
-    "py-opensonic==5.1.0"
+    "py-opensonic==5.1.1"
   ],
   "documentation": "https://music-assistant.io/music-providers/subsonic/",
   "multi_instance": true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -27,7 +27,7 @@ music-assistant-frontend==2.5.15
 orjson==3.10.5
 pillow==10.4.0
 plexapi==4.15.13
-py-opensonic==5.1.0
+py-opensonic==5.1.1
 PyChromecast==14.0.1
 pycryptodome==3.20.0
 python-fullykiosk==0.0.14


### PR DESCRIPTION
For a relaxation of the responses package version requirement.