### PR TITLE
Fix spaces in GUID for podcasts in iTunes and Gpodder

### DIFF
--- a/music_assistant/providers/gpodder/__init__.py
+++ b/music_assistant/providers/gpodder/__init__.py
@@ -510,9 +510,9 @@ class GPodder(MusicProvider):
         self, prov_episode_id: str, add_progress: bool = True
     ) -> PodcastEpisode:
         """Get Podcast Episode. Add progress information."""
-        podcast_id, guid_or_stream_url = prov_episode_id.split(" ")
+        podcast_id, guid_or_stream_url = prov_episode_id.split(" ", 1)
         async for mass_episode in self.get_podcast_episodes(podcast_id, add_progress=add_progress):
-            _, _guid_or_stream_url = mass_episode.item_id.split(" ")
+            _, _guid_or_stream_url = mass_episode.item_id.split(" ", 1)
             # this is enough, as internal
             if guid_or_stream_url == _guid_or_stream_url:
                 return mass_episode
@@ -521,7 +521,7 @@ class GPodder(MusicProvider):
     async def get_resume_position(self, item_id: str, media_type: MediaType) -> tuple[bool, int]:
         """Return: finished, position_ms."""
         assert media_type == MediaType.PODCAST_EPISODE
-        podcast_id, guid_or_stream_url = item_id.split(" ")
+        podcast_id, guid_or_stream_url = item_id.split(" ", 1)
         stream_url = await self._get_episode_stream_url(podcast_id, guid_or_stream_url)
         try:
             progresses, timestamp = await self._client.get_episode_actions(
@@ -568,7 +568,7 @@ class GPodder(MusicProvider):
             return
         if time.time() - self.progress_guard_timestamp <= 5:
             return
-        podcast_id, guid_or_stream_url = prov_item_id.split(" ")
+        podcast_id, guid_or_stream_url = prov_item_id.split(" ", 1)
         stream_url = await self._get_episode_stream_url(podcast_id, guid_or_stream_url)
         assert stream_url is not None
         duration = media_item.duration
@@ -587,7 +587,7 @@ class GPodder(MusicProvider):
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Get streamdetails for item."""
-        podcast_id, guid_or_stream_url = item_id.split(" ")
+        podcast_id, guid_or_stream_url = item_id.split(" ", 1)
         stream_url = await self._get_episode_stream_url(podcast_id, guid_or_stream_url)
         if stream_url is None:
             raise MediaNotFoundError

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -241,9 +241,9 @@ class ITunesPodcastsProvider(MusicProvider):
 
     async def get_podcast_episode(self, prov_episode_id: str) -> PodcastEpisode:
         """Get single podcast episode."""
-        podcast_id, guid_or_stream_url = prov_episode_id.split(" ")
+        podcast_id, guid_or_stream_url = prov_episode_id.split(" ", 1)
         async for mass_episode in self.get_podcast_episodes(podcast_id):
-            _, _guid_or_stream_url = mass_episode.item_id.split(" ")
+            _, _guid_or_stream_url = mass_episode.item_id.split(" ", 1)
             # this is enough, as internal
             if guid_or_stream_url == _guid_or_stream_url:
                 return mass_episode
@@ -281,7 +281,7 @@ class ITunesPodcastsProvider(MusicProvider):
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Get streamdetails for item."""
-        podcast_id, guid_or_stream_url = item_id.split(" ")
+        podcast_id, guid_or_stream_url = item_id.split(" ", 1)
         stream_url = await self._get_episode_stream_url(podcast_id, guid_or_stream_url)
         if stream_url is None:
             raise MediaNotFoundError


### PR DESCRIPTION
Currently, if the RSS feed GUID has a space in it, such as in the [This American Life](https://www.thisamericanlife.org/podcast/rss.xml) podcast, both iTunes Podcast Search and Gpodder break due to splitting on every space. This PR fixes that issue by forcing them to only split on the first space.

I don't really like that this requires combining two strings and then splitting them apart later, and it would break if the podcast ID had a space in it, but this works well enough for now while I'm attempting a refactor.