### PR TITLE
Refactor SnapCastProvider cmd_volume_mute method

### DIFF
--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -447,8 +447,12 @@ class SnapCastProvider(PlayerProvider):
 
     async def cmd_volume_mute(self, player_id: str, muted: bool) -> None:
         """Send MUTE command to given player."""
+        ma_player = self.mass.players.get(player_id, raise_unavailable=False)
         snap_client_id = self._get_snapclient_id(player_id)
-        await self._snapserver.client(snap_client_id).set_muted(muted)
+        snapclient = self._snapserver.client(snap_client_id)
+        await snapclient.set_muted(muted)
+        ma_player.volume_muted = snapclient.muted
+        self.mass.players.update(player_id)
 
     async def cmd_sync(self, player_id: str, target_player: str) -> None:
         """Sync Snapcast player."""

--- a/music_assistant/server/providers/snapcast/__init__.py
+++ b/music_assistant/server/providers/snapcast/__init__.py
@@ -450,6 +450,7 @@ class SnapCastProvider(PlayerProvider):
         ma_player = self.mass.players.get(player_id, raise_unavailable=False)
         snap_client_id = self._get_snapclient_id(player_id)
         snapclient = self._snapserver.client(snap_client_id)
+        # Using optimistic value because the library does not return the response from the api
         await snapclient.set_muted(muted)
         ma_player.volume_muted = snapclient.muted
         self.mass.players.update(player_id)


### PR DESCRIPTION
This pull request includes a small but important change to the `cmd_volume_mute` method in the `music_assistant/server/providers/snapcast/__init__.py` file. The change ensures that the player's mute status is correctly updated in the system.