### PR TITLE
Fix: Reauthenticate with SiriusXM when playing a station

### DIFF
--- a/music_assistant/providers/siriusxm/__init__.py
+++ b/music_assistant/providers/siriusxm/__init__.py
@@ -218,7 +218,7 @@ class SiriusXMProvider(MusicProvider):
         # There's a chance that the SiriusXM auth session has expired
         # by the time the user clicks to play a station.  The sxm-client
         # will attempt to reauthenticate automatically, but this causes
-        # a delay in streaming with ffmpeg treats as a TimeoutError.
+        # a delay in streaming, and ffmpeg raises a TimeoutError.
         # To prevent this, we're going to explicitly authenticate with
         # SiriusXM proactively when a station has been chosen to avoid
         # this.

--- a/music_assistant/providers/siriusxm/__init__.py
+++ b/music_assistant/providers/siriusxm/__init__.py
@@ -215,6 +215,15 @@ class SiriusXMProvider(MusicProvider):
         self, item_id: str, media_type: MediaType = MediaType.RADIO
     ) -> StreamDetails:
         """Get streamdetails for a track/radio."""
+        # There's a chance that the SiriusXM auth session has expired
+        # by the time the user clicks to play a station.  The sxm-client
+        # will attempt to reauthenticate automatically, but this causes
+        # a delay in streaming with ffmpeg treats as a TimeoutError.
+        # To prevent this, we're going to explicitly authenticate with
+        # SiriusXM proactively when a station has been chosen to avoid
+        # this.
+        await self._client.authenticate()
+
         hls_path = f"http://{self._base_url}/{item_id}.m3u8"
 
         # Keep a reference to the current `StreamDetails` object so that we can


### PR DESCRIPTION
This attempts to address https://github.com/music-assistant/hass-music-assistant/issues/3165

As stated on the issue:
I think the problem is that we authenticate with SiriusXM when the server starts up so that we can confirm authentication details, and load the list of channels.  However, the sxm session expires frequently.  By the time the user attempts to play a station, there's a decent chance that the session is expired.  The `sxm-client` will attempt to re-authenticate automatically, but by the time this happens, there's a decent chance ffmpeg will raise a `TimeoutError`.

This patch makes it so that the code preemptively attempts to re-authenticate with SiriusXM before handing over the m3u8 playlist, ensuring that there is a valid session.  It's possible this will cause a slight delay to start the feed, but in my (limited) testing, this was fine, and still preferable to the `TimeoutError` being raised.