### PR TITLE
Album track sort order - Add track name as fallback when track number is missing

### DIFF
--- a/music_assistant/server/controllers/media/albums.py
+++ b/music_assistant/server/controllers/media/albums.py
@@ -227,7 +227,7 @@ class AlbumsController(MediaControllerBase[Album]):
         result: UniqueList[Track] = UniqueList(db_items)
         if in_library_only:
             # return in-library items only
-            return sorted(db_items, key=lambda x: (x.disc_number, x.track_number))
+            return sorted(db_items, key=lambda x: (x.disc_number, x.track_number, x.sort_name))
 
         # return all (unique) items from all providers
         # because we are returning the items from all providers combined,
@@ -254,7 +254,7 @@ class AlbumsController(MediaControllerBase[Album]):
                 result.append(provider_track)
         # NOTE: we need to return the results sorted on disc/track here
         # to ensure the correct order at playback
-        return sorted(result, key=lambda x: (x.disc_number, x.track_number))
+        return sorted(result, key=lambda x: (x.disc_number, x.track_number, x.sort_name))
 
     async def versions(
         self,


### PR DESCRIPTION
When using an album without track numbers set, track order is random.
With this fix track name is used as fallback to sort files (generally name starting with 01, 02, 03 etc...)