### PR TITLE
Plugin fixes

### DIFF
--- a/music_assistant/controllers/players/player_controller.py
+++ b/music_assistant/controllers/players/player_controller.py
@@ -2019,6 +2019,9 @@ class PlayerController(CoreController):
                 # to ensure the queue has accurate details
                 player_playing = player.playback_state == PlaybackState.PLAYING
                 if player_playing:
+                    if player.active_source and self.get_plugin_source(player.active_source):
+                        self.trigger_player_update(player.player_id)
+                        continue
                     self.mass.loop.call_soon(
                         self.mass.player_queues.on_player_update,
                         player,

--- a/music_assistant/controllers/streams.py
+++ b/music_assistant/controllers/streams.py
@@ -1009,7 +1009,7 @@ class StreamsController(CoreController):
             if plugin_source.stream_type == StreamType.CUSTOM
             else plugin_source.path
         )
-        player.state.active_source = plugin_source_id
+        player.active_source = plugin_source_id
         plugin_source.in_use_by = player_id
         try:
             async for chunk in get_ffmpeg_stream(
@@ -1026,7 +1026,7 @@ class StreamsController(CoreController):
                 "Finished streaming PluginSource %s to %s", plugin_source_id, player_id
             )
             await asyncio.sleep(0.5)
-            player.state.active_source = player.player_id
+            player.active_source = player.player_id
             plugin_source.in_use_by = None
 
     async def get_queue_item_stream(

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -814,7 +814,6 @@ class Player(ABC):
         return None
 
     @property
-    @final
     def active_source(self) -> str | None:
         """
         Return the FINAL active source of the player.
@@ -828,6 +827,12 @@ class Player(ABC):
                 return parent_player.active_source
         # in case player's source is None, return the player_id (to indicate MA is active source)
         return self._active_source or self.player_id
+
+    @active_source.setter
+    @final
+    def active_source(self, source: str) -> None:
+        """Set the active source of the player."""
+        self._attr_active_source = source
 
     @cached_property
     @final

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -940,7 +940,9 @@ class Player(ABC):
         if self.active_source and (
             source := self.mass.players.get_plugin_source(self.active_source)
         ):
-            return source.metadata
+            # Return a copy to ensure metadata prev_state vs new _state comparisons in
+            # update_state are detected after plugin updates its metadata
+            return deepcopy(source.metadata)
 
         return self._current_media
 

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -382,7 +382,6 @@ class SqueezelitePlayer(Player):
         self._attr_playback_state = STATE_MAP[self.client.state]
         self._attr_volume_level = self.client.volume_level
         self._attr_volume_muted = self.client.muted
-        self._attr_active_source = self.player_id
         self._attr_device_info = DeviceInfo(
             model=self.client.device_model,
             ip_address=self.client.device_address,


### PR DESCRIPTION
A few fixes for state updates when a player's source is a plugin.

### prev_state vs new state issues at update_state time
#### player.active_source setter
player.state.active_source = plugin_source_id gets overwritten with player_id at next state update as the getter player.active_source always returns player_id unless _attr_active_source is set.

#### deepcopy(source.metadata)
Without the copy, spotify-connect plugin updates its metadata object on track change but  prev_state = deepcopy(self._state) already has the changed metadata so no differences are detected when compared against new state.

### polling updates for player with plugin source
Think this is required as I can't see anywhere else an update_state will occur for a player with a plugin source.

Only the spotify-connect plugin currently updates its PluginSource.metadata on track changes and requires a player to update_state() in order to send the changes to frontend. Not all plugins will require this as they're just an audio stream with no changes in metadata, so for a little bit more efficiency could add a boolean attribute in models.plugin.PluginSource to set whether state updates are required.
