### PR TITLE
Fix typo preventing translation

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1193,7 +1193,7 @@ class MusicController(CoreController):
                 item_id="favorite_radio",
                 provider="library",
                 name="Favorite Radio stations",
-                translation_key="favorite_radio",
+                translation_key="favorite_radio_stations",
                 icon="mdi-access-point",
                 items=await self.radio.library_items(favorite=True, limit=10, order_by="random"),
             ),


### PR DESCRIPTION
Translation was noted to be not working. Translation key appears incorrect based on this:

![image](https://github.com/user-attachments/assets/61da0677-1c4f-42be-afe7-4de1eb308790)
