### PR TITLE
Chore: Audiobookshelf - adapt schema to reflect the naming scheme used in the API docs

### DIFF
--- a/music_assistant/providers/audiobookshelf/abs_client.py
+++ b/music_assistant/providers/audiobookshelf/abs_client.py
@@ -172,11 +172,18 @@ class ABSClient:
                 yield podcast
 
     async def _get_lib_items(self, lib: ABSLibrary) -> AsyncGenerator[bytes]:
-        """Get library items with pagination."""
+        """Get library items with pagination.
+
+        Note:
+           - minified=1 -> minified items. However, there appears to be
+             a bug in abs, so we always get minified items. Still there for
+             consistency
+           - collapseseries=0 -> even if books are part of a series, they will be single items
+        """
         page_cnt = 0
         while True:
             data = await self._get(
-                f"/libraries/{lib.id_}/items",
+                f"/libraries/{lib.id_}/items?minified=1&collapseseries=0",
                 params={"limit": LIMIT_ITEMS_PER_PAGE, "page": page_cnt},
             )
             page_cnt += 1

--- a/music_assistant/providers/audiobookshelf/abs_client.py
+++ b/music_assistant/providers/audiobookshelf/abs_client.py
@@ -12,18 +12,20 @@ from aiohttp import ClientSession
 from music_assistant_models.media_items import UniqueList
 
 from music_assistant.providers.audiobookshelf.abs_schema import (
-    ABSAudioBook,
     ABSDeviceInfo,
-    ABSLibrariesItemsResponse,
+    ABSLibrariesItemsMinifiedBookResponse,
+    ABSLibrariesItemsMinifiedPodcastResponse,
     ABSLibrariesResponse,
     ABSLibrary,
-    ABSLibraryItem,
+    ABSLibraryItemExpandedBook,
+    ABSLibraryItemExpandedPodcast,
+    ABSLibraryItemMinifiedBook,
+    ABSLibraryItemMinifiedPodcast,
     ABSLoginResponse,
     ABSMediaProgress,
     ABSPlaybackSession,
     ABSPlaybackSessionExpanded,
     ABSPlayRequest,
-    ABSPodcast,
     ABSSessionsResponse,
     ABSSessionUpdate,
     ABSUser,
@@ -163,7 +165,7 @@ class ABSClient:
                     self.podcast_libraries.append(library)
         self.user = await self.get_authenticated_user()
 
-    async def get_all_podcasts(self) -> AsyncGenerator[ABSPodcast]:
+    async def get_all_podcasts(self) -> AsyncGenerator[ABSLibraryItemExpandedPodcast]:
         """Get all available podcasts."""
         for library in self.podcast_libraries:
             async for podcast in self.get_all_podcasts_by_library(library):
@@ -180,14 +182,18 @@ class ABSClient:
             page_cnt += 1
             yield data
 
-    async def get_all_podcasts_by_library(self, lib: ABSLibrary) -> AsyncGenerator[ABSPodcast]:
+    async def get_all_podcasts_by_library(
+        self, lib: ABSLibrary
+    ) -> AsyncGenerator[ABSLibraryItemExpandedPodcast]:
         """Get all podcasts in a library."""
         async for podcast_data in self._get_lib_items(lib):
-            podcast_list = ABSLibrariesItemsResponse.from_json(podcast_data).results
+            podcast_list = ABSLibrariesItemsMinifiedPodcastResponse.from_json(podcast_data).results
             if not podcast_list:  # [] if page exceeds
                 return
 
-            async def _get_id(plist: list[ABSLibraryItem] = podcast_list) -> AsyncGenerator[str]:
+            async def _get_id(
+                plist: list[ABSLibraryItemMinifiedPodcast] = podcast_list,
+            ) -> AsyncGenerator[str]:
                 for entry in plist:
                     yield entry.id_
 
@@ -195,11 +201,11 @@ class ABSClient:
                 podcast = await self.get_podcast(id_)
                 yield podcast
 
-    async def get_podcast(self, id_: str) -> ABSPodcast:
+    async def get_podcast(self, id_: str) -> ABSLibraryItemExpandedPodcast:
         """Get a single Podcast by ID."""
         # this endpoint gives more podcast extra data
         data = await self._get(f"items/{id_}?expanded=1")
-        return ABSPodcast.from_json(data)
+        return ABSLibraryItemExpandedPodcast.from_json(data)
 
     async def _get_progress_ms(
         self,
@@ -288,20 +294,24 @@ class ABSClient:
         endpoint = f"me/progress/{audiobook_id}"
         await self._update_progress(endpoint, progress_s, duration_s, is_finished)
 
-    async def get_all_audiobooks(self) -> AsyncGenerator[ABSAudioBook]:
+    async def get_all_audiobooks(self) -> AsyncGenerator[ABSLibraryItemExpandedBook]:
         """Get all audiobooks."""
         for library in self.audiobook_libraries:
             async for book in self.get_all_audiobooks_by_library(library):
                 yield book
 
-    async def get_all_audiobooks_by_library(self, lib: ABSLibrary) -> AsyncGenerator[ABSAudioBook]:
+    async def get_all_audiobooks_by_library(
+        self, lib: ABSLibrary
+    ) -> AsyncGenerator[ABSLibraryItemExpandedBook]:
         """Get all Audiobooks in a library."""
         async for audiobook_data in self._get_lib_items(lib):
-            audiobook_list = ABSLibrariesItemsResponse.from_json(audiobook_data).results
+            audiobook_list = ABSLibrariesItemsMinifiedBookResponse.from_json(audiobook_data).results
             if not audiobook_list:  # [] if page exceeds
                 return
 
-            async def _get_id(alist: list[ABSLibraryItem] = audiobook_list) -> AsyncGenerator[str]:
+            async def _get_id(
+                alist: list[ABSLibraryItemMinifiedBook] = audiobook_list,
+            ) -> AsyncGenerator[str]:
                 for entry in alist:
                     yield entry.id_
 
@@ -309,11 +319,11 @@ class ABSClient:
                 audiobook = await self.get_audiobook(id_)
                 yield audiobook
 
-    async def get_audiobook(self, id_: str) -> ABSAudioBook:
+    async def get_audiobook(self, id_: str) -> ABSLibraryItemExpandedBook:
         """Get a single Audiobook by ID."""
         # this endpoint gives more audiobook extra data
         audiobook = await self._get(f"items/{id_}?expanded=1")
-        return ABSAudioBook.from_json(audiobook)
+        return ABSLibraryItemExpandedBook.from_json(audiobook)
 
     async def get_playback_session_podcast(
         self, device_info: ABSDeviceInfo, podcast_id: str, episode_id: str

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -42,7 +42,7 @@ class ABSAudioTrack(BaseModel):
     https://api.audiobookshelf.org/#audio-track
     """
 
-    index: int
+    index: int | None
     start_offset: Annotated[float, Alias("startOffset")] = 0.0
     duration: float = 0.0
     title: str = ""

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -1,6 +1,15 @@
-"""Schema definition of Audiobookshelf.
+"""Schema definition of Audiobookshelf (ABS).
 
 https://api.audiobookshelf.org/
+
+Some schema definitions have variants. Take book as example:
+https://api.audiobookshelf.org/#book
+Naming Scheme in this file:
+    - the standard definition has nothing added
+    - minified/ expanded: here, 2 additional variants
+
+Sometimes these variants remove or change attributes in such a way, that
+it makes sense to define a base class for inheritance.
 """
 
 from dataclasses import dataclass, field
@@ -28,7 +37,7 @@ class BaseModel(DataClassJSONMixin):
 
 @dataclass
 class ABSAudioTrack(BaseModel):
-    """ABS audioTrack.
+    """ABS audioTrack. No variants.
 
     https://api.audiobookshelf.org/#audio-track
     """
@@ -43,14 +52,144 @@ class ABSAudioTrack(BaseModel):
 
 
 @dataclass
+class ABSBookChapter(BaseModel):
+    """
+    ABSBookChapter. No variants.
+
+    https://api.audiobookshelf.org/#book-chapter
+    """
+
+    id_: Annotated[int, Alias("id")]
+    start: float
+    end: float
+    title: str
+
+
+@dataclass
+class ABSAudioBookmark(BaseModel):
+    """ABSAudioBookmark. No variants.
+
+    https://api.audiobookshelf.org/#audio-bookmark
+    """
+
+    library_item_id: Annotated[str, Alias("libraryItemId")]
+    title: str
+    time: float  # seconds
+    created_at: Annotated[int, Alias("createdAt")]  # unix epoch ms
+
+
+@dataclass
+class ABSUserPermissions(BaseModel):
+    """ABSUserPermissions. No variants.
+
+    https://api.audiobookshelf.org/#user-permissions
+    """
+
+    download: bool
+    update: bool
+    delete: bool
+    upload: bool
+    access_all_libraries: Annotated[bool, Alias("accessAllLibraries")]
+    access_all_tags: Annotated[bool, Alias("accessAllTags")]
+    access_explicit_content: Annotated[bool, Alias("accessExplicitContent")]
+
+
+@dataclass
+class ABSLibrary(BaseModel):
+    """ABSLibrary. No variants.
+
+    https://api.audiobookshelf.org/#library
+    Only attributes we need
+    """
+
+    id_: Annotated[str, Alias("id")]
+    name: str
+    # folders
+    # displayOrder: Integer
+    # icon: String
+    media_type: Annotated[str, Alias("mediaType")]
+    provider: str
+    # settings
+    created_at: Annotated[int, Alias("createdAt")]
+    last_update: Annotated[int, Alias("lastUpdate")]
+
+
+@dataclass
+class ABSDeviceInfo(BaseModel):
+    """ABSDeviceInfo. No variants.
+
+    https://api.audiobookshelf.org/#device-info-parameters
+    https://api.audiobookshelf.org/#device-info
+    https://github.com/advplyr/audiobookshelf/blob/master/server/objects/DeviceInfo.js#L3
+    """
+
+    device_id: Annotated[str, Alias("deviceId")] = ""
+    client_name: Annotated[str, Alias("clientName")] = ""
+    client_version: Annotated[str, Alias("clientVersion")] = ""
+    manufacturer: str = ""
+    model: str = ""
+    # sdkVersion # meant for an Android client
+
+
+### Author: https://api.audiobookshelf.org/#author
+
+
+@dataclass
 class ABSAuthorMinified(BaseModel):
-    """ABSAuthor.
+    """ABSAuthorMinified.
 
     https://api.audiobookshelf.org/#author
     """
 
     id_: Annotated[str, Alias("id")]
     name: str
+
+
+@dataclass
+class ABSAuthor(ABSAuthorMinified):
+    """ABSAuthor."""
+
+    asin: str | None
+    description: str | None
+    image_path: Annotated[str | None, Alias("imagePath")]
+    added_at: Annotated[int, Alias("addedAt")]  # ms epoch
+    updated_at: Annotated[int, Alias("updatedAt")]  # ms epoch
+
+
+@dataclass
+class ABSAuthorExpanded(ABSAuthor):
+    """ABSAuthorExpanded."""
+
+    num_books: Annotated[int, Alias("numBooks")]
+
+
+### Series: https://api.audiobookshelf.org/#series
+
+
+@dataclass
+class _ABSSeriesBase(BaseModel):
+    """_ABSSeriesBase."""
+
+    id_: Annotated[str, Alias("id")]
+    name: str
+
+
+@dataclass
+class ABSSeries(_ABSSeriesBase):
+    """ABSSeries."""
+
+    description: str | None
+    added_at: Annotated[int, Alias("addedAt")]  # ms epoch
+    updated_at: Annotated[int, Alias("updatedAt")]  # ms epoch
+
+
+@dataclass
+class ABSSeriesNumBooks(_ABSSeriesBase):
+    """ABSSeriesNumBooks."""
+
+    name_ignore_prefix: Annotated[str, Alias("nameIgnorePrefix")]
+    library_item_ids: Annotated[list[str], Alias("libraryItemIds")]
+    num_books: Annotated[int, Alias("numBooks")]
 
 
 @dataclass
@@ -65,26 +204,15 @@ class ABSSeriesSequence(BaseModel):
     sequence: str | None
 
 
-@dataclass
-class ABSAudioBookChapter(BaseModel):
-    """
-    ABSAudioBookChapter.
+# another variant, ABSSeriesBooks is further down
 
-    https://api.audiobookshelf.org/#book-chapter
-    """
 
-    id_: Annotated[int, Alias("id")]
-    start: float
-    end: float
-    title: str
+###  https://api.audiobookshelf.org/#media-progress
 
 
 @dataclass
 class ABSMediaProgress(BaseModel):
-    """ABSMediaProgress.
-
-    https://api.audiobookshelf.org/#media-progress
-    """
+    """ABSMediaProgress."""
 
     id_: Annotated[str, Alias("id")]
     library_item_id: Annotated[str, Alias("libraryItemId")]
@@ -99,27 +227,7 @@ class ABSMediaProgress(BaseModel):
     finished_at: Annotated[int | None, Alias("finishedAt")]  # ms epoch
 
 
-@dataclass
-class ABSAudioBookmark(BaseModel):
-    """ABSAudioBookmark."""
-
-    library_item_id: Annotated[str, Alias("libraryItemId")]
-    title: str
-    time: float  # seconds
-    created_at: Annotated[int, Alias("createdAt")]  # unix epoch ms
-
-
-@dataclass
-class ABSUserPermissions(BaseModel):
-    """ABSUserPermissions."""
-
-    download: bool
-    update: bool
-    delete: bool
-    upload: bool
-    access_all_libraries: Annotated[bool, Alias("accessAllLibraries")]
-    access_all_tags: Annotated[bool, Alias("accessAllTags")]
-    access_explicit_content: Annotated[bool, Alias("accessExplicitContent")]
+# two additional progress variants, 'with media' book and podcast, further down.
 
 
 @dataclass
@@ -150,74 +258,7 @@ class ABSUser(BaseModel):
     # item_tags_accessible: Annotated[list[str], Alias("itemTagsAccessible")]
 
 
-@dataclass
-class ABSLoginResponse(BaseModel):
-    """ABSLoginResponse."""
-
-    user: ABSUser
-
-    # this seems to be missing
-    # user_default_library_id: Annotated[str, Alias("defaultLibraryId")]
-
-
-@dataclass
-class ABSLibrary(BaseModel):
-    """ABSLibrary.
-
-    Only attributes we need
-    """
-
-    id_: Annotated[str, Alias("id")]
-    name: str
-    # folders
-    # displayOrder: Integer
-    # icon: String
-    media_type: Annotated[str, Alias("mediaType")]
-    provider: str
-    # settings
-    created_at: Annotated[int, Alias("createdAt")]
-    last_update: Annotated[int, Alias("lastUpdate")]
-
-
-@dataclass
-class ABSLibrariesResponse(BaseModel):
-    """ABSLibrariesResponse."""
-
-    libraries: list[ABSLibrary]
-
-
-# Schema to enable sessions:
-@dataclass
-class ABSDeviceInfo(BaseModel):
-    """ABSDeviceInfo.
-
-    https://api.audiobookshelf.org/#device-info-parameters
-    https://api.audiobookshelf.org/#device-info
-    https://github.com/advplyr/audiobookshelf/blob/master/server/objects/DeviceInfo.js#L3
-    """
-
-    device_id: Annotated[str, Alias("deviceId")] = ""
-    client_name: Annotated[str, Alias("clientName")] = ""
-    client_version: Annotated[str, Alias("clientVersion")] = ""
-    manufacturer: str = ""
-    model: str = ""
-    # sdkVersion # meant for an Android client
-
-
-@dataclass
-class ABSPlayRequest(BaseModel):
-    """ABSPlayRequest.
-
-    https://api.audiobookshelf.org/#play-a-library-item-or-podcast-episode
-    """
-
-    device_info: Annotated[ABSDeviceInfo, Alias("deviceInfo")]
-    force_direct_play: Annotated[bool, Alias("forceDirectPlay")] = False
-    force_transcode: Annotated[bool, Alias("forceTranscode")] = False
-    supported_mime_types: Annotated[list[str], Alias("supportedMimeTypes")] = field(
-        default_factory=list
-    )
-    media_player: Annotated[str, Alias("mediaPlayer")] = "unknown"
+# two additional user variants do exist
 
 
 class ABSPlayMethod(Enum):
@@ -229,12 +270,12 @@ class ABSPlayMethod(Enum):
     LOCAL = 3
 
 
+### https://api.audiobookshelf.org/#playback-session
+
+
 @dataclass
 class ABSPlaybackSession(BaseModel):
-    """ABSPlaybackSessionExpanded.
-
-    https://api.audiobookshelf.org/#play-method
-    """
+    """ABSPlaybackSession."""
 
     id_: Annotated[str, Alias("id")]
     user_id: Annotated[str, Alias("userId")]
@@ -265,10 +306,7 @@ class ABSPlaybackSession(BaseModel):
 
 @dataclass
 class ABSPlaybackSessionExpanded(ABSPlaybackSession):
-    """ABSPlaybackSessionExpanded.
-
-    https://api.audiobookshelf.org/#play-method
-    """
+    """ABSPlaybackSessionExpanded."""
 
     audio_tracks: Annotated[list[ABSAudioTrack], Alias("audioTracks")]
 
@@ -276,34 +314,12 @@ class ABSPlaybackSessionExpanded(ABSPlaybackSession):
     # libraryItem:
 
 
-@dataclass
-class ABSSessionUpdate(BaseModel):
-    """
-    ABSSessionUpdate.
-
-    Can be used as optional data to sync or closing request.
-    unit is seconds
-    """
-
-    current_time: Annotated[float, Alias("currentTime")]
-    time_listened: Annotated[float, Alias("timeListened")]
-    duration: float
+### https://api.audiobookshelf.org/#podcast-metadata
 
 
 @dataclass
-class ABSSessionsResponse(BaseModel):
-    """Response to GET http://abs.example.com/api/me/listening-sessions."""
-
-    total: int
-    num_pages: Annotated[int, Alias("numPages")]
-    items_per_page: Annotated[int, Alias("itemsPerPage")]
-    sessions: list[ABSPlaybackSession]
-
-
-## REWORK
-@dataclass
-class ABSPodcastMetaDataNormal(BaseModel):
-    """ABSPodcastMetaDataNormal."""
+class ABSPodcastMetadata(BaseModel):
+    """ABSPodcastMetadata."""
 
     title: str | None
     author: str | None
@@ -321,18 +337,20 @@ class ABSPodcastMetaDataNormal(BaseModel):
 
 
 @dataclass
-class ABSPodcastMetaDataMinified(ABSPodcastMetaDataNormal):
-    """ABSPodcastMetaDataMinified."""
+class ABSPodcastMetadataMinified(ABSPodcastMetadata):
+    """ABSPodcastMetadataMinified."""
 
     title_ignore_prefix: Annotated[str, Alias("titleIgnorePrefix")]
 
 
-ABSPodcastMetaDataExpanded = ABSPodcastMetaDataMinified
+ABSPodcastMetaDataExpanded = ABSPodcastMetadataMinified
+
+### https://api.audiobookshelf.org/#podcast-episode
 
 
 @dataclass
-class ABSPodcastEpisodeNormal(BaseModel):
-    """ABSPodcastEpisodeNormal."""
+class ABSPodcastEpisode(BaseModel):
+    """ABSPodcastEpisode."""
 
     library_item_id: Annotated[str, Alias("libraryItemId")]
     id_: Annotated[str, Alias("id")]
@@ -383,33 +401,36 @@ class ABSPodcastEpisodeExpanded(BaseModel):
 
 
 @dataclass
-class ABSPodcastBase(BaseModel):
-    """ABSPodcastNormal."""
+class _ABSPodcastBase(BaseModel):
+    """_ABSPodcastBase."""
 
     cover_path: Annotated[str, Alias("coverPath")]
 
 
-@dataclass
-class ABSPodcastNormal(BaseModel):
-    """ABSPodcastNormal."""
+### https://api.audiobookshelf.org/#podcast
 
-    metadata: ABSPodcastMetaDataNormal
+
+@dataclass
+class ABSPodcast(_ABSPodcastBase):
+    """ABSPodcast."""
+
+    metadata: ABSPodcastMetadata
     library_item_id: Annotated[str, Alias("libraryItemId")]
     tags: list[str]
-    episodes: list[ABSPodcastEpisodeNormal]
+    episodes: list[ABSPodcastEpisode]
 
 
 @dataclass
-class ABSPodcastMinified(ABSPodcastBase):
+class ABSPodcastMinified(_ABSPodcastBase):
     """ABSPodcastMinified."""
 
-    metadata: ABSPodcastMetaDataMinified
+    metadata: ABSPodcastMetadataMinified
     size: int  # bytes
     num_episodes: Annotated[int, Alias("numEpisodes")] = 0
 
 
 @dataclass
-class ABSPodcastExpanded(ABSPodcastBase):
+class ABSPodcastExpanded(_ABSPodcastBase):
     """ABSPodcastEpisodeExpanded."""
 
     size: int  # bytes
@@ -417,9 +438,12 @@ class ABSPodcastExpanded(ABSPodcastBase):
     episodes: list[ABSPodcastEpisodeExpanded]
 
 
+### https://api.audiobookshelf.org/#book-metadata
+
+
 @dataclass
-class ABSAudioBookMetaDataBase(BaseModel):
-    """ABSAudioBookMetaDataMinified."""
+class _ABSBookMetadataBase(BaseModel):
+    """_ABSBookMetadataBase."""
 
     title: str
     subtitle: str
@@ -435,8 +459,8 @@ class ABSAudioBookMetaDataBase(BaseModel):
 
 
 @dataclass
-class ABSAudioBookMetaDataNormal(ABSAudioBookMetaDataBase):
-    """ABSAudioBookMetaDataNormal."""
+class ABSBookMetadata(_ABSBookMetadataBase):
+    """ABSBookMetadata."""
 
     authors: list[ABSAuthorMinified]
     narrators: list[str]
@@ -444,8 +468,8 @@ class ABSAudioBookMetaDataNormal(ABSAudioBookMetaDataBase):
 
 
 @dataclass
-class ABSAudioBookMetaDataMinified(ABSAudioBookMetaDataBase):
-    """ABSAudioBookMetaDataMinified."""
+class ABSBookMetadataMinified(_ABSBookMetadataBase):
+    """ABSBookMetadataMinified."""
 
     # these are normally there
     title_ignore_prefix: Annotated[str, Alias("titleIgnorePrefix")]
@@ -456,34 +480,37 @@ class ABSAudioBookMetaDataMinified(ABSAudioBookMetaDataBase):
 
 
 @dataclass
-class ABSAudioBookMetaDataExpanded(ABSAudioBookMetaDataNormal, ABSAudioBookMetaDataMinified):
+class ABSBookMetadataExpanded(ABSBookMetadata, ABSBookMetadataMinified):
     """ABSAudioBookMetaDataExpanded."""
 
 
+### https://api.audiobookshelf.org/#book
+
+
 @dataclass
-class ABSAudioBookBase(BaseModel):
-    """ABSAudioBookBase."""
+class _ABSBookBase(BaseModel):
+    """_ABSBookBase."""
 
     tags: list[str]
     cover_path: Annotated[str | None, Alias("coverPath")]
 
 
 @dataclass
-class ABSAudioBookNormal(ABSAudioBookBase):
-    """ABSAudioBookNormal."""
+class ABSBook(_ABSBookBase):
+    """ABSBook."""
 
     library_item_id: Annotated[str, Alias("libraryItemId")]
-    metadata: ABSAudioBookMetaDataNormal
+    metadata: ABSBookMetadata
     # audioFiles
-    chapters: list[ABSAudioBookChapter]
+    chapters: list[ABSBookChapter]
     # ebookFile
 
 
 @dataclass
-class ABSAudioBookMinified(ABSAudioBookBase):
-    """ABSAudioBookBase."""
+class ABSBookMinified(_ABSBookBase):
+    """ABSBookBase."""
 
-    metadata: ABSAudioBookMetaDataMinified
+    metadata: ABSBookMetadataMinified
     num_tracks: Annotated[int, Alias("numTracks")]
     num_audiofiles: Annotated[int, Alias("numAudioFiles")]
     num_chapters: Annotated[int, Alias("numChapters")]
@@ -493,20 +520,23 @@ class ABSAudioBookMinified(ABSAudioBookBase):
 
 
 @dataclass
-class ABSAudioBookExpanded(ABSAudioBookBase):
-    """ABSAudioBookExpanded."""
+class ABSBookExpanded(_ABSBookBase):
+    """ABSBookExpanded."""
 
     library_item_id: Annotated[str, Alias("libraryItemId")]
-    metadata: ABSAudioBookMetaDataExpanded
-    chapters: list[ABSAudioBookChapter]
+    metadata: ABSBookMetadataExpanded
+    chapters: list[ABSBookChapter]
     duration: float
     size: int  # bytes
     tracks: list[ABSAudioTrack]
 
 
+### https://api.audiobookshelf.org/#library-item
+
+
 @dataclass
-class ABSLibraryItemBase(BaseModel):
-    """ABSLibraryItemBase."""
+class _ABSLibraryItemBase(BaseModel):
+    """_ABSLibraryItemBase."""
 
     id_: Annotated[str, Alias("id")]
     ino: str
@@ -526,8 +556,8 @@ class ABSLibraryItemBase(BaseModel):
 
 
 @dataclass
-class ABSLibraryItemNormal(ABSLibraryItemBase):
-    """ABSLibraryItemNormal."""
+class _ABSLibraryItem(_ABSLibraryItemBase):
+    """ABSLibraryItem."""
 
     last_scan: Annotated[int | None, Alias("lastScan")]  # ms epoch
     scan_version: Annotated[str | None, Alias("scanVersion")]
@@ -535,21 +565,33 @@ class ABSLibraryItemNormal(ABSLibraryItemBase):
 
 
 @dataclass
-class ABSLibraryItemNormalBook(ABSLibraryItemNormal):
-    """ABSLibraryItemNormalBook."""
+class ABSLibraryItemBook(_ABSLibraryItem):
+    """ABSLibraryItemBook."""
 
-    media: ABSAudioBookNormal
-
-
-@dataclass
-class ABSLibraryItemNormalPodcast(ABSLibraryItemNormal):
-    """ABSLibraryItemNormalBook."""
-
-    media: ABSPodcastNormal
+    media: ABSBook
 
 
 @dataclass
-class ABSLibraryItemMinified(ABSLibraryItemBase):
+class ABSLibraryItemBookSeries(ABSLibraryItemBook):
+    """ABSLibraryItemNormalBookSeries.
+
+    Special class, when having the scheme of SeriesBooks, see
+    https://api.audiobookshelf.org/#series, it gets an extra
+    sequence key.
+    """
+
+    sequence: int
+
+
+@dataclass
+class ABSLibraryItemPodcast(_ABSLibraryItem):
+    """ABSLibraryItemPodcast."""
+
+    media: ABSPodcast
+
+
+@dataclass
+class _ABSLibraryItemMinified(_ABSLibraryItemBase):
     """ABSLibraryItemMinified."""
 
     num_files: Annotated[int, Alias("numFiles")]
@@ -557,38 +599,98 @@ class ABSLibraryItemMinified(ABSLibraryItemBase):
 
 
 @dataclass
-class ABSLibraryItemMinifiedBook(ABSLibraryItemMinified):
+class ABSLibraryItemMinifiedBook(_ABSLibraryItemMinified):
     """ABSLibraryItemMinifiedBook."""
 
-    media: ABSAudioBookMinified
+    media: ABSBookMinified
 
 
 @dataclass
-class ABSLibraryItemMinifiedPodcast(ABSLibraryItemMinified):
+class ABSLibraryItemMinifiedPodcast(_ABSLibraryItemMinified):
     """ABSLibraryItemMinifiedBook."""
 
     media: ABSPodcastMinified
 
 
 @dataclass
-class ABSLibraryItemExpanded(ABSLibraryItemBase):
+class _ABSLibraryItemExpanded(_ABSLibraryItemBase):
     """ABSLibraryItemExpanded."""
 
     size: int  # bytes
 
 
 @dataclass
-class ABSLibraryItemExpandedBook(ABSLibraryItemExpanded):
+class ABSLibraryItemExpandedBook(_ABSLibraryItemExpanded):
     """ABSLibraryItemExpanded."""
 
-    media: ABSAudioBookExpanded
+    media: ABSBookExpanded
 
 
 @dataclass
-class ABSLibraryItemExpandedPodcast(ABSLibraryItemExpanded):
+class ABSLibraryItemExpandedPodcast(_ABSLibraryItemExpanded):
     """ABSLibraryItemExpanded."""
 
     media: ABSPodcastExpanded
+
+
+# extra classes down here so they can make proper references
+
+
+@dataclass
+class ABSSeriesBooks(_ABSSeriesBase):
+    """ABSSeriesBooks."""
+
+    added_at: Annotated[int, Alias("addedAt")]  # ms epoch
+    name_ignore_prefix: Annotated[str, Alias("nameIgnorePrefix")]
+    name_ignore_prefix_sort: Annotated[str, Alias("nameIgnorePrefixSort")]
+    type_: Annotated[str, Alias("type")]
+    books: list[ABSLibraryItemBookSeries]
+    total_duration: Annotated[float, Alias("totalDuration")]  # s
+
+
+@dataclass
+class ABSMediaProgressWithMediaBook(ABSMediaProgress):
+    """ABSMediaProgressWithMediaBook."""
+
+    media: ABSBookExpanded
+
+
+@dataclass
+class ABSMediaProgressWithMediaPodcast(ABSMediaProgress):
+    """ABSMediaProgressWithMediaBook."""
+
+    media: ABSPodcastExpanded
+    episode: ABSPodcastEpisode
+
+
+### Response to API Requests
+
+
+@dataclass
+class ABSLoginResponse(BaseModel):
+    """ABSLoginResponse."""
+
+    user: ABSUser
+
+    # this seems to be missing
+    # user_default_library_id: Annotated[str, Alias("defaultLibraryId")]
+
+
+@dataclass
+class ABSLibrariesResponse(BaseModel):
+    """ABSLibrariesResponse."""
+
+    libraries: list[ABSLibrary]
+
+
+@dataclass
+class ABSSessionsResponse(BaseModel):
+    """Response to GET http://abs.example.com/api/me/listening-sessions."""
+
+    total: int
+    num_pages: Annotated[int, Alias("numPages")]
+    items_per_page: Annotated[int, Alias("itemsPerPage")]
+    sessions: list[ABSPlaybackSession]
 
 
 @dataclass
@@ -612,3 +714,36 @@ class ABSLibrariesItemsMinifiedPodcastResponse(BaseModel):
     """
 
     results: list[ABSLibraryItemMinifiedPodcast]
+
+
+### Requests to API we can make
+
+
+@dataclass
+class ABSPlayRequest(BaseModel):
+    """ABSPlayRequest.
+
+    https://api.audiobookshelf.org/#play-a-library-item-or-podcast-episode
+    """
+
+    device_info: Annotated[ABSDeviceInfo, Alias("deviceInfo")]
+    force_direct_play: Annotated[bool, Alias("forceDirectPlay")] = False
+    force_transcode: Annotated[bool, Alias("forceTranscode")] = False
+    supported_mime_types: Annotated[list[str], Alias("supportedMimeTypes")] = field(
+        default_factory=list
+    )
+    media_player: Annotated[str, Alias("mediaPlayer")] = "unknown"
+
+
+@dataclass
+class ABSSessionUpdate(BaseModel):
+    """
+    ABSSessionUpdate.
+
+    Can be used as optional data to sync or closing request.
+    unit is seconds
+    """
+
+    current_time: Annotated[float, Alias("currentTime")]
+    time_listened: Annotated[float, Alias("timeListened")]
+    duration: float

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -43,76 +43,6 @@ class ABSAudioTrack(BaseModel):
 
 
 @dataclass
-class ABSPodcastEpisodeExpanded(BaseModel):
-    """ABSPodcastEpisode.
-
-    https://api.audiobookshelf.org/#podcast-episode
-    """
-
-    library_item_id: Annotated[str, Alias("libraryItemId")]
-    id_: Annotated[str, Alias("id")]
-    index: int | None
-    # audio_file: # not needed for mass application
-    published_at: Annotated[int | None, Alias("publishedAt")]  # ms posix epoch
-    added_at: Annotated[int | None, Alias("addedAt")]  # ms posix epoch
-    updated_at: Annotated[int | None, Alias("updatedAt")]  # ms posix epoch
-    audio_track: Annotated[ABSAudioTrack, Alias("audioTrack")]
-    size: int  # in bytes
-    season: str = ""
-    episode: str = ""
-    episode_type: Annotated[str, Alias("episodeType")] = ""
-    title: str = ""
-    subtitle: str = ""
-    description: str = ""
-    enclosure: str = ""
-    pub_date: Annotated[str, Alias("pubDate")] = ""
-    guid: str = ""
-    # chapters
-    duration: float = 0.0
-
-
-@dataclass
-class ABSPodcastMetaData(BaseModel):
-    """PodcastMetaData https://api.audiobookshelf.org/?shell#podcasts."""
-
-    title: str | None
-    author: str | None
-    description: str | None
-    release_date: Annotated[str | None, Alias("releaseDate")]
-    genres: list[str] | None
-    feed_url: Annotated[str | None, Alias("feedUrl")]
-    image_url: Annotated[str | None, Alias("imageUrl")]
-    itunes_page_url: Annotated[str | None, Alias("itunesPageUrl")]
-    itunes_id: Annotated[int | None, Alias("itunesId")]
-    itunes_artist_id: Annotated[int | None, Alias("itunesArtistId")]
-    explicit: bool
-    language: str | None
-    type_: Annotated[str | None, Alias("type")]
-
-
-@dataclass
-class ABSPodcastMedia(BaseModel):
-    """ABSPodcastMedia."""
-
-    metadata: ABSPodcastMetaData
-    cover_path: Annotated[str, Alias("coverPath")]
-    episodes: list[ABSPodcastEpisodeExpanded]
-    num_episodes: Annotated[int, Alias("numEpisodes")] = 0
-
-
-@dataclass
-class ABSPodcast(BaseModel):
-    """ABSPodcast.
-
-    Depending on endpoint we get different results. This class does not
-    fully reflect https://api.audiobookshelf.org/#podcast.
-    """
-
-    id_: Annotated[str, Alias("id")]
-    media: ABSPodcastMedia
-
-
-@dataclass
 class ABSAuthorMinified(BaseModel):
     """ABSAuthor.
 
@@ -136,29 +66,6 @@ class ABSSeriesSequence(BaseModel):
 
 
 @dataclass
-class ABSAudioBookMetaData(BaseModel):
-    """ABSAudioBookMetaData.
-
-    https://api.audiobookshelf.org/#book-metadata
-    """
-
-    title: str
-    subtitle: str
-    authors: list[ABSAuthorMinified]
-    narrators: list[str]
-    series: list[ABSSeriesSequence]
-    genres: list[str] | None
-    published_year: Annotated[str | None, Alias("publishedYear")]
-    published_date: Annotated[str | None, Alias("publishedDate")]
-    publisher: str | None
-    description: str | None
-    isbn: str | None
-    asin: str | None
-    language: str | None
-    explicit: bool
-
-
-@dataclass
 class ABSAudioBookChapter(BaseModel):
     """
     ABSAudioBookChapter.
@@ -170,32 +77,6 @@ class ABSAudioBookChapter(BaseModel):
     start: float
     end: float
     title: str
-
-
-@dataclass
-class ABSAudioBookMedia(BaseModel):
-    """ABSAudioBookMedia.
-
-    Helper class due to API endpoint used.
-    """
-
-    metadata: ABSAudioBookMetaData
-    cover_path: Annotated[str, Alias("coverPath")]
-    chapters: list[ABSAudioBookChapter]
-    duration: float
-    tracks: list[ABSAudioTrack]
-
-
-@dataclass
-class ABSAudioBook(BaseModel):
-    """ABSAudioBook.
-
-    Depending on endpoint we get different results. This class does not
-    full reflect https://api.audiobookshelf.org/#book.
-    """
-
-    id_: Annotated[str, Alias("id")]
-    media: ABSAudioBookMedia
 
 
 @dataclass
@@ -303,23 +184,6 @@ class ABSLibrariesResponse(BaseModel):
     """ABSLibrariesResponse."""
 
     libraries: list[ABSLibrary]
-
-
-@dataclass
-class ABSLibraryItem(BaseModel):
-    """ABSLibraryItem."""
-
-    id_: Annotated[str, Alias("id")]
-
-
-@dataclass
-class ABSLibrariesItemsResponse(BaseModel):
-    """ABSLibrariesItemsResponse.
-
-    https://api.audiobookshelf.org/#get-a-library-39-s-items
-    """
-
-    results: list[ABSLibraryItem]
 
 
 # Schema to enable sessions:
@@ -490,6 +354,35 @@ class ABSPodcastEpisodeNormal(BaseModel):
 
 
 @dataclass
+class ABSPodcastEpisodeExpanded(BaseModel):
+    """ABSPodcastEpisode.
+
+    https://api.audiobookshelf.org/#podcast-episode
+    """
+
+    library_item_id: Annotated[str, Alias("libraryItemId")]
+    id_: Annotated[str, Alias("id")]
+    index: int | None
+    # audio_file: # not needed for mass application
+    published_at: Annotated[int | None, Alias("publishedAt")]  # ms posix epoch
+    added_at: Annotated[int | None, Alias("addedAt")]  # ms posix epoch
+    updated_at: Annotated[int | None, Alias("updatedAt")]  # ms posix epoch
+    audio_track: Annotated[ABSAudioTrack, Alias("audioTrack")]
+    size: int  # in bytes
+    season: str = ""
+    episode: str = ""
+    episode_type: Annotated[str, Alias("episodeType")] = ""
+    title: str = ""
+    subtitle: str = ""
+    description: str = ""
+    enclosure: str = ""
+    pub_date: Annotated[str, Alias("pubDate")] = ""
+    guid: str = ""
+    # chapters
+    duration: float = 0.0
+
+
+@dataclass
 class ABSPodcastBase(BaseModel):
     """ABSPodcastNormal."""
 
@@ -649,6 +542,13 @@ class ABSLibraryItemNormalBook(ABSLibraryItemNormal):
 
 
 @dataclass
+class ABSLibraryItemNormalPodcast(ABSLibraryItemNormal):
+    """ABSLibraryItemNormalBook."""
+
+    media: ABSPodcastNormal
+
+
+@dataclass
 class ABSLibraryItemMinified(ABSLibraryItemBase):
     """ABSLibraryItemMinified."""
 
@@ -664,6 +564,13 @@ class ABSLibraryItemMinifiedBook(ABSLibraryItemMinified):
 
 
 @dataclass
+class ABSLibraryItemMinifiedPodcast(ABSLibraryItemMinified):
+    """ABSLibraryItemMinifiedBook."""
+
+    media: ABSPodcastMinified
+
+
+@dataclass
 class ABSLibraryItemExpanded(ABSLibraryItemBase):
     """ABSLibraryItemExpanded."""
 
@@ -675,3 +582,33 @@ class ABSLibraryItemExpandedBook(ABSLibraryItemExpanded):
     """ABSLibraryItemExpanded."""
 
     media: ABSAudioBookExpanded
+
+
+@dataclass
+class ABSLibraryItemExpandedPodcast(ABSLibraryItemExpanded):
+    """ABSLibraryItemExpanded."""
+
+    media: ABSPodcastExpanded
+
+
+@dataclass
+class ABSLibrariesItemsMinifiedBookResponse(BaseModel):
+    """ABSLibrariesItemsResponse.
+
+    https://api.audiobookshelf.org/#get-a-library-39-s-items
+    No matter what options I append to the request, I always end up with
+    minified items. Maybe a bug in abs. If that would be fixed, there is
+    potential for reduced in API calls.
+    """
+
+    results: list[ABSLibraryItemMinifiedBook]
+
+
+@dataclass
+class ABSLibrariesItemsMinifiedPodcastResponse(BaseModel):
+    """ABSLibrariesItemsResponse.
+
+    see above.
+    """
+
+    results: list[ABSLibraryItemMinifiedPodcast]

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -434,3 +434,244 @@ class ABSSessionsResponse(BaseModel):
     num_pages: Annotated[int, Alias("numPages")]
     items_per_page: Annotated[int, Alias("itemsPerPage")]
     sessions: list[ABSPlaybackSession]
+
+
+## REWORK
+@dataclass
+class ABSPodcastMetaDataNormal(BaseModel):
+    """ABSPodcastMetaDataNormal."""
+
+    title: str | None
+    author: str | None
+    description: str | None
+    release_date: Annotated[str | None, Alias("releaseDate")]
+    genres: list[str] | None
+    feed_url: Annotated[str | None, Alias("feedUrl")]
+    image_url: Annotated[str | None, Alias("imageUrl")]
+    itunes_page_url: Annotated[str | None, Alias("itunesPageUrl")]
+    itunes_id: Annotated[int | None, Alias("itunesId")]
+    itunes_artist_id: Annotated[int | None, Alias("itunesArtistId")]
+    explicit: bool
+    language: str | None
+    type_: Annotated[str | None, Alias("type")]
+
+
+@dataclass
+class ABSPodcastMetaDataMinified(ABSPodcastMetaDataNormal):
+    """ABSPodcastMetaDataMinified."""
+
+    title_ignore_prefix: Annotated[str, Alias("titleIgnorePrefix")]
+
+
+ABSPodcastMetaDataExpanded = ABSPodcastMetaDataMinified
+
+
+@dataclass
+class ABSPodcastEpisodeNormal(BaseModel):
+    """ABSPodcastEpisodeNormal."""
+
+    library_item_id: Annotated[str, Alias("libraryItemId")]
+    id_: Annotated[str, Alias("id")]
+    index: int | None
+    # audio_file: # not needed for mass application
+    published_at: Annotated[int | None, Alias("publishedAt")]  # ms posix epoch
+    added_at: Annotated[int | None, Alias("addedAt")]  # ms posix epoch
+    updated_at: Annotated[int | None, Alias("updatedAt")]  # ms posix epoch
+    season: str = ""
+    episode: str = ""
+    episode_type: Annotated[str, Alias("episodeType")] = ""
+    title: str = ""
+    subtitle: str = ""
+    description: str = ""
+    enclosure: str = ""
+    pub_date: Annotated[str, Alias("pubDate")] = ""
+    guid: str = ""
+    # chapters
+
+
+@dataclass
+class ABSPodcastBase(BaseModel):
+    """ABSPodcastNormal."""
+
+    cover_path: Annotated[str, Alias("coverPath")]
+
+
+@dataclass
+class ABSPodcastNormal(BaseModel):
+    """ABSPodcastNormal."""
+
+    metadata: ABSPodcastMetaDataNormal
+    library_item_id: Annotated[str, Alias("libraryItemId")]
+    tags: list[str]
+    episodes: list[ABSPodcastEpisodeNormal]
+
+
+@dataclass
+class ABSPodcastMinified(ABSPodcastBase):
+    """ABSPodcastMinified."""
+
+    metadata: ABSPodcastMetaDataMinified
+    size: int  # bytes
+    num_episodes: Annotated[int, Alias("numEpisodes")] = 0
+
+
+@dataclass
+class ABSPodcastExpanded(ABSPodcastBase):
+    """ABSPodcastEpisodeExpanded."""
+
+    size: int  # bytes
+    metadata: ABSPodcastMetaDataExpanded
+    episodes: list[ABSPodcastEpisodeExpanded]
+
+
+@dataclass
+class ABSAudioBookMetaDataBase(BaseModel):
+    """ABSAudioBookMetaDataMinified."""
+
+    title: str
+    subtitle: str
+    genres: list[str] | None
+    published_year: Annotated[str | None, Alias("publishedYear")]
+    published_date: Annotated[str | None, Alias("publishedDate")]
+    publisher: str | None
+    description: str | None
+    isbn: str | None
+    asin: str | None
+    language: str | None
+    explicit: bool
+
+
+@dataclass
+class ABSAudioBookMetaDataNormal(ABSAudioBookMetaDataBase):
+    """ABSAudioBookMetaDataNormal."""
+
+    authors: list[ABSAuthorMinified]
+    narrators: list[str]
+    series: list[ABSSeriesSequence]
+
+
+@dataclass
+class ABSAudioBookMetaDataMinified(ABSAudioBookMetaDataBase):
+    """ABSAudioBookMetaDataMinified."""
+
+    # these are normally there
+    title_ignore_prefix: Annotated[str, Alias("titleIgnorePrefix")]
+    author_name: Annotated[str, Alias("authorName")]
+    author_name_lf: Annotated[str, Alias("authorNameLF")]
+    narrator_name: Annotated[str, Alias("narratorName")]
+    series_name: Annotated[str, Alias("seriesName")]
+
+
+@dataclass
+class ABSAudioBookMetaDataExpanded(ABSAudioBookMetaDataNormal, ABSAudioBookMetaDataMinified):
+    """ABSAudioBookMetaDataExpanded."""
+
+
+@dataclass
+class ABSAudioBookBase(BaseModel):
+    """ABSAudioBookBase."""
+
+    tags: list[str]
+    cover_path: Annotated[str | None, Alias("coverPath")]
+
+
+@dataclass
+class ABSAudioBookNormal(ABSAudioBookBase):
+    """ABSAudioBookNormal."""
+
+    library_item_id: Annotated[str, Alias("libraryItemId")]
+    metadata: ABSAudioBookMetaDataNormal
+    # audioFiles
+    chapters: list[ABSAudioBookChapter]
+    # ebookFile
+
+
+@dataclass
+class ABSAudioBookMinified(ABSAudioBookBase):
+    """ABSAudioBookBase."""
+
+    metadata: ABSAudioBookMetaDataMinified
+    num_tracks: Annotated[int, Alias("numTracks")]
+    num_audiofiles: Annotated[int, Alias("numAudioFiles")]
+    num_chapters: Annotated[int, Alias("numChapters")]
+    duration: float  # in s
+    size: int  # in bytes
+    # ebookFormat
+
+
+@dataclass
+class ABSAudioBookExpanded(ABSAudioBookBase):
+    """ABSAudioBookExpanded."""
+
+    library_item_id: Annotated[str, Alias("libraryItemId")]
+    metadata: ABSAudioBookMetaDataExpanded
+    chapters: list[ABSAudioBookChapter]
+    duration: float
+    size: int  # bytes
+    tracks: list[ABSAudioTrack]
+
+
+@dataclass
+class ABSLibraryItemBase(BaseModel):
+    """ABSLibraryItemBase."""
+
+    id_: Annotated[str, Alias("id")]
+    ino: str
+    library_id: Annotated[str, Alias("libraryId")]
+    folder_id: Annotated[str, Alias("folderId")]
+    path: str
+    relative_path: Annotated[str, Alias("relPath")]
+    is_file: Annotated[bool, Alias("isFile")]
+    last_modified_ms: Annotated[int, Alias("mtimeMs")]  # epoch
+    last_changed_ms: Annotated[int, Alias("ctimeMs")]  # epoch
+    birthtime_ms: Annotated[int, Alias("birthtimeMs")]  # epoch
+    added_at: Annotated[int, Alias("addedAt")]  # ms epoch
+    updated_at: Annotated[int, Alias("updatedAt")]  # ms epoch
+    is_missing: Annotated[bool, Alias("isMissing")]
+    is_invalid: Annotated[bool, Alias("isInvalid")]
+    media_type: Annotated[str, Alias("mediaType")]
+
+
+@dataclass
+class ABSLibraryItemNormal(ABSLibraryItemBase):
+    """ABSLibraryItemNormal."""
+
+    last_scan: Annotated[int | None, Alias("lastScan")]  # ms epoch
+    scan_version: Annotated[str | None, Alias("scanVersion")]
+    # libraryFiles
+
+
+@dataclass
+class ABSLibraryItemNormalBook(ABSLibraryItemNormal):
+    """ABSLibraryItemNormalBook."""
+
+    media: ABSAudioBookNormal
+
+
+@dataclass
+class ABSLibraryItemMinified(ABSLibraryItemBase):
+    """ABSLibraryItemMinified."""
+
+    num_files: Annotated[int, Alias("numFiles")]
+    size: int  # bytes
+
+
+@dataclass
+class ABSLibraryItemMinifiedBook(ABSLibraryItemMinified):
+    """ABSLibraryItemMinifiedBook."""
+
+    media: ABSAudioBookMinified
+
+
+@dataclass
+class ABSLibraryItemExpanded(ABSLibraryItemBase):
+    """ABSLibraryItemExpanded."""
+
+    size: int  # bytes
+
+
+@dataclass
+class ABSLibraryItemExpandedBook(ABSLibraryItemExpanded):
+    """ABSLibraryItemExpanded."""
+
+    media: ABSAudioBookExpanded


### PR DESCRIPTION
This PR adapts classes defined in `abs_schema.py` to use the same names (+ prefix ABS) as in the API doc of Audiobookshelf. Many items have multiple variants, e.g. a [Book](https://api.audiobookshelf.org/#book) exists in a minified, expanded and normal version. Now, classes are named accordingly:

- ABSBook
- ABSBookMinified
- ABSBookExpanded

I've been rather loose in the initial version, however, I believe this makes future maintenance and possible enhancements much easier. There is no logical code change in this PR.