### PR TITLE
Fix Web Player playback on iOS and iPadOS

### DIFF
--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -412,6 +412,18 @@ class BuiltinPlayerProvider(PlayerProvider):
         if request.method != "GET":
             return resp
 
+        # Check for a client probe request (from an iPhone/iPad)
+        if (range_header := request.headers.get("Range")) and range_header == "bytes=0-1":
+            self.logger.debug("Client is probing the stream.")
+
+            # Avoids us to staring multiple ffmpeg instances for probe requests
+            return web.Response(
+                status=206,  # Partial Content
+                headers=headers,
+                # Just send something
+                body=b"\x00\x00",
+            )
+
         media = player.current_media
         if queue is None or media is None:
             raise web.HTTPNotFound(reason="No active queue or media found!")

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -392,6 +392,7 @@ class BuiltinPlayerProvider(PlayerProvider):
         format_str = request.path.rsplit(".")[-1]
         # bitrate = request.query.get("bitrate")
         queue = self.mass.player_queues.get(player_id)
+        self.logger.debug("Serving audio stream to %s", player_id)
 
         if not (player := self.mass.players.get(player_id)):
             raise web.HTTPNotFound(reason=f"Unknown player: {player_id}")

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -450,15 +450,6 @@ class BuiltinPlayerProvider(PlayerProvider):
             channels=DEFAULT_PCM_FORMAT.channels,
         )
 
-        if (user_agent := request.headers.get("User-Agent")) and "Safari" in user_agent:
-            # This is possibly an iPhone or iPad. Since Apple ignores "Accept-Ranges=none" on iOS
-            # and iPadOS for some reason, we need to slowly feed the music to avoid Safari
-            # stopping and later restarting the audio stream (from a wrong position!).
-            extra_input_args = ["-readrate", "1.0", "-readrate_initial_burst", "15"]
-            self.logger.debug("Safari detected, limiting readrate")
-        else:
-            extra_input_args = None
-
         async for chunk in get_ffmpeg_stream(
             audio_input=self.mass.streams.get_queue_flow_stream(
                 queue=queue,
@@ -467,7 +458,10 @@ class BuiltinPlayerProvider(PlayerProvider):
             ),
             input_format=pcm_format,
             output_format=stream_format,
-            extra_input_args=extra_input_args,
+            # Apple ignores "Accept-Ranges=none" on iOS and iPadOS for some reason,
+            # so we need to slowly feed the music to avoid the Browser stopping and later
+            # restarting the audio stream (from a wrong position!) by keeping the buffer short.
+            extra_input_args=["-readrate", "1.0", "-readrate_initial_burst", "15"],
             filter_params=get_player_filter_params(self.mass, player_id, pcm_format, stream_format),
         ):
             try:

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -438,6 +438,15 @@ class BuiltinPlayerProvider(PlayerProvider):
             channels=DEFAULT_PCM_FORMAT.channels,
         )
 
+        if "Safari" in request.headers["User-Agent"]:
+            # This is possibly an iPhone or iPad. Since Apple ignores "Accept-Ranges=none" on iOS
+            # and iPadOS for some reason, we need to slowly feed the music to avoid Safari
+            # stopping and later restarting the audio stream (from a wrong position!).
+            extra_input_args = ["-readrate", "1.0", "-readrate_initial_burst", "15"]
+            self.logger.debug("Safari detected, limiting readrate")
+        else:
+            extra_input_args = None
+
         async for chunk in get_ffmpeg_stream(
             audio_input=self.mass.streams.get_queue_flow_stream(
                 queue=queue,
@@ -446,6 +455,7 @@ class BuiltinPlayerProvider(PlayerProvider):
             ),
             input_format=pcm_format,
             output_format=stream_format,
+            extra_input_args=extra_input_args,
             filter_params=get_player_filter_params(self.mass, player_id, pcm_format, stream_format),
         ):
             try:

--- a/music_assistant/providers/builtin_player/__init__.py
+++ b/music_assistant/providers/builtin_player/__init__.py
@@ -450,7 +450,7 @@ class BuiltinPlayerProvider(PlayerProvider):
             channels=DEFAULT_PCM_FORMAT.channels,
         )
 
-        if "Safari" in request.headers["User-Agent"]:
+        if (user_agent := request.headers.get("User-Agent")) and "Safari" in user_agent:
             # This is possibly an iPhone or iPad. Since Apple ignores "Accept-Ranges=none" on iOS
             # and iPadOS for some reason, we need to slowly feed the music to avoid Safari
             # stopping and later restarting the audio stream (from a wrong position!).


### PR DESCRIPTION
I was finally able to get my hands on an iPad, so here is a workaround for iPad's and iPhone's.
This fixes the previous periodic audio restarts by only allowing Safari to only buffer exactly 15s of audio.
This keeps Safari from closing the HTTP connection, therefore correctly keeping the single connection alive.
Also adds handling of probe requests made by Safari.

Fixes https://github.com/music-assistant/support/issues/3858