### PR TITLE
Switch the Soundcloud artist tracks to the full listing

### DIFF
--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -275,7 +275,7 @@ class SoundcloudMusicProvider(MusicProvider):
         return result
 
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
-        """Get a list of 500 tracks for the given artist."""
+        """Get a list of (max 500) tracks for the given artist."""
         tracks_obj = await self._soundcloud.get_tracks_from_user(prov_artist_id, 500)
 
         tracks = []

--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -275,8 +275,9 @@ class SoundcloudMusicProvider(MusicProvider):
         return result
 
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
-        """Get a list of 25 most popular tracks for the given artist."""
-        tracks_obj = await self._soundcloud.get_popular_tracks_user(prov_artist_id, 25)
+        """Get a list of 500 tracks for the given artist."""
+        tracks_obj = await self._soundcloud.get_tracks_from_user(prov_artist_id, 500)
+
         tracks = []
         for item in tracks_obj["collection"]:
             song = await self._soundcloud.get_track_details(item["id"])


### PR DESCRIPTION
Switched the artist tracks to the full listing instead of the popular ones. Limited by 500 items based on Marcel's recommendation.

Solves [#3456](https://github.com/music-assistant/support/issues/3456)