### PR TITLE
YTMusic: Auto update dependencies for frequently breaking packages

### DIFF
--- a/music_assistant/providers/ytmusic/manifest.json
+++ b/music_assistant/providers/ytmusic/manifest.json
@@ -7,9 +7,7 @@
   "codeowners": ["@MarvinSchenkel"],
   "requirements": [
     "ytmusicapi==1.10.3",
-    "yt-dlp==2025.6.30",
-    "duration-parser==1.0.1",
-    "bgutil-ytdlp-pot-provider==1.1.0"
+    "duration-parser==1.0.1"
   ],
   "documentation": "https://music-assistant.io/music-providers/youtube-music/",
   "multi_instance": true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ test = [
   "pytest-cov==6.2.1",
   "syrupy==4.9.1",
   "tomli==2.2.1",
-  "ruff==0.12.5",
+  "ruff==0.12.7",
 ]
 
 [project.scripts]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -15,7 +15,6 @@ aiosqlite==0.21.0
 alexapy==1.29.5
 async-upnp-client==0.45.0
 audible==0.10.0
-bgutil-ytdlp-pot-provider==1.1.0
 bidict==0.23.1
 certifi==2025.7.14
 chardet>=5.2.0
@@ -56,6 +55,5 @@ sxm==0.2.8
 unidecode==1.4.0
 websocket-client==1.8.0
 xmltodict==0.14.2
-yt-dlp==2025.6.30
 ytmusicapi==1.10.3
 zeroconf==0.147.0


### PR DESCRIPTION
This PR adds some logic to automatically update packages that frequently break when Google changes things on their end. Installing these packages to their latest version on provider.init() ensures that we implement these fixes as soon as they are available, thus not requiring us to push out a patch release every time YT Music is broken.