### PR TITLE
Make Zeroconf only bind to the default interface

### DIFF
--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -19,7 +19,13 @@ from music_assistant_models.errors import MusicAssistantError, SetupFailedError
 from music_assistant_models.event import MassEvent
 from music_assistant_models.helpers import set_global_cache_values
 from music_assistant_models.provider import ProviderManifest
-from zeroconf import InterfaceChoice, IPVersion, NonUniqueNameException, ServiceStateChange, Zeroconf
+from zeroconf import (
+    InterfaceChoice,
+    IPVersion,
+    NonUniqueNameException,
+    ServiceStateChange,
+    Zeroconf,
+)
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from music_assistant.constants import (
@@ -129,7 +135,7 @@ class MusicAssistant:
         self.version = await get_package_version("music_assistant") or "0.0.0"
         # create shared zeroconf instance
         # TODO: enumerate interfaces and enable IPv6 support
-        self.aiozc = AsyncZeroconf(ip_version=IPVersion.V4Onlyy, interfaces=InterfaceChoice.Default)
+        self.aiozc = AsyncZeroconf(ip_version=IPVersion.V4Only, interfaces=InterfaceChoice.Default)
         # create shared aiohttp ClientSession
         self.http_session = ClientSession(
             loop=self.loop,

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -19,7 +19,7 @@ from music_assistant_models.errors import MusicAssistantError, SetupFailedError
 from music_assistant_models.event import MassEvent
 from music_assistant_models.helpers import set_global_cache_values
 from music_assistant_models.provider import ProviderManifest
-from zeroconf import IPVersion, NonUniqueNameException, ServiceStateChange, Zeroconf
+from zeroconf import InterfaceChoice, IPVersion, NonUniqueNameException, ServiceStateChange, Zeroconf
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from music_assistant.constants import (
@@ -129,7 +129,7 @@ class MusicAssistant:
         self.version = await get_package_version("music_assistant") or "0.0.0"
         # create shared zeroconf instance
         # TODO: enumerate interfaces and enable IPv6 support
-        self.aiozc = AsyncZeroconf(ip_version=IPVersion.V4Only)
+        self.aiozc = AsyncZeroconf(ip_version=IPVersion.V4Onlyy, interfaces=InterfaceChoice.Default)
         # create shared aiohttp ClientSession
         self.http_session = ClientSession(
             loop=self.loop,


### PR DESCRIPTION
Aligning Music Assistant and Home Assistant behavior. This patch forces Zeroconf to bind only to the default interface, that actually already includes all possible system interfaces

Currently Zoeroconf in Mass is listening on all interfaces, inclusing the default interface 0.0.0.0. This causes errors in setups when the system re-connects to different WiFi networks and systems dunning Docker containers.

Similar issue was fixes in Hass in 2020, issue link: https://github.com/home-assistant/core/issues/35031