### PR TITLE
Maintenance: Replace pylint with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,17 +80,12 @@ repos:
         always_run: true
         args:
           - --branch=main
-      # - id: pylint
-      #   name: 🌟 Starring code with pylint
-      #   language: system
-      #   types: [python]
-      #   entry: scripts/run-in-env.sh pylint
-      # - id: trailing-whitespace
-      #   name: ✄  Trim Trailing Whitespace
-      #   language: system
-      #   types: [text]
-      #   entry: scripts/run-in-env.sh trailing-whitespace-fixer
-      #   stages: [commit, push, manual]
+      - id: trailing-whitespace
+        name: ✄  Trim Trailing Whitespace
+        language: system
+        types: [text]
+        entry: scripts/run-in-env.sh trailing-whitespace-fixer
+        stages: [commit, push, manual]
       - id: mypy
         name: mypy
         entry: scripts/run-in-env.sh mypy

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN uv pip install \
     --no-cache \
     --find-links "https://wheels.home-assistant.io/musllinux/" \
     "music-assistant[server]@dist/music_assistant-${MASS_VERSION}-py3-none-any.whl"
-    
+
 # Set some labels
 LABEL \
     org.opencontainers.image.title="Music Assistant Server" \
@@ -32,7 +32,7 @@ LABEL \
     io.hass.platform="${TARGETPLATFORM}" \
     io.hass.type="addon"
 
-RUN rm -rf dist    
+RUN rm -rf dist
 
 VOLUME [ "/data" ]
 EXPOSE 8095

--- a/music_assistant/__main__.py
+++ b/music_assistant/__main__.py
@@ -134,7 +134,6 @@ def setup_logger(data_path: str, level: str = "DEBUG"):
 
 def _enable_posix_spawn() -> None:
     """Enable posix_spawn on Alpine Linux."""
-    # pylint: disable=protected-access
     if subprocess._USE_POSIX_SPAWN:
         return
 

--- a/music_assistant/common/helpers/util.py
+++ b/music_assistant/common/helpers/util.py
@@ -12,10 +12,8 @@ from typing import Any, TypeVar
 from urllib.parse import urlparse
 from uuid import UUID
 
-# pylint: disable=invalid-name
 T = TypeVar("T")
 CALLBACK_TYPE = Callable[[], None]
-# pylint: enable=invalid-name
 
 keyword_pattern = re.compile("title=|artist=")
 title_pattern = re.compile(r"title=\"(?P<title>.*?)\"")
@@ -207,7 +205,6 @@ async def get_ip() -> str:
 
     def _get_ip() -> str:
         """Get primary IP-address for this host."""
-        # pylint: disable=broad-except,no-member
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
             # doesn't even have to be reachable
@@ -251,7 +248,7 @@ async def get_ip_from_host(dns_name: str) -> str | None:
     def _resolve() -> str | None:
         try:
             return socket.gethostbyname(dns_name)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             # fail gracefully!
             return None
 
@@ -262,7 +259,6 @@ async def get_ip_pton(ip_string: str | None = None) -> bytes:
     """Return socket pton for local ip."""
     if ip_string is None:
         ip_string = await get_ip()
-    # pylint:disable=no-member
     try:
         return await asyncio.to_thread(socket.inet_pton, socket.AF_INET, ip_string)
     except OSError:
@@ -272,12 +268,10 @@ async def get_ip_pton(ip_string: str | None = None) -> bytes:
 def get_folder_size(folderpath: str) -> float:
     """Return folder size in gb."""
     total_size = 0
-    # pylint: disable=unused-variable
     for dirpath, _dirnames, filenames in os.walk(folderpath):
         for _file in filenames:
             _fp = os.path.join(dirpath, _file)
             total_size += os.path.getsize(_fp)
-    # pylint: enable=unused-variable
     return total_size / float(1 << 30)
 
 

--- a/music_assistant/common/models/api.py
+++ b/music_assistant/common/models/api.py
@@ -10,8 +10,6 @@ from mashumaro.mixins.orjson import DataClassORJSONMixin
 from music_assistant.common.helpers.json import get_serializable_value
 from music_assistant.common.models.event import MassEvent
 
-# pylint: disable=unnecessary-lambda
-
 
 @dataclass
 class CommandMessage(DataClassORJSONMixin):

--- a/music_assistant/common/models/event.py
+++ b/music_assistant/common/models/event.py
@@ -17,7 +17,5 @@ class MassEvent(DataClassORJSONMixin):
     object_id: str | None = None  # player_id, queue_id or uri
     data: Any = field(
         default=None,
-        metadata={
-            "serialize": lambda v: get_serializable_value(v)  # pylint: disable=unnecessary-lambda
-        },
+        metadata={"serialize": lambda v: get_serializable_value(v)},
     )

--- a/music_assistant/server/controllers/cache.py
+++ b/music_assistant/server/controllers/cache.py
@@ -111,7 +111,7 @@ class CacheController(CoreController):
         ) and (not checksum or db_row["checksum"] == checksum and db_row["expires"] >= cur_time):
             try:
                 data = await asyncio.to_thread(json_loads, db_row["data"])
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception as exc:
                 LOGGER.error(
                     "Error parsing cache data for %s: %s",
                     memory_key,

--- a/music_assistant/server/controllers/config.py
+++ b/music_assistant/server/controllers/config.py
@@ -665,7 +665,7 @@ class ConfigController:
                     return
             except FileNotFoundError:
                 pass
-            except JSON_DECODE_EXCEPTIONS:  # pylint: disable=catching-non-exception
+            except JSON_DECODE_EXCEPTIONS:
                 LOGGER.exception("Error while reading persistent storage file %s", filename)
         LOGGER.debug("Started with empty storage: No persistent storage file found.")
 

--- a/music_assistant/server/controllers/players.py
+++ b/music_assistant/server/controllers/players.py
@@ -1125,7 +1125,7 @@ class PlayerController(CoreController):
                         player.available = False
                         player.state = PlayerState.IDLE
                         player.powered = False
-                    except Exception as err:  # pylint: disable=broad-except
+                    except Exception as err:
                         self.logger.warning(
                             "Error while requesting latest state from player %s: %s",
                             player.display_name,

--- a/music_assistant/server/controllers/streams.py
+++ b/music_assistant/server/controllers/streams.py
@@ -98,8 +98,6 @@ FLOW_DEFAULT_SAMPLE_RATE = 48000
 FLOW_DEFAULT_BIT_DEPTH = 24
 
 
-# pylint:disable=too-many-locals
-
 isfile = wrap(os.path.isfile)
 
 

--- a/music_assistant/server/controllers/webserver.py
+++ b/music_assistant/server/controllers/webserver.py
@@ -298,7 +298,7 @@ class WebsocketClientHandler:
         except asyncio.CancelledError:
             self._logger.debug("Connection closed by client")
 
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             self._logger.exception("Unexpected error inside websocket API")
 
         finally:
@@ -361,7 +361,7 @@ class WebsocketClientHandler:
             elif asyncio.iscoroutine(result):
                 result = await result
             self._send_message(SuccessResultMessage(msg.message_id, result))
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception as err:
             if self._logger.isEnabledFor(logging.DEBUG):
                 self._logger.exception("Error handling message: %s", msg)
             else:

--- a/music_assistant/server/helpers/api.py
+++ b/music_assistant/server/helpers/api.py
@@ -137,7 +137,7 @@ def parse_value(name: str, value: Any, value_type: Any, default: Any = MISSING) 
         logging.getLogger(__name__).warning(err)
         return None
     if origin is type:
-        return eval(value)  # pylint: disable=eval-used
+        return eval(value)
     if value_type is Any:
         return value
     if value is None and value_type is not NoneType:

--- a/music_assistant/server/helpers/app_vars.py
+++ b/music_assistant/server/helpers/app_vars.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 # fmt: off
 # flake8: noqa
 # ruff: noqa

--- a/music_assistant/server/helpers/audio.py
+++ b/music_assistant/server/helpers/audio.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from music_assistant.server import MusicAssistant
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.audio")
-# pylint:disable=consider-using-f-string,too-many-locals,too-many-statements
+
 # ruff: noqa: PLR0915
 
 HTTP_HEADERS = {"User-Agent": "Lavf/60.16.100.MusicAssistant"}
@@ -425,7 +425,6 @@ async def get_media_stream(
 
 def create_wave_header(samplerate=44100, channels=2, bitspersample=16, duration=None):
     """Generate a wave header from given params."""
-    # pylint: disable=no-member
     file = BytesIO()
 
     # Generate format chunk

--- a/music_assistant/server/helpers/images.py
+++ b/music_assistant/server/helpers/images.py
@@ -78,7 +78,7 @@ async def get_image_thumb(
         except UnidentifiedImageError:
             raise FileNotFoundError(f"Invalid image: {path_or_url}")
         if size:
-            img.thumbnail((size, size), Image.LANCZOS)  # pylint: disable=no-member
+            img.thumbnail((size, size), Image.LANCZOS)
 
         mode = "RGBA" if image_format == "PNG" else "RGB"
         img.convert(mode).save(data, image_format, optimize=True)

--- a/music_assistant/server/helpers/logging.py
+++ b/music_assistant/server/helpers/logging.py
@@ -140,7 +140,7 @@ def catch_log_exception(
             """Catch and log exception."""
             try:
                 await async_func(*args)
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 log_exception(format_err, *args)
 
         wrapper_func = async_wrapper
@@ -152,7 +152,7 @@ def catch_log_exception(
             """Catch and log exception."""
             try:
                 func(*args)
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 log_exception(format_err, *args)
 
         wrapper_func = wrapper
@@ -168,7 +168,7 @@ def catch_log_coro_exception(
         """Catch and log exception."""
         try:
             return await target
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             log_exception(format_err, *args)
             return None
 

--- a/music_assistant/server/helpers/process.py
+++ b/music_assistant/server/helpers/process.py
@@ -25,8 +25,6 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.helpers.process")
 
 DEFAULT_CHUNKSIZE = 64000
 
-# pylint: disable=invalid-name
-
 
 class AsyncProcess:
     """

--- a/music_assistant/server/helpers/webserver.py
+++ b/music_assistant/server/helpers/webserver.py
@@ -105,7 +105,7 @@ class Webserver:
             msg = "Dynamic routes are not enabled"
             raise RuntimeError(msg)
         key = f"{method}.{path}"
-        if key in self._dynamic_routes:  # pylint: disable=unsupported-membership-test
+        if key in self._dynamic_routes:
             msg = f"Route {path} already registered."
             raise RuntimeError(msg)
         self._dynamic_routes[key] = handler

--- a/music_assistant/server/models/player_provider.py
+++ b/music_assistant/server/models/player_provider.py
@@ -269,7 +269,6 @@ class PlayerProvider(Provider):
     @property
     def players(self) -> list[Player]:
         """Return all players belonging to this provider."""
-        # pylint: disable=no-member
         return [
             player
             for player in self.mass.players

--- a/music_assistant/server/providers/apple_music/__init__.py
+++ b/music_assistant/server/providers/apple_music/__init__.py
@@ -38,8 +38,6 @@ from music_assistant.common.models.media_items import (
 )
 from music_assistant.common.models.streamdetails import StreamDetails
 from music_assistant.constants import CONF_PASSWORD
-
-# pylint: disable=no-name-in-module
 from music_assistant.server.helpers.app_vars import app_var
 from music_assistant.server.helpers.audio import get_hls_substream
 from music_assistant.server.helpers.throttle_retry import ThrottlerManager, throttle_with_retries

--- a/music_assistant/server/providers/chromecast/helpers.py
+++ b/music_assistant/server/providers/chromecast/helpers.py
@@ -228,7 +228,6 @@ class CastStatusListener:
 
         All following callbacks won't be forwarded.
         """
-        # pylint: disable=protected-access
         if self.castplayer.cast_info.is_audio_group:
             self._mz_mgr.remove_multizone(self._uuid)
         else:

--- a/music_assistant/server/providers/deezer/__init__.py
+++ b/music_assistant/server/providers/deezer/__init__.py
@@ -44,11 +44,7 @@ from music_assistant.common.models.media_items import (
 )
 from music_assistant.common.models.provider import ProviderManifest
 from music_assistant.common.models.streamdetails import StreamDetails
-
-# pylint: disable=no-name-in-module
 from music_assistant.server.helpers.app_vars import app_var
-
-# pylint: enable=no-name-in-module
 from music_assistant.server.helpers.auth import AuthenticationHelper
 from music_assistant.server.models import ProviderInstanceType
 from music_assistant.server.models.music_provider import MusicProvider
@@ -128,7 +124,7 @@ async def setup(
 
 async def get_config_entries(
     mass: MusicAssistant,
-    instance_id: str | None = None,  # noqa: ARG001 pylint: disable=W0613
+    instance_id: str | None = None,  # noqa: ARG001
     action: str | None = None,
     values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
@@ -166,7 +162,7 @@ async def get_config_entries(
     )
 
 
-class DeezerProvider(MusicProvider):  # pylint: disable=W0223
+class DeezerProvider(MusicProvider):
     """Deezer provider support."""
 
     client: deezer.Client

--- a/music_assistant/server/providers/fanarttv/__init__.py
+++ b/music_assistant/server/providers/fanarttv/__init__.py
@@ -11,7 +11,7 @@ from music_assistant.common.models.config_entries import ConfigEntry
 from music_assistant.common.models.enums import ConfigEntryType, ExternalID, ProviderFeature
 from music_assistant.common.models.media_items import ImageType, MediaItemImage, MediaItemMetadata
 from music_assistant.server.controllers.cache import use_cache
-from music_assistant.server.helpers.app_vars import app_var  # pylint: disable=no-name-in-module
+from music_assistant.server.helpers.app_vars import app_var
 from music_assistant.server.helpers.throttle_retry import Throttler
 from music_assistant.server.models.metadata_provider import MetadataProvider
 

--- a/music_assistant/server/providers/filesystem_local/__init__.py
+++ b/music_assistant/server/providers/filesystem_local/__init__.py
@@ -340,7 +340,7 @@ class LocalFileSystemProvider(MusicProvider):
                     playlist,
                     overwrite_existing=prev_checksum is not None,
                 )
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception as err:
             # we don't want the whole sync to crash on one file so we catch all exceptions here
             self.logger.error(
                 "Error processing %s - %s",
@@ -553,7 +553,7 @@ class LocalFileSystemProvider(MusicProvider):
                     track.position = idx
                     result.append(track)
 
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception as err:
             self.logger.warning(
                 "Error while parsing playlist %s: %s",
                 prov_playlist_id,

--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -81,7 +81,7 @@ async def setup(
 
 async def get_config_entries(
     mass: MusicAssistant,
-    instance_id: str | None = None,  # pylint: disable=W0613
+    instance_id: str | None = None,
     action: str | None = None,
     values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:

--- a/music_assistant/server/providers/qobuz/__init__.py
+++ b/music_assistant/server/providers/qobuz/__init__.py
@@ -47,11 +47,7 @@ from music_assistant.constants import (
     VARIOUS_ARTISTS_MBID,
     VARIOUS_ARTISTS_NAME,
 )
-
-# pylint: disable=no-name-in-module
 from music_assistant.server.helpers.app_vars import app_var
-
-# pylint: enable=no-name-in-module
 from music_assistant.server.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
 from music_assistant.server.helpers.util import lock
 from music_assistant.server.models.music_provider import MusicProvider
@@ -585,7 +581,6 @@ class QobuzProvider(MusicProvider):
 
     async def _parse_track(self, track_obj: dict) -> Track:
         """Parse qobuz track object to generic layout."""
-        # pylint: disable=too-many-branches
         name, version = parse_title_and_version(track_obj["title"], track_obj.get("version"))
         track = Track(
             item_id=str(track_obj["id"]),
@@ -743,7 +738,6 @@ class QobuzProvider(MusicProvider):
     @throttle_with_retries
     async def _get_data(self, endpoint, sign_request=False, **kwargs):
         """Get data from api."""
-        # pylint: disable=too-many-branches
         self.logger.debug("Handling GET request to %s", endpoint)
         url = f"http://www.qobuz.com/api.json/0.2/{endpoint}"
         headers = {"X-App-Id": app_var(0)}

--- a/music_assistant/server/providers/sonos_s1/helpers.py
+++ b/music_assistant/server/providers/sonos_s1/helpers.py
@@ -86,7 +86,7 @@ def _find_target_identifier(instance: Any, fallback_soco: SoCo | None) -> str | 
     if soco := getattr(instance, "soco", fallback_soco):
         # Holds a SoCo instance attribute
         # Only use attributes with no I/O
-        return soco._player_name or soco.ip_address  # pylint: disable=protected-access
+        return soco._player_name or soco.ip_address
     return None
 
 

--- a/music_assistant/server/providers/spotify/__init__.py
+++ b/music_assistant/server/providers/spotify/__init__.py
@@ -41,12 +41,8 @@ from music_assistant.common.models.media_items import (
     Track,
 )
 from music_assistant.common.models.streamdetails import StreamDetails
-
-# pylint: disable=no-name-in-module
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.server.helpers.app_vars import app_var
-
-# pylint: enable=no-name-in-module
 from music_assistant.server.helpers.audio import get_chunksize
 from music_assistant.server.helpers.auth import AuthenticationHelper
 from music_assistant.server.helpers.process import AsyncProcess, check_output

--- a/music_assistant/server/server.py
+++ b/music_assistant/server/server.py
@@ -456,7 +456,6 @@ class MusicAssistant:
 
         try:
             await self.load_provider_config(prov_conf)
-        # pylint: disable=broad-except
         except Exception as exc:
             # if loading failed, we store the error in the config object
             # so we can show something useful to the user
@@ -653,7 +652,7 @@ class MusicAssistant:
                             provider_manifest.icon_svg_dark = await get_icon_string(icon_path)
                     self._provider_manifests[provider_manifest.domain] = provider_manifest
                     LOGGER.debug("Loaded manifest for provider %s", provider_manifest.name)
-                except Exception as exc:  # pylint: disable=broad-except
+                except Exception as exc:
                     LOGGER.exception(
                         "Error while loading manifest for provider %s",
                         provider_domain,
@@ -709,7 +708,7 @@ class MusicAssistant:
 
     def _on_mdns_service_state_change(
         self,
-        zeroconf: Zeroconf,  # pylint: disable=unused-argument
+        zeroconf: Zeroconf,
         service_type: str,
         name: str,
         state_change: ServiceStateChange,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ test = [
   "mypy==1.11.2",
   "pre-commit==3.8.0",
   "pre-commit-hooks==4.6.0",
-  "pylint==3.2.7",
   "pytest==8.3.3",
   "pytest-aiohttp==1.0.5",
   "pytest-cov==5.0.0",
@@ -121,61 +120,6 @@ warn_unused_ignores = true
 [tool.ruff.format]
 # Force Linux/MacOS line endings
 line-ending = "lf"
-
-[tool.pylint.MASTER]
-extension-pkg-whitelist = ["orjson"]
-ignore = ["tests"]
-
-[tool.pylint.BASIC]
-good-names = ["_", "id", "on", "Run", "T"]
-
-[tool.pylint.DESIGN]
-max-attributes = 8
-
-[tool.pylint."MESSAGES CONTROL"]
-disable = [
-  "duplicate-code",
-  "format",
-  "unsubscriptable-object",
-  "unused-argument", # handled by ruff
-  "unspecified-encoding", # handled by ruff
-  "isinstance-second-argument-not-valid-type", # conflict with ruff
-  "fixme", # we're still developing  # TEMPORARY DISABLED rules  # The below rules must be enabled later one-by-one !
-  "too-many-return-statements",
-  "unsupported-assignment-operation",
-  "invalid-name",
-  "redefined-outer-name",
-  "too-many-statements",
-  "deprecated-method",
-  "logging-fstring-interpolation",
-  "attribute-defined-outside-init",
-  "broad-exception-caught",
-  "expression-not-assigned",
-  "consider-using-f-string",
-  "consider-using-with",
-  "arguments-renamed",
-  "protected-access",
-  "too-many-boolean-expressions",
-  "raise-missing-from",
-  "too-many-locals",
-  "abstract-method",
-  "unnecessary-lambda",
-  "stop-iteration-return",
-  "no-else-return",
-  "no-else-raise",
-  "undefined-loop-variable",
-  "too-many-nested-blocks",
-  "too-many-public-methods", # unavoidable?
-  "too-many-arguments", # unavoidable?
-  "too-many-branches", # unavoidable?
-  "too-many-instance-attributes", # unavoidable?
-]
-
-[tool.pylint.SIMILARITIES]
-ignore-imports = true
-
-[tool.pylint.FORMAT]
-max-line-length = 100
 
 [tool.pytest.ini_options]
 addopts = "--cov music_assistant"


### PR DESCRIPTION
We switched to ruff for all linting/checking. Remove all (leftover) traces of pylint.
Next step: Enable the ruff rules one by one that are now temporary disabled.