### PR TITLE
fix: Built-in Web Player Part 4

### DIFF
--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -332,6 +332,7 @@ class BuiltinPlayerProvider(PlayerProvider):
             player.available = False
             player.state = PlayerState.IDLE
             player.powered = False
+            self.mass.players.update(player.player_id)
 
     async def update_player_state(self, player_id: str, state: BuiltinPlayerState) -> bool:
         """Update current state of a player.

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -284,7 +284,7 @@ class BuiltinPlayerProvider(PlayerProvider):
         if player_id is None:
             player_id = f"ma_{shortuuid.random(10).lower()}"
 
-        instance = self.instances.pop(player_id, None)
+        already_registered = player_id in self.instances
 
         player_features = {
             PlayerFeature.VOLUME_SET,
@@ -293,7 +293,7 @@ class BuiltinPlayerProvider(PlayerProvider):
             PlayerFeature.POWER,
         }
 
-        if instance is None:
+        if not already_registered:
             self.instances[player_id] = PlayerInstance(
                 unregister_cbs=[
                     self.mass.webserver.register_dynamic_route(
@@ -317,7 +317,7 @@ class BuiltinPlayerProvider(PlayerProvider):
             poll_interval=POLL_INTERVAL,
             hidden_by_default=True,
             expose_to_ha_by_default=False,
-            state=PlayerState.IDLE if instance is None else PlayerState.PAUSED,
+            state=PlayerState.IDLE,
         )
 
         await self.mass.players.register_or_update(player)
@@ -348,8 +348,9 @@ class BuiltinPlayerProvider(PlayerProvider):
         if not (player := self.mass.players.get(player_id)):
             return False
 
-        if not (instance := self.instances[player_id]):
-            raise RuntimeError("No instance found")
+        if player_id not in self.instances:
+            return False
+        instance = self.instances[player_id]
         instance.last_update = time()
 
         if not player.powered and state.powered:

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -284,7 +284,7 @@ class BuiltinPlayerProvider(PlayerProvider):
         if player_id is None:
             player_id = f"ma_{shortuuid.random(10).lower()}"
 
-        await self.unregister_player(player_id)
+        instance = self.instances.pop(player_id, None)
 
         player_features = {
             PlayerFeature.VOLUME_SET,
@@ -293,14 +293,15 @@ class BuiltinPlayerProvider(PlayerProvider):
             PlayerFeature.POWER,
         }
 
-        self.instances[player_id] = PlayerInstance(
-            unregister_cbs=[
-                self.mass.webserver.register_dynamic_route(
-                    f"/builtin_player/flow/{player_id}.mp3", self._serve_audio_stream
-                ),
-            ],
-            last_update=time(),
-        )
+        if instance is None:
+            self.instances[player_id] = PlayerInstance(
+                unregister_cbs=[
+                    self.mass.webserver.register_dynamic_route(
+                        f"/builtin_player/flow/{player_id}.mp3", self._serve_audio_stream
+                    ),
+                ],
+                last_update=time(),
+            )
 
         player = Player(
             player_id=player_id,
@@ -316,6 +317,7 @@ class BuiltinPlayerProvider(PlayerProvider):
             poll_interval=POLL_INTERVAL,
             hidden_by_default=True,
             expose_to_ha_by_default=False,
+            state=PlayerState.IDLE if instance is None else PlayerState.PAUSED,
         )
 
         await self.mass.players.register_or_update(player)

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -323,8 +323,7 @@ class BuiltinPlayerProvider(PlayerProvider):
                 state=PlayerState.IDLE,
             )
         else:
-            if player.state == PlayerState.PLAYING:
-                player.state = PlayerState.PAUSED
+            player.state = PlayerState.IDLE
             player.name = player_name
             player.available = True
             player.powered = False

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -303,22 +303,31 @@ class BuiltinPlayerProvider(PlayerProvider):
                 last_update=time(),
             )
 
-        player = Player(
-            player_id=player_id,
-            provider=self.instance_id,
-            type=PlayerType.PLAYER,
-            name=player_name,
-            available=True,
-            power_control=PLAYER_CONTROL_NATIVE,
-            powered=False,
-            device_info=DeviceInfo(),
-            supported_features=player_features,
-            needs_poll=True,
-            poll_interval=POLL_INTERVAL,
-            hidden_by_default=True,
-            expose_to_ha_by_default=False,
-            state=PlayerState.IDLE,
-        )
+        player = self.mass.players.get(player_id)
+
+        if player is None:
+            player = Player(
+                player_id=player_id,
+                provider=self.instance_id,
+                type=PlayerType.PLAYER,
+                name=player_name,
+                available=True,
+                power_control=PLAYER_CONTROL_NATIVE,
+                powered=False,
+                device_info=DeviceInfo(),
+                supported_features=player_features,
+                needs_poll=True,
+                poll_interval=POLL_INTERVAL,
+                hidden_by_default=True,
+                expose_to_ha_by_default=False,
+                state=PlayerState.IDLE,
+            )
+        else:
+            if player.state == PlayerState.PLAYING:
+                player.state = PlayerState.PAUSED
+            player.name = player_name
+            player.available = True
+            player.powered = False
 
         await self.mass.players.register_or_update(player)
         return player


### PR DESCRIPTION
Frontend PR: https://github.com/music-assistant/frontend/pull/948
Hopefully the final round of fixes for the Web Player.

Mainly addresses:
- Missing `self.mass.players.update` on unregister
- Unreliable re-register due to a unregister
- Unreliable passing of control on tab close
- Queue restore errors due to unregister + re-register -> now the player is just updated
- Still marked as playing on network error