### PR TITLE
Refactor Audible Provider with Initial Podcast Support

### DIFF
--- a/music_assistant/providers/audible/__init__.py
+++ b/music_assistant/providers/audible/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import os
 from collections.abc import AsyncGenerator
-from logging import getLevelName
 from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
@@ -20,17 +19,20 @@ from music_assistant_models.enums import ConfigEntryType, EventType, MediaType, 
 from music_assistant_models.errors import LoginFailed, MediaNotFoundError
 
 from music_assistant.models.music_provider import MusicProvider
-from music_assistant.providers.audible.audible_helper import (
-    AudibleHelper,
+from music_assistant.providers.audible.api import (
+    _AUTH_CACHE,
+    AudibleAPI,
     audible_custom_login,
     audible_get_auth_info,
     cached_authenticator_from_file,
     check_file_exists,
     remove_file,
 )
+from music_assistant.providers.audible.audiobook import AudiobookHelper
+from music_assistant.providers.audible.podcast import PodcastHelper
 
 if TYPE_CHECKING:
-    from music_assistant_models.media_items import Audiobook, MediaItemType
+    from music_assistant_models.media_items import Audiobook, MediaItemType, Podcast, PodcastEpisode
     from music_assistant_models.provider import ProviderManifest
     from music_assistant_models.streamdetails import StreamDetails
 
@@ -38,7 +40,6 @@ if TYPE_CHECKING:
     from music_assistant.models import ProviderInstanceType
 
 
-# Constants for config actions
 CONF_ACTION_AUTH = "authenticate"
 CONF_ACTION_VERIFY = "verify_link"
 CONF_ACTION_CLEAR_AUTH = "clear_auth"
@@ -48,6 +49,34 @@ CONF_CODE_VERIFIER = "code_verifier"
 CONF_SERIAL = "serial"
 CONF_LOGIN_URL = "login_url"
 CONF_LOCALE = "locale"
+
+MARKETPLACE_OPTIONS = [
+    ConfigValueOption("US and all other countries not listed", "us"),
+    ConfigValueOption("Canada", "ca"),
+    ConfigValueOption("UK and Ireland", "uk"),
+    ConfigValueOption("Australia and New Zealand", "au"),
+    ConfigValueOption("France, Belgium, Switzerland", "fr"),
+    ConfigValueOption("Germany, Austria, Switzerland", "de"),
+    ConfigValueOption("Japan", "jp"),
+    ConfigValueOption("Italy", "it"),
+    ConfigValueOption("India", "in"),
+    ConfigValueOption("Spain", "es"),
+    ConfigValueOption("Brazil", "br"),
+]
+
+AUTH_REQUIRED_MESSAGE = (
+    "You need to authenticate with Audible. Click the authenticate button below"
+    "to start the authentication process which will open in a new (popup) window,"
+    "so make sure to disable any popup blockers.\n\n"
+    "NOTE: \n"
+    "After successful login you will get a 'page not found' message - this is expected."
+    "Copy the address to the textbox below and press verify."
+    "This will register this provider as a virtual device with Audible."
+)
+
+AUTH_SUCCESS_MESSAGE = (
+    "Successfully authenticated with Audible.\nNote: Changing marketplace needs new authorization"
+)
 
 
 async def setup(
@@ -66,66 +95,118 @@ async def get_config_entries(
     """
     Return Config entries to setup this provider.
 
-    instance_id: id of an existing provider instance (None if new instance setup).
-    action: [optional] action key called from config entries UI.
-    values: the (intermediate) raw values for config entries sent with the action.
+    Args:
+        mass: The MusicAssistant instance
+        instance_id: id of an existing provider instance (None if new instance setup)
+        action: [optional] action key called from config entries UI
+        values: the (intermediate) raw values for config entries sent with the action
+
+    Returns:
+        Tuple of ConfigEntry objects for the provider setup
     """
     if values is None:
         values = {}
 
-    locale = cast(str, values.get("locale", "") or "us")
+    locale = cast(str, values.get(CONF_LOCALE, "") or "us")
     auth_file = cast(str, values.get(CONF_AUTH_FILE))
-
-    auth_required = True
-    if auth_file and await check_file_exists(auth_file):
-        try:
-            auth = await cached_authenticator_from_file(auth_file)
-            auth_required = False
-        except Exception:
-            auth_required = True
-    label_text = ""
-    if auth_required:
-        label_text = (
-            "You need to authenticate with Audible. Click the authenticate button below"
-            "to start the authentication process which will open in a new (popup) window,"
-            "so make sure to disable any popup blockers.\n\n"
-            "NOTE: \n"
-            "After successful login you will get a 'page not found' message - this is expected."
-            "Copy the address to the textbox below and press verify."
-            "This will register this provider as a virtual device with Audible."
-        )
-    else:
-        label_text = (
-            "Successfully authenticated with Audible."
-            "\nNote: Changing marketplace needs new authorization"
-        )
-
+    auth_required = await _check_auth_required(auth_file)
+    label_text = AUTH_REQUIRED_MESSAGE if auth_required else AUTH_SUCCESS_MESSAGE
     if action == CONF_ACTION_AUTH:
-        if auth_file and await check_file_exists(auth_file):
-            await remove_file(auth_file)
-            values[CONF_AUTH_FILE] = None
-            auth_file = ""
-
-        code_verifier, login_url, serial = await audible_get_auth_info(locale)
-        values[CONF_CODE_VERIFIER] = code_verifier
-        values[CONF_SERIAL] = serial
-        values[CONF_LOGIN_URL] = login_url
-        session_id = str(values["session_id"])
-        mass.signal_event(EventType.AUTH_SESSION, session_id, login_url)
-        await asyncio.sleep(15)
+        await _handle_auth_action(mass, values, auth_file, locale)
 
     if action == CONF_ACTION_VERIFY:
-        code_verifier = str(values.get(CONF_CODE_VERIFIER))
-        serial = str(values.get(CONF_SERIAL))
-        post_login_url = str(values.get(CONF_POST_LOGIN_URL))
-        storage_path = mass.storage_path
-
-        auth = await audible_custom_login(code_verifier, post_login_url, serial, locale)
-        auth_file_path = os.path.join(storage_path, f"audible_auth_{uuid4().hex}.json")
-        await asyncio.to_thread(auth.to_file, auth_file_path)
-        values[CONF_AUTH_FILE] = auth_file_path
+        await _handle_verify_action(mass, values, locale)
         auth_required = False
 
+    return _create_config_entries(label_text, locale, auth_required, values)
+
+
+async def _check_auth_required(auth_file: str | None) -> bool:
+    """Check if authentication is required.
+
+    Args:
+        auth_file: Path to the authentication file
+
+    Returns:
+        True if authentication is required, False otherwise
+    """
+    if not auth_file or not await check_file_exists(auth_file):
+        return True
+
+    try:
+        await cached_authenticator_from_file(auth_file)
+        return False
+    except Exception:
+        return True
+
+
+async def _handle_auth_action(
+    mass: MusicAssistant, values: dict[str, ConfigValueType], auth_file: str | None, locale: str
+) -> None:
+    """Handle the authentication action.
+
+    Args:
+        mass: The MusicAssistant instance
+        values: The config values dictionary
+        auth_file: Path to the authentication file
+        locale: The locale string
+    """
+    if auth_file and await check_file_exists(auth_file):
+        await remove_file(auth_file)
+        values[CONF_AUTH_FILE] = None
+
+    code_verifier, login_url, serial = await audible_get_auth_info(locale)
+
+    values[CONF_CODE_VERIFIER] = code_verifier
+    values[CONF_SERIAL] = serial
+    values[CONF_LOGIN_URL] = login_url
+
+    session_id = str(values["session_id"])
+    mass.signal_event(EventType.AUTH_SESSION, session_id, login_url)
+
+    await asyncio.sleep(15)
+
+
+async def _handle_verify_action(
+    mass: MusicAssistant, values: dict[str, ConfigValueType], locale: str
+) -> None:
+    """Handle the verification action.
+
+    Args:
+        mass: The MusicAssistant instance
+        values: The config values dictionary
+        locale: The locale string
+    """
+    code_verifier = str(values.get(CONF_CODE_VERIFIER))
+    serial = str(values.get(CONF_SERIAL))
+    post_login_url = str(values.get(CONF_POST_LOGIN_URL))
+
+    auth = await audible_custom_login(code_verifier, post_login_url, serial, locale)
+
+    storage_path = mass.storage_path
+    auth_file_path = os.path.join(storage_path, f"audible_auth_{uuid4().hex}.json")
+    await asyncio.to_thread(auth.to_file, auth_file_path)
+
+    values[CONF_AUTH_FILE] = auth_file_path
+
+
+def _create_config_entries(
+    label_text: str,
+    locale: str,
+    auth_required: bool,
+    values: dict[str, ConfigValueType],
+) -> tuple[ConfigEntry, ...]:
+    """Create config entries for the provider setup.
+
+    Args:
+        label_text: The label text to display
+        locale: The locale string
+        auth_required: Whether authentication is required
+        values: The config values dictionary
+
+    Returns:
+        Tuple of ConfigEntry objects
+    """
     return (
         ConfigEntry(
             key="label_text",
@@ -139,19 +220,7 @@ async def get_config_entries(
             hidden=not auth_required,
             required=True,
             value=locale,
-            options=[
-                ConfigValueOption("US and all other countries not listed", "us"),
-                ConfigValueOption("Canada", "ca"),
-                ConfigValueOption("UK and Ireland", "uk"),
-                ConfigValueOption("Australia and New Zealand", "au"),
-                ConfigValueOption("France, Belgium, Switzerland", "fr"),
-                ConfigValueOption("Germany, Austria, Switzerland", "de"),
-                ConfigValueOption("Japan", "jp"),
-                ConfigValueOption("Italy", "it"),
-                ConfigValueOption("India", "in"),
-                ConfigValueOption("Spain", "es"),
-                ConfigValueOption("Brazil", "br"),
-            ],
+            options=MARKETPLACE_OPTIONS,
             default_value="us",
         ),
         ConfigEntry(
@@ -222,25 +291,32 @@ class Audibleprovider(MusicProvider):
         super().__init__(mass, manifest, config)
         self.locale = cast(str, self.config.get_value(CONF_LOCALE) or "us")
         self.auth_file = cast(str, self.config.get_value(CONF_AUTH_FILE))
-        self._client: audible.AsyncClient | None = None
-        audible.log_helper.set_level(getLevelName(self.logger.level))
+        self._client: audible.AsyncClient
+        self.api: AudibleAPI
+        self.audiobook_helper: AudiobookHelper
+        self.podcast_helper: PodcastHelper
+
+        audible.log_helper.set_level("INFO")
 
     async def handle_async_init(self) -> None:
         """Handle asynchronous initialization of the provider."""
         await self._login()
 
-    # Cache for authenticators to avoid repeated file I/O
-    _AUTH_CACHE: dict[str, audible.Authenticator] = {}
-
     async def _login(self) -> None:
-        """Authenticate with Audible using the saved authentication file."""
-        try:
-            auth = self._AUTH_CACHE.get(self.instance_id)
+        """Authenticate with Audible using the saved authentication file.
 
+        Raises:
+            LoginFailed: If authentication fails
+        """
+        try:
+            self.logger.debug("Authenticating with Audible")
+
+            auth = _AUTH_CACHE.get(self.instance_id)
             if auth is None:
-                self.logger.debug("Loading authenticator from file")
+                self.logger.debug("Loading authenticator from file: %s", self.auth_file)
                 auth = await cached_authenticator_from_file(self.auth_file)
-                self._AUTH_CACHE[self.instance_id] = auth
+                _AUTH_CACHE[self.instance_id] = auth
+                self.logger.debug("Authenticator loaded and cached")
             else:
                 self.logger.debug("Using cached authenticator")
 
@@ -248,28 +324,53 @@ class Audibleprovider(MusicProvider):
                 self.logger.debug("Access token expired, refreshing")
                 await asyncio.to_thread(auth.refresh_access_token)
                 await asyncio.to_thread(auth.to_file, self.auth_file)
-                self._AUTH_CACHE[self.instance_id] = auth
+                _AUTH_CACHE[self.instance_id] = auth
+                self.logger.debug("Access token refreshed")
 
             self._client = audible.AsyncClient(auth)
+            self.logger.debug("Audible client created")
 
-            self.helper = AudibleHelper(
-                mass=self.mass,
+            self.api = AudibleAPI(
                 client=self._client,
+                mass=self.mass,
                 provider_instance=self.instance_id,
                 provider_domain=self.domain,
                 logger=self.logger,
             )
+            self.logger.debug("API helper created")
 
-            self.logger.info("Successfully authenticated with Audible.")
+            self.audiobook_helper = AudiobookHelper(
+                api=self.api,
+                mass=self.mass,
+                provider_instance=self.instance_id,
+                provider_domain=self.domain,
+                logger=self.logger,
+            )
+            self.logger.debug("Audiobook helper created")
 
-        except Exception as e:
-            self.logger.error(f"Failed to authenticate with Audible: {e}")
-            raise LoginFailed("Failed to authenticate with Audible.")
+            self.podcast_helper = PodcastHelper(
+                api=self.api,
+                mass=self.mass,
+                provider_instance=self.instance_id,
+                provider_domain=self.domain,
+                logger=self.logger,
+            )
+            self.logger.debug("Podcast helper created")
+
+            self.logger.info("Successfully authenticated with Audible")
+
+        except Exception as exc:
+            self.logger.error("Failed to authenticate with Audible: %s", exc)
+            raise LoginFailed(f"Failed to authenticate with Audible: {exc}") from exc
 
     @property
     def supported_features(self) -> set[ProviderFeature]:
         """Return the features supported by this Provider."""
-        return {ProviderFeature.BROWSE, ProviderFeature.LIBRARY_AUDIOBOOKS}
+        return {
+            ProviderFeature.BROWSE,
+            ProviderFeature.LIBRARY_AUDIOBOOKS,
+            ProviderFeature.LIBRARY_PODCASTS,
+        }
 
     @property
     def is_streaming_provider(self) -> bool:
@@ -277,19 +378,139 @@ class Audibleprovider(MusicProvider):
         return True
 
     async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook, None]:
-        """Get all audiobooks from the library."""
-        async for audiobook in self.helper.get_library():
-            yield audiobook
+        """Get all audiobooks from the user's Audible library.
+
+        Yields:
+            Audiobook objects from the user's library
+        """
+        self.logger.debug("Fetching audiobooks from library")
+        try:
+            async for audiobook in self.audiobook_helper.get_library():
+                yield audiobook
+        except Exception as exc:
+            self.logger.error("Error fetching audiobooks from library: %s", exc)
+            raise
 
     async def get_audiobook(self, prov_audiobook_id: str) -> Audiobook:
-        """Get full audiobook details by id."""
-        return await self.helper.get_audiobook(asin=prov_audiobook_id, use_cache=False)
+        """Get full audiobook details by id.
+
+        Args:
+            prov_audiobook_id: The Audible ASIN for the audiobook
+
+        Returns:
+            Audiobook object with full details
+
+        Raises:
+            MediaNotFoundError: If the audiobook cannot be found
+        """
+        self.logger.debug("Fetching audiobook details for ID: %s", prov_audiobook_id)
+        try:
+            return await self.audiobook_helper.get_audiobook(
+                asin=prov_audiobook_id, use_cache=False
+            )
+        except Exception as exc:
+            self.logger.error("Error fetching audiobook %s: %s", prov_audiobook_id, exc)
+            if not isinstance(exc, MediaNotFoundError):
+                raise MediaNotFoundError(f"Audiobook not found: {prov_audiobook_id}") from exc
+            raise
+
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+        """Get all podcasts from the user's Audible library.
+
+        Yields:
+            Podcast objects from the user's library
+        """
+        self.logger.debug("Fetching podcasts from library")
+        try:
+            async for podcast in self.podcast_helper.get_podcasts():
+                yield podcast
+        except Exception as exc:
+            self.logger.error("Error fetching podcasts from library: %s", exc)
+            raise
+
+    async def get_podcast(self, prov_podcast_id: str) -> Podcast:
+        """Get full podcast details by id.
+
+        Args:
+            prov_podcast_id: The Audible ASIN for the podcast
+
+        Returns:
+            Podcast object with full details
+
+        Raises:
+            Exception: If there's an error fetching the podcast
+        """
+        try:
+            return await self.podcast_helper.get_podcast(prov_podcast_id)
+        except Exception as exc:
+            self.logger.error("Error fetching podcasts from library: %s", exc)
+            raise
+
+    async def get_podcast_episodes(
+        self, prov_podcast_id: str
+    ) -> AsyncGenerator[PodcastEpisode, None]:
+        """Get episodes for a podcast.
+
+        Args:
+            prov_podcast_id: The Audible ASIN for the podcast
+
+        Yields:
+            PodcastEpisode objects for the specified podcast
+        """
+        self.logger.debug("Fetching episodes for podcast ID: %s", prov_podcast_id)
+        try:
+            async for episode in self.podcast_helper.get_podcast_episodes(
+                podcast_asin=prov_podcast_id
+            ):
+                yield episode
+        except Exception as exc:
+            self.logger.error("Error fetching episodes for podcast %s: %s", prov_podcast_id, exc)
+            raise
+
+    async def get_podcast_episode(self, prov_episode_id: str) -> PodcastEpisode:
+        """Get single podcast episode by id.
+
+        Args:
+            prov_episode_id: The Audible episode ID (format: podcast_asin:episode_asin)
+
+        Returns:
+            PodcastEpisode object
+
+        Raises:
+            MediaNotFoundError: If the episode cannot be found
+        """
+        self.logger.debug("Fetching podcast episode: %s", prov_episode_id)
+        try:
+            return await self.podcast_helper.get_podcast_episode(episode_id=prov_episode_id)
+        except Exception as exc:
+            self.logger.error("Error fetching podcast episode %s: %s", prov_episode_id, exc)
+            if not isinstance(exc, MediaNotFoundError):
+                raise MediaNotFoundError(f"Podcast episode not found: {prov_episode_id}") from exc
+            raise
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
-        """Get streamdetails for a audiobook based of asin."""
+        """Get stream details for an audiobook or podcast episode.
+
+        Args:
+            item_id: The Audible ID for the item
+            media_type: The type of media (AUDIOBOOK or PODCAST_EPISODE)
+
+        Returns:
+            StreamDetails object with streaming information
+
+        Raises:
+            MediaNotFoundError: If the stream details cannot be retrieved
+        """
+        self.logger.debug("Getting stream details for %s (type: %s)", item_id, media_type)
         try:
-            return await self.helper.get_stream(asin=item_id)
+            if media_type == MediaType.PODCAST_EPISODE:
+                return await self.podcast_helper.get_stream(item_id)
+            return await self.audiobook_helper.get_stream(asin=item_id)
         except ValueError as exc:
+            self.logger.error("Failed to get stream details for %s: %s", item_id, exc)
+            raise MediaNotFoundError(f"Failed to get stream details for {item_id}") from exc
+        except Exception as exc:
+            self.logger.error("Unexpected error getting stream details for %s: %s", item_id, exc)
             raise MediaNotFoundError(f"Failed to get stream details for {item_id}") from exc
 
     async def on_played(
@@ -319,7 +540,10 @@ class Audibleprovider(MusicProvider):
 
         media_item is the full media item details of the played/playing track.
         """
-        await self.helper.set_last_position(prov_item_id, position)
+        if media_type == MediaType.PODCAST_EPISODE:
+            await self.podcast_helper.set_last_position(prov_item_id, position)
+        else:
+            await self.audiobook_helper.set_last_position(prov_item_id, position)
 
     async def unload(self, is_removed: bool = False) -> None:
         """
@@ -329,4 +553,4 @@ class Audibleprovider(MusicProvider):
         is_removed will be set to True when the provider is removed from the configuration.
         """
         if is_removed:
-            await self.helper.deregister()
+            await self.api.deregister()

--- a/music_assistant/providers/audible/api.py
+++ b/music_assistant/providers/audible/api.py
@@ -1,0 +1,322 @@
+"""API and authentication handling for Audible."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import html
+import json
+import logging
+import os
+import re
+from os import PathLike
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import audible
+import audible.register
+from music_assistant_models.errors import LoginFailed
+
+# Cache constants
+CACHE_DOMAIN = "audible"
+CACHE_CATEGORY_API = 0
+
+# Cache for authenticator objects to avoid repeated file reads
+_AUTH_CACHE: dict[str, audible.Authenticator] = {}
+
+
+async def cached_authenticator_from_file(path: str) -> audible.Authenticator:
+    """Get an authenticator from file with caching to avoid repeated file reads.
+
+    Args:
+        path: Path to the authenticator file
+
+    Returns:
+        Audible Authenticator object
+
+    Raises:
+        FileNotFoundError: If the authenticator file doesn't exist
+        ValueError: If the authenticator file is invalid
+    """
+    logger = logging.getLogger("audible_api")
+
+    # Return from cache if available
+    if path in _AUTH_CACHE:
+        logger.debug("Using cached authenticator for %s", path)
+        return _AUTH_CACHE[path]
+
+    # Check if file exists
+    if not await check_file_exists(path):
+        logger.error("Authenticator file not found: %s", path)
+        raise FileNotFoundError(f"Authenticator file not found: {path}")
+
+    try:
+        logger.debug("Loading authenticator from file %s and caching it", path)
+        auth = await asyncio.to_thread(audible.Authenticator.from_file, path)
+        _AUTH_CACHE[path] = auth
+        return auth
+    except Exception as exc:
+        logger.error("Failed to load authenticator from %s: %s", path, exc)
+        raise ValueError(f"Invalid authenticator file: {exc}") from exc
+
+
+async def audible_get_auth_info(locale: str) -> tuple[str, str, str]:
+    """
+    Generate the login URL and auth info for Audible OAuth flow asynchronously.
+
+    Args:
+        locale: The locale string (e.g., 'us', 'uk', 'de') to determine region settings
+
+    Returns:
+        A tuple containing:
+        - code_verifier (str): The OAuth code verifier string
+        - oauth_url (str): The complete OAuth URL for login
+        - serial (str): The generated device serial number
+
+    Raises:
+        ValueError: If the locale is invalid or OAuth URL generation fails
+    """
+    logger = logging.getLogger("audible_api")
+    logger.debug("Generating auth info for locale: %s", locale)
+
+    try:
+        # Create locale object
+        locale_obj = audible.localization.Locale(locale)
+
+        # Generate code verifier
+        try:
+            code_verifier = await asyncio.to_thread(audible.login.create_code_verifier)
+        except Exception as exc:
+            logger.error("Failed to create code verifier: %s", exc)
+            raise ValueError(f"Failed to create code verifier: {exc}") from exc
+
+        # Build OAuth URL
+        try:
+            oauth_url, serial = await asyncio.to_thread(
+                audible.login.build_oauth_url,
+                country_code=locale_obj.country_code,
+                domain=locale_obj.domain,
+                market_place_id=locale_obj.market_place_id,
+                code_verifier=code_verifier,
+                with_username=False,
+            )
+        except Exception as exc:
+            logger.error("Failed to build OAuth URL: %s", exc)
+            raise ValueError(f"Failed to build OAuth URL: {exc}") from exc
+
+        logger.debug("Successfully generated auth info for locale: %s", locale)
+        return code_verifier.decode(), oauth_url, serial
+
+    except Exception as exc:
+        if isinstance(exc, ValueError):
+            # Re-raise ValueError exceptions
+            raise
+        # Convert other exceptions to TypeError
+        logger.error("Unexpected error generating auth info: %s", exc)
+        raise TypeError(f"Failed to generate auth info: {exc}") from exc
+
+
+async def audible_custom_login(
+    code_verifier: str, response_url: str, serial: str, locale: str
+) -> audible.Authenticator:
+    """
+    Complete the authentication using the code_verifier, response_url, and serial asynchronously.
+
+    Args:
+        code_verifier: The code verifier string used in OAuth flow
+        response_url: The response URL containing the authorization code
+        serial: The device serial number
+        locale: The locale string
+
+    Returns:
+        Audible Authenticator object
+
+    Raises:
+        LoginFailed: If authorization code is not found in the URL or registration fails
+    """
+    logger = logging.getLogger("audible_api")
+    logger.debug("Starting custom login process for locale: %s", locale)
+
+    try:
+        # Create authenticator with locale
+        auth = audible.Authenticator()
+        auth.locale = audible.localization.Locale(locale)
+
+        # Parse the response URL to extract authorization code
+        response_url_parsed = urlparse(response_url)
+        parsed_qs = parse_qs(response_url_parsed.query)
+
+        authorization_codes = parsed_qs.get("openid.oa2.authorization_code")
+        if not authorization_codes:
+            logger.error("Authorization code not found in the provided URL")
+            raise LoginFailed("Authorization code not found in the provided URL.")
+
+        authorization_code = authorization_codes[0]
+        logger.debug("Authorization code extracted successfully")
+
+        # Register the device with Audible
+        try:
+            registration_data = await asyncio.to_thread(
+                audible.register.register,
+                authorization_code=authorization_code,
+                code_verifier=code_verifier.encode(),
+                domain=auth.locale.domain,
+                serial=serial,
+            )
+            auth._update_attrs(**registration_data)
+            logger.debug("Registration completed successfully")
+            return auth
+
+        except Exception as exc:
+            logger.error("Registration failed: %s", exc)
+            raise LoginFailed(f"Failed to register with Audible: {exc}") from exc
+
+    except LoginFailed:
+        # Re-raise LoginFailed exceptions
+        raise
+    except Exception as exc:
+        # Convert other exceptions to LoginFailed
+        logger.error("Unexpected error during login: %s", exc)
+        raise LoginFailed(f"Login process failed: {exc}") from exc
+
+
+async def check_file_exists(path: str | PathLike[str]) -> bool:
+    """Check if a file exists asynchronously.
+
+    Args:
+        path: Path to the file to check
+
+    Returns:
+        True if the file exists, False otherwise
+    """
+    return await asyncio.to_thread(os.path.exists, path)
+
+
+async def remove_file(path: str | PathLike[str]) -> None:
+    """Delete a file asynchronously.
+
+    Args:
+        path: Path to the file to delete
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+        PermissionError: If the user doesn't have permission to delete the file
+    """
+    await asyncio.to_thread(os.remove, path)
+
+
+def html_to_txt(html_text: str) -> str:
+    """Convert HTML text to plain text.
+
+    Args:
+        html_text: The HTML text to convert
+
+    Returns:
+        Plain text with HTML tags removed
+    """
+    if not html_text:
+        return ""
+
+    try:
+        # Unescape HTML entities
+        txt = html.unescape(html_text)
+
+        # Remove HTML tags
+        tags = re.findall("<[^>]+>", txt)
+        for tag in tags:
+            txt = txt.replace(tag, "")
+
+        # Replace multiple spaces with single space
+        txt = re.sub(r"\s+", " ", txt)
+
+        # Replace multiple newlines with single newline
+        txt = re.sub(r"\n+", "\n", txt)
+
+        # Trim leading/trailing whitespace
+        return txt.strip()
+    except Exception:
+        # If any error occurs, return the original text
+        return str(html_text)
+
+
+class AudibleAPI:
+    """API client for Audible."""
+
+    def __init__(
+        self,
+        client: audible.AsyncClient,
+        mass: Any,
+        provider_domain: str,
+        provider_instance: str,
+        logger: logging.Logger | None = None,
+    ):
+        """Initialize the Audible API client."""
+        self.client = client
+        self.mass = mass
+        self.provider_domain = provider_domain
+        self.provider_instance = provider_instance
+        self.logger = logger or logging.getLogger("audible_api")
+
+    async def call_api(self, path: str, **kwargs: Any) -> Any:
+        """Call the Audible API with caching.
+
+        Args:
+            path: The API endpoint path
+            **kwargs: Additional parameters to pass to the API call
+
+        Returns:
+            The API response data
+
+        Note:
+            The 'use_cache' parameter (default: False) can be included in kwargs
+            to control whether to use cached responses
+        """
+        response = None
+        use_cache = kwargs.pop("use_cache", False)
+
+        # Create a unique cache key based on the path and parameters
+        params_str = json.dumps(kwargs, sort_keys=True)
+        params_hash = hashlib.md5(params_str.encode()).hexdigest()
+        cache_key = f"{path}:{params_hash}"
+
+        self.logger.debug("Calling Audible API: %s (use_cache=%s)", path, use_cache)
+
+        try:
+            # Try to get from cache if enabled
+            if use_cache:
+                self.logger.debug("Attempting to retrieve from cache: %s", cache_key)
+                response = await self.mass.cache.get(
+                    key=cache_key, base_key=CACHE_DOMAIN, category=CACHE_CATEGORY_API
+                )
+                if response:
+                    self.logger.debug("Cache hit for: %s", cache_key)
+
+            # Make API call if not in cache
+            if not response:
+                self.logger.debug("Making API request to: %s", path)
+                response = await self.client.get(path, **kwargs)
+
+                # Cache the response
+                await self.mass.cache.set(
+                    key=cache_key, base_key=CACHE_DOMAIN, category=CACHE_CATEGORY_API, data=response
+                )
+                self.logger.debug("Cached response for: %s", cache_key)
+
+            return response
+
+        except Exception as exc:
+            self.logger.error("Error calling Audible API %s: %s", path, exc)
+            raise
+
+    async def deregister(self) -> None:
+        """Deregister this provider from Audible.
+
+        This removes the device registration from Audible's servers.
+        """
+        self.logger.debug("Deregistering device from Audible")
+        try:
+            await asyncio.to_thread(self.client.auth.deregister_device)
+            self.logger.debug("Device successfully deregistered from Audible")
+        except Exception as exc:
+            self.logger.error("Failed to deregister device from Audible: %s", exc)
+            raise

--- a/music_assistant/providers/audible/audiobook.py
+++ b/music_assistant/providers/audible/audiobook.py
@@ -1,24 +1,13 @@
-"""Helper for parsing and using audible api."""
+"""Audiobook functionality for Audible provider."""
 
 from __future__ import annotations
 
-import asyncio
-import hashlib
-import html
-import json
 import logging
-import os
-import re
 from collections.abc import AsyncGenerator
-from os import PathLike
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
-import audible
-import audible.register
-from audible import AsyncClient
 from music_assistant_models.enums import ContentType, ImageType, MediaType, StreamType
-from music_assistant_models.errors import LoginFailed, MediaNotFoundError
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import (
     Audiobook,
     AudioFormat,
@@ -30,77 +19,92 @@ from music_assistant_models.media_items import (
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.mass import MusicAssistant
+from music_assistant.providers.audible.api import AudibleAPI, html_to_txt
 
 CACHE_DOMAIN = "audible"
-CACHE_CATEGORY_API = 0
 CACHE_CATEGORY_AUDIOBOOK = 1
 CACHE_CATEGORY_CHAPTERS = 2
 
-# Cache for authenticator objects to avoid repeated file reads
-_AUTH_CACHE: dict[str, audible.Authenticator] = {}
+AUDIOBOOK_RESPONSE_GROUPS = (
+    "contributors,"
+    "customer_rights,"
+    "media,"
+    "product_attrs,"
+    "product_desc,"
+    "product_details,"
+    "product_extended_attrs"
+)
+
+AUDIOBOOK_DETAIL_RESPONSE_GROUPS = (
+    "contributors,"
+    "customer_rights,"
+    "media,"
+    "product_attrs,"
+    "product_desc,"
+    "product_details,"
+    "product_extended_attrs,"
+    "is_finished"
+)
+
+CHAPTER_RESPONSE_GROUPS = "chapter_info,content_reference,content_url"
 
 
-async def cached_authenticator_from_file(path: str) -> audible.Authenticator:
-    """Get an authenticator from file with caching to avoid repeated file reads."""
-    logger = logging.getLogger("audible_helper")
-    if path in _AUTH_CACHE:
-        return _AUTH_CACHE[path]
-
-    logger.debug("Loading authenticator from file %s and caching it", path)
-    auth = await asyncio.to_thread(audible.Authenticator.from_file, path)
-    _AUTH_CACHE[path] = auth
-    return auth
-
-
-class AudibleHelper:
-    """Helper for parsing and using audible api."""
+class AudiobookHelper:
+    """Helper for Audible audiobook functionality."""
 
     def __init__(
         self,
+        api: AudibleAPI,
         mass: MusicAssistant,
-        client: AsyncClient,
         provider_domain: str,
         provider_instance: str,
         logger: logging.Logger | None = None,
     ):
-        """Initialize the Audible Helper."""
+        """Initialize the Audiobook Helper."""
+        self.api = api
         self.mass = mass
-        self.client = client
         self.provider_domain = provider_domain
         self.provider_instance = provider_instance
-        self.logger = logger or logging.getLogger("audible_helper")
+        self.logger = logger or logging.getLogger("audible_audiobook")
+
+    async def _get_from_cache(self, key: str, category: int, default: Any = None) -> Any:
+        """Get item from cache with standard parameters."""
+        return await self.mass.cache.get(
+            key=key, base_key=CACHE_DOMAIN, category=category, default=default
+        )
+
+    async def _set_to_cache(self, key: str, category: int, data: Any) -> None:
+        """Set item to cache with standard parameters."""
+        await self.mass.cache.set(key=key, base_key=CACHE_DOMAIN, category=category, data=data)
+
+    async def _create_media_item_image(
+        self, image_url: str, image_type: ImageType
+    ) -> MediaItemImage:
+        """Create a MediaItemImage with standard parameters."""
+        return MediaItemImage(
+            type=image_type,
+            path=image_url,
+            provider=self.provider_instance,
+            remotely_accessible=True,
+        )
 
     async def get_library(self) -> AsyncGenerator[Audiobook, None]:
-        """Fetch the user's library with pagination."""
-        response_groups = [
-            "contributors",
-            "media",
-            "product_attrs",
-            "product_desc",
-            "product_details",
-            "product_extended_attrs",
-        ]
-
+        """Fetch the user's audiobook library with pagination."""
         page = 1
         page_size = 50
         total_processed = 0
-        max_iterations = 100
-        iteration = 0
 
-        while iteration < max_iterations:
-            iteration += 1
-
+        while True:
             self.logger.debug(
-                "Audible: Fetching library page %s with page_size %s (processed so far: %s)",
+                "Audible: Fetching library page %s with page_size %s",
                 page,
                 page_size,
-                total_processed,
             )
 
-            library = await self._call_api(
+            library = await self.api.call_api(
                 "library",
                 use_cache=False,
-                response_groups=",".join(response_groups),
+                response_groups=AUDIOBOOK_RESPONSE_GROUPS,
                 page=page,
                 num_results=page_size,
             )
@@ -112,15 +116,14 @@ class AudibleHelper:
                 "Audible: Got %s items (total reported by API: %s)", len(items), total_items
             )
 
-            if not items or len(items) < page_size:
+            if not items:
                 self.logger.debug(
-                    "Audible: No more items or fewer than page size returned, "
-                    "ending pagination (processed %s items)",
+                    "Audible: No more items returned, ending pagination (processed %s items)",
                     total_processed,
                 )
                 break
 
-            items_processed_this_page = 0
+            page_processed = 0
             for audiobook_data in items:
                 content_type = audiobook_data.get("content_delivery_type", "")
                 if content_type in ("PodcastParent", "NonAudio"):
@@ -129,13 +132,20 @@ class AudibleHelper:
                         audiobook_data.get("title", "Unknown"),
                         content_type,
                     )
-                    total_processed += 1
+                    continue
+                customer_rights = audiobook_data.get(
+                    "customer_rights", {"is_consumable_offline": False}
+                )
+                is_consumable_offline = customer_rights.get("is_consumable_offline", False)
+                if not is_consumable_offline:
+                    self.logger.info(
+                        "Skipping audiobook: %s, no stream license.",
+                        audiobook_data.get("title", "Unknown"),
+                    )
                     continue
 
                 asin = audiobook_data.get("asin")
-                cached_book = await self.mass.cache.get(
-                    key=asin, base_key=CACHE_DOMAIN, category=CACHE_CATEGORY_AUDIOBOOK, default=None
-                )
+                cached_book = await self._get_from_cache(asin, CACHE_CATEGORY_AUDIOBOOK)
 
                 try:
                     if cached_book is not None:
@@ -144,17 +154,24 @@ class AudibleHelper:
                     else:
                         album = await self._parse_audiobook(audiobook_data)
                         yield album
-
+                    page_processed += 1
                     total_processed += 1
-                    items_processed_this_page += 1
+
                 except MediaNotFoundError as exc:
                     self.logger.warning(f"Skipping invalid audiobook: {exc}")
-                    total_processed += 1
                     continue
 
             self.logger.debug(
-                "Audible: Processed %s valid audiobooks on page %s", items_processed_this_page, page
+                "Audible: Processed %s valid audiobooks on page %s", page_processed, page
             )
+
+            # If we got fewer items than requested, we've reached the end
+            if len(items) < page_size:
+                self.logger.debug(
+                    "Audible: Fewer items than page size returned, ending pagination "
+                    f"(processed {total_processed} items total)",
+                )
+                break
 
             page += 1
             self.logger.debug(
@@ -164,31 +181,16 @@ class AudibleHelper:
                 total_items,
             )
 
-        if iteration >= max_iterations:
-            self.logger.warning(
-                "Audible: Reached maximum iteration limit (%s) with %s items processed",
-                max_iterations,
-                total_processed,
-            )
-        else:
-            self.logger.info(
-                "Audible: Successfully retrieved %s audiobooks from library", total_processed
-            )
-
     async def get_audiobook(self, asin: str, use_cache: bool = True) -> Audiobook:
         """Fetch the audiobook by asin."""
         if use_cache:
-            cached_book = await self.mass.cache.get(
-                key=asin, base_key=CACHE_DOMAIN, category=CACHE_CATEGORY_AUDIOBOOK, default=None
-            )
+            cached_book = await self._get_from_cache(asin, CACHE_CATEGORY_AUDIOBOOK)
             if cached_book is not None:
                 return await self._parse_audiobook(cached_book)
-        response = await self._call_api(
+
+        response = await self.api.call_api(
             f"library/{asin}",
-            response_groups="""
-                contributors, media, price, product_attrs, product_desc, product_details,
-                product_extended_attrs,is_finished
-                """,
+            response_groups=AUDIOBOOK_DETAIL_RESPONSE_GROUPS,
         )
 
         if response is None:
@@ -198,12 +200,7 @@ class AudibleHelper:
         if item_data is None:
             raise MediaNotFoundError(f"Audiobook data for ASIN {asin} is empty")
 
-        await self.mass.cache.set(
-            key=asin,
-            base_key=CACHE_DOMAIN,
-            category=CACHE_CATEGORY_AUDIOBOOK,
-            data=item_data,
-        )
+        await self._set_to_cache(asin, CACHE_CATEGORY_AUDIOBOOK, item_data)
         return await self._parse_audiobook(item_data)
 
     async def get_stream(self, asin: str) -> StreamDetails:
@@ -220,7 +217,7 @@ class AudibleHelper:
             duration = sum(chapter["length_ms"] for chapter in chapters) / 1000
 
         try:
-            playback_info = await self.client.post(
+            playback_info = await self.api.client.post(
                 f"content/{asin}/licenserequest",
                 body={
                     "quality": "High",
@@ -276,15 +273,13 @@ class AudibleHelper:
             )
             return []
 
-        chapters_data: list[Any] = await self.mass.cache.get(
-            base_key=CACHE_DOMAIN, category=CACHE_CATEGORY_CHAPTERS, key=asin, default=[]
-        )
+        chapters_data: list[Any] = await self._get_from_cache(asin, CACHE_CATEGORY_CHAPTERS, [])
 
         if not chapters_data:
             try:
-                response = await self._call_api(
+                response = await self.api.call_api(
                     f"content/{asin}/metadata",
-                    response_groups="chapter_info, always-returned, content_reference, content_url",
+                    response_groups=CHAPTER_RESPONSE_GROUPS,
                     chapter_titles_type="Flat",
                 )
 
@@ -304,12 +299,7 @@ class AudibleHelper:
 
                 chapters_data = chapter_info.get("chapters", [])
 
-                await self.mass.cache.set(
-                    base_key=CACHE_DOMAIN,
-                    category=CACHE_CATEGORY_CHAPTERS,
-                    key=asin,
-                    data=chapters_data,
-                )
+                await self._set_to_cache(asin, CACHE_CATEGORY_CHAPTERS, chapters_data)
             except Exception as exc:
                 self.logger.error(f"Error fetching chapters for ASIN {asin}: {exc}")
                 chapters_data = []
@@ -322,7 +312,7 @@ class AudibleHelper:
             return 0
 
         try:
-            response = await self._call_api("annotations/lastpositions", asins=asin)
+            response = await self.api.call_api("annotations/lastpositions", asins=asin)
 
             if not response:
                 self.logger.debug(f"No last position data available for ASIN {asin}")
@@ -370,8 +360,14 @@ class AudibleHelper:
                 self.logger.warning(f"No ACR available for ASIN {asin}, cannot report position")
                 return
 
-            await self.client.put(
-                f"lastpositions/{asin}", body={"acr": acr, "asin": asin, "position_ms": position_ms}
+            await self.api.client.put(
+                f"lastpositions/{asin}",
+                body={
+                    "acr": acr,
+                    "asin": asin,
+                    "position_ms": position_ms,
+                    "response_groups": "last_position",
+                },
             )
 
             self.logger.debug(f"Successfully reported position {position_ms}ms for ASIN {asin}")
@@ -387,24 +383,8 @@ class AudibleHelper:
         except Exception as exc:
             self.logger.error(f"Unexpected error reporting position for ASIN {asin}: {exc}")
 
-    async def _call_api(self, path: str, **kwargs: Any) -> Any:
-        response = None
-        use_cache = kwargs.pop("use_cache", False)
-        params_str = json.dumps(kwargs, sort_keys=True)
-        params_hash = hashlib.md5(params_str.encode()).hexdigest()
-        cache_key_with_params = f"{path}:{params_hash}"
-        if use_cache:
-            response = await self.mass.cache.get(
-                key=cache_key_with_params, base_key=CACHE_DOMAIN, category=CACHE_CATEGORY_API
-            )
-        if not response:
-            response = await self.client.get(path, **kwargs)
-            await self.mass.cache.set(
-                key=cache_key_with_params, base_key=CACHE_DOMAIN, data=response
-            )
-        return response
-
     async def _parse_audiobook(self, audiobook_data: dict[str, Any] | None) -> Audiobook:
+        """Parse audiobook data from Audible API and convert to Music Assistant Audiobook object."""
         if audiobook_data is None:
             self.logger.error("Received None audiobook_data in _parse_audiobook")
             raise MediaNotFoundError("Audiobook data not found")
@@ -444,33 +424,25 @@ class AudibleHelper:
             narrators=UniqueList(narrators),
         )
         book.metadata.copyright = audiobook_data.get("copyright")
-        book.metadata.description = _html_to_txt(
+        book.metadata.description = html_to_txt(
             str(audiobook_data.get("extended_product_description", ""))
         )
         book.metadata.languages = UniqueList([audiobook_data.get("language", "")])
         book.metadata.release_date = audiobook_data.get("release_date")
         reviews = audiobook_data.get("editorial_reviews", [])
         if reviews:
-            book.metadata.review = _html_to_txt(reviews[0])
+            book.metadata.review = html_to_txt(reviews[0])
         book.metadata.genres = {
             genre.replace("_", " ") for genre in audiobook_data.get("platinum_keywords", "")
         }
-        book.metadata.images = UniqueList(
-            [
-                MediaItemImage(
-                    type=ImageType.THUMB,
-                    path=audiobook_data.get("product_images", {}).get("500"),
-                    provider=self.provider_instance,
-                    remotely_accessible=True,
-                ),
-                MediaItemImage(
-                    type=ImageType.CLEARART,
-                    path=audiobook_data.get("product_images", {}).get("500"),
-                    provider=self.provider_instance,
-                    remotely_accessible=True,
-                ),
-            ]
-        )
+        image_url = audiobook_data.get("product_images", {}).get("500")
+        if image_url:
+            book.metadata.images = UniqueList(
+                [
+                    await self._create_media_item_image(image_url, ImageType.THUMB),
+                    await self._create_media_item_image(image_url, ImageType.CLEARART),
+                ]
+            )
 
         chapters = []
         for index, chapter_data in enumerate(chapters_data):
@@ -493,89 +465,3 @@ class AudibleHelper:
         book.metadata.chapters = chapters
         book.resume_position_ms = await self.get_last_postion(asin=asin)
         return book
-
-    async def deregister(self) -> None:
-        """Deregister this provider from Audible."""
-        await asyncio.to_thread(self.client.auth.deregister_device)
-
-
-def _html_to_txt(html_text: str) -> str:
-    txt = html.unescape(html_text)
-    tags = re.findall("<[^>]+>", txt)
-    for tag in tags:
-        txt = txt.replace(tag, "")
-    return txt
-
-
-async def audible_get_auth_info(locale: str) -> tuple[str, str, str]:
-    """
-    Generate the login URL and auth info for Audible OAuth flow asynchronously.
-
-    Args:
-        locale: The locale string (e.g., 'us', 'uk', 'de') to determine region settings
-    Returns:
-        A tuple containing:
-        - code_verifier (str): The OAuth code verifier string
-        - oauth_url (str): The complete OAuth URL for login
-        - serial (str): The generated device serial number
-    """
-    locale_obj = audible.localization.Locale(locale)
-    code_verifier = await asyncio.to_thread(audible.login.create_code_verifier)
-    oauth_url, serial = await asyncio.to_thread(
-        audible.login.build_oauth_url,
-        country_code=locale_obj.country_code,
-        domain=locale_obj.domain,
-        market_place_id=locale_obj.market_place_id,
-        code_verifier=code_verifier,
-        with_username=False,
-    )
-
-    return code_verifier.decode(), oauth_url, serial
-
-
-async def audible_custom_login(
-    code_verifier: str, response_url: str, serial: str, locale: str
-) -> audible.Authenticator:
-    """
-    Complete the authentication using the code_verifier, response_url, and serial asynchronously.
-
-    Args:
-        code_verifier: The code verifier string used in OAuth flow
-        response_url: The response URL containing the authorization code
-        serial: The device serial number
-        locale: The locale string
-    Returns:
-        Audible Authenticator object
-    Raises:
-        LoginFailed: If authorization code is not found in the URL
-    """
-    auth = audible.Authenticator()
-    auth.locale = audible.localization.Locale(locale)
-
-    response_url_parsed = urlparse(response_url)
-    parsed_qs = parse_qs(response_url_parsed.query)
-
-    authorization_codes = parsed_qs.get("openid.oa2.authorization_code")
-    if not authorization_codes:
-        raise LoginFailed("Authorization code not found in the provided URL.")
-
-    authorization_code = authorization_codes[0]
-    registration_data = await asyncio.to_thread(
-        audible.register.register,
-        authorization_code=authorization_code,
-        code_verifier=code_verifier.encode(),
-        domain=auth.locale.domain,
-        serial=serial,
-    )
-    auth._update_attrs(**registration_data)
-    return auth
-
-
-async def check_file_exists(path: str | PathLike[str]) -> bool:
-    """Async file exists check."""
-    return await asyncio.to_thread(os.path.exists, path)
-
-
-async def remove_file(path: str | PathLike[str]) -> None:
-    """Async file delete."""
-    await asyncio.to_thread(os.remove, path)

--- a/music_assistant/providers/audible/manifest.json
+++ b/music_assistant/providers/audible/manifest.json
@@ -2,7 +2,7 @@
   "type": "music",
   "domain": "audible",
   "name": "Audible",
-  "description": "Audible provider",
+  "description": "Audible provider for audiobooks and podcasts",
   "codeowners": ["@ztripez"],
   "requirements": ["audible==0.10.0"],
   "documentation": "https://www.music-assistant.io/music-providers/audible"

--- a/music_assistant/providers/audible/podcast.py
+++ b/music_assistant/providers/audible/podcast.py
@@ -1,0 +1,632 @@
+"""Podcast functionality for Audible provider."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from music_assistant_models.enums import ContentType, ImageType, MediaType, StreamType
+from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.media_items import (
+    AudioFormat,
+    ItemMapping,
+    MediaItemImage,
+    Podcast,
+    PodcastEpisode,
+    ProviderMapping,
+    UniqueList,
+)
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.mass import MusicAssistant
+from music_assistant.providers.audible.api import AudibleAPI, html_to_txt
+
+CACHE_DOMAIN = "audible"
+CACHE_CATEGORY_PODCAST = 3
+CACHE_CATEGORY_PODCAST_EPISODE = 4
+
+PODCAST_RESPONSE_GROUPS = (
+    "contributors,media,product_attrs,product_desc,product_details,product_extended_attrs"
+)
+
+EPISODE_RESPONSE_GROUPS = (
+    "contributors,media,product_attrs,product_desc,product_details,product_extended_attrs"
+)
+
+
+class PodcastHelper:
+    """Helper for Audible podcast functionality."""
+
+    def __init__(
+        self,
+        api: AudibleAPI,
+        mass: MusicAssistant,
+        provider_domain: str,
+        provider_instance: str,
+        logger: logging.Logger | None = None,
+    ):
+        """Initialize the Podcast Helper."""
+        self.api = api
+        self.mass = mass
+        self.provider_domain = provider_domain
+        self.provider_instance = provider_instance
+        self.logger = logger or logging.getLogger("audible_podcast")
+
+    async def _get_from_cache(self, key: str, category: int, default: Any = None) -> Any:
+        """Get item from cache with standard parameters."""
+        return await self.mass.cache.get(
+            key=key, base_key=CACHE_DOMAIN, category=category, default=default
+        )
+
+    async def _set_to_cache(self, key: str, category: int, data: dict[str, Any]) -> None:
+        """Set item to cache with standard parameters."""
+        await self.mass.cache.set(key=key, base_key=CACHE_DOMAIN, category=category, data=data)
+
+    async def _create_media_item_image(
+        self, image_url: str, image_type: ImageType
+    ) -> MediaItemImage:
+        """Create a MediaItemImage with standard parameters."""
+        return MediaItemImage(
+            type=image_type,
+            path=image_url,
+            provider=self.provider_instance,
+            remotely_accessible=True,
+        )
+
+    async def get_podcast(self, asin: str, use_cache: bool = True) -> Podcast:
+        """Fetch the podcast by asin."""
+        if use_cache:
+            cached_podcast = await self._get_from_cache(asin, CACHE_CATEGORY_PODCAST)
+            if cached_podcast is not None:
+                return await self._parse_podcast(cached_podcast)
+
+        response = await self.api.call_api(
+            f"library/{asin}",
+            response_groups=PODCAST_RESPONSE_GROUPS,
+        )
+
+        if response is None:
+            raise MediaNotFoundError(f"Podcast with ASIN {asin} not found")
+
+        item_data = response.get("item")
+        if item_data is None:
+            raise MediaNotFoundError(f"Podcast data for ASIN {asin} is empty")
+
+        await self._set_to_cache(asin, CACHE_CATEGORY_PODCAST, item_data)
+        return await self._parse_podcast(item_data)
+
+    async def get_podcasts(self) -> AsyncGenerator[Podcast, None]:
+        """Fetch the user's podcast library with pagination."""
+        page = 1
+        page_size = 50
+        total_processed = 0
+
+        while True:
+            self.logger.debug(
+                "Audible: Fetching library page %s with page_size %s",
+                page,
+                page_size,
+            )
+
+            library = await self.api.call_api(
+                "library",
+                use_cache=False,
+                response_groups=PODCAST_RESPONSE_GROUPS,
+                page=page,
+                num_results=page_size,
+            )
+
+            items = library.get("items", [])
+            total_items = library.get("total_results", 0)
+
+            self.logger.debug(
+                "Audible: Got %s items (total reported by API: %s)", len(items), total_items
+            )
+
+            if not items:
+                self.logger.debug(
+                    "Audible: No more items returned, ending pagination (processed %s podcasts)",
+                    total_processed,
+                )
+                break
+
+            page_processed = 0
+            for podcast_data in items:
+                content_type = podcast_data.get("content_delivery_type", "")
+                if content_type != "PodcastParent":
+                    continue
+
+                asin = podcast_data.get("asin")
+                cached_podcast = await self._get_from_cache(asin, CACHE_CATEGORY_PODCAST)
+
+                try:
+                    if cached_podcast is not None:
+                        podcast = await self._parse_podcast(cached_podcast)
+                        yield podcast
+                    else:
+                        podcast = await self._parse_podcast(podcast_data)
+                        yield podcast
+
+                    page_processed += 1
+                    total_processed += 1
+
+                except MediaNotFoundError as exc:
+                    self.logger.warning(f"Skipping invalid podcast: {exc}")
+                    continue
+
+            self.logger.debug(
+                "Audible: Processed %s valid podcasts on page %s", page_processed, page
+            )
+
+            # If we got fewer items than requested, we've reached the end
+            if len(items) < page_size:
+                self.logger.debug(
+                    "Audible: Fewer items than page size returned, ending pagination "
+                    f"(processed {total_processed} podcasts total)",
+                )
+                break
+
+            page += 1
+            self.logger.debug(
+                "Audible: Moving to page %s (processed: %s, total reported: %s)",
+                page,
+                total_processed,
+                total_items,
+            )
+
+        self.logger.info(
+            "Audible: Successfully retrieved %s podcasts from library", total_processed
+        )
+
+    async def _parse_podcast(self, podcast_data: dict[str, Any] | None) -> Podcast:
+        """Parse podcast data from Audible API.
+
+        Convert Audible API podcast data to Music Assistant Podcast object.
+        """
+        if podcast_data is None:
+            self.logger.error("Received None podcast_data in _parse_podcast")
+            raise MediaNotFoundError("Podcast data not found")
+
+        asin = podcast_data.get("asin", "")
+        title = podcast_data.get("title", "")
+
+        podcast = Podcast(
+            item_id=asin,
+            provider=self.provider_instance,
+            name=title,
+            publisher=podcast_data.get("publisher_name", ""),
+            provider_mappings={
+                ProviderMapping(
+                    item_id=asin,
+                    provider_domain=self.provider_domain,
+                    provider_instance=self.provider_instance,
+                )
+            },
+        )
+
+        podcast.metadata.description = html_to_txt(
+            str(podcast_data.get("extended_product_description", ""))
+        )
+        podcast.metadata.languages = UniqueList([podcast_data.get("language", "")])
+        podcast.metadata.release_date = podcast_data.get("release_date")
+
+        podcast.metadata.genres = {
+            genre.replace("_", " ") for genre in podcast_data.get("platinum_keywords", "")
+        }
+
+        image_url = podcast_data.get("product_images", {}).get("500")
+        if image_url:
+            podcast.metadata.images = UniqueList(
+                [
+                    await self._create_media_item_image(image_url, ImageType.THUMB),
+                    await self._create_media_item_image(image_url, ImageType.CLEARART),
+                ]
+            )
+
+        await self._set_to_cache(asin, CACHE_CATEGORY_PODCAST, podcast_data)
+
+        return podcast
+
+    async def get_podcast_episodes(self, podcast_asin: str) -> AsyncGenerator[PodcastEpisode, None]:
+        """Fetch episodes for a podcast by its ASIN with pagination."""
+        if not podcast_asin:
+            self.logger.error("Invalid podcast ASIN provided to get_podcast_episodes")
+            return
+
+        page = 1
+        page_size = 50
+        total_processed = 0
+        overall_position = 0
+
+        while True:
+            self.logger.debug(
+                "Audible: Fetching episodes for podcast %s (page %s, page_size %s)",
+                podcast_asin,
+                page,
+                page_size,
+            )
+
+            try:
+                episodes_response = await self.api.call_api(
+                    "library",
+                    parent_asin=podcast_asin,
+                    response_groups=EPISODE_RESPONSE_GROUPS,
+                    use_cache=False,
+                    page=page,
+                    num_results=page_size,
+                )
+
+                items = episodes_response.get("items", [])
+                total_items = episodes_response.get("total_results", 0)
+
+                self.logger.debug(
+                    "Audible: Got %s episodes for podcast %s (total reported by API: %s)",
+                    len(items),
+                    podcast_asin,
+                    total_items,
+                )
+
+                if not items:
+                    self.logger.debug(
+                        "Audible: No more episodes returned, ending pagination "
+                        f"(processed {total_processed} episodes)",
+                    )
+                    break
+
+                page_processed = 0
+                for episode_data in items:
+                    try:
+                        content_type = episode_data.get("content_delivery_type", "")
+                        episode_asin = episode_data.get("asin")
+
+                        self.logger.debug(
+                            "Audible: Episode %s has content_delivery_type: %s",
+                            episode_asin,
+                            content_type,
+                        )
+
+                        cache_key = self._create_episode_id(podcast_asin, episode_asin)
+                        cached_episode = await self._get_from_cache(
+                            cache_key, CACHE_CATEGORY_PODCAST_EPISODE
+                        )
+
+                        if cached_episode is not None:
+                            episode = await self._parse_podcast_episode(
+                                cached_episode, podcast_asin, overall_position
+                            )
+                            yield episode
+                        else:
+                            episode = await self._parse_podcast_episode(
+                                episode_data, podcast_asin, overall_position
+                            )
+                            yield episode
+
+                        page_processed += 1
+                        total_processed += 1
+                        overall_position += 1
+
+                    except MediaNotFoundError as exc:
+                        self.logger.warning(f"Skipping invalid podcast episode: {exc}")
+                        continue
+
+                self.logger.debug(
+                    "Audible: Processed %s valid episodes on page %s", page_processed, page
+                )
+
+                # If we got fewer items than requested, we've reached the end
+                if len(items) < page_size:
+                    self.logger.debug(
+                        "Audible: Fewer episodes than page size returned, ending pagination "
+                        f"(processed {total_processed} episodes total)",
+                    )
+                    break
+
+                page += 1
+                self.logger.debug(
+                    "Audible: Moving to page %s (processed: %s, total reported: %s)",
+                    page,
+                    total_processed,
+                    total_items,
+                )
+
+            except Exception as exc:
+                self.logger.error(f"Error fetching episodes for podcast {podcast_asin}: {exc}")
+                return
+
+    async def _get_podcast_name(self, podcast_asin: str) -> str:
+        """Get podcast name from cache."""
+        try:
+            podcast_data = await self._get_from_cache(podcast_asin, CACHE_CATEGORY_PODCAST)
+            return (
+                podcast_data.get("title", "Unknown Podcast") if podcast_data else "Unknown Podcast"
+            )
+        except Exception:
+            return "Unknown Podcast"
+
+    async def get_podcast_episode(self, episode_id: str) -> PodcastEpisode:
+        """Get a single podcast episode by its ID (format: podcast_asin:episode_asin)."""
+        try:
+            podcast_asin, episode_asin = self._split_episode_id(episode_id)
+        except ValueError:
+            self.logger.error("Invalid episode ID format: %s", episode_id)
+            raise MediaNotFoundError(f"Invalid episode ID format: {episode_id}")
+
+        # First check cache
+        cached_episode = await self._get_from_cache(episode_id, CACHE_CATEGORY_PODCAST_EPISODE)
+        if cached_episode is not None:
+            return await self._parse_podcast_episode(cached_episode, podcast_asin, 0)
+
+        # If not in cache, fetch directly using episode ASIN
+        try:
+            response = await self.api.call_api(
+                f"library/{episode_asin}",
+                parent_asin=podcast_asin,
+                response_groups=EPISODE_RESPONSE_GROUPS,
+                use_cache=False,
+            )
+
+            if response is None:
+                raise MediaNotFoundError(f"Episode {episode_id} not found")
+
+            episode_data = response.get("item")
+            if episode_data is None:
+                raise MediaNotFoundError(f"Episode data for {episode_id} is empty")
+
+            return await self._parse_podcast_episode(episode_data, podcast_asin, 0)
+
+        except Exception as exc:
+            self.logger.error(f"Error fetching episode {episode_id}: {exc}")
+            raise MediaNotFoundError(f"Failed to fetch episode {episode_id}: {exc}")
+
+    async def _parse_podcast_episode(
+        self, episode_data: dict[str, Any], podcast_asin: str, position: int
+    ) -> PodcastEpisode:
+        """Parse podcast episode data from Audible API.
+
+        Convert Audible API podcast episode data to Music Assistant PodcastEpisode object.
+        """
+        episode_asin = episode_data.get("asin", "")
+        title = episode_data.get("title", "")
+        episode_id = self._create_episode_id(podcast_asin, episode_asin)
+        podcast_name = await self._get_podcast_name(podcast_asin)
+        duration_min = episode_data.get("runtime_length_min", 0)
+        duration = int(duration_min * 60) if duration_min else 0
+        resume_position_ms = await self.get_last_position(podcast_asin, episode_asin)
+
+        episode = PodcastEpisode(
+            item_id=episode_id,
+            provider=self.provider_instance,
+            name=title,
+            duration=duration,
+            position=position,
+            resume_position_ms=resume_position_ms,
+            podcast=ItemMapping(
+                item_id=podcast_asin,
+                provider=self.provider_instance,
+                name=podcast_name,
+                media_type=MediaType.PODCAST,
+            ),
+            provider_mappings={
+                ProviderMapping(
+                    item_id=episode_id,
+                    provider_domain=self.provider_domain,
+                    provider_instance=self.provider_instance,
+                    audio_format=AudioFormat(content_type=ContentType.AAC),
+                )
+            },
+        )
+
+        episode.metadata.description = html_to_txt(
+            str(episode_data.get("extended_product_description", ""))
+        )
+        episode.metadata.release_date = episode_data.get("release_date")
+
+        image_url = episode_data.get("product_images", {}).get("500")
+        if image_url:
+            episode.metadata.images = UniqueList(
+                [await self._create_media_item_image(image_url, ImageType.THUMB)]
+            )
+
+        await self._set_to_cache(episode_id, CACHE_CATEGORY_PODCAST_EPISODE, episode_data)
+
+        return episode
+
+    async def _get_episode_data(self, item_id: str) -> dict[str, Any]:
+        """Get episode data from cache or API."""
+        try:
+            podcast_asin, episode_asin = self._split_episode_id(item_id)
+        except ValueError as exc:
+            raise ValueError(str(exc))
+
+        # First check cache
+        cached_episode = await self._get_from_cache(item_id, CACHE_CATEGORY_PODCAST_EPISODE)
+        if cached_episode is not None:
+            return dict(cached_episode)
+
+        # If not in cache, fetch directly using episode ASIN
+        try:
+            response = await self.api.call_api(
+                f"library/{episode_asin}",
+                parent_asin=podcast_asin,
+                response_groups=EPISODE_RESPONSE_GROUPS,
+                use_cache=False,
+            )
+
+            if response is None:
+                raise ValueError(f"Episode {item_id} not found")
+
+            episode_data = response.get("item")
+            if episode_data is None:
+                raise ValueError(f"Episode data for {item_id} is empty")
+
+            return dict(episode_data)
+
+        except Exception as exc:
+            self.logger.error(f"Error fetching episode data for {item_id}: {exc}")
+            raise ValueError(f"Failed to fetch episode data: {exc}")
+
+    async def get_stream(self, item_id: str) -> StreamDetails:
+        """Get stream details for a podcast episode."""
+        try:
+            podcast_asin, episode_asin = self._split_episode_id(item_id)
+        except ValueError as exc:
+            self.logger.error(f"Invalid item_id provided to get_stream: {exc}")
+            raise ValueError(f"Invalid item_id provided to get_stream: {exc}")
+
+        try:
+            try:
+                episode_data = await self._get_episode_data(item_id)
+            except ValueError as exc:
+                self.logger.error(f"Episode data not found for {item_id}: {exc}")
+                raise ValueError(f"Episode data not found for {item_id}")
+
+            duration_min = episode_data.get("runtime_length_min", 0)
+            duration = int(duration_min * 60) if duration_min else 0
+
+            content_type = episode_data.get("content_delivery_type", "")
+            self.logger.debug(
+                "Audible: Episode %s has content_delivery_type: %s for streaming",
+                episode_asin,
+                content_type,
+            )
+
+            playback_info = await self.api.client.post(
+                f"content/{episode_asin}/licenserequest",
+                body={
+                    "quality": "High",
+                    "consumption_type": "Streaming",
+                    "supported_media_features": {
+                        "codecs": ["mp4a.40.2", "mp4a.40.42"],
+                        "drm_types": ["Mpeg", "Hls"],
+                    },
+                },
+            )
+
+            content_license = playback_info.get("content_license", {})
+            if not content_license:
+                self.logger.error(f"No content_license in playback_info for episode {item_id}")
+                raise ValueError(f"Missing content_license for episode {item_id}")
+
+            content_metadata = content_license.get("content_metadata", {})
+            content_reference = content_metadata.get("content_reference", {})
+            size = content_reference.get("content_size_in_bytes", 0)
+
+            m3u8_url = content_license.get("license_response")
+            if not m3u8_url:
+                self.logger.error(f"No license_response (stream URL) for episode {item_id}")
+                raise ValueError(f"Missing stream URL for episode {item_id}")
+
+            acr = content_license.get("acr")
+
+            return StreamDetails(
+                provider=self.provider_instance,
+                size=size,
+                item_id=item_id,
+                audio_format=AudioFormat(content_type=ContentType.AAC),
+                media_type=MediaType.PODCAST_EPISODE,
+                stream_type=StreamType.HTTP,
+                path=m3u8_url,
+                can_seek=True,
+                allow_seek=True,
+                duration=duration,
+                data={"acr": acr},
+            )
+
+        except Exception as exc:
+            self.logger.error(f"Error getting stream details for episode {item_id}: {exc}")
+            raise ValueError(f"Failed to get stream details: {exc}") from exc
+
+    async def get_last_position(self, podcast_asin: str, episode_asin: str) -> int:
+        """Fetch last position of a podcast episode."""
+        if not podcast_asin or not episode_asin:
+            return 0
+
+        try:
+            response = await self.api.call_api("annotations/lastpositions", asins=episode_asin)
+
+            if not response:
+                self.logger.debug(f"No last position data available for episode {episode_asin}")
+                return 0
+
+            annotations = response.get("asin_last_position_heard_annots")
+            if not annotations or not isinstance(annotations, list) or len(annotations) == 0:
+                self.logger.debug(f"No annotations found for episode {episode_asin}")
+                return 0
+
+            annotation = annotations[0]
+            if not annotation or not isinstance(annotation, dict):
+                self.logger.debug(f"Invalid annotation for episode {episode_asin}")
+                return 0
+
+            last_position = annotation.get("last_position_heard")
+            if not last_position or not isinstance(last_position, dict):
+                self.logger.debug(f"Invalid last_position for episode {episode_asin}")
+                return 0
+
+            position_ms = last_position.get("position_ms", 0)
+            return int(position_ms)
+
+        except Exception as exc:
+            self.logger.error(f"Error getting last position for episode {episode_asin}: {exc}")
+            return 0
+
+    def _create_episode_id(self, podcast_asin: str, episode_asin: str) -> str:
+        """Create a unique ID for an episode using podcast_asin:episode_asin format."""
+        return f"{podcast_asin}:{episode_asin}"
+
+    def _split_episode_id(self, episode_id: str) -> tuple[str, str]:
+        """Split an episode ID into podcast_asin and episode_asin."""
+        if not episode_id or ":" not in episode_id:
+            raise ValueError(f"Invalid episode ID format: {episode_id}")
+
+        podcast_asin, episode_asin = episode_id.split(":", 1)
+
+        if not podcast_asin or not episode_asin:
+            raise ValueError(f"Invalid podcast_asin or episode_asin in {episode_id}")
+
+        return podcast_asin, episode_asin
+
+    async def set_last_position(self, item_id: str, pos: int) -> None:
+        """Report last position to Audible for a podcast episode.
+
+        Args:
+            item_id: The podcast episode ID in format podcast_asin:episode_asin
+            pos: Position in seconds
+        """
+        if not item_id or ":" not in item_id or pos <= 0:
+            return
+
+        try:
+            _, episode_asin = self._split_episode_id(item_id)
+            position_ms = pos * 1000
+
+            try:
+                stream_details = await self.get_stream(item_id=item_id)
+                acr = stream_details.data.get("acr")
+            except Exception as exc:
+                self.logger.error(f"Error getting stream details for episode {item_id}: {exc}")
+                raise ValueError(f"Failed to get ACR: {exc}") from exc
+
+            if not acr:
+                self.logger.warning(
+                    f"No ACR available for episode {item_id}, cannot report position"
+                )
+                return
+
+            await self.api.client.put(
+                f"lastpositions/{episode_asin}",
+                body={
+                    "acr": acr,
+                    "asin": episode_asin,
+                    "position_ms": position_ms,
+                    "response_groups": "last_position",
+                },
+            )
+
+            self.logger.debug(
+                f"Successfully reported position {position_ms}ms for episode {item_id}"
+            )
+
+        except Exception as exc:
+            self.logger.error(f"Error reporting position for episode {item_id}: {exc}")


### PR DESCRIPTION

### Summary

This PR refactors the Audible provider for improved maintainability and introduces experimental support for Audible podcasts.

---

### Changes

#### Refactor
- Split the monolithic `audible_helper.py` into dedicated modules:
  - `api.py` handles authentication, caching, and low-level API interaction
  - `audiobook.py` contains all audiobook-related logic
  - `podcast.py` adds podcast-specific logic
- Removed legacy `AudibleHelper` in favor of `AudiobookHelper` and `PodcastHelper`
- Consolidated API call and caching logic inside `AudibleAPI` for consistency and reuse

#### Features

##### Audiobooks
- Improved library fetching with proper pagination and filtering
- Enhanced error handling and caching
- Respects stream license availability and skips invalid entries
- Resume position tracking and reporting retained

##### Podcasts (Experimental)
- Initial implementation of Audible podcast support:
  - Library listing
  - Full podcast metadata
  - Episode listing and playback
  - Resume position tracking

**Limitations**:
- Only the 10 latest episodes are listed due to unknown backend/API behavior
- Audible’s podcast support is undocumented and requires reverse engineering, so this feature should be considered unstable for now

#### Config Flow
- Config flow refactored and simplified
- Added better auth flow separation and marketplace selection
- Includes informative messages for required and successful authentication states

### Notes
- Audible podcast support is based entirely on undocumented behavior and may break at any time.
- Further work is required to improve podcast pagination and stability as more is understood about the backend.
