### PR TITLE
Fix issue with filter iterator in ARD MediaThek provider

### DIFF
--- a/music_assistant/providers/ard_audiothek/__init__.py
+++ b/music_assistant/providers/ard_audiothek/__init__.py
@@ -559,8 +559,8 @@ class ARDAudiothek(MusicProvider):
                 return True
             return int(val["audioBitrate"]) < self.max_bitrate
 
-        filtered_streams = filter(filter_func, streams)
-        if len(list(filtered_streams)) == 0:
+        filtered_streams = list(filter(filter_func, streams))
+        if len(filtered_streams) == 0:
             raise UnplayableMediaError("No stream exceeding the minimum bitrate available.")
         selected_stream = max(filtered_streams, key=lambda x: x["audioBitrate"])
 


### PR DESCRIPTION
This fix is necessary as the filter function returns an iterator. This leads to an empty "list" at the second usage of the iterator and therefore no valid stream

Fixes issue mentioned here: https://github.com/music-assistant/server/pull/2229#issuecomment-3295765654

