### PR TITLE
Throttler: sleep without busy wait, log delayed calls

### DIFF
--- a/music_assistant/server/providers/fanarttv/__init__.py
+++ b/music_assistant/server/providers/fanarttv/__init__.py
@@ -6,12 +6,12 @@ from json import JSONDecodeError
 from typing import TYPE_CHECKING
 
 import aiohttp.client_exceptions
-from asyncio_throttle import Throttler
 
 from music_assistant.common.models.enums import ExternalID, ProviderFeature
 from music_assistant.common.models.media_items import ImageType, MediaItemImage, MediaItemMetadata
 from music_assistant.server.controllers.cache import use_cache
 from music_assistant.server.helpers.app_vars import app_var  # pylint: disable=no-name-in-module
+from music_assistant.server.helpers.throttle_retry import Throttler
 from music_assistant.server.models.metadata_provider import MetadataProvider
 
 if TYPE_CHECKING:

--- a/music_assistant/server/providers/theaudiodb/__init__.py
+++ b/music_assistant/server/providers/theaudiodb/__init__.py
@@ -6,7 +6,6 @@ from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp.client_exceptions
-from asyncio_throttle import Throttler
 
 from music_assistant.common.models.enums import ExternalID, ProviderFeature
 from music_assistant.common.models.media_items import (
@@ -24,6 +23,7 @@ from music_assistant.common.models.media_items import (
 from music_assistant.server.controllers.cache import use_cache
 from music_assistant.server.helpers.app_vars import app_var  # type: ignore[attr-defined]
 from music_assistant.server.helpers.compare import compare_strings
+from music_assistant.server.helpers.throttle_retry import Throttler
 from music_assistant.server.models.metadata_provider import MetadataProvider
 
 if TYPE_CHECKING:

--- a/music_assistant/server/providers/tunein/__init__.py
+++ b/music_assistant/server/providers/tunein/__init__.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from asyncio_throttle import Throttler
-
 from music_assistant.common.models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant.common.models.enums import ConfigEntryType, ProviderFeature, StreamType
 from music_assistant.common.models.errors import InvalidDataError, LoginFailed, MediaNotFoundError
@@ -20,6 +18,7 @@ from music_assistant.common.models.media_items import (
 )
 from music_assistant.common.models.streamdetails import StreamDetails
 from music_assistant.constants import CONF_USERNAME
+from music_assistant.server.helpers.throttle_retry import Throttler
 from music_assistant.server.models.music_provider import MusicProvider
 
 SUPPORTED_FEATURES = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ server = [
   "aiodns>=3.0.0",
   "Brotli>=1.0.9",
   "aiohttp==3.9.5",
-  "asyncio-throttle==1.0.2",
   "aiofiles==24.1.0",
   "aiorun==2024.5.1",
   "certifi==2024.7.4",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -9,7 +9,6 @@ aiorun==2024.5.1
 aioslimproto==3.0.1
 aiosqlite==0.20.0
 async-upnp-client==0.39.0
-asyncio-throttle==1.0.2
 bidict==0.23.1
 certifi==2024.7.4
 colorlog==6.8.2


### PR DESCRIPTION
This PR adds two improvements to throttling:

1. Accurate sleep until the next available time. `asyncio_throttle` by default wakes every 10msecs which is crazy. `ThrottlerManager` sets the wait to 100mecs, which is still unnecessary, but some modules don't use `ThrottlerManager` anyway.

2. Return the delay caused by the throttler (0 means no throttling) and log it in `throttle_with_retries`.

Since `asyncio_throttle` is very simple and looks unmaintained (PR ignored for years) I copied the code in `server/helpers/throttle_retry.py`, no point having an unmaintained dependency for a few lines of code.

