### PR TITLE
Fix backport workflow to filter out beta/rc tags

### DIFF
--- a/.github/workflows/backport-to-stable.yml
+++ b/.github/workflows/backport-to-stable.yml
@@ -63,12 +63,13 @@ jobs:
         id: nextver
         run: |
           git fetch origin stable --tags
-          latest_tag=$(git tag --merged origin/stable --sort=-v:refname | head -1)
+          # Filter out beta/rc tags and get only stable versions (e.g., 2.5.5, v2.5.5)
+          latest_tag=$(git tag --merged origin/stable --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [[ -z "$latest_tag" ]]; then
-            echo "No tags found on stable branch" >&2
+            echo "No stable tags found on stable branch" >&2
             exit 1
           fi
-          echo "Latest tag: $latest_tag"
+          echo "Latest stable tag: $latest_tag"
 
           # Remove 'v' prefix if present
           version="$latest_tag"


### PR DESCRIPTION
## Summary
- Fixed the backport workflow to properly filter out beta/rc tags when calculating next patch version
- Added regex filter to only match stable version tags (e.g., 2.5.5, v2.5.5)
- Improved error messages to clarify when no stable tags are found

## Problem
The workflow was failing because it selected beta tags like `2.6.0b3` instead of stable tags like `2.5.5` when calculating the next patch version for backports.

## Solution
Added `grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$'` filter to only match stable version format, excluding beta/rc/pre-release tags.

## Test plan
- [ ] Verify workflow runs correctly with existing stable tags
- [ ] Confirm beta tags are properly filtered out
- [ ] Test that both `v` prefixed and non-prefixed tags work

🤖 Generated with [Claude Code](https://claude.ai/code)