### PR TITLE
Refactor/cleanup the get/add logic for mediaitems + metadata retrieval

### DIFF
--- a/music_assistant/client/music.py
+++ b/music_assistant/client/music.py
@@ -474,9 +474,6 @@ class Music:
         media_type: MediaType,
         item_id: str,
         provider_instance_id_or_domain: str,
-        force_refresh: bool = False,
-        lazy: bool = True,
-        add_to_library: bool = False,
     ) -> MediaItemType | ItemMapping:
         """Get single music item by id and media type."""
         return media_from_dict(
@@ -485,9 +482,6 @@ class Music:
                 media_type=media_type,
                 item_id=item_id,
                 provider_instance_id_or_domain=provider_instance_id_or_domain,
-                force_refresh=force_refresh,
-                lazy=lazy,
-                add_to_library=add_to_library,
             )
         )
 

--- a/music_assistant/server/controllers/media/artists.py
+++ b/music_assistant/server/controllers/media/artists.py
@@ -421,7 +421,7 @@ class ArtistsController(MediaControllerBase[Artist]):
         msg = "No Music Provider found that supports requesting similar tracks."
         raise UnsupportedFeaturedException(msg)
 
-    async def _match(self, db_artist: Artist) -> None:
+    async def match_providers(self, db_artist: Artist) -> None:
         """Try to find matching artists on all providers for the provided (database) item_id.
 
         This is used to link objects of different providers together.
@@ -485,6 +485,7 @@ class ArtistsController(MediaControllerBase[Artist]):
                         # 100% match, we update the db with the additional provider mapping(s)
                         for provider_mapping in prov_artist.provider_mappings:
                             await self.add_provider_mapping(db_artist.item_id, provider_mapping)
+                            db_artist.provider_mappings.add(provider_mapping)
                         return True
         # try to get a match with some reference albums of this artist
         ref_albums = await self.mass.music.artists.albums(db_artist.item_id, db_artist.provider)

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -338,18 +338,24 @@ class PlayerQueuesController(CoreController):
                     radio_source.append(media_item)
                 elif media_item.media_type == MediaType.PLAYLIST:
                     tracks += await self.mass.music.playlists.get_all_playlist_tracks(media_item)
-                    await self.mass.music.mark_item_played(
-                        media_item.media_type, media_item.item_id, media_item.provider
+                    self.mass.create_task(
+                        self.mass.music.mark_item_played(
+                            media_item.media_type, media_item.item_id, media_item.provider
+                        )
                     )
                 elif media_item.media_type == MediaType.ARTIST:
                     tracks += await self.get_artist_tracks(media_item)
-                    await self.mass.music.mark_item_played(
-                        media_item.media_type, media_item.item_id, media_item.provider
+                    self.mass.create_task(
+                        self.mass.music.mark_item_played(
+                            media_item.media_type, media_item.item_id, media_item.provider
+                        )
                     )
                 elif media_item.media_type == MediaType.ALBUM:
                     tracks += await self.get_album_tracks(media_item)
-                    await self.mass.music.mark_item_played(
-                        media_item.media_type, media_item.item_id, media_item.provider
+                    self.mass.create_task(
+                        self.mass.music.mark_item_played(
+                            media_item.media_type, media_item.item_id, media_item.provider
+                        )
                     )
                 else:
                     # single track or radio item


### PR DESCRIPTION
Better differentiate the logic to get a media item with the logic to add an item to the library and/or refresh metadata.
Introduce a background scanner that very slowly checks for missing metadata (with only a limited amount of online calls allowed per day) which is better than refreshing the UI when you view it.

This fixes the various race conditions we've seen with continuous loops (also reported as wiggling UI)