### PR TITLE
feat: allow music videos to be imported from Jellyfin

### DIFF
--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -54,8 +54,10 @@ from .const import (
     ITEM_KEY_MEDIA_CODEC,
     ITEM_KEY_MEDIA_SOURCES,
     ITEM_KEY_MEDIA_STREAMS,
+    ITEM_KEY_MEDIA_TYPE,
     ITEM_KEY_NAME,
     ITEM_KEY_RUNTIME_TICKS,
+    SUPPORTED_COLLECTION_TYPES,
     SUPPORTED_CONTAINER_FORMATS,
     TRACK_FIELDS,
     UNKNOWN_ARTIST_MAPPING,
@@ -454,7 +456,15 @@ class JellyfinProvider(MusicProvider):
         jellyfin_track = await self._client.get_track(item_id)
         mimetype = self._media_mime_type(jellyfin_track)
         media_stream = jellyfin_track[ITEM_KEY_MEDIA_STREAMS][0]
-        url = self._client.audio_url(jellyfin_track[ITEM_KEY_ID], SUPPORTED_CONTAINER_FORMATS)
+        if jellyfin_track[ITEM_KEY_MEDIA_TYPE] == "Video":
+            for stream in jellyfin_track[ITEM_KEY_MEDIA_STREAMS]:
+                if stream.get(ITEM_KEY_MEDIA_CODEC) in SUPPORTED_CONTAINER_FORMATS:
+                    media_stream = stream
+                    break
+            # Since video, we need to transcode to audio (demux not supported through this Jellyfin endpoint)
+            url = self._client.audio_url(jellyfin_track[ITEM_KEY_ID], audio_codec='flac', transcoding_container='flac')
+        else:
+            url = self._client.audio_url(jellyfin_track[ITEM_KEY_ID], SUPPORTED_CONTAINER_FORMATS)
         if ITEM_KEY_MEDIA_CODEC in media_stream:
             content_type = ContentType.try_parse(media_stream[ITEM_KEY_MEDIA_CODEC])
         else:
@@ -464,7 +474,7 @@ class JellyfinProvider(MusicProvider):
             provider=self.instance_id,
             audio_format=AudioFormat(
                 content_type=content_type,
-                channels=jellyfin_track[ITEM_KEY_MEDIA_STREAMS][0][ITEM_KEY_MEDIA_CHANNELS],
+                channels=media_stream[ITEM_KEY_MEDIA_CHANNELS],
             ),
             stream_type=StreamType.HTTP,
             duration=int(
@@ -489,7 +499,7 @@ class JellyfinProvider(MusicProvider):
         libraries = response["Items"]
         result = []
         for library in libraries:
-            if ITEM_KEY_COLLECTION_TYPE in library and library[ITEM_KEY_COLLECTION_TYPE] in "music":
+            if ITEM_KEY_COLLECTION_TYPE in library and library[ITEM_KEY_COLLECTION_TYPE] in SUPPORTED_COLLECTION_TYPES:
                 result.append(library)
         return result
 

--- a/music_assistant/providers/jellyfin/const.py
+++ b/music_assistant/providers/jellyfin/const.py
@@ -16,6 +16,7 @@ CLIENT_VERSION: Final = "0.1"
 COLLECTION_TYPE_MOVIES: Final = "movies"
 COLLECTION_TYPE_MUSIC: Final = "music"
 COLLECTION_TYPE_TVSHOWS: Final = "tvshows"
+COLLECTION_TYPE_MUSIC_VIDEOS: Final = "musicvideos"
 
 CONF_CLIENT_DEVICE_ID: Final = "client_device_id"
 
@@ -62,7 +63,7 @@ MEDIA_SOURCE_KEY_PATH: Final = "Path"
 MEDIA_TYPE_AUDIO: Final = "Audio"
 MEDIA_TYPE_NONE: Final = ""
 
-SUPPORTED_COLLECTION_TYPES: Final = [COLLECTION_TYPE_MUSIC]
+SUPPORTED_COLLECTION_TYPES: Final = [COLLECTION_TYPE_MUSIC, COLLECTION_TYPE_MUSIC_VIDEOS]
 
 SUPPORTED_CONTAINER_FORMATS: Final = "ogg,flac,mp3,aac,mpeg,alac,wav,aiff,wma,m4a,m4b,dsf,opus,wv"
 


### PR DESCRIPTION
This PR adds basic support for music video type from Jellyfin to allow music only playback. Technically the same approach can be applied to all videos from Jellyfin, but that is unlikely to be desirable for most users. Maybe this should be a setting for what libraries to include.

Note this requires https://github.com/Jc2k/aiojellyfin/pull/2

Maybe also need a note as this requires the user set up in Jellyfin to have transcode permissions.