### PR TITLE
Reload Snapcast provider when connection to the server gets lost

### DIFF
--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -313,7 +313,11 @@ class ConfigController:
     @api_command("config/providers/reload")
     async def reload_provider(self, instance_id: str) -> None:
         """Reload provider."""
-        config = await self.get_provider_config(instance_id)
+        try:
+            config = await self.get_provider_config(instance_id)
+        except KeyError:
+            # Edge case: Provider was removed before we could reload it
+            return
         await self._load_provider_config(config)
 
     @api_command("config/players")


### PR DESCRIPTION
Another implementation for reloading snapcast when the connection to the server gets lost, which will work for both the builtin and external servers. It will also prevent a race condition when the connection drops 