### PR TITLE
YT Music: Auto generate PO tokens for stream urls

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -80,6 +80,8 @@ if TYPE_CHECKING:
 
 
 CONF_COOKIE = "cookie"
+CONF_PO_TOKEN_SERVER_URL = "po_token_server_url"
+DEFAULT_PO_TOKEN_SERVER_URL = "http://127.0.0.1:4416"
 
 YTM_DOMAIN = "https://music.youtube.com"
 YTM_COOKIE_DOMAIN = ".youtube.com"
@@ -157,6 +159,15 @@ async def get_config_entries(
             description="The Login cookie you grabbed from an existing session, "
             "see the documentation.",
         ),
+        ConfigEntry(
+            key=CONF_PO_TOKEN_SERVER_URL,
+            type=ConfigEntryType.STRING,
+            default_value=DEFAULT_PO_TOKEN_SERVER_URL,
+            label="PO Token Server URL",
+            required=True,
+            description="The URL to the PO Token server. Can be left as default for most people. \n\n"
+            "**Note that this does require you to have the 'YT Music PO Token Generator' addon installed!**",
+        ),
     )
 
 
@@ -174,6 +185,9 @@ class YoutubeMusicProvider(MusicProvider):
         """Set up the YTMusic provider."""
         logging.getLogger("yt_dlp").setLevel(self.logger.level + 10)
         self._cookie = self.config.get_value(CONF_COOKIE)
+        self._po_token_server_url = (
+            self.config.get_value(CONF_PO_TOKEN_SERVER_URL) or DEFAULT_PO_TOKEN_SERVER_URL
+        )
         yt_username = self.config.get_value(CONF_USERNAME)
         self._yt_user = yt_username if is_brand_account(yt_username) else None
         # yt-dlp needs a netscape formatted cookie
@@ -853,8 +867,8 @@ class YoutubeMusicProvider(MusicProvider):
                         "skip": ["translated_subs", "dash"],
                         "player_client": ["web_music"],
                         "player_skip": ["webpage"],
-                        "formats": ["missing_pot"],
-                    }
+                        "getpot_bgutil_baseurl": [self._po_token_server_url],
+                    },
                 },
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 
 import yt_dlp
+from aiohttp import ClientConnectorError
 from duration_parser import parse as parse_str_duration
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
@@ -188,6 +189,10 @@ class YoutubeMusicProvider(MusicProvider):
         self._po_token_server_url = (
             self.config.get_value(CONF_PO_TOKEN_SERVER_URL) or DEFAULT_PO_TOKEN_SERVER_URL
         )
+        if not await self._verify_po_token_url():
+            raise LoginFailed(
+                "PO Token server URL is not reachable. Make sure you have installed the YT Music PO Token Generator addon from the MusicAssistant repository."
+            )
         yt_username = self.config.get_value(CONF_USERNAME)
         self._yt_user = yt_username if is_brand_account(yt_username) else None
         # yt-dlp needs a netscape formatted cookie
@@ -896,6 +901,16 @@ class YoutubeMusicProvider(MusicProvider):
         if not artist_id and artist_obj["name"] == "Various Artists":
             artist_id = VARIOUS_ARTISTS_YTM_ID
         return self._get_item_mapping(MediaType.ARTIST, artist_id, artist_obj.get("name"))
+
+    async def _verify_po_token_url(self) -> bool:
+        """Ping the PO Token server and verify the response."""
+        url = f"{self._po_token_server_url}/ping"
+        try:
+            async with self.mass.http_session.get(url) as response:
+                response.raise_for_status()
+                return response.status == 200
+        except ClientConnectorError:
+            return False
 
     async def _user_has_ytm_premium(self) -> bool:
         """Check if the user has Youtube Music Premium."""

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -47,7 +47,7 @@ from ytmusicapi.constants import SUPPORTED_LANGUAGES
 from ytmusicapi.exceptions import YTMusicServerError
 from ytmusicapi.helpers import get_authorization, sapisid_from_cookie
 
-from music_assistant.constants import CONF_USERNAME
+from music_assistant.constants import CONF_USERNAME, VERBOSE_LOG_LEVEL
 from music_assistant.models.music_provider import MusicProvider
 
 from .helpers import (
@@ -870,8 +870,8 @@ class YoutubeMusicProvider(MusicProvider):
         def _extract_best_stream_url_format() -> dict[str, Any]:
             url = f"{YTM_DOMAIN}/watch?v={item_id}"
             ydl_opts = {
-                # "quiet": self.logger.level > logging.DEBUG,
-                "verbose": True,
+                "quiet": self.logger.level > logging.DEBUG,
+                "verbose": self.logger.level == VERBOSE_LOG_LEVEL,
                 "cookiefile": StringIO(self._netscape_cookie),
                 # This enforces a player client and skips unnecessary scraping to increase speed
                 "extractor_args": {

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -613,6 +613,12 @@ class YoutubeMusicProvider(MusicProvider):
             "x-origin": YTM_DOMAIN,
             "Cookie": self._cookie,
         }
+        if "__Secure-3PAPISID" not in self._cookie:
+            raise LoginFailed(
+                "Invalid Cookie detected. Cookie is missing the __Secure-3PAPISID field. "
+                "Please ensure you are passing the correct cookie. You can verify this by checking if the string"
+                "'__Secure-3PAPISID' is present in the cookie string."
+            )
         sapisid = sapisid_from_cookie(self._cookie)
         headers["Authorization"] = get_authorization(sapisid + " " + YTM_DOMAIN)
         self._headers = headers

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -191,7 +191,7 @@ class YoutubeMusicProvider(MusicProvider):
         )
         if not await self._verify_po_token_url():
             raise LoginFailed(
-                "PO Token server URL is not reachable. Make sure you have installed the YT Music PO Token Generator addon from the MusicAssistant repository."
+                "PO Token server URL is not reachable. Make sure you have installed the YT Music PO Token Generator addon from the MusicAssistant repository and that it is running."
             )
         yt_username = self.config.get_value(CONF_USERNAME)
         self._yt_user = yt_username if is_brand_account(yt_username) else None
@@ -870,7 +870,8 @@ class YoutubeMusicProvider(MusicProvider):
         def _extract_best_stream_url_format() -> dict[str, Any]:
             url = f"{YTM_DOMAIN}/watch?v={item_id}"
             ydl_opts = {
-                "quiet": self.logger.level > logging.DEBUG,
+                # "quiet": self.logger.level > logging.DEBUG,
+                "verbose": True,
                 "cookiefile": StringIO(self._netscape_cookie),
                 # This enforces a player client and skips unnecessary scraping to increase speed
                 "extractor_args": {
@@ -914,6 +915,7 @@ class YoutubeMusicProvider(MusicProvider):
         try:
             async with self.mass.http_session.get(url) as response:
                 response.raise_for_status()
+                self.logger.debug("PO Token server responded with %s", response.status)
                 return response.status == 200
         except ClientConnectorError:
             return False

--- a/music_assistant/providers/ytmusic/manifest.json
+++ b/music_assistant/providers/ytmusic/manifest.json
@@ -4,7 +4,7 @@
   "name": "YouTube Music",
   "description": "Support for the YouTube Music streaming provider in Music Assistant.",
   "codeowners": ["@MarvinSchenkel"],
-  "requirements": ["ytmusicapi==1.10.2", "yt-dlp==2025.3.26", "duration-parser==1.0.1", "yt-dlp-get-pot==0.3.0"],
+  "requirements": ["ytmusicapi==1.10.2", "yt-dlp==2025.3.26", "duration-parser==1.0.1", "bgutil-ytdlp-pot-provider==0.8.1"],
   "documentation": "https://music-assistant.io/music-providers/youtube-music/",
   "multi_instance": true
 }

--- a/music_assistant/providers/ytmusic/manifest.json
+++ b/music_assistant/providers/ytmusic/manifest.json
@@ -4,7 +4,7 @@
   "name": "YouTube Music",
   "description": "Support for the YouTube Music streaming provider in Music Assistant.",
   "codeowners": ["@MarvinSchenkel"],
-  "requirements": ["ytmusicapi==1.10.2", "yt-dlp==2025.2.19", "duration-parser==1.0.1"],
+  "requirements": ["ytmusicapi==1.10.2", "yt-dlp==2025.3.26", "duration-parser==1.0.1", "yt-dlp-get-pot==0.3.0"],
   "documentation": "https://music-assistant.io/music-providers/youtube-music/",
   "multi_instance": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -51,6 +51,7 @@ sxm==0.2.8
 unidecode==1.3.8
 websocket-client==1.8.0
 xmltodict==0.14.2
-yt-dlp==2025.2.19
+yt-dlp==2025.3.26
+yt-dlp-get-pot==0.3.0
 ytmusicapi==1.10.2
 zeroconf==0.146.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,6 +52,6 @@ unidecode==1.3.8
 websocket-client==1.8.0
 xmltodict==0.14.2
 yt-dlp==2025.3.26
-yt-dlp-get-pot==0.3.0
+bgutil-ytdlp-pot-provider==0.8.1
 ytmusicapi==1.10.2
 zeroconf==0.146.1


### PR DESCRIPTION
Google recently introduce PO (proof of origin) in its fight against piracy. This PR adds the possibility to configure the YT provider to use an external PO token generation server so we can play music again.

Fixes:
- https://github.com/music-assistant/support/issues/3739#issuecomment-2757279833