### PR TITLE
Fix UGP member detection in `get_stream`

### DIFF
--- a/music_assistant/controllers/streams.py
+++ b/music_assistant/controllers/streams.py
@@ -877,8 +877,15 @@ class StreamsController(CoreController):
                 # because this could have been a group
                 player_id=media.custom_data["player_id"],
             )
-        elif media.source_id and media.source_id.startswith(UGP_PREFIX):
-            # special case: UGP stream
+        elif (
+            media.media_type == MediaType.FLOW_STREAM
+            and media.source_id
+            and media.source_id.startswith(UGP_PREFIX)
+            and media.uri
+            and "/ugp/" in media.uri
+        ):
+            # special case: member player accessing UGP stream
+            # Check URI to distinguish from the UGP accessing its own stream
             ugp_player = cast("UniversalGroupPlayer", self.mass.players.get(media.source_id))
             ugp_stream = ugp_player.stream
             assert ugp_stream is not None  # for type checker


### PR DESCRIPTION
Add checks to distinguish between the universal group player's stream and member players accessing an existing UGP stream.
Both have `source_id` starting with "ugp_", but only member players have URIs containing "/ugp/".

## Example Error
This PR fixes an `AssertionError` when a UGP player tries to access its own stream before it exists.
```
2025-11-10 13:57:17.814 ERROR (MainThread) [music_assistant.webserver] Error handling message: CommandMessage(message_id='b0c1d104-4ac4-4c5d-a56f-844d444c48da', command='players/cmd/play_pause', args={'player_id': 'ugp_4eyzahd4'})
Traceback (most recent call last):
  File "/var/home/maximr/projects/music-assistant/server/music_assistant/controllers/players/player_controller.py", line 128, in wrapper
    await func(self, *args, **kwargs)
  File "/var/home/maximr/projects/music-assistant/server/music_assistant/controllers/players/player_controller.py", line 1004, in play_media
    await player.play_media(media)
  File "/var/home/maximr/projects/music-assistant/server/music_assistant/providers/universal_group/player.py", line 225, in play_media
    audio_source = self.mass.streams.get_stream(media, UGP_FORMAT)
  File "/var/home/maximr/projects/music-assistant/server/music_assistant/controllers/streams.py", line 884, in get_stream
    assert ugp_stream is not None  # for type checker
           ^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```