### PR TITLE
Fix CI by installing all provider's dependencies when linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ffmpeg
           python -m pip install --upgrade pip build setuptools
-          pip install . .[test]
+          pip install . .[test] -r requirements_all.txt
       - name: Lint/test with pre-commit
         run: SKIP=no-commit-to-branch pre-commit run --all-files
 


### PR DESCRIPTION
Mypy fails in cases like #2616, where installing provider dependencies are required for `pre-commit` to pass.
Otherwise mypy is unable to check all types.