### PR TITLE
Fix: Provide a proper track number for Deezer tracks if available

### DIFF
--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -674,7 +674,7 @@ class DeezerProvider(MusicProvider):
                 )
             },
             metadata=self.parse_metadata_track(track=track),
-            track_number=position,
+            track_number=getattr(track, "track_position", position),
             position=position,
             disc_number=getattr(track, "disk_number", 0),
         )


### PR DESCRIPTION
Use the track_position attribute if it's available as the track number. This ensures we get the right track number for things like multi-disc albums. Without this, tracks seem to follow the order in which they have been added, which does not match the actual track numbering.