### PR TITLE
Fix provider load at startup

### DIFF
--- a/music_assistant/server/providers/hass/__init__.py
+++ b/music_assistant/server/providers/hass/__init__.py
@@ -117,6 +117,14 @@ async def get_config_entries(
                 value=None,
                 hidden=True,
             ),
+            ConfigEntry(
+                key=CONF_VERIFY_SSL,
+                type=ConfigEntryType.BOOLEAN,
+                label=CONF_VERIFY_SSL,
+                required=False,
+                default_value=False,
+                hidden=True,
+            ),
         )
     # manual configuration
     return (


### PR DESCRIPTION
- Prevent that one failing provider aborts the other provider loads
- Fix Home Assistant Plugin load on supervisor installs