### PR TITLE
Remove the handle_async_init() call from provider __init__.py

### DIFF
--- a/music_assistant/server/providers/opensubsonic/__init__.py
+++ b/music_assistant/server/providers/opensubsonic/__init__.py
@@ -29,9 +29,7 @@ async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
-    prov = OpenSonicProvider(mass, manifest, config)
-    await prov.handle_async_init()
-    return prov
+    return OpenSonicProvider(mass, manifest, config)
 
 
 async def get_config_entries(


### PR DESCRIPTION
This is moving to the core server, no need to do it in each provider.