### PR TITLE
Disable new PO token generation to avoid warnings in the logs.

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -934,6 +934,9 @@ class YoutubeMusicProvider(MusicProvider):
                 "extractor_args": {
                     "youtubepot-bgutilhttp": {
                         "base_url": [self._po_token_server_url],
+                        # Disable new PO Token server behavior. Disable after this issue is fixed:
+                        # https://github.com/Brainicism/bgutil-ytdlp-pot-provider/issues/138
+                        "disable_innertube": "1",
                     },
                     "youtube": {
                         "skip": ["translated_subs", "dash"],


### PR DESCRIPTION
Addresses the flood of warnings related to PO tokens in the YT Music provider.