### PR TITLE
Mypy fixes

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -3,11 +3,8 @@
 import pathlib
 from typing import Final
 
-from music_assistant_models.config_entries import (
-    ConfigEntry,
-    ConfigEntryType,
-    ConfigValueOption,
-)
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.enums import ConfigEntryType
 
 API_SCHEMA_VERSION: Final[int] = 26
 MIN_SCHEMA_VERSION: Final[int] = 24

--- a/music_assistant/controllers/media/albums.py
+++ b/music_assistant/controllers/media/albums.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from music_assistant.models.music_provider import MusicProvider
 
 
-class AlbumsController(MediaControllerBase[Album]):
+class AlbumsController(MediaControllerBase[Album, Album]):
     """Controller managing MediaItems of type Album."""
 
     db_table = DB_TABLE_ALBUMS

--- a/music_assistant/controllers/media/artists.py
+++ b/music_assistant/controllers/media/artists.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from music_assistant.models.music_provider import MusicProvider
 
 
-class ArtistsController(MediaControllerBase[Artist]):
+class ArtistsController(MediaControllerBase[Artist, Artist | ItemMapping]):
     """Controller managing MediaItems of type Artist."""
 
     db_table = DB_TABLE_ARTISTS

--- a/music_assistant/controllers/media/audiobooks.py
+++ b/music_assistant/controllers/media/audiobooks.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from music_assistant.models.music_provider import MusicProvider
 
 
-class AudiobooksController(MediaControllerBase[Audiobook]):
+class AudiobooksController(MediaControllerBase[Audiobook, Audiobook]):
     """Controller managing MediaItems of type Audiobook."""
 
     db_table = DB_TABLE_AUDIOBOOKS

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -39,7 +39,9 @@ if TYPE_CHECKING:
 
     from music_assistant import MusicAssistant
 
+MediaItemTypeBound = MediaItemType | ItemMapping
 ItemCls = TypeVar("ItemCls", bound="MediaItemType")
+LibraryUpdate = TypeVar("LibraryUpdate", bound="MediaItemTypeBound")
 
 JSON_KEYS = (
     "artists",
@@ -75,7 +77,7 @@ SORT_KEYS = {
 }
 
 
-class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
+class MediaControllerBase(Generic[ItemCls, LibraryUpdate], metaclass=ABCMeta):
     """Base model for controller managing a MediaType."""
 
     media_type: MediaType
@@ -162,7 +164,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         return None
 
     async def update_item_in_library(
-        self, item_id: str | int, update: ItemCls, overwrite: bool = False
+        self, item_id: str | int, update: LibraryUpdate, overwrite: bool = False
     ) -> ItemCls:
         """Update existing library record in the library database."""
         await self._update_library_item(item_id, update, overwrite=overwrite)

--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -22,7 +22,7 @@ from music_assistant.models.music_provider import MusicProvider
 from .base import MediaControllerBase
 
 
-class PlaylistController(MediaControllerBase[Playlist]):
+class PlaylistController(MediaControllerBase[Playlist, Playlist]):
     """Controller managing MediaItems of type Playlist."""
 
     db_table = DB_TABLE_PLAYLISTS

--- a/music_assistant/controllers/media/podcasts.py
+++ b/music_assistant/controllers/media/podcasts.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from music_assistant.models.music_provider import MusicProvider
 
 
-class PodcastsController(MediaControllerBase[Podcast]):
+class PodcastsController(MediaControllerBase[Podcast, Podcast]):
     """Controller managing MediaItems of type Podcast."""
 
     db_table = DB_TABLE_PODCASTS

--- a/music_assistant/controllers/media/radio.py
+++ b/music_assistant/controllers/media/radio.py
@@ -14,7 +14,7 @@ from music_assistant.helpers.json import serialize_to_json
 from .base import MediaControllerBase
 
 
-class RadioController(MediaControllerBase[Radio]):
+class RadioController(MediaControllerBase[Radio, Radio]):
     """Controller managing MediaItems of type Radio."""
 
     db_table = DB_TABLE_RADIOS

--- a/music_assistant/controllers/media/tracks.py
+++ b/music_assistant/controllers/media/tracks.py
@@ -41,7 +41,7 @@ from music_assistant.models.music_provider import MusicProvider
 from .base import MediaControllerBase
 
 
-class TracksController(MediaControllerBase[Track]):
+class TracksController(MediaControllerBase[Track, Track]):
     """Controller managing MediaItems of type Track."""
 
     db_table = DB_TABLE_TRACKS

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -21,6 +21,7 @@ from music_assistant_models.enums import (
     ContentType,
     ExternalID,
     ImageType,
+    MediaType,
     ProviderFeature,
     StreamType,
 )
@@ -33,7 +34,6 @@ from music_assistant_models.media_items import (
     ItemMapping,
     MediaItemImage,
     MediaItemType,
-    MediaType,
     Playlist,
     ProviderMapping,
     SearchResults,

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -901,7 +901,7 @@ class PlexProvider(MusicProvider):
 
         media: PlexMedia = plex_track.media[0]
 
-        media_type = (
+        content_type = (
             ContentType.try_parse(media.container) if media.container else ContentType.UNKNOWN
         )
         media_part: PlexMediaPart = media.parts[0]
@@ -911,7 +911,7 @@ class PlexProvider(MusicProvider):
             item_id=plex_track.key,
             provider=self.instance_id,
             audio_format=AudioFormat(
-                content_type=media_type,
+                content_type=content_type,
                 channels=media.audioChannels,
             ),
             stream_type=StreamType.HTTP,
@@ -919,7 +919,7 @@ class PlexProvider(MusicProvider):
             data=plex_track,
         )
 
-        if media_type != ContentType.M4A:
+        if content_type != ContentType.M4A:
             stream_details.path = self._plex_server.url(media_part.key, True)
             if audio_stream.samplingRate:
                 stream_details.audio_format.sample_rate = audio_stream.samplingRate

--- a/music_assistant/providers/radiobrowser/__init__.py
+++ b/music_assistant/providers/radiobrowser/__init__.py
@@ -11,6 +11,7 @@ from music_assistant_models.enums import (
     ContentType,
     ImageType,
     LinkType,
+    MediaType,
     ProviderFeature,
     StreamType,
 )
@@ -21,7 +22,6 @@ from music_assistant_models.media_items import (
     MediaItemImage,
     MediaItemLink,
     MediaItemType,
-    MediaType,
     ProviderMapping,
     Radio,
     SearchResults,

--- a/music_assistant/providers/test/__init__.py
+++ b/music_assistant/providers/test/__init__.py
@@ -207,7 +207,7 @@ class TestProvider(MusicProvider):
             metadata=MediaItemMetadata(images=UniqueList([DEFAULT_THUMB])),
         )
 
-    async def get_podcast(self, prov_podcast_id: str) -> Album:
+    async def get_podcast(self, prov_podcast_id: str) -> Podcast:
         """Get full podcast details by id."""
         return Podcast(
             item_id=prov_podcast_id,
@@ -255,13 +255,16 @@ class TestProvider(MusicProvider):
     async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
         """Retrieve library artists from the provider."""
         num_artists = self.config.get_value(CONF_KEY_NUM_ARTISTS)
+        assert isinstance(num_artists, int)
         for artist_idx in range(num_artists):
             yield await self.get_artist(str(artist_idx))
 
     async def get_library_albums(self) -> AsyncGenerator[Album, None]:
         """Retrieve library albums from the provider."""
         num_artists = self.config.get_value(CONF_KEY_NUM_ARTISTS) or 5
+        assert isinstance(num_artists, int)
         num_albums = self.config.get_value(CONF_KEY_NUM_ALBUMS)
+        assert isinstance(num_albums, int)
         for artist_idx in range(num_artists):
             for album_idx in range(num_albums):
                 album_item_id = f"{artist_idx}_{album_idx}"
@@ -270,8 +273,11 @@ class TestProvider(MusicProvider):
     async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
         """Retrieve library tracks from the provider."""
         num_artists = self.config.get_value(CONF_KEY_NUM_ARTISTS) or 5
+        assert isinstance(num_artists, int)
         num_albums = self.config.get_value(CONF_KEY_NUM_ALBUMS) or 5
+        assert isinstance(num_albums, int)
         num_tracks = self.config.get_value(CONF_KEY_NUM_TRACKS)
+        assert isinstance(num_tracks, int)
         for artist_idx in range(num_artists):
             for album_idx in range(num_albums):
                 for track_idx in range(num_tracks):
@@ -281,12 +287,14 @@ class TestProvider(MusicProvider):
     async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
         """Retrieve library tracks from the provider."""
         num_podcasts = self.config.get_value(CONF_KEY_NUM_PODCASTS)
+        assert isinstance(num_podcasts, int)
         for podcast_idx in range(num_podcasts):
             yield await self.get_podcast(str(podcast_idx))
 
     async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook, None]:
         """Retrieve library audiobooks from the provider."""
         num_audiobooks = self.config.get_value(CONF_KEY_NUM_AUDIOBOOKS)
+        assert isinstance(num_audiobooks, int)
         for audiobook_idx in range(num_audiobooks):
             yield await self.get_audiobook(str(audiobook_idx))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "mashumaro==3.14",
   "memory-tempfile==2.2.3",
   "music-assistant-frontend==2.10.4",
-  "music-assistant-models==1.1.9",
+  "music-assistant-models==1.1.10",
   "orjson==3.10.12",
   "pillow==11.0.0",
   "podcastparser==0.6.10",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -24,7 +24,7 @@ ifaddr==0.2.0
 mashumaro==3.14
 memory-tempfile==2.2.3
 music-assistant-frontend==2.10.4
-music-assistant-models==1.1.9
+music-assistant-models==1.1.10
 orjson==3.10.12
 pillow==11.0.0
 pkce==1.0.3

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -1,7 +1,6 @@
 """Tests for utility/helper functions."""
 
 import pytest
-from music_assistant_models import media_items
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MusicAssistantError
 

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -2,6 +2,7 @@
 
 import pytest
 from music_assistant_models import media_items
+from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MusicAssistantError
 
 from music_assistant.helpers import uri, util
@@ -44,37 +45,37 @@ async def test_uri_parsing() -> None:
     # test regular uri
     test_uri = "spotify://track/123456789"
     media_type, provider, item_id = await uri.parse_uri(test_uri)
-    assert media_type == media_items.MediaType.TRACK
+    assert media_type == MediaType.TRACK
     assert provider == "spotify"
     assert item_id == "123456789"
     # test spotify uri
     test_uri = "spotify:track:123456789"
     media_type, provider, item_id = await uri.parse_uri(test_uri)
-    assert media_type == media_items.MediaType.TRACK
+    assert media_type == MediaType.TRACK
     assert provider == "spotify"
     assert item_id == "123456789"
     # test public play/open url
     test_uri = "https://open.spotify.com/playlist/5lH9NjOeJvctAO92ZrKQNB?si=04a63c8234ac413e"
     media_type, provider, item_id = await uri.parse_uri(test_uri)
-    assert media_type == media_items.MediaType.PLAYLIST
+    assert media_type == MediaType.PLAYLIST
     assert provider == "spotify"
     assert item_id == "5lH9NjOeJvctAO92ZrKQNB"
     # test filename with slashes as item_id
     test_uri = "filesystem://track/Artist/Album/Track.flac"
     media_type, provider, item_id = await uri.parse_uri(test_uri)
-    assert media_type == media_items.MediaType.TRACK
+    assert media_type == MediaType.TRACK
     assert provider == "filesystem"
     assert item_id == "Artist/Album/Track.flac"
     # test regular url to builtin provider
     test_uri = "http://radiostream.io/stream.mp3"
     media_type, provider, item_id = await uri.parse_uri(test_uri)
-    assert media_type == media_items.MediaType.UNKNOWN
+    assert media_type == MediaType.UNKNOWN
     assert provider == "builtin"
     assert item_id == "http://radiostream.io/stream.mp3"
     # test local file to builtin provider
     test_uri = __file__
     media_type, provider, item_id = await uri.parse_uri(test_uri)
-    assert media_type == media_items.MediaType.UNKNOWN
+    assert media_type == MediaType.UNKNOWN
     assert provider == "builtin"
     assert item_id == __file__
     # test invalid uri


### PR DESCRIPTION
See https://github.com/music-assistant/models/pull/30. These are the typing failures that have snuck in because py.typed escaped the new models pypi package.

Not sure if this will work without https://github.com/music-assistant/models/pull/30 + tag + bump in here.

There are 2 i'm not sure about:

```
music_assistant/providers/theaudiodb/__init__.py:331: error: Argument 2 to "update_item_in_library" of "MediaControllerBase" has incompatible type "Artist | ItemMapping"; expected "Artist"  [arg-type]
music_assistant/providers/theaudiodb/__init__.py:377: error: Argument 2 to "update_item_in_library" of "MediaControllerBase" has incompatible type "Artist | ItemMapping"; expected "Artist"  [arg-type]
```