### PR TITLE
Also use previous track to work out if an album is playing

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1041,9 +1041,9 @@ class PlayerQueuesController(CoreController):
                 and queue_item.media_item.album.item_id == next_item.media_item.album.item_id
             )
         )
+        current_index = self.index_by_id(queue_id, queue_item.queue_item_id)
         previous_track_from_same_album = (
-            queue.current_index is not None
-            and (previous_index := max(queue.current_index - 1, 0))
+            (previous_index := max(current_index - 1, 0))
             and (previous_index > 0)
             and (previous_item := self.get_item(queue_id, previous_index))
             and (

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1026,8 +1026,9 @@ class PlayerQueuesController(CoreController):
             queue.display_name,
         )
 
-        # work out if we are playing an album and if we should prefer album loudness
-        playing_album_tracks = (
+        # work out if we are playing an album and if we should prefer album
+        # loudness
+        next_track_from_same_album = (
             next_index is not None
             and (next_item := self.get_item(queue_id, next_index))
             and (
@@ -1040,6 +1041,22 @@ class PlayerQueuesController(CoreController):
                 and queue_item.media_item.album.item_id == next_item.media_item.album.item_id
             )
         )
+        previous_track_from_same_album = (
+            queue.current_index is not None
+            and (previous_index := max(queue.current_index - 1, 0))
+            and (previous_index > 0)
+            and (previous_item := self.get_item(queue_id, previous_index))
+            and (
+                queue_item.media_item
+                and hasattr(queue_item.media_item, "album")
+                and queue_item.media_item.album
+                and previous_item.media_item
+                and hasattr(previous_item.media_item, "album")
+                and previous_item.media_item.album
+                and queue_item.media_item.album.item_id == previous_item.media_item.album.item_id
+            )
+        )
+        playing_album_tracks = next_track_from_same_album or previous_track_from_same_album
         if queue_item.media_item and queue_item.media_item.media_type == MediaType.TRACK:
             album = queue_item.media_item.album
             # prefer the full library media item so we have all metadata and provider(quality) info


### PR DESCRIPTION
In the previous implementation the last track in an album used the track replay gain instead of the album replay gain

Related to https://github.com/orgs/music-assistant/discussions/3822