### PR TITLE
Add Infer album type to streaming providers

### DIFF
--- a/music_assistant/providers/builtin_player/player.py
+++ b/music_assistant/providers/builtin_player/player.py
@@ -63,7 +63,7 @@ class BuiltinPlayer(Player):
         self._attr_needs_poll = True
         self._attr_poll_interval = POLL_INTERVAL
         self._attr_hidden_by_default = True
-        self._attr_expose_to_ha_by_default = False
+        self._attr_expose_to_ha_by_default = True
         self.register(name, False)
 
     def unregister_routes(self) -> None:

--- a/music_assistant/providers/builtin_player/player.py
+++ b/music_assistant/providers/builtin_player/player.py
@@ -63,7 +63,7 @@ class BuiltinPlayer(Player):
         self._attr_needs_poll = True
         self._attr_poll_interval = POLL_INTERVAL
         self._attr_hidden_by_default = True
-        self._attr_expose_to_ha_by_default = True
+        self._attr_expose_to_ha_by_default = False
         self.register(name, False)
 
     def unregister_routes(self) -> None:

--- a/music_assistant/providers/ibroadcast/__init__.py
+++ b/music_assistant/providers/ibroadcast/__init__.py
@@ -8,7 +8,6 @@ from aiohttp import ClientSession
 from ibroadcastaio import IBroadcastClient
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
-    AlbumType,
     ConfigEntryType,
     ContentType,
     ImageType,
@@ -37,7 +36,7 @@ from music_assistant.constants import (
     VARIOUS_ARTISTS_MBID,
     VARIOUS_ARTISTS_NAME,
 )
-from music_assistant.helpers.util import parse_title_and_version
+from music_assistant.helpers.util import infer_album_type, parse_title_and_version
 from music_assistant.models.music_provider import MusicProvider
 
 SUPPORTED_FEATURES = {
@@ -333,8 +332,9 @@ class IBroadcastProvider(MusicProvider):
 
         if "rating" in album_obj and album_obj["rating"] == 5:
             album.favorite = True
-        # iBroadcast doesn't seem to know album type
-        album.album_type = AlbumType.UNKNOWN
+        # iBroadcast doesn't seem to know album type - try inference
+        album.album_type = infer_album_type(name, version)
+
         # There is only an artwork in the tracks, lets get the first track one
         artwork_url = await self._client.get_album_artwork_url(album_id)
         if artwork_url:

--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -39,6 +39,7 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
 from music_assistant.helpers.json import json_loads
+from music_assistant.helpers.util import infer_album_type
 from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
@@ -275,6 +276,9 @@ class NugsProvider(MusicProvider):
                 year = date.split("-")[0]
         if year:
             album.year = int(year)
+
+        # No album type info in this provider so try and infer it
+        album.album_type = infer_album_type(album.name, "")
 
         return album
 

--- a/music_assistant/providers/tidal/__init__.py
+++ b/music_assistant/providers/tidal/__init__.py
@@ -52,6 +52,7 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import CACHE_CATEGORY_DEFAULT, CACHE_CATEGORY_RECOMMENDATIONS
 from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
+from music_assistant.helpers.util import infer_album_type
 from music_assistant.models.music_provider import MusicProvider
 
 from .auth_manager import ManualAuthenticationHelper, TidalAuthManager
@@ -1726,6 +1727,11 @@ class TidalProvider(MusicProvider):
             album.album_type = AlbumType.EP
         elif album_type == "SINGLE":
             album.album_type = AlbumType.SINGLE
+
+        # Try inference - override if it finds something more specific
+        inferred_type = infer_album_type(name, version)
+        if inferred_type in (AlbumType.SOUNDTRACK, AlbumType.LIVE):
+            album.album_type = inferred_type
 
         # Safely parse year
         if release_date := album_obj.get("releaseDate", ""):


### PR DESCRIPTION
With the merging of the live and soundtrack enhancement this PR adds support for that to each of the streaming providers.

Additionally, made some MyPy fixes for Apple Music and YouTube Music in the methods I was working on.