### PR TITLE
Bluesound provider: use ip_address not address

### DIFF
--- a/music_assistant/providers/bluesound/__init__.py
+++ b/music_assistant/providers/bluesound/__init__.py
@@ -248,7 +248,7 @@ class BluesoundPlayerProvider(PlayerProvider):
             if mass_player := self.mass.players.get(self.player_id):
                 cur_address = get_primary_ip_address_from_zeroconf(info)
                 cur_port = get_port_from_zeroconf(info)
-                if cur_address and cur_address != mass_player.device_info.address:
+                if cur_address and cur_address != mass_player.device_info.ip_address:
                     self.logger.debug(
                         "Address updated to %s for player %s", cur_address, mass_player.display_name
                     )


### PR DESCRIPTION
`music_assistant_models.player.DeviceInfo` has an `ip_address` field, not an `address` field. I had been getting the following exceptions in the bluesound provider for a while:

```
2025-04-04 09:00:47.446 ERROR (MainThread) [music_assistant] Error doing task: Task exception was never retrieved
Traceback (most recent call last):
  File "/app/venv/lib/python3.12/site-packages/music_assistant/mass.py", line 797, in process_mdns_state_change
    await prov.on_mdns_service_state_change(name, state_change, info)
  File "/app/venv/lib/python3.12/site-packages/music_assistant/providers/bluesound/__init__.py", line 251, in on_mdns_service_state_change
    if cur_address and cur_address != mass_player.device_info.address:
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DeviceInfo' object has no attribute 'address'. Did you mean: 'ip_address'?
```

This commit addresses that exception.