### PR TITLE
Plex: Add anatosun as codeowner and change stage to alpha

### DIFF
--- a/music_assistant/providers/plex/manifest.json
+++ b/music_assistant/providers/plex/manifest.json
@@ -1,10 +1,10 @@
 {
   "type": "music",
   "domain": "plex",
-  "stage": "unmaintained",
+  "stage": "alpha",
   "name": "Plex Media Server Library",
   "description": "Stream your personal music, podcasts, and radio via your Plex media server.",
-  "codeowners": ["@micha91"],
+  "codeowners": ["@micha91", "@anatosun"],
   "requirements": ["plexapi==4.17.1"],
   "documentation": "https://music-assistant.io/music-providers/plex/",
   "multi_instance": true


### PR DESCRIPTION
I'd like to take over as maintainer of the Plex provider and move it from unmaintained to alpha stage. Some features still need more testing by fellow Plex users, which is why this is marked as alpha for now. Now that the Plex API has become public, we might need to rejuvenate the code and explore new features.

Question: How can I discuss additional features with other contributors? Is there a discord I can join?