### PR TITLE
Fix loading state from cache when connecting to slimproto players

### DIFF
--- a/music_assistant/server/providers/slimproto/__init__.py
+++ b/music_assistant/server/providers/slimproto/__init__.py
@@ -861,7 +861,7 @@ class SlimprotoProvider(PlayerProvider):
             )
             self.mass.players.update(_player.player_id)
         # restore volume and power state
-        if last_state := await self.mass.cache.get(f"{CACHE_KEY_PREV_STATE}.{player_id}"):
+        if last_state := await self.mass.cache.get(player_id, base_key=CACHE_KEY_PREV_STATE):
             init_power = last_state[0]
             init_volume = last_state[1]
         else:


### PR DESCRIPTION
The cache keys being used for saving previous state and for loading state when connecting did not match.