### PR TITLE
Fix AirPlay streams get mixed up when started in quick succession

### DIFF
--- a/music_assistant/common/models/player_queue.py
+++ b/music_assistant/common/models/player_queue.py
@@ -53,7 +53,6 @@ class PlayerQueue(DataClassDictMixin):
         d.pop("current_item", None)
         d.pop("next_item", None)
         d.pop("index_in_buffer", None)
-        d.pop("announcement_in_progress", None)
         d.pop("flow_mode", None)
         d.pop("flow_mode_start_index", None)
         return d
@@ -64,7 +63,6 @@ class PlayerQueue(DataClassDictMixin):
         d.pop("current_item", None)
         d.pop("next_item", None)
         d.pop("index_in_buffer", None)
-        d.pop("announcement_in_progress", None)
         d.pop("flow_mode", None)
         d.pop("flow_mode_start_index", None)
         return cls.from_dict(d)

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -743,10 +743,15 @@ class PlayerQueuesController(CoreController):
             self.mass, queue_item, seek_position=seek_position, fade_in=fade_in
         )
         # send play_media request to player
-        await self.mass.players.play_media(
+        # NOTE that we debounce this a bit to account for someone hitting the next button
+        # like a madman. This will prevent the player from being overloaded with requests.
+        self.mass.call_later(
+            0.25,
+            self.mass.players.play_media,
             player_id=queue_id,
             # transform into PlayerMedia to send to the actual player implementation
             media=self.player_media_from_queue_item(queue_item, queue.flow_mode),
+            task_id=f"play_media_{queue_id}",
         )
 
     # Interaction with player

--- a/music_assistant/server/controllers/streams.py
+++ b/music_assistant/server/controllers/streams.py
@@ -498,6 +498,9 @@ class StreamsController(CoreController):
         use_crossfade = await self.mass.config.get_player_config_value(
             queue.queue_id, CONF_CROSSFADE
         )
+        if not start_queue_item:
+            # this can happen in some (edge case) race conditions
+            return
         if start_queue_item.media_type != MediaType.TRACK:
             use_crossfade = False
         pcm_sample_size = int(
@@ -775,6 +778,9 @@ class StreamsController(CoreController):
                     # del chunk
                 finished = True
         finally:
+            if "ffmpeg_proc" not in locals():
+                # edge case: ffmpeg process was not yet started
+                return  # noqa: B012
             if finished and not ffmpeg_proc.closed:
                 await asyncio.wait_for(ffmpeg_proc.wait(), 60)
             elif not ffmpeg_proc.closed:

--- a/music_assistant/server/helpers/util.py
+++ b/music_assistant/server/helpers/util.py
@@ -149,9 +149,9 @@ class TaskManager:
         self.mass = mass
         self._tasks: list[asyncio.Task] = []
 
-    def create_task(self, coro: Coroutine) -> None:
+    def create_task(self, coro: Coroutine, eager_start: bool = False) -> None:
         """Create a new task and add it to the manager."""
-        task = self.mass.create_task(coro)
+        task = self.mass.create_task(coro, eager_start=eager_start)
         self._tasks.append(task)
 
     async def __aenter__(self) -> Self:

--- a/music_assistant/server/providers/builtin/__init__.py
+++ b/music_assistant/server/providers/builtin/__init__.py
@@ -162,8 +162,7 @@ class BuiltinProvider(MusicProvider):
 
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
-        parsed_item = await self.parse_item(prov_track_id)
-        assert isinstance(parsed_item, Track)
+        parsed_item: Track = await self.parse_item(prov_track_id)
         stored_items: list[StoredItem] = self.mass.config.get(CONF_KEY_TRACKS, [])
         if stored_item := next((x for x in stored_items if x["item_id"] == prov_track_id), None):
             # always prefer the stored info, such as the name

--- a/music_assistant/server/providers/builtin/__init__.py
+++ b/music_assistant/server/providers/builtin/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, NotRequired, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict, cast
 
 import aiofiles
 import shortuuid
@@ -162,7 +162,7 @@ class BuiltinProvider(MusicProvider):
 
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
-        parsed_item: Track = await self.parse_item(prov_track_id)
+        parsed_item = cast(Track, await self.parse_item(prov_track_id))
         stored_items: list[StoredItem] = self.mass.config.get(CONF_KEY_TRACKS, [])
         if stored_item := next((x for x in stored_items if x["item_id"] == prov_track_id), None):
             # always prefer the stored info, such as the name


### PR DESCRIPTION
Fix weird issue where multiple airplay streams get mangled together when they're started in quick succession. 
For example when resyncing or hitting the next button fast. Also guard a few other places that could use a bit of throttling/locking