### PR TITLE
Fix: Avoid extra call to get playlist metadata when fetching playlist tracks in Jellyfin

### DIFF
--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -413,9 +413,8 @@ class JellyfinProvider(MusicProvider):
             # paging not supported, we always return the whole list at once
             return []
         # TODO: Does Jellyfin support paging here?
-        jellyfin_playlist = await self._client.get_playlist(prov_playlist_id)
         playlist_items = (
-            await self._client.tracks.parent(jellyfin_playlist[ITEM_KEY_ID])
+            await self._client.tracks.parent(prov_playlist_id)
             .enable_userdata()
             .fields(*TRACK_FIELDS)
             .request()


### PR DESCRIPTION
Avoids 1 API call per playlist.

May help with https://github.com/music-assistant/support/issues/3278 as it removes the API call that was 404ing, but suspect user will just end up with empty playlists. More to follow for that one.