### PR TITLE
Add live and soundtrack album types

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -733,3 +733,22 @@ ATTR_ANNOUNCEMENT_IN_PROGRESS: Final[str] = "announcement_in_progress"
 ATTR_PREVIOUS_VOLUME: Final[str] = "previous_volume"
 ATTR_LAST_POLL: Final[str] = "last_poll"
 ATTR_GROUP_MEMBERS: Final[str] = "group_members"
+
+# Album type detection patterns
+LIVE_INDICATORS = [
+    r"\bunplugged\b",
+    r"\bin concert\b",
+    r"\bon stage\b",
+    r"\blive\b",
+]
+
+SOUNDTRACK_INDICATORS = [
+    r"\bsoundtrack\b",  # Catches all soundtrack variations
+    r"\bmusic from the motion picture\b",
+    r"\boriginal score\b",
+    r"\bthe score\b",
+    r"\bfilm score\b",
+    r"(^|\b)score:\s*",  # e.g., "Score: The Two Towers"
+    r"\bfrom the film\b",
+    r"\boriginal.*cast.*recording\b",
+]

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -441,7 +441,7 @@ class AudioTags:
             if stream.get("codec_type") == "video":
                 continue
             for key, value in stream.get("tags", {}).items():
-                alt_key = key.lower().replace(" ", "").replace("_", "").replace("-", "")
+                alt_key = key.lower().replace(" ", "").replace("_", "").replace("-", "").replace("/", "")
                 if alt_key in tags:
                     continue
                 tags[alt_key] = value

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -20,7 +20,7 @@ from music_assistant_models.errors import InvalidDataError
 from music_assistant.constants import MASS_LOGGER_NAME, UNKNOWN_ARTIST
 from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.process import AsyncProcess
-from music_assistant.helpers.util import try_parse_int
+from music_assistant.helpers.util import infer_album_type, try_parse_int
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.tags")
 
@@ -336,8 +336,7 @@ class AudioTags:
 
     # No valid tag found, try inference from album title
     album_title = self.tags.get("album", "")
-    inferred_type = infer_album_type(album_title, "")
-    return inferred_type
+    return infer_album_type(album_title, "")
 
     @property
     def isrc(self) -> tuple[str, ...]:

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -324,6 +324,8 @@ class AudioTags:
         # the album type tag is messy within id3 and may even contain multiple types
         # try to parse one in order of preference
         for album_type in (
+            AlbumType.LIVE,
+            AlbumType.SOUNDTRACK,
             AlbumType.COMPILATION,
             AlbumType.EP,
             AlbumType.SINGLE,

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -441,7 +441,9 @@ class AudioTags:
             if stream.get("codec_type") == "video":
                 continue
             for key, value in stream.get("tags", {}).items():
-                alt_key = key.lower().replace(" ", "").replace("_", "").replace("-", "").replace("/", "")
+                alt_key = key.lower()
+                for char in [" ", "_", "-", "/"]:
+                    alt_key = alt_key.replace(char, "")
                 if alt_key in tags:
                     continue
                 tags[alt_key] = value

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -314,27 +314,30 @@ class AudioTags:
         """Return albumtype tag if present."""
         if self.tags.get("compilation", "") == "1":
             return AlbumType.COMPILATION
+
         tag = (
             self.tags.get("musicbrainzalbumtype")
             or self.tags.get("albumtype")
             or self.tags.get("releasetype")
         )
-        if tag is None:
-            return AlbumType.UNKNOWN
-        # the album type tag is messy within id3 and may even contain multiple types
-        # try to parse one in order of preference
-        for album_type in (
-            AlbumType.LIVE,
-            AlbumType.SOUNDTRACK,
-            AlbumType.COMPILATION,
-            AlbumType.EP,
-            AlbumType.SINGLE,
-            AlbumType.ALBUM,
-        ):
-            if album_type.value in tag.lower():
-                return album_type
 
-        return AlbumType.UNKNOWN
+        if tag is not None:
+            # try to parse one in order of preference
+            for album_type in (
+                AlbumType.LIVE,
+                AlbumType.SOUNDTRACK,
+                AlbumType.COMPILATION,
+                AlbumType.EP,
+                AlbumType.SINGLE,
+                AlbumType.ALBUM,
+            ):
+                if album_type.value in tag.lower():
+                    return album_type
+
+    # No valid tag found, try inference from album title
+    album_title = self.tags.get("album", "")
+    inferred_type = infer_album_type(album_title, "")
+    return inferred_type
 
     @property
     def isrc(self) -> tuple[str, ...]:

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -334,9 +334,9 @@ class AudioTags:
                 if album_type.value in tag.lower():
                     return album_type
 
-    # No valid tag found, try inference from album title
-    album_title = self.tags.get("album", "")
-    return infer_album_type(album_title, "")
+        # No valid tag found, try inference from album title
+        album_title = self.tags.get("album", "")
+        return infer_album_type(album_title, "")
 
     @property
     def isrc(self) -> tuple[str, ...]:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -11,7 +11,6 @@ import re
 import shutil
 import socket
 import urllib.error
-import urllib.parse
 import urllib.request
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine
 from contextlib import suppress
@@ -24,9 +23,10 @@ from urllib.parse import urlparse
 
 import chardet
 import ifaddr
+from music_assistant_models.enums import AlbumType
 from zeroconf import IPVersion
 
-from music_assistant.constants import VERBOSE_LOG_LEVEL
+from music_assistant.constants import LIVE_INDICATORS, SOUNDTRACK_INDICATORS, VERBOSE_LOG_LEVEL
 from music_assistant.helpers.process import check_output
 
 if TYPE_CHECKING:
@@ -150,6 +150,18 @@ def parse_title_and_version(title: str, track_version: str | None = None) -> tup
                 title = title.replace(title_part, "").strip()
                 return (title, version)
     return title, version
+
+
+def infer_album_type(title: str, version: str) -> AlbumType:
+    """Infer album type by looking for live or soundtrack indicators."""
+    combined = f"{title} {version}".lower()
+    for pat in LIVE_INDICATORS:
+        if re.search(pat, combined):
+            return AlbumType.LIVE
+    for pat in SOUNDTRACK_INDICATORS:
+        if re.search(pat, combined):
+            return AlbumType.SOUNDTRACK
+    return AlbumType.UNKNOWN
 
 
 def strip_ads(line: str) -> str:

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -6,7 +6,6 @@ from asyncio import TaskGroup
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from math import ceil
-from typing import Any, Literal
 
 import deezer
 from aiohttp import ClientSession, ClientTimeout
@@ -23,7 +22,7 @@ from music_assistant_models.enums import (
     ProviderFeature,
     StreamType,
 )
-from music_assistant_models.errors import LoginFailed, MediaNotFoundError
+from music_assistant_models.errors import LoginFailed
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -37,13 +36,12 @@ from music_assistant_models.media_items import (
     RecommendationFolder,
     SearchResults,
     Track,
-    UniqueList,
 )
 from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant import MusicAssistant
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.auth import AuthenticationHelper
 from music_assistant.helpers.datetime import utc_timestamp
 from music_assistant.helpers.util import infer_album_type
@@ -132,11 +130,11 @@ async def get_config_entries(
     # Action is to launch oauth flow
     if action == CONF_ACTION_AUTH:
         # Use the AuthenticationHelper to authenticate
-        async with AuthenticationHelper(mass, values["session_id"]) as auth_helper:  # type: ignore[arg-type, index]
+        async with AuthenticationHelper(mass, values["session_id"]) as auth_helper:  # type: ignore
             url = f"{DEEZER_AUTH_URL}?app_id={DEEZER_APP_ID}&redirect_uri={RELAY_URL}\
 &perms={DEEZER_PERMS}&state={auth_helper.callback_url}"
             code = (await auth_helper.authenticate(url))["code"]
-            values[CONF_ACCESS_TOKEN] = await get_access_token(  # type: ignore[index]
+            values[CONF_ACCESS_TOKEN] = await get_access_token(  # type: ignore
                 DEEZER_APP_ID, DEEZER_APP_SECRET, code, mass.http_session
             )
 
@@ -175,7 +173,7 @@ class DeezerProvider(MusicProvider):
         self.credentials = DeezerCredentials(
             app_id=DEEZER_APP_ID,
             app_secret=DEEZER_APP_SECRET,
-            access_token=self.config.get_value(CONF_ACCESS_TOKEN),  # type: ignore[arg-type]
+            access_token=self.config.get_value(CONF_ACCESS_TOKEN),  # type: ignore
         )
 
         self.client = deezer.Client(
@@ -188,8 +186,8 @@ class DeezerProvider(MusicProvider):
 
         self.gw_client = GWClient(
             self.mass.http_session,
-            str(self.config.get_value(CONF_ACCESS_TOKEN)),
-            str(self.config.get_value(CONF_ARL_TOKEN)),
+            self.config.get_value(CONF_ACCESS_TOKEN),
+            self.config.get_value(CONF_ARL_TOKEN),
         )
         await self.gw_client.setup()
 
@@ -199,7 +197,7 @@ class DeezerProvider(MusicProvider):
         return SUPPORTED_FEATURES
 
     async def search(
-        self, search_query: str, media_types: list[MediaType], limit: int = 5
+        self, search_query: str, media_types=list[MediaType], limit: int = 5
     ) -> SearchResults:
         """Perform search on music provider.
 
@@ -207,7 +205,7 @@ class DeezerProvider(MusicProvider):
         :param media_types: A list of media_types to include. All types if None.
         """
         # Create a task for each media_type
-        tasks: dict[MediaType, Any] = {}
+        tasks = {}
 
         async with TaskGroup() as taskgroup:
             for media_type in media_types:
@@ -274,7 +272,6 @@ class DeezerProvider(MusicProvider):
             )
         except deezer_exceptions.DeezerErrorResponse as error:
             self.logger.warning("Failed getting artist: %s", error)
-            raise MediaNotFoundError(f"Artist {prov_artist_id} not found on Deezer") from error
 
     async def get_album(self, prov_album_id: str) -> Album:
         """Get full album details by id."""
@@ -282,7 +279,6 @@ class DeezerProvider(MusicProvider):
             return self.parse_album(album=await self.client.get_album(album_id=int(prov_album_id)))
         except deezer_exceptions.DeezerErrorResponse as error:
             self.logger.warning("Failed getting album: %s", error)
-            raise MediaNotFoundError(f"Album {prov_album_id} not found on Deezer") from error
 
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
         """Get full playlist details by id."""
@@ -292,7 +288,6 @@ class DeezerProvider(MusicProvider):
             )
         except deezer_exceptions.DeezerErrorResponse as error:
             self.logger.warning("Failed getting playlist: %s", error)
-            raise MediaNotFoundError(f"Album {prov_playlist_id} not found on Deezer") from error
 
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
@@ -303,7 +298,6 @@ class DeezerProvider(MusicProvider):
             )
         except deezer_exceptions.DeezerErrorResponse as error:
             self.logger.warning("Failed getting track: %s", error)
-            raise MediaNotFoundError(f"Album {prov_track_id} not found on Deezer") from error
 
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get all tracks in an album."""
@@ -401,15 +395,12 @@ class DeezerProvider(MusicProvider):
         return [
             RecommendationFolder(
                 item_id="recommended_tracks",
-                provider=self.lookup_key,
                 name="Recommended tracks",
                 translation_key="recommended_tracks",
-                items=UniqueList(
-                    [
-                        self.parse_track(track=track, user_country=self.gw_client.user_country)
-                        for track in await self.client.get_user_recommended_tracks()
-                    ]
-                ),
+                items=[
+                    self.parse_track(track=track, user_country=self.gw_client.user_country)
+                    for track in await self.client.get_user_recommended_tracks()
+                ],
             )
         ]
 
@@ -437,17 +428,17 @@ class DeezerProvider(MusicProvider):
         playlist = await self.client.get_playlist(playlist_id)
         return self.parse_playlist(playlist=playlist)
 
-    async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
+    async def get_similar_tracks(self, prov_track_id, limit=25) -> list[Track]:
         """Retrieve a dynamic list of tracks based on the provided item."""
         endpoint = "song.getSearchTrackMix"
-        tracks = (await self.gw_client._gw_api_call(endpoint, args={"SNG_ID": prov_track_id}))[  # type: ignore[no-untyped-call]
+        tracks = (await self.gw_client._gw_api_call(endpoint, args={"SNG_ID": prov_track_id}))[
             "results"
         ]["data"][:limit]
         return [await self.get_track(track["SNG_ID"]) for track in tracks]
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Return the content details for the given track when it will be streamed."""
-        url_details, song_data = await self.gw_client.get_deezer_track_urls(item_id)  # type: ignore[no-untyped-call]
+        url_details, song_data = await self.gw_client.get_deezer_track_urls(item_id)
         url = url_details["sources"][0]["url"]
         return StreamDetails(
             item_id=item_id,
@@ -473,7 +464,7 @@ class DeezerProvider(MusicProvider):
         blowfish_key = self.get_blowfish_key(streamdetails.data["track_id"])
         chunk_index = 0
         timeout = ClientTimeout(total=0, connect=30, sock_read=600)
-        headers: dict[str, str] = {}
+        headers = {}
         # if seek_position and streamdetails.size:
         #     chunk_count = ceil(streamdetails.size / 2048)
         #     chunk_index = int(chunk_count / streamdetails.duration) * seek_position
@@ -483,7 +474,7 @@ class DeezerProvider(MusicProvider):
         # NOTE: Seek with using the Range header is not working properly
         # causing malformed audio so this is a temporary patch
         # by just skipping chunks
-        if seek_position and streamdetails.size and streamdetails.duration:
+        if seek_position and streamdetails.size:
             chunk_count = ceil(streamdetails.size / 2048)
             skip_chunks = int(chunk_count / streamdetails.duration) * seek_position
         else:
@@ -525,48 +516,46 @@ class DeezerProvider(MusicProvider):
             metadata.preview = track.preview
         if hasattr(track, "explicit_lyrics"):
             metadata.explicit = track.explicit_lyrics
+        if hasattr(track, "duration"):
+            metadata.duration = track.duration
         if hasattr(track, "rank"):
             metadata.popularity = track.rank
         if hasattr(track, "album") and hasattr(track.album, "cover_big"):
-            metadata.add_image(
+            metadata.images = [
                 MediaItemImage(
                     type=ImageType.THUMB,
                     path=track.album.cover_big,
                     provider=self.lookup_key,
                     remotely_accessible=True,
                 )
-            )
+            ]
         return metadata
 
     def parse_metadata_album(self, album: deezer.Album) -> MediaItemMetadata:
         """Parse the album metadata."""
         return MediaItemMetadata(
             explicit=album.explicit_lyrics,
-            images=UniqueList(
-                [
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=album.cover_big,
-                        provider=self.lookup_key,
-                        remotely_accessible=True,
-                    )
-                ]
-            ),
+            images=[
+                MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=album.cover_big,
+                    provider=self.lookup_key,
+                    remotely_accessible=True,
+                )
+            ],
         )
 
     def parse_metadata_artist(self, artist: deezer.Artist) -> MediaItemMetadata:
         """Parse the artist metadata."""
         return MediaItemMetadata(
-            images=UniqueList(
-                [
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=artist.picture_big,
-                        provider=self.lookup_key,
-                        remotely_accessible=True,
-                    )
-                ]
-            ),
+            images=[
+                MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=artist.picture_big,
+                    provider=self.lookup_key,
+                    remotely_accessible=True,
+                )
+            ],
         )
 
     ### PARSING FUNCTIONS ###
@@ -595,16 +584,14 @@ class DeezerProvider(MusicProvider):
             item_id=str(album.id),
             provider=self.lookup_key,
             name=album.title,
-            artists=UniqueList(
-                [
-                    ItemMapping(
-                        media_type=MediaType.ARTIST,
-                        item_id=str(album.artist.id),
-                        provider=self.lookup_key,
-                        name=album.artist.name,
-                    )
-                ]
-            ),
+            artists=[
+                ItemMapping(
+                    media_type=MediaType.ARTIST,
+                    item_id=str(album.artist.id),
+                    provider=self.lookup_key,
+                    name=album.artist.name,
+                )
+            ],
             media_type=MediaType.ALBUM,
             provider_mappings={
                 ProviderMapping(
@@ -635,23 +622,21 @@ class DeezerProvider(MusicProvider):
                 )
             },
             metadata=MediaItemMetadata(
-                images=UniqueList(
-                    [
-                        MediaItemImage(
-                            type=ImageType.THUMB,
-                            path=playlist.picture_big,
-                            provider=self.lookup_key,
-                            remotely_accessible=True,
-                        )
-                    ]
-                ),
+                images=[
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=playlist.picture_big,
+                        provider=self.lookup_key,
+                        remotely_accessible=True,
+                    )
+                ],
             ),
             is_editable=is_editable,
             owner=creator.name,
             cache_checksum=playlist.checksum,
         )
 
-    def get_playlist_creator(self, playlist: deezer.Playlist) -> deezer.User:
+    def get_playlist_creator(self, playlist: deezer.Playlist):
         """On playlists, the creator is called creator, elsewhere it's called user."""
         if hasattr(playlist, "creator"):
             return playlist.creator
@@ -684,7 +669,7 @@ class DeezerProvider(MusicProvider):
             name=track.title,
             sort_name=self.get_short_title(track),
             duration=track.duration,
-            artists=UniqueList([artist]) if artist else UniqueList(),
+            artists=[artist] if artist else [],
             album=album,
             provider_mappings={
                 ProviderMapping(
@@ -704,11 +689,11 @@ class DeezerProvider(MusicProvider):
             item.external_ids.add((ExternalID.ISRC, isrc))
         return item
 
-    def get_short_title(self, track: deezer.Track) -> str:
+    def get_short_title(self, track: deezer.Track):
         """Short names only returned, if available."""
         if hasattr(track, "title_short"):
-            return str(track.title_short)
-        return str(track.title)
+            return track.title_short
+        return track.title
 
     def get_album_type(self, album: deezer.Album) -> AlbumType:
         """Read and convert the Deezer album type."""
@@ -778,11 +763,9 @@ class DeezerProvider(MusicProvider):
 
     ### OTHER FUNCTIONS ###
 
-    async def get_track_content_type(
-        self, gw_client: GWClient, track_id: int
-    ) -> Literal[ContentType.FLAC, ContentType.MP3]:
+    async def get_track_content_type(self, gw_client: GWClient, track_id: int):
         """Get a tracks contentType."""
-        song_data = await gw_client.get_song_data(track_id)  # type: ignore[no-untyped-call]
+        song_data = await gw_client.get_song_data(track_id)
         if song_data["results"]["FILESIZE_FLAC"]:
             return ContentType.FLAC
 
@@ -798,12 +781,12 @@ class DeezerProvider(MusicProvider):
             return user_country in track.available_countries
         return True
 
-    def _md5(self, data: str, data_type: str = "ascii") -> str:
+    def _md5(self, data, data_type="ascii"):
         md5sum = hashlib.md5()
         md5sum.update(data.encode(data_type))
         return md5sum.hexdigest()
 
-    def get_blowfish_key(self, track_id: str) -> str:
+    def get_blowfish_key(self, track_id):
         """Get blowfish key to decrypt a chunk of a track."""
         secret = app_var(5)
         id_md5 = self._md5(track_id)
@@ -811,7 +794,7 @@ class DeezerProvider(MusicProvider):
             chr(ord(id_md5[i]) ^ ord(id_md5[i + 16]) ^ ord(secret[i])) for i in range(16)
         )
 
-    def decrypt_chunk(self, chunk: bytes, blowfish_key: str) -> bytes:
+    def decrypt_chunk(self, chunk, blowfish_key):
         """Decrypt a given chunk using the blow fish key."""
         cipher = Blowfish.new(
             blowfish_key.encode("ascii"),

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -6,6 +6,7 @@ from asyncio import TaskGroup
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from math import ceil
+from typing import Any, Literal
 
 import deezer
 from aiohttp import ClientSession, ClientTimeout
@@ -22,7 +23,7 @@ from music_assistant_models.enums import (
     ProviderFeature,
     StreamType,
 )
-from music_assistant_models.errors import LoginFailed
+from music_assistant_models.errors import LoginFailed, MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -36,14 +37,16 @@ from music_assistant_models.media_items import (
     RecommendationFolder,
     SearchResults,
     Track,
+    UniqueList,
 )
 from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant import MusicAssistant
-from music_assistant.helpers.app_vars import app_var
+from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
 from music_assistant.helpers.auth import AuthenticationHelper
 from music_assistant.helpers.datetime import utc_timestamp
+from music_assistant.helpers.util import infer_album_type
 from music_assistant.models import ProviderInstanceType
 from music_assistant.models.music_provider import MusicProvider
 
@@ -129,11 +132,11 @@ async def get_config_entries(
     # Action is to launch oauth flow
     if action == CONF_ACTION_AUTH:
         # Use the AuthenticationHelper to authenticate
-        async with AuthenticationHelper(mass, values["session_id"]) as auth_helper:  # type: ignore
+        async with AuthenticationHelper(mass, values["session_id"]) as auth_helper:  # type: ignore[arg-type, index]
             url = f"{DEEZER_AUTH_URL}?app_id={DEEZER_APP_ID}&redirect_uri={RELAY_URL}\
 &perms={DEEZER_PERMS}&state={auth_helper.callback_url}"
             code = (await auth_helper.authenticate(url))["code"]
-            values[CONF_ACCESS_TOKEN] = await get_access_token(  # type: ignore
+            values[CONF_ACCESS_TOKEN] = await get_access_token(  # type: ignore[index]
                 DEEZER_APP_ID, DEEZER_APP_SECRET, code, mass.http_session
             )
 
@@ -172,7 +175,7 @@ class DeezerProvider(MusicProvider):
         self.credentials = DeezerCredentials(
             app_id=DEEZER_APP_ID,
             app_secret=DEEZER_APP_SECRET,
-            access_token=self.config.get_value(CONF_ACCESS_TOKEN),  # type: ignore
+            access_token=self.config.get_value(CONF_ACCESS_TOKEN),  # type: ignore[arg-type]
         )
 
         self.client = deezer.Client(
@@ -185,8 +188,8 @@ class DeezerProvider(MusicProvider):
 
         self.gw_client = GWClient(
             self.mass.http_session,
-            self.config.get_value(CONF_ACCESS_TOKEN),
-            self.config.get_value(CONF_ARL_TOKEN),
+            str(self.config.get_value(CONF_ACCESS_TOKEN)),
+            str(self.config.get_value(CONF_ARL_TOKEN)),
         )
         await self.gw_client.setup()
 
@@ -196,7 +199,7 @@ class DeezerProvider(MusicProvider):
         return SUPPORTED_FEATURES
 
     async def search(
-        self, search_query: str, media_types=list[MediaType], limit: int = 5
+        self, search_query: str, media_types: list[MediaType], limit: int = 5
     ) -> SearchResults:
         """Perform search on music provider.
 
@@ -204,7 +207,7 @@ class DeezerProvider(MusicProvider):
         :param media_types: A list of media_types to include. All types if None.
         """
         # Create a task for each media_type
-        tasks = {}
+        tasks: dict[MediaType, Any] = {}
 
         async with TaskGroup() as taskgroup:
             for media_type in media_types:
@@ -271,6 +274,7 @@ class DeezerProvider(MusicProvider):
             )
         except deezer_exceptions.DeezerErrorResponse as error:
             self.logger.warning("Failed getting artist: %s", error)
+            raise MediaNotFoundError(f"Artist {prov_artist_id} not found on Deezer") from error
 
     async def get_album(self, prov_album_id: str) -> Album:
         """Get full album details by id."""
@@ -278,6 +282,7 @@ class DeezerProvider(MusicProvider):
             return self.parse_album(album=await self.client.get_album(album_id=int(prov_album_id)))
         except deezer_exceptions.DeezerErrorResponse as error:
             self.logger.warning("Failed getting album: %s", error)
+            raise MediaNotFoundError(f"Album {prov_album_id} not found on Deezer") from error
 
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
         """Get full playlist details by id."""
@@ -287,6 +292,7 @@ class DeezerProvider(MusicProvider):
             )
         except deezer_exceptions.DeezerErrorResponse as error:
             self.logger.warning("Failed getting playlist: %s", error)
+            raise MediaNotFoundError(f"Album {prov_playlist_id} not found on Deezer") from error
 
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
@@ -297,6 +303,7 @@ class DeezerProvider(MusicProvider):
             )
         except deezer_exceptions.DeezerErrorResponse as error:
             self.logger.warning("Failed getting track: %s", error)
+            raise MediaNotFoundError(f"Album {prov_track_id} not found on Deezer") from error
 
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get all tracks in an album."""
@@ -394,12 +401,15 @@ class DeezerProvider(MusicProvider):
         return [
             RecommendationFolder(
                 item_id="recommended_tracks",
+                provider=self.lookup_key,
                 name="Recommended tracks",
                 translation_key="recommended_tracks",
-                items=[
-                    self.parse_track(track=track, user_country=self.gw_client.user_country)
-                    for track in await self.client.get_user_recommended_tracks()
-                ],
+                items=UniqueList(
+                    [
+                        self.parse_track(track=track, user_country=self.gw_client.user_country)
+                        for track in await self.client.get_user_recommended_tracks()
+                    ]
+                ),
             )
         ]
 
@@ -427,17 +437,17 @@ class DeezerProvider(MusicProvider):
         playlist = await self.client.get_playlist(playlist_id)
         return self.parse_playlist(playlist=playlist)
 
-    async def get_similar_tracks(self, prov_track_id, limit=25) -> list[Track]:
+    async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
         """Retrieve a dynamic list of tracks based on the provided item."""
         endpoint = "song.getSearchTrackMix"
-        tracks = (await self.gw_client._gw_api_call(endpoint, args={"SNG_ID": prov_track_id}))[
+        tracks = (await self.gw_client._gw_api_call(endpoint, args={"SNG_ID": prov_track_id}))[  # type: ignore[no-untyped-call]
             "results"
         ]["data"][:limit]
         return [await self.get_track(track["SNG_ID"]) for track in tracks]
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Return the content details for the given track when it will be streamed."""
-        url_details, song_data = await self.gw_client.get_deezer_track_urls(item_id)
+        url_details, song_data = await self.gw_client.get_deezer_track_urls(item_id)  # type: ignore[no-untyped-call]
         url = url_details["sources"][0]["url"]
         return StreamDetails(
             item_id=item_id,
@@ -463,7 +473,7 @@ class DeezerProvider(MusicProvider):
         blowfish_key = self.get_blowfish_key(streamdetails.data["track_id"])
         chunk_index = 0
         timeout = ClientTimeout(total=0, connect=30, sock_read=600)
-        headers = {}
+        headers: dict[str, str] = {}
         # if seek_position and streamdetails.size:
         #     chunk_count = ceil(streamdetails.size / 2048)
         #     chunk_index = int(chunk_count / streamdetails.duration) * seek_position
@@ -473,7 +483,7 @@ class DeezerProvider(MusicProvider):
         # NOTE: Seek with using the Range header is not working properly
         # causing malformed audio so this is a temporary patch
         # by just skipping chunks
-        if seek_position and streamdetails.size:
+        if seek_position and streamdetails.size and streamdetails.duration:
             chunk_count = ceil(streamdetails.size / 2048)
             skip_chunks = int(chunk_count / streamdetails.duration) * seek_position
         else:
@@ -515,46 +525,48 @@ class DeezerProvider(MusicProvider):
             metadata.preview = track.preview
         if hasattr(track, "explicit_lyrics"):
             metadata.explicit = track.explicit_lyrics
-        if hasattr(track, "duration"):
-            metadata.duration = track.duration
         if hasattr(track, "rank"):
             metadata.popularity = track.rank
         if hasattr(track, "album") and hasattr(track.album, "cover_big"):
-            metadata.images = [
+            metadata.add_image(
                 MediaItemImage(
                     type=ImageType.THUMB,
                     path=track.album.cover_big,
                     provider=self.lookup_key,
                     remotely_accessible=True,
                 )
-            ]
+            )
         return metadata
 
     def parse_metadata_album(self, album: deezer.Album) -> MediaItemMetadata:
         """Parse the album metadata."""
         return MediaItemMetadata(
             explicit=album.explicit_lyrics,
-            images=[
-                MediaItemImage(
-                    type=ImageType.THUMB,
-                    path=album.cover_big,
-                    provider=self.lookup_key,
-                    remotely_accessible=True,
-                )
-            ],
+            images=UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=album.cover_big,
+                        provider=self.lookup_key,
+                        remotely_accessible=True,
+                    )
+                ]
+            ),
         )
 
     def parse_metadata_artist(self, artist: deezer.Artist) -> MediaItemMetadata:
         """Parse the artist metadata."""
         return MediaItemMetadata(
-            images=[
-                MediaItemImage(
-                    type=ImageType.THUMB,
-                    path=artist.picture_big,
-                    provider=self.lookup_key,
-                    remotely_accessible=True,
-                )
-            ],
+            images=UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=artist.picture_big,
+                        provider=self.lookup_key,
+                        remotely_accessible=True,
+                    )
+                ]
+            ),
         )
 
     ### PARSING FUNCTIONS ###
@@ -583,14 +595,16 @@ class DeezerProvider(MusicProvider):
             item_id=str(album.id),
             provider=self.lookup_key,
             name=album.title,
-            artists=[
-                ItemMapping(
-                    media_type=MediaType.ARTIST,
-                    item_id=str(album.artist.id),
-                    provider=self.lookup_key,
-                    name=album.artist.name,
-                )
-            ],
+            artists=UniqueList(
+                [
+                    ItemMapping(
+                        media_type=MediaType.ARTIST,
+                        item_id=str(album.artist.id),
+                        provider=self.lookup_key,
+                        name=album.artist.name,
+                    )
+                ]
+            ),
             media_type=MediaType.ALBUM,
             provider_mappings={
                 ProviderMapping(
@@ -621,21 +635,23 @@ class DeezerProvider(MusicProvider):
                 )
             },
             metadata=MediaItemMetadata(
-                images=[
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=playlist.picture_big,
-                        provider=self.lookup_key,
-                        remotely_accessible=True,
-                    )
-                ],
+                images=UniqueList(
+                    [
+                        MediaItemImage(
+                            type=ImageType.THUMB,
+                            path=playlist.picture_big,
+                            provider=self.lookup_key,
+                            remotely_accessible=True,
+                        )
+                    ]
+                ),
             ),
             is_editable=is_editable,
             owner=creator.name,
             cache_checksum=playlist.checksum,
         )
 
-    def get_playlist_creator(self, playlist: deezer.Playlist):
+    def get_playlist_creator(self, playlist: deezer.Playlist) -> deezer.User:
         """On playlists, the creator is called creator, elsewhere it's called user."""
         if hasattr(playlist, "creator"):
             return playlist.creator
@@ -668,7 +684,7 @@ class DeezerProvider(MusicProvider):
             name=track.title,
             sort_name=self.get_short_title(track),
             duration=track.duration,
-            artists=[artist] if artist else [],
+            artists=UniqueList([artist]) if artist else UniqueList(),
             album=album,
             provider_mappings={
                 ProviderMapping(
@@ -688,28 +704,34 @@ class DeezerProvider(MusicProvider):
             item.external_ids.add((ExternalID.ISRC, isrc))
         return item
 
-    def get_short_title(self, track: deezer.Track):
+    def get_short_title(self, track: deezer.Track) -> str:
         """Short names only returned, if available."""
         if hasattr(track, "title_short"):
-            return track.title_short
-        return track.title
+            return str(track.title_short)
+        return str(track.title)
 
     def get_album_type(self, album: deezer.Album) -> AlbumType:
         """Read and convert the Deezer album type."""
-        if not hasattr(album, "record_type"):
-            return AlbumType.UNKNOWN
+        # Get provider's basic type first
+        provider_type = AlbumType.UNKNOWN
+        if hasattr(album, "record_type"):
+            match album.record_type:
+                case "album":
+                    provider_type = AlbumType.ALBUM
+                case "single":
+                    provider_type = AlbumType.SINGLE
+                case "ep":
+                    provider_type = AlbumType.EP
+                case "compile":
+                    provider_type = AlbumType.COMPILATION
 
-        match album.record_type:
-            case "album":
-                return AlbumType.ALBUM
-            case "single":
-                return AlbumType.SINGLE
-            case "ep":
-                return AlbumType.EP
-            case "compile":
-                return AlbumType.COMPILATION
-            case _:
-                return AlbumType.UNKNOWN
+        # Try inference - override if it finds something more specific
+        inferred_type = infer_album_type(album.title, "")
+        if inferred_type in (AlbumType.SOUNDTRACK, AlbumType.LIVE):
+            return inferred_type
+
+        # Otherwise use provider type
+        return provider_type
 
     ### SEARCH AND PARSE FUNCTIONS ###
     async def search_and_parse_tracks(
@@ -756,9 +778,11 @@ class DeezerProvider(MusicProvider):
 
     ### OTHER FUNCTIONS ###
 
-    async def get_track_content_type(self, gw_client: GWClient, track_id: int):
+    async def get_track_content_type(
+        self, gw_client: GWClient, track_id: int
+    ) -> Literal[ContentType.FLAC, ContentType.MP3]:
         """Get a tracks contentType."""
-        song_data = await gw_client.get_song_data(track_id)
+        song_data = await gw_client.get_song_data(track_id)  # type: ignore[no-untyped-call]
         if song_data["results"]["FILESIZE_FLAC"]:
             return ContentType.FLAC
 
@@ -774,12 +798,12 @@ class DeezerProvider(MusicProvider):
             return user_country in track.available_countries
         return True
 
-    def _md5(self, data, data_type="ascii"):
+    def _md5(self, data: str, data_type: str = "ascii") -> str:
         md5sum = hashlib.md5()
         md5sum.update(data.encode(data_type))
         return md5sum.hexdigest()
 
-    def get_blowfish_key(self, track_id):
+    def get_blowfish_key(self, track_id: str) -> str:
         """Get blowfish key to decrypt a chunk of a track."""
         secret = app_var(5)
         id_md5 = self._md5(track_id)
@@ -787,7 +811,7 @@ class DeezerProvider(MusicProvider):
             chr(ord(id_md5[i]) ^ ord(id_md5[i + 16]) ^ ord(secret[i])) for i in range(16)
         )
 
-    def decrypt_chunk(self, chunk, blowfish_key):
+    def decrypt_chunk(self, chunk: bytes, blowfish_key: str) -> bytes:
         """Decrypt a given chunk using the blow fish key."""
         cipher = Blowfish.new(
             blowfish_key.encode("ascii"),

--- a/music_assistant/providers/spotify/parsers.py
+++ b/music_assistant/providers/spotify/parsers.py
@@ -20,7 +20,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.unique_list import UniqueList
 
-from music_assistant.helpers.util import parse_title_and_version
+from music_assistant.helpers.util import infer_album_type, parse_title_and_version
 
 if TYPE_CHECKING:
     from .provider import SpotifyProvider
@@ -115,6 +115,11 @@ def parse_album(album_obj: dict[str, Any], provider: SpotifyProvider) -> Album:
 
     with contextlib.suppress(ValueError):
         album.album_type = AlbumType(album_obj["album_type"])
+
+    # Override with inferred type if version indicates it
+    inferred_type = infer_album_type(album.name, album.version)
+    if inferred_type in (AlbumType.LIVE, AlbumType.SOUNDTRACK):
+        album.album_type = inferred_type
 
     if "genres" in album_obj:
         album.metadata.genres = set(album_obj["genres"])


### PR DESCRIPTION
This is working well locally. If the approach is sound I will add the inference logic to the other providers.

I did a reasonable amount of research on the inference logic and I believe the number of false positives will be very low. In my testing I got none. Even if there is one it just means one album appears in the filtered list which I think is acceptable given the features overall usefulness.

Frontend changes https://github.com/music-assistant/frontend/pull/1138