### PR TITLE
Fix issue when a cast stereo pair is added to a cast group

### DIFF
--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -82,7 +82,7 @@ class ChromecastInfo:
         self.is_dynamic_group = self.uuid in dynamic_groups
         if self.uuid in multichannel_groups:
             self.is_multichannel_group = True
-        elif multichannel_groups:
+        elif multichannel_groups and self.cast_type != "group" and cast_info.model_name != "Google Cast Group":
             self.is_multichannel_child = True
 
 

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -82,7 +82,11 @@ class ChromecastInfo:
         self.is_dynamic_group = self.uuid in dynamic_groups
         if self.uuid in multichannel_groups:
             self.is_multichannel_group = True
-        elif multichannel_groups and self.cast_type != "group" and cast_info.model_name != "Google Cast Group":
+        elif (
+            multichannel_groups
+            and self.cast_type != "group" 
+            and cast_info.model_name != "Google Cast Group"
+        ):
             self.is_multichannel_child = True
 
 

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -84,7 +84,8 @@ class ChromecastInfo:
             self.is_multichannel_group = True
         elif (
             multichannel_groups
-            # Prevent a multichannel group being marked as a multichannel child if not in UUID list
+            # Prevent a multichannel group being marked as a multichannel child
+            # if not in UUID list
             and self.cast_type != "group"
             and self.model_name != "Google Cast Group"
         ):

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -84,7 +84,7 @@ class ChromecastInfo:
             self.is_multichannel_group = True
         elif (
             multichannel_groups
-            and self.cast_type != "group" 
+            and self.cast_type != "group"
             and self.model_name != "Google Cast Group"
         ):
             self.is_multichannel_child = True

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -85,7 +85,7 @@ class ChromecastInfo:
         elif (
             multichannel_groups
             and self.cast_type != "group" 
-            and cast_info.model_name != "Google Cast Group"
+            and self.model_name != "Google Cast Group"
         ):
             self.is_multichannel_child = True
 

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -84,6 +84,7 @@ class ChromecastInfo:
             self.is_multichannel_group = True
         elif (
             multichannel_groups
+            # Prevent a multichannel group being marked as a multichannel child if not in UUID list
             and self.cast_type != "group"
             and self.model_name != "Google Cast Group"
         ):


### PR DESCRIPTION
Fix: for Chromecast group with stereo pair and another speaker becomes unavailable https://github.com/music-assistant/support/issues/4106