### PR TITLE
Fix: Rewrite YT stream resolver to use web formats.

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -748,7 +748,11 @@ class YoutubeMusicProvider(MusicProvider):
                 "cookiefile": StringIO(self._netscape_cookie),
                 # This enforces a player client and skips unnecessary scraping to increase speed
                 "extractor_args": {
-                    "youtube": {"skip": ["translated_subs", "dash"], "player_client": ["ios"]}
+                    "youtube": {
+                        "skip": ["translated_subs", "dash"],
+                        "player_client": ["web_music"],
+                        "player_skip": ["webpage"],
+                    }
                 },
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/music_assistant/providers/ytmusic/manifest.json
+++ b/music_assistant/providers/ytmusic/manifest.json
@@ -4,7 +4,7 @@
   "name": "YouTube Music",
   "description": "Support for the YouTube Music streaming provider in Music Assistant.",
   "codeowners": ["@MarvinSchenkel"],
-  "requirements": ["ytmusicapi==1.8.2", "yt-dlp==2024.10.7"],
+  "requirements": ["ytmusicapi==1.8.2", "yt-dlp==2024.12.13"],
   "documentation": "https://music-assistant.io/music-providers/youtube-music/",
   "multi_instance": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -44,6 +44,6 @@ sxm==0.2.8
 tidalapi==0.8.1
 unidecode==1.3.8
 xmltodict==0.14.2
-yt-dlp==2024.10.7
+yt-dlp==2024.12.13
 ytmusicapi==1.8.2
 zeroconf==0.136.2


### PR DESCRIPTION
This PR changes the client of the stream resolver to the 'web_music' client, since cookies in combination with the `ios` format is not working anymore. Unfortunately this adds a small delay (+-5s) in resolving the url, but there currently is no other option.