### PR TITLE
YTMusic: Use instance name as playlist owner as fallback.

### DIFF
--- a/music_assistant/server/providers/ytmusic/__init__.py
+++ b/music_assistant/server/providers/ytmusic/__init__.py
@@ -81,6 +81,7 @@ VARIOUS_ARTISTS_YTM_ID = "UCUTXlgdcKU5vfzFqHOWIvkA"
 YT_PLAYLIST_ID_DELIMITER = "🎵"
 YT_PERSONAL_PLAYLISTS = (
     "LM",  # Liked songs
+    "SE"  # Episodes for Later
     "RDTMAK5uy_kset8DisdE7LSD4TNjEVvrKRTmG7a56sY",  # SuperMix
     "RDTMAK5uy_nGQKSMIkpr4o9VI_2i56pkGliD6FQRo50",  # My Mix 1
     "RDTMAK5uy_lz2owBgwWf1mjzyn_NbxzMViQzIg8IAIg",  # My Mix 2
@@ -711,7 +712,7 @@ class YoutubeMusicProvider(MusicProvider):
             else:
                 playlist.owner = authors["name"]
         else:
-            playlist.owner = self.instance_id
+            playlist.owner = self.name
         playlist.cache_checksum = playlist_obj.get("checksum")
         return playlist
 


### PR DESCRIPTION
Use a readable name for playlists that do not have a name (e.g. Likes) so the user can easily distinguish the playlist when multiple instances are configured.