### PR TITLE
Snapserver v0.30.0 don't support add/remove stream

### DIFF
--- a/music_assistant/providers/snapcast/__init__.py
+++ b/music_assistant/providers/snapcast/__init__.py
@@ -127,9 +127,11 @@ async def get_config_entries(
     """
     returncode, output = await check_output("snapserver", "-v")
     snapserver_version = int(output.decode().split(".")[1]) if returncode == 0 else -1
-    local_snapserver_present = snapserver_version >= 27
+    local_snapserver_present = snapserver_version >= 27 and snapserver_version != 30
     if returncode == 0 and not local_snapserver_present:
-        raise SetupFailedError("Invalid snapserver version")
+        raise SetupFailedError(
+            f"Invalid snapserver version. Expected >= 27 and != 30, got {snapserver_version}"
+        )
 
     return (
         ConfigEntry(


### PR DESCRIPTION
This pull request includes a small but important change to the `music_assistant/providers/snapcast/__init__.py` file. The change adjusts the logic for determining if a local Snapserver is present by excluding version 30, and it improves the error message for invalid Snapserver versions.

* [`music_assistant/providers/snapcast/__init__.py`](diffhunk://#diff-501277de422d4f17e0b03861f010609b553d5cf9dd2c348d193baa5c1baf56c5L130-R134): Modified the `local_snapserver_present` check to exclude Snapserver version 30 and updated the `SetupFailedError` message to include the invalid version number.