### PR TITLE
Define track limit for get_playlist to avoid standard limit of 100 to…

### DIFF
--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -52,7 +52,7 @@ async def get_playlist(
 
     def _get_playlist():
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
-        playlist = ytm.get_playlist(playlistId=prov_playlist_id, limit=None)
+        playlist = ytm.get_playlist(playlistId=prov_playlist_id, limit=9999)
         playlist["checksum"] = get_playlist_checksum(playlist)
         # Fix missing playlist id in some edge cases
         playlist["id"] = prov_playlist_id if not playlist.get("id") else playlist["id"]


### PR DESCRIPTION
Currently when calling the get_playlist method of the YT Music API, the limit parameter is passed as "None" which causes the default limit of 100 tracks to apply. In order to load larger playlists, increasing the limit in line with other occurrences in the provider where 9999 is set as the limit.