### PR TITLE
Don't remove players on load in Home Assistant Player Provider

### DIFF
--- a/music_assistant/providers/hass_players/provider.py
+++ b/music_assistant/providers/hass_players/provider.py
@@ -62,10 +62,6 @@ class HomeAssistantPlayerProvider(PlayerProvider):
         self.on_unload_callbacks = [
             await self.hass_prov.hass.subscribe_entities(self._on_entity_state_update, player_ids)
         ]
-        # remove any leftover players (after reconfigure of players)
-        for player in self.players:
-            if player.player_id not in player_ids:
-                await self.mass.players.unregister(player.player_id)
 
     async def unload(self, is_removed: bool = False) -> None:
         """

--- a/music_assistant/providers/hass_players/provider.py
+++ b/music_assistant/providers/hass_players/provider.py
@@ -65,7 +65,7 @@ class HomeAssistantPlayerProvider(PlayerProvider):
         # remove any leftover players (after reconfigure of players)
         for player in self.players:
             if player.player_id not in player_ids:
-                self.mass.players.remove(player.player_id)
+                await self.mass.players.unregister(player.player_id)
 
     async def unload(self, is_removed: bool = False) -> None:
         """


### PR DESCRIPTION
This is not required, since:
- Unloading a provider already unregisters all its players in `mass.py`s `unload_provider`
- Reloading a player provider first unloads the provider