### PR TITLE
Round loudness measurements to two digits

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -842,10 +842,11 @@ class MusicController(CoreController):
             },
         )
         if db_row and db_row["loudness"] != inf and db_row["loudness"] != -inf:
-            loudness = db_row["loudness"]
+            loudness = round(db_row["loudness"], 2)
             loudness_album = db_row["loudness_album"]
-            if loudness_album in (inf, -inf):
-                loudness_album = None
+            loudness_album = (
+                None if loudness_album in (None, inf, -inf) else round(loudness_album, 2)
+            )
             return (loudness, loudness_album)
 
         return None


### PR DESCRIPTION
This avoids very long floating point nunbers showing up in the frontend.

Before:

<img width="347" alt="image" src="https://github.com/user-attachments/assets/960ad333-c13a-4b93-97ee-4eb48e05a30e" />

After:

<img width="341" alt="image" src="https://github.com/user-attachments/assets/2022002e-8b26-4d9c-b154-ec4544e90dfb" />
