### PR TITLE
Add missing enforced flow mode config entry for Resonate

### DIFF
--- a/music_assistant/providers/resonate/player.py
+++ b/music_assistant/providers/resonate/player.py
@@ -42,7 +42,11 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
 
-from music_assistant.constants import CONF_ENTRY_OUTPUT_CODEC, CONF_OUTPUT_CODEC
+from music_assistant.constants import (
+    CONF_ENTRY_FLOW_MODE_ENFORCED,
+    CONF_ENTRY_OUTPUT_CODEC,
+    CONF_OUTPUT_CODEC,
+)
 from music_assistant.helpers.audio import get_player_filter_params
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
 from music_assistant.models.player import Player, PlayerMedia
@@ -361,6 +365,7 @@ class ResonatePlayer(Player):
         default_entries = await super().get_config_entries(action=action, values=values)
         return [
             *default_entries,
+            CONF_ENTRY_FLOW_MODE_ENFORCED,
             ConfigEntry.from_dict(
                 {
                     **CONF_ENTRY_OUTPUT_CODEC.to_dict(),


### PR DESCRIPTION
With dc097bda407c Resonate no longer uses workarounds to directly access the queue flow stream.
This, however, requires a correct configuration to use the queue flow stream, which is fixed here.