### PR TITLE
Fix API compatibility

### DIFF
--- a/music_assistant/common/models/queue_item.py
+++ b/music_assistant/common/models/queue_item.py
@@ -44,6 +44,11 @@ class QueueItem(DataClassDictMixin):
             streamdetails.pop("expires", None)
             streamdetails.pop("path", None)
             streamdetails.pop("decryption_key", None)
+            # pop loudness from streamdetails in api to keep api from breaking
+            # (due to the loudness field's type change in 2.3)
+            # this may be removed after 2.3 has been launched to stable
+            streamdetails.pop("loudness", None)
+            streamdetails.pop("loudness_album", None)
         return d
 
     @property

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -3,7 +3,7 @@
 import pathlib
 from typing import Final
 
-API_SCHEMA_VERSION: Final[int] = 25
+API_SCHEMA_VERSION: Final[int] = 26
 MIN_SCHEMA_VERSION: Final[int] = 24
 
 

--- a/music_assistant/server/controllers/player_queues.py
+++ b/music_assistant/server/controllers/player_queues.py
@@ -949,12 +949,12 @@ class PlayerQueuesController(CoreController):
             if item_id := self._parse_player_current_item_id(queue_id, player):
                 queue.current_index = self.index_by_id(queue_id, item_id)
             if player.state in (PlayerState.PLAYING, PlayerState.PAUSED):
-                queue.elapsed_time = int(player.corrected_elapsed_time)
-                queue.elapsed_time_last_updated = player.elapsed_time_last_updated
+                queue.elapsed_time = int(player.corrected_elapsed_time or 0)
+                queue.elapsed_time_last_updated = player.elapsed_time_last_updated or 0
 
         # only update these attributes if the queue is active
         # and has an item loaded so we are able to resume it
-        queue.state = player.state
+        queue.state = player.state or PlayerState.IDLE
         queue.current_item = self.get_item(queue_id, queue.current_index)
         queue.next_item = self._get_next_item(queue_id)
 
@@ -1448,7 +1448,7 @@ class PlayerQueuesController(CoreController):
         """Calculate current queue index and current track elapsed time."""
         # player is playing a constant stream so we need to do this the hard way
         queue_index = 0
-        elapsed_time_queue = player.corrected_elapsed_time
+        elapsed_time_queue = player.corrected_elapsed_time or 0
         total_time = 0
         track_time = 0
         queue_items = self._queue_items[queue.queue_id]


### PR DESCRIPTION
Change API schema a tiny bit while being compatible

- Account for updated type of loudness in streamdetails
- Mark some player attributes as optional

For now the updated values will be converted/omitted during serializing.
We can remove that code in a few weeks/months.