### PR TITLE
Use secure connection to MusicBrainz API

### DIFF
--- a/music_assistant/providers/musicbrainz/__init__.py
+++ b/music_assistant/providers/musicbrainz/__init__.py
@@ -430,7 +430,7 @@ class MusicbrainzProvider(MetadataProvider):
     @throttle_with_retries
     async def get_data(self, endpoint: str, **kwargs: str) -> Any:
         """Get data from api."""
-        url = f"http://musicbrainz.org/ws/2/{endpoint}"
+        url = f"https://musicbrainz.org/ws/2/{endpoint}"
         headers = {
             "User-Agent": f"Music Assistant/{self.mass.version} (https://music-assistant.io)"
         }


### PR DESCRIPTION
Currently, plain HTTP is used to connect to MusicBrainz, which isn't state of the art and imposes both privacy and security risks.

To quote https://musicbrainz.org/doc/MusicBrainz_API:
> The API root URL is https://musicbrainz.org/ws/2/.

So this PR switches to the documented and secure HTTPS URL.

I didn't observe any errors after the patch and verified that Music Assistant was indeed connecting to musicbrainz.org:443.
