### PR TITLE
Fix: Missing `MULTI_DEVICE_DSP` in player groups

### DIFF
--- a/music_assistant/providers/player_group/__init__.py
+++ b/music_assistant/providers/player_group/__init__.py
@@ -790,7 +790,12 @@ class PlayerGroupProvider(PlayerProvider):
             model_name = "Sync Group"
             manufacturer = self.mass.get_provider(group_type).name
             can_group_with = {player_provider.instance_id}
-            for feature in (PlayerFeature.PAUSE, PlayerFeature.VOLUME_MUTE, PlayerFeature.ENQUEUE):
+            for feature in (
+                PlayerFeature.PAUSE,
+                PlayerFeature.VOLUME_MUTE,
+                PlayerFeature.ENQUEUE,
+                PlayerFeature.MULTI_DEVICE_DSP,
+            ):
                 if all(feature in x.supported_features for x in player_provider.players):
                     player_features.add(feature)
         else:


### PR DESCRIPTION
Previously permanent syncgroups (other than universal groups) did not support `MULTI_DEVICE_DSP`, even if the underlying player provider did support DSP for individual players in the group.