### PR TITLE
Add Apple Music token extractor script and documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ See here https://music-assistant.io/installation/
 
 Note that although Music Assistant's main code is written in python, it has multiple dependencies on external/OS components such as ffmpeg and custom binaries and it is therefore not possible to run it as standalone pypi package. The only available installation method to run the Music Assistant server is by running the Docker container or the Home Assistant add-on.
 
+## Development and Utilities
+
+For development setup and utility scripts, see:
+- [Development Guide](DEVELOPMENT.md) - Complete development setup and contribution guidelines
+- [Scripts](scripts/README.md) - Utility scripts including Apple Music token extraction
+
 ---
 
 [![A project from the Open Home Foundation](https://www.openhomefoundation.org/badges/ohf-project.png)](https://www.openhomefoundation.org/)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,68 @@
+# Scripts
+
+This directory contains utility scripts for Music Assistant development and setup.
+
+## Apple Music Token Extractor
+
+The `apple_music_token_playwright.py` script helps you extract the required user token for the Apple Music provider in Music Assistant.
+
+### Prerequisites
+
+1. **Python 3.12+** - The script requires Python 3.12 or higher
+2. **Playwright** - Install Playwright and its browser dependencies:
+   ```bash
+   pip install playwright
+   playwright install chromium
+   ```
+
+### Usage
+
+1. **Run the script:**
+   ```bash
+   python scripts/apple_music_token_playwright.py
+   ```
+
+2. **Follow the prompts:**
+   - The script will open a browser window to Apple Music
+   - Log in to your Apple Music account in the browser
+   - Once logged in and you can see your library, press Enter in the terminal
+   - The script will extract your user token and save it to `apple_music_token.json`
+
+3. **Use the token in Music Assistant:**
+   - Copy the token value from the output or from `apple_music_token.json`
+   - In Music Assistant, go to Settings → Music Providers → Apple Music
+   - Paste the token in the "Music User Token" field
+
+### What the script does
+
+- Opens a browser window to Apple Music
+- Waits for you to log in manually (this ensures the token is valid)
+- Extracts the `media-user-token` cookie from your browser session
+- Saves the token with metadata (extraction time, expiration) to a JSON file
+- Provides the token value for use in Music Assistant
+
+### Token expiration
+
+Apple Music user tokens typically expire after 180 days. When your token expires:
+1. Re-run this script to get a new token
+2. Update the token in your Music Assistant configuration
+
+### Troubleshooting
+
+- **"Could not find media-user-token cookie"**: Make sure you're fully logged in to Apple Music in the browser window
+- **Browser doesn't open**: Ensure Playwright is properly installed with `playwright install chromium`
+- **Permission errors**: Make sure you have write permissions in the current directory for the JSON output file
+
+### Security notes
+
+- The token is a semi-private key in JWT format
+- Store it securely and don't share it publicly
+- The script saves the token locally for convenience, but you can delete the JSON file after copying the token to Music Assistant
+
+### Alternative methods
+
+If you prefer to extract the token manually:
+1. Open Apple Music in your browser
+2. Open Developer Tools (F12)
+3. Go to Application/Storage → Cookies → https://music.apple.com
+4. Find the `media-user-token` cookie and copy its value

--- a/scripts/apple_music_token_playwright.py
+++ b/scripts/apple_music_token_playwright.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Apple Music Token Extractor for Music Assistant.
+
+Uses Playwright to automate token extraction from Apple Music.
+"""
+
+import asyncio
+import json
+from datetime import datetime
+
+from playwright.async_api import async_playwright
+
+
+async def extract_apple_music_token():
+    """Extract the Apple Music user token from browser cookies."""
+    async with async_playwright() as p:
+        # Launch browser (use chromium for best compatibility)
+        browser = await p.chromium.launch(
+            headless=False,  # Set to True for headless operation
+            args=["--disable-blink-features=AutomationControlled"],
+        )
+
+        context = await browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+            )
+        )
+
+        page = await context.new_page()
+
+        print("🎵 Navigating to Apple Music...")  # noqa: T201
+        await page.goto("https://music.apple.com/")
+
+        print("⏳ Please log in to Apple Music in the browser window that opened.")  # noqa: T201
+        print("   Once you're logged in and can see your library, press Enter here...")  # noqa: T201
+        input()
+
+        # Wait a moment for any redirects/page loads
+        await page.wait_for_timeout(2000)
+
+        # Get cookies from the page
+        cookies = await context.cookies("https://music.apple.com")
+
+        # Find the media-user-token cookie
+        token_cookie = None
+        for cookie in cookies:
+            if cookie["name"] == "media-user-token":
+                token_cookie = cookie
+                break
+
+        if token_cookie:
+            token_value = token_cookie["value"]
+            expires = (
+                datetime.fromtimestamp(token_cookie["expires"])
+                if "expires" in token_cookie
+                else None
+            )
+
+            print("✅ Token extracted successfully!")  # noqa: T201
+            print(f"🔑 Token: {token_value}")  # noqa: T201
+            if expires:
+                print(f"⏰ Expires: {expires.strftime('%Y-%m-%d %H:%M:%S')}")  # noqa: T201
+
+            # Save to file
+            token_data = {
+                "token": token_value,
+                "extracted_at": datetime.now().isoformat(),
+                "expires_at": expires.isoformat() if expires else None,
+            }
+
+            with open("apple_music_token.json", "w") as f:  # noqa: ASYNC230
+                json.dump(token_data, f, indent=2)
+
+            print("💾 Token saved to apple_music_token.json")  # noqa: T201
+            print("\n🎯 Use this token in Music Assistant:")  # noqa: T201
+            print(f"   Music User Token: {token_value}")  # noqa: T201
+
+        else:
+            print("❌ Could not find media-user-token cookie.")  # noqa: T201
+            print("   Make sure you're logged in to Apple Music.")  # noqa: T201
+
+            # Print all available cookies for debugging
+            print("\n🔍 Available cookies:")  # noqa: T201
+            for cookie in cookies:
+                print(f"   - {cookie['name']}")  # noqa: T201
+
+        await browser.close()
+        return token_cookie["value"] if token_cookie else None
+
+
+async def main():
+    """Run the Apple Music token extractor."""
+    print("🍎 Apple Music Token Extractor for Music Assistant")  # noqa: T201
+    print("=" * 50)  # noqa: T201
+
+    try:
+        token = await extract_apple_music_token()
+        if token:
+            print("\n✨ Success! Your Apple Music token is ready for Music Assistant.")  # noqa: T201
+        else:
+            print("\n❌ Failed to extract token. Please try again.")  # noqa: T201
+    except Exception as e:
+        print(f"❌ Error: {e}")  # noqa: T201
+
+
+if __name__ == "__main__":
+    # Install required packages:
+    # pip install playwright
+    # playwright install chromium
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

This PR adds a utility script (`scripts/apple_music_token_playwright.py`) to help users extract the required Apple Music user token for the Apple Music provider in Music Assistant. It also includes comprehensive documentation in `scripts/README.md`.

## Details

- **New script:** `scripts/apple_music_token_playwright.py`
  - Uses Playwright to automate browser login and extract the `media-user-token` cookie from Apple Music.
  - Saves the token and metadata to `apple_music_token.json`.
  - Provides clear instructions and error messages for the user.
- **Documentation:** `scripts/README.md`
  - Step-by-step instructions for installing prerequisites, running the script, and using the extracted token in Music Assistant.
  - Troubleshooting and security notes included.

## Motivation

Apple Music user tokens are required for the provider and can be difficult for users to extract manually. This script streamlines the process and improves the user experience.

## Testing

- Linting and formatting pass with pre-commit hooks.
- Script tested on macOS with Python 3.13 and Playwright.

---

Closes #apple-music-token-extractor