### PR TITLE
Fix library query with random order

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -715,7 +715,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         query_parts: list[str] = extra_query_parts or []
         join_parts: list[str] = extra_join_parts or []
         # create special performant random query
-        if not search and order_by and order_by.startswith("random"):
+        if not search and not favorite and order_by and order_by.startswith("random"):
             query_parts.append(
                 f"{self.db_table}.item_id in "
                 f"(SELECT item_id FROM {self.db_table} ORDER BY RANDOM() LIMIT {limit})"

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -714,7 +714,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         query_params = extra_query_params or {}
         query_parts: list[str] = extra_query_parts or []
         join_parts: list[str] = extra_join_parts or []
-        already_filtered_favorites = False
+        already_filtered_favorite = False
         already_filtered_search = False
 
         # handle search preprocessing
@@ -725,15 +725,15 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         # create special performant random query
         if order_by and order_by.startswith("random"):
             sub_query_parts = []
-            # Add search filter to subquery if present
+            # If favorite or search filter is active, add it to the subquery so we limit the number
+            # of results to the correct amount
             if search:
                 sub_query_parts.append(f"{self.db_table}.search_name LIKE :search")
                 already_filtered_search = True
-            # If favorite filter is active, add it to the subquery so
             if favorite is not None:
                 sub_query_parts.append(f"{self.db_table}.favorite = :favorite")
                 query_params["favorite"] = favorite
-                already_filtered_favorites = True
+                already_filtered_favorite = True
             sub_query = f"SELECT item_id FROM {self.db_table}"
             if sub_query_parts:
                 sub_query += " WHERE " + " AND ".join(sub_query_parts)
@@ -743,7 +743,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         if search and not already_filtered_search:
             query_parts.append(f"{self.db_table}.search_name LIKE :search")
         # handle favorite filter
-        if favorite is not None and not already_filtered_favorites:
+        if favorite is not None and not already_filtered_favorite:
             query_parts.append(f"{self.db_table}.favorite = :favorite")
             query_params["favorite"] = favorite
         # handle provider filter

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -714,19 +714,27 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         query_params = extra_query_params or {}
         query_parts: list[str] = extra_query_parts or []
         join_parts: list[str] = extra_join_parts or []
+        already_filtered_favorites = False
         # create special performant random query
-        if not search and not favorite and order_by and order_by.startswith("random"):
-            query_parts.append(
-                f"{self.db_table}.item_id in "
-                f"(SELECT item_id FROM {self.db_table} ORDER BY RANDOM() LIMIT {limit})"
-            )
+        if not search and order_by and order_by.startswith("random"):
+            sub_query_parts = []
+            # If favorite filter is active, add it to the subquery so
+            if favorite is not None:
+                sub_query_parts.append(f"{self.db_table}.favorite = :favorite")
+                query_params["favorite"] = favorite
+                already_filtered_favorites = True
+            sub_query = f"SELECT item_id FROM {self.db_table}"
+            if sub_query_parts:
+                sub_query += " WHERE " + " AND ".join(sub_query_parts)
+            sub_query += f" ORDER BY RANDOM() LIMIT {limit}"
+            query_parts.append(f"{self.db_table}.item_id in ({sub_query})")
         # handle search
         if search:
             search = create_safe_string(search, True, True)
             query_params["search"] = f"%{search}%"
             query_parts.append(f"{self.db_table}.search_name LIKE :search")
         # handle favorite filter
-        if favorite is not None:
+        if favorite is not None and not already_filtered_favorites:
             query_parts.append(f"{self.db_table}.favorite = :favorite")
             query_params["favorite"] = favorite
         # handle provider filter

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -715,9 +715,20 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         query_parts: list[str] = extra_query_parts or []
         join_parts: list[str] = extra_join_parts or []
         already_filtered_favorites = False
+        already_filtered_search = False
+
+        # handle search preprocessing
+        if search:
+            search = create_safe_string(search, True, True)
+            query_params["search"] = f"%{search}%"
+
         # create special performant random query
-        if not search and order_by and order_by.startswith("random"):
+        if order_by and order_by.startswith("random"):
             sub_query_parts = []
+            # Add search filter to subquery if present
+            if search:
+                sub_query_parts.append(f"{self.db_table}.search_name LIKE :search")
+                already_filtered_search = True
             # If favorite filter is active, add it to the subquery so
             if favorite is not None:
                 sub_query_parts.append(f"{self.db_table}.favorite = :favorite")
@@ -729,9 +740,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
             sub_query += f" ORDER BY RANDOM() LIMIT {limit}"
             query_parts.append(f"{self.db_table}.item_id in ({sub_query})")
         # handle search
-        if search:
-            search = create_safe_string(search, True, True)
-            query_params["search"] = f"%{search}%"
+        if search and not already_filtered_search:
             query_parts.append(f"{self.db_table}.search_name LIKE :search")
         # handle favorite filter
         if favorite is not None and not already_filtered_favorites:


### PR DESCRIPTION
My attempt to fix random ordering with search and favorite filters not working correctly due to filters being applied after random selection instead of before.
Tested with a couple dozens of query's through Home Assistant, seams to work correctly now.  

Supersedes #2206

Fixes music-assistant/support#3943 and music-assistant/backlog#10
