### PR TITLE
fix: Subsonic: Allow user to force player provider seek

### DIFF
--- a/music_assistant/providers/opensubsonic/__init__.py
+++ b/music_assistant/providers/opensubsonic/__init__.py
@@ -13,6 +13,7 @@ from .sonic_provider import (
     CONF_BASE_URL,
     CONF_ENABLE_LEGACY_AUTH,
     CONF_ENABLE_PODCASTS,
+    CONF_OVERRIDE_OFFSET,
     OpenSonicProvider,
 )
 
@@ -88,6 +89,15 @@ async def get_config_entries(
             label="Enable legacy auth",
             required=True,
             description='Enable OpenSubsonic "legacy" auth support',
+            default_value=False,
+        ),
+        ConfigEntry(
+            key=CONF_OVERRIDE_OFFSET,
+            type=ConfigEntryType.BOOLEAN,
+            label="Force player provider seek",
+            required=True,
+            description="Some Subsonic implementations advertise that they support seeking when "
+            "they do not always. If seeking does not work for you, enable this.",
             default_value=False,
         ),
     )

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
 CONF_BASE_URL = "baseURL"
 CONF_ENABLE_PODCASTS = "enable_podcasts"
 CONF_ENABLE_LEGACY_AUTH = "enable_legacy_auth"
+CONF_OVERRIDE_OFFSET = "override_transcode_offest"
 
 UNKNOWN_ARTIST_ID = "fake_artist_unknown"
 
@@ -71,6 +72,7 @@ class OpenSonicProvider(MusicProvider):
     _conn: SonicConnection = None
     _enable_podcasts: bool = True
     _seek_support: bool = False
+    _ignore_offset: bool = False
 
     async def handle_async_init(self) -> None:
         """Set up the music provider and test the connection."""
@@ -101,11 +103,12 @@ class OpenSonicProvider(MusicProvider):
             )
             raise LoginFailed(msg) from e
         self._enable_podcasts = self.config.get_value(CONF_ENABLE_PODCASTS)
+        self._ignore_offset = self.config.get_value(CONF_OVERRIDE_OFFSET)
         try:
             ret = await self._run_async(self._conn.getOpenSubsonicExtensions)
             extensions = ret["openSubsonicExtensions"]
             for entry in extensions:
-                if entry["name"] == "transcodeOffset":
+                if entry["name"] == "transcodeOffset" and not self._ignore_offset:
                     self._seek_support = True
                     break
         except OSError:


### PR DESCRIPTION
Some Subsonic implementations advertise the ability to specify an offset when calling the stream endpoint. This offset should allow a user to seek by setting that value, however, at least on Gonic this value is only honored with transcoding. Allow a user to tell the subsonic provider that their server is broken and provider seek should be used instead.

Fixes: https://github.com/music-assistant/hass-music-assistant/issues/3184