### PR TITLE
Fix: Use of incorrect type for group_childs in player_group provider

### DIFF
--- a/music_assistant/providers/player_group/__init__.py
+++ b/music_assistant/providers/player_group/__init__.py
@@ -36,7 +36,7 @@ from music_assistant_models.errors import (
     ProviderUnavailableError,
     UnsupportedFeaturedException,
 )
-from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.media_items import AudioFormat, UniqueList
 from music_assistant_models.player import DeviceInfo, Player, PlayerMedia
 
 from music_assistant.constants import (
@@ -711,7 +711,7 @@ class PlayerGroupProvider(PlayerProvider):
             needs_poll=True,
             poll_interval=30,
             can_group_with=can_group_with,
-            group_childs=set(members),
+            group_childs=UniqueList(members),
         )
 
         await self.mass.players.register_or_update(player)


### PR DESCRIPTION
Previously, `set` was incorrectly used, resulting in errors like:
```
2025-01-08 16:22:15.562 ERROR (MainThread) [music_assistant.webserver] Error handling message: CommandMessage(message_id=68, command='players/cmd/group_many', args={'target_player': 'ugp_xmn2f854', 'child_player_ids': ['797d4357-e2f5-4d50-8b16-f5e9cde1be6b']})
Traceback (most recent call last):
  File "/home/maximr/projects/music-assistant/music-assistant-server/music_assistant/controllers/players.py", line 734, in cmd_group_many
    await player_provider.cmd_group_many(target_player, final_player_ids)
  File "/home/maximr/projects/music-assistant/music-assistant-server/music_assistant/models/player_provider.py", line 202, in cmd_group_many
    await self.cmd_group(child_id, target_player)
  File "/home/maximr/projects/music-assistant/music-assistant-server/music_assistant/providers/player_group/__init__.py", line 576, in cmd_group
    group_player.group_childs.append(player_id)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'set' object has no attribute 'append'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/maximr/projects/music-assistant/music-assistant-server/music_assistant/controllers/webserver.py", line 361, in _run_handler
    result = await result
             ^^^^^^^^^^^^
  File "/home/maximr/projects/music-assistant/music-assistant-server/music_assistant/controllers/players.py", line 737, in cmd_group_many
    parent_player.group_childs.set(prev_group_childs)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'set' object has no attribute 'set'
```