### PR TITLE
Fix pulling ARD Audiothek subscriptions and ordering of podcasts with many episodes

### DIFF
--- a/music_assistant/providers/ard_audiothek/__init__.py
+++ b/music_assistant/providers/ard_audiothek/__init__.py
@@ -511,7 +511,7 @@ class ARDAudiothek(MusicProvider):
                         episode,
                         episode_id,
                         result["title"],
-                        idx,
+                        offset + idx,
                         progress,
                     )
 

--- a/music_assistant/providers/ard_audiothek/database_queries.py
+++ b/music_assistant/providers/ard_audiothek/database_queries.py
@@ -279,11 +279,11 @@ query CheckLogin($loginId: String!) {
 
 get_subscriptions_query = gql(
     """
-query GetBookmarksByLoginId($loginId: String!, $count: Int = 96) {
+query GetBookmarksByLoginId($loginId: String!) {
   allEndUsers(filter: { loginId: { eq: $loginId } }) {
     count
     nodes {
-      subscriptions(first: $count, orderBy: LASTLISTENEDAT_DESC) {
+      subscriptions {
         programSets {
           nodes {
             subscribedProgramSet {


### PR DESCRIPTION
This fix removes the unsupported subscription filtering.
Further it fixes the missing offset to the episode idx and corrects the ordering of displayed episodes.