### PR TITLE
A collection of small bugfixes and optimizations

### DIFF
--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -479,6 +479,10 @@ CONF_ENTRY_ENFORCE_MP3 = ConfigEntry(
     category="audio",
 )
 
+CONF_ENTRY_ENFORCE_MP3_DEFAULT_ENABLED = ConfigEntry.from_dict(
+    {**CONF_ENTRY_ENFORCE_MP3.to_dict(), "default_value": True}
+)
+
 CONF_ENTRY_SYNC_ADJUST = ConfigEntry(
     key=CONF_SYNC_ADJUST,
     type=ConfigEntryType.INTEGER,

--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -54,10 +54,10 @@ ConfigValueType = (
     | int
     | float
     | bool
+    | list[tuple[int, int]]
     | tuple[int, int]
     | list[str]
     | list[int]
-    | list[tuple[int, int]]
     | Enum
     | None
 )

--- a/music_assistant/common/models/media_items.py
+++ b/music_assistant/common/models/media_items.py
@@ -479,12 +479,18 @@ class AlbumTrack(Track):
     ) -> AlbumTrack:
         """Cast Track to AlbumTrack."""
         album_track = track.to_dict()
-        if album is None and track.album:
-            album_track["album"] = track.album
-        if disc_number is None:
-            album_track["disc_number"] = track.disc_number
-        if track_number is None:
-            album_track["track_number"] = track.track_number
+        if album_track["album"] is None:
+            if not album:
+                raise InvalidDataError("AlbumTrack requires an album")
+            album_track["album"] = album
+        if album_track["disc_number"] is None:
+            if disc_number is None:
+                raise InvalidDataError("AlbumTrack requires a disc_number")
+            album_track["disc_number"] = disc_number
+        if album_track["track_number"] is None:
+            if track_number is None:
+                raise InvalidDataError("AlbumTrack requires a track_number")
+            album_track["track_number"] = track_number
         # let mushmumaro instantiate a new object - this will ensure that valididation takes place
         return AlbumTrack.from_dict(album_track)
 

--- a/music_assistant/common/models/media_items.py
+++ b/music_assistant/common/models/media_items.py
@@ -482,7 +482,7 @@ class AlbumTrack(Track):
         if album_track["album"] is None:
             if not album:
                 raise InvalidDataError("AlbumTrack requires an album")
-            album_track["album"] = album
+            album_track["album"] = album.to_dict()
         if album_track["disc_number"] is None:
             if disc_number is None:
                 raise InvalidDataError("AlbumTrack requires a disc_number")

--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -837,7 +837,7 @@ class ConfigController:
                 deps.add(dep_prov.instance_id)
                 await self.mass.unload_provider(dep_prov.instance_id)
         # (re)load the provider
-        await self.mass.load_provider(config.instance_id)
+        await self.mass.load_provider_config(config)
         # reload any dependants
         for dep in deps:
             conf = await self.get_provider_config(dep)

--- a/music_assistant/server/helpers/tags.py
+++ b/music_assistant/server/helpers/tags.py
@@ -431,7 +431,12 @@ async def parse_tags(
         if not tags.duration and tags.raw.get("format", {}).get("duration"):
             tags.duration = float(tags.raw["format"]["duration"])
 
-        if file_path.endswith(".mp3") and "musicbrainzrecordingid" not in tags.tags:
+        if (
+            not file_path.startswith("http")
+            and file_path.endswith(".mp3")
+            and "musicbrainzrecordingid" not in tags.tags
+            and await asyncio.to_thread(os.path.isfile, file_path)
+        ):
             # eyed3 is able to extract the musicbrainzrecordingid from the unique file id
             # this is actually a bug in ffmpeg/ffprobe which does not expose this tag
             # so we use this as alternative approach for mp3 files

--- a/music_assistant/server/providers/airplay/__init__.py
+++ b/music_assistant/server/providers/airplay/__init__.py
@@ -115,6 +115,15 @@ AIRPLAY_PCM_FORMAT = AudioFormat(
 CONF_ENTRY_SAMPLE_RATES_AIRPLAY = create_sample_rates_config_entry(44100, 16, 44100, 16, True)
 
 
+# TODO: Airplay provider
+# - split up and cleanup the code into more digestable parts
+# - Implement authentication for Apple TV
+# - Implement volume control for Apple devices using pyatv
+# - Implement metadata for Apple Apple devices using pyatv
+# - Use pyatv for communicating with original Apple devices
+# and use cliraop for actual streaming
+
+
 async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:

--- a/music_assistant/server/providers/dlna/helpers.py
+++ b/music_assistant/server/providers/dlna/helpers.py
@@ -28,13 +28,10 @@ class DLNANotifyServer(UpnpNotifyServer):
 
     async def _handle_request(self, request: Request) -> Response:
         """Handle incoming requests."""
-        headers = request.headers
-        body = await request.text()
-
         if request.method != "NOTIFY":
             return Response(status=405)
 
-        status = await self.event_handler.handle_notify(headers, body)
+        status = await self.event_handler.handle_notify(request)
 
         return Response(status=status)
 

--- a/music_assistant/server/providers/dlna/helpers.py
+++ b/music_assistant/server/providers/dlna/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from aiohttp.web import Request, Response
+from async_upnp_client.const import HttpRequest
 from async_upnp_client.event_handler import UpnpEventHandler, UpnpNotifyServer
 
 if TYPE_CHECKING:
@@ -31,7 +32,15 @@ class DLNANotifyServer(UpnpNotifyServer):
         if request.method != "NOTIFY":
             return Response(status=405)
 
-        status = await self.event_handler.handle_notify(request)
+        # transform aiohttp request to async_upnp_client request
+        http_request = HttpRequest(
+            method=request.method,
+            url=request.url,
+            headers=request.headers,
+            body=await request.text(),
+        )
+
+        status = await self.event_handler.handle_notify(http_request)
 
         return Response(status=status)
 

--- a/music_assistant/server/providers/filesystem_smb/__init__.py
+++ b/music_assistant/server/providers/filesystem_smb/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import platform
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
@@ -221,6 +222,7 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
             [m.replace(password, "########") if password else m for m in mount_cmd],
         )
         env_vars = {
+            **os.environ,
             "USER": username,
         }
         if password:

--- a/music_assistant/server/providers/fully_kiosk/__init__.py
+++ b/music_assistant/server/providers/fully_kiosk/__init__.py
@@ -12,7 +12,7 @@ from fullykiosk import FullyKiosk
 from music_assistant.common.models.config_entries import (
     CONF_ENTRY_CROSSFADE,
     CONF_ENTRY_CROSSFADE_DURATION,
-    CONF_ENTRY_ENFORCE_MP3,
+    CONF_ENTRY_ENFORCE_MP3_DEFAULT_ENABLED,
     CONF_ENTRY_FLOW_MODE_ENFORCED,
     ConfigEntry,
     ConfigValueType,
@@ -25,7 +25,13 @@ from music_assistant.common.models.enums import (
 )
 from music_assistant.common.models.errors import PlayerUnavailableError, SetupFailedError
 from music_assistant.common.models.player import DeviceInfo, Player, PlayerMedia
-from music_assistant.constants import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, VERBOSE_LOG_LEVEL
+from music_assistant.constants import (
+    CONF_ENFORCE_MP3,
+    CONF_IP_ADDRESS,
+    CONF_PASSWORD,
+    CONF_PORT,
+    VERBOSE_LOG_LEVEL,
+)
 from music_assistant.server.models.player_provider import PlayerProvider
 
 if TYPE_CHECKING:
@@ -35,7 +41,6 @@ if TYPE_CHECKING:
     from music_assistant.server.models import ProviderInstanceType
 
 AUDIOMANAGER_STREAM_MUSIC = 3
-CONF_ENFORCE_MP3 = "enforce_mp3"
 
 
 async def setup(
@@ -164,7 +169,7 @@ class FullyKioskProvider(PlayerProvider):
             CONF_ENTRY_FLOW_MODE_ENFORCED,
             CONF_ENTRY_CROSSFADE,
             CONF_ENTRY_CROSSFADE_DURATION,
-            CONF_ENTRY_ENFORCE_MP3,
+            CONF_ENTRY_ENFORCE_MP3_DEFAULT_ENABLED,
         )
 
     async def cmd_volume_set(self, player_id: str, volume_level: int) -> None:
@@ -188,7 +193,7 @@ class FullyKioskProvider(PlayerProvider):
     ) -> None:
         """Handle PLAY MEDIA on given player."""
         player = self.mass.players.get(player_id)
-        if self.mass.config.get_raw_player_config_value(player_id, CONF_ENFORCE_MP3, False):
+        if self.mass.config.get_raw_player_config_value(player_id, CONF_ENFORCE_MP3, True):
             media.uri = media.uri.replace(".flac", ".mp3")
         await self._fully.playSound(media.uri, AUDIOMANAGER_STREAM_MUSIC)
         player.current_media = media

--- a/music_assistant/server/providers/hass/__init__.py
+++ b/music_assistant/server/providers/hass/__init__.py
@@ -165,7 +165,8 @@ class HomeAssistant(PluginProvider):
         try:
             await self.hass.connect()
         except BaseHassClientError as err:
-            raise SetupFailedError(str(err) or err.__class__.__name__) from err
+            err_msg = str(err) or err.__class__.__name__
+            raise SetupFailedError(err_msg) from err
         self._listen_task = self.mass.create_task(self._hass_listener())
 
     async def unload(self) -> None:

--- a/music_assistant/server/providers/hass/__init__.py
+++ b/music_assistant/server/providers/hass/__init__.py
@@ -165,7 +165,7 @@ class HomeAssistant(PluginProvider):
         try:
             await self.hass.connect()
         except BaseHassClientError as err:
-            raise SetupFailedError from err
+            raise SetupFailedError(str(err) or err.__class__.__name__) from err
         self._listen_task = self.mass.create_task(self._hass_listener())
 
     async def unload(self) -> None:

--- a/music_assistant/server/providers/hass_players/__init__.py
+++ b/music_assistant/server/providers/hass_players/__init__.py
@@ -15,7 +15,7 @@ from music_assistant.common.helpers.datetime import from_iso_string
 from music_assistant.common.models.config_entries import (
     CONF_ENTRY_CROSSFADE_DURATION,
     CONF_ENTRY_CROSSFADE_FLOW_MODE_REQUIRED,
-    CONF_ENTRY_ENFORCE_MP3,
+    CONF_ENTRY_ENFORCE_MP3_DEFAULT_ENABLED,
     CONF_ENTRY_FLOW_MODE_DEFAULT_ENABLED,
     ConfigEntry,
     ConfigValueOption,
@@ -89,9 +89,6 @@ class MediaPlayerEntityFeature(IntFlag):
 
 CONF_ENFORCE_MP3 = "enforce_mp3"
 
-CONF_ENTRY_ENFORCE_MP3_DEFAULT_ENABLED = ConfigEntry.from_dict(
-    {**CONF_ENTRY_ENFORCE_MP3.to_dict(), "default_value": True}
-)
 
 PLAYER_CONFIG_ENTRIES = (
     CONF_ENTRY_CROSSFADE_FLOW_MODE_REQUIRED,
@@ -233,7 +230,7 @@ class HomeAssistantPlayers(PlayerProvider):
 
     async def play_media(self, player_id: str, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on given player."""
-        if self.mass.config.get_raw_player_config_value(player_id, CONF_ENFORCE_MP3, False):
+        if self.mass.config.get_raw_player_config_value(player_id, CONF_ENFORCE_MP3, True):
             media.uri = media.uri.replace(".flac", ".mp3")
         await self.hass_prov.hass.call_service(
             domain="media_player",
@@ -264,7 +261,7 @@ class HomeAssistantPlayers(PlayerProvider):
 
     async def enqueue_next_media(self, player_id: str, media: PlayerMedia) -> None:
         """Handle enqueuing of the next queue item on the player."""
-        if self.mass.config.get_raw_player_config_value(player_id, CONF_ENFORCE_MP3, False):
+        if self.mass.config.get_raw_player_config_value(player_id, CONF_ENFORCE_MP3, True):
             media.uri = media.uri.replace(".flac", ".mp3")
         await self.hass_prov.hass.call_service(
             domain="media_player",


### PR DESCRIPTION
- Fix AlbumTrack parse from regular track
- Prevent lookups in non-existent folders
- Do not try to read ID3 tags from URL's with eyed3 
- Ignore volume DMCP request from apple devices
- Fix event handler for DLNA
- Fix saving more than 2 sample rates
- Enforce default mp3 codec on hass players