### PR TITLE
Use separate ingress TCP site for HA add-on

### DIFF
--- a/music_assistant/providers/universal_group/constants.py
+++ b/music_assistant/providers/universal_group/constants.py
@@ -18,7 +18,7 @@ CONF_ENTRY_SAMPLE_RATES_UGP = create_sample_rates_config_entry(
 )
 CONFIG_ENTRY_UGP_NOTE = ConfigEntry(
     key="ugp_note",
-    type=ConfigEntryType.LABEL,
+    type=ConfigEntryType.ALERT,
     label="Please note that although the Universal Group "
     "allows you to group any player, it will not (and can not) enable audio sync "
     "between players of different ecosystems. It is advised to always use native "


### PR DESCRIPTION
To fix the issues with our auth callbacks not working, we need to ensure that we can always rely on MA's own webserver.
Step 1 is by simply always exposing it on the network (unprotected, unfortunately) and use a dedicated TCP site to host HA ingress.

A follow-up step after this PR could be to add SSL and/or authentication to the webserver.