### PR TITLE
Snapcast: Reload built-in server in case of connection loss

### DIFF
--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -301,8 +301,8 @@ class SnapCastProvider(PlayerProvider):
                 "Started connection to Snapserver %s",
                 f"{self._snapcast_server_host}:{self._snapcast_server_control_port}",
             )
-            if self._use_builtin_server:
-                self._snapserver.set_on_disconnect_callback(self._restart_builtin_server)
+            # if self._use_builtin_server:
+            # self._snapserver.set_on_disconnect_callback(self._restart_builtin_server)
 
         except OSError as err:
             msg = "Unable to start the Snapserver connection ?"

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -284,7 +284,7 @@ class SnapCastProvider(PlayerProvider):
         self._ids_map = bidict({})
 
         if self._use_builtin_server:
-            self._start_builtin_server()
+            await self._start_builtin_server()
         else:
             self._snapserver_runner = None
             self._snapserver_started = None

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -675,7 +675,7 @@ class SnapCastProvider(PlayerProvider):
         if self._use_builtin_server and self._builtin_server_retry > 1:
             self.logger.info("Restarting, built-in Snapserver.")
             await self._stop_builtin_server()
-            await asyncio.sleep(10)
+            await asyncio.sleep(10)  # prevent race conditions when reloading
             await self._start_builtin_server()
         else:
             self._builtin_server_retry += 1
@@ -686,7 +686,6 @@ class SnapCastProvider(PlayerProvider):
         self.logger.info("Stopping, built-in Snapserver")
         if self._snapserver_runner and not self._snapserver_runner.done():
             self._snapserver_runner.cancel()
-            await asyncio.sleep(10)  # prevent race conditions when reloading
             self._snapserver_started.clear()
 
     async def _start_builtin_server(self) -> None:

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -669,7 +669,7 @@ class SnapCastProvider(PlayerProvider):
                         # where we try to connect too soon
                         self.mass.loop.call_later(2, self._snapserver_started.set)
 
-    async def _restart_builtin_server(self):
+    async def _restart_builtin_server(self) -> None:
         """Restart the built-in Snapserver."""
         if self._use_builtin_server:
             self.logger.info("Restarting, built-in Snapserver.")
@@ -677,7 +677,7 @@ class SnapCastProvider(PlayerProvider):
             await asyncio.sleep(10)
             await self._start_builtin_server()
 
-    async def _stop_builtin_server(self):
+    async def _stop_builtin_server(self) -> None:
         """Stop the built-in Snapserver."""
         self.logger.info("Stopping, built-in Snapserver")
         if self._snapserver_runner and not self._snapserver_runner.done():
@@ -685,7 +685,7 @@ class SnapCastProvider(PlayerProvider):
             await asyncio.sleep(10)  # prevent race conditions when reloading
             self._snapserver_started.clear()
 
-    async def _start_builtin_server(self):
+    async def _start_builtin_server(self) -> None:
         """Start the built-in Snapserver."""
         self._snapserver_started = asyncio.Event()
         self._snapserver_runner = asyncio.create_task(self._builtin_server_runner())

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -285,6 +285,7 @@ class SnapCastProvider(PlayerProvider):
 
         if self._use_builtin_server:
             await self._start_builtin_server()
+            await asyncio.sleep(10)
         else:
             self._snapserver_runner = None
             self._snapserver_started = None

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -674,7 +674,8 @@ class SnapCastProvider(PlayerProvider):
         if self._use_builtin_server:
             self.logger.info("Restarting, built-in Snapserver.")
             await self._stop_builtin_server()
-            raise NotImplementedError
+            await asyncio.sleep(10)
+            await self._start_builtin_server()
 
     async def _stop_builtin_server(self):
         """Stop the built-in Snapserver."""

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -285,7 +285,6 @@ class SnapCastProvider(PlayerProvider):
 
         if self._use_builtin_server:
             await self._start_builtin_server()
-            await asyncio.sleep(10)
         else:
             self._snapserver_runner = None
             self._snapserver_started = None
@@ -301,8 +300,8 @@ class SnapCastProvider(PlayerProvider):
                 "Started connection to Snapserver %s",
                 f"{self._snapcast_server_host}:{self._snapcast_server_control_port}",
             )
-            # if self._use_builtin_server:
-            # self._snapserver.set_on_disconnect_callback(self._restart_builtin_server)
+            if self._use_builtin_server:
+                self._snapserver.set_on_disconnect_callback(self._restart_builtin_server)
 
         except OSError as err:
             msg = "Unable to start the Snapserver connection ?"

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -320,7 +320,6 @@ class SnapCastProvider(PlayerProvider):
             player_id = self._get_ma_id(snap_client_id)
             await self.cmd_stop(player_id)
         self._snapserver.stop()
-        await asyncio.sleep(10)
         await self._stop_builtin_server()
 
     def on_player_config_removed(self, player_id: str) -> None:

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -673,11 +673,14 @@ class SnapCastProvider(PlayerProvider):
 
     async def _restart_builtin_server(self) -> None:
         """Restart the built-in Snapserver."""
-        if self._use_builtin_server:
+        if self._use_builtin_server and self._builtin_server_retry > 1:
             self.logger.info("Restarting, built-in Snapserver.")
             await self._stop_builtin_server()
             await asyncio.sleep(10)
             await self._start_builtin_server()
+        else:
+            self._builtin_server_retry += 1
+            self.logger.debug("Increase snapcast retry count")
 
     async def _stop_builtin_server(self) -> None:
         """Stop the built-in Snapserver."""
@@ -689,12 +692,8 @@ class SnapCastProvider(PlayerProvider):
 
     async def _start_builtin_server(self) -> None:
         """Start the built-in Snapserver."""
-        if not self._use_builtin_server:
-            return
-        if self._builtin_server_retry > 1:
+        if self._use_builtin_server:
             self._builtin_server_retry = 0
             self._snapserver_started = asyncio.Event()
             self._snapserver_runner = asyncio.create_task(self._builtin_server_runner())
             await asyncio.wait_for(self._snapserver_started.wait(), 10)
-        else:
-            self._builtin_server_retry += 1


### PR DESCRIPTION
I have found that sometimes the snapserver can crash, due to lack of ram I think. Use the connection down callback. Allow 1 try. if it fails restart the server. 