### PR TITLE
Spotify: remove deprecated user-read-birthdate scope

### DIFF
--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -718,7 +718,6 @@ class SpotifyProvider(MusicProvider):
             "user-library-modify",
             "user-read-private",
             "user-read-email",
-            "user-read-birthdate",
             "user-top-read",
         ]
         scope = ",".join(scopes)


### PR DESCRIPTION
This tiny PR removes the `user-read-birthdate` scope which seems to be deprecated (see for instance https://github.com/jbszczepaniak/spotify-cli/pull/9). Spotify probably ignores it for old apps to avoid breaking them, but if a different client-id is used authentication fails unless `user-read-birthdate` is removed.