### PR TITLE
Replace windows separators in m3u

### DIFF
--- a/music_assistant/server/helpers/playlists.py
+++ b/music_assistant/server/helpers/playlists.py
@@ -89,6 +89,8 @@ def parse_m3u(m3u_data: str) -> list[PlaylistItem]:
             if "%20" in line:
                 # apparently VLC manages to encode spaces in filenames
                 line = line.replace("%20", " ")  # noqa: PLW2901
+            # replace Windows directory separators
+            line = line.replace("\\", "/")
             playlist.append(
                 PlaylistItem(
                     path=line, length=length, title=title, stream_info=stream_info, key=key


### PR DESCRIPTION
Fixes https://github.com/music-assistant/hass-music-assistant/issues/2432

Replace instances of backslash with forward slashes when parsing m3u files.