### PR TITLE
Fix stop command on some Home Assistant players

### DIFF
--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -186,7 +186,7 @@ class HomeAssistantPlayer(Player):
             )
         except FailedCommand as exc:
             # some HA players do not support STOP
-            if "does not support this service" not in str(exc):
+            if "does not support" not in str(exc):
                 raise
             if PlayerFeature.PAUSE in self.supported_features:
                 await self.pause()


### PR DESCRIPTION
Music Assistant attempts to detect the case where a media_stop command issued to a Home Assistant media player returns an error because the media player does not support it.

However, the error message that Home Assistant emits has changed since this check was originally added to Music Assistant.  In this commit:

https://github.com/home-assistant/core/commit/3aae9b629fc8ca0b8cbf8a2981f0bce20a78e16f

It was changed from:

>  "Entity {entity.entity_id} does not support this service."

To:

> "Entity {entity_id} does not support action {domain}.{service}."

To correct this and support both versions, the substring check is reduced to the common substring "does not support".