### PR TITLE
Audible: adding multipart audiobooks

### DIFF
--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -76,7 +76,7 @@ class AudibleHelper:
     ) -> tuple[Audiobook | None, int]:
         """Process a single audiobook item from the library."""
         content_type = audiobook_data.get("content_delivery_type", "")
-        if content_type not in ("SinglePartBook",):
+        if content_type not in ("SinglePartBook", "MultiPartBook"):
             self.logger.debug(
                 "Skipping non-audiobook item: %s (%s)",
                 audiobook_data.get("title", "Unknown"),


### PR DESCRIPTION
Got the hold of a multipart book and it follows the same format as a singlepart so we are in luck, all we needed was to allow multipart in the parser.

fixes: https://github.com/music-assistant/support/issues/3880