### PR TITLE
use the trixie-slim image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
 
 # BASE docker image for music assistant container
-# Based on Debian Trixie (unstable) because we need a newer version of ffmpeg (and snapcast)
+# Based on Debian Trixie (testing) because we need a newer version of ffmpeg (and snapcast)
 # TODO: Switch back to regular python stable debian image + manually build ffmpeg and snapcast
-FROM debian:trixie
+FROM debian:trixie-slim
 
 ARG TARGETPLATFORM
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,7 +2,7 @@
 
 # BASE docker image for music assistant container
 # Based on Debian Trixie (testing) because we need a newer version of ffmpeg (and snapcast)
-# TODO: Switch back to regular python stable debian image + manually build ffmpeg and snapcast
+# TODO: Switch back to regular python stable debian image + manually build ffmpeg and snapcast ?
 FROM debian:trixie-slim
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
Tiny PR to use the "slim" version of trixie, which saves a bit of space by removing unneeded stuff (man pages, documentation, etc).