### PR TITLE
Apple Music: Fix playlist page size for Apple music.

### DIFF
--- a/music_assistant/server/providers/apple_music/__init__.py
+++ b/music_assistant/server/providers/apple_music/__init__.py
@@ -280,7 +280,7 @@ class AppleMusicProvider(MusicProvider):
         else:
             endpoint = f"me/library/playlists/{prov_playlist_id}/tracks"
         result = []
-        page_size = 200
+        page_size = 100
         offset = page * page_size
         response = await self._get_data(
             endpoint, include="artists,catalog", limit=page_size, offset=offset


### PR DESCRIPTION
100 is the max allowed, exceeding this limit results in a 400 error: https://github.com/music-assistant/hass-music-assistant/issues/2618