### PR TITLE
Subsonic: UNKNOWN_ARTIST handling

### DIFF
--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -681,6 +681,10 @@ class OpenSonicProvider(MusicProvider):
 
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
         """Get the top listed tracks for a specified artist."""
+        # We have seen top tracks requested for the UNKNOWN_ARTIST ID, protect against that
+        if prov_artist_id == UNKNOWN_ARTIST_ID:
+            return []
+
         try:
             sonic_artist: SonicArtist = await self._run_async(self._conn.getArtist, prov_artist_id)
         except DataNotFoundError as e:

--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -320,6 +320,10 @@ class OpenSonicProvider(MusicProvider):
                 )
             )
         else:
+            logging.getLogger("libopensonic").info(
+                f"Unable to find an artist ID for album '{sonic_album.name}' with "
+                f"ID '{sonic_album.id}'."
+            )
             album.artists.append(
                 Artist(
                     item_id=UNKNOWN_ARTIST_ID,
@@ -400,6 +404,10 @@ class OpenSonicProvider(MusicProvider):
                 track.artists.append(self._get_item_mapping(MediaType.ARTIST, entry.id, entry.name))
 
         if not track.artists:
+            logging.getLogger("libopensonic").info(
+                f"Unable to find artist ID for track '{sonic_song.title}' with "
+                f"ID '{sonic_song.id}'."
+            )
             track.artists.append(
                 Artist(
                     item_id=UNKNOWN_ARTIST_ID,


### PR DESCRIPTION
We are playing a little fast and loose with this UKNOWN_ARTIST_ID, it should never escape from the provider  code. The first patch here protects get_artist_toptracks() from sending this fake ID to the subsonic server. The second patch logs any time we find an album or track that ends up using UKNOWN_ARTIST.