### PR TITLE
Fix playback with the Web Player for iOS devices 

### DIFF
--- a/music_assistant/providers/builtin_player/player.py
+++ b/music_assistant/providers/builtin_player/player.py
@@ -244,6 +244,12 @@ class BuiltinPlayer(Player):
         if request.method != "GET":
             return resp
 
+        # Check for a client probe request (from an iPhone/iPad)
+        if (range_header := request.headers.get("Range")) and range_header == "bytes=0-1":
+            self.logger.debug("Client is probing the stream.")
+            # We don't early exit here since playback would otherwise never start
+            # when using iOS with Home Assistant OS
+
         media = player.current_media
         if queue is None or media is None:
             raise web.HTTPNotFound(reason="No active queue or media found!")

--- a/music_assistant/providers/builtin_player/player.py
+++ b/music_assistant/providers/builtin_player/player.py
@@ -244,18 +244,6 @@ class BuiltinPlayer(Player):
         if request.method != "GET":
             return resp
 
-        # Check for a client probe request (from an iPhone/iPad)
-        if (range_header := request.headers.get("Range")) and range_header == "bytes=0-1":
-            self.logger.debug("Client is probing the stream.")
-
-            # Avoids us to staring multiple ffmpeg instances for probe requests
-            return web.Response(
-                status=206,  # Partial Content
-                headers=headers,
-                # Just send something
-                body=b"\x00\x00",
-            )
-
         media = player.current_media
         if queue is None or media is None:
             raise web.HTTPNotFound(reason="No active queue or media found!")

--- a/music_assistant/providers/builtin_player/player.py
+++ b/music_assistant/providers/builtin_player/player.py
@@ -248,7 +248,7 @@ class BuiltinPlayer(Player):
         if (range_header := request.headers.get("Range")) and range_header == "bytes=0-1":
             self.logger.debug("Client is probing the stream.")
             # We don't early exit here since playback would otherwise never start
-            # when using iOS with Home Assistant OS
+            # on iOS devices with Home Assistant OS installations.
 
         media = player.current_media
         if queue is None or media is None:


### PR DESCRIPTION
This PR removes special handling of probe requests since they only worked on docker installations of Music Assistant.
With this PR the Web Player now should also work with Home Assistant OS installations of Music Assistant.

Closes https://github.com/music-assistant/support/issues/4146