### PR TITLE
Jellyfin: Fix artist enumeration

### DIFF
--- a/music_assistant/server/providers/jellyfin/manifest.json
+++ b/music_assistant/server/providers/jellyfin/manifest.json
@@ -4,7 +4,7 @@
   "name": "Jellyfin Media Server Library",
   "description": "Support for the Jellyfin streaming provider in Music Assistant.",
   "codeowners": ["@lokiberra", "@Jc2k"],
-  "requirements": ["aiojellyfin==0.9.1"],
+  "requirements": ["aiojellyfin==0.9.2"],
   "documentation": "https://music-assistant.io/music-providers/jellyfin/",
   "multi_instance": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ Brotli>=1.0.9
 aiodns>=3.0.0
 aiofiles==24.1.0
 aiohttp==3.9.5
-aiojellyfin==0.9.1
+aiojellyfin==0.9.2
 aiorun==2024.5.1
 aioslimproto==3.0.1
 aiosqlite==0.20.0


### PR DESCRIPTION
At some point I had switched to `/Items` instead of `/Artists` for consistency with every other object type and it seemed to work. However it was only returning a subset of artists. This reverts that, which restores full sync speed.

https://github.com/Jc2k/aiojellyfin/releases/tag/v0.9.2