### PR TITLE
Jellyfin: Skip tracks with no MediaStreams

### DIFF
--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -341,6 +341,11 @@ class JellyfinProvider(MusicProvider):
                 fields=TRACK_FIELDS,
             )
             for track in response["Items"]:
+                if not len(track[ITEM_KEY_MEDIA_STREAMS]):
+                    self.logger.warning(
+                        "Invalid track %s: Does not have any media streams", track[ITEM_KEY_NAME]
+                    )
+                    continue
                 yield parse_track(self.logger, self.instance_id, self._client, track)
 
             while offset < response["TotalRecordCount"]:


### PR DESCRIPTION
Towards https://github.com/music-assistant/hass-music-assistant/issues/2594. It's not clear why this library has tracks with no MediaStreams - maybe API misuse on our part, maybe a corrupt library, maybe a setting. But lets log such tracks and allow the sync to continue.