### PR TITLE
Providers(spotify): look for librespot in PATH

### DIFF
--- a/music_assistant/providers/spotify/helpers.py
+++ b/music_assistant/providers/spotify/helpers.py
@@ -20,6 +20,7 @@ async def get_librespot_binary() -> str:
         except OSError:
             return None
 
+    # Try to find platform-specific binary
     base_path = os.path.join(os.path.dirname(__file__), "bin")
     system = platform.system().lower().replace("darwin", "macos")
     architecture = platform.machine().lower()
@@ -29,5 +30,9 @@ async def get_librespot_binary() -> str:
     ):
         return librespot_binary
 
-    msg = f"Unable to locate Librespot for {system}/{architecture}"
+    # Fallback to librespot in PATH
+    if librespot_binary := await check_librespot("librespot"):
+        return librespot_binary
+
+    msg = f"Unable to locate Librespot in PATH or for {system}/{architecture}"
     raise RuntimeError(msg)


### PR DESCRIPTION
In NixOS, we include librespot in the path through the NixOS service: https://github.com/NixOS/nixpkgs/blob/1423943d263a71447fa97f7444ce6f63f36c2257/nixos/modules/services/audio/music-assistant.nix#L87

It fixes my immediate issue, but I still have :
Failed to verify credentials on Librespot: Error parsing command line options: Unrecognized option: 'check-auth'

I'm using librespot 0.7.0 (the available version in nixpkgs-unstable). I checkout the previous versions too, I couldn't find a `--check-auth` option. What am I missing ?

Edit:
Okay, I see: https://github.com/music-assistant/librespot/commit/f1991f68aefe1301bbed1e82a1403405f57383d9
You only support your custom version of librespot, is that it ?

You're probably not interested in this PR then. I'll let you close it.