### PR TITLE
fix: audiobookshelf: authenticate not necessary in streamdetails

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -541,8 +541,6 @@ for more details.
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Get stream of item."""
-        # ensure we have a valid token
-        await self.reauthenticate()
         if media_type == MediaType.PODCAST_EPISODE:
             return await self._get_stream_details_episode(item_id)
         elif media_type == MediaType.AUDIOBOOK:


### PR DESCRIPTION
This line is not necessary, we handle a bad token via ffmpeg failing, and it blocks streaming for token only users.