### PR TITLE
fix: musiccast - volume level handling + device discovery + current track

### DIFF
--- a/music_assistant/providers/musiccast/__init__.py
+++ b/music_assistant/providers/musiccast/__init__.py
@@ -9,7 +9,10 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
-from aiohttp.client_exceptions import ServerDisconnectedError
+from aiohttp.client_exceptions import (
+    ClientError,
+    ServerDisconnectedError,
+)
 from aiomusiccast.exceptions import MusicCastGroupException
 from aiomusiccast.musiccast_device import MusicCastDevice
 from aiomusiccast.pyamaha import MusicCastConnectionException
@@ -512,10 +515,16 @@ class MusicCast(PlayerProvider):
         device_ip = get_primary_ip_address(info)
         if device_ip is None:
             return
-        device_info = await self.mass.http_session.get(
-            f"http://{device_ip}/{MC_DEVICE_INFO_ENDPOINT}"
-        )
-        if device_info.status == 404:
+        try:
+            device_info = await self.mass.http_session.get(
+                f"http://{device_ip}/{MC_DEVICE_INFO_ENDPOINT}", raise_for_status=True
+            )
+        except ClientError:
+            # typical Errors are
+            # ClientResponseError -> raise_for_status
+            # ClientConnectorError -> unable to connect/ not existing/ timeout
+            # but we can use the base exception class, as we only check
+            # if the device is suitable
             return
         device_info_json = await device_info.json()
         device_id = device_info_json.get("device_id")

--- a/music_assistant/providers/musiccast/__init__.py
+++ b/music_assistant/providers/musiccast/__init__.py
@@ -752,7 +752,7 @@ class MusicCast(PlayerProvider):
         # and player.set_current_media is the helper function
         # do not access the queue controller to gain playback information here
         if update_helper.current_uri is not None and update_helper.controlled_by_mass:
-            player.set_current_media(uri=update_helper.current_uri)
+            player.set_current_media(uri=update_helper.current_uri, clear_all=True)
         elif device.is_client:
             _server = device.group_server
             _server_id = self._get_player_id_from_mc_zone_player(_server)

--- a/music_assistant/providers/musiccast/__init__.py
+++ b/music_assistant/providers/musiccast/__init__.py
@@ -7,7 +7,7 @@ import logging
 import time
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp.client_exceptions import ServerDisconnectedError
 from aiomusiccast.exceptions import MusicCastGroupException
@@ -656,9 +656,19 @@ class MusicCast(PlayerProvider):
         player.name = zone_data.name or "UNKNOWN NAME"
         player.powered = zone_data.power == "on"
 
-        player.volume_level = int(
-            zone_data.current_volume / (zone_data.max_volume - zone_data.min_volume) * 100
-        )
+        # NOTE: aiomusiccast does not type hint the volume variables, and they may
+        # be none, and not only integers
+        _current_volume = cast("int | None", zone_data.current_volume)
+        _max_volume = cast("int | None", zone_data.max_volume)
+        _min_volume = cast("int | None", zone_data.min_volume)
+        if _current_volume is None:
+            player.volume_level = None
+        else:
+            _min_volume = 0 if _min_volume is None else _min_volume
+            _max_volume = 100 if _max_volume is None else _max_volume
+            if _min_volume == _max_volume:
+                _max_volume += 1
+            player.volume_level = int(_current_volume / (_max_volume - _min_volume) * 100)
         player.volume_muted = zone_data.mute
 
         # STATE


### PR DESCRIPTION
Fixes for 2 bugs reported in music-assistant/support#3953

1. volume attributes have no type hints in aiomusiccast, and can be None - this is properly handled now
2. device discovery did not cover all possible connection errors - this should be fixed as well

Update May, 4th:
I added an additional commit - the current song/ queue progress didn't update correctly, but playing itself was without problems. Fixed by using "clear_all" within the current_media helper function.
