### PR TITLE
Fix release drafter workflow `latest` value

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,7 +2,7 @@ name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 version-template: "$MAJOR.$MINOR.0.b$PATCH"
 change-template: '- #$NUMBER - $TITLE (@$AUTHOR)'
-latest: false
+latest: 'false'
 prerelease: true
 categories:
 


### PR DESCRIPTION
### Proposed change
This should (maybe) fix the release drafter workflow not working after https://github.com/music-assistant/server/commit/f4fc25b14c24ecde3e2e7e6b4edfadd8a82586f7.
To fix the issue, we apparently want the value for `latest` to be a string, as it accepts `true`, `false`, and `legacy`. This PR just does that.

### Details


Underlying code: https://github.com/release-drafter/release-drafter/blob/b1476f6e6eb133afa41ed8589daba6dc69b4d3f5/lib/schema.js#L84-L86
Example of failing workflow: https://github.com/music-assistant/server/actions/runs/18207599918/job/51841488378

Haven't tested this change, so maybe something else blows up then. *Should* be fine though.

Also, the release drafter config file uses a good mix of `'` and `"`. Could be cleaned up at some point—not that it matters..