### PR TITLE
Fix support links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Music Assistant is a free, opensource Media library manager that connects to you
 
 Documentation https://music-assistant.io
 
-For issues, please go to [the issue tracker](https://github.com/music-assistant/hass-music-assistant/issues).
+For issues, please go to [the issue tracker](https://github.com/music-assistant/support/issues).
 
-For feature requests, please see [feature requests](https://github.com/music-assistant/hass-music-assistant/discussions/categories/feature-requests-and-ideas).
+For feature requests, please see [feature requests](https://github.com/music-assistant/support/discussions/categories/feature-requests-and-ideas).
 
 ____________
 


### PR DESCRIPTION
For some reason I'm used to access the issue page via the README links, and I just realized they stopped working.