### PR TITLE
Feat: Move the output limiter option from DSP to Player Settings

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -47,6 +47,7 @@ CONF_USERNAME: Final[str] = "username"
 CONF_PASSWORD: Final[str] = "password"
 CONF_VOLUME_NORMALIZATION: Final[str] = "volume_normalization"
 CONF_VOLUME_NORMALIZATION_TARGET: Final[str] = "volume_normalization_target"
+CONF_OUTPUT_LIMITER: Final[str] = "output_limiter"
 CONF_DEPRECATED_EQ_BASS: Final[str] = "eq_bass"
 CONF_DEPRECATED_EQ_MID: Final[str] = "eq_mid"
 CONF_DEPRECATED_EQ_TREBLE: Final[str] = "eq_treble"
@@ -219,6 +220,15 @@ CONF_ENTRY_VOLUME_NORMALIZATION_TARGET = ConfigEntry(
     description="Adjust average (perceived) loudness to this target level",
     depends_on=CONF_VOLUME_NORMALIZATION,
     category="advanced",
+)
+
+CONF_ENTRY_OUTPUT_LIMITER = ConfigEntry(
+    key=CONF_OUTPUT_LIMITER,
+    type=ConfigEntryType.BOOLEAN,
+    label="Enable limiting to prevent clipping",
+    default_value=True,
+    description="Activates a limiter that prevents audio distortion by making loud peaks quieter.",
+    category="audio",
 )
 
 # These EQ Options are deprecated and will be removed in the future
@@ -560,6 +570,7 @@ BASE_PLAYER_CONFIG_ENTRIES = (
     CONF_ENTRY_PLAYER_ICON,
     CONF_ENTRY_FLOW_MODE,
     CONF_ENTRY_VOLUME_NORMALIZATION,
+    CONF_ENTRY_OUTPUT_LIMITER,
     CONF_ENTRY_AUTO_PLAY,
     CONF_ENTRY_VOLUME_NORMALIZATION_TARGET,
     CONF_ENTRY_HIDE_PLAYER,

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -38,6 +38,7 @@ from music_assistant.constants import (
     CONF_DEPRECATED_EQ_MID,
     CONF_DEPRECATED_EQ_TREBLE,
     CONF_ONBOARD_DONE,
+    CONF_OUTPUT_LIMITER,
     CONF_PLAYER_DSP,
     CONF_PLAYERS,
     CONF_PROVIDERS,
@@ -459,7 +460,20 @@ class ConfigController:
         In case the player does not have a DSP configuration, a default one is returned.
         """
         if raw_conf := self.get(f"{CONF_PLAYER_DSP}/{player_id}"):
-            return DSPConfig.from_dict(raw_conf)
+            config = DSPConfig.from_dict(raw_conf)
+            if config.enabled and not config.output_limiter:
+                # The DSP is enabled, and the user disabled the output limiter in a prior version
+                # Migrate the output limiter option to the player config
+                self.mass.config.set_raw_player_config_value(player_id, CONF_OUTPUT_LIMITER, False)
+                # The output_limiter option in the DSP config is now only used for knowing
+                # if the user disabled the limiter before. We therefore need to set it
+                # to the default value (so enabled), so this migration logic will never be called
+                # anymore for this player.
+                # TODO: remove this in a future release
+                config.output_limiter = True
+                self.set(f"{CONF_PLAYER_DSP}/{player_id}", config.to_dict())
+
+            return config
         else:
             # return default DSP config
             dsp_config = DSPConfig()

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -835,14 +835,9 @@ class ConfigController:
                     player := players.get(player_id)
                 ):
                     player["values"][CONF_OUTPUT_LIMITER] = False
-                # The output_limiter option in the DSP config is now only used for knowing
-                # if the user disabled the limiter before. We therefore need to set it
-                # to the default value (so enabled), so this migration logic will never be called
-                # anymore for this player.
-                dsp_config["output_limiter"] = True
-            else:
-                # This prevents magic disabling of the limiter when the DSP is activated again
-                dsp_config["output_limiter"] = True
+            # Delete the old option, so this migration logic will never be called
+            # anymore for this player.
+            del dsp_config["output_limiter"]
             changed = True
 
         # set 'onboard_done' flag if we have any (non default) provider configs

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -33,8 +33,8 @@ from music_assistant_models.errors import (
 from music_assistant_models.streamdetails import AudioFormat
 
 from music_assistant.constants import (
+    CONF_ENTRY_OUTPUT_LIMITER,
     CONF_OUTPUT_CHANNELS,
-    CONF_OUTPUT_LIMITER,
     CONF_VOLUME_NORMALIZATION,
     CONF_VOLUME_NORMALIZATION_RADIO,
     CONF_VOLUME_NORMALIZATION_TARGET,
@@ -994,7 +994,11 @@ def is_output_limiter_enabled(mass: MusicAssistant, player: Player) -> bool:
     elif player.synced_to:
         # Not in sync group, but synced, get from the leader
         deciding_player_id = player.synced_to
-    return mass.config.get_raw_player_config_value(deciding_player_id, CONF_OUTPUT_LIMITER, True)
+    return mass.config.get_raw_player_config_value(
+        deciding_player_id,
+        CONF_ENTRY_OUTPUT_LIMITER.key,
+        CONF_ENTRY_OUTPUT_LIMITER.default_value,
+    )
 
 
 def get_player_filter_params(


### PR DESCRIPTION
This PR moves the "output limiter" option from the DSP Settings to the regular Player Settings.

This has 3 advantages:
- Better discoverability.
- Decoupling from the DSP, since this option is more related with Volume Normalization.
- More control in grouped playback scenarios.

Migration is done automatically.

# Grouped Playback

The previous in the DSP integrated approach, the limiter could not be deactivated when synced with other players.
Now, the settings behaves the similarly to the Volume Normalization options:
- In permanent sync groups, the groups setting has priority.
- In regular sync groups, the leader has priority.