### PR TITLE
Fix group volume and player state after Players controller refactor

### DIFF
--- a/music_assistant/controllers/players.py
+++ b/music_assistant/controllers/players.py
@@ -1354,6 +1354,16 @@ class PlayerController(CoreController):
                     # - the leader has DSP enabled
                     self.mass.create_task(self.mass.players.on_player_dsp_change(player_id))
 
+        if ATTR_GROUP_MEMBERS in changed_values:
+            # Removed group members also need to be updated since they are no longer part
+            # of this group and are available for playback again
+            prev_group_members = changed_values[ATTR_GROUP_MEMBERS][0] or []
+            new_group_members = changed_values[ATTR_GROUP_MEMBERS][1] or []
+            removed_members = set(prev_group_members) - set(new_group_members)
+            for player_id in removed_members:
+                if removed_player := self.get(player_id):
+                    self.mass.loop.call_soon(removed_player.update_state, True)
+
         # signal player update on the eventbus
         self.mass.signal_event(EventType.PLAYER_UPDATED, object_id=player_id, data=player)
 
@@ -1366,6 +1376,9 @@ class PlayerController(CoreController):
         # update/signal group player(s) when child updates
         for group_player in self._get_player_groups(player, powered_only=False):
             self.mass.loop.call_soon(group_player.update_state, True)
+        # update/signal manually synced to player when child updates
+        if (synced_to := player.synced_to) and (synced_to_player := self.get(synced_to)):
+            self.mass.loop.call_soon(synced_to_player.update_state, True)
 
     async def register_player_control(self, player_control: PlayerControl) -> None:
         """Register a new PlayerControl on the controller."""

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -289,7 +289,13 @@ class Player(ABC):
 
         If there are currently no group members, this should return an empty list.
         """
-        return self._attr_group_members
+        if len(self._attr_group_members) >= 1 and self.player_id not in self._attr_group_members:
+            # always ensure the player_id is in the group_members list
+            return [self.player_id, *self._attr_group_members]
+        elif self._attr_group_members == [self.player_id]:
+            return []
+        else:
+            return self._attr_group_members
 
     @property
     def can_group_with(self) -> set[str]:

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -289,16 +289,14 @@ class Player(ABC):
 
         If there are currently no group members, this should return an empty list.
         """
-        if len(self._attr_group_members) >= 1 and self.player_id not in self._attr_group_members:
-            if self.type == PlayerType.PLAYER:
-                # always ensure the player_id is in the group_members list
-                return [self.player_id, *self._attr_group_members]
-            else:
-                return self._attr_group_members
+        if self.type == PlayerType.PLAYER and (
+            len(self._attr_group_members) >= 1 and self.player_id not in self._attr_group_members
+        ):
+            # always ensure the player_id is in the group_members list for players
+            return [self.player_id, *self._attr_group_members]
         elif self._attr_group_members == [self.player_id]:
             return []
-        else:
-            return self._attr_group_members
+        return self._attr_group_members
 
     @property
     def can_group_with(self) -> set[str]:

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -290,8 +290,11 @@ class Player(ABC):
         If there are currently no group members, this should return an empty list.
         """
         if len(self._attr_group_members) >= 1 and self.player_id not in self._attr_group_members:
-            # always ensure the player_id is in the group_members list
-            return [self.player_id, *self._attr_group_members]
+            if self.type == PlayerType.PLAYER:
+                # always ensure the player_id is in the group_members list
+                return [self.player_id, *self._attr_group_members]
+            else:
+                return self._attr_group_members
         elif self._attr_group_members == [self.player_id]:
             return []
         else:


### PR DESCRIPTION
This PR fixes 2 grouping related issues after the player refactor:
1. `group_volume` is now correctly updated after a group members volume was changed
2. Make players removed from a group available for playback (by immediately updating their state that includes `synced_to`)