### PR TITLE
Volume fixes for native announcements

### DIFF
--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -377,7 +377,6 @@ class SonosPlayerProvider(PlayerProvider):
             announcement.uri,
             sonos_player.mass_player.display_name,
         )
-        volume_level = self.mass.players.get_announcement_volume(player_id, volume_level)
         await sonos_player.client.player.play_audio_clip(
             announcement.uri, volume_level, name="Announcement"
         )


### PR DESCRIPTION
Two volume-related fixes for native announcements:

- Sonos & Snapcast: don't call `get_announcement_volume` in `play_announcement`.
  The `volume_level` argument we get was already adjusted by `get_announcement_volume` (see `PlayerController::play_announcement`), we shouldn't adjust it twice (although in the current implementation of `get_announcement_volume` the second call makes no difference).

- Snapcast: don't adjust the volume when `volume_level is None`