### PR TITLE
Adding `number` as valid volume player control entities

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -92,7 +92,7 @@ def filename_from_string(string: str) -> str:
 def try_parse_int(possible_int: Any, default: int | None = 0) -> int | None:
     """Try to parse an int."""
     try:
-        return int(possible_int)
+        return int(float(possible_int))
     except (TypeError, ValueError):
         return default
 

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -454,14 +454,15 @@ class HomeAssistantProvider(PluginProvider):
                 service_data={"volume_level": volume_level / 100},
                 target={"entity_id": entity_id},
             )
-        else:
-            # The call to `set_value` works for both `number` and `input_number` entities
-            await self.hass.call_service(
-                domain=domain,
-                service="set_value",
-                target={"entity_id": entity_id},
-                service_data={"value": volume_level},
-            )
+            return
+
+        # At this point, `set_value` will work for both `number` or `input_number`
+        await self.hass.call_service(
+            domain=domain,
+            service="set_value",
+            target={"entity_id": entity_id},
+            service_data={"value": volume_level},
+        )
 
     def _update_control_from_state_msg(self, entity_id: str, state: CompressedState) -> None:
         """Update PlayerControl from state(update) message."""


### PR DESCRIPTION
`input_number` entities are already accepted as volume player control entities. Adding `number` is natural as they behave almost identically.

[Discussion 3560](https://github.com/orgs/music-assistant/discussions/3560)