### PR TITLE
Better handle of SMB mount with special characters in username/password

### DIFF
--- a/music_assistant/server/helpers/process.py
+++ b/music_assistant/server/helpers/process.py
@@ -257,12 +257,10 @@ class AsyncProcess:
         return self._returncode
 
 
-async def check_output(*args: str) -> tuple[int, bytes]:
+async def check_output(*args: str, env: dict[str, str] | None = None) -> tuple[int, bytes]:
     """Run subprocess and return returncode and output."""
     proc = await asyncio.create_subprocess_exec(
-        *args,
-        stderr=asyncio.subprocess.STDOUT,
-        stdout=asyncio.subprocess.PIPE,
+        *args, stderr=asyncio.subprocess.STDOUT, stdout=asyncio.subprocess.PIPE, env=env
     )
     stdout, _ = await proc.communicate()
     return (proc.returncode, stdout)

--- a/music_assistant/server/providers/filesystem_smb/__init__.py
+++ b/music_assistant/server/providers/filesystem_smb/__init__.py
@@ -190,17 +190,19 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
                 "mount",
                 "-t",
                 "smbfs",
-                f"//{username}:{password_str}@{server}/{share}{subfolder}",
+                f"//{username}{password_str}@{server}/{share}{subfolder}",
                 self.base_path,
             ]
 
         elif platform.system() == "Linux":
+            quote = '"' if "'" in username else "'"
             options = [
                 "rw",
-                f'username="{username}"',
+                f"username={quote}{username}{quote}",
             ]
             if password:
-                options.append(f'password="{password}"')
+                quote = '"' if "'" in password else "'"
+                options.append(f"password={quote}{password}{quote}")
             if mount_options := self.config.get_value(CONF_MOUNT_OPTIONS):
                 options += mount_options.split(",")
 

--- a/music_assistant/server/providers/filesystem_smb/__init__.py
+++ b/music_assistant/server/providers/filesystem_smb/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import platform
+import urllib.parse
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
@@ -174,9 +175,6 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
         username: str = self.config.get_value(CONF_USERNAME)
         password: str = self.config.get_value(CONF_PASSWORD)
         share: str = self.config.get_value(CONF_SHARE)
-        # escape quotes in username and password
-        username_str = username.replace('"', '\\"')
-        password_str = f":{password.replace('"', '\\"')}" if password else ""
 
         # handle optional subfolder
         subfolder: str = self.config.get_value(CONF_SUBFOLDER)
@@ -188,6 +186,8 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
                 subfolder = subfolder[:-1]
 
         if platform.system() == "Darwin":
+            username_str = urllib.parse.quote(username)
+            password_str = f":{urllib.parse.quote(password)}" if password else ""
             mount_cmd = [
                 "mount",
                 "-t",
@@ -197,6 +197,9 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
             ]
 
         elif platform.system() == "Linux":
+            # escape quotes in username and password
+            username_str = username.replace('"', '\\"')
+            password_str = f":{password.replace('"', '\\"')}" if password else ""
             options = [
                 "rw",
                 f"username={username_str}",

--- a/music_assistant/server/providers/filesystem_smb/__init__.py
+++ b/music_assistant/server/providers/filesystem_smb/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import platform
-import urllib.parse
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
@@ -186,13 +185,13 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
                 subfolder = subfolder[:-1]
 
         if platform.system() == "Darwin":
-            username_str = urllib.parse.quote(username)
-            password_str = f":{urllib.parse.quote(password)}" if password else ""
+            # NOTE: MacOS does not support special characters in the username/password
+            password_str = f":{password}" if password else ""
             mount_cmd = [
                 "mount",
                 "-t",
                 "smbfs",
-                f"//{username_str}{password_str}@{server}/{share}{subfolder}",
+                f"//{username}{password_str}@{server}/{share}{subfolder}",
                 self.base_path,
             ]
 


### PR DESCRIPTION
- Fix smb mount on MacOS
- Fix mount command if the username or password includes quotes

To handle special characters in the username and/or password, they need to be quoted correctly but the username/password can also contain quotes on its own, so our previous solution wasnt fail proof

Using environmental variables it works - it accepts all the special characters now
Only MacOS doesn't work but as that is dev only, we shouldn't care
