### PR TITLE
Fix: Double grouped players with Universal Groups

### DIFF
--- a/music_assistant/providers/player_group/__init__.py
+++ b/music_assistant/providers/player_group/__init__.py
@@ -627,6 +627,10 @@ class PlayerGroupProvider(PlayerProvider):
             raise InvalidDataError(
                 f"Player {child_player.display_name} already has another group active"
             )
+        if len(child_player.group_childs) > 0 or child_player.synced_to:
+            raise InvalidDataError(
+                f"Player {child_player.display_name} is already part of another group"
+            )
         group_player.group_childs.append(player_id)
 
         # handle resync/resume if group player was already playing

--- a/music_assistant/providers/player_group/__init__.py
+++ b/music_assistant/providers/player_group/__init__.py
@@ -551,6 +551,7 @@ class PlayerGroupProvider(PlayerProvider):
         """
         if group_player := self.mass.players.get(player_id):
             self._update_attributes(group_player)
+            await self._ungroup_subgroups_if_found(group_player)
 
     async def create_group(
         self, group_type: str, name: str, members: list[str], dynamic: bool = False
@@ -896,6 +897,28 @@ class PlayerGroupProvider(PlayerProvider):
             can_group_with = {}
         player.can_group_with = can_group_with
         self.mass.players.update(player.player_id)
+
+    async def _ungroup_subgroups_if_found(self, player: Player) -> None:
+        """Verify that no player is part of a separate group."""
+        group_type = self.mass.config.get_raw_player_config_value(
+            player.player_id, CONF_ENTRY_GROUP_TYPE.key, CONF_ENTRY_GROUP_TYPE.default_value
+        )
+        if group_type == GROUP_TYPE_UNIVERSAL:
+            # Verify that no player is part of a separate group
+            for child_player_id in player.group_childs:
+                child_player = self.mass.players.get(child_player_id)
+                if PlayerFeature.SET_MEMBERS not in child_player.supported_features:
+                    continue
+                if child_player.group_childs:
+                    # This is a leader in another group
+                    player_provider = self.mass.players.get_player_provider(child_player_id)
+                    for sync_child_id in child_player.group_childs:
+                        if sync_child_id == child_player_id:
+                            continue
+                        await player_provider.cmd_ungroup(sync_child_id)
+                if child_player.synced_to:
+                    # This is a member of another group
+                    await self.cmd_ungroup_member(child_player.player_id, child_player.synced_to)
 
     async def _serve_ugp_stream(self, request: web.Request) -> web.Response:
         """Serve the UGP (multi-client) flow stream audio to a player."""

--- a/music_assistant/providers/player_group/__init__.py
+++ b/music_assistant/providers/player_group/__init__.py
@@ -628,11 +628,10 @@ class PlayerGroupProvider(PlayerProvider):
             raise InvalidDataError(
                 f"Player {child_player.display_name} already has another group active"
             )
-        if len(child_player.group_childs) > 0 or child_player.synced_to:
-            raise InvalidDataError(
-                f"Player {child_player.display_name} is already part of another group"
-            )
         group_player.group_childs.append(player_id)
+
+        # Ensure that all player are just in this group and not in any other group
+        await self._ungroup_subgroups_if_found(group_player)
 
         # handle resync/resume if group player was already playing
         if group_player.state == PlayerState.PLAYING and group_type == GROUP_TYPE_UNIVERSAL:

--- a/music_assistant/providers/player_group/__init__.py
+++ b/music_assistant/providers/player_group/__init__.py
@@ -903,6 +903,7 @@ class PlayerGroupProvider(PlayerProvider):
             player.player_id, CONF_ENTRY_GROUP_TYPE.key, CONF_ENTRY_GROUP_TYPE.default_value
         )
         if group_type == GROUP_TYPE_UNIVERSAL:
+            changed = False
             # Verify that no player is part of a separate group
             for child_player_id in player.group_childs:
                 child_player = self.mass.players.get(child_player_id)
@@ -915,9 +916,14 @@ class PlayerGroupProvider(PlayerProvider):
                         if sync_child_id == child_player_id:
                             continue
                         await player_provider.cmd_ungroup(sync_child_id)
+                        changed = True
                 if child_player.synced_to:
                     # This is a member of another group
                     await self.cmd_ungroup_member(child_player.player_id, child_player.synced_to)
+                    changed = True
+            if changed and player.state == PlayerState.PLAYING:
+                # Restart playback to ensure all members play the same content
+                await self.mass.player_queues.resume(player.player_id)
 
     async def _serve_ugp_stream(self, request: web.Request) -> web.Response:
         """Serve the UGP (multi-client) flow stream audio to a player."""


### PR DESCRIPTION
This PR addressed the bugs I found with https://github.com/music-assistant/server/pull/1912#issuecomment-2615244536.

Previously, it was possible to add already synchronized players to a universal group.