### PR TITLE
Use TaskManager instead of TaskGroup

### DIFF
--- a/music_assistant/server/helpers/multi_client_stream.py
+++ b/music_assistant/server/helpers/multi_client_stream.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from music_assistant.common.helpers.util import empty_queue
 from music_assistant.common.models.media_items import AudioFormat
 from music_assistant.server.helpers.audio import get_ffmpeg_stream
+from music_assistant.server.helpers.util import TaskManager
 
 LOGGER = logging.getLogger(__name__)
 
@@ -93,6 +94,6 @@ class MultiClientStream:
                 *[sub.put(chunk) for sub in self.subscribers], return_exceptions=True
             )
         # EOF: send empty chunk
-        async with asyncio.TaskGroup() as tg:
+        async with TaskManager(self.mass) as tg:
             for sub in list(self.subscribers):
                 tg.create_task(sub.put(b""))

--- a/music_assistant/server/providers/airplay/__init__.py
+++ b/music_assistant/server/providers/airplay/__init__.py
@@ -46,6 +46,7 @@ from music_assistant.common.models.player_queue import PlayerQueue
 from music_assistant.constants import CONF_SYNC_ADJUST, VERBOSE_LOG_LEVEL
 from music_assistant.server.helpers.audio import FFMpeg, get_ffmpeg_stream, get_player_filter_params
 from music_assistant.server.helpers.process import AsyncProcess, check_output
+from music_assistant.server.helpers.util import TaskManager
 from music_assistant.server.models.player_provider import PlayerProvider
 
 if TYPE_CHECKING:
@@ -590,7 +591,7 @@ class AirplayProvider(PlayerProvider):
         - player_id: player_id of the player to handle the command.
         """
         # forward command to player and any connected sync members
-        async with asyncio.TaskGroup() as tg:
+        async with TaskManager(self.mass) as tg:
             for airplay_player in self._get_sync_clients(player_id):
                 if airplay_player.active_stream:
                     tg.create_task(airplay_player.active_stream.stop())
@@ -604,7 +605,7 @@ class AirplayProvider(PlayerProvider):
         - player_id: player_id of the player to handle the command.
         """
         # forward command to player and any connected sync members
-        async with asyncio.TaskGroup() as tg:
+        async with TaskManager(self.mass) as tg:
             for airplay_player in self._get_sync_clients(player_id):
                 if airplay_player.active_stream and airplay_player.active_stream.running:
                     # prefer interactive command to our streamer
@@ -639,7 +640,7 @@ class AirplayProvider(PlayerProvider):
             # should not happen, but just in case
             raise RuntimeError("Player is synced")
         # always stop existing stream first
-        async with asyncio.TaskGroup() as tg:
+        async with TaskManager(self.mass) as tg:
             for airplay_player in self._get_sync_clients(player_id):
                 if airplay_player.active_stream and airplay_player.active_stream:
                     tg.create_task(airplay_player.active_stream.stop())

--- a/music_assistant/server/providers/dlna/__init__.py
+++ b/music_assistant/server/providers/dlna/__init__.py
@@ -41,6 +41,7 @@ from music_assistant.common.models.errors import PlayerUnavailableError
 from music_assistant.common.models.player import DeviceInfo, Player, PlayerMedia
 from music_assistant.constants import CONF_ENFORCE_MP3, CONF_PLAYERS, VERBOSE_LOG_LEVEL
 from music_assistant.server.helpers.didl_lite import create_didl_metadata
+from music_assistant.server.helpers.util import TaskManager
 from music_assistant.server.models.player_provider import PlayerProvider
 
 from .helpers import DLNANotifyServer
@@ -286,7 +287,7 @@ class DLNAPlayerProvider(PlayerProvider):
         Called when provider is deregistered (e.g. MA exiting or config reloading).
         """
         self.mass.streams.unregister_dynamic_route("/notify", "NOTIFY")
-        async with asyncio.TaskGroup() as tg:
+        async with TaskManager(self.mass) as tg:
             for dlna_player in self.dlnaplayers.values():
                 tg.create_task(self._device_disconnect(dlna_player))
 

--- a/music_assistant/server/providers/sonos/__init__.py
+++ b/music_assistant/server/providers/sonos/__init__.py
@@ -36,6 +36,7 @@ from music_assistant.common.models.errors import PlayerCommandFailed, PlayerUnav
 from music_assistant.common.models.player import DeviceInfo, Player, PlayerMedia
 from music_assistant.constants import CONF_CROSSFADE, SYNCGROUP_PREFIX, VERBOSE_LOG_LEVEL
 from music_assistant.server.helpers.didl_lite import create_didl_metadata
+from music_assistant.server.helpers.util import TaskManager
 from music_assistant.server.models.player_provider import PlayerProvider
 
 from .player import SonosPlayer
@@ -417,7 +418,7 @@ class SonosPlayerProvider(PlayerProvider):
         """Handle (provider native) playback of an announcement on given player."""
         if player_id.startswith(SYNCGROUP_PREFIX):
             # handle syncgroup, unwrap to all underlying child's
-            async with asyncio.TaskGroup() as tg:
+            async with TaskManager(self.mass) as tg:
                 if group_player := self.mass.players.get(player_id):
                     # execute on all child players
                     for child_player_id in group_player.group_childs:


### PR DESCRIPTION
For operations where we don't want to stop other tasks when one of the tasks fails we shouldn't use asyncio.TaskGroup
This PR introduces a small helper that can be used as context manager (like TaskGroup) but uses our builtin create_task logic to properly keep track of tasks and log unhandled exceptions.

This will at least guarantee that all tasks are executed where we don't want to abort the entire operation if one subtasks fails.