### PR TITLE
fix: album directory parsing with album versions

### DIFF
--- a/music_assistant/server/providers/filesystem_local/helpers.py
+++ b/music_assistant/server/providers/filesystem_local/helpers.py
@@ -79,7 +79,7 @@ def get_album_dir(track_dir: str, album_name: str) -> str | None:
         if compare_strings(album_name, dirname.split(" - ")[-1], False):
             # account for ArtistName - AlbumName format in the directory name
             return parentdir
-        if compare_strings(album_name, dirname.split(" - ")[1].split("(")[0], False):
+        if compare_strings(album_name, dirname.split(" - ")[-1].split("(")[0], False):
             # account for ArtistName - AlbumName (Version) format in the directory name
             return parentdir
         if compare_strings(album_name.split("(")[0], dirname, False):

--- a/music_assistant/server/providers/filesystem_local/helpers.py
+++ b/music_assistant/server/providers/filesystem_local/helpers.py
@@ -79,7 +79,7 @@ def get_album_dir(track_dir: str, album_name: str) -> str | None:
         if compare_strings(album_name, dirname.split(" - ")[-1], False):
             # account for ArtistName - AlbumName format in the directory name
             return parentdir
-        if compare_strings(album_name, dirname.split("(")[0], False):
+        if compare_strings(album_name, dirname.split(" - ")[1].split("(")[0], False):
             # account for ArtistName - AlbumName (Version) format in the directory name
             return parentdir
         if compare_strings(album_name.split("(")[0], dirname, False):

--- a/tests/server/providers/filesystem/test_helpers.py
+++ b/tests/server/providers/filesystem/test_helpers.py
@@ -1,5 +1,7 @@
 """Tests for utility/helper functions."""
 
+import pytest
+
 from music_assistant.server.providers.filesystem_local import helpers
 
 # ruff: noqa: S108
@@ -31,3 +33,59 @@ def test_get_artist_dir() -> None:
     album_path = "/tmp/Antonin Dvorak/Album"
     artist_name = "Antonín Dvořák"
     assert helpers.get_artist_dir(artist_name, album_path) == "/tmp/Antonin Dvorak"
+
+
+@pytest.mark.parametrize(
+    ("album_name", "track_dir", "expected"),
+    [
+        # Test literal match
+        (
+            "Selected Ambient Works 85-92",
+            "/home/user/Music/Aphex Twin/Selected Ambient Works 85-92",
+            "/home/user/Music/Aphex Twin/Selected Ambient Works 85-92",
+        ),
+        # Test artist - album format
+        (
+            "Selected Ambient Works 85-92",
+            "/home/user/Music/Aphex Twin - Selected Ambient Works 85-92",
+            "/home/user/Music/Aphex Twin - Selected Ambient Works 85-92",
+        ),
+        # Test artist - album (version) format
+        (
+            "Selected Ambient Works 85-92",
+            "/home/user/Music/Aphex Twin - Selected Ambient Works 85-92 (Remastered)",
+            "/home/user/Music/Aphex Twin - Selected Ambient Works 85-92 (Remastered)",
+        ),
+        # Test artist - album (version) format
+        (
+            "Selected Ambient Works 85-92",
+            "/home/user/Music/Aphex Twin - Selected Ambient Works 85-92 (Remastered) - WEB",
+            "/home/user/Music/Aphex Twin - Selected Ambient Works 85-92 (Remastered) - WEB",
+        ),
+        # Test album (version) format
+        (
+            "Selected Ambient Works 85-92",
+            "/home/user/Music/Aphex Twin/Selected Ambient Works 85-92 (Remastered)",
+            "/home/user/Music/Aphex Twin/Selected Ambient Works 85-92 (Remastered)",
+        ),
+        # Test album name in dir
+        (
+            "Selected Ambient Works 85-92",
+            "/home/user/Music/RandomDirWithSelected Ambient Works 85-92InIt",
+            "/home/user/Music/RandomDirWithSelected Ambient Works 85-92InIt",
+        ),
+        # Test no match
+        (
+            "NonExistentAlbumName",
+            "/home/user/Music/Aphex Twin/Selected Ambient Works 85-92",
+            None,
+        ),
+        # Test empty album name
+        ("", "/home/user/Music/Aphex Twin/Selected Ambient Works 85-92", None),
+        # Test empty track dir
+        ("Selected Ambient Works 85-92", "", None),
+    ],
+)
+def test_get_album_dir(album_name: str, track_dir: str, expected: str) -> None:
+    """Test the extraction of an album dir."""
+    assert helpers.get_album_dir(track_dir, album_name) == expected


### PR DESCRIPTION
I have found this problem while investigating why some of the covers don't load for me in https://github.com/orgs/music-assistant/discussions/2976.

This fixes how the album directory is parsed when the directory name includes the version.

Prior to this patch:

```
>>> print(get_album_dir(track_dir='/media/download/others/Kiasmos - II - (WEB)', album_name="II"))
None
```

After the patch:

```
>>> print(get_album_dir(track_dir='/media/download/others/Kiasmos - II - (WEB)', album_name="II"))
/media/download/others/Kiasmos - II - (WEB)
```