### PR TITLE
Adjust smart fades filters from testing

### DIFF
--- a/music_assistant/helpers/smart_fades.py
+++ b/music_assistant/helpers/smart_fades.py
@@ -870,7 +870,7 @@ class SmartFadesMixer:
             start_time=fadeout_eq_start,
             sweep_direction="fade_in",
             poles=1,
-            curve_type="exponential",  # Use exponential curve for smoother DJ-style transitions
+            curve_type="logarithmic",  # Use logarithmic curve so give the next track more space
         )
 
         # fadein (high-pass → unfiltered)
@@ -883,7 +883,7 @@ class SmartFadesMixer:
             start_time=0,
             sweep_direction="fade_out",
             poles=1,
-            curve_type="exponential",  # Use exponential curve for smoother DJ-style transitions
+            curve_type="linear",  # Use linear curve for transition, predictable and not too abrupt
         )
 
         return fadeout_filters + fadein_filters

--- a/music_assistant/helpers/smart_fades.py
+++ b/music_assistant/helpers/smart_fades.py
@@ -870,7 +870,7 @@ class SmartFadesMixer:
             start_time=fadeout_eq_start,
             sweep_direction="fade_in",
             poles=1,
-            curve_type="logarithmic",  # Use logarithmic curve so give the next track more space
+            curve_type="logarithmic",  # Use logarithmic curve to give the next track more space
         )
 
         # fadein (high-pass → unfiltered)


### PR DESCRIPTION
@MarvinSchenkel and I evaluated many track transitions across a wide range of genres, testing various crossover frequencies and several fade curves for the new Smart Fades feature. From our testing, the most universally effective options were:
- the existing dynamic crossover frequency,
- a logarithmic fade-out for the previous track, and
- a linear fade-in for the next track.

# Test setup
Comparisons were made using a hacky export setup that rendered all transitions into a single audio stem for more consistent A/B testing.
<img width="3191" height="1634" alt="Screenshot From 2025-09-29 08-49-38" src="https://github.com/user-attachments/assets/0cec7bd2-e77e-4122-b5dd-63e408ab45e3" />
