### PR TITLE
Add local lrc lyrics parsing to filesystem provider

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -971,6 +971,16 @@ class LocalFileSystemProvider(MusicProvider):
                     tags.track_album_loudness,
                 )
             )
+
+        # possible lrclib metadata
+        # synced lyrics are saved as "filename.lrc" by lrcget alongside
+        # the actual file location - just change the file extension
+        assert file_item.ext is not None  # for type checking
+        lrc_path = f"{file_item.absolute_path.removesuffix(file_item.ext)}lrc"
+        if await self.exists(lrc_path):
+            async with aiofiles.open(lrc_path) as lrc_file:
+                track.metadata.lrc_lyrics = await lrc_file.read()
+
         return track
 
     async def _parse_artist(

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -972,9 +972,14 @@ class LocalFileSystemProvider(MusicProvider):
                 )
             )
 
-        # lrc lyrics
-        if lrc_lyrics := await self._get_lrc_data(track):
-            track.metadata.lrc_lyrics = lrc_lyrics
+        # possible lrclib metadata
+        # synced lyrics are saved as "filename.lrc" by lrcget alongside
+        # the actual file location - just change the file extension
+        assert file_item.ext is not None  # for type checking
+        lrc_path = f"{file_item.absolute_path.removesuffix(file_item.ext)}lrc"
+        if await self.exists(lrc_path):
+            async with aiofiles.open(lrc_path) as lrc_file:
+                track.metadata.lrc_lyrics = await lrc_file.read()
 
         return track
 
@@ -1499,21 +1504,6 @@ class LocalFileSystemProvider(MusicProvider):
 
         await self.cache.set(folder, images, base_key=cache_base_key, expiration=120)
         return images
-
-    async def _get_lrc_data(self, track: Track) -> str | None:
-        # possible lrclib metadata
-        # synced lyrics are saved as "filename.lrc" by lrcget alongside
-        # the actual file location - just change the file extension
-        file_item = await self.resolve(track.item_id)
-        assert file_item.ext is not None  # for type checking
-        lrc_path = f"{file_item.absolute_path.removesuffix(file_item.ext)}lrc"
-        if await self.exists(lrc_path):
-            async with aiofiles.open(lrc_path) as lrc_file:
-                lrc_lyrics = await lrc_file.read()
-                if not isinstance(lrc_lyrics, str):
-                    return None
-                return lrc_lyrics
-        return None
 
     async def check_write_access(self) -> None:
         """Perform check if we have write access."""

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -972,14 +972,9 @@ class LocalFileSystemProvider(MusicProvider):
                 )
             )
 
-        # possible lrclib metadata
-        # synced lyrics are saved as "filename.lrc" by lrcget alongside
-        # the actual file location - just change the file extension
-        assert file_item.ext is not None  # for type checking
-        lrc_path = f"{file_item.absolute_path.removesuffix(file_item.ext)}lrc"
-        if await self.exists(lrc_path):
-            async with aiofiles.open(lrc_path) as lrc_file:
-                track.metadata.lrc_lyrics = await lrc_file.read()
+        # lrc lyrics
+        if lrc_lyrics := await self._get_lrc_data(track):
+            track.metadata.lrc_lyrics = lrc_lyrics
 
         return track
 
@@ -1504,6 +1499,21 @@ class LocalFileSystemProvider(MusicProvider):
 
         await self.cache.set(folder, images, base_key=cache_base_key, expiration=120)
         return images
+
+    async def _get_lrc_data(self, track: Track) -> str | None:
+        # possible lrclib metadata
+        # synced lyrics are saved as "filename.lrc" by lrcget alongside
+        # the actual file location - just change the file extension
+        file_item = await self.resolve(track.item_id)
+        assert file_item.ext is not None  # for type checking
+        lrc_path = f"{file_item.absolute_path.removesuffix(file_item.ext)}lrc"
+        if await self.exists(lrc_path):
+            async with aiofiles.open(lrc_path) as lrc_file:
+                lrc_lyrics = await lrc_file.read()
+                if not isinstance(lrc_lyrics, str):
+                    return None
+                return lrc_lyrics
+        return None
 
     async def check_write_access(self) -> None:
         """Perform check if we have write access."""

--- a/music_assistant/providers/lrclib/__init__.py
+++ b/music_assistant/providers/lrclib/__init__.py
@@ -16,6 +16,8 @@ from music_assistant_models.media_items import MediaItemMetadata, Track
 
 from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
 from music_assistant.models.metadata_provider import MetadataProvider
+from music_assistant.providers.filesystem_local import LocalFileSystemProvider
+from music_assistant.providers.filesystem_smb import SMBFileSystemProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
@@ -109,6 +111,16 @@ class LrclibProvider(MetadataProvider):
                 "Skipping lyrics lookup for %s: Already has synchronized lyrics", track.name
             )
             return None
+
+        # check, if the track comes from any filesystem provider, and might have stored
+        # local lyrics
+        if (filesystem_provider := self.mass.get_provider(track.provider)) and isinstance(
+            filesystem_provider, LocalFileSystemProvider | SMBFileSystemProvider
+        ):
+            if lrc_lyrics := await filesystem_provider._get_lrc_data(track):
+                metadata = MediaItemMetadata()
+                metadata.lrc_lyrics = lrc_lyrics
+                return metadata
 
         if not track.artists:
             self.logger.debug("Skipping lyrics lookup for %s: No artist information", track.name)

--- a/music_assistant/providers/lrclib/__init__.py
+++ b/music_assistant/providers/lrclib/__init__.py
@@ -16,8 +16,6 @@ from music_assistant_models.media_items import MediaItemMetadata, Track
 
 from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
 from music_assistant.models.metadata_provider import MetadataProvider
-from music_assistant.providers.filesystem_local import LocalFileSystemProvider
-from music_assistant.providers.filesystem_smb import SMBFileSystemProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
@@ -111,16 +109,6 @@ class LrclibProvider(MetadataProvider):
                 "Skipping lyrics lookup for %s: Already has synchronized lyrics", track.name
             )
             return None
-
-        # check, if the track comes from any filesystem provider, and might have stored
-        # local lyrics
-        if (filesystem_provider := self.mass.get_provider(track.provider)) and isinstance(
-            filesystem_provider, LocalFileSystemProvider | SMBFileSystemProvider
-        ):
-            if lrc_lyrics := await filesystem_provider._get_lrc_data(track):
-                metadata = MediaItemMetadata()
-                metadata.lrc_lyrics = lrc_lyrics
-                return metadata
 
         if not track.artists:
             self.logger.debug("Skipping lyrics lookup for %s: No artist information", track.name)


### PR DESCRIPTION
Adds reading a local lrc file to the filesystem provider as discussed on github (1st commit). 

The 2. commit is and idea how this could be used in the lrclib provider - should the local lrc file have been added later than the library sync, then we could still receive it. However, **I didn't know how to properly test the lrc provider part.**