### PR TITLE
Fix: Disable the DSP by default

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -463,6 +463,7 @@ class ConfigController:
                 # add a tone control filter with the old values, reset the deprecated values and
                 # save this as the new DSP config
                 # TODO: remove this in a future release
+                dsp_config.enabled = True
                 dsp_config.filters.append(
                     ToneControlFilter(
                         enabled=True,
@@ -482,6 +483,9 @@ class ConfigController:
                         self.mass.config.set_raw_player_config_value(player_id, key, 0)
 
                 self.set(f"{CONF_PLAYER_DSP}/{player_id}", dsp_config.to_dict())
+            else:
+                # The DSP config does not do anything by default, so we disable it
+                dsp_config.enabled = False
 
             return dsp_config
 


### PR DESCRIPTION
This PR disables the DSP by default.

As discussed in https://github.com/music-assistant/frontend/pull/798#issuecomment-2566995204, this will show the DSP as disabled if it was not explicitly enabled by the user (or migrated from the old EQ options).
This will later allow for a more useful UI for showing if the DSP is enabled/disabled.

I will later also make a PR to change the default state of `DSPConfig` to disabled in https://github.com/music-assistant/models`. However, this PR also works without changes to models.
