### PR TITLE
fix: incorrect DSP in Audio Pipeline  of group leader or when disabled

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -251,6 +251,9 @@ def get_stream_dsp_details(
     if player and player.group_childs:
         # grouped playback, get DSP details for each player in the group
         for child_id in player.group_childs:
+            # skip if we already have the details (so if it's the group leader)
+            if child_id in dsp:
+                continue
             if child_player := mass.players.get(child_id):
                 dsp[child_id] = get_player_dsp_details(
                     mass, child_player, group_preventing_dsp=group_preventing_dsp

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -200,6 +200,9 @@ def get_player_dsp_details(
     ):
         dsp_state = DSPState.DISABLED_BY_UNSUPPORTED_GROUP
         dsp_config = DSPConfig(enabled=False)
+    elif dsp_state == DSPState.DISABLED:
+        # DSP is disabled by the user, remove all filters
+        dsp_config = DSPConfig(enabled=False)
 
     # remove disabled filters
     dsp_config.filters = [x for x in dsp_config.filters if x.enabled]


### PR DESCRIPTION
Previously disabled DSP configs would still show as if they were enabled.

Also, in case the leader is in the `group_childs` list, the DSP details of the leader will now no longer be overwritten.