### PR TITLE
 Fix for some HLS radio streams playback

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -672,6 +672,7 @@ async def get_media_stream(
         if isinstance(err, asyncio.CancelledError | GeneratorExit):
             # we were cancelled, just raise
             cancelled = True
+            raise
         logger.error("Error while streaming %s: %s", streamdetails.uri, err)
         # dump the last 10 lines of the log in case of an unclean exit
         logger.warning("\n".join(list(ffmpeg_proc.log_history)[-10:]))

--- a/music_assistant/helpers/playlists.py
+++ b/music_assistant/helpers/playlists.py
@@ -84,7 +84,12 @@ def parse_m3u(m3u_data: str) -> list[PlaylistItem]:
                 kev_value_parts = part.strip().split("=")
                 stream_info[kev_value_parts[0]] = kev_value_parts[1]
         elif line.startswith("#EXT-X-KEY:"):
-            key = line.split(",URI=")[1].strip('"')
+            # Extract encryption key URI if present
+            # METHOD=NONE means no encryption, so explicitly clear the key
+            if "METHOD=NONE" in line:
+                key = None
+            elif ",URI=" in line:
+                key = line.split(",URI=")[1].strip('"')
         elif line.startswith("#"):
             # Ignore other extensions
             continue


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/4322

  ### Summary

  This PR fixes a bug preventing certain HLS radio streams from playing, specifically those using unencrypted segments
  (METHOD=NONE). The issue caused an immediate stream abort with an IndexError during playlist parsing.

  ### Changes

###   1. Fixed HLS playlist parser to handle METHOD=NONE encryption (playlists.py)

  **Problem:**
  The M3U playlist parser assumed all #EXT-X-KEY: tags would contain a ,URI= parameter. However, per the
  https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.4, when METHOD=NONE is specified, no URI is present as the
  segments are unencrypted.

  Example of failing playlist:
  #EXT-X-KEY:METHOD=NONE
  #EXTINF:6,
  segment.ts

  **Fix:**
  - Check if METHOD=NONE is present and explicitly set key = None (per HLS spec, this clears any previous encryption)
  - Only attempt to extract URI when ,URI= is present in the line
  - Prevents IndexError: list index out of range crash

  Affected stream: https://radioitaliasmi.akamaized.net/hls/live/2093120/RISMI/stream01/streamPlaylist.m3u8

 **References**

  - https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.4 - Defines encryption key behavior including METHOD=NONE