### PR TITLE
apple_music: Fix creation of dummy albums

### DIFF
--- a/music_assistant/server/providers/apple_music/__init__.py
+++ b/music_assistant/server/providers/apple_music/__init__.py
@@ -430,7 +430,12 @@ class AppleMusicProvider(MusicProvider):
         else:
             album_id = album_obj["id"]
             # No more details available other than the id, return an ItemMapping
-            return ItemMapping(MediaType.ALBUM, item_id=album_id, name=album_id)
+            return ItemMapping(
+                media_type=MediaType.ALBUM,
+                provider=self.instance_id,
+                item_id=album_id,
+                name=album_id,
+            )
         album = Album(
             item_id=album_id,
             provider=self.domain,


### PR DESCRIPTION
Fix TypeError on creation of dummy albums (Introduced in https://github.com/music-assistant/server/pull/1463/)

@MarvinSchenkel See comment in https://github.com/music-assistant/hass-music-assistant/issues/2431