### PR TITLE
Add dev manual build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,11 @@ jobs:
       packages: write
     needs: build-artifact
     steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
       - uses: actions/checkout@v4.1.4
       - name: Download Widevine CDM client files from private repository
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,15 +22,15 @@ jobs:
       - uses: actions/checkout@v4.1.4
       - name: Get tag
         id: vars
-        run:
-          if [[ "${{ inputs.tags }}" ]]; then
+        run: >-
+          if [[ "${{ inputs.tags }}" == "true" ]]; then
             echo "tag=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_OUTPUT
           else
             echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
           fi  
       - name: Validate version number
         run: >-
-          if [[ "${{ inputs.tags }}" ]]; then
+          if [[ "${{ inputs.tags }}" == "true" ]]; then
             echo "Skipping version validation for manual trigger"
           else  
             if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,13 @@ name: Publish releases
 on:
   release:
     types: [published]
+  workflow_dispatch:
 env:
   PYTHON_VERSION: "3.11"
 
 jobs:
-  build-and-publish-pypi:
-    name: Builds and publishes releases to PyPI
+  build-artifact:
+    name: Builds python artifact uploads to Github Artifact store
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.vars.outputs.tag }}
@@ -19,17 +20,22 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Validate version number
         run: >-
-          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            if ! [[ "${{ steps.vars.outputs.tag }}" =~ "b" || "${{ steps.vars.outputs.tag }}" =~ "rc" ]]; then
-            echo "Pre-release: Tag is missing beta suffix (${{ steps.vars.outputs.tag }})"
-              exit 1
+          if [[ "${{ github.event.workflow_dispatch }}" == "true" ]]; then
+            echo "tag=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_OUTPUT
+            echo "Skipping version validation for manual trigger"
+          else  
+            if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+              if ! [[ "${{ steps.vars.outputs.tag }}" =~ "b" || "${{ steps.vars.outputs.tag }}" =~ "rc" ]]; then
+              echo "Pre-release: Tag is missing beta suffix (${{ steps.vars.outputs.tag }})"
+                exit 1
+              fi
+            else
+              if [[ "${{ steps.vars.outputs.tag }}" =~ "b" || "${{ steps.vars.outputs.tag }}" =~ "rc" ]]; then
+                echo "Release: Tag must not have a beta (or rc) suffix (${{ steps.vars.outputs.tag }})"
+                exit 1
+              fi
             fi
-          else
-            if [[ "${{ steps.vars.outputs.tag }}" =~ "b" || "${{ steps.vars.outputs.tag }}" =~ "rc" ]]; then
-              echo "Release: Tag must not have a beta (or rc) suffix (${{ steps.vars.outputs.tag }})"
-              exit 1
-            fi
-          fi
+          fi  
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5.2.0
         with:
@@ -53,6 +59,22 @@ jobs:
       - name: Build python package
         run: >-
           python3 -m build
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+      
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - build-artifact
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
       - name: Publish release to PyPI
         uses: pypa/gh-action-pypi-publish@v1.9.0
         with:
@@ -66,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: build-and-publish-pypi
+    needs: build-artifact
     steps:
       - uses: actions/checkout@v4.1.4
       - name: Download Widevine CDM client files from private repository
@@ -95,7 +117,7 @@ jobs:
           echo "major=${patch%.*.*}" >> $GITHUB_OUTPUT
       - name: Build and Push release
         uses: docker/build-push-action@v6.7.0
-        if: github.event.release.prerelease == false
+        if: !github.event.workflow_dispatch && github.event.release.prerelease == false
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -107,10 +129,10 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/server:stable,
             ghcr.io/${{ github.repository_owner }}/server:latest
           push: true
-          build-args: "MASS_VERSION=${{ needs.build-and-publish-pypi.outputs.version }}"
+          build-args: "MASS_VERSION=${{ needs.build-artifact.outputs.version }}"
       - name: Build and Push pre-release
         uses: docker/build-push-action@v6.7.0
-        if: github.event.release.prerelease == true
+        if: !github.event.workflow_dispatch && github.event.release.prerelease == true
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -119,25 +141,38 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/server:${{ steps.tags.outputs.patch }},
             ghcr.io/${{ github.repository_owner }}/server:beta
           push: true
-          build-args: "MASS_VERSION=${{ needs.build-and-publish-pypi.outputs.version }}"
+          build-args: "MASS_VERSION=${{ needs.build-artifact.outputs.version }}"
+      - name: Build and Push dev-release
+        uses: docker/build-push-action@v6.7.0
+        if: github.event.workflow_dispatch == true
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          tags: |-
+            ghcr.io/${{ github.repository_owner }}/server:${{ needs.build-artifact.outputs.version }},
+            ghcr.io/${{ github.repository_owner }}/server:dev
+          push: true
+          build-args: "MASS_VERSION=${{ needs.build-artifact.outputs.version }}"
 
   release-notes-update:
     name: Updates the release notes and changelog
-    needs: [build-and-publish-pypi, build-and-push-container-image]
+    needs: [build-artifact, pypi-publish, build-and-push-container-image]
     runs-on: ubuntu-latest
     steps:
       - name: Update changelog and release notes including frontend notes
         uses: music-assistant/release-notes-merge-action@main
         with:
           github_token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
-          release_tag: ${{ needs.build-and-publish-pypi.outputs.version }}
+          release_tag: ${{ needs.build-artifact.outputs.version }}
           pre_release: ${{ github.event.release.prerelease }}
 
   addon-version-update:
     name: Updates the Addon repository with the new version
     needs:
       [
-        build-and-publish-pypi,
+        build-artifact,  
+        pypi-publish,
         build-and-push-container-image,
         release-notes-update,
       ]
@@ -147,5 +182,5 @@ jobs:
         uses: music-assistant/addon-update-action@main
         with:
           github_token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
-          new_server_version: ${{ needs.build-and-publish-pypi.outputs.version }}
+          new_server_version: ${{ needs.build-artifact.outputs.version }}
           pre_release: ${{ github.event.release.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Run Dev Build'
+        required: true
+        type: boolean
 env:
   PYTHON_VERSION: "3.11"
 
@@ -18,14 +23,14 @@ jobs:
       - name: Get tag
         id: vars
         run:
-          if [[ "${{ github.event.workflow_dispatch }}" == "true" ]]; then
+          if [[ "${{ inputs.tags }}" ]]; then
             echo "tag=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_OUTPUT
           else
             echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
           fi  
       - name: Validate version number
         run: >-
-          if [[ "${{ github.event.workflow_dispatch }}" == "true" ]]; then
+          if [[ "${{ inputs.tags }}" ]]; then
             echo "Skipping version validation for manual trigger"
           else  
             if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
@@ -71,7 +76,7 @@ jobs:
       
   pypi-publish:
     runs-on: ubuntu-latest
-    if: !github.event.workflow_dispatch
+    if: ${{ ! inputs.tags }}
     needs:
       - build-artifact
     steps:
@@ -127,7 +132,7 @@ jobs:
           echo "major=${patch%.*.*}" >> $GITHUB_OUTPUT
       - name: Build and Push release
         uses: docker/build-push-action@v6.7.0
-        if: !github.event.workflow_dispatch && github.event.release.prerelease == false
+        if: ${{ ! inputs.tags && github.event.release.prerelease == false }}
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -142,7 +147,7 @@ jobs:
           build-args: "MASS_VERSION=${{ needs.build-artifact.outputs.version }}"
       - name: Build and Push pre-release
         uses: docker/build-push-action@v6.7.0
-        if: !github.event.workflow_dispatch && github.event.release.prerelease == true
+        if: ${{ ! inputs.tags && github.event.release.prerelease == true }}
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -154,7 +159,7 @@ jobs:
           build-args: "MASS_VERSION=${{ needs.build-artifact.outputs.version }}"
       - name: Build and Push dev-release
         uses: docker/build-push-action@v6.7.0
-        if: github.event.workflow_dispatch == true
+        if: inputs.tags
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,15 @@ jobs:
       - uses: actions/checkout@v4.1.4
       - name: Get tag
         id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        run:
+          if [[ "${{ github.event.workflow_dispatch }}" == "true" ]]; then
+            echo "tag=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+          fi  
       - name: Validate version number
         run: >-
           if [[ "${{ github.event.workflow_dispatch }}" == "true" ]]; then
-            echo "tag=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_OUTPUT
             echo "Skipping version validation for manual trigger"
           else  
             if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
@@ -67,6 +71,7 @@ jobs:
       
   pypi-publish:
     runs-on: ubuntu-latest
+    if: !github.event.workflow_dispatch
     needs:
       - build-artifact
     steps:
@@ -153,7 +158,10 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/server:${{ needs.build-artifact.outputs.version }},
             ghcr.io/${{ github.repository_owner }}/server:dev
           push: true
-          build-args: "MASS_VERSION=${{ needs.build-artifact.outputs.version }}"
+          build-args: |
+            MASS_VERSION=${{ needs.build-artifact.outputs.version }}
+            DEV_RELEASE="true"
+            MASS_INSTALL_LOCATION="/tmp/music_assitant-${{ needs.build-artifact.outputs.version }}-py3-none-any.whl"
 
   release-notes-update:
     name: Updates the release notes and changelog

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.12-alpine3.20
 
 ARG MASS_VERSION
 ARG TARGETPLATFORM
+ARG DEV_RELEASE="false"
+ARG MASS_INSTALL_LOCATION="music-assistant[server]==${MASS_VERSION}"
 
 RUN set -x \
     && apk add --no-cache \
@@ -27,6 +29,9 @@ RUN set -x \
 # Copy widevine client files to container
 RUN mkdir -p /usr/local/bin/widevine_cdm
 COPY widevine_cdm/* /usr/local/bin/widevine_cdm/
+COPY dist/music_assitant-${MASS_VERSION}-py3-none-any.whl /tmp/
+
+RUN bash -c 'if [ "${DEV_RELEASE}" = "false" ]; then rm /tmp/music_assitant-${MASS_VERSION}-py3-none-any.whl; fi'
 
 # Upgrade pip + Install uv
 RUN pip install --upgrade pip \
@@ -37,7 +42,7 @@ RUN uv pip install \
     --system \
     --no-cache \
     --find-links "https://wheels.home-assistant.io/musllinux/" \
-    music-assistant[server]==${MASS_VERSION}
+    ${MASS_INSTALL_LOCATION}
 
 # Configure runtime environmental variables
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"


### PR DESCRIPTION
Split the main pypi publish into 2 jobs with artifact upload/download
in-between. Added both jobs as dependencies to the release-notes and
addons update jobs, and made a start on a manually triggered dev build
with git hash as version tag

Added new build args with a MASS_INSTALL_LOCATION and DEV_RELEASE to
manipulate how and where the mass wheel is installed in the Dockerfile. Both have defaults that should cause the standard behaviour.