### PR TITLE
Fix library query with random order and improve maintainability

### DIFF
--- a/music_assistant/controllers/media/albums.py
+++ b/music_assistant/controllers/media/albums.py
@@ -171,7 +171,7 @@ class AlbumsController(MediaControllerBase[Album]):
             # Calculate how many more items we need to reach the original limit
             remaining_limit = limit - len(result)
 
-            for _album in await self._get_library_items_by_query(
+            for album in await self._get_library_items_by_query(
                 favorite=favorite,
                 search=None,
                 limit=remaining_limit,
@@ -182,8 +182,8 @@ class AlbumsController(MediaControllerBase[Album]):
                 extra_join_parts=extra_join_parts,
             ):
                 # prevent duplicates (when artist is also in the title)
-                if _album.uri not in existing_uris:
-                    result.append(_album)
+                if album.uri not in existing_uris:
+                    result.append(album)
                     # Stop if we've reached the original limit
                     if len(result) >= limit:
                         break

--- a/music_assistant/controllers/media/albums.py
+++ b/music_assistant/controllers/media/albums.py
@@ -167,10 +167,14 @@ class AlbumsController(MediaControllerBase[Album]):
             )
             extra_query_params["search_artist"] = f"%{search}%"
             existing_uris = {item.uri for item in result}
+
+            # Calculate how many more items we need to reach the original limit
+            remaining_limit = limit - len(result)
+
             for _album in await self._get_library_items_by_query(
                 favorite=favorite,
                 search=None,
-                limit=limit,
+                limit=remaining_limit,
                 order_by=order_by,
                 provider=provider,
                 extra_query_parts=extra_query_parts,
@@ -180,6 +184,9 @@ class AlbumsController(MediaControllerBase[Album]):
                 # prevent duplicates (when artist is also in the title)
                 if _album.uri not in existing_uris:
                     result.append(_album)
+                    # Stop if we've reached the original limit
+                    if len(result) >= limit:
+                        break
         return result
 
     async def library_count(

--- a/music_assistant/controllers/media/albums.py
+++ b/music_assistant/controllers/media/albums.py
@@ -155,7 +155,11 @@ class AlbumsController(MediaControllerBase[Album]):
             extra_query_params=extra_query_params,
             extra_join_parts=extra_join_parts,
         )
-        if search and len(result) < 25 and not offset:
+
+        # Calculate how many more items we need to reach the original limit
+        remaining_limit = limit - len(result)
+
+        if search and len(result) < 25 and not offset and remaining_limit > 0:
             # append artist items to result
             search = create_safe_string(search, True, True)
             extra_join_parts.append(
@@ -167,9 +171,6 @@ class AlbumsController(MediaControllerBase[Album]):
             )
             extra_query_params["search_artist"] = f"%{search}%"
             existing_uris = {item.uri for item in result}
-
-            # Calculate how many more items we need to reach the original limit
-            remaining_limit = limit - len(result)
 
             for album in await self._get_library_items_by_query(
                 favorite=favorite,

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -724,7 +724,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
 
         # create special performant random query
         if order_by and order_by.startswith("random"):
-            sub_query_parts = []
+            sub_query_parts = query_parts
             # If favorite or search filter is active, add it to the subquery so we limit the number
             # of results to the correct amount
             if search:
@@ -734,11 +734,29 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
                 sub_query_parts.append(f"{self.db_table}.favorite = :favorite")
                 query_params["favorite"] = favorite
                 already_filtered_favorite = True
-            sub_query = f"SELECT item_id FROM {self.db_table}"
+            if provider:
+                sub_query_parts.append(
+                    f"JOIN provider_mappings ON provider_mappings.item_id "
+                    f"= {self.db_table}.item_id "
+                    f"AND provider_mappings.media_type = '{self.media_type.value}' "
+                    f"AND (provider_mappings.provider_instance = '{provider}' "
+                    f"OR provider_mappings.provider_domain = '{provider}')"
+                )
+                provider = None
+            sub_query = f"SELECT {self.db_table}.item_id FROM {self.db_table}"
+            if join_parts:
+                sub_query += f" {' '.join(join_parts)}"
+                join_parts = []  # are now part of the subquery
             if sub_query_parts:
+                # prevent duplicate where statement
+                sub_query_parts = [
+                    x[5:] if x.lower().startswith("where ") else x for x in sub_query_parts
+                ]
                 sub_query += " WHERE " + " AND ".join(sub_query_parts)
             sub_query += f" ORDER BY RANDOM() LIMIT {limit}"
-            query_parts.append(f"{self.db_table}.item_id in ({sub_query})")
+            # reset main query parts and replace with just the subquery
+            query_parts = [f"{self.db_table}.item_id in ({sub_query})"]
+
         # handle search
         if search and not already_filtered_search:
             query_parts.append(f"{self.db_table}.search_name LIKE :search")

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -710,60 +710,97 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         extra_join_parts: list[str] | None = None,
     ) -> list[ItemCls]:
         """Fetch MediaItem records from database by building the query."""
-        sql_query = self.base_query
         query_params = extra_query_params or {}
         query_parts: list[str] = extra_query_parts or []
         join_parts: list[str] = extra_join_parts or []
-        already_filtered_favorite = False
-        already_filtered_search = False
 
-        # handle search preprocessing
-        if search:
-            search = create_safe_string(search, True, True)
-            query_params["search"] = f"%{search}%"
+        search = self._preprocess_search(search, query_params)
 
         # create special performant random query
         if order_by and order_by.startswith("random"):
-            sub_query_parts = query_parts
-            # If favorite or search filter is active, add it to the subquery so we limit the number
-            # of results to the correct amount
-            if search:
-                sub_query_parts.append(f"{self.db_table}.search_name LIKE :search")
-                already_filtered_search = True
-            if favorite is not None:
-                sub_query_parts.append(f"{self.db_table}.favorite = :favorite")
-                query_params["favorite"] = favorite
-                already_filtered_favorite = True
-            if provider:
-                sub_query_parts.append(
-                    f"JOIN provider_mappings ON provider_mappings.item_id "
-                    f"= {self.db_table}.item_id "
-                    f"AND provider_mappings.media_type = '{self.media_type.value}' "
-                    f"AND (provider_mappings.provider_instance = '{provider}' "
-                    f"OR provider_mappings.provider_domain = '{provider}')"
-                )
-                provider = None
-            sub_query = f"SELECT {self.db_table}.item_id FROM {self.db_table}"
-            if join_parts:
-                sub_query += f" {' '.join(join_parts)}"
-                join_parts = []  # are now part of the subquery
-            if sub_query_parts:
-                # prevent duplicate where statement
-                sub_query_parts = [
-                    x[5:] if x.lower().startswith("where ") else x for x in sub_query_parts
-                ]
-                sub_query += " WHERE " + " AND ".join(sub_query_parts)
-            sub_query += f" ORDER BY RANDOM() LIMIT {limit}"
-            # reset main query parts and replace with just the subquery
-            query_parts = [f"{self.db_table}.item_id in ({sub_query})"]
+            self._apply_random_subquery(
+                query_parts, query_params, join_parts, favorite, search, provider, limit
+            )
+        else:
+            # apply filters
+            self._apply_filters(query_parts, query_params, join_parts, favorite, search, provider)
 
+        # build and execute final query
+        sql_query = self._build_final_query(query_parts, join_parts, order_by)
+
+        return [
+            self.item_cls.from_dict(self._parse_db_row(db_row))
+            for db_row in await self.mass.music.database.get_rows_from_query(
+                sql_query, query_params, limit=limit, offset=offset
+            )
+        ]
+
+    def _preprocess_search(self, search: str | None, query_params: dict[str, Any]) -> str | None:
+        """Preprocess search string and add to query params."""
+        if search:
+            search = create_safe_string(search, True, True)
+            query_params["search"] = f"%{search}%"
+        return search
+
+    @staticmethod
+    def _clean_query_parts(query_parts: list[str]) -> list[str]:
+        """Clean the query parts list by removing duplicate where statements."""
+        return [x[5:] if x.lower().startswith("where ") else x for x in query_parts]
+
+    def _apply_random_subquery(
+        self,
+        query_parts: list[str],
+        query_params: dict[str, Any],
+        join_parts: list[str],
+        favorite: bool | None,
+        search: str | None,
+        provider: str | None,
+        limit: int,
+    ) -> None:
+        """Build a fast random subquery with all filters applied."""
+        sub_query_parts = query_parts.copy()
+        sub_join_parts = join_parts.copy()
+
+        # Apply all filters to the subquery
+        self._apply_filters(
+            sub_query_parts, query_params, sub_join_parts, favorite, search, provider
+        )
+
+        # Build the subquery
+        sub_query = f"SELECT {self.db_table}.item_id FROM {self.db_table}"
+
+        if sub_join_parts:
+            sub_query += f" {' '.join(sub_join_parts)}"
+
+        if sub_query_parts:
+            sub_query += " WHERE " + " AND ".join(self._clean_query_parts(sub_query_parts))
+
+        sub_query += f" ORDER BY RANDOM() LIMIT {limit}"
+
+        # The query now only consists of the random subquery, which applies all filters
+        # within itself
+        query_parts.clear()
+        query_parts.append(f"{self.db_table}.item_id in ({sub_query})")
+
+    def _apply_filters(
+        self,
+        query_parts: list[str],
+        query_params: dict[str, Any],
+        join_parts: list[str],
+        favorite: bool | None,
+        search: str | None,
+        provider: str | None,
+    ) -> None:
+        """Apply search, favorite, and provider filters."""
         # handle search
-        if search and not already_filtered_search:
+        if search:
             query_parts.append(f"{self.db_table}.search_name LIKE :search")
+
         # handle favorite filter
-        if favorite is not None and not already_filtered_favorite:
+        if favorite is not None:
             query_parts.append(f"{self.db_table}.favorite = :favorite")
             query_params["favorite"] = favorite
+
         # handle provider filter
         if provider:
             join_parts.append(
@@ -772,25 +809,33 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
                 f"AND (provider_mappings.provider_instance = '{provider}' "
                 f"OR provider_mappings.provider_domain = '{provider}')"
             )
-        # prevent duplicate where statement
-        query_parts = [x[5:] if x.lower().startswith("where ") else x for x in query_parts]
-        # concetenate all join and/or where queries
+
+    def _build_final_query(
+        self,
+        query_parts: list[str],
+        join_parts: list[str],
+        order_by: str | None,
+    ) -> str:
+        """Build the final SQL query string."""
+        sql_query = self.base_query
+
+        # Add joins
         if join_parts:
             sql_query += f" {' '.join(join_parts)} "
+
+        # Add where clauses
         if query_parts:
-            sql_query += " WHERE " + " AND ".join(query_parts)
-        # build final query
+            # prevent duplicate where statement
+            sql_query += " WHERE " + " AND ".join(self._clean_query_parts(query_parts))
+
+        # Add grouping and ordering
         sql_query += f" GROUP BY {self.db_table}.item_id"
+
         if order_by:
             if sort_key := SORT_KEYS.get(order_by):
                 sql_query += f" ORDER BY {sort_key}"
-        # return dbresult parsed to media item model
-        return [
-            self.item_cls.from_dict(self._parse_db_row(db_row))
-            for db_row in await self.mass.music.database.get_rows_from_query(
-                sql_query, query_params, limit=limit, offset=offset
-            )
-        ]
+
+        return sql_query
 
     async def _set_provider_mappings(
         self,

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -781,6 +781,7 @@ class MediaControllerBase(Generic[ItemCls], metaclass=ABCMeta):
         # within itself
         query_parts.clear()
         query_parts.append(f"{self.db_table}.item_id in ({sub_query})")
+        join_parts.clear()
 
     def _apply_filters(
         self,


### PR DESCRIPTION
This PR fixes a couple of issues I missed in #2255 and refactors the query building logic into smaller, maintainable helper methods.

## Fixes:

Random Ordering with Filters: Fixed random ordering not working correctly when search/favorite filters were applied. Filters were being applied after random selection instead of before. Now all filters are applied within the random subquery itself.

Album Search Limits: Fixed album searches returning more results than the specified limit due to duplicate prevention logic. Now properly calculates remaining limit and stops when the original limit is reached.

## Testing:

Verified with a couple of search queries through Home Assistant and Music Assistant with various combinations of random ordering, search filters, and favorite filters.

For my dev setup, these queries previously worked incorrectly:
```yaml
action: music_assistant.get_library
data:
  config_entry_id: 01JZAM4T977MRTC2XFKXC925PA
  media_type: album
  offset: 0
  order_by: random
  limit: 1
  favorite: true
  search: ghost
```
and:
```yaml
action: music_assistant.get_library
data:
  config_entry_id: 01JZAM4T977MRTC2XFKXC925PA
  media_type: album
  offset: 0
  order_by: random
  favorite: true
  album_type:
    - single
  search: ad
  limit: 1
```

## Limitations

In case a search term does not yield enough results, it additionally searches results with the Album Artists and appends them to the search results. But both results are randomized independently.
This means the search results aren't fully randomized together - album name matches appear first in random order, then artist name matches appear in their own random order.

Fixes: music-assistant/support#3943, music-assistant/backlog#10