### PR TITLE
Fix album info being lost for non-library items

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1126,7 +1126,11 @@ class PlayerQueuesController(CoreController):
                 )
             ):
                 queue_item.media_item.album = library_album
-            else:
+            elif not album and queue_item.media_item.album:
+                # Keep the good album we got from get_item_by_uri
+                pass  # Do nothing - keep existing album
+            elif album:
+                # Only restore original if we have no better alternative
                 queue_item.media_item.album = album
             # prefer album image over track image
             if queue_item.media_item.album and queue_item.media_item.album.image:

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1126,11 +1126,8 @@ class PlayerQueuesController(CoreController):
                 )
             ):
                 queue_item.media_item.album = library_album
-            elif not album and queue_item.media_item.album:
-                # Keep the good album we got from get_item_by_uri
-                pass  # Do nothing - keep existing album
             elif album:
-                # Only restore original if we have no better alternative
+                # Restore original album if we have no better alternative from the library
                 queue_item.media_item.album = album
             # prefer album image over track image
             if queue_item.media_item.album and queue_item.media_item.album.image:


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/4069

From what I can tell the album variable was captured at the beginning when tracks had incomplete information. After get_item_by_uri successfully fetched the complete track data the code would overwrite the good album data with the original album variable which could have been None