### PR TITLE
Jellyfin: Use aiojellyfin 0.10.0 for stricter typing and more speed

### DIFF
--- a/music_assistant/server/providers/jellyfin/const.py
+++ b/music_assistant/server/providers/jellyfin/const.py
@@ -2,7 +2,8 @@
 
 from typing import Final
 
-from aiojellyfin.const import ImageType as JellyImageType
+from aiojellyfin import ImageType as JellyImageType
+from aiojellyfin import ItemFields
 
 from music_assistant.common.models.enums import ImageType, MediaType
 from music_assistant.common.models.media_items import ItemMapping
@@ -67,9 +68,23 @@ SUPPORTED_CONTAINER_FORMATS: Final = "ogg,flac,mp3,aac,mpeg,alac,wav,aiff,wma,m4
 
 PLAYABLE_ITEM_TYPES: Final = [ITEM_TYPE_AUDIO]
 
-ARTIST_FIELDS = ["Overview", "ProviderIds", "SortName"]
-ALBUM_FIELDS = ["ProductionYear", "Overview", "ProviderIds", "SortName"]
-TRACK_FIELDS = ["ProviderIds", "CanDownload", "SortName", "MediaSources", "MediaStreams"]
+ARTIST_FIELDS: Final = [
+    ItemFields.Overview,
+    ItemFields.ProviderIds,
+    ItemFields.SortName,
+]
+ALBUM_FIELDS: Final = [
+    ItemFields.Overview,
+    ItemFields.ProviderIds,
+    ItemFields.SortName,
+]
+TRACK_FIELDS: Final = [
+    ItemFields.ProviderIds,
+    ItemFields.CanDownload,
+    ItemFields.SortName,
+    ItemFields.MediaSources,
+    ItemFields.MediaStreams,
+]
 
 USER_APP_NAME: Final = "Music Assistant"
 USER_AGENT: Final = "Music-Assistant-1.0"

--- a/music_assistant/server/providers/jellyfin/manifest.json
+++ b/music_assistant/server/providers/jellyfin/manifest.json
@@ -4,7 +4,7 @@
   "name": "Jellyfin Media Server Library",
   "description": "Support for the Jellyfin streaming provider in Music Assistant.",
   "codeowners": ["@lokiberra", "@Jc2k"],
-  "requirements": ["aiojellyfin==0.9.2"],
+  "requirements": ["aiojellyfin==0.10.0"],
   "documentation": "https://music-assistant.io/music-providers/jellyfin/",
   "multi_instance": true
 }

--- a/music_assistant/server/providers/jellyfin/parsers.py
+++ b/music_assistant/server/providers/jellyfin/parsers.py
@@ -6,7 +6,7 @@ import logging
 from logging import Logger
 from typing import TYPE_CHECKING
 
-from aiojellyfin.const import ImageType as JellyImageType
+from aiojellyfin import ImageType as JellyImageType
 
 from music_assistant.common.models.enums import ContentType, ExternalID, ImageType, MediaType
 from music_assistant.common.models.errors import InvalidDataError

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ Brotli>=1.0.9
 aiodns>=3.0.0
 aiofiles==24.1.0
 aiohttp==3.9.5
-aiojellyfin==0.9.2
+aiojellyfin==0.10.0
 aiorun==2024.5.1
 aioslimproto==3.0.1
 aiosqlite==0.20.0

--- a/tests/server/providers/jellyfin/test_init.py
+++ b/tests/server/providers/jellyfin/test_init.py
@@ -16,13 +16,13 @@ async def jellyfin_provider(mass: MusicAssistant) -> AsyncGenerator[ProviderConf
     """Configure an aiojellyfin test fixture, and add a provider to mass that uses it."""
     f = FixtureBuilder()
     async for _, artist in get_fixtures_dir("artists", "jellyfin"):
-        f.add_artist_bytes(artist)
+        f.add_json_bytes(artist)
 
     async for _, album in get_fixtures_dir("albums", "jellyfin"):
-        f.add_album_bytes(album)
+        f.add_json_bytes(album)
 
     async for _, track in get_fixtures_dir("tracks", "jellyfin"):
-        f.add_track_bytes(track)
+        f.add_json_bytes(track)
 
     authenticate_by_name = f.to_authenticate_by_name()
 


### PR DESCRIPTION
* The latest aiojellyfin uses the builder pattern. Mostly this is because the number of arguments the `/Items` API has is huuuge and my function bodies were getting ugly.
* Along with that, some of the fields become more strictly typed (so for example the `fields` query arg now has an enum instead of being text).
* Pagination moved out of MA and into the backing library, where its implemented once instead of 4 times. I also added a new prefetching strategy. It takes time to process a page of results and insert them in the MA db. On one of my older dev boxes that takes long enough that we can prefetch the next page.

(This isn't for backporting, though it could be after some time to brew up I guess).