### PR TITLE
Remove scrobble from Subsonic provider

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -764,7 +764,15 @@ class OpenSonicProvider(MusicProvider):
             raise UnsupportedFeaturedException(msg)
 
         mime_type = item.content_type
-        if mime_type.endswith("mpeg"):
+        # For mp4 or m4a files, better to let ffmpeg detect the codec in use so mark them unknown
+        if mime_type.endswith("mp4"):
+            self.logger.warning(
+                "Due to the streaming method used by the subsonic API, M4A files "
+                "may fail. See provider documentation for more information."
+            )
+            mime_type = "?"
+        # For mp3 files, ffmpeg wants to be told 'mp3' instead of 'audio/mpeg'
+        elif mime_type.endswith("mpeg"):
             mime_type = item.suffix
 
         return StreamDetails(
@@ -821,7 +829,7 @@ class OpenSonicProvider(MusicProvider):
                     timeOffset=seek_position,
                     estimateContentLength=True,
                 ) as stream:
-                    for chunk in stream.iter_content(chunk_size=40960):
+                    for chunk in stream.iter_content(chunk_size=4096):
                         asyncio.run_coroutine_threadsafe(
                             audio_buffer.put(chunk), self.mass.loop
                         ).result()

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -751,7 +751,6 @@ class OpenSonicProvider(MusicProvider):
                 item.content_type,
             )
 
-            self.mass.create_task(self._report_playback_started(item_id))
         elif media_type == MediaType.PODCAST_EPISODE:
             item = await self._get_podcast_episode(item_id)
 
@@ -760,7 +759,6 @@ class OpenSonicProvider(MusicProvider):
                 item.id,
                 item.content_type,
             )
-            self.mass.create_task(self._report_playback_started(item.id))
         else:
             msg = f"Unsupported media type encountered '{media_type}'"
             raise UnsupportedFeaturedException(msg)
@@ -779,10 +777,6 @@ class OpenSonicProvider(MusicProvider):
             stream_type=StreamType.CUSTOM,
             duration=item.duration if item.duration else 0,
         )
-
-    async def _report_playback_started(self, item_id: str) -> None:
-        self.logger.debug("scrobble for now playing called for %s", item_id)
-        await self._run_async(self._conn.scrobble, sid=item_id, submission=False)
 
     async def on_played(
         self,
@@ -804,8 +798,8 @@ class OpenSonicProvider(MusicProvider):
         When fully_played is set to false and position is 0,
         the user marked the item as unplayed in the UI.
         """
-        self.logger.debug("scrobble for listen count called for %s", item_id)
-        await self._run_async(self._conn.scrobble, sid=item_id, submission=True)
+        # Leave this function as the place where we will create a bookmark for podcasts when they
+        # are stopped early and delete the bookmark when they are finished.
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -829,7 +829,7 @@ class OpenSonicProvider(MusicProvider):
                     timeOffset=seek_position,
                     estimateContentLength=True,
                 ) as stream:
-                    for chunk in stream.iter_content(chunk_size=4096):
+                    for chunk in stream.iter_content(chunk_size=40960):
                         asyncio.run_coroutine_threadsafe(
                             audio_buffer.put(chunk), self.mass.loop
                         ).result()


### PR DESCRIPTION
The first commit disables scrobbling in the music provider so we don't step on the scrobble providers. The second adds a warning when a user plays an MPEG-4 file referencing our documentation on the possible problem.