### PR TITLE
Small fix for checking playlist url

### DIFF
--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -169,7 +169,7 @@ async def fetch_playlist(
     ) or "#EXT-X-STREAM-INF:" in playlist_data:
         raise IsHLSPlaylist
 
-    if url.endswith((".m3u", ".m3u8")):
+    if urlparse(url).path.endswith((".m3u", ".m3u8")):
         playlist = parse_m3u(playlist_data)
     else:
         playlist = parse_pls(playlist_data)


### PR DESCRIPTION
fix: allow m3u/m3u8 detection with query parameters

Previously, URLs containing query parameters were not being correctly detected
as m3u/m3u8 playlists. This patch ensures URLs with query strings are properly
identified as valid playlist formats.