### PR TITLE
Plugin fixes

### DIFF
--- a/music_assistant/controllers/players/player_controller.py
+++ b/music_assistant/controllers/players/player_controller.py
@@ -2062,6 +2062,7 @@ class PlayerController(CoreController):
                 uri=stream_url,
                 media_type=MediaType.PLUGIN_SOURCE,
                 title=plugin_source.name,
+                source_id=plugin_source.id,
                 custom_data={
                     "provider": plugin_prov.instance_id,
                     "source_id": plugin_source.id,

--- a/music_assistant/controllers/players/player_controller.py
+++ b/music_assistant/controllers/players/player_controller.py
@@ -2019,6 +2019,9 @@ class PlayerController(CoreController):
                 # to ensure the queue has accurate details
                 player_playing = player.playback_state == PlaybackState.PLAYING
                 if player_playing:
+                    if player.active_source and self.get_plugin_source(player.active_source):
+                        player.update_state()
+                        continue
                     self.mass.loop.call_soon(
                         self.mass.player_queues.on_player_update,
                         player,

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -935,7 +935,9 @@ class Player(ABC):
         if self.active_source and (
             source := self.mass.players.get_plugin_source(self.active_source)
         ):
-            return source.metadata
+            # Return a copy to ensure metadata prev_state vs new _state comparisons in
+            # update_state are detected after plugin updates its metadata
+            return deepcopy(source.metadata)
 
         return self._current_media
 

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -216,6 +216,11 @@ class SqueezelitePlayer(Player):
             msg = "A synced player cannot receive play commands directly"
             raise RuntimeError(msg)
 
+        if media.source_id and self.mass.players.get_plugin_source(media.source_id):
+            self._attr_active_source = media.source_id
+        else:
+            self._attr_active_source = self.player_id
+
         if not self.group_members:
             # Simple, single-player playback
             await self._handle_play_url_for_slimplayer(
@@ -382,7 +387,6 @@ class SqueezelitePlayer(Player):
         self._attr_playback_state = STATE_MAP[self.client.state]
         self._attr_volume_level = self.client.volume_level
         self._attr_volume_muted = self.client.muted
-        self._attr_active_source = self.player_id
         self._attr_device_info = DeviceInfo(
             model=self.client.device_model,
             ip_address=self.client.device_address,


### PR DESCRIPTION
A few fixes for when a player's source is a plugin.

Only the spotify-connect plugin currently updates its PluginSource.metadata on track changes and requires a player to update_state() in order to send the changes to frontend.   Not all plugins will require this as they're just an audio stream with no changes in metadata, so for a bit more efficiency could add a boolean attribute in models.plugin.PluginSource to set whether state updates are required.