### PR TITLE
fix: Make sure that Jellyfin playlists are sorted and paginated

### DIFF
--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -409,23 +409,21 @@ class JellyfinProvider(MusicProvider):
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """Get playlist tracks."""
         result: list[Track] = []
-        if page > 0:
-            # paging not supported, we always return the whole list at once
-            return []
-        # TODO: Does Jellyfin support paging here?
         playlist_items = (
-            await self._client.tracks.parent(prov_playlist_id)
+            await self._client.tracks.in_playlist(prov_playlist_id)
             .enable_userdata()
             .fields(*TRACK_FIELDS)
+            .limit(100)
+            .start_index(page * 100)
             .request()
         )
         for index, jellyfin_track in enumerate(playlist_items["Items"], 1):
+            pos = (page * 100) + index
             try:
                 if track := parse_track(
                     self.logger, self.instance_id, self._client, jellyfin_track
                 ):
-                    if not track.position:
-                        track.position = index
+                    track.position = pos
                     result.append(track)
             except (KeyError, ValueError) as err:
                 self.logger.error(

--- a/music_assistant/providers/jellyfin/manifest.json
+++ b/music_assistant/providers/jellyfin/manifest.json
@@ -4,7 +4,7 @@
   "name": "Jellyfin Media Server Library",
   "description": "Support for the Jellyfin streaming provider in Music Assistant.",
   "codeowners": ["@lokiberra", "@Jc2k"],
-  "requirements": ["aiojellyfin==0.10.1"],
+  "requirements": ["aiojellyfin==0.11.2"],
   "documentation": "https://music-assistant.io/music-providers/jellyfin/",
   "multi_instance": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@ Brotli>=1.0.9
 aiodns>=3.0.0
 aiofiles==24.1.0
 aiohttp==3.11.6
-aiojellyfin==0.10.1
+aiojellyfin==0.11.2
 aiorun==2024.8.1
 aioslimproto==3.1.0
 aiosonos==0.1.7


### PR DESCRIPTION
We were using the wrong endpoint for playlists so they were unsorted. We also need to use the order that they are returned in, rather than any index from the track object itself.

This also fixes pagination for that API endpoint.