### PR TITLE
Fix error on missing key in RSS Podcast data.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,6 +16,7 @@ With this repository cloned locally, execute the following commands in a termina
 * Run our development setup script to setup the development environment:
 * `scripts/setup.sh` (creates a new separate virtual environment to nicely separate the project dependencies)
 * The setup script will create a separate virtual environment (if needed), install all the project/test dependencies and configure pre-commit for linting and testing.
+* Make sure, that the python interpreter in VS Code is set to the newly generated venv.
 * Debug: Hit (Fn +) F5 to start Music Assistant locally
 * The pre-compiled UI of Music Assistant will be available at `localhost:8095` 🎉
 

--- a/music_assistant/providers/podcastfeed/__init__.py
+++ b/music_assistant/providers/podcastfeed/__init__.py
@@ -266,6 +266,7 @@ class PodcastMusicprovider(MusicProvider):
                 )
             ]
         episode.metadata.description = episode_obj["description"]
-        episode.metadata.explicit = episode_obj["explicit"]
+        if "explicit" in episode_obj:
+            episode.metadata.explicit = episode_obj["explicit"]
 
         return episode


### PR DESCRIPTION
In my case the python venv was not set automatically. In order to prevent trouble an additional note has been added. about making sure that the right venv was selected.

The RSS Podcast Feed may not define the "explicit" key. This will cause in an error. Fixing this by testing for the key.