### PR TITLE
MusicCast: Fix ungroup & discovery

### DIFF
--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -527,9 +527,18 @@ class MusicCastPlayer(Player):
     ) -> None:
         """Set multiple members.
 
-        If we are a server, this is called.
-        We can ignore removed devices, these are handled via ungroup individually.
+        This function is called on the server.
         """
+        # Removing players
+        if player_ids_to_remove:
+            for player_id in player_ids_to_remove:
+                if player := self.mass.players.get(player_id):
+                    assert isinstance(player, MusicCastPlayer)  # for type checking
+                    await player.ungroup()
+
+        # Adding players
+        if not player_ids_to_add:
+            return
         children: set[str] = set()  # set[ma_player_id]
         children_zones: list[str] = []  # list[ma_player_id]
         player_ids_to_add = [] if player_ids_to_add is None else player_ids_to_add

--- a/music_assistant/providers/musiccast/provider.py
+++ b/music_assistant/providers/musiccast/provider.py
@@ -126,14 +126,15 @@ class MusicCastProvider(PlayerProvider):
             device_info = await self.mass.http_session.get(
                 f"http://{device_ip}/{MC_DEVICE_INFO_ENDPOINT}", raise_for_status=True
             )
+            device_info_json = await device_info.json()
         except ClientError:
             # typical Errors are
             # ClientResponseError -> raise_for_status
             # ClientConnectorError -> unable to connect/ not existing/ timeout
+            # ContentTypeError -> device returns something, but is not json
             # but we can use the base exception class, as we only check
             # if the device is suitable
             return
-        device_info_json = await device_info.json()
         device_id = device_info_json.get("device_id")
         if device_id is None:
             return


### PR DESCRIPTION
2 fixes in this PR:
* music-assistant/support#4335
  aiohttp's json parsing is part of exception handling now
* Ungrouping not working:
  Ungrouping calls player.set_members, and the player remove was not implemented in the rewrite. As a side note: If I shut down Music Assistant, player.ungroup is called directly, i.e. then the players are ungroup even without the fix. Is this expected?