### PR TITLE
Fix: Prevent NoneType error whenever the track or album name is empty in a Plex playlist

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -425,8 +425,18 @@ class PlexProvider(MusicProvider):
         return cast("PlexObjectT", results)
 
     def _get_item_mapping(self, media_type: MediaType, key: str, name: str) -> ItemMapping:
+        """Get item mapping for a given media type, key, and name."""
+        # Ensure name is a valid string
+        if not name:
+            self.logger.warning(
+                "Received None or empty name for media item. Media type: %s, Key: %s",
+                media_type,
+                key,
+            )
+            name = "[Unknown]"  # Default name if None or empty
+
         mapped_name, mapped_version = parse_title_and_version(name)
-        
+
         if not mapped_name:
             self.logger.warning(
                 "Failed to map name for media item. Media type: %s, Key: %s, Original name: %s",

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -426,14 +426,13 @@ class PlexProvider(MusicProvider):
 
     def _get_item_mapping(self, media_type: MediaType, key: str, name: str) -> ItemMapping:
         """Get item mapping for a given media type, key, and name."""
-        # Ensure name is a valid string
         if not name:
             self.logger.info(
                 "Received None or empty name for media item. Media type: %s, Key: %s",
                 media_type,
                 key,
             )
-            name = "[Unknown]"  # Default name if None or empty
+            name = "[Unknown]"
 
         mapped_name, mapped_version = parse_title_and_version(name)
 
@@ -444,10 +443,10 @@ class PlexProvider(MusicProvider):
                 key,
                 name,
             )
-            mapped_name = "[Unknown]"  # Default name if mapping fails
+            mapped_name = "[Unknown]"
         if not mapped_version and media_type not in (MediaType.ALBUM, MediaType.TRACK):
-            mapped_version = ""  # Default version if parsing fails
-        
+            mapped_version = ""
+
         return ItemMapping(
             media_type=media_type,
             item_id=key,

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -425,17 +425,25 @@ class PlexProvider(MusicProvider):
         return cast("PlexObjectT", results)
 
     def _get_item_mapping(self, media_type: MediaType, key: str, name: str) -> ItemMapping:
-        name, version = parse_title_and_version(name)
-        if media_type in (MediaType.ALBUM, MediaType.TRACK):
-            name, version = parse_title_and_version(name)
-        else:
-            version = ""
+        mapped_name, mapped_version = parse_title_and_version(name)
+        
+        if not mapped_name:
+            self.logger.warning(
+                "Failed to map name for media item. Media type: %s, Key: %s, Original name: %s",
+                media_type,
+                key,
+                name,
+            )
+            mapped_name = "[Unknown]"  # Default name if mapping fails
+        if not mapped_version and media_type not in (MediaType.ALBUM, MediaType.TRACK):
+            mapped_version = ""  # Default version if parsing fails
+        
         return ItemMapping(
             media_type=media_type,
             item_id=key,
             provider=self.lookup_key,
-            name=name,
-            version=version,
+            name=mapped_name,
+            version=mapped_version,
         )
 
     async def _get_or_create_artist_by_name(self, artist_name: str) -> Artist | ItemMapping:

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -428,7 +428,7 @@ class PlexProvider(MusicProvider):
         """Get item mapping for a given media type, key, and name."""
         # Ensure name is a valid string
         if not name:
-            self.logger.warning(
+            self.logger.info(
                 "Received None or empty name for media item. Media type: %s, Key: %s",
                 media_type,
                 key,
@@ -438,7 +438,7 @@ class PlexProvider(MusicProvider):
         mapped_name, mapped_version = parse_title_and_version(name)
 
         if not mapped_name:
-            self.logger.warning(
+            self.logger.info(
                 "Failed to map name for media item. Media type: %s, Key: %s, Original name: %s",
                 media_type,
                 key,


### PR DESCRIPTION
This pull request resolves cases when a Plex playlist has one (or more) track where the track name and/or album are not defined. In this case, a NoneType error exception was raised, and loading the playlist was totally blocked, as described in https://github.com/music-assistant/support/issues/2711#issuecomment-2746682724.

Additional info log message added for the user to be notified.