### PR TITLE
fix: correctly refresh streamdetails in group/ungroup scenarios

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -980,6 +980,8 @@ class PlayerQueuesController(CoreController):
         for child_id in player.group_childs:
             if (child := self.mass.players.get(child_id)) and child.output_format:
                 output_formats.append(child.output_format.output_format_str)
+            else:
+                output_formats.append("unknown")
 
         # basic throttle: do not send state changed events if queue did not actually change
         new_state = CompareState(


### PR DESCRIPTION
This fixes a bug, where change detection wasn't working when the output format is not known. This is for example the case with any grouped child of a player provider that does not support multi device DSP.