### PR TITLE
docker: use alpine3.21 with ffmpeg from mwader/static-ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,64 @@
 # syntax=docker/dockerfile:1
 
-# FINAL docker image for music assistant server
-# This image is based on the base image and installs
-# the music assistant server from our built wheel on top.
-
+# Builder image. It builds the venv that will be copied to the final image
+# 
 ARG BASE_IMAGE_VERSION=latest
+FROM ghcr.io/music-assistant/base:$BASE_IMAGE_VERSION AS builder
 
-FROM ghcr.io/music-assistant/base:$BASE_IMAGE_VERSION
+# Fastest way to install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-ARG MASS_VERSION
-ARG TARGETPLATFORM
+# create venv which will be copied to the final image
+ENV VIRTUAL_ENV=/app/venv
+RUN uv venv $VIRTUAL_ENV
+
 ADD dist dist
+COPY requirements_all.txt .
 
 # pre-install ALL requirements
 # comes at a cost of a slightly larger image size but is faster to start
 # because we do not have to install dependencies at runtime
-COPY requirements_all.txt .
 RUN uv pip install \
-    --no-cache \
+    --find-links "https://wheels.home-assistant.io/musllinux/" \
     -r requirements_all.txt
 
 # Install Music Assistant from prebuilt wheel
+ARG MASS_VERSION
 RUN uv pip install \
     --no-cache \
+    --find-links "https://wheels.home-assistant.io/musllinux/" \
     "music-assistant@dist/music_assistant-${MASS_VERSION}-py3-none-any.whl"
 
+# TODO: delete the unneeded architecture of librespot to decrease size!
+
+# we need to set (very permissive) permissions to the workdir
+# and /tmp to allow running the container as non-root
+# NOTE that home assistant add-ons always run as root (and use apparmor)
+# so we can't specify a user here
+#
+# IMPORTANT: chmod here, NOT on the final image, to avoid creating extra layers and increase size!
+#
+RUN chmod -R 777 /app
+
+##################################################################################################
+
+# FINAL docker image for music assistant server
+
+FROM ghcr.io/music-assistant/base:$BASE_IMAGE_VERSION
+
+ENV VIRTUAL_ENV=/app/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# copy the already build /app dir
+COPY --from=builder /app /app
+
+# the /app contents have correct permissinos but for some reason /app itself does not.
+# so apply again, but ONLY to the dir (otherwise we increase the size)
+RUN chmod 777 /app
+
 # Set some labels
+ARG MASS_VERSION
+ARG TARGETPLATFORM
 LABEL \
     org.opencontainers.image.title="Music Assistant Server" \
     org.opencontainers.image.description="Music Assistant Server/Core" \
@@ -40,9 +73,9 @@ LABEL \
     io.hass.platform="${TARGETPLATFORM}" \
     io.hass.type="addon"
 
-RUN rm -rf dist
-
 VOLUME [ "/data" ]
 EXPOSE 8095
+
+WORKDIR $VIRTUAL_ENV
 
 ENTRYPOINT ["mass", "--config", "/data"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,64 +1,38 @@
 # syntax=docker/dockerfile:1
 
 # BASE docker image for music assistant container
-# Based on Debian Trixie (testing) because we need a newer version of ffmpeg (and snapcast)
-# TODO: Switch back to regular python stable debian image + manually build ffmpeg and snapcast ?
-FROM debian:trixie-slim
+#
+# It should contain ONLY packages we want to deploy in the final image, not
+# packages needed to build. Build dependencies should be installed in the
+# "builder" image in the main Dockerfile.
 
-ARG TARGETPLATFORM
-
+FROM python:3.12-alpine3.21
 
 RUN set -x \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && apk add --no-cache \
         ca-certificates \
-        curl \
-        git \
-        wget \
+        jemalloc \
         tzdata \
-        python3 \
-        python3-venv \
-        python3-pip \
-        libsox-fmt-all \
-        libsox3 \
-        ffmpeg \
         sox \
-        openssl \
         cifs-utils \
-        libnfs-utils \
-        libjemalloc2 \
-        snapserver \
-    # cleanup
-    && rm -rf /tmp/* \
-    && rm -rf /var/lib/apt/lists/*
+        snapcast \
+        libnfs \
+        openssl-dev  # needed for airplay
 
+# Get static ffmpeg builds from https://hub.docker.com/r/mwader/static-ffmpeg/
+COPY --from=mwader/static-ffmpeg:7.1 /ffmpeg /usr/local/bin/
+COPY --from=mwader/static-ffmpeg:7.1 /ffprobe /usr/local/bin/
 
 # Copy widevine client files to container
 RUN mkdir -p /usr/local/bin/widevine_cdm
 COPY widevine_cdm/* /usr/local/bin/widevine_cdm/
 
-WORKDIR /app
-
-# Enable jemalloc
-RUN \
-    export LD_PRELOAD="$(find /usr/lib/ -name *libjemalloc.so.2)" \
-    export MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000"
-
-# create python venv
-ENV VIRTUAL_ENV=/app/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip install --upgrade pip \
-    && pip install uv==0.4.17
+# Configure runtime environmental variables
+ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 
 # we need to set (very permissive) permissions to the workdir
 # and /tmp to allow running the container as non-root
-# NOTE that home assistant add-ons always run as root (and use apparmor)
-# so we can't specify a user here
-RUN chmod -R 777 /app \
-    && chmod -R 777 /tmp
-
-WORKDIR $VIRTUAL_ENV
+RUN chmod -R 777 /tmp
 
 LABEL \
     org.opencontainers.image.title="Music Assistant Base Image" \


### PR DESCRIPTION
This is an experiment with improving the docker images. It does two main things:

1. Uses `python:3.12-alpine3.21` with static ffmpeg 7.1 builds from `mwader/static-ffmpeg`. These builds are created on alpine, but I think they overcome the musl issues by using glibc although they build on alpine.

2. Use a multi-stage build to decrease the image size. The python venv is build in a separate image and copied to the final one.

NOTE: I've only done some light testing of the resulting images.