### PR TITLE
Squeezelite: Remove volume mute PlayerFeature

### DIFF
--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -15,11 +15,6 @@ from aioslimproto.models import Preset as SlimPreset
 from aioslimproto.models import SlimEvent
 from aioslimproto.models import VisualisationType as SlimVisualisationType
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
-from music_assistant_models.constants import (
-    PLAYER_CONTROL_FAKE,
-    PLAYER_CONTROL_NATIVE,
-    PLAYER_CONTROL_NONE,
-)
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
@@ -39,7 +34,6 @@ from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE_FORCED_2,
     CONF_ENTRY_OUTPUT_CODEC,
     CONF_ENTRY_SYNC_ADJUST,
-    CONF_MUTE_CONTROL,
     DEFAULT_PCM_FORMAT,
     VERBOSE_LOG_LEVEL,
     create_sample_rates_config_entry,
@@ -95,7 +89,6 @@ class SqueezelitePlayer(Player):
             PlayerFeature.MULTI_DEVICE_DSP,
             PlayerFeature.VOLUME_SET,
             PlayerFeature.PAUSE,
-            PlayerFeature.VOLUME_MUTE,
             PlayerFeature.ENQUEUE,
             PlayerFeature.GAPLESS_PLAYBACK,
         }
@@ -154,28 +147,8 @@ class SqueezelitePlayer(Player):
             )
             for index in range(1, preset_count + 1)
         ]
-        # Override the mute control entry to default to fake control
-        # This works around a bug in Squeezelite where native unmute doesn't work
-        mute_control_entry = ConfigEntry(
-            key=CONF_MUTE_CONTROL,
-            type=ConfigEntryType.STRING,
-            label="Mute Control",
-            default_value=PLAYER_CONTROL_FAKE,  # Changed from PLAYER_CONTROL_NATIVE
-            required=True,
-            options=[
-                ConfigValueOption(title="None", value=PLAYER_CONTROL_NONE),
-                ConfigValueOption(title="Fake mute control", value=PLAYER_CONTROL_FAKE),
-                ConfigValueOption(title="Native mute control", value=PLAYER_CONTROL_NATIVE),
-            ],
-            category="player_controls",
-        )
-
-        # Filter out the base mute control entry and add our custom one
-        filtered_entries = [e for e in base_entries if e.key != CONF_MUTE_CONTROL]
-
         return [
-            *filtered_entries,
-            mute_control_entry,
+            *base_entries,
             *preset_entries,
             CONF_ENTRY_DEPRECATED_EQ_BASS,
             CONF_ENTRY_DEPRECATED_EQ_MID,

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -15,6 +15,11 @@ from aioslimproto.models import Preset as SlimPreset
 from aioslimproto.models import SlimEvent
 from aioslimproto.models import VisualisationType as SlimVisualisationType
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.constants import (
+    PLAYER_CONTROL_FAKE,
+    PLAYER_CONTROL_NATIVE,
+    PLAYER_CONTROL_NONE,
+)
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
@@ -34,6 +39,7 @@ from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE_FORCED_2,
     CONF_ENTRY_OUTPUT_CODEC,
     CONF_ENTRY_SYNC_ADJUST,
+    CONF_MUTE_CONTROL,
     DEFAULT_PCM_FORMAT,
     VERBOSE_LOG_LEVEL,
     create_sample_rates_config_entry,
@@ -148,8 +154,28 @@ class SqueezelitePlayer(Player):
             )
             for index in range(1, preset_count + 1)
         ]
+        # Override the mute control entry to default to fake control
+        # This works around a bug in Squeezelite where native unmute doesn't work
+        mute_control_entry = ConfigEntry(
+            key=CONF_MUTE_CONTROL,
+            type=ConfigEntryType.STRING,
+            label="Mute Control",
+            default_value=PLAYER_CONTROL_FAKE,  # Changed from PLAYER_CONTROL_NATIVE
+            required=True,
+            options=[
+                ConfigValueOption(title="None", value=PLAYER_CONTROL_NONE),
+                ConfigValueOption(title="Fake mute control", value=PLAYER_CONTROL_FAKE),
+                ConfigValueOption(title="Native mute control", value=PLAYER_CONTROL_NATIVE),
+            ],
+            category="player_controls",
+        )
+
+        # Filter out the base mute control entry and add our custom one
+        filtered_entries = [e for e in base_entries if e.key != CONF_MUTE_CONTROL]
+
         return [
-            *base_entries,
+            *filtered_entries,
+            mute_control_entry,
             *preset_entries,
             CONF_ENTRY_DEPRECATED_EQ_BASS,
             CONF_ENTRY_DEPRECATED_EQ_MID,


### PR DESCRIPTION
Looking at https://github.com/music-assistant/support/issues/3903 and https://github.com/music-assistant/support/issues/4023

After investigation I think the issue lies in the squeezelite software and I have proposed a change to address it here https://github.com/ralph-irving/squeezelite/pull/253

While waiting for that this PR switches squeezelite to the fake mute control

P.S. And I'm not sure if this fixes it but this seems to be solved as well https://github.com/music-assistant/support/issues/3944 so if this is accepted I will close that as well.