### PR TITLE
Return to snapcast-mod

### DIFF
--- a/music_assistant/server/providers/snapcast/manifest.json
+++ b/music_assistant/server/providers/snapcast/manifest.json
@@ -4,7 +4,7 @@
   "name": "Snapcast",
   "description": "Support for snapcast server and clients.",
   "codeowners": ["@SantigoSotoC"],
-  "requirements": ["snapcast==2.3.6", "bidict==0.23.1"],
+  "requirements": ["snapcast-mod==2.4.6", "bidict==0.23.1"],
   "documentation": "https://music-assistant.io/player-support/snapcast/",
   "multi_instance": false,
   "builtin": false

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -36,7 +36,7 @@ python-slugify==8.0.4
 pywidevine==1.8.0
 radios==0.3.1
 shortuuid==1.0.13
-snapcast==2.3.6
+snapcast-mod==2.4.6
 soco==0.30.4
 soundcloudpy==0.1.0
 tidalapi==0.7.6


### PR DESCRIPTION
I would like to go back to python-snapcast-mod, python-snapcast seems abandoned, so I can add functionality without it taking a lifetime. Like being able to add/remove multiple clients to a group at once, something that snapcast api allows and improve code quality sometimes even PEP is not respected.

I have a PR since July with a fix in the Readme since June without seeing any intetion of being merged.

In this version I include a solution to a frequently seen error in our log.
https://github.com/happyleavesaoc/python-snapcast/issues/74