### PR TITLE
Fix `RuntimeError` in Chromecast player creation

### DIFF
--- a/music_assistant/providers/chromecast/provider.py
+++ b/music_assistant/providers/chromecast/provider.py
@@ -133,12 +133,17 @@ class ChromecastProvider(PlayerProvider):
                 self.mass.aiozc.zeroconf,
             )
             # create and register the new ChromeCastPlayer
-            castplayer = ChromecastPlayer(
-                self, player_id, cast_info=cast_info, chromecast=chromecast
-            )
             asyncio.run_coroutine_threadsafe(
-                self.mass.players.register_or_update(castplayer), loop=self.mass.loop
+                self._create_and_register_player(player_id, cast_info, chromecast),
+                loop=self.mass.loop,
             )
+
+    async def _create_and_register_player(
+        self, player_id: str, cast_info: ChromecastInfo, chromecast: pychromecast.Chromecast
+    ) -> None:
+        """Create and register a new ChromecastPlayer."""
+        castplayer = ChromecastPlayer(self, player_id, cast_info=cast_info, chromecast=chromecast)
+        await self.mass.players.register_or_update(castplayer)
 
     def _on_chromecast_removed(self, uuid: str, service: object, cast_info: object) -> None:
         """Handle zeroconf discovery of a removed Chromecast."""


### PR DESCRIPTION
Moves `ChromecastPlayer` creation to the main Music Assistant event loop thread to fix this bug after the player model refactor:
```
2025-09-02 13:23:08.309 ERROR (zeroconf-ServiceBrowser-_googlecast._tcp-42943) [root] Uncaught thread exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "src/zeroconf/_services/browser.py", line 805, in zeroconf._services.browser.ServiceBrowser.run
  File "src/zeroconf/_services/browser.py", line 724, in zeroconf._services.browser._ServiceBrowserBase._fire_service_state_changed_event
  File "src/zeroconf/_services/browser.py", line 734, in zeroconf._services.browser._ServiceBrowserBase._fire_service_state_changed_event
  File "src/zeroconf/_services/__init__.py", line 58, in zeroconf._services.Signal.fire
  File "src/zeroconf/_services/browser.py", line 300, in zeroconf._services.browser._on_change_dispatcher
  File "/home/mass/.local/music-assistant-venv/lib/python3.13/site-packages/pychromecast/discovery.py", line 153, in add_service
    self._add_update_service(zc, type_, name, self._cast_listener.add_cast)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mass/.local/music-assistant-venv/lib/python3.13/site-packages/pychromecast/discovery.py", line 276, in _add_update_service
    callback(uuid, name)
    ~~~~~~~~^^^^^^^^^^^^
  File "/home/mass/.local/music-assistant-venv/lib/python3.13/site-packages/pychromecast/discovery.py", line 93, in add_cast
    self._add_callback(uuid, service)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/workspaces/server/music_assistant/providers/chromecast/provider.py", line 136, in _on_chromecast_discovered
    castplayer = ChromecastPlayer(
        self, player_id, cast_info=cast_info, chromecast=chromecast
    )
  File "/workspaces/server/music_assistant/providers/chromecast/player.py", line 55, in __init__
    super().__init__(provider, player_id)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/server/music_assistant/models/player.py", line 150, in __init__
    self.mass.config.create_default_player_config(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        player_id, self.provider_id, self.name, self.enabled_by_default
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/workspaces/server/music_assistant/controllers/config.py", line 601, in create_default_player_config
    self.set(
    ~~~~~~~~^
        conf_key,
        ^^^^^^^^^
        default_conf_raw,
        ^^^^^^^^^^^^^^^^^
    )
    ^
  File "/workspaces/server/music_assistant/controllers/config.py", line 143, in set
    self.save()
    ~~~~~~~~~^^
  File "/workspaces/server/music_assistant/controllers/config.py", line 806, in save
    self._timer_handle = self.mass.loop.call_later(
                         ~~~~~~~~~~~~~~~~~~~~~~~~~^
        DEFAULT_SAVE_DELAY, self.mass.create_task, self._async_save
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 799, in call_later
    timer = self.call_at(self.time() + delay, callback, *args,
                         context=context)
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 814, in call_at
    self._check_thread()
    ~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 872, in _check_thread
    raise RuntimeError(
        "Non-thread-safe operation invoked on an event loop other "
        "than the current one")
RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one
```