### PR TITLE
Make airplay provider robust to empty dacp request

### DIFF
--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -553,7 +553,7 @@ class AirplayProvider(PlayerProvider):
                 # Maybe as a ack message? we have nothing to do here with empty request
                 # so we return early.
                 return
-                
+
             request = raw_request.decode("UTF-8")
             if "\r\n\r\n" in request:
                 headers_raw, body = request.split("\r\n\r\n", 1)

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -548,7 +548,6 @@ class AirplayProvider(PlayerProvider):
                 raw_request += recv
                 if len(recv) < 1024:
                     break
-            
             if not raw_request:
                 # Some device (Phorus PS10) seems to send empty request
                 # Maybe as a ack message? we have nothing to do here with empty request

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -548,7 +548,13 @@ class AirplayProvider(PlayerProvider):
                 raw_request += recv
                 if len(recv) < 1024:
                     break
-
+            
+            if not raw_request:
+                # Some device (Phorus PS10) seems to send empty request
+                # Maybe as a ack message? we have nothing to do here with empty request
+                # so we return early.
+                return
+                
             request = raw_request.decode("UTF-8")
             if "\r\n\r\n" in request:
                 headers_raw, body = request.split("\r\n\r\n", 1)


### PR DESCRIPTION
Some device (Phorus PS10) seems to send empty request
Maybe as a ack message?
Since there is nothing to do in that function with empty request we return early instead of failing later on the header parsing.