### PR TITLE
Fix crash on missing names for album, artist or track

### DIFF
--- a/music_assistant/common/helpers/util.py
+++ b/music_assistant/common/helpers/util.py
@@ -71,6 +71,8 @@ def try_parse_duration(duration_str: str) -> float:
 
 def create_sort_name(input_str: str) -> str:
     """Create sort name/title from string."""
+    if not input_str:
+        return ""
     input_str = input_str.lower().strip()
     for item in ["the ", "de ", "les ", "dj ", ".", "-", "'", "`"]:
         if input_str.startswith(item):

--- a/music_assistant/server/providers/apple_music/__init__.py
+++ b/music_assistant/server/providers/apple_music/__init__.py
@@ -204,8 +204,8 @@ class AppleMusicProvider(MusicProvider):
             if not catalog_id:
                 self.logger.warning(
                     "Skipping track. No catalog version found for %s - %s",
-                    item["attributes"]["artistName"],
-                    item["attributes"]["name"],
+                    item["attributes"].get("artistName", "?No ArtistName"),
+                    item["attributes"].get("name", "?No Name"),
                 )
                 continue
             song_catalog_ids.append(catalog_id)


### PR DESCRIPTION
Avoid exceptions if apple music library contains tracks, albums or artists without names.

For more info see comment in https://github.com/music-assistant/hass-music-assistant/issues/2431#issuecomment-2212468656