### PR TITLE
fix: remove `is_leader` for better grouping in the Audio Pipeline

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -238,7 +238,6 @@ def get_stream_dsp_details(
     else:
         # We only add real players (so skip the PlayerGroups as they only sync containing players)
         details = get_player_dsp_details(mass, player)
-        details.is_leader = True
         dsp[player.player_id] = details
         if group_preventing_dsp:
             # The leader is responsible for sending the (combined) audio stream, so get


### PR DESCRIPTION
Previously `is_leader` was used as a stopgap before the new Audio Pipeline was implemented.
But now it just prevents grouping of players in the UI (in case one is a leader, and one is not).

Later PRs will follow to remove `is_leader` from the backend and frontend models.