### PR TITLE
Various fixes for the Subsonic provider

### DIFF
--- a/music_assistant/server/providers/opensubsonic/manifest.json
+++ b/music_assistant/server/providers/opensubsonic/manifest.json
@@ -7,7 +7,7 @@
     "@khers"
   ],
   "requirements": [
-    "py-opensonic==5.1.1"
+    "py-opensonic==5.2.1"
   ],
   "documentation": "https://music-assistant.io/music-providers/subsonic/",
   "multi_instance": true

--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -99,14 +99,12 @@ class OpenSonicProvider(MusicProvider):
         try:
             success = await self._run_async(self._conn.ping)
             if not success:
-                msg = (
-                    f"Failed to connect to {self.config.get_value(CONF_BASE_URL)}, "
-                    "check your settings."
-                )
-                raise LoginFailed(msg)
+                raise CredentialError
         except (AuthError, CredentialError) as e:
             msg = (
-                f"Failed to connect to {self.config.get_value(CONF_BASE_URL)}, check your settings."
+                "Failed to connect to "
+                f"{self.config.get_value(CONF_BASE_URL)}"
+                ", check your settings."
             )
             raise LoginFailed(msg) from e
         self._enable_podcasts = self.config.get_value(CONF_ENABLE_PODCASTS)
@@ -322,8 +320,9 @@ class OpenSonicProvider(MusicProvider):
             )
         else:
             self.logger.info(
-                f"Unable to find an artist ID for album '{sonic_album.name}' with "
-                f"ID '{sonic_album.id}'."
+                "Unable to find an artist ID for album '%s' with ID '%s'.",
+                sonic_album.name,
+                sonic_album.id,
             )
             album.artists.append(
                 Artist(
@@ -425,8 +424,9 @@ class OpenSonicProvider(MusicProvider):
                 )
             else:
                 self.logger.info(
-                    f"Unable to find artist ID for track '{sonic_song.title}' with "
-                    f"ID '{sonic_song.id}'."
+                    "Unable to find artist ID for track '%s' with ID '%s'.",
+                    sonic_song.title,
+                    sonic_song.id,
                 )
                 artist = Artist(
                     item_id=UNKNOWN_ARTIST_ID,

--- a/music_assistant/server/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/server/providers/opensubsonic/sonic_provider.py
@@ -368,7 +368,7 @@ class OpenSonicProvider(MusicProvider):
             # We are setting disc number to 0 because the standard for what is part of
             # a Open Subsonic Song is not yet set and the implementations I have checked
             # do not contain this field. We should revisit this when the spec is finished
-            disc_number=0,
+            disc_number=sonic_song.disc_number or 0,
             favorite=bool(sonic_song.starred),
             provider_mappings={
                 ProviderMapping(
@@ -410,13 +410,14 @@ class OpenSonicProvider(MusicProvider):
                 # because it will not have an entry in the artists table so the best we can do it
                 # add a 'fake' id with the proper artist name and have get_artist() check for this
                 # id and handle it locally.
+                fake_id = f"{NAVI_VARIOUS_PREFIX}{sonic_song.artist}"
                 artist = Artist(
-                    item_id=f"{NAVI_VARIOUS_PREFIX}{sonic_song.artist}",
+                    item_id=fake_id,
                     provider=self.domain,
                     name=sonic_song.artist,
                     provider_mappings={
                         ProviderMapping(
-                            item_id=UNKNOWN_ARTIST_ID,
+                            item_id=fake_id,
                             provider_domain=self.domain,
                             provider_instance=self.instance_id,
                         )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -27,7 +27,7 @@ orjson==3.10.7
 pillow==11.0.0
 pkce==1.0.3
 plexapi==4.15.16
-py-opensonic==5.1.1
+py-opensonic==5.2.1
 pyblu==1.0.4
 PyChromecast==14.0.4
 pycryptodome==3.21.0


### PR DESCRIPTION
Update py-opensonic to 5.2.0 for the updated song parsing (now includes disc_number).

With the new disc_number field, pass this information on to MA for better track sorting.

Finally, we have yet another attempt to fix the Navidrome multi-artist disc issue. The original hack did not include the calculated item id and overloaded all artists that needed it with UNKNOWN_ARTIST instead causing odd artists to be listed.