### PR TITLE
Feat: Audiobookshelf - extended browse + caching

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -705,8 +705,11 @@ class Audiobookshelf(MusicProvider):
             series = target.series
             books = target.audiobooks
             books_in_series: list[str] = []
+            library_id = sub_paths[1]
             for series_id in series:
-                _series = self._client.audiobook_libraries.series.get(series_id, None)
+                _series = self._client.audiobook_libraries.libraries[library_id].series.get(
+                    series_id, None
+                )
                 if _series is None:
                     continue
                 books_in_series.extend(_series.audiobooks)
@@ -716,7 +719,7 @@ class Audiobookshelf(MusicProvider):
                 items.append(
                     BrowseFolder(
                         item_id=series_id,
-                        name=f"{series_name} (Series)",
+                        name=f"{series_name} ({BrowseExtendedKeys.SERIES.value})",
                         provider=self.lookup_key,
                         path=f"{_path}/{BrowseExtendedKeys.SERIES.value.lower()}/{series_id}",
                     )
@@ -808,7 +811,7 @@ class Audiobookshelf(MusicProvider):
                 items.append(
                     BrowseFolder(
                         item_id=audiobook_library_id,
-                        name=f"{audiobook_library.name} (Audiobooks)",
+                        name=f"{audiobook_library.name} ({BrowseExtendedKeys.AUDIOBOOKS.value})",
                         provider=self.lookup_key,
                         path=f"{self.lookup_key}://{audiobook_library_id}",
                     )
@@ -820,7 +823,7 @@ class Audiobookshelf(MusicProvider):
                 items.append(
                     BrowseFolder(
                         item_id=podcast_library_id,
-                        name=f"{podcast_library.name} (Podcasts)",
+                        name=f"{podcast_library.name} ({BrowseExtendedKeys.PODCASTS.value})",
                         provider=self.lookup_key,
                         path=f"{self.lookup_key}://{podcast_library_id}",
                     )

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -166,7 +166,7 @@ class Audiobookshelf(MusicProvider):
                 base_url=base_url,
                 username=username,
                 password=str(self.config.get_value(CONF_PASSWORD)),
-                instance_id=self.instance_id,
+                lookup_key=self.lookup_key,
                 logger=self.logger,
                 check_ssl=bool(self.config.get_value(CONF_VERIFY_SSL)),
             )
@@ -176,14 +176,14 @@ class Audiobookshelf(MusicProvider):
 
         # this will be provided when creating sessions or receive already opened sessions
         self.device_info = ABSDeviceInfo(
-            device_id=self.instance_id,
+            device_id=self.lookup_key,
             client_name="Music Assistant",
             client_version=self.mass.version,
             manufacturer="",
             model=self.mass.server_id,
         )
 
-        self.logger.debug(f"Our playback session device_id is {self.instance_id}")
+        self.logger.debug(f"Our playback session device_id is {self.lookup_key}")
 
     async def loaded_in_mass(self) -> None:
         """Call when provider loaded."""
@@ -231,7 +231,7 @@ class Audiobookshelf(MusicProvider):
                 ProviderMapping(
                     item_id=abs_podcast.id_,
                     provider_domain=self.domain,
-                    provider_instance=self.instance_id,
+                    provider_instance=self.lookup_key,
                 )
             },
         )
@@ -294,7 +294,7 @@ class Audiobookshelf(MusicProvider):
                 ProviderMapping(
                     item_id=episode_id,
                     provider_domain=self.domain,
-                    provider_instance=self.instance_id,
+                    provider_instance=self.lookup_key,
                     audio_format=AudioFormat(
                         content_type=ContentType.UNKNOWN,
                     ),
@@ -372,7 +372,7 @@ class Audiobookshelf(MusicProvider):
                 ProviderMapping(
                     item_id=abs_audiobook.id_,
                     provider_domain=self.domain,
-                    provider_instance=self.instance_id,
+                    provider_instance=self.lookup_key,
                 )
             },
             publisher=abs_audiobook.media.metadata.publisher,
@@ -461,7 +461,7 @@ class Audiobookshelf(MusicProvider):
         media_url = track.content_url
         stream_url = f"{base_url}{media_url}?token={token}"
         return StreamDetails(
-            provider=self.instance_id,
+            provider=self.lookup_key,
             item_id=item_id,
             audio_format=AudioFormat(
                 content_type=ContentType.UNKNOWN,
@@ -598,7 +598,7 @@ class Audiobookshelf(MusicProvider):
                     item_id=library.id_,
                     name=library.name,
                     provider=self.lookup_key,
-                    path=f"{self.instance_id}://{item_path}/{library.id_}",
+                    path=f"{self.lookup_key}://{item_path}/{library.id_}",
                 )
             )
         return items
@@ -629,7 +629,7 @@ class Audiobookshelf(MusicProvider):
                 mass_item = await self.mass.music.get_library_item_by_prov_id(
                     media_type=media_type,
                     item_id=item_id,
-                    provider_instance_id_or_domain=self.instance_id,
+                    provider_instance_id_or_domain=self.lookup_key,
                 )
                 if mass_item is not None:
                     items.append(mass_item)

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -36,8 +36,8 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.audiobookshelf.abs_cache_helpers import (
-    AudiobookLibrary,
-    PodcastLibrary,
+    CacheAudiobookLibrary,
+    CachePodcastLibrary,
 )
 from music_assistant.providers.audiobookshelf.abs_client import ABSClient
 from music_assistant.providers.audiobookshelf.abs_schema import (
@@ -560,7 +560,9 @@ class Audiobookshelf(MusicProvider):
             )
 
     async def _browse_root(
-        self, library_dict: dict[str, PodcastLibrary] | dict[str, AudiobookLibrary], item_path: str
+        self,
+        library_dict: dict[str, CachePodcastLibrary] | dict[str, CacheAudiobookLibrary],
+        item_path: str,
     ) -> Sequence[MediaItemType | ItemMapping]:
         """Browse root folder in browse view.
 
@@ -582,7 +584,7 @@ class Audiobookshelf(MusicProvider):
     async def _browse_lib(
         self,
         library_id: str,
-        library_dict: dict[str, PodcastLibrary] | dict[str, AudiobookLibrary],
+        library_dict: dict[str, CachePodcastLibrary] | dict[str, CacheAudiobookLibrary],
         media_type: MediaType,
     ) -> Sequence[MediaItemType | ItemMapping]:
         """Browse lib folder in browse view.

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -560,7 +560,7 @@ class Audiobookshelf(MusicProvider):
             )
 
     async def _browse_root(
-        self, library_list: list[PodcastLibrary] | list[AudiobookLibrary], item_path: str
+        self, library_dict: dict[str, PodcastLibrary] | dict[str, AudiobookLibrary], item_path: str
     ) -> Sequence[MediaItemType | ItemMapping]:
         """Browse root folder in browse view.
 
@@ -568,7 +568,7 @@ class Audiobookshelf(MusicProvider):
         of both podcasts and audiobooks.
         """
         items: list[MediaItemType | ItemMapping] = []
-        for library in library_list:
+        for library in library_dict.values():
             items.append(
                 BrowseFolder(
                     item_id=library.id_,
@@ -582,17 +582,14 @@ class Audiobookshelf(MusicProvider):
     async def _browse_lib(
         self,
         library_id: str,
-        library_list: list[PodcastLibrary] | list[AudiobookLibrary],
+        library_dict: dict[str, PodcastLibrary] | dict[str, AudiobookLibrary],
         media_type: MediaType,
     ) -> Sequence[MediaItemType | ItemMapping]:
         """Browse lib folder in browse view.
 
         Helper functions. Shows the items which are part of an ABS library.
         """
-        library = None
-        for library in library_list:
-            if library_id == library.id_:
-                break
+        library = library_dict.get(library_id, None)
         if library is None:
             raise MediaNotFoundError("Lib missing.")
 
@@ -618,21 +615,21 @@ class Audiobookshelf(MusicProvider):
 
         # HANDLE ROOT PATH
         if item_path == "audiobooks":
-            book_list = self._client.audiobook_libraries.libraries
-            return await self._browse_root(book_list, item_path)
+            book_dict = self._client.audiobook_libraries.libraries
+            return await self._browse_root(book_dict, item_path)
         elif item_path == "podcasts":
-            podcast_list = self._client.podcast_libraries.libraries
-            return await self._browse_root(podcast_list, item_path)
+            podcast_dict = self._client.podcast_libraries.libraries
+            return await self._browse_root(podcast_dict, item_path)
 
         # HANDLE WITHIN LIBRARY
         library_type, library_id = item_path.split("/")
         if library_type == "audiobooks":
-            audiobook_list = self._client.audiobook_libraries.libraries
+            audiobook_dict = self._client.audiobook_libraries.libraries
             media_type = MediaType.AUDIOBOOK
-            return await self._browse_lib(library_id, audiobook_list, media_type)
+            return await self._browse_lib(library_id, audiobook_dict, media_type)
         elif library_type == "podcasts":
-            podcast_list = self._client.podcast_libraries.libraries
+            podcast_dict = self._client.podcast_libraries.libraries
             media_type = MediaType.PODCAST
-            return await self._browse_lib(library_id, podcast_list, media_type)
+            return await self._browse_lib(library_id, podcast_dict, media_type)
         else:
             raise MediaNotFoundError("Specified Lib Type unknown")

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -138,7 +138,7 @@ class Audiobookshelf(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Pass config values to client and initialize."""
-        self._client = ABSClient()
+        self._client = ABSClient(mass=self.mass)
         base_url = str(self.config.get_value(CONF_URL))
         username = str(self.config.get_value(CONF_USERNAME))
         try:
@@ -147,6 +147,7 @@ class Audiobookshelf(MusicProvider):
                 base_url=base_url,
                 username=username,
                 password=str(self.config.get_value(CONF_PASSWORD)),
+                instance_id=self.instance_id,
                 logger=self.logger,
                 check_ssl=bool(self.config.get_value(CONF_VERIFY_SSL)),
             )
@@ -612,19 +613,19 @@ class Audiobookshelf(MusicProvider):
 
         # HANDLE ROOT PATH
         if item_path == "audiobooks":
-            library_list = self._client.audiobook_libraries
+            library_list = self._client.libraries.audiobook_libraries
             return await self._browse_root(library_list, item_path)
         elif item_path == "podcasts":
-            library_list = self._client.podcast_libraries
+            library_list = self._client.libraries.podcast_libraries
             return await self._browse_root(library_list, item_path)
 
         # HANDLE WITHIN LIBRARY
         library_type, library_id = item_path.split("/")
         if library_type == "audiobooks":
-            library_list = self._client.audiobook_libraries
+            library_list = self._client.libraries.podcast_libraries
             media_type = MediaType.AUDIOBOOK
         elif library_type == "podcasts":
-            library_list = self._client.podcast_libraries
+            library_list = self._client.libraries.podcast_libraries
             media_type = MediaType.PODCAST
         else:
             raise MediaNotFoundError("Specified Lib Type unknown")

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
 from music_assistant_models.enums import (
@@ -692,16 +692,9 @@ class Audiobookshelf(MusicProvider):
                 )
             return items
 
-        client_lib = self._client.audiobook_libraries
-        target = None
+        target: Any | CacheAudiobookLibrary = self._client.audiobook_libraries
         for sub_path in sub_paths:
-            target = (
-                client_lib.get(sub_path)
-                if isinstance(client_lib, dict)
-                else getattr(client_lib, sub_path)
-            )
-        if target is None:
-            raise RuntimeError("Unable to browse.")
+            target = target.get(sub_path) if isinstance(target, dict) else getattr(target, sub_path)
         if isinstance(target, dict):
             for id_, params in target.items():
                 items.append(
@@ -712,6 +705,7 @@ class Audiobookshelf(MusicProvider):
                         path=f"{full_path}/{id_}",
                     )
                 )
+            return items
         elif isinstance(target, CacheAuthor | CacheCollection | CacheSeries):
             for book_id in target.audiobooks:
                 mass_item = await self.mass.music.get_library_item_by_prov_id(
@@ -766,16 +760,9 @@ class Audiobookshelf(MusicProvider):
                 )
             return items
 
-        client_lib = self._client.podcast_libraries
-        target = None
+        target: Any | CachePodcastLibrary = self._client.podcast_libraries
         for sub_path in sub_paths:
-            target = (
-                client_lib.get(sub_path)
-                if isinstance(client_lib, dict)
-                else getattr(client_lib, sub_path)
-            )
-        if target is None:
-            raise RuntimeError("Unable to browse.")
+            target = target.get(sub_path) if isinstance(target, dict) else getattr(target, sub_path)
 
         if isinstance(target, dict):
             for id_, params in target.items():

--- a/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
+++ b/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
@@ -5,16 +5,28 @@ used when syncing the library for caching.
 """
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 
 from mashumaro import DataClassDictMixin
 from music_assistant_models.media_items import UniqueList
+
+
+class BrowseExtendedKeys(StrEnum):
+    """BrowseExtendedKeys."""
+
+    AUTHORS = "Authors"
+    SERIES = "Series"
+    COLLECTIONS = "Collections"
+    AUDIOBOOKS = "Audiobooks"
+    PODCASTS = "Podcasts"
+    LIBRARIES = "Libraries"
 
 
 @dataclass
 class _SCBase(DataClassDictMixin):
     id_: str
     name: str = ""
-    books: UniqueList[str] = field(default_factory=UniqueList[str])
+    audiobooks: UniqueList[str] = field(default_factory=UniqueList[str])
 
 
 @dataclass
@@ -33,7 +45,7 @@ class CacheAuthor(DataClassDictMixin):
 
     id_: str
     name: str = ""
-    books: UniqueList[str] = field(default_factory=UniqueList[str])
+    audiobooks: UniqueList[str] = field(default_factory=UniqueList[str])
     series: UniqueList[str] = field(default_factory=UniqueList[str])
 
 
@@ -43,21 +55,26 @@ class _Library(DataClassDictMixin):
 
     id_: str
     name: str = ""
-    item_ids: UniqueList[str] = field(default_factory=UniqueList[str])
 
 
 @dataclass
 class CachePodcastLibrary(_Library):
     """PodcastLibrary."""
 
+    podcasts: UniqueList[str] = field(default_factory=UniqueList[str])
+
 
 @dataclass
 class CacheAudiobookLibrary(_Library):
-    """AudiobookLibrary."""
+    """AudiobookLibrary.
+
+    Here we keep what is specific to that single library
+    """
 
     authors: dict[str, CacheAuthor] = field(default_factory=dict)
     series: dict[str, CacheSeries] = field(default_factory=dict)
     collections: dict[str, CacheCollection] = field(default_factory=dict)
+    audiobooks: UniqueList[str] = field(default_factory=UniqueList[str])
 
 
 @dataclass
@@ -66,10 +83,18 @@ class CachePodcastLibraries(DataClassDictMixin):
 
     # id: PodcastLibrary
     libraries: dict[str, CachePodcastLibrary] = field(default_factory=dict)
+    podcasts: UniqueList[str] = field(default_factory=UniqueList[str])
 
 
 @dataclass
 class CacheAudiobookLibraries(DataClassDictMixin):
-    """AudiobookLibraries."""
+    """AudiobookLibraries.
+
+    Here we keep items from all libraries.
+    """
 
     libraries: dict[str, CacheAudiobookLibrary] = field(default_factory=dict)
+    series: dict[str, CacheSeries] = field(default_factory=dict)
+    authors: dict[str, CacheAuthor] = field(default_factory=dict)
+    collections: dict[str, CacheCollection] = field(default_factory=dict)
+    audiobooks: UniqueList[str] = field(default_factory=UniqueList[str])

--- a/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
+++ b/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
@@ -11,16 +11,24 @@ from music_assistant_models.media_items import UniqueList
 
 
 @dataclass
-class Series(DataClassDictMixin):
-    """Series."""
-
+class _SCBase(DataClassDictMixin):
     id_: str
     name: str = ""
     books: UniqueList[str] = field(default_factory=UniqueList[str])
 
 
 @dataclass
-class Author(DataClassDictMixin):
+class CacheSeries(_SCBase):
+    """Series."""
+
+
+@dataclass
+class CacheCollection(_SCBase):
+    """collections."""
+
+
+@dataclass
+class CacheAuthor(DataClassDictMixin):
     """Author."""
 
     id_: str
@@ -39,28 +47,29 @@ class _Library(DataClassDictMixin):
 
 
 @dataclass
-class PodcastLibrary(_Library):
+class CachePodcastLibrary(_Library):
     """PodcastLibrary."""
 
 
 @dataclass
-class AudiobookLibrary(_Library):
+class CacheAudiobookLibrary(_Library):
     """AudiobookLibrary."""
 
-    authors: dict[str, Author] = field(default_factory=dict)
-    series: dict[str, Series] = field(default_factory=dict)
+    authors: dict[str, CacheAuthor] = field(default_factory=dict)
+    series: dict[str, CacheSeries] = field(default_factory=dict)
+    collections: dict[str, CacheCollection] = field(default_factory=dict)
 
 
 @dataclass
-class CacheablePodcastLibraries(DataClassDictMixin):
+class CachePodcastLibraries(DataClassDictMixin):
     """PodcastLibraries."""
 
     # id: PodcastLibrary
-    libraries: dict[str, PodcastLibrary] = field(default_factory=dict)
+    libraries: dict[str, CachePodcastLibrary] = field(default_factory=dict)
 
 
 @dataclass
-class CacheableAudiobookLibraries(DataClassDictMixin):
+class CacheAudiobookLibraries(DataClassDictMixin):
     """AudiobookLibraries."""
 
-    libraries: dict[str, AudiobookLibrary] = field(default_factory=dict)
+    libraries: dict[str, CacheAudiobookLibrary] = field(default_factory=dict)

--- a/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
+++ b/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
@@ -66,10 +66,7 @@ class CachePodcastLibrary(_Library):
 
 @dataclass
 class CacheAudiobookLibrary(_Library):
-    """AudiobookLibrary.
-
-    Here we keep what is specific to that single library
-    """
+    """AudiobookLibrary."""
 
     authors: dict[str, CacheAuthor] = field(default_factory=dict)
     series: dict[str, CacheSeries] = field(default_factory=dict)
@@ -83,18 +80,10 @@ class CachePodcastLibraries(DataClassDictMixin):
 
     # id: PodcastLibrary
     libraries: dict[str, CachePodcastLibrary] = field(default_factory=dict)
-    podcasts: UniqueList[str] = field(default_factory=UniqueList[str])
 
 
 @dataclass
 class CacheAudiobookLibraries(DataClassDictMixin):
-    """AudiobookLibraries.
-
-    Here we keep items from all libraries.
-    """
+    """AudiobookLibraries."""
 
     libraries: dict[str, CacheAudiobookLibrary] = field(default_factory=dict)
-    series: dict[str, CacheSeries] = field(default_factory=dict)
-    authors: dict[str, CacheAuthor] = field(default_factory=dict)
-    collections: dict[str, CacheCollection] = field(default_factory=dict)
-    audiobooks: UniqueList[str] = field(default_factory=UniqueList[str])

--- a/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
+++ b/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
@@ -14,11 +14,11 @@ from music_assistant_models.media_items import UniqueList
 class BrowseExtendedKeys(StrEnum):
     """BrowseExtendedKeys."""
 
-    AUTHORS = "Authors"
-    SERIES = "Series"
-    COLLECTIONS = "Collections"
     AUDIOBOOKS = "Audiobooks"
     PODCASTS = "Podcasts"
+    SERIES = "Series"
+    COLLECTIONS = "Collections"
+    AUTHORS = "Authors"
     LIBRARIES = "Libraries"
 
 

--- a/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
+++ b/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
@@ -1,0 +1,43 @@
+"""Cache Helpers.
+
+These are not ABS Schema classes, but are
+used when syncing the library for caching.
+"""
+
+from dataclasses import dataclass, field
+
+from mashumaro import DataClassDictMixin
+from music_assistant_models.media_items import UniqueList
+
+
+@dataclass
+class _Library(DataClassDictMixin):
+    """Helper class to store ABSLibrary, and the ids of the items associated."""
+
+    id_: str
+    name: str = ""
+    item_ids: UniqueList[str] = field(default_factory=UniqueList[str])
+
+
+@dataclass
+class PodcastLibrary(_Library):
+    """PodcastLibrary."""
+
+
+@dataclass
+class AudiobookLibrary(_Library):
+    """AudiobookLibrary."""
+
+
+@dataclass
+class CacheablePodcastLibraries(DataClassDictMixin):
+    """PodcastLibraries."""
+
+    libraries: UniqueList[PodcastLibrary] = field(default_factory=UniqueList[PodcastLibrary])
+
+
+@dataclass
+class CacheableAudiobookLibraries(DataClassDictMixin):
+    """AudiobookLibraries."""
+
+    libraries: UniqueList[AudiobookLibrary] = field(default_factory=UniqueList[AudiobookLibrary])

--- a/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
+++ b/music_assistant/providers/audiobookshelf/abs_cache_helpers.py
@@ -11,6 +11,25 @@ from music_assistant_models.media_items import UniqueList
 
 
 @dataclass
+class Series(DataClassDictMixin):
+    """Series."""
+
+    id_: str
+    name: str = ""
+    books: UniqueList[str] = field(default_factory=UniqueList[str])
+
+
+@dataclass
+class Author(DataClassDictMixin):
+    """Author."""
+
+    id_: str
+    name: str = ""
+    books: UniqueList[str] = field(default_factory=UniqueList[str])
+    series: UniqueList[str] = field(default_factory=UniqueList[str])
+
+
+@dataclass
 class _Library(DataClassDictMixin):
     """Helper class to store ABSLibrary, and the ids of the items associated."""
 
@@ -28,16 +47,20 @@ class PodcastLibrary(_Library):
 class AudiobookLibrary(_Library):
     """AudiobookLibrary."""
 
+    authors: dict[str, Author] = field(default_factory=dict)
+    series: dict[str, Series] = field(default_factory=dict)
+
 
 @dataclass
 class CacheablePodcastLibraries(DataClassDictMixin):
     """PodcastLibraries."""
 
-    libraries: UniqueList[PodcastLibrary] = field(default_factory=UniqueList[PodcastLibrary])
+    # id: PodcastLibrary
+    libraries: dict[str, PodcastLibrary] = field(default_factory=dict)
 
 
 @dataclass
 class CacheableAudiobookLibraries(DataClassDictMixin):
     """AudiobookLibraries."""
 
-    libraries: UniqueList[AudiobookLibrary] = field(default_factory=UniqueList[AudiobookLibrary])
+    libraries: dict[str, AudiobookLibrary] = field(default_factory=dict)

--- a/music_assistant/providers/audiobookshelf/abs_client.py
+++ b/music_assistant/providers/audiobookshelf/abs_client.py
@@ -83,7 +83,7 @@ class ABSClient:
         base_url: str,
         username: str,
         password: str,
-        instance_id: str,
+        lookup_key: str,
         logger: logging.Logger | None = None,
         check_ssl: bool = True,
     ) -> None:
@@ -103,7 +103,7 @@ class ABSClient:
         self.token: str = self.user.token
         self.session_headers = {"Authorization": f"Bearer {self.token}"}
 
-        self.cache_base_key = f"{CACHE_BASE_KEY_PREFIX}_{instance_id}"
+        self.cache_base_key = f"{CACHE_BASE_KEY_PREFIX}_{lookup_key}"
 
     async def _loaded_in_mass(self) -> None:
         if self.mass is not None:

--- a/music_assistant/providers/audiobookshelf/abs_client.py
+++ b/music_assistant/providers/audiobookshelf/abs_client.py
@@ -263,9 +263,6 @@ class ABSClient:
                 # store ids of library items for later use
                 if podcast.id_ not in lib.podcasts:
                     lib.podcasts.append(podcast.id_)
-                # all record
-                if podcast.id_ not in self.podcast_libraries.podcasts:
-                    self.podcast_libraries.podcasts.append(podcast.id_)
                 yield podcast
 
     async def get_podcast_expanded(self, id_: str) -> ABSLibraryItemExpandedPodcast:
@@ -395,9 +392,6 @@ class ABSClient:
                 # store ids of library items for later use
                 if audiobook.id_ not in lib.audiobooks:
                     lib.audiobooks.append(audiobook.id_)
-                # all record
-                if audiobook.id_ not in self.audiobook_libraries.audiobooks:
-                    self.audiobook_libraries.audiobooks.append(audiobook.id_)
                 yield audiobook
 
     async def get_audiobook_expanded(self, id_: str) -> ABSLibraryItemExpandedBook:
@@ -561,9 +555,6 @@ class ABSClient:
                 _author.series = UniqueList([x.id_ for x in response.series])
                 lib.authors[_author.id_] = _author
 
-                # keep also an "all record"
-                self.audiobook_libraries.authors[_author.id_] = _author
-
                 for series in response.series:
                     _series = CacheSeries(
                         id_=series.id_,
@@ -571,9 +562,6 @@ class ABSClient:
                         audiobooks=UniqueList([x.id_ for x in series.items]),
                     )
                     lib.series[_series.id_] = _series
-
-                    # keep also an "all record"
-                    self.audiobook_libraries.series[_series.id_] = _series
 
     async def _sync_collections(self) -> None:
         """Sync collections."""
@@ -608,6 +596,3 @@ class ABSClient:
                         audiobooks=UniqueList([x.id_ for x in collection.books]),
                     )
                     lib.collections[collection.id_] = _collection
-
-                    # keep also an "all record"
-                    self.audiobook_libraries.collections[collection.id_] = _collection

--- a/music_assistant/providers/audiobookshelf/abs_client.py
+++ b/music_assistant/providers/audiobookshelf/abs_client.py
@@ -105,6 +105,7 @@ class ABSClient:
 
         self.cache_base_key = f"{CACHE_BASE_KEY_PREFIX}_{instance_id}"
 
+    async def _loaded_in_mass(self) -> None:
         if self.mass is not None:
             # try obtaining cached library items
             data = await self.mass.cache.get(
@@ -113,7 +114,7 @@ class ABSClient:
                 category=CACHE_CATEGORY_ABS_CLIENT,
                 default=None,
             )
-            if data is not None:
+            if data is not None and isinstance(data, dict):
                 self.podcast_libraries = CachePodcastLibraries.from_dict(data)
 
             data = await self.mass.cache.get(
@@ -122,10 +123,8 @@ class ABSClient:
                 category=CACHE_CATEGORY_ABS_CLIENT,
                 default=None,
             )
-            if data is not None:
+            if data is not None and isinstance(data, dict):
                 self.audiobook_libraries = CacheAudiobookLibraries.from_dict(data)
-        self.logger.debug(self.audiobook_libraries.to_dict())
-        self.logger.debug(self.podcast_libraries.to_dict())
 
     async def _post(
         self,
@@ -214,6 +213,8 @@ class ABSClient:
                     self.podcast_libraries.libraries[library.id_] = plib
         self.user = await self.get_authenticated_user()
 
+    async def sync_extended(self) -> None:
+        """Sync for extended browse."""
         await self._sync_authors_series()
         await self._sync_collections()
 
@@ -260,8 +261,11 @@ class ABSClient:
 
             for podcast in podcast_list:
                 # store ids of library items for later use
-                if podcast.id_ not in lib.item_ids:
-                    lib.item_ids.append(podcast.id_)
+                if podcast.id_ not in lib.podcasts:
+                    lib.podcasts.append(podcast.id_)
+                # all record
+                if podcast.id_ not in self.podcast_libraries.podcasts:
+                    self.podcast_libraries.podcasts.append(podcast.id_)
                 yield podcast
 
     async def get_podcast_expanded(self, id_: str) -> ABSLibraryItemExpandedPodcast:
@@ -389,8 +393,11 @@ class ABSClient:
 
             for audiobook in audiobook_list:
                 # store ids of library items for later use
-                if audiobook.id_ not in lib.item_ids:
-                    lib.item_ids.append(audiobook.id_)
+                if audiobook.id_ not in lib.audiobooks:
+                    lib.audiobooks.append(audiobook.id_)
+                # all record
+                if audiobook.id_ not in self.audiobook_libraries.audiobooks:
+                    self.audiobook_libraries.audiobooks.append(audiobook.id_)
                 yield audiobook
 
     async def get_audiobook_expanded(self, id_: str) -> ABSLibraryItemExpandedBook:
@@ -550,17 +557,23 @@ class ABSClient:
                     self.logger.error(exc)
                     continue
                 _author = CacheAuthor(id_=author.id_, name=author.name)
-                _author.books = UniqueList([x.id_ for x in response.library_items])
+                _author.audiobooks = UniqueList([x.id_ for x in response.library_items])
                 _author.series = UniqueList([x.id_ for x in response.series])
                 lib.authors[_author.id_] = _author
+
+                # keep also an "all record"
+                self.audiobook_libraries.authors[_author.id_] = _author
 
                 for series in response.series:
                     _series = CacheSeries(
                         id_=series.id_,
                         name=series.name,
-                        books=UniqueList([x.id_ for x in series.items]),
+                        audiobooks=UniqueList([x.id_ for x in series.items]),
                     )
                     lib.series[_series.id_] = _series
+
+                    # keep also an "all record"
+                    self.audiobook_libraries.series[_series.id_] = _series
 
     async def _sync_collections(self) -> None:
         """Sync collections."""
@@ -592,6 +605,9 @@ class ABSClient:
                     _collection = CacheCollection(
                         id_=collection.id_,
                         name=collection.name,
-                        books=UniqueList([x.id_ for x in collection.books]),
+                        audiobooks=UniqueList([x.id_ for x in collection.books]),
                     )
                     lib.collections[collection.id_] = _collection
+
+                    # keep also an "all record"
+                    self.audiobook_libraries.collections[collection.id_] = _collection

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -663,6 +663,20 @@ class ABSMediaProgressWithMediaPodcast(ABSMediaProgress):
     episode: ABSPodcastEpisode
 
 
+## https://api.audiobookshelf.org/#collection
+@dataclass
+class ABSCollection(BaseModel):
+    """ABSCollectionMinified.
+
+    https://api.audiobookshelf.org/#get-a-library-39-s-collections
+    """
+
+    id_: Annotated[str, Alias("id")]
+    name: str
+    description: str | None
+    books: list[ABSLibraryItemBook]
+
+
 ### Response to API Requests
 
 
@@ -732,6 +746,13 @@ class ABSLibrariesItemsMinifiedBookResponse(BaseModel):
     """
 
     results: list[ABSLibraryItemMinifiedBook]
+
+
+@dataclass
+class ABSLibrariesItemsMinifiedCollectionResponse(BaseModel):
+    """ABSLibrariesItemsResponse."""
+
+    results: list[ABSCollection]
 
 
 @dataclass

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -694,6 +694,13 @@ class ABSSessionsResponse(BaseModel):
 
 
 @dataclass
+class ABSAuthorsResponse(BaseModel):
+    """ABSAuthorsResponse."""
+
+    authors: list[ABSAuthorExpanded]
+
+
+@dataclass
 class ABSLibrariesItemsMinifiedBookResponse(BaseModel):
     """ABSLibrariesItemsResponse.
 

--- a/music_assistant/providers/audiobookshelf/abs_schema.py
+++ b/music_assistant/providers/audiobookshelf/abs_schema.py
@@ -701,6 +701,27 @@ class ABSAuthorsResponse(BaseModel):
 
 
 @dataclass
+class ABSAuthorSeries(BaseModel):
+    """ABSAuthorSeries.
+
+    When acquiring an author including series items.
+    Data are series attributes, not author.
+    """
+
+    id_: Annotated[str, Alias("id")]
+    name: str
+    items: list[ABSLibraryItemMinifiedBook]
+
+
+@dataclass
+class ABSAuthorResponse(BaseModel):
+    """If series _and_ items included."""
+
+    library_items: Annotated[list[ABSLibraryItemMinifiedBook], Alias("libraryItems")]
+    series: list[ABSAuthorSeries]
+
+
+@dataclass
 class ABSLibrariesItemsMinifiedBookResponse(BaseModel):
     """ABSLibrariesItemsResponse.
 


### PR DESCRIPTION
# Browse function
## Simple browse mode
Simple browse mode has the advantage, that a single sync call can be used, thus syncing is faster (previous implementation).
```
Audiobookshelf
    Library_Name_A (Audiobooks)
        Audiobook_1
        Audiobook_2
    Library_Name_B (Podcasts)
        Podcast_1
        Podcast_2
```
## Extended browse mode
Implements browsing by Author, Series, and Collections for Audiobook Libraries.
```
Audiobookshelf
    Library_Name_A (Audiobooks)
        Audiobooks
            Audiobook_1
            Audiobook_2
        Series
            Series_1
                Audiobook_1
                Audiobook_2
            Series_2
                Audiobook_3
                Audiobook_4
        Collections
            Collection_1
                Audiobook_1
                Audiobook_2
            Collection_2
                Audiobook_3
                Audiobook_4
        Authors
            Author_1
                Series_1
                Audiobook_1
                Audiobook_2
            Author_2
                Audiobook_3
    Library_Name_B (Podcasts)
        Podcast_1
        Podcast_2
```
The library sync here takes a little longer, as multiple API calls are required. I made it an option of the provider (up for discussion, I personally would always use extended browse, however, keeping the simple version around doesn't increase future maintenance really for me....). Browsing itself is always fast, as I only walk my data structure without any API calls.

## Caching
Simple data structure is filled with abs ids on sync, and cached using mass' cache functions. Thus browsing works also after restart without triggering a manual resync/ no API calls required.

# Documentation
If that PR were to be merged:
- not yet supported: only playlists
- If the user chooses to change browse mode of an already configured abs provider, the user should trigger a manual resync after adjusting.