### PR TITLE
Fix Subsonic: Use transcode metadata when present

### DIFF
--- a/music_assistant/providers/opensubsonic/manifest.json
+++ b/music_assistant/providers/opensubsonic/manifest.json
@@ -7,7 +7,7 @@
     "@khers"
   ],
   "requirements": [
-    "py-opensonic==5.2.1"
+    "py-opensonic==5.3.0"
   ],
   "documentation": "https://music-assistant.io/music-providers/subsonic/",
   "multi_instance": true

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -746,15 +746,21 @@ class OpenSonicProvider(MusicProvider):
                 msg = f"Item {item_id} not found"
                 raise MediaNotFoundError(msg) from e
 
+            if item.transcoded_content_type:
+                mime_type = item.transcoded_content_type
+            else:
+                mime_type = item.content_type
+
             self.logger.debug(
                 "Fetching stream details for id %s '%s' with format '%s'",
                 item.id,
                 item.title,
-                item.content_type,
+                mime_type,
             )
 
         elif media_type == MediaType.PODCAST_EPISODE:
             item = await self._get_podcast_episode(item_id)
+            mime_type = item.content_type
 
             self.logger.debug(
                 "Fetching stream details for podcast episode '%s' with format '%s'",
@@ -765,7 +771,6 @@ class OpenSonicProvider(MusicProvider):
             msg = f"Unsupported media type encountered '{media_type}'"
             raise UnsupportedFeaturedException(msg)
 
-        mime_type = item.content_type
         # For mp4 or m4a files, better to let ffmpeg detect the codec in use so mark them unknown
         if mime_type.endswith("mp4"):
             self.logger.warning(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -33,7 +33,7 @@ pillow==11.1.0
 pkce==1.0.3
 plexapi==4.16.1
 podcastparser==0.6.10
-py-opensonic==5.2.1
+py-opensonic==5.3.0
 pyblu==2.0.0
 PyChromecast==14.0.5
 pycryptodome==3.21.0


### PR DESCRIPTION
When transcoding, a server should fill out the transcode_content_type field when metadata for a track is requested. If this field is present we need to use it instead of the on disk format.

Fixes: https://github.com/music-assistant/support/issues/3586