### PR TITLE
fix: 🐛 move download to after checkout, fix conditionals

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,18 +98,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: build-artifact
+    needs: 
+      - build-artifact
+      - pypi-publish
+    if: |
+      always() &&
+      needs.build-artifact.result == 'success' &&
+      (needs.pypi-publish.result == 'success' || needs.pypi-publish.result == 'skipped')  
     steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
-      - name: Copy Wheel to new location
-        shell: bash
-        run: |
-          mkdir -p pre_built_whl
-          cp dist/*.whl pre_built_whl/ 
       - uses: actions/checkout@v4.1.4
       - name: Download Widevine CDM client files from private repository
         shell: bash
@@ -119,6 +115,11 @@ jobs:
           mkdir -p widevine_cdm && cd widevine_cdm
           curl -OJ -H "Authorization: token ${TOKEN}" https://raw.githubusercontent.com/music-assistant/appvars/main/widevine_cdm_client/private_key.pem
           curl -OJ -H "Authorization: token ${TOKEN}" https://raw.githubusercontent.com/music-assistant/appvars/main/widevine_cdm_client/client_id.bin
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
       - name: Log in to the GitHub container registry
         uses: docker/login-action@v3.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: build-artifact
+    needs: 
+      - build-artifact
+      - pypi-publish
+    if: |
+      always() &&
+      ((github.event.release.prerelease == false && needs.pypi-publish.result == 'success') || 
+      (github.event.release.prerelease == true && needs.pypi-publish.result == 'skipped') ||
+      (inputs.tags && needs.pypi-publish.result == 'skipped'))
     steps:
       - uses: actions/checkout@v4.1.4
       - name: Download Widevine CDM client files from private repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,7 @@ jobs:
   pypi-publish:
     runs-on: ubuntu-latest
     if: ${{ ! inputs.tags }}
-    needs:
-      - build-artifact
+    needs: build-artifact
     steps:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4
@@ -98,13 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: 
-      - build-artifact
-      - pypi-publish
-    if: |
-      always() &&
-      needs.build-artifact.result == 'success' &&
-      (needs.pypi-publish.result == 'success' || needs.pypi-publish.result == 'skipped')  
+    needs: build-artifact
     steps:
       - uses: actions/checkout@v4.1.4
       - name: Download Widevine CDM client files from private repository
@@ -176,8 +169,6 @@ jobs:
           push: true
           build-args: |
             MASS_VERSION=${{ needs.build-artifact.outputs.version }}
-            DEV_RELEASE="true"
-            MASS_INSTALL_LOCATION="/tmp/music_assistant-${{ needs.build-artifact.outputs.version }}-py3-none-any.whl"
 
   release-notes-update:
     name: Updates the release notes and changelog

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ FROM python:3.12-alpine3.20
 
 ARG MASS_VERSION
 ARG TARGETPLATFORM
-ARG DEV_RELEASE="false"
-ARG MASS_INSTALL_LOCATION="music-assistant[server]==${MASS_VERSION}"
 
 RUN set -x \
     && apk add --no-cache \
@@ -29,9 +27,6 @@ RUN set -x \
 # Copy widevine client files to container
 RUN mkdir -p /usr/local/bin/widevine_cdm
 COPY widevine_cdm/* /usr/local/bin/widevine_cdm/
-COPY dist/music_assistant-${MASS_VERSION}-py3-none-any.whl /tmp/
-
-RUN bash -c 'if [ "${DEV_RELEASE}" = "false" ]; then rm /tmp/music_assistant-${MASS_VERSION}-py3-none-any.whl; fi'
 
 # Upgrade pip + Install uv
 RUN pip install --upgrade pip \
@@ -42,7 +37,7 @@ RUN uv pip install \
     --system \
     --no-cache \
     --find-links "https://wheels.home-assistant.io/musllinux/" \
-    ${MASS_INSTALL_LOCATION}
+    dist/music_assistant-${MASS_VERSION}-py3-none-any.whl
 
 # Configure runtime environmental variables
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN set -x \
 # Copy widevine client files to container
 RUN mkdir -p /usr/local/bin/widevine_cdm
 COPY widevine_cdm/* /usr/local/bin/widevine_cdm/
-COPY pre_built_whl/music_assistant-${MASS_VERSION}-py3-none-any.whl /tmp/
+COPY dist/music_assistant-${MASS_VERSION}-py3-none-any.whl /tmp/
 
 RUN bash -c 'if [ "${DEV_RELEASE}" = "false" ]; then rm /tmp/music_assistant-${MASS_VERSION}-py3-none-any.whl; fi'
 


### PR DESCRIPTION
Add if always() to ensure further expression is checked, ensure that
build and push docker job runs after pypi publish is either successful
or skipped.  Move download artifacts job to after checkout so that it
isn't wiped out by the checkout