### PR TITLE
Various bugfixes for the LastFM provider

### DIFF
--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -45,6 +45,7 @@ class LastFMScrobbleProvider(PluginProvider):
     _network: pylast._Network = None
     _currently_playing: str | None = None
     _on_unload: list[Callable[[], None]] = []
+    _last_scrobbled: str | None = None
 
     def _get_network_config(self) -> dict[str, ConfigValueType]:
         return {
@@ -85,7 +86,16 @@ class LastFMScrobbleProvider(PluginProvider):
             self.logger.error("no network available during _on_mass_media_item_played")
             return
 
-        report = event.data
+        report: MediaItemPlaybackProgressReport = event.data
+
+        # poor mans attempt to detect a song on loop
+        if not report.fully_played and report.uri == self._last_scrobbled:
+            self.logger.debug(
+                "reset _last_scrobbled and _currently_playing because the song was restarted"
+            )
+            self._last_scrobbled = None
+            # reset currently playing to avoid it expiring when looping single songs
+            self._currently_playing = None
 
         def update_now_playing() -> None:
             try:
@@ -113,6 +123,7 @@ class LastFMScrobbleProvider(PluginProvider):
                     duration=report.duration,
                     mbid=report.mbid,
                 )
+                self._last_scrobbled = report.uri
             except Exception as err:
                 self.logger.exception(err)
 
@@ -123,12 +134,12 @@ class LastFMScrobbleProvider(PluginProvider):
         if self.should_scrobble(report):
             await asyncio.to_thread(scrobble)
 
-        if report.fully_played:
-            # reset currently playing to avoid it expiring when looping songs
-            self._currently_playing = None
-
     def should_scrobble(self, report: MediaItemPlaybackProgressReport) -> bool:
         """Determine if a track should be scrobbled, to be extended later."""
+        if self._last_scrobbled == report.uri:
+            self.logger.debug("skipped scrobbling due to duplicate event")
+            return False
+
         # ideally we want more precise control
         # but because the event is triggered every 30s
         # and we don't have full queue details to determine

--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -32,8 +32,9 @@ async def setup(
     """Initialize provider(instance) with given configuration."""
     provider = LastFMScrobbleProvider(mass, manifest, config)
     pylast.logger.setLevel(provider.logger.level)
-    if provider.logger.level == logging.DEBUG:
-        # httpcore is quite spammy without providing useful information 99% of the time
+
+    # httpcore is very spammy on debug without providing useful information 99% of the time
+    if logging.getLogger("httpcore").level <= logging.DEBUG:
         logging.getLogger("httpcore").setLevel(logging.INFO)
 
     return provider

--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -34,8 +34,10 @@ async def setup(
     pylast.logger.setLevel(provider.logger.level)
 
     # httpcore is very spammy on debug without providing useful information 99% of the time
-    if logging.getLogger("httpcore").level <= logging.DEBUG:
+    if provider.logger.level == logging.DEBUG:
         logging.getLogger("httpcore").setLevel(logging.INFO)
+    else:
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
 
     return provider
 


### PR DESCRIPTION
Tracks were scrobbled multiple times in certain cases, related to how `fully_played` is determined.

For example:
A song is 03:05 long, an event is triggered at 03:00, with `fully_played: True` because 03:00 is more than 90% of the duration. Then when the track is done and switches to the next in queue, another event is fired.

Published as draft, as the same fix need to be applied to Listenbrainz, but I'd like some feedback first.

The logging changes are a bit random based on a mention in Discord about DEBUG logs happening. These logs didn't happen in Beta9, so I suspect the cause might be somewhere else.