### PR TITLE
Fix all lowercase display names for AirPlay players

### DIFF
--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -188,8 +188,8 @@ class AirplayProvider(PlayerProvider):
         """Handle MDNS service state callback."""
         if not info:
             return
-        if "@" in name:
-            raw_id, display_name = name.split(".")[0].split("@", 1)
+        if "@" in info.name:
+            raw_id, display_name = info.name.split(".")[0].split("@", 1)
         elif deviceid := info.decoded_properties.get("deviceid"):
             raw_id = deviceid.replace(":", "")
             display_name = info.name.split(".")[0]


### PR DESCRIPTION
The Zeroconf cache keys are all lowercase, use service name from AsyncServiceInfo.