### PR TITLE
Jellyfin: Fix login for some instances

### DIFF
--- a/music_assistant/server/providers/jellyfin/manifest.json
+++ b/music_assistant/server/providers/jellyfin/manifest.json
@@ -4,7 +4,7 @@
   "name": "Jellyfin Media Server Library",
   "description": "Support for the Jellyfin streaming provider in Music Assistant.",
   "codeowners": ["@lokiberra", "@Jc2k"],
-  "requirements": ["aiojellyfin==0.10.0"],
+  "requirements": ["aiojellyfin==0.10.1"],
   "documentation": "https://music-assistant.io/music-providers/jellyfin/",
   "multi_instance": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ Brotli>=1.0.9
 aiodns>=3.0.0
 aiofiles==24.1.0
 aiohttp==3.10.4
-aiojellyfin==0.10.0
+aiojellyfin==0.10.1
 aiorun==2024.8.1
 aioslimproto==3.0.1
 aiosonos==0.1.1


### PR DESCRIPTION
We weren't using the shared MA ClientSession for the login code. This meant login was hitting some extra YARL validation when instancing a ClientSession for a subpath on a url, causing logins to fail.

Hopefully fixes: https://github.com/music-assistant/hass-music-assistant/issues/2727