### PR TITLE
feat: add DSP Config changed event

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -520,6 +520,12 @@ class ConfigController:
         # Save and apply the new config to the player
         self.set(f"{CONF_PLAYER_DSP}/{player_id}", config.to_dict())
         await self.mass.players.on_player_dsp_change(player_id)
+        # send the dsp config updated event
+        self.mass.signal_event(
+            EventType.PLAYER_DSP_CONFIG_UPDATED,
+            object_id=player_id,
+            data=config,
+        )
         return config
 
     def create_default_player_config(


### PR DESCRIPTION
Depends on https://github.com/music-assistant/models/pull/70
Frontend implementation https://github.com/music-assistant/frontend/pull/940

This PR fixes the issue added with #913, where the DSP status wasn't updated when:
1. Opening the DSP Settings through the link
2. Enabling/Disabling the DSP
3. Going back

Additionally, having the DSP editor open on multiple devices now correctly shows the settings as applied at all times.
