### PR TITLE
Catch invalid replaygain tag values

### DIFF
--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -405,8 +405,8 @@ class AudioTags:
         """Try to read/calculate the integrated loudness from the tags (album level)."""
         if tag := self.tags.get("r128albumgain"):
             try:
-                value = int(tag.split(" ")[0]) / 256
-                return -23 - float(value)
+                gain_adjustment = int(tag.split(" ")[0]) / 256
+                return -23 - gain_adjustment
             except (ValueError, IndexError) as e:
                 LOGGER.warning(f"Invalid r128albumgain tag value: {tag!r} — {e}")
 

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -383,20 +383,40 @@ class AudioTags:
 
     @property
     def track_loudness(self) -> float | None:
-        """Try to read/calculate the integrated loudness from the tags."""
-        if (tag := self.tags.get("r128trackgain")) is not None:
-            return -23 - float(int(tag.split(" ")[0]) / 256)
-        if (tag := self.tags.get("replaygaintrackgain")) is not None:
-            return -18 - float(tag.split(" ")[0])
+        """Try to read/calculate the integrated loudness from the tags (track level)."""
+        if tag := self.tags.get("r128trackgain"):
+            try:
+                value = int(tag.split(" ")[0]) / 256
+                return -23 - float(value)
+            except (ValueError, IndexError) as e:
+                LOGGER.warning(f"Invalid r128trackgain tag value: {tag!r} — {e}")
+
+        if tag := self.tags.get("replaygaintrackgain"):
+            try:
+                value = float(tag.split(" ")[0])
+                return -18 - value
+            except (ValueError, IndexError) as e:
+                LOGGER.warning(f"Invalid replaygaintrackgain tag value: {tag!r} — {e}")
+
         return None
 
     @property
     def track_album_loudness(self) -> float | None:
         """Try to read/calculate the integrated loudness from the tags (album level)."""
         if tag := self.tags.get("r128albumgain"):
-            return -23 - float(int(tag.split(" ")[0]) / 256)
-        if (tag := self.tags.get("replaygainalbumgain")) is not None:
-            return -18 - float(tag.split(" ")[0])
+            try:
+                value = int(tag.split(" ")[0]) / 256
+                return -23 - float(value)
+            except (ValueError, IndexError) as e:
+                LOGGER.warning(f"Invalid r128albumgain tag value: {tag!r} — {e}")
+
+        if tag := self.tags.get("replaygainalbumgain"):
+            try:
+                value = float(tag.split(" ")[0])
+                return -18 - value
+            except (ValueError, IndexError) as e:
+                LOGGER.warning(f"Invalid replaygainalbumgain tag value: {tag!r} — {e}")
+
         return None
 
     @classmethod

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -386,8 +386,8 @@ class AudioTags:
         """Try to read/calculate the integrated loudness from the tags (track level)."""
         if tag := self.tags.get("r128trackgain"):
             try:
-                value = int(tag.split(" ")[0]) / 256
-                return -23 - float(value)
+                gain_adjustment = int(tag.split(" ")[0]) / 256
+                return -23 - gain_adjustment
             except (ValueError, IndexError) as e:
                 LOGGER.warning(f"Invalid r128trackgain tag value: {tag!r} — {e}")
 

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -412,8 +412,8 @@ class AudioTags:
 
         if tag := self.tags.get("replaygainalbumgain"):
             try:
-                value = float(tag.split(" ")[0])
-                return -18 - value
+                gain_adjustment = float(tag.split(" ")[0])
+                return -18 - gain_adjustment
             except (ValueError, IndexError) as e:
                 LOGGER.warning(f"Invalid replaygainalbumgain tag value: {tag!r} — {e}")
 

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -393,8 +393,8 @@ class AudioTags:
 
         if tag := self.tags.get("replaygaintrackgain"):
             try:
-                value = float(tag.split(" ")[0])
-                return -18 - value
+                gain_adjustment = float(tag.split(" ")[0])
+                return -18 - gain_adjustment
             except (ValueError, IndexError) as e:
                 LOGGER.warning(f"Invalid replaygaintrackgain tag value: {tag!r} — {e}")
 


### PR DESCRIPTION
A number of issues have been raised where for some reason the replaygain tag value is eplaygai

For example https://github.com/music-assistant/support/issues/4112#issuecomment-3072208150

This catches the error and logs a warning.