### PR TITLE
ARD Audiothek: Introduce filter of not published episodes to reduce loading times

### DIFF
--- a/music_assistant/providers/ard_audiothek/__init__.py
+++ b/music_assistant/providers/ard_audiothek/__init__.py
@@ -487,8 +487,12 @@ class ARDAudiothek(MusicProvider):
     ) -> AsyncGenerator[PodcastEpisode, None]:
         """Get podcast episodes."""
         await self._update_progress()
+        depublished_filter = {"isPublished": {"equalTo": True}}
         async with await self.get_client() as session:
-            show_length_query.variable_values = {"showId": prov_podcast_id}
+            show_length_query.variable_values = {
+                "showId": prov_podcast_id,
+                "filter": depublished_filter,
+            }
             length = await session.execute(show_length_query)
             length = length["show"]["items"]["totalCount"]
             step_size = 128
@@ -497,6 +501,7 @@ class ARDAudiothek(MusicProvider):
                     "showId": prov_podcast_id,
                     "first": step_size,
                     "offset": offset,
+                    "filter": depublished_filter,
                 }
                 result = (await session.execute(show_query))["show"]
                 for idx, episode in enumerate(result["items"]["nodes"]):

--- a/music_assistant/providers/ard_audiothek/database_queries.py
+++ b/music_assistant/providers/ard_audiothek/database_queries.py
@@ -140,9 +140,9 @@ query Livestream($coreId: String!) {
 
 
 show_length_query = gql("""
-query Show($showId: ID!) {
+query Show($showId: ID!, $filter: ItemFilter) {
   show(id: $showId) {
-    items {
+    items(filter: $filter) {
       totalCount
     }
   }
@@ -152,13 +152,12 @@ query Show($showId: ID!) {
 
 show_query = gql(
     """
-query Show($showId: ID!, $first: Int, $offset: Int) {
+query Show($showId: ID!, $first: Int, $offset: Int, $filter: ItemFilter) {
   show(id: $showId) {
     synopsis
     title
     showType
-    items(first: $first, offset: $offset) {
-      totalCount
+    items(first: $first, offset: $offset, filter: $filter) {
       nodes {
         duration
         title


### PR DESCRIPTION
This change adds a filter to the GraphQL request to filter not yet or no longer published episodes. Some live channels contain more than 1000 depublished episodes and this reduces the loading times by a significant amount