### PR TITLE
Audible: fixes type error of release_date metadata

### DIFF
--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -11,7 +11,7 @@ import os
 import re
 from collections.abc import AsyncGenerator
 from contextlib import suppress
-from datetime import datetime
+from datetime import UTC, datetime
 from os import PathLike
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -531,7 +531,7 @@ class AudibleHelper:
         book.metadata.languages = UniqueList([audiobook_data.get("language") or ""])
         if release_date := audiobook_data.get("release_date"):
             with suppress(ValueError):
-                datetime.datetime.strptime(release_date, "%Y-%m-%d").astimezone(datetime.UTC)
+                datetime.strptime(release_date, "%Y-%m-%d").astimezone(UTC)
 
         # Set review if available
         reviews = audiobook_data.get("editorial_reviews", [])

--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import hashlib
 import html
 import json
@@ -527,7 +528,12 @@ class AudibleHelper:
             str(audiobook_data.get("extended_product_description", ""))
         )
         book.metadata.languages = UniqueList([audiobook_data.get("language") or ""])
-        book.metadata.release_date = audiobook_data.get("release_date")
+        release_date_str = audiobook_data.get("release_date")
+        book.metadata.release_date = (
+            datetime.datetime.strptime(release_date_str, "%Y-%m-%d").astimezone(datetime.UTC)
+            if release_date_str
+            else None
+        )
 
         # Set review if available
         reviews = audiobook_data.get("editorial_reviews", [])


### PR DESCRIPTION
Small fix to address provider crash if the audiobook returns release_date as a string