### PR TITLE
Audible: inverse of the suppoorted content type rule

### DIFF
--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -74,7 +74,7 @@ class AudibleHelper:
     ) -> tuple[Audiobook | None, int]:
         """Process a single audiobook item from the library."""
         content_type = audiobook_data.get("content_delivery_type", "")
-        if content_type in ("PodcastParent", "NonAudio"):
+        if content_type not in (["SinglePartBook"]):
             self.logger.debug(
                 "Skipping non-audiobook item: %s (%s)",
                 audiobook_data.get("title", "Unknown"),

--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -74,7 +74,7 @@ class AudibleHelper:
     ) -> tuple[Audiobook | None, int]:
         """Process a single audiobook item from the library."""
         content_type = audiobook_data.get("content_delivery_type", "")
-        if content_type not in (["SinglePartBook"]):
+        if content_type not in ("SinglePartBook",):
             self.logger.debug(
                 "Skipping non-audiobook item: %s (%s)",
                 audiobook_data.get("title", "Unknown"),


### PR DESCRIPTION
Flipped the boolean logic of what content types is supported.

Fixes: https://github.com/music-assistant/support/issues/3817