### PR TITLE
iterate over async generator

### DIFF
--- a/music_assistant/server/controllers/metadata.py
+++ b/music_assistant/server/controllers/metadata.py
@@ -577,8 +577,7 @@ class MetaDataController(CoreController):
         playlist_genres: dict[str, int] = {}
         # retrieve metadata for the playlist from the tracks (such as genres etc.)
         # TODO: retrieve style/mood ?
-        playlist_items = await self.mass.music.playlists.tracks(playlist.item_id, playlist.provider)
-        for track in playlist_items:
+        async for track in self.mass.music.playlists.tracks(playlist.item_id, playlist.provider):
             if track.image:
                 all_playlist_tracks_images.add(track.image)
             if track.metadata.genres:


### PR DESCRIPTION
Should fix:
```
2024-07-13 22:35:50.409 WARNING (MainThread) [music_assistant] Exception in task Task-607 - target: <coroutine object MetaDataController.metadata_scanner at 0x7fd1dc666460>: object async_generator can't be used in 'await' expression
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/music_assistant/server/controllers/metadata.py", line 274, in metadata_scanner
    await self._update_playlist_metadata(playlist)
  File "/usr/local/lib/python3.12/site-packages/music_assistant/server/controllers/metadata.py", line 580, in _update_playlist_metadata
    playlist_items = await self.mass.music.playlists.tracks(playlist.item_id, playlist.provider)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object async_generator can't be used in 'await' expression
```