### PR TITLE
Subsonic: Set metadata.release_date when available

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
 from libopensonic.connection import Connection as SonicConnection
@@ -358,6 +359,9 @@ class OpenSonicProvider(MusicProvider):
             },
             duration=sonic_episode.duration,
         )
+
+        if sonic_episode.publish_date:
+            episode.metadata.release_date = datetime.fromisoformat(sonic_episode.publish_date)
 
         if sonic_episode.description:
             episode.metadata.description = sonic_episode.description


### PR DESCRIPTION
We want to use this field for sorting episodes when displayed.