### PR TITLE
YTM: Also install default ytdlp dependencies

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -120,7 +120,7 @@ YT_PERSONAL_PLAYLISTS = (
 )
 DYNAMIC_PLAYLIST_TRACK_LIMIT = 300
 YTM_PREMIUM_CHECK_TRACK_ID = "dQw4w9WgXcQ"
-PACKAGES_TO_INSTALL = ("yt-dlp", "bgutil-ytdlp-pot-provider")
+PACKAGES_TO_INSTALL = ("yt-dlp[default]", "bgutil-ytdlp-pot-provider")
 
 SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_ARTISTS,


### PR DESCRIPTION
According to [this](https://github.com/yt-dlp/yt-dlp/issues/14404) announcement we will also need the `default` dependency group of `yt-dlp` going forward. We can already merge this ahead of [this](https://github.com/yt-dlp/yt-dlp/pull/14157) that will solve the 403 errors that are currently preventing users from listening to music.