### PR TITLE
Allow use of a personal client id for Spotify

### DIFF
--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -187,7 +187,7 @@ class Config(DataClassDictMixin):
     def get_value(self, key: str) -> ConfigValueType:
         """Return config value for given key."""
         config_value = self.values[key]
-        if config_value.type == ConfigEntryType.SECURE_STRING:
+        if config_value.type == ConfigEntryType.SECURE_STRING and config_value.value:
             assert isinstance(config_value.value, str)
             assert DECRYPT_CALLBACK is not None
             return DECRYPT_CALLBACK(config_value.value)

--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
     from music_assistant.server import MusicAssistant
     from music_assistant.server.models import ProviderInstanceType
 
+CONF_CLIENT_ID = "client_id"
 
 CACHE_DIR = gettempdir()
 LIKED_SONGS_FAKE_PLAYLIST_ID_PREFIX = "liked_songs"
@@ -118,6 +119,15 @@ async def get_config_entries(
             label="Password",
             required=True,
         ),
+        ConfigEntry(
+            key=CONF_CLIENT_ID,
+            type=ConfigEntryType.SECURE_STRING,
+            label="Client ID",
+            description="By default, a generic client ID is used which is heavy rate limited. "
+            "It is advised that you create your own Spotify Developer account and use "
+            "that client ID here to speedup performance.",
+            required=False,
+        ),
     )
 
 
@@ -135,10 +145,13 @@ class SpotifyProvider(MusicProvider):
         """Handle async initialization of the provider."""
         self._cache_dir = CACHE_DIR
         self._ap_workaround = False
-        # try to get a token, raise if that fails
         self._cache_dir = os.path.join(CACHE_DIR, self.instance_id)
         # try login which will raise if it fails
         await self.login()
+        if self.config.get_value(CONF_CLIENT_ID):
+            # loosen the throttler a bit when a custom client id is used
+            self.throttler.rate_limit = 45
+            self.throttler.period = 30
 
     @property
     def supported_features(self) -> tuple[ProviderFeature, ...]:
@@ -727,7 +740,7 @@ class SpotifyProvider(MusicProvider):
             "-O",
             "-t",
             "--client-id",
-            app_var(2),
+            self.config.get_value(CONF_CLIENT_ID) or app_var(2),
             "--scope",
             scope,
             "-c",

--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -146,12 +146,12 @@ class SpotifyProvider(MusicProvider):
         self._cache_dir = CACHE_DIR
         self._ap_workaround = False
         self._cache_dir = os.path.join(CACHE_DIR, self.instance_id)
-        # try login which will raise if it fails
-        await self.login()
         if self.config.get_value(CONF_CLIENT_ID):
             # loosen the throttler a bit when a custom client id is used
             self.throttler.rate_limit = 45
             self.throttler.period = 30
+        # try login which will raise if it fails
+        await self.login()
 
     @property
     def supported_features(self) -> tuple[ProviderFeature, ...]:


### PR DESCRIPTION
Use a personal clientid for spotify to overcome the heavy rate limit limitation of our global clientid 