### PR TITLE
Use webserver for auth helper

### DIFF
--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -129,7 +129,8 @@ async def get_config_entries(
     if action == "CONF_ACTION_AUTH":
         # TODO: check the developer token is valid otherwise user is going to have bad experience
         async with AuthenticationHelper(mass, values["session_id"]) as auth_helper:
-            flow_base_url = f"apple_music_auth/{values['session_id']}/"
+            callback_url = auth_helper.callback_url
+            flow_base_path = f"apple_music_auth/{values['session_id']}/"
             flow_timeout = 600
             parent_file_path = pathlib.Path(__file__).parent.resolve()
 
@@ -144,17 +145,20 @@ async def get_config_entries(
             async def serve_mk_glue(request: web.Request) -> web.Response:
                 return_html = f"const app_token='{values[CONF_MUSIC_APP_TOKEN]}';"
                 return_html += f"const user_token='{values[CONF_MUSIC_USER_TOKEN]}';"
-                return_html += f"const return_url='{auth_helper.callback_url}';"
+                return_html += f"const return_url='{callback_url}';"
                 return_html += f"const flow_timeout={flow_timeout - 10};"
                 return_html += f"const mass_buid='{mass.version}';"
                 return web.Response(body=return_html, headers={"content-type": "text/javascript"})
 
-            mass.webserver.register_dynamic_route(f"/{flow_base_url}index.html", serve_mk_auth_page)
-            mass.webserver.register_dynamic_route(f"/{flow_base_url}index.css", serve_mk_auth_css)
-            mass.webserver.register_dynamic_route(f"/{flow_base_url}index.js", serve_mk_glue)
+            mass.webserver.register_dynamic_route(
+                f"/{flow_base_path}index.html", serve_mk_auth_page
+            )
+            mass.webserver.register_dynamic_route(f"/{flow_base_path}index.css", serve_mk_auth_css)
+            mass.webserver.register_dynamic_route(f"/{flow_base_path}index.js", serve_mk_glue)
+            flow_base_url = f"{mass.webserver.base_url}/{flow_base_path}index.html"
             try:
                 values[CONF_MUSIC_USER_TOKEN] = (
-                    await auth_helper.authenticate(f"{flow_base_url}index.html", flow_timeout)
+                    await auth_helper.authenticate(flow_base_url, flow_timeout)
                 )["music-user-token"]
             except KeyError:
                 # no music-user-token URL param was found so user probably cancelled the auth
@@ -162,9 +166,9 @@ async def get_config_entries(
             except Exception as error:
                 raise LoginFailed(f"Failed to authenticate with Apple '{error}'.")
             finally:
-                mass.webserver.unregister_dynamic_route(f"/{flow_base_url}index.html")
-                mass.webserver.unregister_dynamic_route(f"/{flow_base_url}index.css")
-                mass.webserver.unregister_dynamic_route(f"/{flow_base_url}index.js")
+                mass.webserver.unregister_dynamic_route(f"/{flow_base_path}index.html")
+                mass.webserver.unregister_dynamic_route(f"/{flow_base_path}index.css")
+                mass.webserver.unregister_dynamic_route(f"/{flow_base_path}index.js")
 
     # ruff: noqa: ARG001
     return (


### PR DESCRIPTION
Always prefer webserver for auth helper and try to dynamically detect/handle reverse proxy/ingress in front of the webserver.
Unfortunately this also has a few side effects but we'll have to look into those one by one.

This is a preparation in order to fix the auth issue of Apple Music when used behind Ingress.