### PR TITLE
fix: abs - discarded progress

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -517,6 +517,41 @@ class MusicController(CoreController):
             )
         return result
 
+    async def get_in_progress_media_provider_item_ids(
+        self, provider_instance_id: str, limit: int = 0
+    ) -> list[tuple[MediaType, str]]:
+        """Return a list of MediaType and provider_item_id of items in progress of provider."""
+        query = (
+            f"SELECT * FROM {DB_TABLE_PLAYLOG} "
+            f"WHERE media_type in ('audiobook', 'podcast_episode') AND fully_played = 0 "
+            f"AND provider in ('library','{provider_instance_id}') "
+            "AND seconds_played > 0 "
+        )
+        assert self.mass.music.database is not None  # for type checking
+        db_rows = await self.mass.music.database.get_rows_from_query(query, limit=limit)
+
+        result: list[tuple[MediaType, str]] = []
+        for db_row in db_rows:
+            if db_row["provider"] == "library":
+                # if the provider is library, we need to make sure that the item
+                # is part of the passed provider_instance_id
+                # a podcast_episode cannot be in the provider_mappings
+                # so these entries must be audiobooks
+                subquery = (
+                    f"SELECT * FROM {DB_TABLE_PROVIDER_MAPPINGS} "
+                    f"WHERE media_type in ('audiobook') AND item_id = {db_row['item_id']} "
+                    f"AND provider_instance = '{provider_instance_id}'"
+                )
+                subrow = await self.mass.music.database.get_rows_from_query(subquery)
+                if len(subrow) != 1:
+                    continue
+                result.append((MediaType.AUDIOBOOK, subrow[0]["provider_item_id"]))
+                continue
+            # non library - item id is provider_item_id
+            result.append((MediaType(db_row["media_type"]), db_row["item_id"]))
+
+        return result
+
     @api_command("music/item_by_uri")
     async def get_item_by_uri(self, uri: str) -> MediaItemType | BrowseFolder:
         """Fetch MediaItem by uri."""

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -517,7 +517,7 @@ class MusicController(CoreController):
             )
         return result
 
-    async def get_in_progress_media_provider_item_ids(
+    async def get_in_progress_provider_item_ids(
         self, provider_instance_id: str, limit: int = 0
     ) -> list[tuple[MediaType, str]]:
         """Return a list of MediaType and provider_item_id of items in progress of provider."""
@@ -533,13 +533,13 @@ class MusicController(CoreController):
         result: list[tuple[MediaType, str]] = []
         for db_row in db_rows:
             if db_row["provider"] == "library":
-                # if the provider is library, we need to make sure that the item
-                # is part of the passed provider_instance_id
-                # a podcast_episode cannot be in the provider_mappings
-                # so these entries must be audiobooks
+                # If the provider is library, we need to make sure that the item
+                # is part of the passed provider_instance_id.
+                # A podcast_episode cannot be in the provider_mappings
+                # so these entries must be audiobooks.
                 subquery = (
                     f"SELECT * FROM {DB_TABLE_PROVIDER_MAPPINGS} "
-                    f"WHERE media_type in ('audiobook') AND item_id = {db_row['item_id']} "
+                    f"WHERE media_type = 'audiobook' AND item_id = {db_row['item_id']} "
                     f"AND provider_instance = '{provider_instance_id}'"
                 )
                 subrow = await self.mass.music.database.get_rows_from_query(subquery)

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -517,10 +517,10 @@ class MusicController(CoreController):
             )
         return result
 
-    async def get_in_progress_provider_item_ids(
+    async def get_playlog_provider_item_ids(
         self, provider_instance_id: str, limit: int = 0
     ) -> list[tuple[MediaType, str]]:
-        """Return a list of MediaType and provider_item_id of items in progress of provider."""
+        """Return a list of MediaType and provider_item_id of items in playlog of provider."""
         query = (
             f"SELECT * FROM {DB_TABLE_PLAYLOG} "
             "WHERE media_type in ('audiobook', 'podcast_episode') "

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -523,9 +523,8 @@ class MusicController(CoreController):
         """Return a list of MediaType and provider_item_id of items in progress of provider."""
         query = (
             f"SELECT * FROM {DB_TABLE_PLAYLOG} "
-            f"WHERE media_type in ('audiobook', 'podcast_episode') AND fully_played = 0 "
-            f"AND provider in ('library','{provider_instance_id}') "
-            "AND seconds_played > 0 "
+            "WHERE media_type in ('audiobook', 'podcast_episode') "
+            f"AND provider in ('library','{provider_instance_id}')"
         )
         assert self.mass.music.database is not None  # for type checking
         db_rows = await self.mass.music.database.get_rows_from_query(query, limit=limit)

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -1434,6 +1434,14 @@ for more details.
         abs_ids_with_progress = set()
 
         for progress in progresses:
+            # save progress ids for later
+            ma_item_id = (
+                progress.library_item_id
+                if progress.episode_id is None
+                else f"{progress.library_item_id} {progress.episode_id}"
+            )
+            abs_ids_with_progress.add(ma_item_id)
+
             # Guard. Also makes sure, that we don't write to db again if no state change happened.
             # This is achieved by adding a Helper Progress in the update playlog functions, which
             # then has the most recent timestamp. If a subsequent progress sent by abs has an older
@@ -1448,21 +1456,19 @@ for more details.
             __updated_items += 1
             if progress.episode_id is None:
                 await self._update_playlog_book(progress)
-                abs_ids_with_progress.add(f"{progress.library_item_id}")
             else:
                 await self._update_playlog_episode(progress)
-                abs_ids_with_progress.add(f"{progress.library_item_id} {progress.episode_id}")
+        self.logger.debug(f"Updated {__updated_items} from full playlog.")
 
-        # Get known MA's known progresses of ABS
+        # Get MA's known progresses of ABS.
         # In ABS the user may discard a progress, which removes the progress completely.
-        # To prevent calling the ABS api for every single item, we compare what MA knows
-        # with what ABS knows.
+        # There is no socket notification for this event.
         ma_playlog_state = await self.mass.music.get_in_progress_provider_item_ids(
             provider_instance_id=self.instance_id
         )
         ma_ids_with_progress = {x for _, x in ma_playlog_state}
-        discarded_progresses_ids = ma_ids_with_progress.difference(abs_ids_with_progress)
-        for discarded_progress_id in discarded_progresses_ids:
+        discarded_progress_ids = ma_ids_with_progress.difference(abs_ids_with_progress)
+        for discarded_progress_id in discarded_progress_ids:
             if len(discarded_progress_id.split(" ")) == 1:
                 if discarded_item := await self.mass.music.get_library_item_by_prov_id(
                     media_type=MediaType.AUDIOBOOK,
@@ -1479,8 +1485,6 @@ for more details.
                     self.progress_guard.add_progress(*discarded_progress_id.split(" "))
                     await self.mass.music.mark_item_unplayed(discarded_item)
             self.logger.debug("Discarded item %s ", discarded_progress_id)
-
-        self.logger.debug(f"Updated {__updated_items} from full playlog.")
 
     async def _update_playlog_book(self, progress: MediaProgress) -> None:
         # helper progress also ensures no useless progress updates,

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -1463,7 +1463,7 @@ for more details.
         # Get MA's known progresses of ABS.
         # In ABS the user may discard a progress, which removes the progress completely.
         # There is no socket notification for this event.
-        ma_playlog_state = await self.mass.music.get_in_progress_provider_item_ids(
+        ma_playlog_state = await self.mass.music.get_playlog_provider_item_ids(
             provider_instance_id=self.instance_id
         )
         ma_ids_with_progress = {x for _, x in ma_playlog_state}

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -1457,7 +1457,7 @@ for more details.
         # In ABS the user may discard a progress, which removes the progress completely.
         # To prevent calling the ABS api for every single item, we compare what MA knows
         # with what ABS knows.
-        ma_playlog_state = await self.mass.music.get_in_progress_media_provider_item_ids(
+        ma_playlog_state = await self.mass.music.get_in_progress_provider_item_ids(
             provider_instance_id=self.instance_id
         )
         ma_ids_with_progress = {x for _, x in ma_playlog_state}

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -61,6 +61,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.media_items.media_item import RecommendationFolder
 from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 
+from music_assistant.constants import DB_TABLE_PLAYLOG
 from music_assistant.controllers.cache import use_cache
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.audiobookshelf.parsers import (
@@ -1430,6 +1431,7 @@ for more details.
         __updated_items = 0
 
         known_ids = self._get_all_known_item_ids()
+        abs_ids_with_progress = set()
 
         for progress in progresses:
             # Guard. Also makes sure, that we don't write to db again if no state change happened.
@@ -1446,8 +1448,55 @@ for more details.
             __updated_items += 1
             if progress.episode_id is None:
                 await self._update_playlog_book(progress)
+                abs_ids_with_progress.add(f"{progress.library_item_id}")
             else:
                 await self._update_playlog_episode(progress)
+                abs_ids_with_progress.add(f"{progress.library_item_id} {progress.episode_id}")
+
+        # Get known MA's known progresses of ABS
+        # In ABS the user may discard a progress, which removes the progress completely.
+        # To prevent calling the ABS api for every single item, we compare what MA knows
+        # with what ABS knows.
+        query = (
+            f"SELECT * FROM {DB_TABLE_PLAYLOG} "
+            f"WHERE media_type in ('audiobook', 'podcast_episode') AND fully_played = 0 "
+            f"AND provider in ('{self.lookup_key}', 'library')"
+            "AND seconds_played > 0 "
+            "ORDER BY timestamp DESC"
+        )
+        assert self.mass.music.database is not None  # for type checking
+        db_rows = await self.mass.music.database.get_rows_from_query(query)
+        ma_ids_with_progress = set()
+        for db_row in db_rows:
+            if db_row["provider"] == self.lookup_key:
+                # these are podcast episodes
+                ma_ids_with_progress.add(db_row["item_id"])
+            else:
+                # library - these are audiobooks
+                try:
+                    if _item := await self.mass.music.get_library_item_by_prov_id(
+                        media_type=MediaType.AUDIOBOOK,
+                        item_id=db_row["item_id"],
+                        provider_instance_id_or_domain="library",
+                    ):
+                        for provider_mapping in _item.provider_mappings:
+                            if provider_mapping.provider_instance == self.instance_id:
+                                ma_ids_with_progress.add(provider_mapping.item_id)
+                except MediaNotFoundError:
+                    continue
+
+        discarded_progresses_ids = ma_ids_with_progress.difference(abs_ids_with_progress)
+        self.logger.debug("Discarded progresses %s", discarded_progresses_ids)
+        for discarded_progress_id in discarded_progresses_ids:
+            if discarded_item := await self.mass.music.get_library_item_by_prov_id(
+                media_type=MediaType.AUDIOBOOK
+                if len(discarded_progress_id.split(" ")) == 1
+                else MediaType.PODCAST_EPISODE,
+                item_id=discarded_progress_id,
+                provider_instance_id_or_domain=self.lookup_key,
+            ):
+                await self.mass.music.mark_item_unplayed(discarded_item)
+
         self.logger.debug(f"Updated {__updated_items} from full playlog.")
 
     async def _update_playlog_book(self, progress: MediaProgress) -> None:

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -6,6 +6,7 @@ import functools
 import itertools
 import time
 from collections.abc import AsyncGenerator, Callable, Coroutine, Sequence
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
 import aioaudiobookshelf as aioabs
@@ -61,7 +62,6 @@ from music_assistant_models.media_items import (
 from music_assistant_models.media_items.media_item import RecommendationFolder
 from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 
-from music_assistant.constants import DB_TABLE_PLAYLOG
 from music_assistant.controllers.cache import use_cache
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.audiobookshelf.parsers import (
@@ -1457,45 +1457,28 @@ for more details.
         # In ABS the user may discard a progress, which removes the progress completely.
         # To prevent calling the ABS api for every single item, we compare what MA knows
         # with what ABS knows.
-        query = (
-            f"SELECT * FROM {DB_TABLE_PLAYLOG} "
-            f"WHERE media_type in ('audiobook', 'podcast_episode') AND fully_played = 0 "
-            f"AND provider in ('{self.lookup_key}', 'library')"
-            "AND seconds_played > 0 "
-            "ORDER BY timestamp DESC"
+        ma_playlog_state = await self.mass.music.get_in_progress_media_provider_item_ids(
+            provider_instance_id=self.instance_id
         )
-        assert self.mass.music.database is not None  # for type checking
-        db_rows = await self.mass.music.database.get_rows_from_query(query)
-        ma_ids_with_progress = set()
-        for db_row in db_rows:
-            if db_row["provider"] == self.lookup_key:
-                # these are podcast episodes
-                ma_ids_with_progress.add(db_row["item_id"])
-            else:
-                # library - these are audiobooks
-                try:
-                    if _item := await self.mass.music.get_library_item_by_prov_id(
-                        media_type=MediaType.AUDIOBOOK,
-                        item_id=db_row["item_id"],
-                        provider_instance_id_or_domain="library",
-                    ):
-                        for provider_mapping in _item.provider_mappings:
-                            if provider_mapping.provider_instance == self.instance_id:
-                                ma_ids_with_progress.add(provider_mapping.item_id)
-                except MediaNotFoundError:
-                    continue
-
+        ma_ids_with_progress = {x for _, x in ma_playlog_state}
         discarded_progresses_ids = ma_ids_with_progress.difference(abs_ids_with_progress)
-        self.logger.debug("Discarded progresses %s", discarded_progresses_ids)
         for discarded_progress_id in discarded_progresses_ids:
-            if discarded_item := await self.mass.music.get_library_item_by_prov_id(
-                media_type=MediaType.AUDIOBOOK
-                if len(discarded_progress_id.split(" ")) == 1
-                else MediaType.PODCAST_EPISODE,
-                item_id=discarded_progress_id,
-                provider_instance_id_or_domain=self.lookup_key,
-            ):
-                await self.mass.music.mark_item_unplayed(discarded_item)
+            if len(discarded_progress_id.split(" ")) == 1:
+                if discarded_item := await self.mass.music.get_library_item_by_prov_id(
+                    media_type=MediaType.AUDIOBOOK,
+                    item_id=discarded_progress_id,
+                    provider_instance_id_or_domain=self.lookup_key,
+                ):
+                    self.progress_guard.add_progress(discarded_progress_id)
+                    await self.mass.music.mark_item_unplayed(discarded_item)
+            else:
+                with suppress(MediaNotFoundError):
+                    discarded_item = await self.get_podcast_episode(
+                        prov_episode_id=discarded_progress_id, add_progress=False
+                    )
+                    self.progress_guard.add_progress(*discarded_progress_id.split(" "))
+                    await self.mass.music.mark_item_unplayed(discarded_item)
+            self.logger.debug("Discarded item %s ", discarded_progress_id)
 
         self.logger.debug(f"Updated {__updated_items} from full playlog.")
 


### PR DESCRIPTION
Fixes a discarded progress in abs not being synced to MA, see music-assistant/support#4379. If a user discards an abs progress, the api does not return anything, and no socket event is emitted. So we need to compare items in MA's playlog with items still present in abs.

This PR adds a core function to obtain in-progress media item ids and types from the database. The abs provider uses this function to cleanup the playlog on regular provider syncs if necessary.