### PR TITLE
Fix: Handle radio stations providing non utf-8 in streamtitle

### DIFF
--- a/music_assistant/server/helpers/audio.py
+++ b/music_assistant/server/helpers/audio.py
@@ -564,7 +564,12 @@ async def get_icy_radio_stream(
             stream_title = re.search(rb"StreamTitle='([^']*)';", meta_data)
             if not stream_title:
                 continue
-            stream_title = stream_title.group(1).decode()
+            try:
+                # in 99% of the cases the stream title is utf-8 encoded
+                stream_title = stream_title.group(1).decode("utf-8")
+            except UnicodeDecodeError:
+                # fallback to iso-8859-1
+                stream_title = stream_title.group(1).decode("iso-8859-1", errors="replace")
             cleaned_stream_title = clean_stream_title(stream_title)
             if cleaned_stream_title != streamdetails.stream_title:
                 LOGGER.log(VERBOSE_LOG_LEVEL, "ICY Radio streamtitle original: %s", stream_title)


### PR DESCRIPTION
While UTF-8 should be the standard, apparently there are radio stations providing the streamtitle in another charset.

Fixes: https://github.com/music-assistant/hass-music-assistant/issues/2908
