### PR TITLE
itunes_podcast: add log info if podcast has no feed url

### DIFF
--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -177,6 +177,10 @@ class ITunesPodcastsProvider(MusicProvider):
         podcast_list: list[Podcast] = []
         for result in results:
             if result.feed_url is None or result.track_name is None:
+                self.logger.info(
+                    "The podcast '%s' does not have a feed url. Please see the docs for more info.",
+                    result.track_name,
+                )
                 continue
             podcast = Podcast(
                 name=result.track_name,


### PR DESCRIPTION
As discussed on Discord, adds a log message if the podcast exists, but has no feed url.

@OzGav for the Docs maybe something along these lines?

Podcast does not appear in search results, but is known to be freely available on Apple Podcasts:
-> A content creator may optionally hide RSS feed within Apple Podcasts [source](https://stackoverflow.com/questions/65843154/itunes-search-podcast-json-api-repository-sometimes-does-not-return-feedurl). Without the feed URL the provider is unable to access the media information. You may try to search the web for an RSS feed url for your specific podcasts. If it exists, use the [Podcast RSS Feed](https://music-assistant.io/music-providers/podcastfeed/) to add it to MA manually.