### PR TITLE
Fix player grouping

### DIFF
--- a/music_assistant/controllers/players.py
+++ b/music_assistant/controllers/players.py
@@ -956,7 +956,7 @@ class PlayerController(CoreController):
             # check if player can be synced/grouped with the target player
             if not (
                 child_player_id in parent_player.can_group_with
-                or child_player.provider.instance_id in parent_player.can_group_with
+                or child_player.provider.lookup_key in parent_player.can_group_with
                 or "*" in parent_player.can_group_with
             ):
                 raise UnsupportedFeaturedException(

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -101,7 +101,7 @@ class AirPlayPlayer(Player):
             PlayerFeature.VOLUME_SET,
         }
         self._attr_volume_level = initial_volume
-        self._attr_can_group_with = {provider.instance_id}
+        self._attr_can_group_with = {provider.lookup_key}
         self._attr_enabled_by_default = not is_broken_raop_model(manufacturer, model)
 
     async def get_config_entries(self) -> list[ConfigEntry]:

--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -93,7 +93,7 @@ class BluesoundPlayer(Player):
         self._attr_available = True
         self._attr_needs_poll = True
         self._attr_poll_interval = 30
-        self._attr_can_group_with = {provider.instance_id}
+        self._attr_can_group_with = {provider.lookup_key}
 
     async def setup(self) -> None:
         """Set up the player."""

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -114,7 +114,7 @@ class MusicCastPlayer(Player):
             self._attr_name = self.zone_device.zone_data.name
 
         # group
-        self._attr_can_group_with = {self.provider.instance_id}
+        self._attr_can_group_with = {self.provider.lookup_key}
 
         self._attr_available = True
 

--- a/music_assistant/providers/snapcast/player.py
+++ b/music_assistant/providers/snapcast/player.py
@@ -88,7 +88,7 @@ class SnapCastPlayer(Player):
             PlayerFeature.VOLUME_MUTE,
             PlayerFeature.PLAY_ANNOUNCEMENT,
         }
-        self._attr_can_group_with = {self.provider.instance_id}
+        self._attr_can_group_with = {self.provider.lookup_key}
 
     async def volume_set(self, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -143,7 +143,7 @@ class SonosPlayer(Player):
         )
         self._attr_device_info.model = self.discovery_info["device"]["modelDisplayName"]
         self._attr_device_info.manufacturer = self._provider.manifest.name
-        self._attr_can_group_with = {self._provider.instance_id}
+        self._attr_can_group_with = {self._provider.lookup_key}
 
         if SonosCapability.LINE_IN in self.discovery_info["device"]["capabilities"]:
             self._attr_source_list.append(PLAYER_SOURCE_MAP[SOURCE_LINE_IN])
@@ -582,7 +582,7 @@ class SonosPlayer(Player):
                     if x.player_id != airplay_player.player_id
                 )
             else:
-                self._attr_can_group_with = {self._provider.instance_id}
+                self._attr_can_group_with = {self._provider.lookup_key}
         else:
             # player is group child (synced to another player)
             group_parent: SonosPlayer = self.mass.players.get(

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -99,7 +99,7 @@ class SonosPlayer(Player):
             ip_address=soco.ip_address,
         )
         self._attr_available = True
-        self._attr_can_group_with = {provider.instance_id}
+        self._attr_can_group_with = {provider.lookup_key}
 
         # Cached attributes
         self.crossfade: bool = False

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -106,7 +106,7 @@ class SqueezelitePlayer(Player):
             ip_address=client.device_address,
             manufacturer=client.device_type,
         )
-        self._attr_can_group_with = {provider.instance_id}
+        self._attr_can_group_with = {provider.lookup_key}
 
     async def setup(self) -> None:
         """Set up the player."""

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -73,9 +73,9 @@ class UniversalGroupPlayer(GroupPlayer):
         )
         # allow grouping with all providers, except the ugp provider itself
         self._attr_can_group_with = {
-            x.instance_id
+            x.lookup_key
             for x in self.mass.players.providers
-            if x.instance_id != self.provider.instance_id
+            if x.lookup_key != self.provider.lookup_key
         }
         self._set_attributes()
 


### PR DESCRIPTION
#2249 introduced `Provider.lookup_key`, which is now used instead of `Provider.instance_id` when referring to a providers instance.

With this PR, `lookup_key` is now used to verify that a players can be grouped.