### PR TITLE
Feat: Ability to use Audiobookshelf Sessions/ HLS Stream

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -55,8 +55,6 @@ CONF_URL = "url"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_VERIFY_SSL = "verify_ssl"
-CONF_USE_SESSION_AUDIOBOOK = "use_session_audiobook"
-CONF_USE_SESSION_PODCAST = "use_session_podcast"
 
 
 async def setup(
@@ -101,24 +99,6 @@ async def get_config_entries(
             label="Password",
             required=False,
             description="The password to authenticate to the remote server.",
-        ),
-        ConfigEntry(
-            key=CONF_USE_SESSION_AUDIOBOOK,
-            type=ConfigEntryType.BOOLEAN,
-            label="Use session/ HLS stream for audiobooks.",
-            required=False,
-            description="Opens a session at abs, enables support for multiple file audiobooks.",
-            category="advanced",
-            default_value=True,
-        ),
-        ConfigEntry(
-            key=CONF_USE_SESSION_PODCAST,
-            type=ConfigEntryType.BOOLEAN,
-            label="Use session/ HLS stream for podcasts.",
-            required=False,
-            description="Opens a session at abs for podcasts.",
-            category="advanced",
-            default_value=False,
         ),
         ConfigEntry(
             key=CONF_VERIFY_SSL,
@@ -442,38 +422,26 @@ class Audiobookshelf(MusicProvider):
         """Get stream of item."""
         # self.logger.debug(f"Streamdetails: {item_id}")
         if media_type == MediaType.PODCAST_EPISODE:
-            if not bool(self.config.get_value(CONF_USE_SESSION_PODCAST)):
-                return await self._get_stream_details_podcast_episode(item_id)
-            abs_podcast_id, abs_episode_id = item_id.split(" ")
-            session = await self._client.get_playback_session_podcast(
-                device_info=self.device_info,
-                podcast_id=abs_podcast_id,
-                episode_id=abs_episode_id,
-            )
-            return await self.get_streamdetails_from_playback_session(session)
+            return await self._get_stream_details_podcast_episode(item_id)
         elif media_type == MediaType.AUDIOBOOK:
-            if not bool(self.config.get_value(CONF_USE_SESSION_AUDIOBOOK)):
-                return await self._get_stream_details_audiobook(item_id)
-            session = await self._client.get_playback_session_audiobook(
-                device_info=self.device_info, audiobook_id=item_id
-            )
-            return await self.get_streamdetails_from_playback_session(session)
+            abs_audiobook = await self._client.get_audiobook(item_id)
+            tracks = abs_audiobook.media.tracks
+            if len(tracks) == 0:
+                raise MediaNotFoundError("Stream not found")
+            if len(tracks) > 1:
+                session = await self._client.get_playback_session_audiobook(
+                    device_info=self.device_info, audiobook_id=item_id
+                )
+                return await self.get_streamdetails_from_playback_session(session)
+            return await self._get_stream_details_audiobook(abs_audiobook)
         raise MediaNotFoundError("Stream unknown")
 
-    async def _get_stream_details_audiobook(self, audiobook_id: str) -> StreamDetails:
+    async def _get_stream_details_audiobook(self, abs_audiobook: ABSAudioBook) -> StreamDetails:
         """Only single audio file in audiobook."""
-        abs_audiobook = await self._client.get_audiobook(audiobook_id)
         self.logger.debug(
             f"Using direct playback for audiobook {abs_audiobook.media.metadata.title}"
         )
         tracks = abs_audiobook.media.tracks
-        if len(tracks) == 0:
-            raise MediaNotFoundError("Stream not found")
-        if len(tracks) > 1:
-            self.logger.warning(
-                "Music Assistant only supports single file based audiobooks. "
-                "Switch to HLS stream for multiple file audiobooks."
-            )
         token = self._client.token
         base_url = str(self.config.get_value(CONF_URL))
         media_url = tracks[0].content_url
@@ -482,7 +450,7 @@ class Audiobookshelf(MusicProvider):
         # to lift unknown at some point.
         return StreamDetails(
             provider=self.lookup_key,
-            item_id=audiobook_id,
+            item_id=abs_audiobook.id_,
             audio_format=AudioFormat(
                 content_type=ContentType.UNKNOWN,
             ),

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -5,7 +5,6 @@ Audiobookshelf is abbreviated ABS here.
 
 from __future__ import annotations
 
-import hashlib
 from collections.abc import AsyncGenerator, Sequence
 from typing import TYPE_CHECKING
 
@@ -143,20 +142,16 @@ class Audiobookshelf(MusicProvider):
             raise LoginFailed(f"Login to abs instance at {base_url} failed.")
         await self._client.sync()
 
-        # this is stolen from the Jellyfin provider, and gives an id surviving
-        # reboots/ provider removal+adds
-        self.device_id = hashlib.sha256(f"{self.instance_id}+{username}".encode()).hexdigest()
-
         # this will be provided when creating sessions or receive already opened sessions
         self.device_info = ABSDeviceInfo(
-            device_id=self.device_id,
+            device_id=self.instance_id,
             client_name="Music Assistant",
             client_version=self.mass.version,
             manufacturer="",
             model=self.mass.server_id,
         )
 
-        self.logger.debug(f"Our playback session device_id is {self.device_id=}")
+        self.logger.debug(f"Our playback session device_id is {self.instance_id}")
 
     async def unload(self, is_removed: bool = False) -> None:
         """

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -145,7 +145,7 @@ class Audiobookshelf(MusicProvider):
 
         # this is stolen from the Jellyfin provider, and gives an id surviving
         # reboots/ provider removal+adds
-        self.device_id = hashlib.sha256(f"{self.mass.server_id}+{username}".encode()).hexdigest()
+        self.device_id = hashlib.sha256(f"{self.instance_id}+{username}".encode()).hexdigest()
 
         # this will be provided when creating sessions or receive already opened sessions
         self.device_info = ABSDeviceInfo(

--- a/music_assistant/providers/audiobookshelf/abs_client.py
+++ b/music_assistant/providers/audiobookshelf/abs_client.py
@@ -409,7 +409,8 @@ class ABSClient:
 
     async def close_all_playback_sessions(self) -> None:
         """Cleanup all playback sessions opened by us."""
-        self.logger.debug("Closing our playback sessions")
+        if self.open_playback_session_ids:
+            self.logger.debug("Closing our playback sessions.")
         for session_id in self.open_playback_session_ids:
             try:
                 await self.close_playback_session(session_id)

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -3,7 +3,8 @@
 https://api.audiobookshelf.org/
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Annotated
 
 from mashumaro.config import BaseConfig
@@ -12,12 +13,17 @@ from mashumaro.types import Alias
 
 
 class BaseModel(DataClassJSONMixin):
-    """BaseModel for Schema part where we don't need all keys."""
+    """BaseModel for Schema.
+
+    forbid_extra_keys: response of API may have more keys than used by us
+    serialize_by_alias: when using to_json(), we get the Alias keys
+    """
 
     class Config(BaseConfig):
-        """Not all keys required."""
+        """Config."""
 
         forbid_extra_keys = False
+        serialize_by_alias = True
 
 
 @dataclass
@@ -314,3 +320,82 @@ class ABSLibrariesItemsResponse(BaseModel):
     """
 
     results: list[ABSLibraryItem]
+
+
+# Schema to enable sessions:
+@dataclass
+class ABSDeviceInfo(BaseModel):
+    """ABSDeviceInfo.
+
+    https://api.audiobookshelf.org/#device-info-parameters
+    """
+
+    device_id: Annotated[str, Alias("deviceId")]
+    client_name: Annotated[str, Alias("clientName")]
+    client_version: Annotated[str, Alias("clientVersion")]
+    manufacturer: str
+    model: str
+    # sdkVersion # meant for an Android client
+
+
+@dataclass
+class ABSPlayRequest(BaseModel):
+    """ABSPlayRequest.
+
+    https://api.audiobookshelf.org/#play-a-library-item-or-podcast-episode
+    """
+
+    device_info: Annotated[ABSDeviceInfo, Alias("deviceInfo")]
+    force_direct_play: Annotated[bool, Alias("forceDirectPlay")] = False
+    force_transcode: Annotated[bool, Alias("forceTranscode")] = False
+    supported_mime_types: Annotated[list[str], Alias("supportedMimeTypes")] = field(
+        default_factory=list
+    )
+    media_player: Annotated[str, Alias("mediaPlayer")] = "unknown"
+
+
+class ABSPlayMethod(Enum):
+    """Playback method in playback session."""
+
+    DIRECT_PLAY = 0
+    DIRECT_STREAM = 1
+    TRANSCODE = 2
+    LOCAL = 3
+
+
+@dataclass
+class ABSPlaybackSessionExpanded(BaseModel):
+    """ABSPlaybackSessionExpanded.
+
+    https://api.audiobookshelf.org/#play-method
+    """
+
+    id_: Annotated[str, Alias("id")]
+    user_id: Annotated[str, Alias("userId")]
+    library_id: Annotated[str, Alias("libraryId")]
+    library_item_id: Annotated[str, Alias("libraryItemId")]
+    episode_id: Annotated[str | None, Alias("episodeId")]
+    media_type: Annotated[str, Alias("mediaType")]
+    media_metadata: Annotated[ABSPodcastMetaData | ABSAudioBookMetaData, Alias("mediaMetadata")]
+    chapters: list[ABSAudioBookChapter]
+    display_title: Annotated[str, Alias("displayTitle")]
+    display_author: Annotated[str, Alias("displayAuthor")]
+    cover_path: Annotated[str, Alias("coverPath")]
+    duration: float
+    # 0: direct play, 1: direct stream, 2: transcode, 3: local
+    play_method: Annotated[ABSPlayMethod, Alias("playMethod")]
+    media_player: Annotated[str, Alias("mediaPlayer")]
+    device_info: Annotated[ABSDeviceInfo, Alias("deviceInfo")]
+    server_version: Annotated[str, Alias("serverVersion")]
+    # YYYY-MM-DD
+    date: str
+    day_of_week: Annotated[str, Alias("dayOfWeek")]
+    time_listening: Annotated[float, Alias("timeListening")]  # s
+    start_time: Annotated[float, Alias("startTime")]  # s
+    current_time: Annotated[float, Alias("currentTime")]  # s
+    started_at: Annotated[int, Alias("startedAt")]  # ms since Unix Epoch
+    updated_at: Annotated[int, Alias("updatedAt")]  # ms since Unix Epoch
+    audio_tracks: Annotated[list[ABSAudioTrack], Alias("audioTracks")]
+
+    # videoTrack:
+    # libraryItem:

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -330,18 +330,14 @@ class ABSDeviceInfo(BaseModel):
     https://api.audiobookshelf.org/#device-info-parameters
     https://api.audiobookshelf.org/#device-info
     https://github.com/advplyr/audiobookshelf/blob/master/server/objects/DeviceInfo.js#L3
-    apparently there was a change, which at some point not yet reflected
-    in API docs
     """
 
     device_id: Annotated[str, Alias("deviceId")] = ""
-    # sdkVersion # meant for an Android client
-
+    client_name: Annotated[str, Alias("clientName")] = ""
     client_version: Annotated[str, Alias("clientVersion")] = ""
     manufacturer: str = ""
     model: str = ""
-    client_name: Annotated[str, Alias("clientName")] = ""
-    # device_name: Annotated[str, Alias("deviceName")] = ""
+    # sdkVersion # meant for an Android client
 
 
 @dataclass

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -399,3 +399,17 @@ class ABSPlaybackSessionExpanded(BaseModel):
 
     # videoTrack:
     # libraryItem:
+
+
+@dataclass
+class ABSSessionUpdate(BaseModel):
+    """
+    ABSSessionUpdate.
+
+    Can be used as optional data to sync or closing request.
+    unit is seconds
+    """
+
+    current_time: Annotated[float, Alias("currentTime")]
+    time_listened: Annotated[float, Alias("timeListened")]
+    duration: float

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -330,11 +330,11 @@ class ABSDeviceInfo(BaseModel):
     https://api.audiobookshelf.org/#device-info-parameters
     """
 
-    device_id: Annotated[str, Alias("deviceId")]
-    client_name: Annotated[str, Alias("clientName")]
-    client_version: Annotated[str, Alias("clientVersion")]
-    manufacturer: str
-    model: str
+    device_id: Annotated[str, Alias("deviceId")] = ""
+    client_name: Annotated[str, Alias("clientName")] = ""
+    client_version: Annotated[str, Alias("clientVersion")] = ""
+    manufacturer: str = ""
+    model: str = ""
     # sdkVersion # meant for an Android client
 
 
@@ -364,7 +364,7 @@ class ABSPlayMethod(Enum):
 
 
 @dataclass
-class ABSPlaybackSessionExpanded(BaseModel):
+class ABSPlaybackSession(BaseModel):
     """ABSPlaybackSessionExpanded.
 
     https://api.audiobookshelf.org/#play-method
@@ -376,8 +376,8 @@ class ABSPlaybackSessionExpanded(BaseModel):
     library_item_id: Annotated[str, Alias("libraryItemId")]
     episode_id: Annotated[str | None, Alias("episodeId")]
     media_type: Annotated[str, Alias("mediaType")]
-    media_metadata: Annotated[ABSPodcastMetaData | ABSAudioBookMetaData, Alias("mediaMetadata")]
-    chapters: list[ABSAudioBookChapter]
+    # media_metadata: Annotated[ABSPodcastMetaData | ABSAudioBookMetaData, Alias("mediaMetadata")]
+    # chapters: list[ABSAudioBookChapter]
     display_title: Annotated[str, Alias("displayTitle")]
     display_author: Annotated[str, Alias("displayAuthor")]
     cover_path: Annotated[str, Alias("coverPath")]
@@ -395,6 +395,15 @@ class ABSPlaybackSessionExpanded(BaseModel):
     current_time: Annotated[float, Alias("currentTime")]  # s
     started_at: Annotated[int, Alias("startedAt")]  # ms since Unix Epoch
     updated_at: Annotated[int, Alias("updatedAt")]  # ms since Unix Epoch
+
+
+@dataclass
+class ABSPlaybackSessionExpanded(ABSPlaybackSession):
+    """ABSPlaybackSessionExpanded.
+
+    https://api.audiobookshelf.org/#play-method
+    """
+
     audio_tracks: Annotated[list[ABSAudioTrack], Alias("audioTracks")]
 
     # videoTrack:
@@ -413,3 +422,13 @@ class ABSSessionUpdate(BaseModel):
     current_time: Annotated[float, Alias("currentTime")]
     time_listened: Annotated[float, Alias("timeListened")]
     duration: float
+
+
+@dataclass
+class ABSSessionsResponse(BaseModel):
+    """Response to GET http://abs.example.com/api/me/listening-sessions."""
+
+    total: int
+    num_pages: Annotated[int, Alias("numPages")]
+    items_per_page: Annotated[int, Alias("itemsPerPage")]
+    sessions: list[ABSPlaybackSession]

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -328,14 +328,20 @@ class ABSDeviceInfo(BaseModel):
     """ABSDeviceInfo.
 
     https://api.audiobookshelf.org/#device-info-parameters
+    https://api.audiobookshelf.org/#device-info
+    https://github.com/advplyr/audiobookshelf/blob/master/server/objects/DeviceInfo.js#L3
+    apparently there was a change, which at some point not yet reflected
+    in API docs
     """
 
     device_id: Annotated[str, Alias("deviceId")] = ""
-    client_name: Annotated[str, Alias("clientName")] = ""
+    # sdkVersion # meant for an Android client
+
     client_version: Annotated[str, Alias("clientVersion")] = ""
     manufacturer: str = ""
     model: str = ""
-    # sdkVersion # meant for an Android client
+    client_name: Annotated[str, Alias("clientName")] = ""
+    # device_name: Annotated[str, Alias("deviceName")] = ""
 
 
 @dataclass


### PR DESCRIPTION
Updated 01/19 14:20 documentation part

This PR introduces the ability to use an HLS stream for audiobooks ~~both audiobooks and podcasts~~. This allows to have an audiobook to be split among multiple files, as this is effectively hidden from Music Assistant.

# Details
- ABS:
    - We can acquire a [Session](https://api.audiobookshelf.org/#play-a-library-item-or-podcast-episode) for podcasts or audiobooks in ABS, as long as we provide a unique device id in our [Device Info Parameters](https://api.audiobookshelf.org/#device-info-parameters)
    - A transcoding session (that's what we use here) launches an ffmpeg process at ABS providing an HLS stream.
    - ffmpeg process only terminates, when we close the session.
- Implementation:
    - I used the device id approach of the jellyfin provider, and then added the id of the media item the session is for. This allows a session per media item.
    - ~~I added two config options - HLS for podcast, HLS for audiobooks~~
        - ~~For audiobooks default is true.~~
        - ~~For podcasts default is false.~~
    - If a session is need for audiobooks is determined automatically.
    - Schema has been updated for sessions.
    - Logging: I added a couple of debug logging information.
- Advice needed/ open questions:
    - I currently just collect the ids of open sessions in a `list[str]`.
    - I close all open sessions when we shutdown Music Assistant. I figured that's the only safe place to do so.
    - Reasoning:
        - If I were to close the session once on_played is called, a potentially running parallel stream of the same media item to another speaker would terminate as well.
        - Even if that's not the case, I think mass caches the stream details, i.e. `get_stream_details` would not be called again when the item is replayed.
    - Is the approach in place ok? Is there a better place to close open sessions?
    - Shall I limit the amount of sessions possible, and then maybe raise an error once we hit that limit? I could add another config option for the amount of possible open sessions.
- Possible improvements:
    - We could potentially update the time spent in that session, which would update the ABS statistics view. For me that's very low priority as I don't see an easy way of accessing the time spent (i.e. including possible seeking by user etc, not the media progress!) on that stream.
- Remarks:
    - on_played works nicely now, progress reporting to ABS seems functional.
      Thanks for that!

# Documentation update:
If that PR is merged, then:
## Known Issues/ Notes:
- Restarting Audiobookshelf terminates all open sessions. Music Assistant has no way to know this, so you must reload the provider. Otherwise the stream of your audiobook will be not available.
