### PR TITLE
Volume normalization improvements

### DIFF
--- a/music_assistant/common/models/config_entries.py
+++ b/music_assistant/common/models/config_entries.py
@@ -631,7 +631,7 @@ CONF_ENTRY_ENABLE_ICY_METADATA = ConfigEntry(
         ConfigValueOption("Profile 2 - full info (including image)", "full"),
     ),
     depends_on=CONF_FLOW_MODE,
-    default_value="basic",
+    default_value="disabled",
     label="Try to ingest metadata into stream (ICY)",
     category="advanced",
     description="Try to ingest metadata into the stream (ICY) to show track info on the player, "

--- a/music_assistant/common/models/media_items.py
+++ b/music_assistant/common/models/media_items.py
@@ -109,6 +109,10 @@ class ProviderMapping(DataClassDictMixin):
     audio_format: AudioFormat = field(default_factory=AudioFormat)
     # url = link to provider details page if exists
     url: str | None = None
+    # loudness: integrated loudness in LUFS (measured according EBU R128)
+    loudness: float | None = None
+    # loudness_album: same as loudness but as seen in relation to the entire album
+    loudness_album: float | None = None
     # optional details to store provider specific details
     details: str | None = None
 

--- a/music_assistant/common/models/media_items.py
+++ b/music_assistant/common/models/media_items.py
@@ -109,10 +109,6 @@ class ProviderMapping(DataClassDictMixin):
     audio_format: AudioFormat = field(default_factory=AudioFormat)
     # url = link to provider details page if exists
     url: str | None = None
-    # loudness: integrated loudness in LUFS (measured according EBU R128)
-    loudness: float | None = None
-    # loudness_album: same as loudness but as seen in relation to the entire album
-    loudness_album: float | None = None
     # optional details to store provider specific details
     details: str | None = None
 

--- a/music_assistant/common/models/streamdetails.py
+++ b/music_assistant/common/models/streamdetails.py
@@ -48,6 +48,7 @@ class StreamDetails(DataClassDictMixin):
     loudness: float | None = None
     loudness_album: float | None = None
     prefer_album_loudness: bool = False
+    force_dynamic_volume_normalization: bool = False
     queue_id: str | None = None
     seconds_streamed: float | None = None
     target_loudness: float | None = None

--- a/music_assistant/common/models/streamdetails.py
+++ b/music_assistant/common/models/streamdetails.py
@@ -44,7 +44,10 @@ class StreamDetails(DataClassDictMixin):
     # the fields below will be set/controlled by the streamcontroller
     seek_position: int = 0
     fade_in: bool = False
+    enable_volume_normalization: bool = False
     loudness: float | None = None
+    loudness_album: float | None = None
+    prefer_album_loudness: bool = False
     queue_id: str | None = None
     seconds_streamed: float | None = None
     target_loudness: float | None = None

--- a/music_assistant/common/models/streamdetails.py
+++ b/music_assistant/common/models/streamdetails.py
@@ -12,17 +12,6 @@ from music_assistant.common.models.media_items import AudioFormat
 
 
 @dataclass(kw_only=True)
-class LoudnessMeasurement(DataClassDictMixin):
-    """Model for EBU-R128 loudness measurement details."""
-
-    integrated: float
-    true_peak: float
-    lra: float
-    threshold: float
-    target_offset: float | None = None
-
-
-@dataclass(kw_only=True)
 class StreamDetails(DataClassDictMixin):
     """Model for streamdetails."""
 
@@ -55,11 +44,10 @@ class StreamDetails(DataClassDictMixin):
     # the fields below will be set/controlled by the streamcontroller
     seek_position: int = 0
     fade_in: bool = False
-    loudness: LoudnessMeasurement | None = None
+    loudness: float | None = None
     queue_id: str | None = None
     seconds_streamed: float | None = None
     target_loudness: float | None = None
-    bypass_loudness_normalization: bool = False
     strip_silence_begin: bool = False
     strip_silence_end: bool = False
     stream_error: bool | None = None

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -67,7 +67,6 @@ CONF_SAMPLE_RATES: Final[str] = "sample_rates"
 CONF_HTTP_PROFILE: Final[str] = "http_profile"
 CONF_SYNC_LEADER: Final[str] = "sync_leader"
 CONF_BYPASS_NORMALIZATION_RADIO: Final[str] = "bypass_normalization_radio"
-CONF_BYPASS_NORMALIZATION_SHORT: Final[str] = "bypass_normalization_short"
 CONF_PREVENT_SYNC_LEADER_OFF: Final[str] = "prevent_sync_leader_off"
 CONF_SYNCGROUP_DEFAULT_ON: Final[str] = "syncgroup_default_on"
 CONF_ENABLE_ICY_METADATA: Final[str] = "enable_icy_metadata"
@@ -77,7 +76,6 @@ DEFAULT_HOST: Final[str] = "0.0.0.0"
 DEFAULT_PORT: Final[int] = 8095
 
 # common db tables
-DB_TABLE_TRACK_LOUDNESS: Final[str] = "track_loudness"
 DB_TABLE_PLAYLOG: Final[str] = "playlog"
 DB_TABLE_ARTISTS: Final[str] = "artists"
 DB_TABLE_ALBUMS: Final[str] = "albums"

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -70,6 +70,7 @@ CONF_BYPASS_NORMALIZATION_RADIO: Final[str] = "bypass_normalization_radio"
 CONF_PREVENT_SYNC_LEADER_OFF: Final[str] = "prevent_sync_leader_off"
 CONF_SYNCGROUP_DEFAULT_ON: Final[str] = "syncgroup_default_on"
 CONF_ENABLE_ICY_METADATA: Final[str] = "enable_icy_metadata"
+CONF_VOLUME_NORMALIZATION_RADIO: Final[str] = "volume_normalization_radio"
 
 # config default values
 DEFAULT_HOST: Final[str] = "0.0.0.0"

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -89,6 +89,7 @@ DB_TABLE_PROVIDER_MAPPINGS: Final[str] = "provider_mappings"
 DB_TABLE_ALBUM_TRACKS: Final[str] = "album_tracks"
 DB_TABLE_TRACK_ARTISTS: Final[str] = "track_artists"
 DB_TABLE_ALBUM_ARTISTS: Final[str] = "album_artists"
+DB_TABLE_LOUDNESS_MEASUREMENTS: Final[str] = "loudness_measurements"
 
 
 # all other

--- a/music_assistant/server/controllers/music.py
+++ b/music_assistant/server/controllers/music.py
@@ -694,9 +694,9 @@ class MusicController(CoreController):
             f"(provider_instance = '{provider_instance_id_or_domain}' OR "
             f"provider_instance = '{provider_instance_id_or_domain}')",
         ):
-            if row["loudness"] == inf or row["loudness"] == -inf:
+            if row[column] == inf or row[column] == -inf:
                 continue
-            return row["loudness"]
+            return row[column]
         if prefer_album_loudness:
             # try again without preferring album loudness
             return await self.get_loudness(

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -787,6 +787,8 @@ class PlayerQueuesController(CoreController):
             and (next_item := self.get_item(queue_id, next_index))
             and (
                 queue_item.media_item
+                and hasattr(queue_item.media_item, "album")
+                and hasattr(next_item.media_item, "album")
                 and queue_item.media_item.album
                 and next_item.media_item
                 and next_item.media_item.album

--- a/music_assistant/server/helpers/audio.py
+++ b/music_assistant/server/helpers/audio.py
@@ -1231,7 +1231,7 @@ def get_ffmpeg_args(
             resample_filter += f":osr={output_format.sample_rate}"
 
         # bit depth conversion: apply dithering when going down to 16 bits
-        if output_format.bit_depth < input_format.bit_depth:
+        if output_format.bit_depth == 16 and input_format.bit_depth > 16:
             resample_filter += ":osf=s16:dither_method=triangular_hp"
 
         filter_params.append(resample_filter)

--- a/music_assistant/server/helpers/audio.py
+++ b/music_assistant/server/helpers/audio.py
@@ -333,6 +333,7 @@ async def get_stream_details(
     queue_item: QueueItem,
     seek_position: int = 0,
     fade_in: bool = False,
+    prefer_album_loudness: bool = False,
 ) -> StreamDetails:
     """Get streamdetails for the given QueueItem.
 
@@ -366,7 +367,9 @@ async def get_stream_details(
         # get streamdetails from provider
         try:
             streamdetails: StreamDetails = await music_prov.get_stream_details(prov_media.item_id)
-            streamdetails.loudness = prov_media.loudness
+            streamdetails.loudness = (
+                prov_media.loudness_album if prefer_album_loudness else prov_media.loudness
+            )
         except MusicAssistantError as err:
             LOGGER.warning(str(err))
         else:
@@ -399,7 +402,7 @@ async def get_stream_details(
         streamdetails.loudness = await mass.music.get_loudness(
             streamdetails.item_id,
             streamdetails.provider,
-            album_loudness=False,
+            prefer_album_loudness=prefer_album_loudness,
             media_type=queue_item.media_type,
         )
     player_settings = await mass.config.get_player_config(streamdetails.queue_id)

--- a/music_assistant/server/helpers/audio.py
+++ b/music_assistant/server/helpers/audio.py
@@ -39,6 +39,7 @@ from music_assistant.constants import (
     CONF_EQ_TREBLE,
     CONF_OUTPUT_CHANNELS,
     CONF_VOLUME_NORMALIZATION,
+    CONF_VOLUME_NORMALIZATION_RADIO,
     CONF_VOLUME_NORMALIZATION_TARGET,
     MASS_LOGGER_NAME,
     VERBOSE_LOG_LEVEL,
@@ -399,6 +400,15 @@ async def get_stream_details(
     player_settings = await mass.config.get_player_config(streamdetails.queue_id)
     streamdetails.enable_volume_normalization = player_settings.get_value(CONF_VOLUME_NORMALIZATION)
     streamdetails.target_loudness = player_settings.get_value(CONF_VOLUME_NORMALIZATION_TARGET)
+
+    radio_norm_pref = await mass.config.get_core_config_value(
+        "streams", CONF_VOLUME_NORMALIZATION_RADIO
+    )
+    if streamdetails.media_type == MediaType.RADIO and radio_norm_pref == "disabled":
+        streamdetails.enable_volume_normalization = False
+    elif streamdetails.media_type == MediaType.RADIO and radio_norm_pref == "dynamic":
+        streamdetails.force_dynamic_volume_normalization = True
+
     process_time = int((time.time() - time_start) * 1000)
     LOGGER.debug("retrieved streamdetails for %s in %s milliseconds", queue_item.uri, process_time)
     return streamdetails

--- a/music_assistant/server/helpers/tags.py
+++ b/music_assistant/server/helpers/tags.py
@@ -329,6 +329,24 @@ class AudioTags:
                 return value
         return None
 
+    @property
+    def track_loudness(self) -> float | None:
+        """Try to read/calculate the integrated loudness from the tags."""
+        if (tag := self.tags.get("r128trackgain")) is not None:
+            return -23 - float(int(tag.split(" ")[0]) / 256)
+        if (tag := self.tags.get("replaygaintrackgain")) is not None:
+            return -18 - float(tag.split(" ")[0])
+        return None
+
+    @property
+    def track_album_loudness(self) -> float | None:
+        """Try to read/calculate the integrated loudness from the tags (album level)."""
+        if tag := self.tags.get("r128albumgain"):
+            return -23 - float(int(tag.split(" ")[0]) / 256)
+        if (tag := self.tags.get("replaygainalbumgain")) is not None:
+            return -18 - float(tag.split(" ")[0])
+        return None
+
     @classmethod
     def parse(cls, raw: dict) -> AudioTags:
         """Parse instance from raw ffmpeg info output."""

--- a/music_assistant/server/providers/airplay/__init__.py
+++ b/music_assistant/server/providers/airplay/__init__.py
@@ -110,6 +110,11 @@ CONF_CREDENTIALS = "credentials"
 CACHE_KEY_PREV_VOLUME = "airplay_prev_volume"
 FALLBACK_VOLUME = 20
 
+AIRPLAY_FLOW_PCM_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_F32LE,
+    sample_rate=44100,
+    bit_depth=32,
+)
 AIRPLAY_PCM_FORMAT = AudioFormat(
     content_type=ContentType.from_bit_depth(16), sample_rate=44100, bit_depth=16
 )
@@ -674,23 +679,15 @@ class AirplayProvider(PlayerProvider):
                 ugp_stream = ugp_provider.streams[media.queue_id]
                 input_format = ugp_stream.output_format
                 audio_source = ugp_stream.subscribe()
-            elif media.media_type == MediaType.RADIO and media.queue_id and media.queue_item_id:
-                # radio stream - consume media stream directly
-                input_format = AIRPLAY_PCM_FORMAT
-                queue_item = self.mass.player_queues.get_item(media.queue_id, media.queue_item_id)
-                audio_source = self.mass.streams.get_media_stream(
-                    streamdetails=queue_item.streamdetails,
-                    pcm_format=AIRPLAY_PCM_FORMAT,
-                )
             elif media.queue_id and media.queue_item_id:
                 # regular queue (flow) stream request
-                input_format = AIRPLAY_PCM_FORMAT
+                input_format = AIRPLAY_FLOW_PCM_FORMAT
                 audio_source = self.mass.streams.get_flow_stream(
                     queue=self.mass.player_queues.get(media.queue_id),
                     start_queue_item=self.mass.player_queues.get_item(
                         media.queue_id, media.queue_item_id
                     ),
-                    pcm_format=AIRPLAY_PCM_FORMAT,
+                    pcm_format=input_format,
                 )
             else:
                 # assume url or some other direct path

--- a/music_assistant/server/providers/filesystem_local/__init__.py
+++ b/music_assistant/server/providers/filesystem_local/__init__.py
@@ -705,8 +705,6 @@ class LocalFileSystemProvider(MusicProvider):
                         channels=tags.channels,
                         bit_rate=tags.bit_rate,
                     ),
-                    loudness=tags.track_loudness,
-                    loudness_album=tags.track_album_loudness,
                     details=file_item.checksum,
                 )
             },
@@ -786,6 +784,11 @@ class LocalFileSystemProvider(MusicProvider):
         if tags.musicbrainz_recordingid:
             track.mbid = tags.musicbrainz_recordingid
         track.metadata.chapters = UniqueList(tags.chapters)
+        # handle (optional) loudness measurement tag(s)
+        if tags.track_loudness is not None:
+            await self.mass.music.set_loudness(
+                track.item_id, self.instance_id, tags.track_loudness, tags.track_album_loudness
+            )
         return track
 
     async def _parse_artist(

--- a/music_assistant/server/providers/filesystem_local/__init__.py
+++ b/music_assistant/server/providers/filesystem_local/__init__.py
@@ -705,6 +705,8 @@ class LocalFileSystemProvider(MusicProvider):
                         channels=tags.channels,
                         bit_rate=tags.bit_rate,
                     ),
+                    loudness=tags.track_loudness,
+                    loudness_album=tags.track_album_loudness,
                     details=file_item.checksum,
                 )
             },

--- a/music_assistant/server/providers/slimproto/__init__.py
+++ b/music_assistant/server/providers/slimproto/__init__.py
@@ -371,7 +371,9 @@ class SlimprotoProvider(PlayerProvider):
 
         # this is a syncgroup, we need to handle this with a multi client stream
         master_audio_format = AudioFormat(
-            content_type=ContentType.from_bit_depth(24), sample_rate=48000, bit_depth=24
+            content_type=ContentType.PCM_F32LE,
+            sample_rate=48000,
+            bit_depth=32,
         )
         if media.media_type == MediaType.ANNOUNCEMENT:
             # special case: stream announcement

--- a/music_assistant/server/providers/ugp/__init__.py
+++ b/music_assistant/server/providers/ugp/__init__.py
@@ -54,7 +54,9 @@ if TYPE_CHECKING:
 # ruff: noqa: ARG002
 
 UGP_FORMAT = AudioFormat(
-    content_type=ContentType.from_bit_depth(16), sample_rate=44100, bit_depth=16
+    content_type=ContentType.PCM_F32LE,
+    sample_rate=44100,
+    bit_depth=32,
 )
 UGP_PREFIX = "ugp_"
 


### PR DESCRIPTION
- Allow reading normalization tags from files
- Use gain-based correction when measurement exists, fallback to dynamic if not.
- Allow dynamic mode to be enforced for radio streams
- Use f32 in the intermediate pcm stream
- Apply limiter (just in case) at the end of the chain 