### PR TITLE
Add extra artist splitters in tag parser

### DIFF
--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -66,7 +66,7 @@ def split_artists(
     # string. Try to parse the featuring artists and separate them.
     splitters = (
         "featuring", " feat. ", " feat ", "feat.",
-        "duet with", "with", " with ", " duet with "
+        "duet with", "with", " duet with ", " with "
     )
     if allow_ampersand:
         splitters = (*splitters, " & ")

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -64,7 +64,7 @@ def split_artists(
     # when not using the multi artist tag, the artist string may contain
     # multiple artists in freeform, even featuring artists may be included in this
     # string. Try to parse the featuring artists and separate them.
-    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ", 
+    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ",
                  " duet with ", "duet with")
     if allow_ampersand:
         splitters = (*splitters, " & ")

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -71,6 +71,7 @@ def split_artists(
         " duet with ",
         " with ",
         " ft. ",
+        " vs. ",
         ", ",
         " + ",
     )

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -71,7 +71,7 @@ def split_artists(
         " duet with ",
         " with ",
         " ft. ",
-        " Ft. "
+        " Ft. ",
     )
     if allow_ampersand:
         splitters = (*splitters, " & ")

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -64,7 +64,7 @@ def split_artists(
     # when not using the multi artist tag, the artist string may contain
     # multiple artists in freeform, even featuring artists may be included in this
     # string. Try to parse the featuring artists and separate them.
-    splitters = ("featuring", " feat. ", " feat ", "feat.")
+    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ")
     if allow_ampersand:
         splitters = (*splitters, " & ")
     artists = split_items(org_artists, allow_unsafe_splitters=False)

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -70,6 +70,8 @@ def split_artists(
         " feat ",
         " duet with ",
         " with ",
+        " ft. ",
+        " Ft. "
     )
     if allow_ampersand:
         splitters = (*splitters, " & ")

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -68,8 +68,6 @@ def split_artists(
         " featuring ",
         " feat. ",
         " feat ",
-        "duet with",
-        "with",
         " duet with ",
         " with ",
     )

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -68,7 +68,6 @@ def split_artists(
         "featuring",
         " feat. ",
         " feat ",
-        "feat.",
         "duet with",
         "with",
         " duet with ",

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -65,8 +65,14 @@ def split_artists(
     # multiple artists in freeform, even featuring artists may be included in this
     # string. Try to parse the featuring artists and separate them.
     splitters = (
-        "featuring", " feat. ", " feat ", "feat.",
-        "duet with", "with", " duet with ", " with "
+        "featuring",
+        " feat. ",
+        " feat ",
+        "feat.",
+        "duet with",
+        "with",
+        " duet with ",
+        " with ",
     )
     if allow_ampersand:
         splitters = (*splitters, " & ")

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -71,7 +71,8 @@ def split_artists(
         " duet with ",
         " with ",
         " ft. ",
-        " Ft. ",
+        ", ",
+        " + ",
     )
     if allow_ampersand:
         splitters = (*splitters, " & ")

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -57,14 +57,14 @@ def split_items(org_str: str, allow_unsafe_splitters: bool = False) -> tuple[str
 
 
 def split_artists(
-    org_artists: str | tuple[str, ...], allow_ampersand: bool = False
+    org_artists: str | tuple[str, ...], allow_extra_splitters: bool = False
 ) -> tuple[str, ...]:
     """Parse all artists from a string."""
     final_artists: list[str] = []
     # when not using the multi artist tag, the artist string may contain
     # multiple artists in freeform, even featuring artists may be included in this
     # string. Try to parse the featuring artists and separate them.
-    splitters = (
+    splitters = [
         " featuring ",
         " feat. ",
         " feat ",
@@ -72,11 +72,10 @@ def split_artists(
         " with ",
         " ft. ",
         " vs. ",
-        ", ",
-        " + ",
-    )
-    if allow_ampersand:
-        splitters = (*splitters, " & ")
+    ]
+    splitters += [x.title() for x in splitters]
+    if allow_extra_splitters:
+        splitters += [" & ", ", ", " + "]
     artists = split_items(org_artists, allow_unsafe_splitters=False)
     for item in artists:
         for splitter in splitters:
@@ -160,6 +159,11 @@ class AudioTags:
         if tag := self.tags.get("artist"):
             if TAG_SPLITTER in tag:
                 return split_items(tag)
+            if len(self.musicbrainz_artistids) > 1:
+                # special case: artist noted as 2 artists with ampersand or other splitter
+                # but with 2 mb ids so they should be treated as 2 artists
+                # example: John Travolta & Olivia Newton John on the Grease album
+                return split_artists(tag, allow_extra_splitters=True)
             return split_artists(tag)
         # fallback to parsing from filename
         title = self.filename.rsplit(os.sep, 1)[-1].split(".")[0]
@@ -193,10 +197,10 @@ class AudioTags:
             if TAG_SPLITTER in tag:
                 return split_items(tag)
             if len(self.musicbrainz_albumartistids) > 1:
-                # special case: album artist noted as 2 artists with ampersand
+                # special case: album artist noted as 2 artists with ampersand or other splitter
                 # but with 2 mb ids so they should be treated as 2 artists
                 # example: John Travolta & Olivia Newton John on the Grease album
-                return split_artists(tag, allow_ampersand=True)
+                return split_artists(tag, allow_extra_splitters=True)
             return split_artists(tag)
         return ()
 

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -64,7 +64,8 @@ def split_artists(
     # when not using the multi artist tag, the artist string may contain
     # multiple artists in freeform, even featuring artists may be included in this
     # string. Try to parse the featuring artists and separate them.
-    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ", " duet with ", "duet with")
+    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ", 
+                 " duet with ", "duet with")
     if allow_ampersand:
         splitters = (*splitters, " & ")
     artists = split_items(org_artists, allow_unsafe_splitters=False)

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -66,7 +66,7 @@ def split_artists(
     # string. Try to parse the featuring artists and separate them.
     splitters = (
         "featuring", " feat. ", " feat ", "feat.",
-        "with", " with ", " duet with ", "duet with"
+        "duet with", "with", " with ", " duet with "
     )
     if allow_ampersand:
         splitters = (*splitters, " & ")

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -64,7 +64,7 @@ def split_artists(
     # when not using the multi artist tag, the artist string may contain
     # multiple artists in freeform, even featuring artists may be included in this
     # string. Try to parse the featuring artists and separate them.
-    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ", "duet with", " duet with ")
+    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ", " duet with ", "duet with")
     if allow_ampersand:
         splitters = (*splitters, " & ")
     artists = split_items(org_artists, allow_unsafe_splitters=False)

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -65,7 +65,7 @@ def split_artists(
     # multiple artists in freeform, even featuring artists may be included in this
     # string. Try to parse the featuring artists and separate them.
     splitters = (
-        "featuring",
+        " featuring ",
         " feat. ",
         " feat ",
         "duet with",

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -64,7 +64,7 @@ def split_artists(
     # when not using the multi artist tag, the artist string may contain
     # multiple artists in freeform, even featuring artists may be included in this
     # string. Try to parse the featuring artists and separate them.
-    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ")
+    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ", "duet with", " duet with ")
     if allow_ampersand:
         splitters = (*splitters, " & ")
     artists = split_items(org_artists, allow_unsafe_splitters=False)

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -64,8 +64,10 @@ def split_artists(
     # when not using the multi artist tag, the artist string may contain
     # multiple artists in freeform, even featuring artists may be included in this
     # string. Try to parse the featuring artists and separate them.
-    splitters = ("featuring", " feat. ", " feat ", "feat.", "with", " with ",
-                 " duet with ", "duet with")
+    splitters = (
+        "featuring", " feat. ", " feat ", "feat.",
+        "with", " with ", " duet with ", "duet with"
+    )
     if allow_ampersand:
         splitters = (*splitters, " & ")
     artists = split_items(org_artists, allow_unsafe_splitters=False)


### PR DESCRIPTION
This might fix https://github.com/music-assistant/support/issues/3926

Musicbrainz shows this 
![image](https://github.com/user-attachments/assets/3b2e32d4-6f50-4593-95a4-550b43301cd8)

I considered that perhaps an artist might have "with" in their name but it appears not according to ChatGPT and the MB Artist IDs should clarify anyway?

![image](https://github.com/user-attachments/assets/1624b130-6130-4a0e-910b-b6d84feec6b0)
