### PR TITLE
Feat: Add DSP pipeline details to stream information

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -297,6 +297,14 @@ async def get_stream_details(
 
     streamdetails.dsp = get_dsp_details(mass, player)
 
+    if player and player.group_childs:
+        # grouped playback, get DSP details for each player in the group
+        dsp_grouped = {}
+        for child_id in player.group_childs:
+            if child_player := mass.players.get(child_id):
+                dsp_grouped[child_id] = get_dsp_details(mass, child_player)
+        streamdetails.dsp_grouped_childs = dsp_grouped
+
     process_time = int((time.time() - time_start) * 1000)
     LOGGER.debug(
         "retrieved streamdetails for %s in %s milliseconds",

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -185,7 +185,7 @@ async def strip_silence(
     return stripped_data
 
 
-def get_dsp_details(mass: MusicAssistant, player: Player) -> DSPDetails:
+def get_player_dsp_details(mass: MusicAssistant, player: Player) -> DSPDetails:
     """Return DSP details of single a player."""
     dsp_config = mass.config.get_player_dsp_config(player.player_id)
     dsp_state = DSPState.ENABLED if dsp_config.enabled else DSPState.DISABLED
@@ -216,7 +216,7 @@ def get_stream_dsp_details(
     # We skip the PlayerGroups as they don't provide an audio output
     # by themselves, but only sync other players.
     if not player.provider.startswith("player_group"):
-        details = get_dsp_details(mass, player)
+        details = get_player_dsp_details(mass, player)
         details.is_leader = True
         dsp[player.player_id] = details
 
@@ -224,7 +224,7 @@ def get_stream_dsp_details(
         # grouped playback, get DSP details for each player in the group
         for child_id in player.group_childs:
             if child_player := mass.players.get(child_id):
-                dsp[child_id] = get_dsp_details(mass, child_player)
+                dsp[child_id] = get_player_dsp_details(mass, child_player)
     return dsp
 
 

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -294,18 +294,21 @@ async def get_stream_details(
 
     # attach the applied DSP to the streamdetails
     player = mass.players.get(streamdetails.queue_id)
+    dsp = {}
 
+    # player groups have no (explicit) leader since a player group has no audio output
     if not player.provider.startswith("player_group"):
-        # player groups have no leader!
-        streamdetails.dsp = get_dsp_details(mass, player)
+        details = get_dsp_details(mass, player)
+        details.is_leader = True
+        dsp[player.player_id] = details
 
     if player and player.group_childs:
         # grouped playback, get DSP details for each player in the group
-        dsp_grouped = {}
         for child_id in player.group_childs:
             if child_player := mass.players.get(child_id):
-                dsp_grouped[child_id] = get_dsp_details(mass, child_player)
-        streamdetails.dsp_grouped_childs = dsp_grouped
+                dsp[child_id] = get_dsp_details(mass, child_player)
+
+    streamdetails.dsp = dsp
 
     process_time = int((time.time() - time_start) * 1000)
     LOGGER.debug(

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -295,7 +295,9 @@ async def get_stream_details(
     # attach the applied DSP to the streamdetails
     player = mass.players.get(streamdetails.queue_id)
 
-    streamdetails.dsp = get_dsp_details(mass, player)
+    if not player.provider.startswith("player_group"):
+        # player groups have no leader!
+        streamdetails.dsp = get_dsp_details(mass, player)
 
     if player and player.group_childs:
         # grouped playback, get DSP details for each player in the group


### PR DESCRIPTION
Depends on: https://github.com/music-assistant/models/pull/32
Companion Frontend PR: https://github.com/music-assistant/frontend/pull/822

# Overview

With this PR, details about the DSP are now attached to `streamdetails`, allowing us to display the DSP processing pipeline to the users.

# Implementation Details

To discern between a user-disabled DSP and a DSP disabled by Music Assistant, `DSPState` was introduced.

The DSP field of `StreamDetails` should always be up to date, since:
- Playback is restarted on changes to the `DSPConfig`
- `DSPDetails` are refreshed in case the number of players in the group changes

# DSPDetails

`DSPDetails` is essentially a `DSPConfig` with some adjustments to add dynamic information, enabling the frontend to display the DSP pipeline at any desired level of detail.
