### PR TITLE
 Improve sync stability by adapting to diff trend shifts

### DIFF
--- a/music_assistant/providers/squeezelite/__init__.py
+++ b/music_assistant/providers/squeezelite/__init__.py
@@ -759,7 +759,7 @@ class SlimprotoProvider(PlayerProvider):
             - self._get_corrected_elapsed_milliseconds(slimplayer)
         )
 
-	sync_playpoints.append(SyncPlayPoint(now, sync_master.player_id, diff))
+        sync_playpoints.append(SyncPlayPoint(now, sync_master.player_id, diff))
 
         # ignore unexpected spikes
         if (

--- a/music_assistant/providers/squeezelite/__init__.py
+++ b/music_assistant/providers/squeezelite/__init__.py
@@ -759,15 +759,14 @@ class SlimprotoProvider(PlayerProvider):
             - self._get_corrected_elapsed_milliseconds(slimplayer)
         )
 
+	sync_playpoints.append(SyncPlayPoint(now, sync_master.player_id, diff))
+
         # ignore unexpected spikes
         if (
             sync_playpoints
-            and abs(statistics.fmean(x.diff for x in sync_playpoints)) > DEVIATION_JUMP_IGNORE
+            and abs(statistics.fmean(abs(x.diff) for x in sync_playpoints) - abs(diff)) > DEVIATION_JUMP_IGNORE
         ):
             return
-
-        # we can now append the current playpoint to our list
-        sync_playpoints.append(SyncPlayPoint(now, sync_master.player_id, diff))
 
         min_req_playpoints = 2 if sync_master.elapsed_seconds < 2 else MIN_REQ_PLAYPOINTS
         if len(sync_playpoints) < min_req_playpoints:

--- a/music_assistant/providers/squeezelite/__init__.py
+++ b/music_assistant/providers/squeezelite/__init__.py
@@ -764,9 +764,8 @@ class SlimprotoProvider(PlayerProvider):
         # ignore unexpected spikes
         if (
             sync_playpoints
-            and abs(
-                statistics.fmean(abs(x.diff) for x in sync_playpoints) - abs(diff)
-            ) > DEVIATION_JUMP_IGNORE
+            and abs(statistics.fmean(abs(x.diff) for x in sync_playpoints) - abs(diff))
+            > DEVIATION_JUMP_IGNORE
         ):
             return
 

--- a/music_assistant/providers/squeezelite/__init__.py
+++ b/music_assistant/providers/squeezelite/__init__.py
@@ -764,7 +764,9 @@ class SlimprotoProvider(PlayerProvider):
         # ignore unexpected spikes
         if (
             sync_playpoints
-            and abs(statistics.fmean(abs(x.diff) for x in sync_playpoints) - abs(diff)) > DEVIATION_JUMP_IGNORE
+            and abs(
+                statistics.fmean(abs(x.diff) for x in sync_playpoints) - abs(diff)
+            ) > DEVIATION_JUMP_IGNORE
         ):
             return
 


### PR DESCRIPTION
📌 **Summary**
This PR refines the synchronization logic for the Squeezelite provider to better handle temporary spikes and shifting playback trends. Instead of rejecting large diffs outright, we now append all samples and evaluate whether the latest sample deviates significantly from the absolute average of previous diffs.

✅ **Motivation**
Previously, a single large diff value early in the sync process could poison the floating-point mean and prevent future points from being added — effectively stalling synchronization. This was problematic, especially if the spike was part of a genuine shift in playback timing. This behavior was particularly detrimental on less powerful devices like ESP32 running squeezelite-esp32 over Wi-Fi.

🔄 **What's Changed**
- Always append the current sync point (diff) to the list.
- Changed sync filter to compare the current diff against the absolute mean of previous diffs, instead of checking if the mean itself exceeds a threshold. This allows the sync logic to detect and adjust to new trends, rather than blocking them prematurely.
- Maintains protection against random spikes while allowing the mean to evolve.

📈 **Benefits**
- Eliminates deadlock caused by early outliers.
- Improves responsiveness to gradual drift or jump in sync.