### PR TITLE
Fix custom name & image for manually added radio URL's

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -671,6 +671,11 @@ class MusicController(CoreController):
         # ensure we have a full item
         if isinstance(item, str):
             full_item = await self.get_item_by_uri(item)
+        # For builtin provider (manual URLs), use the provided item directly
+        # to preserve custom modifications (name, images, etc.)
+        # For other providers, fetch fresh to ensure data validity
+        elif item.provider == "builtin":
+            full_item = item
         else:
             full_item = await self.get_item(
                 item.media_type,


### PR DESCRIPTION
The issue: Custom name/image for manual radio stations weren't being saved

I went with a, I think, safe option and only altered the behaviour of the builtin provider. 