### PR TITLE
Subsonic: Handle uninitialized port config value

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -99,7 +99,7 @@ class OpenSonicProvider(MusicProvider):
     async def handle_async_init(self) -> None:
         """Set up the music provider and test the connection."""
         port = self.config.get_value(CONF_PORT)
-        port = int(str(port)) or 443
+        port = int(str(port)) if port is not None else 443
         path = self.config.get_value(CONF_PATH)
         if path is None:
             path = ""


### PR DESCRIPTION
The or construction does not seem to protect against None value when there are tranformations applied in the lhs (or evaluates after the str() and int() conversions. This leads to problems when no value is set for port. Change back to the more verbose if port else 443 construction to fix this.

Fixes: https://github.com/music-assistant/support/issues/4086