### PR TITLE
Enforce flow mode when player does not support enqueueing

### DIFF
--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -33,6 +33,7 @@ from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.player import PlayerMedia
 
 from music_assistant.constants import (
+    CONF_ENTRY_FLOW_MODE_ENFORCED,
     CONF_ENTRY_HTTP_PROFILE_DEFAULT_2,
     CONF_ENTRY_OUTPUT_CODEC,
     create_sample_rates_config_entry,
@@ -59,9 +60,7 @@ if TYPE_CHECKING:
 
 SUPPORTED_FEATURES = {
     PlayerFeature.PAUSE,
-    PlayerFeature.NEXT_PREVIOUS,
     PlayerFeature.SEEK,
-    PlayerFeature.SELECT_SOURCE,
     PlayerFeature.SELECT_SOURCE,
     PlayerFeature.ENQUEUE,
     PlayerFeature.SET_MEMBERS,
@@ -206,6 +205,8 @@ class SonosPlayer(Player):
                 hidden=False,
             ),
         ]
+        if self.get_linked_airplay_player(False):
+            base_entries.append(CONF_ENTRY_FLOW_MODE_ENFORCED)
         return [
             *base_entries,
             ConfigEntry(

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -33,7 +33,6 @@ from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.player import PlayerMedia
 
 from music_assistant.constants import (
-    CONF_ENTRY_FLOW_MODE_ENFORCED,
     CONF_ENTRY_HTTP_PROFILE_DEFAULT_2,
     CONF_ENTRY_OUTPUT_CODEC,
     create_sample_rates_config_entry,
@@ -62,7 +61,6 @@ SUPPORTED_FEATURES = {
     PlayerFeature.PAUSE,
     PlayerFeature.SEEK,
     PlayerFeature.SELECT_SOURCE,
-    PlayerFeature.ENQUEUE,
     PlayerFeature.SET_MEMBERS,
     PlayerFeature.GAPLESS_PLAYBACK,
     PlayerFeature.GAPLESS_DIFFERENT_SAMPLERATE,
@@ -147,6 +145,8 @@ class SonosPlayer(Player):
             _supported_features.add(PlayerFeature.VOLUME_MUTE)
         if not self.get_linked_airplay_player(False):
             _supported_features.add(PlayerFeature.NEXT_PREVIOUS)
+        if not self.get_linked_airplay_player(True):
+            _supported_features.add(PlayerFeature.ENQUEUE)
         self._attr_supported_features = _supported_features
 
         self._attr_name = (
@@ -205,8 +205,6 @@ class SonosPlayer(Player):
                 hidden=False,
             ),
         ]
-        if self.get_linked_airplay_player(False):
-            base_entries.append(CONF_ENTRY_FLOW_MODE_ENFORCED)
         return [
             *base_entries,
             ConfigEntry(

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -126,6 +126,9 @@ class SonosPlayerProvider(PlayerProvider):
             # edge case: we switched from airplay mode to sonos mode (or vice versa)
             # we need to make sure that playback gets stopped on the airplay player
             await airplay_player.stop()
+            # We also need to run setup again on the Sonos player to ensure the supported
+            # features are updated.
+            await sonos_player.setup()
 
     async def _setup_player(self, player_id: str, name: str, info: AsyncServiceInfo) -> None:
         """Handle setup of a new player that is discovered using mdns."""


### PR DESCRIPTION
This PR fixes a bug in the Sonos player with airplay mode on where music would stop after 1 track, because Airplay players cannot handle enqueueing. We now simply enforce flow mode when a player does not support enqueueing.

A Sonos player's enqueueing feature is now dynamically updated based on the airplay mode config.

Also removed the duplicate PlayerFeature.SELECT_SOURCE and removed the NEXT_PREVIOUS from the default supported features, as this is already conditionally set in the setup().