### PR TITLE
Fix several issues with enqueueing of next track

### DIFF
--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -359,6 +359,7 @@ CONF_ENTRY_FLOW_MODE_HIDDEN_DISABLED = ConfigEntry.from_dict(
     {**CONF_ENTRY_FLOW_MODE.to_dict(), "default_value": False, "value": False, "hidden": True}
 )
 
+
 CONF_ENTRY_AUTO_PLAY = ConfigEntry(
     key=CONF_AUTO_PLAY,
     type=ConfigEntryType.BOOLEAN,

--- a/music_assistant/common/models/enums.py
+++ b/music_assistant/common/models/enums.py
@@ -292,7 +292,6 @@ class PlayerFeature(StrEnum):
     PAUSE = "pause"
     SYNC = "sync"
     SEEK = "seek"
-    ENQUEUE_NEXT = "enqueue_next"
     PLAY_ANNOUNCEMENT = "play_announcement"
     UNKNOWN = "unknown"
 

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -954,6 +954,17 @@ class PlayerQueuesController(CoreController):
         elif prev_state["current_index"] != new_state["current_index"]:
             queue.end_of_track_reached = False
 
+        # handle auto restart of queue in flow mode when repeat is enabled
+        if (
+            queue.flow_mode
+            and queue.repeat_mode != RepeatMode.OFF
+            and queue.stream_finished
+            and prev_state["state"] == PlayerState.PLAYING
+            and new_state["state"] == PlayerState.IDLE
+        ):
+            # flow mode and repeat mode is on, restart the queue
+            self.mass.create_task(self.next(queue_id))
+
         # do not send full updates if only time was updated
         if changed_keys == {"elapsed_time"}:
             self.mass.signal_event(

--- a/music_assistant/server/controllers/streams.py
+++ b/music_assistant/server/controllers/streams.py
@@ -338,7 +338,7 @@ class StreamsController(CoreController):
             queue_item.uri,
             queue.display_name,
         )
-        queue.index_in_buffer = self.mass.player_queues.index_by_id(queue_id, queue_item_id)
+        self.mass.player_queues.track_loaded_in_buffer(queue_id, queue_item_id)
         pcm_format = AudioFormat(
             content_type=ContentType.from_bit_depth(output_format.bit_depth),
             sample_rate=queue_item.streamdetails.audio_format.sample_rate,
@@ -617,7 +617,7 @@ class StreamsController(CoreController):
                 queue_track.name,
                 queue.display_name,
             )
-            queue.index_in_buffer = self.mass.player_queues.index_by_id(
+            self.mass.player_queues.track_loaded_in_buffer(
                 queue.queue_id, queue_track.queue_item_id
             )
 

--- a/music_assistant/server/models/player_provider.py
+++ b/music_assistant/server/models/player_provider.py
@@ -167,9 +167,8 @@ class PlayerProvider(Provider):
         """
         Handle enqueuing of the next (queue) item on the player.
 
-        Only called if the player supports PlayerFeature.ENQUE_NEXT.
-        Called about 1 second after a new track started playing.
-        Called about 15 seconds before the end of the current track.
+        Called when player reports it started buffering a queue item
+        and when the queue items updated.
 
         A PlayerProvider implementation is in itself responsible for handling this
         so that the queue items keep playing until its empty or the player stopped.

--- a/music_assistant/server/providers/_template_player_provider/__init__.py
+++ b/music_assistant/server/providers/_template_player_provider/__init__.py
@@ -215,7 +215,6 @@ class MyDemoPlayerprovider(PlayerProvider):
                 PlayerFeature.VOLUME_SET,
                 PlayerFeature.VOLUME_MUTE,
                 PlayerFeature.PLAY_ANNOUNCEMENT,  # see play_announcement method
-                PlayerFeature.ENQUEUE_NEXT,  # see play_media/enqueue_next_media methods
             ),
         )
         # register the player with the player manager
@@ -333,9 +332,8 @@ class MyDemoPlayerprovider(PlayerProvider):
         """
         Handle enqueuing of the next (queue) item on the player.
 
-        Only called if the player supports PlayerFeature.ENQUE_NEXT.
-        Called about 1 second after a new track started playing.
-        Called about 15 seconds before the end of the current track.
+        Called when player reports it started buffering a queue item
+        and when the queue items updated.
 
         A PlayerProvider implementation is in itself responsible for handling this
         so that the queue items keep playing until its empty or the player stopped.
@@ -343,7 +341,6 @@ class MyDemoPlayerprovider(PlayerProvider):
         This will NOT be called if the end of the queue is reached (and repeat disabled).
         This will NOT be called if the player is using flow mode to playback the queue.
         """
-        # OPTIONAL - required only if you specified PlayerFeature.ENQUEUE_NEXT
         # this method should handle the enqueuing of the next queue item on the player.
 
     async def cmd_sync(self, player_id: str, target_player: str) -> None:

--- a/music_assistant/server/providers/chromecast/__init__.py
+++ b/music_assistant/server/providers/chromecast/__init__.py
@@ -372,7 +372,6 @@ class ChromecastProvider(PlayerProvider):
                         PlayerFeature.POWER,
                         PlayerFeature.VOLUME_MUTE,
                         PlayerFeature.VOLUME_SET,
-                        PlayerFeature.ENQUEUE_NEXT,
                         PlayerFeature.PAUSE,
                     ),
                     enabled_by_default=enabled_by_default,
@@ -431,7 +430,6 @@ class ChromecastProvider(PlayerProvider):
             castplayer.player.supported_features = (
                 PlayerFeature.POWER,
                 PlayerFeature.VOLUME_SET,
-                PlayerFeature.ENQUEUE_NEXT,
                 PlayerFeature.PAUSE,
             )
 

--- a/music_assistant/server/providers/dlna/__init__.py
+++ b/music_assistant/server/providers/dlna/__init__.py
@@ -64,20 +64,8 @@ BASE_PLAYER_FEATURES = (
     PlayerFeature.VOLUME_SET,
 )
 
-CONF_ENQUEUE_NEXT = "enqueue_next"
-
 
 PLAYER_CONFIG_ENTRIES = (
-    ConfigEntry(
-        key=CONF_ENQUEUE_NEXT,
-        type=ConfigEntryType.BOOLEAN,
-        label="Player supports enqueue next/gapless",
-        default_value=False,
-        description="If the player supports enqueuing the next item for fluid/gapless playback. "
-        "\n\nUnfortunately this feature is missing or broken on many DLNA players. \n"
-        "Enable it with care. If music stops after one song, "
-        "disable this setting (and use flow-mode instead).",
-    ),
     CONF_ENTRY_CROSSFADE_FLOW_MODE_REQUIRED,
     CONF_ENTRY_CROSSFADE_DURATION,
     CONF_ENTRY_ENFORCE_MP3,
@@ -627,9 +615,3 @@ class DLNAPlayerProvider(PlayerProvider):
     def _set_player_features(self, dlna_player: DLNAPlayer) -> None:
         """Set Player Features based on config values and capabilities."""
         dlna_player.player.supported_features = BASE_PLAYER_FEATURES
-        player_id = dlna_player.player.player_id
-        if self.mass.config.get_raw_player_config_value(player_id, CONF_ENQUEUE_NEXT, False):
-            dlna_player.player.supported_features = (
-                *dlna_player.player.supported_features,
-                PlayerFeature.ENQUEUE_NEXT,
-            )

--- a/music_assistant/server/providers/slimproto/__init__.py
+++ b/music_assistant/server/providers/slimproto/__init__.py
@@ -465,12 +465,14 @@ class SlimprotoProvider(PlayerProvider):
             transition_duration = 0
 
         metadata = {
-            "item_id": media.queue_item_id or media.uri,
+            "item_id": media.uri,
             "title": media.title,
             "album": media.album,
             "artist": media.artist,
             "image_url": media.image_url,
             "duration": media.duration,
+            "queue_id": media.queue_id,
+            "queue_item_id": media.queue_item_id,
         }
         queue = self.mass.player_queues.get(media.queue_id or player_id)
         slimplayer.extra_data["playlist repeat"] = REPEATMODE_MAP[queue.repeat_mode]
@@ -652,11 +654,19 @@ class SlimprotoProvider(PlayerProvider):
 
         # update player state on player events
         player.available = True
-        player.current_item_id = (
-            slimplayer.current_media.metadata.get("item_id")
-            if slimplayer.current_media and slimplayer.current_media.metadata
-            else slimplayer.current_url
-        )
+        if slimplayer.current_media and (metadata := slimplayer.current_media.metadata):
+            player.current_media = PlayerMedia(
+                uri=metadata.get("item_id"),
+                title=metadata.get("title"),
+                album=metadata.get("album"),
+                artist=metadata.get("artist"),
+                image_url=metadata.get("image_url"),
+                duration=metadata.get("duration"),
+                queue_id=metadata.get("queue_id"),
+                queue_item_id=metadata.get("queue_item_id"),
+            )
+        else:
+            player.current_media = None
         player.active_source = player.player_id
         player.name = slimplayer.name
         player.powered = slimplayer.powered

--- a/music_assistant/server/providers/slimproto/__init__.py
+++ b/music_assistant/server/providers/slimproto/__init__.py
@@ -643,7 +643,6 @@ class SlimprotoProvider(PlayerProvider):
                     PlayerFeature.VOLUME_SET,
                     PlayerFeature.PAUSE,
                     PlayerFeature.VOLUME_MUTE,
-                    PlayerFeature.ENQUEUE_NEXT,
                 ),
                 can_sync_with=tuple(
                     x.player_id for x in self.slimproto.players if x.player_id != player_id

--- a/music_assistant/server/providers/sonos/__init__.py
+++ b/music_assistant/server/providers/sonos/__init__.py
@@ -65,7 +65,6 @@ PLAYBACK_STATE_MAP = {
 PLAYER_FEATURES_BASE = {
     PlayerFeature.SYNC,
     PlayerFeature.VOLUME_MUTE,
-    PlayerFeature.ENQUEUE_NEXT,
     PlayerFeature.PAUSE,
 }
 

--- a/music_assistant/server/providers/sonos_s1/__init__.py
+++ b/music_assistant/server/providers/sonos_s1/__init__.py
@@ -55,7 +55,6 @@ if TYPE_CHECKING:
 PLAYER_FEATURES = (
     PlayerFeature.SYNC,
     PlayerFeature.VOLUME_MUTE,
-    PlayerFeature.ENQUEUE_NEXT,
     PlayerFeature.PAUSE,
 )
 
@@ -179,7 +178,12 @@ class SonosPlayerProvider(PlayerProvider):
         base_entries = await super().get_player_config_entries(player_id)
         if not (self.sonosplayers.get(player_id)):
             # most probably a syncgroup
-            return (*base_entries, CONF_ENTRY_CROSSFADE, CONF_ENTRY_ENFORCE_MP3)
+            return (
+                *base_entries,
+                CONF_ENTRY_CROSSFADE,
+                CONF_ENTRY_ENFORCE_MP3,
+                CONF_ENTRY_FLOW_MODE_HIDDEN_DISABLED,
+            )
         return (
             *base_entries,
             CONF_ENTRY_CROSSFADE,

--- a/music_assistant/server/providers/sonos_s1/player.py
+++ b/music_assistant/server/providers/sonos_s1/player.py
@@ -47,7 +47,6 @@ PLAYER_FEATURES = (
     PlayerFeature.SYNC,
     PlayerFeature.VOLUME_MUTE,
     PlayerFeature.VOLUME_SET,
-    PlayerFeature.ENQUEUE_NEXT,
 )
 DURATION_SECONDS = "duration_in_s"
 POSITION_SECONDS = "position_in_s"


### PR DESCRIPTION
- Use flow mode by default if device does not support enqueue next
- Remove (hacky) workaround to play next track if current track stopped playback (as alternative for no native enqueue support) - it caused too many side effects and complicated code. Just use flow mode if the device does not support enqueuing.
- Fix enqueuing of short tracks
- Fix enqueuing in case of repeat mode
- Fix current track reporting for slimproto