### PR TITLE
Fix Jellyfin similar tracks

### DIFF
--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -491,7 +491,9 @@ class JellyfinProvider(MusicProvider):
 
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
         """Retrieve a dynamic list of tracks based on the provided item."""
-        resp = await self._client.get_similar_tracks(prov_track_id, limit=limit)
+        resp = await self._client.get_similar_tracks(
+            prov_track_id, limit=limit, fields=TRACK_FIELDS
+        )
         return [
             parse_track(self.logger, self.instance_id, self._client, track)
             for track in resp["Items"]


### PR DESCRIPTION
Somehow lost this in a merge or a rebase. If we don't specific the "extra" fields there's not enough data for _parse_track to work off.