### PR TITLE
Fix race condition when ungrouping/grouping sonos/airplay players

### DIFF
--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -571,7 +571,7 @@ class SonosPlayer(Player):
             # append airplay child's to group childs
             if self.airplay_mode_enabled and airplay_player:
                 airplay_childs = [
-                    x for x in airplay_player._attr_group_members if x != airplay_player.player_id
+                    x for x in airplay_player.group_members if x != airplay_player.player_id
                 ]
                 self._attr_group_members.extend(airplay_childs)
                 airplay_prov = airplay_player.provider


### PR DESCRIPTION
Fixes scenario where group state might become inconsistent between sonos and their linked airplay players: 
<img width="461" height="848" alt="image" src="https://github.com/user-attachments/assets/c9307641-6b1b-47b8-b263-7378eed89415" />
