### PR TITLE
Fix recursion loop in fake volume mute control

### DIFF
--- a/music_assistant/controllers/players/player_controller.py
+++ b/music_assistant/controllers/players/player_controller.py
@@ -793,8 +793,8 @@ class PlayerController(CoreController):
                 player._attr_volume_muted = False
                 prev_volume = player.extra_data.get(ATTR_PREVIOUS_VOLUME, 1)
                 player.extra_data[ATTR_FAKE_MUTE] = False
-                await self.cmd_volume_set(player_id, prev_volume)
                 player.update_state()
+                await self.cmd_volume_set(player_id, prev_volume)
         else:
             # handle external player control
             player_control = self._controls.get(player.mute_control)


### PR DESCRIPTION
When using fake mute control, unmuting causes infinite recursion because:

`cmd_volume_mute(False)` sets internal flags and calls `cmd_volume_set()` to restore volume
`cmd_volume_set()` checks if player is muted, and if so, calls `cmd_volume_mute(False)`
This creates a loop because `player.update_state()` wasn't called before step 2

Fix: Call `player.update_state()` before `cmd_volume_set()` to ensure the player's muted state is updated and visible to the volume set check.