### PR TITLE
feat: Built-in Web Player Part 2

### DIFF
--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -288,6 +288,8 @@ class BuiltinPlayerProvider(PlayerProvider):
             supported_features=player_features,
             needs_poll=True,
             poll_interval=POLL_INTERVAL,
+            hidden_by_default=True,
+            expose_to_ha_by_default=False,
         )
 
         await self.mass.players.register_or_update(player)

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -214,6 +214,8 @@ class BuiltinPlayerProvider(PlayerProvider):
                 else BuiltinPlayerEventType.POWER_OFF
             ),
         )
+        if (not powered) and (player := self.mass.players.get(player_id)):
+            player.powered = False
 
     async def poll_player(self, player_id: str) -> None:
         """Poll player for state updates.
@@ -233,7 +235,11 @@ class BuiltinPlayerProvider(PlayerProvider):
 
     async def remove_player(self, player_id: str) -> None:
         """Remove a player."""
-        await self.cmd_power(player_id, False)
+        self.mass.signal_event(
+            EventType.BUILTIN_PLAYER,
+            player_id,
+            BuiltinPlayerEvent(type=BuiltinPlayerEventType.TIMEOUT),
+        )
         await self.unregister_player(player_id)
 
     async def register_player(self, player_name: str, player_id: str | None) -> Player:
@@ -310,6 +316,11 @@ class BuiltinPlayerProvider(PlayerProvider):
         if not (instance := self.instances[player_id]):
             raise RuntimeError("No instance found")
         instance.last_update = time()
+
+        if not player.powered and state.powered:
+            # The player was powered off, so this state message is already out of date
+            # Skip, it.
+            return
 
         player.elapsed_time_last_updated = time()
         player.elapsed_time = float(state.position)

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
 
 # If the player does not send an update within this time, it will be considered offline
 DURATION_UNTIL_TIMEOUT = 70
+POLL_INTERVAL = 10
 
 
 async def setup(
@@ -261,7 +262,7 @@ class BuiltinPlayerProvider(PlayerProvider):
             device_info=DeviceInfo(),
             supported_features=player_features,
             needs_poll=True,
-            poll_interval=10,
+            poll_interval=POLL_INTERVAL,
         )
 
         await self.mass.players.register_or_update(player)

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, cast
 import shortuuid
 from aiohttp import web
 from music_assistant_models.builtin_player import BuiltinPlayerEvent, BuiltinPlayerState
-from music_assistant_models.constants import PLAYER_CONTROL_NONE
+from music_assistant_models.constants import PLAYER_CONTROL_NATIVE
 from music_assistant_models.enums import (
     BuiltinPlayerEventType,
     ContentType,
@@ -199,6 +199,22 @@ class BuiltinPlayerProvider(PlayerProvider):
             BuiltinPlayerEvent(type=BuiltinPlayerEventType.PLAY_MEDIA, media_url=url),
         )
 
+    async def cmd_power(self, player_id: str, powered: bool) -> None:
+        """Send POWER command to given player.
+
+        - player_id: player_id of the player to handle the command.
+        - powered: bool if player should be powered on or off.
+        """
+        self.mass.signal_event(
+            EventType.BUILTIN_PLAYER,
+            player_id,
+            BuiltinPlayerEvent(
+                type=BuiltinPlayerEventType.POWER_ON
+                if powered
+                else BuiltinPlayerEventType.POWER_OFF
+            ),
+        )
+
     async def poll_player(self, player_id: str) -> None:
         """Poll player for state updates.
 
@@ -217,6 +233,7 @@ class BuiltinPlayerProvider(PlayerProvider):
 
     async def remove_player(self, player_id: str) -> None:
         """Remove a player."""
+        await self.cmd_power(player_id, False)
         await self.unregister_player(player_id)
 
     async def register_player(self, player_name: str, player_id: str | None) -> Player:
@@ -241,6 +258,7 @@ class BuiltinPlayerProvider(PlayerProvider):
             PlayerFeature.VOLUME_SET,
             PlayerFeature.VOLUME_MUTE,
             PlayerFeature.PAUSE,
+            PlayerFeature.POWER,
         }
 
         self.instances[player_id] = PlayerInstance(
@@ -258,7 +276,8 @@ class BuiltinPlayerProvider(PlayerProvider):
             type=PlayerType.PLAYER,
             name=player_name,
             available=True,
-            power_control=PLAYER_CONTROL_NONE,
+            power_control=PLAYER_CONTROL_NATIVE,
+            powered=False,
             device_info=DeviceInfo(),
             supported_features=player_features,
             needs_poll=True,
@@ -278,6 +297,7 @@ class BuiltinPlayerProvider(PlayerProvider):
         if player := self.mass.players.get(player_id):
             player.available = False
             player.state = PlayerState.IDLE
+            player.powered = False
 
     async def update_player_state(self, player_id: str, state: BuiltinPlayerState) -> None:
         """Update current state of a player.
@@ -295,11 +315,17 @@ class BuiltinPlayerProvider(PlayerProvider):
         player.elapsed_time = float(state.position)
         player.volume_muted = state.muted
         player.volume_level = state.volume
-        if state.playing:
+        if not state.powered:
+            player.powered = False
+            player.state = PlayerState.IDLE
+        elif state.playing:
+            player.powered = True
             player.state = PlayerState.PLAYING
         elif state.paused:
+            player.powered = True
             player.state = PlayerState.PAUSED
         else:
+            player.powered = True
             player.state = PlayerState.IDLE
 
         self.mass.players.update(player_id)


### PR DESCRIPTION
Depends on https://github.com/music-assistant/models/pull/61
Companion PR https://github.com/music-assistant/frontend/pull/918

Expanding on https://github.com/music-assistant/server/pull/2009 this PR better integrates the Web Player into Music Assistant.

# Main changes

- Power controls are now handled just like any other player in Music Assistant. So just pressing play should (hopefully) work now!
- The web player now is registered by default, so the experience is now more seamless.
- The player associated with the currently open browser now gets a screen icon
- Only one tab will be selected for doing the actual playback at a time. If that is closed, a different tab will be selected for playback.
- Players are now hidden from other users by default
- Players will soon also be hidden in Home Assistant by default
- The player is now named "This Device"

# Known Issues

There are still a few issues left. Some of those are:
- Since the player now is registered by default, it will now create (even more) "Experimental Web Players" in the Player Settings in Music Assistant
- There is no way to disable the Web Player for users that don't want to use that
- Don't yet know if the "only one tab plays music" logic is that reliable yet. But it seams to work for me now.

Solutions for all of those and more will come in future PRs.