### PR TITLE
Plex: Use container_start and container_size for pagination

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -832,8 +832,8 @@ class PlexProvider(MusicProvider):
                 await self._run_async(
                     self._plex_library.searchTracks,
                     title=None,
-                    limit=page_size,
-                    offset=offset,
+                    container_size=page_size,
+                    container_start=offset,
                 ),
             )
             if not batch:


### PR DESCRIPTION
Fixes "Unknown filter field" error when syncing Plex library by using the correct pagination parameters (container_start/container_size) expected by plexapi.