### PR TITLE
Fix: Improve accuracy of matching album in directory structure for local filesystem

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1028,7 +1028,7 @@ class LocalFileSystemProvider(MusicProvider):
                 if item.ext != ext:
                     continue
                 # try match on filename = one of our imagetypes
-                if item.name in ImageType:
+                if item.name in ImageType.__members__:
                     images.append(
                         MediaItemImage(
                             type=ImageType(item.name),

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1028,7 +1028,7 @@ class LocalFileSystemProvider(MusicProvider):
                 if item.ext != ext:
                     continue
                 # try match on filename = one of our imagetypes
-                if item.name in ImageType.__members__:
+                if item.name in ImageType:
                     images.append(
                         MediaItemImage(
                             type=ImageType(item.name),

--- a/tests/providers/filesystem/test_helpers.py
+++ b/tests/providers/filesystem/test_helpers.py
@@ -62,17 +62,40 @@ def test_get_artist_dir() -> None:
             "/home/user/Music/Aphex Twin - Selected Ambient Works 85-92 (Remastered) - WEB",
             "/home/user/Music/Aphex Twin - Selected Ambient Works 85-92 (Remastered) - WEB",
         ),
+        # Test tokenizer - dirname with extras
+        (
+            "Fokus - Prewersje",
+            "/home/user/Fokus-Prewersje-PL-WEB-FLAC-2021-PS_INT",
+            "/home/user/Fokus-Prewersje-PL-WEB-FLAC-2021-PS_INT",
+        ),
+        # Test tokenizer - dirname with version and extras
+        (
+            "Layo And Bushwacka - Night Works",
+            "/home/music/Layo_And_Bushwacka-Night_Works_(Reissue)-(XLCD_154X)-FLAC-2003",
+            "/home/music/Layo_And_Bushwacka-Night_Works_(Reissue)-(XLCD_154X)-FLAC-2003",
+        ),
+        # Test tokenizer - extras and approximate match on diacratics
+        (
+            "Łona i Webber - Wyślij Sobie Pocztówkę",
+            "/usr/others/Lona-Discography-PL-FLAC-2020-INT/Lona_I_Webber-Wyslij_Sobie_Pocztowke-PL-WEB-FLAC-2014-PS",
+            "/usr/others/Lona-Discography-PL-FLAC-2020-INT/Lona_I_Webber-Wyslij_Sobie_Pocztowke-PL-WEB-FLAC-2014-PS",
+        ),
+        (
+            "NIC",
+            "/nas/downloads/others/Sokol-NIC-PL-WEB-FLAC-2021",
+            "/nas/downloads/others/Sokol-NIC-PL-WEB-FLAC-2021",
+        ),
         # Test album (version) format
         (
-            "Selected Ambient Works 85-92",
+            "Aphex Twin - Selected Ambient Works 85-92",
             "/home/user/Music/Aphex Twin/Selected Ambient Works 85-92 (Remastered)",
             "/home/user/Music/Aphex Twin/Selected Ambient Works 85-92 (Remastered)",
         ),
         # Test album name in dir
         (
-            "Selected Ambient Works 85-92",
-            "/home/user/Music/RandomDirWithSelected Ambient Works 85-92InIt",
-            "/home/user/Music/RandomDirWithSelected Ambient Works 85-92InIt",
+            "Aphex Twin - Selected Ambient Works 85-92",
+            "/home/user/Music/RandomDirWithAphex Twin - Selected Ambient Works 85-92InIt",
+            "/home/user/Music/RandomDirWithAphex Twin - Selected Ambient Works 85-92InIt",
         ),
         # Test no match
         (


### PR DESCRIPTION
Hi, this is another PR in my quest to fix the album art not loading correctly on my library. Here's a description of the changes from the first commit:

This code resolves a problem with some of the albums not being matched by other heuristics in the `get_album_dir()` method by taking slightly different approach. It emulates what humans do - mentally break down the name into logical chunks that represent an artist name, album name and
ignoring everything else.

The testing suite has been extended with a few examples of albums exhibiting problems with the way matching was done prior to this commit.