### PR TITLE
Refactor common code from listenbrainz and lastfm scrobblers

### DIFF
--- a/music_assistant/helpers/__init__.py
+++ b/music_assistant/helpers/__init__.py
@@ -1,1 +1,1 @@
-"""Various server-seecific utils/helpers."""
+"""Various server-specific utils/helpers."""

--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -1,0 +1,86 @@
+"""Helper class to aid scrobblers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from music_assistant_models.event import MassEvent
+    from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
+
+
+class ScrobblerHelper:
+    """Base class to aid scrobbling tracks."""
+
+    logger: logging.Logger
+    currently_playing: str | None = None
+    last_scrobbled: str | None = None
+
+    def __init__(self, logger: logging.Logger) -> None:
+        """Initialize."""
+        self.logger = logger
+
+    def _is_configured(self) -> bool:
+        """Override if subclass needs specific configuration."""
+        return True
+
+    def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Send a Now Playing update to the scrobbling service."""
+
+    def _scrobble(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Scrobble."""
+
+    async def _on_mass_media_item_played(self, event: MassEvent) -> None:
+        """Media item has finished playing, we'll scrobble the track."""
+        if not self._is_configured():
+            return
+
+        report: MediaItemPlaybackProgressReport = event.data
+
+        # poor mans attempt to detect a song on loop
+        if not report.fully_played and report.uri == self.last_scrobbled:
+            self.logger.debug(
+                "reset _last_scrobbled and _currently_playing because the song was restarted"
+            )
+            self.last_scrobbled = None
+            # reset currently playing to avoid it expiring when looping single songs
+            self.currently_playing = None
+
+        def update_now_playing() -> None:
+            try:
+                self._update_now_playing(report)
+                self.logger.debug(f"track {report.uri} marked as 'now playing'")
+                self.currently_playing = report.uri
+            except Exception as err:
+                self.logger.exception(err)
+
+        def scrobble() -> None:
+            try:
+                self._scrobble(report)
+                self.last_scrobbled = report.uri
+            except Exception as err:
+                self.logger.exception(err)
+
+        # update now playing if needed
+        if report.is_playing and (
+            self.currently_playing is None or self.currently_playing != report.uri
+        ):
+            await asyncio.to_thread(update_now_playing)
+
+        if self.should_scrobble(report):
+            await asyncio.to_thread(scrobble)
+
+    def should_scrobble(self, report: MediaItemPlaybackProgressReport) -> bool:
+        """Determine if a track should be scrobbled, to be extended later."""
+        if self.last_scrobbled == report.uri:
+            self.logger.debug("skipped scrobbling due to duplicate event")
+            return False
+
+        # ideally we want more precise control
+        # but because the event is triggered every 30s
+        # and we don't have full queue details to determine
+        # the exact context in which the event was fired
+        # we can only rely on fully_played for now
+        return bool(report.fully_played)

--- a/tests/core/test_scrobbler.py
+++ b/tests/core/test_scrobbler.py
@@ -5,9 +5,28 @@ import logging
 from music_assistant_models.enums import EventType, MediaType
 from music_assistant_models.event import MassEvent
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
-from pylast import _Network
 
-from music_assistant.providers.lastfm_scrobble import LastFMEventHandler
+from music_assistant.helpers.scrobbler import ScrobblerHelper
+
+
+class DummyHandler(ScrobblerHelper):
+    """Spy version of a ScrobblerHelper to allow easy testing."""
+
+    _tracked = 0
+    _now_playing = 0
+
+    def __init__(self, logger: logging.Logger) -> None:
+        """Initialize."""
+        super().__init__(logger)
+
+    def _is_configured(self) -> bool:
+        return True
+
+    def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:
+        self._now_playing += 1
+
+    def _scrobble(self, report: MediaItemPlaybackProgressReport) -> None:
+        self._tracked += 1
 
 
 async def test_it_does_not_scrobble_the_same_track_twice() -> None:
@@ -15,27 +34,27 @@ async def test_it_does_not_scrobble_the_same_track_twice() -> None:
 
     Here we test that songs only get scrobbled once during each play.
     """
-    handler = LastFMEventHandler(DummyNetwork(), logging.getLogger())
+    handler = DummyHandler(logging.getLogger())
 
     # not fully played yet
     await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=30))
-    assert handler.network._tracked == 0
+    assert handler._tracked == 0
 
     # fully played near the end
     await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=176))
-    assert handler.network._tracked == 1
+    assert handler._tracked == 1
 
     # fully played on track change should not scrobble again
     await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=180))
-    assert handler.network._tracked == 1
+    assert handler._tracked == 1
 
     # single song is on repeat and started playing again
     await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=30))
-    assert handler.network._tracked == 1
+    assert handler._tracked == 1
 
     # fully played for the second time
     await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=179))
-    assert handler.network._tracked == 2
+    assert handler._tracked == 2
 
 
 async def test_it_resets_now_playing_when_songs_are_on_loop() -> None:
@@ -43,29 +62,29 @@ async def test_it_resets_now_playing_when_songs_are_on_loop() -> None:
 
     This ends automatically, so if a single song is on repeat, we need to send the request again
     """
-    handler = LastFMEventHandler(DummyNetwork(), logging.getLogger())
+    handler = DummyHandler(logging.getLogger())
 
     # started playing, should update now_playing
     await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=30))
-    assert handler.network._now_playing == 1
+    assert handler._now_playing == 1
 
     # fully played on track change should not update again
     await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=180))
-    assert handler.network._now_playing == 1
+    assert handler._now_playing == 1
 
     # restarted same song, should scrobble again
     await handler._on_mass_media_item_played(create_report(duration=180, seconds_played=30))
-    assert handler.network._now_playing == 2
+    assert handler._now_playing == 2
 
 
 async def test_it_does_not_update_now_playing_on_pause() -> None:
     """Don't update now_playing when pausing the player early in the song."""
-    handler = LastFMEventHandler(DummyNetwork(), logging.getLogger())
+    handler = DummyHandler(logging.getLogger())
 
     await handler._on_mass_media_item_played(
         create_report(duration=180, seconds_played=20, is_playing=False)
     )
-    assert handler.network._now_playing == 0
+    assert handler._now_playing == 0
 
 
 def create_report(
@@ -92,56 +111,3 @@ def create_report(
 def wrap_event(data: MediaItemPlaybackProgressReport) -> MassEvent:
     """Create a MEDIA_ITEM_PLAYED event."""
     return MassEvent(EventType.MEDIA_ITEM_PLAYED, data.uri, data)
-
-
-class DummyNetwork(_Network):  # type: ignore[misc]
-    """Spy version of a pylast._Network to allow easy testing."""
-
-    _tracked = 0
-    _now_playing = 0
-
-    def __init__(self) -> None:
-        """Initialize."""
-        super().__init__(
-            name="Dummy",
-            homepage="",
-            ws_server="",
-            api_key="",
-            api_secret="",
-            session_key="",
-            username="",
-            password_hash="",
-            token="",
-            domain_names={},
-            urls={},
-        )
-
-    def update_now_playing(
-        self,
-        artist: str,
-        title: str,
-        album: str | None = None,
-        album_artist: str | None = None,
-        duration: str | None = None,
-        track_number: str | None = None,
-        mbid: str | None = None,
-        context: str | None = None,
-    ) -> None:
-        """Track call count."""
-        self._now_playing += 1
-
-    def scrobble(
-        self,
-        artist: str,
-        title: str,
-        timestamp: int,
-        album: str | None = None,
-        album_artist: str | None = None,
-        track_number: int | None = None,
-        duration: int | None = None,
-        stream_id: str | None = None,
-        context: str | None = None,
-        mbid: str | None = None,
-    ) -> None:
-        """Track call count."""
-        self._tracked += 1


### PR DESCRIPTION
Pull the common code from `LastFMEventHandler` into a common base class and use it for `ListenBrainzEventHandler` too.

This puts all the logic for deciding when to scrobble into a single place.

---

I wasn't really sure where the common code (or the tests which I moved over) belonged, happy to move them around to according to maintainer preferences though.

@wjzijderveld FYI