### PR TITLE
Subsonic: Add debug statement for resolving cover art

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -176,6 +176,7 @@ class OpenSonicProvider(MusicProvider):
 
     async def resolve_image(self, path: str) -> bytes | Any:
         """Return the image."""
+        self.logger.debug("Requesting cover art for '%s'", path)
 
         def _get_cover_art() -> bytes | Any:
             try:


### PR DESCRIPTION
I am seeing failures in the request claiming there is no cover art path provided. I want to see this value when the failures occur.