### PR TITLE
Allow frontend to send base url for auth redirects

### DIFF
--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -141,7 +141,9 @@ async def get_config_entries(
         import pkce
 
         code_verifier, code_challenge = pkce.generate_pkce_pair()
-        async with AuthenticationHelper(mass, cast(str, values["session_id"])) as auth_helper:
+        async with AuthenticationHelper(
+            mass, cast(str, values["session_id"]), values.get("frontend_base_url")
+        ) as auth_helper:
             params = {
                 "response_type": "code",
                 "client_id": values.get(CONF_CLIENT_ID) or app_var(2),


### PR DESCRIPTION
By default we use the streamserver for auth callbacks but that is only available on the internal network.
We don't use the webserver because that could potentially be blocked behind a reverse proxy.

The downside of this is that you can't do any (re)auth (e.g. to spotify) when you are outside your home network, connected through HA ingress.

This PR allows the frontend to inform where its being called from so we can dynamically figure out the url for redirection.
This means that auth callbacks/popups should now also work through HA ingress or any other reverse proxy.
