### PR TITLE
Fix: Subsonic: Catch DataNotFoundError for artwork

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -384,8 +384,12 @@ class OpenSonicProvider(MusicProvider):
         """Return the image."""
 
         def _get_cover_art() -> bytes | Any:
-            with self._conn.getCoverArt(path) as art:
-                return art.content
+            try:
+                with self._conn.getCoverArt(path) as art:
+                    return art.content
+            except DataNotFoundError:
+                self.logger.warning("Unable to locate a cover image for %s", path)
+                return None
 
         return await asyncio.to_thread(_get_cover_art)
 


### PR DESCRIPTION
This exception simply means that there is no artwork to return (and probably shouldn't be an exception, but there we are). We will catch the exception and return None.

Fixes: https://github.com/music-assistant/support/issues/3610