### PR TITLE
Enforce default HTTP profile for slimproto players

### DIFF
--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -610,6 +610,13 @@ CONF_ENTRY_HTTP_PROFILE = ConfigEntry(
     "'chunked transfer encoding', works just fine. \n\n",
 )
 
+CONF_ENTRY_HTTP_PROFILE_DEFAULT_2 = ConfigEntry.from_dict(
+    {**CONF_ENTRY_HTTP_PROFILE.to_dict(), "default_value": "no_content_length"}
+)
+CONF_ENTRY_HTTP_PROFILE_FORCED_2 = ConfigEntry.from_dict(
+    {**CONF_ENTRY_HTTP_PROFILE.to_dict(), "default_value": "no_content_length", "hidden": True}
+)
+
 
 def create_sample_rates_config_entry(
     max_sample_rate: int,

--- a/music_assistant/server/controllers/streams.py
+++ b/music_assistant/server/controllers/streams.py
@@ -266,8 +266,8 @@ class StreamsController(CoreController):
             default_sample_rate=queue_item.streamdetails.audio_format.sample_rate,
             default_bit_depth=queue_item.streamdetails.audio_format.bit_depth,
         )
-        http_profile: str = self.mass.config.get_raw_player_config_value(
-            queue_id, CONF_HTTP_PROFILE, "chunked"
+        http_profile: str = await self.mass.config.get_player_config_value(
+            queue_id, CONF_HTTP_PROFILE
         )
         # prepare request, add some DLNA/UPNP compatible headers
         headers = {
@@ -356,8 +356,8 @@ class StreamsController(CoreController):
         icy_meta_interval = 16384
 
         # prepare request, add some DLNA/UPNP compatible headers
-        http_profile: str = self.mass.config.get_raw_player_config_value(
-            queue_id, CONF_HTTP_PROFILE, "chunked"
+        http_profile: str = await self.mass.config.get_player_config_value(
+            queue_id, CONF_HTTP_PROFILE
         )
         # prepare request, add some DLNA/UPNP compatible headers
         headers = {

--- a/music_assistant/server/providers/slimproto/__init__.py
+++ b/music_assistant/server/providers/slimproto/__init__.py
@@ -28,6 +28,7 @@ from music_assistant.common.models.config_entries import (
     CONF_ENTRY_EQ_BASS,
     CONF_ENTRY_EQ_MID,
     CONF_ENTRY_EQ_TREBLE,
+    CONF_ENTRY_HTTP_PROFILE_FORCED_2,
     CONF_ENTRY_OUTPUT_CHANNELS,
     CONF_ENTRY_SYNC_ADJUST,
     ConfigEntry,
@@ -317,6 +318,7 @@ class SlimprotoProvider(PlayerProvider):
                 CONF_ENTRY_SYNC_ADJUST,
                 CONF_ENTRY_DISPLAY,
                 CONF_ENTRY_VISUALIZATION,
+                CONF_ENTRY_HTTP_PROFILE_FORCED_2,
                 create_sample_rates_config_entry(int(slimclient.max_sample_rate), 24, 48000, 24),
             )
         )

--- a/music_assistant/server/providers/ugp/__init__.py
+++ b/music_assistant/server/providers/ugp/__init__.py
@@ -371,8 +371,8 @@ class UniversalGroupProvider(PlayerProvider):
             bit_depth=stream.audio_format.bit_depth,
         )
 
-        http_profile: str = self.mass.config.get_raw_player_config_value(
-            child_player_id, CONF_HTTP_PROFILE, "chunked"
+        http_profile: str = await self.mass.config.get_player_config_value(
+            child_player_id, CONF_HTTP_PROFILE
         )
         headers = {
             **DEFAULT_STREAM_HEADERS,


### PR DESCRIPTION
Apparently some/all slimproto players do not even support HTTP 1.1 so chunked encoding fails.
This PR changes the default http profile to use streaming without content-length and without chunked encoding.