### PR TITLE
Bluos default config tweaks

### DIFF
--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -19,6 +19,7 @@ from music_assistant.constants import (
     CONF_ENTRY_FLOW_MODE_ENFORCED,
     CONF_ENTRY_HTTP_PROFILE_DEFAULT_3,
     CONF_ENTRY_OUTPUT_CODEC,
+    create_sample_rates_config_entry,
 )
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia, PlayerSource
 from music_assistant.providers.bluesound.const import (
@@ -88,6 +89,12 @@ class BluesoundPlayer(Player):
         return [
             *await super().get_config_entries(),
             CONF_ENTRY_HTTP_PROFILE_DEFAULT_3,
+            create_sample_rates_config_entry(
+                max_sample_rate=192000,
+                safe_max_sample_rate=192000,
+                max_bit_depth=24,
+                safe_max_bit_depth=24,
+            ),
             CONF_ENTRY_OUTPUT_CODEC,
             CONF_ENTRY_FLOW_MODE_ENFORCED,
             ConfigEntry.from_dict(

--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -17,7 +17,7 @@ from pyblu.errors import PlayerUnexpectedResponseError, PlayerUnreachableError
 from music_assistant.constants import (
     CONF_ENTRY_ENABLE_ICY_METADATA,
     CONF_ENTRY_FLOW_MODE_ENFORCED,
-    CONF_ENTRY_HTTP_PROFILE_FORCED_2,
+    CONF_ENTRY_HTTP_PROFILE_DEFAULT_3,
     CONF_ENTRY_OUTPUT_CODEC,
 )
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia, PlayerSource
@@ -87,7 +87,7 @@ class BluesoundPlayer(Player):
         """Return all (provider/player specific) Config Entries for the player."""
         return [
             *await super().get_config_entries(),
-            CONF_ENTRY_HTTP_PROFILE_FORCED_2,
+            CONF_ENTRY_HTTP_PROFILE_DEFAULT_3,
             CONF_ENTRY_OUTPUT_CODEC,
             CONF_ENTRY_FLOW_MODE_ENFORCED,
             ConfigEntry.from_dict(


### PR DESCRIPTION
Fixed replay behavior from music-assistant/support#4318
Added default support for hi-rez modes, as all bluos devices support 24bit 192khz