### PR TITLE
Ensure sort_name makes it to cache

### DIFF
--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -753,9 +753,9 @@ class FileSystemProviderBase(MusicProvider):
                         album_path=album_dir,
                         sort_name=(
                             tags.album_artist_sort_names[index]
-                            if index<len(tags.album_artist_sort_names)
+                            if index < len(tags.album_artist_sort_names)
                             else None
-                        )
+                        ),
                     )
                     if not artist.mbid:
                         with contextlib.suppress(IndexError):

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -748,13 +748,14 @@ class FileSystemProviderBase(MusicProvider):
             # album artist(s)
             if tags.album_artists:
                 for index, album_artist_str in enumerate(tags.album_artists):
-                    artist = await self._parse_artist(album_artist_str, album_path=album_dir)
+                    artist = await self._parse_artist(
+                        album_artist_str, 
+                        album_path=album_dir,
+                        sort_name=tags.album_artist_sort_names[index] if index<len(tags.album_artist_sort_names) else None
+                    )
                     if not artist.mbid:
                         with contextlib.suppress(IndexError):
                             artist.mbid = tags.musicbrainz_albumartistids[index]
-                    # album artist sort name
-                    with contextlib.suppress(IndexError):
-                        artist.sort_name = tags.album_artist_sort_names[index]
                     album_artists.append(artist)
             else:
                 # album artist tag is missing, determine fallback

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -751,7 +751,11 @@ class FileSystemProviderBase(MusicProvider):
                     artist = await self._parse_artist(
                         album_artist_str,
                         album_path=album_dir,
-                        sort_name=tags.album_artist_sort_names[index] if index<len(tags.album_artist_sort_names) else None
+                        sort_name=(
+                            tags.album_artist_sort_names[index]
+                            if index<len(tags.album_artist_sort_names)
+                            else None
+                        )
                     )
                     if not artist.mbid:
                         with contextlib.suppress(IndexError):

--- a/music_assistant/server/providers/filesystem_local/base.py
+++ b/music_assistant/server/providers/filesystem_local/base.py
@@ -749,7 +749,7 @@ class FileSystemProviderBase(MusicProvider):
             if tags.album_artists:
                 for index, album_artist_str in enumerate(tags.album_artists):
                     artist = await self._parse_artist(
-                        album_artist_str, 
+                        album_artist_str,
                         album_path=album_dir,
                         sort_name=tags.album_artist_sort_names[index] if index<len(tags.album_artist_sort_names) else None
                     )


### PR DESCRIPTION
If the first time an artist is 'seen' is as an album artist, the sort_name is set into the cache first by the _parse_artist function, but that happens before the sort_name is added to the artist object from the tags. This should fix that.