### PR TITLE
Ignore playlists which are stored with album tracks

### DIFF
--- a/music_assistant/providers/filesystem_local/constants.py
+++ b/music_assistant/providers/filesystem_local/constants.py
@@ -53,6 +53,18 @@ CONF_ENTRY_CONTENT_TYPE_READ_ONLY = ConfigEntry.from_dict(
     }
 )
 
+CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS = ConfigEntry(
+    key="ignore_album_playlists",
+    type=ConfigEntryType.BOOLEAN,
+    label="Ignore playlists with album tracks within album folders",
+    description="A digital album often comes with a playlist file (.m3u) "
+    "that contains the tracks of the album. Adding all these playlists to the library, "
+    "is not very practical so it's better to just ignore them.\n\n"
+    "If this option is enabled, any playlists will be ignored which are more than "
+    "1 level deep in the folder structure. E.g. /music/artistname/albumname/playlist.m3u",
+    default_value=True,
+    required=False,
+)
 
 TRACK_EXTENSIONS = {
     "aac",

--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -17,6 +17,7 @@ from music_assistant.providers.filesystem_local import LocalFileSystemProvider, 
 from music_assistant.providers.filesystem_local.constants import (
     CONF_ENTRY_CONTENT_TYPE,
     CONF_ENTRY_CONTENT_TYPE_READ_ONLY,
+    CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     CONF_ENTRY_MISSING_ALBUM_ARTIST,
 )
 
@@ -121,6 +122,7 @@ async def get_config_entries(
             "want to pass to the mount command if needed for your particular setup.",
         ),
         CONF_ENTRY_MISSING_ALBUM_ARTIST,
+        CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS,
     )
 
     if instance_id is None or values is None:


### PR DESCRIPTION
Add setting to ignore playlist files which are in a nested level (e.g. next to the album tracks). This prevents that 1000s of (unpractical) albumtracks playlists end up in the library. The setting is enabled by default.

It still imports playlists that are in the music folder root or in a single sublevel (e.g. playlists).

Fixes https://github.com/music-assistant/support/issues/3206