### PR TITLE
Allow Chromecast provider to handle/avoid images which are "too big"

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1261,7 +1261,7 @@ class PlayerQueuesController(CoreController):
                 album.name if (album := getattr(queue_item.media_item, "album", None)) else ""
             )
             if queue_item.image:
-                media.image_url = self.mass.metadata.get_image_url(queue_item.image)
+                media.image_url = self.mass.metadata.get_image_url(queue_item.image, size=512)
         return media
 
     async def get_artist_tracks(self, artist: Artist) -> list[Track]:

--- a/music_assistant/providers/chromecast/__init__.py
+++ b/music_assistant/providers/chromecast/__init__.py
@@ -675,7 +675,7 @@ class ChromecastProvider(PlayerProvider):
         # update metadata of current item chromecast
         if media_controller.status.media_custom_data["queue_item_id"] != current_item.queue_item_id:
             image_url = (
-                self.mass.metadata.get_image_url(current_item.image)
+                self.mass.metadata.get_image_url(current_item.image, size=512)
                 if current_item.image
                 else MASS_LOGO_ONLINE
             )

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,7 +13,7 @@ if [ -d "$env_name" ]; then
   echo "Virtual environment '$env_name' already exists."
 else
   echo "Creating Virtual environment..."
-  python -m venv .venv
+  ${PYTHON:-python} -m venv .venv
 fi
 echo "Activating virtual environment..."
 source .venv/bin/activate


### PR DESCRIPTION
My Chromecast Ultra crashes when presented with cover images on the order of 5000x5000 pixels (I've not determined the actual limit, 2048x2048 is ok though).

Allow users to avoid this problem by providing an advanced option per player which downscales the image to a specified size.

Fixes: https://github.com/music-assistant/hass-music-assistant/issues/3285
