### PR TITLE
Add caching and fix audiobook podcast mixup

### DIFF
--- a/music_assistant/providers/spotify/parsers.py
+++ b/music_assistant/providers/spotify/parsers.py
@@ -210,13 +210,8 @@ def parse_playlist(playlist_obj: dict[str, Any], provider: SpotifyProvider) -> P
     return playlist
 
 
-def parse_podcast(podcast_obj: dict[str, Any], provider: SpotifyProvider) -> Podcast | None:
+def parse_podcast(podcast_obj: dict[str, Any], provider: SpotifyProvider) -> Podcast:
     """Parse spotify podcast (show) object to generic layout."""
-    # Filter out audiobooks - they have different characteristics
-    description = podcast_obj.get("description", "")
-    if description.startswith("Author(s):") and "Narrator(s):" in description:
-        return None
-
     podcast = Podcast(
         item_id=podcast_obj["id"],
         provider=provider.lookup_key,

--- a/music_assistant/providers/spotify/parsers.py
+++ b/music_assistant/providers/spotify/parsers.py
@@ -210,8 +210,13 @@ def parse_playlist(playlist_obj: dict[str, Any], provider: SpotifyProvider) -> P
     return playlist
 
 
-def parse_podcast(podcast_obj: dict[str, Any], provider: SpotifyProvider) -> Podcast:
+def parse_podcast(podcast_obj: dict[str, Any], provider: SpotifyProvider) -> Podcast | None:
     """Parse spotify podcast (show) object to generic layout."""
+    # Filter out audiobooks - they have different characteristics
+    description = podcast_obj.get("description", "")
+    if description.startswith("Author(s):") and "Narrator(s):" in description:
+        return None
+
     podcast = Podcast(
         item_id=podcast_obj["id"],
         provider=provider.lookup_key,

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -212,8 +212,10 @@ class SpotifyProvider(MusicProvider):
                         continue
                     # Filter out audiobooks - they have a distinctive description format
                     description = item.get("description", "")
-                    if description.startswith("Author(s):")
-                        and "Narrator(s):" in description:
+                    if (
+                        description.startswith("Author(s):")
+                        and "Narrator(s):" in description
+                    ):
                         continue
                     podcasts.append(parse_podcast(item, self))
                 searchresult.podcasts = [*searchresult.podcasts, *podcasts]

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -142,7 +142,7 @@ class SpotifyProvider(MusicProvider):
         self, search_query: str, media_types: list[MediaType] | None = None, limit: int = 5
     ) -> SearchResults:
         """Perform search on musicprovider.
-
+    
         :param search_query: Search query.
         :param media_types: A list of media_types to include.
         :param limit: Number of items to return in the search (per type).
@@ -205,14 +205,16 @@ class SpotifyProvider(MusicProvider):
                 searchresult.playlists = [*searchresult.playlists, *playlists]
                 items_received += len(api_result["playlists"]["items"])
             if "shows" in api_result:
-                podcasts = [
-                    parse_podcast(item, self)
-                    for item in api_result["shows"]["items"]
-                    if (item and item["id"])
-                ]
-                # Filter out None values (audiobooks)
-                valid_podcasts = [p for p in podcasts if p is not None]
-                searchresult.podcasts = [*searchresult.podcasts, *valid_podcasts]
+                podcasts = []
+                for item in api_result["shows"]["items"]:
+                    if not (item and item["id"]):
+                        continue
+                    # Filter out audiobooks - they have a distinctive description format
+                    description = item.get("description", "")
+                    if description.startswith("Author(s):") and "Narrator(s):" in description:
+                        continue
+                    podcasts.append(parse_podcast(item, self))
+                searchresult.podcasts = [*searchresult.podcasts, *podcasts]
                 items_received += len(api_result["shows"]["items"])
             offset += page_limit
             if offset >= limit:
@@ -255,9 +257,12 @@ class SpotifyProvider(MusicProvider):
         """Retrieve library podcasts from spotify."""
         async for item in self._get_all_items("me/shows"):
             if item["show"] and item["show"]["id"]:
-                podcast = parse_podcast(item["show"], self)
-                if podcast:  # Only yield if parse_podcast didn't return None
-                    yield podcast
+                show_obj = item["show"]
+                # Filter out audiobooks - they have a distinctive description format
+                description = show_obj.get("description", "")
+                if description.startswith("Author(s):") and "Narrator(s):" in description:
+                    continue
+                yield parse_podcast(show_obj, self)
 
     def _get_liked_songs_playlist_id(self) -> str:
         return f"{LIKED_SONGS_FAKE_PLAYLIST_ID_PREFIX}-{self.instance_id}"
@@ -335,13 +340,7 @@ class SpotifyProvider(MusicProvider):
         podcast_obj = await self._get_data(f"shows/{prov_podcast_id}")
         if not podcast_obj:
             raise MediaNotFoundError(f"Podcast not found: {prov_podcast_id}")
-
-        podcast = parse_podcast(podcast_obj, self)
-        if not podcast:
-            # This means it's an audiobook, not a podcast
-            raise MediaNotFoundError(f"Podcast not found: {prov_podcast_id}")
-
-        return podcast
+        return parse_podcast(podcast_obj, self)
 
     async def get_podcast_episodes(
         self, prov_podcast_id: str
@@ -806,3 +805,4 @@ class SpotifyProvider(MusicProvider):
             self.logger.warning(
                 "FIXME: Spotify have fixed their Create Playlist API, this fix can be removed."
             )
+

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -264,7 +264,10 @@ class SpotifyProvider(MusicProvider):
                 show_obj = item["show"]
                 # Filter out audiobooks - they have a distinctive description format
                 description = show_obj.get("description", "")
-                if description.startswith("Author(s):") and "Narrator(s):" in description:
+                if (
+                    description.startswith("Author(s):")
+                    and "Narrator(s):" in description
+                ):
                     continue
                 yield parse_podcast(show_obj, self)
 

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -37,6 +37,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
 from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.process import check_output
@@ -209,7 +210,9 @@ class SpotifyProvider(MusicProvider):
                     for item in api_result["shows"]["items"]
                     if (item and item["id"])
                 ]
-                searchresult.podcasts = [*searchresult.podcasts, *podcasts]
+                # Filter out None values (audiobooks)
+                valid_podcasts = [p for p in podcasts if p is not None]
+                searchresult.podcasts = [*searchresult.podcasts, *valid_podcasts]
                 items_received += len(api_result["shows"]["items"])
             offset += page_limit
             if offset >= limit:
@@ -252,7 +255,9 @@ class SpotifyProvider(MusicProvider):
         """Retrieve library podcasts from spotify."""
         async for item in self._get_all_items("me/shows"):
             if item["show"] and item["show"]["id"]:
-                yield parse_podcast(item["show"], self)
+                podcast = parse_podcast(item["show"], self)
+                if podcast:  # Only yield if parse_podcast didn't return None
+                    yield podcast
 
     def _get_liked_songs_playlist_id(self) -> str:
         return f"{LIKED_SONGS_FAKE_PLAYLIST_ID_PREFIX}-{self.instance_id}"
@@ -324,12 +329,19 @@ class SpotifyProvider(MusicProvider):
         playlist_obj = await self._get_data(f"playlists/{prov_playlist_id}")
         return parse_playlist(playlist_obj, self)
 
+    @use_cache(86400)  # 24 hours
     async def get_podcast(self, prov_podcast_id: str) -> Podcast:
         """Get full podcast details by id."""
         podcast_obj = await self._get_data(f"shows/{prov_podcast_id}")
         if not podcast_obj:
             raise MediaNotFoundError(f"Podcast not found: {prov_podcast_id}")
-        return parse_podcast(podcast_obj, self)
+
+        podcast = parse_podcast(podcast_obj, self)
+        if not podcast:
+            # This means it's an audiobook, not a podcast
+            raise MediaNotFoundError(f"Podcast not found: {prov_podcast_id}")
+
+        return podcast
 
     async def get_podcast_episodes(
         self, prov_podcast_id: str
@@ -349,6 +361,7 @@ class SpotifyProvider(MusicProvider):
             episode_position += 1
             yield episode
 
+    @use_cache(86400)  # 24 hours
     async def get_podcast_episode(self, prov_episode_id: str) -> PodcastEpisode:
         """Get full podcast episode details by id."""
         episode_obj = await self._get_data(f"episodes/{prov_episode_id}", market="from_token")

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -212,7 +212,8 @@ class SpotifyProvider(MusicProvider):
                         continue
                     # Filter out audiobooks - they have a distinctive description format
                     description = item.get("description", "")
-                    if description.startswith("Author(s):") and "Narrator(s):" in description:
+                    if description.startswith("Author(s):")
+                        and "Narrator(s):" in description:
                         continue
                     podcasts.append(parse_podcast(item, self))
                 searchresult.podcasts = [*searchresult.podcasts, *podcasts]

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -138,7 +138,7 @@ class SpotifyProvider(MusicProvider):
             return str(self._sp_user["display_name"])
         return None
 
-# pylint: disable=too-many-statements
+    # ruff: noqa: PLR0915
     async def search(
         self, search_query: str, media_types: list[MediaType] | None = None, limit: int = 5
     ) -> SearchResults:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -138,11 +138,12 @@ class SpotifyProvider(MusicProvider):
             return str(self._sp_user["display_name"])
         return None
 
+# pylint: disable=too-many-statements
     async def search(
         self, search_query: str, media_types: list[MediaType] | None = None, limit: int = 5
     ) -> SearchResults:
         """Perform search on musicprovider.
-    
+
         :param search_query: Search query.
         :param media_types: A list of media_types to include.
         :param limit: Number of items to return in the search (per type).

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -212,10 +212,7 @@ class SpotifyProvider(MusicProvider):
                         continue
                     # Filter out audiobooks - they have a distinctive description format
                     description = item.get("description", "")
-                    if (
-                        description.startswith("Author(s):")
-                        and "Narrator(s):" in description
-                    ):
+                    if description.startswith("Author(s):") and "Narrator(s):" in description:
                         continue
                     podcasts.append(parse_podcast(item, self))
                 searchresult.podcasts = [*searchresult.podcasts, *podcasts]
@@ -264,10 +261,7 @@ class SpotifyProvider(MusicProvider):
                 show_obj = item["show"]
                 # Filter out audiobooks - they have a distinctive description format
                 description = show_obj.get("description", "")
-                if (
-                    description.startswith("Author(s):")
-                    and "Narrator(s):" in description
-                ):
+                if description.startswith("Author(s):") and "Narrator(s):" in description:
                     continue
                 yield parse_podcast(show_obj, self)
 
@@ -812,4 +806,3 @@ class SpotifyProvider(MusicProvider):
             self.logger.warning(
                 "FIXME: Spotify have fixed their Create Playlist API, this fix can be removed."
             )
-


### PR DESCRIPTION
Was adding a first round of caching and during testing realised audiobooks were being returned by Spotify with the podcast API call. These are now filtered out and later a new PR will be done to add audiobook support by using the get audiobook endpoint.

I want to cache the list of episodes as well but that needs more refactoring so will do that in a subsequent PR