### PR TITLE
fix(tidal): fix track playback with lyrics error suppression

### DIFF
--- a/music_assistant/providers/tidal/helpers.py
+++ b/music_assistant/providers/tidal/helpers.py
@@ -208,7 +208,8 @@ async def get_track_lyrics(session: TidalSession, prov_track_id: str) -> TidalLy
             raise MediaNotFoundError(msg) from err
         except MetadataNotAvailable as err:
             msg = f"Lyrics not available for track {prov_track_id}"
-            raise MediaNotFoundError(msg) from err
+            LOGGER.debug(msg)
+            raise MetadataNotAvailable(msg) from err
         except TooManyRequests:
             msg = "Tidal API rate limit reached"
             raise ResourceTemporarilyUnavailable(msg)


### PR DESCRIPTION
raise original error for lyrics not existing, so that error suppression
works as expected and playback is unhindered