### PR TITLE
fix: library items removed by music provider not removed in MA library

### DIFF
--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -674,6 +674,8 @@ class MusicProvider(Provider):
                     library_item = await controller.update_item_in_library(
                         library_item.item_id, prov_item
                     )
+
+                cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
             except MusicAssistantError as err:
                 self.logger.warning(


### PR DESCRIPTION
The `sync_library` function of the music provider model missed adding db ids to the currently available item id set.