### PR TITLE
Update python-snapcast to 2.3.7 (Fix player deletion)

### DIFF
--- a/music_assistant/providers/snapcast/__init__.py
+++ b/music_assistant/providers/snapcast/__init__.py
@@ -460,10 +460,11 @@ class SnapCastProvider(PlayerProvider):
 
     async def remove_player(self, player_id: str) -> None:
         """Remove the client from the snapserver when it is deleted."""
-        try:
-            await self._snapserver.delete_client(self._get_snapclient_id(player_id))
-        except TypeError as err:
-            self.logger.warning("Unable to remove snapclient %s: %s", player_id, str(err))
+        result, error = await self._snapserver.delete_client(self._get_snapclient_id(player_id))
+        if result:
+            self.logger.debug("Snapclient removed %s", player_id)
+        else:
+            self.logger.warning("Unable to remove snapclient %s: %s", player_id, error)
 
     async def cmd_volume_set(self, player_id: str, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""

--- a/music_assistant/providers/snapcast/__init__.py
+++ b/music_assistant/providers/snapcast/__init__.py
@@ -460,11 +460,11 @@ class SnapCastProvider(PlayerProvider):
 
     async def remove_player(self, player_id: str) -> None:
         """Remove the client from the snapserver when it is deleted."""
-        result, error = await self._snapserver.delete_client(self._get_snapclient_id(player_id))
-        if result:
+        success, error_msg = await self._snapserver.delete_client(self._get_snapclient_id(player_id))
+        if success:
             self.logger.debug("Snapclient removed %s", player_id)
         else:
-            self.logger.warning("Unable to remove snapclient %s: %s", player_id, error)
+            self.logger.warning("Unable to remove snapclient %s: %s", player_id, error_msg)
 
     async def cmd_volume_set(self, player_id: str, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""

--- a/music_assistant/providers/snapcast/manifest.json
+++ b/music_assistant/providers/snapcast/manifest.json
@@ -5,7 +5,7 @@
   "description": "Support for snapcast server and clients.",
   "codeowners": ["@SantiagoSotoC"],
   "requirements": [
-    "snapcast==2.3.6",
+    "snapcast==2.3.7",
     "bidict==0.23.1",
     "websocket-client==1.8.0"
   ],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -47,7 +47,7 @@ pywidevine==1.8.0
 radios==0.3.2
 setuptools>=1.0.0
 shortuuid==1.0.13
-snapcast==2.3.6
+snapcast==2.3.7
 soco==0.30.9
 soundcloudpy==0.1.2
 sxm==0.2.8


### PR DESCRIPTION
This PR updates the `python-snapcast` library to version 2.3.7. The changes in this PR are a result of this update, which includes a fix for the provider method that allows deleting music players.