### PR TITLE
fix: Solved a bug for applying genres in Soundcloud tracks

### DIFF
--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -438,7 +438,7 @@ class SoundcloudMusicProvider(MusicProvider):
         if track_obj.get("description"):
             track.metadata.description = track_obj["description"]
         if track_obj.get("genre"):
-            track.metadata.genres = track_obj["genre"]
+            track.metadata.genres = [track_obj["genre"]]
         if track_obj.get("tag_list"):
             track.metadata.style = track_obj["tag_list"]
         return track


### PR DESCRIPTION
Simple bugfix to treat the genre metadata as an array instead of a string.

Original result after sync:
![bug-genre](https://github.com/user-attachments/assets/e8742ae6-df92-457f-988d-d173a5bc4dd4)

With fix applied:
![bug-genre-solved](https://github.com/user-attachments/assets/c7e4ce02-25c1-441a-b169-c03bb9f35997)