### PR TITLE
[Airplay] Handle mDNS remove messages without service info

### DIFF
--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -187,14 +187,18 @@ class AirPlayProvider(PlayerProvider):
     ) -> None:
         """Handle MDNS service state callback."""
         if not info:
-            return
-        if "@" in info.name:
-            raw_id, display_name = info.name.split(".")[0].split("@", 1)
-        elif deviceid := info.decoded_properties.get("deviceid"):
-            raw_id = deviceid.replace(":", "")
-            display_name = info.name.split(".")[0]
+            if state_change != ServiceStateChange.Removed:
+                return
+            if "@" in name:
+                raw_id, display_name = name.split(".")[0].split("@", 1)
         else:
-            return
+            if "@" in info.name:
+                raw_id, display_name = info.name.split(".")[0].split("@", 1)
+            elif deviceid := info.decoded_properties.get("deviceid"):
+                raw_id = deviceid.replace(":", "")
+                display_name = info.name.split(".")[0]
+            else:
+                return
         player_id = f"ap{raw_id.lower()}"
         # handle removed player
         if state_change == ServiceStateChange.Removed:

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -187,10 +187,13 @@ class AirPlayProvider(PlayerProvider):
     ) -> None:
         """Handle MDNS service state callback."""
         if not info:
-            if state_change != ServiceStateChange.Removed:
-                return
-            if "@" in name:
+            # When info are not provided for the service
+            if state_change == ServiceStateChange.Removed and "@" in name:
+                # Service name is enough to mark the player as unavailable on 'Removed' notification
                 raw_id, display_name = name.split(".")[0].split("@", 1)
+            else:
+                # If we are not in a 'Removed' state, we need info to be filled to update correctly the player so we cannot continue
+                return
         else:
             if "@" in info.name:
                 raw_id, display_name = info.name.split(".")[0].split("@", 1)

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -194,14 +194,13 @@ class AirPlayProvider(PlayerProvider):
             else:
                 # If we are not in a 'Removed' state, we need info to be filled to update the player
                 return
+        elif "@" in info.name:
+            raw_id, display_name = info.name.split(".")[0].split("@", 1)
+        elif deviceid := info.decoded_properties.get("deviceid"):
+            raw_id = deviceid.replace(":", "")
+            display_name = info.name.split(".")[0]
         else:
-            if "@" in info.name:
-                raw_id, display_name = info.name.split(".")[0].split("@", 1)
-            elif deviceid := info.decoded_properties.get("deviceid"):
-                raw_id = deviceid.replace(":", "")
-                display_name = info.name.split(".")[0]
-            else:
-                return
+            return
         player_id = f"ap{raw_id.lower()}"
         # handle removed player
         if state_change == ServiceStateChange.Removed:

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -213,6 +213,7 @@ class AirPlayProvider(PlayerProvider):
                 self.mass.players.update(player_id)
             return
         # handle update for existing device
+        assert info is not None  # type guard
         if airplay_player := self._players.get(player_id):
             if mass_player := self.mass.players.get(player_id):
                 cur_address = get_primary_ip_address(info)

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -192,7 +192,7 @@ class AirPlayProvider(PlayerProvider):
                 # Service name is enough to mark the player as unavailable on 'Removed' notification
                 raw_id, display_name = name.split(".")[0].split("@", 1)
             else:
-                # If we are not in a 'Removed' state, we need info to be filled to update correctly the player so we cannot continue
+                # If we are not in a 'Removed' state, we need info to be filled to update the player
                 return
         else:
             if "@" in info.name:


### PR DESCRIPTION
When using some mDNS backend like avahi on shairport-sync, mDNS remove message never contains service information but contains the correct name

Currently the player is correctly discovered but if you down it, its state is never updated to 'unavailable' This is causing an issue if we try to play a music on it when it's down because of music assistant just making the Airplay provider unusable and a restart of the server is needed (for all other Airplay player too)

Since service info are needed only to register the player, this change provides a fallback for this type of mDNS services that will just try to parse the name in case it's a remove state change and no info are provided