### PR TITLE
Guard against eyed3 returning None

### DIFF
--- a/music_assistant/server/helpers/tags.py
+++ b/music_assistant/server/helpers/tags.py
@@ -447,7 +447,7 @@ async def parse_tags(
             # this is actually a bug in ffmpeg/ffprobe which does not expose this tag
             # so we use this as alternative approach for mp3 files
             audiofile = await asyncio.to_thread(eyed3.load, file_path)
-            if audiofile.tag is not None:
+            if audiofile is not None and audiofile.tag is not None:
                 for uf_id in audiofile.tag.unique_file_ids:
                     if uf_id.owner_id == b"http://musicbrainz.org" and uf_id.uniq_id:
                         tags.tags["musicbrainzrecordingid"] = uf_id.uniq_id.decode()


### PR DESCRIPTION
In some cases, `eyed3` will return `None` instead of a file with empty tags. Fixes [issue #2793](https://github.com/music-assistant/hass-music-assistant/issues/2793).