### PR TITLE
No scrobble

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -751,7 +751,6 @@ class OpenSonicProvider(MusicProvider):
                 item.content_type,
             )
 
-            self.mass.create_task(self._report_playback_started(item_id))
         elif media_type == MediaType.PODCAST_EPISODE:
             item = await self._get_podcast_episode(item_id)
 
@@ -760,7 +759,6 @@ class OpenSonicProvider(MusicProvider):
                 item.id,
                 item.content_type,
             )
-            self.mass.create_task(self._report_playback_started(item.id))
         else:
             msg = f"Unsupported media type encountered '{media_type}'"
             raise UnsupportedFeaturedException(msg)
@@ -779,10 +777,6 @@ class OpenSonicProvider(MusicProvider):
             stream_type=StreamType.CUSTOM,
             duration=item.duration if item.duration else 0,
         )
-
-    async def _report_playback_started(self, item_id: str) -> None:
-        self.logger.debug("scrobble for now playing called for %s", item_id)
-        await self._run_async(self._conn.scrobble, sid=item_id, submission=False)
 
     async def on_played(
         self,
@@ -804,8 +798,10 @@ class OpenSonicProvider(MusicProvider):
         When fully_played is set to false and position is 0,
         the user marked the item as unplayed in the UI.
         """
-        self.logger.debug("scrobble for listen count called for %s", item_id)
-        await self._run_async(self._conn.scrobble, sid=item_id, submission=True)
+        # Only scrobble completed plays
+        if fully_played:
+            self.logger.debug("scrobble for listen count called for %s", item_id)
+            await self._run_async(self._conn.scrobble, sid=item_id, submission=True)
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0


### PR DESCRIPTION
Two unrelated commits here:
1. Remove scrobbling from the music provider so that we don't step on the toes of folks who want to use the scrobbling plugins instead.
2.  Emit a warning when a user tries to play an MPEG-4 file as these can fail with out streaming method if the moov atom is at the back of the file.