### PR TITLE
Switch docker base images to Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,12 @@ RUN uv venv $VIRTUAL_ENV
 # comes at a cost of a slightly larger image size but is faster to start
 # because we do not have to install dependencies at runtime
 RUN uv pip install \
-    --find-links "https://wheels.home-assistant.io/musllinux/" \
     -r requirements_all.txt
 
 # Install Music Assistant from prebuilt wheel
 ARG MASS_VERSION
 RUN uv pip install \
     --no-cache \
-    --find-links "https://wheels.home-assistant.io/musllinux/" \
     "music-assistant@dist/music_assistant-${MASS_VERSION}-py3-none-any.whl"
 
 # we need to set (very permissive) permissions to the workdir
@@ -44,7 +42,7 @@ FROM ghcr.io/music-assistant/base:$BASE_IMAGE_VERSION
 ENV VIRTUAL_ENV=/app/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# copy the already build /app dir
+# copy the already built /app dir
 COPY --from=builder /app /app
 
 # the /app contents have correct permissions but for some reason /app itself does not.

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -134,6 +134,7 @@ RUN set -x \
 COPY --from=ffmpeg-builder /usr/local/bin/ffmpeg /usr/local/bin/
 COPY --from=ffmpeg-builder /usr/local/bin/ffprobe /usr/local/bin/
 COPY --from=ffmpeg-builder /usr/local/lib/libavcodec.so* /usr/local/lib/
+COPY --from=ffmpeg-builder /usr/local/lib/libavdevice.so* /usr/local/lib/
 COPY --from=ffmpeg-builder /usr/local/lib/libavformat.so* /usr/local/lib/
 COPY --from=ffmpeg-builder /usr/local/lib/libavutil.so* /usr/local/lib/
 COPY --from=ffmpeg-builder /usr/local/lib/libswresample.so* /usr/local/lib/

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,6 +6,10 @@
 
 FROM python:3.13-slim-bookworm AS ffmpeg-builder
 
+# Enable non-free and contrib repositories for FDK-AAC and other codecs
+RUN sed -i 's/^deb \(.*\) bookworm main$/deb \1 bookworm main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources 2>/dev/null || \
+    sed -i 's/Components: main/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources
+
 # Install build dependencies for FFmpeg
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -36,7 +40,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Build FFmpeg 7.1.2 from source with comprehensive audio codec support
-# Using static linking for self-contained binaries
 ARG FFMPEG_VERSION=7.1.2
 RUN set -x \
     && wget -q "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" -O /tmp/ffmpeg.tar.xz \
@@ -47,9 +50,6 @@ RUN set -x \
         --enable-gpl \
         --enable-nonfree \
         --enable-version3 \
-        --pkg-config-flags="--static" \
-        --extra-ldflags="-static" \
-        --extra-libs="-lpthread -lm -lz" \
         # Audio codecs (comprehensive support)
         --enable-libfdk-aac \
         --enable-libmp3lame \
@@ -84,8 +84,6 @@ RUN set -x \
         --disable-podpages \
         --disable-txtpages \
         --disable-debug \
-        --disable-shared \
-        --enable-static \
     && make -j$(nproc) \
     && make install \
     && strip /usr/local/bin/ffmpeg /usr/local/bin/ffprobe \
@@ -94,6 +92,10 @@ RUN set -x \
 ##################################################################################################
 
 FROM python:3.13-slim-bookworm
+
+# Enable non-free and contrib repositories for codec libraries
+RUN sed -i 's/^deb \(.*\) bookworm main$/deb \1 bookworm main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources 2>/dev/null || \
+    sed -i 's/Components: main/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources
 
 # Install runtime dependencies
 RUN set -x \
@@ -113,15 +115,39 @@ RUN set -x \
         # snapcast server and client for snapcast provider
         snapserver \
         snapclient \
+        # Audio codec runtime libraries (needed for FFmpeg)
+        libfdk-aac2 \
+        libmp3lame0 \
+        libopus0 \
+        libvorbis0a \
+        libvorbisenc2 \
+        libsoxr0 \
+        libspeex1 \
+        libwavpack1 \
+        libflac12 \
+        libtwolame0 \
+        libshine3 \
+        libopencore-amrnb0 \
+        libopencore-amrwb0 \
+        libvo-amrwbenc0 \
+        libsamplerate0 \
+        libbluray2 \
+        libxml2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy statically-linked FFmpeg binaries from builder stage
+# Copy FFmpeg binaries and libraries from builder stage
 COPY --from=ffmpeg-builder /usr/local/bin/ffmpeg /usr/local/bin/
 COPY --from=ffmpeg-builder /usr/local/bin/ffprobe /usr/local/bin/
+COPY --from=ffmpeg-builder /usr/local/lib/libavcodec.so* /usr/local/lib/
+COPY --from=ffmpeg-builder /usr/local/lib/libavformat.so* /usr/local/lib/
+COPY --from=ffmpeg-builder /usr/local/lib/libavutil.so* /usr/local/lib/
+COPY --from=ffmpeg-builder /usr/local/lib/libswresample.so* /usr/local/lib/
+COPY --from=ffmpeg-builder /usr/local/lib/libavfilter.so* /usr/local/lib/
+COPY --from=ffmpeg-builder /usr/local/lib/libswscale.so* /usr/local/lib/
 
-# Verify FFmpeg installation
-RUN ffmpeg -version && ffprobe -version
+# Update shared library cache and verify FFmpeg
+RUN ldconfig && ffmpeg -version && ffprobe -version
 
 # Copy widevine client files to container
 RUN mkdir -p /usr/local/bin/widevine_cdm

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -133,13 +133,9 @@ RUN set -x \
 # Copy FFmpeg binaries and libraries from builder stage
 COPY --from=ffmpeg-builder /usr/local/bin/ffmpeg /usr/local/bin/
 COPY --from=ffmpeg-builder /usr/local/bin/ffprobe /usr/local/bin/
-COPY --from=ffmpeg-builder /usr/local/lib/libavcodec.so* /usr/local/lib/
-COPY --from=ffmpeg-builder /usr/local/lib/libavdevice.so* /usr/local/lib/
-COPY --from=ffmpeg-builder /usr/local/lib/libavformat.so* /usr/local/lib/
-COPY --from=ffmpeg-builder /usr/local/lib/libavutil.so* /usr/local/lib/
-COPY --from=ffmpeg-builder /usr/local/lib/libswresample.so* /usr/local/lib/
-COPY --from=ffmpeg-builder /usr/local/lib/libavfilter.so* /usr/local/lib/
-COPY --from=ffmpeg-builder /usr/local/lib/libswscale.so* /usr/local/lib/
+COPY --from=ffmpeg-builder /usr/local/lib/libav*.so* /usr/local/lib/
+COPY --from=ffmpeg-builder /usr/local/lib/libsw*.so* /usr/local/lib/
+COPY --from=ffmpeg-builder /usr/local/lib/libpostproc.so* /usr/local/lib/
 
 # Update shared library cache and verify FFmpeg
 RUN ldconfig && ffmpeg -version && ffprobe -version

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -33,7 +33,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libopencore-amrwb-dev \
     libshine-dev \
     # Additional audio processing
-    libsamplerate0-dev \
     libbluray-dev \
     libxml2-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -61,7 +60,6 @@ RUN set -x \
         --enable-libopencore-amrwb \
         --enable-libvo-amrwbenc \
         # Audio filters and resampling
-        --enable-libsamplerate \
         --enable-libsoxr \
         # Protocols needed for streaming
         --enable-protocol=file \
@@ -70,6 +68,9 @@ RUN set -x \
         --enable-protocol=tcp \
         --enable-protocol=udp \
         --enable-protocol=rtp \
+        # Optimizations
+        --enable-small \
+        --enable-runtime-cpudetect \
         # Disable unnecessary features for smaller build
         --disable-doc \
         --disable-htmlpages \
@@ -77,6 +78,8 @@ RUN set -x \
         --disable-podpages \
         --disable-txtpages \
         --disable-debug \
+        --disable-static \
+        --enable-shared \
     && make -j$(nproc) \
     && make install \
     && strip /usr/local/bin/ffmpeg /usr/local/bin/ffprobe \
@@ -122,7 +125,6 @@ RUN set -x \
         libopencore-amrnb0 \
         libopencore-amrwb0 \
         libvo-amrwbenc0 \
-        libsamplerate0 \
         libbluray2 \
         libxml2 \
     && apt-get clean \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -27,8 +27,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libvorbis-dev \
     libsoxr-dev \
     libspeex-dev \
-    libwavpack-dev \
-    libflac-dev \
     libtwolame-dev \
     libvo-amrwbenc-dev \
     libopencore-amrnb-dev \
@@ -56,9 +54,7 @@ RUN set -x \
         --enable-libmp3lame \
         --enable-libopus \
         --enable-libvorbis \
-        --enable-libsoxr \
         --enable-libspeex \
-        --enable-libwavpack \
         --enable-libtwolame \
         --enable-libshine \
         --enable-libopencore-amrnb \
@@ -66,11 +62,7 @@ RUN set -x \
         --enable-libvo-amrwbenc \
         # Audio filters and resampling
         --enable-libsamplerate \
-        # Basic video support (minimal)
-        --enable-decoder=h264 \
-        --enable-decoder=hevc \
-        --enable-decoder=vp8 \
-        --enable-decoder=vp9 \
+        --enable-libsoxr \
         # Protocols needed for streaming
         --enable-protocol=file \
         --enable-protocol=http \
@@ -125,8 +117,6 @@ RUN set -x \
         libvorbisenc2 \
         libsoxr0 \
         libspeex1 \
-        libwavpack1 \
-        libflac12 \
         libtwolame0 \
         libshine3 \
         libopencore-amrnb0 \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -7,8 +7,9 @@
 FROM python:3.13-slim-bookworm AS ffmpeg-builder
 
 # Enable non-free and contrib repositories for FDK-AAC and other codecs
-RUN sed -i 's/^deb \(.*\) bookworm main$/deb \1 bookworm main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources 2>/dev/null || \
-    sed -i 's/Components: main/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources
+RUN echo "deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware" > /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware" >> /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware" >> /etc/apt/sources.list
 
 # Install build dependencies for FFmpeg
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -94,8 +95,9 @@ RUN set -x \
 FROM python:3.13-slim-bookworm
 
 # Enable non-free and contrib repositories for codec libraries
-RUN sed -i 's/^deb \(.*\) bookworm main$/deb \1 bookworm main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources 2>/dev/null || \
-    sed -i 's/Components: main/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources
+RUN echo "deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware" > /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware" >> /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware" >> /etc/apt/sources.list
 
 # Install runtime dependencies
 RUN set -x \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -4,40 +4,138 @@
 # This image forms the base for the final image and is not meant to be used directly
 # NOTE that the dev add-on is also based on this base image
 
-FROM python:3.13-alpine3.21
+FROM python:3.13-slim-bookworm AS ffmpeg-builder
 
+# Install build dependencies for FFmpeg
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    yasm \
+    nasm \
+    git \
+    wget \
+    ca-certificates \
+    # Audio codec libraries
+    libfdk-aac-dev \
+    libmp3lame-dev \
+    libopus-dev \
+    libvorbis-dev \
+    libsoxr-dev \
+    libspeex-dev \
+    libwavpack-dev \
+    libflac-dev \
+    libtwolame-dev \
+    libvo-amrwbenc-dev \
+    libopencore-amrnb-dev \
+    libopencore-amrwb-dev \
+    libshine-dev \
+    # Additional audio processing
+    libsamplerate0-dev \
+    libbluray-dev \
+    libxml2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build FFmpeg 7.1.2 from source with comprehensive audio codec support
+# Using static linking for self-contained binaries
+ARG FFMPEG_VERSION=7.1.2
 RUN set -x \
-    && apk add --no-cache \
+    && wget -q "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" -O /tmp/ffmpeg.tar.xz \
+    && tar -xJf /tmp/ffmpeg.tar.xz -C /tmp \
+    && cd /tmp/ffmpeg-${FFMPEG_VERSION} \
+    && ./configure \
+        --prefix=/usr/local \
+        --enable-gpl \
+        --enable-nonfree \
+        --enable-version3 \
+        --pkg-config-flags="--static" \
+        --extra-ldflags="-static" \
+        --extra-libs="-lpthread -lm -lz" \
+        # Audio codecs (comprehensive support)
+        --enable-libfdk-aac \
+        --enable-libmp3lame \
+        --enable-libopus \
+        --enable-libvorbis \
+        --enable-libsoxr \
+        --enable-libspeex \
+        --enable-libwavpack \
+        --enable-libtwolame \
+        --enable-libshine \
+        --enable-libopencore-amrnb \
+        --enable-libopencore-amrwb \
+        --enable-libvo-amrwbenc \
+        # Audio filters and resampling
+        --enable-libsamplerate \
+        # Basic video support (minimal)
+        --enable-decoder=h264 \
+        --enable-decoder=hevc \
+        --enable-decoder=vp8 \
+        --enable-decoder=vp9 \
+        # Protocols needed for streaming
+        --enable-protocol=file \
+        --enable-protocol=http \
+        --enable-protocol=https \
+        --enable-protocol=tcp \
+        --enable-protocol=udp \
+        --enable-protocol=rtp \
+        # Disable unnecessary features for smaller build
+        --disable-doc \
+        --disable-htmlpages \
+        --disable-manpages \
+        --disable-podpages \
+        --disable-txtpages \
+        --disable-debug \
+        --disable-shared \
+        --enable-static \
+    && make -j$(nproc) \
+    && make install \
+    && strip /usr/local/bin/ffmpeg /usr/local/bin/ffprobe \
+    && rm -rf /tmp/ffmpeg*
+
+##################################################################################################
+
+FROM python:3.13-slim-bookworm
+
+# Install runtime dependencies
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
         ca-certificates \
-        jemalloc \
+        libjemalloc2 \
         tzdata \
-        dnscache \
         # cifs utils and libnfs are needed for smb and nfs support (file provider)
         cifs-utils \
-        libnfs \
-        # openssl-dev is needed for airplay
-        openssl-dev  \
-        # install snapcast so the snapcast provider can run the builtin snapcast server
-        snapcast \
-        # build tools and llvm support needed for librosa/numba/llvmlite (smartfades)
-        build-base \
-        llvm15-dev \
+        libnfs13 \
+        # openssl is needed for airplay
+        openssl \
+        libssl-dev \
         # libsndfile needed for librosa audio file support (smartfades)
-        libsndfile-dev
+        libsndfile1 \
+        # snapcast server and client for snapcast provider
+        snapserver \
+        snapclient \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Get static ffmpeg builds from https://hub.docker.com/r/mwader/static-ffmpeg/
-COPY --from=mwader/static-ffmpeg:7.1.1 /ffmpeg /usr/local/bin/
-COPY --from=mwader/static-ffmpeg:7.1.1 /ffprobe /usr/local/bin/
+# Copy statically-linked FFmpeg binaries from builder stage
+COPY --from=ffmpeg-builder /usr/local/bin/ffmpeg /usr/local/bin/
+COPY --from=ffmpeg-builder /usr/local/bin/ffprobe /usr/local/bin/
+
+# Verify FFmpeg installation
+RUN ffmpeg -version && ffprobe -version
 
 # Copy widevine client files to container
 RUN mkdir -p /usr/local/bin/widevine_cdm
 COPY widevine_cdm/* /usr/local/bin/widevine_cdm/
 
 # JEMalloc for more efficient memory management
-ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
-
-# Set LLVM config for llvmlite/numba
-ENV LLVM_CONFIG="/usr/bin/llvm-config-15"
+# Dynamically set the correct path based on architecture
+ARG TARGETARCH
+RUN set -x \
+    && if [ "$TARGETARCH" = "arm64" ]; then \
+        echo "/usr/lib/aarch64-linux-gnu/libjemalloc.so.2" > /etc/ld.so.preload; \
+    else \
+        echo "/usr/lib/x86_64-linux-gnu/libjemalloc.so.2" > /etc/ld.so.preload; \
+    fi
 
 # we need to set (very permissive) permissions to the workdir
 # and /tmp to allow running the container as non-root

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -35,6 +35,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Additional audio processing
     libbluray-dev \
     libxml2-dev \
+    # SSL/TLS support for HTTPS
+    libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Build FFmpeg 7.1.2 from source with comprehensive audio codec support
@@ -61,6 +63,8 @@ RUN set -x \
         --enable-libvo-amrwbenc \
         # Audio filters and resampling
         --enable-libsoxr \
+        # SSL/TLS support for HTTPS
+        --enable-openssl \
         # Protocols needed for streaming
         --enable-protocol=file \
         --enable-protocol=http \


### PR DESCRIPTION
Switches our docker images to be Debian based as we had too many issues piled up trying to stay on Alpine builds, especially with special packages that provide no alpine builds. 

Also we now compile ffmpeg ourselves within the base image build