### PR TITLE
YT Music: Fix missing track thumbs

### DIFF
--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -85,6 +85,8 @@ async def get_track(
         track["thumbnails"] = track_obj["microformat"]["microformatDataRenderer"]["thumbnail"][
             "thumbnails"
         ]
+        if track_thumbs := track_obj["videoDetails"].get("thumbnail", {}).get("thumbnails"):
+            track["thumbnails"] = track["thumbnails"] + track_thumbs
         track["isAvailable"] = track_obj["playabilityStatus"]["status"] == "OK"
         return track
 

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -86,7 +86,7 @@ async def get_track(
             "thumbnails"
         ]
         if track_thumbs := track_obj["videoDetails"].get("thumbnail", {}).get("thumbnails"):
-            track["thumbnails"] = track["thumbnails"] + track_thumbs
+            track["thumbnails"] = track.get("thumbnails", []) + track_thumbs
         track["isAvailable"] = track_obj["playabilityStatus"]["status"] == "OK"
         return track
 


### PR DESCRIPTION
This PR adds missing thumbnail images to the tracks to prevent artist images from showing up all the time