### PR TITLE
Fix: DSP edge cases around groups

### DIFF
--- a/music_assistant/controllers/players.py
+++ b/music_assistant/controllers/players.py
@@ -886,7 +886,7 @@ class PlayerController(CoreController):
         self._prev_states.pop(player_id, None)
         self.mass.signal_event(EventType.PLAYER_REMOVED, player_id)
 
-    def update(
+    def update(  # noqa: PLR0915
         self, player_id: str, skip_forward: bool = False, force_update: bool = False
     ) -> None:
         """Update player state."""

--- a/music_assistant/controllers/players.py
+++ b/music_assistant/controllers/players.py
@@ -964,18 +964,45 @@ class PlayerController(CoreController):
         if len(changed_values) == 0 and not force_update:
             return
 
-        # handle DSP reload when player is grouped or ungrouped
-        prev_is_grouped = bool(prev_state.get("synced_to")) or bool(prev_state.get("group_childs"))
-        new_is_grouped = bool(new_state.get("synced_to")) or bool(new_state.get("group_childs"))
+        # handle DSP reload of the leader when on grouping and ungrouping
+        prev_child_count = len(prev_state.get("group_childs", []))
+        new_child_count = len(new_state.get("group_childs", []))
+        is_player_group = player.provider.startswith("player_group")
 
-        if prev_is_grouped != new_is_grouped:
-            dsp_config = self.mass.config.get_player_dsp_config(player_id)
+        # handle special case for PlayerGroups: since there are no leaders,
+        # DSP still always works with a single player in the group.
+        multi_device_dsp_threshold = 1 if is_player_group else 0
+
+        prev_is_multiple_devices = prev_child_count > multi_device_dsp_threshold
+        new_is_multiple_devices = new_child_count > multi_device_dsp_threshold
+
+        if prev_is_multiple_devices != new_is_multiple_devices:
             supports_multi_device_dsp = PlayerFeature.MULTI_DEVICE_DSP in player.supported_features
-            if dsp_config.enabled and not supports_multi_device_dsp:
-                # We now know that that the player was grouped or ungrouped,
-                # the player has a custom DSP enabled, but the player provider does
-                # not support multi-device DSP.
-                # So we need to reload the DSP configuration.
+            dsp_enabled: bool
+            if is_player_group:
+                # Since player groups do not have leaders, we will use the only child
+                # that was in the group before and after the change
+                if prev_is_multiple_devices:
+                    if childs := new_state.get("group_childs"):
+                        # We shrank the group from multiple players to a single player
+                        # So the now only child will control the DSP
+                        dsp_enabled = self.mass.config.get_player_dsp_config(childs[0]).enabled
+                    else:
+                        dsp_enabled = False
+                elif childs := prev_state.get("group_childs"):
+                    # We grew the group from a single player to multiple players,
+                    # let's see if the previous single player had DSP enabled
+                    dsp_enabled = self.mass.config.get_player_dsp_config(childs[0]).enabled
+                else:
+                    dsp_enabled = False
+            else:
+                dsp_enabled = self.mass.config.get_player_dsp_config(player_id).enabled
+            if dsp_enabled and not supports_multi_device_dsp:
+                # We now know that that the group configuration has changed so:
+                # - multi-device DSP is not supported
+                # - we switched from a group with multiple players to a single player
+                #   (or vice versa)
+                # - the leader has DSP enabled
                 self.mass.create_task(self.mass.players.on_player_dsp_change(player_id))
 
         if changed_values.keys() != {"elapsed_time"} or force_update:


### PR DESCRIPTION
This PR fixes various edge cases I missed with #1839.

# Reload Detection

The existing logic for issuing DSP reloads when grouping or ungrouping was flawed.
This reworks this section, handling all edge cases I can think of including:
- Don't restart playback if the leader already had DSP disabled
- Don't restart playback if a group shrank to a single device that has DSP disabled
- Proper handling of `PlayerGroup`s
-  `PlayerGroup` with only a single member

Additionally, the existing logic had another oversight where it would issue a reload command for every device in the group. This fixes that by only reloading the leader/`PlayerGroup`.

# `PlayerGroup`s with single members

Another previously missed edge case involves groups with single members that would mistakenly use the DSP Config of the `PlayerGroup` instead of the `Player`. This is now fixed.

This now allows all `PlayerGroup`s with single devices to correctly apply DSP.