### PR TITLE
Install JavaScript runtime

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -171,8 +171,13 @@ RUN set -x \
         libpopt0 \
         # pkg-config needed for PyAV (for aioresonate) to find system FFmpeg
         pkg-config \
+        # unzip needed for deno
+        unzip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install deno, required for Youtube Music provider
+RUN curl -fsSL https://deno.land/install.sh | sh -s -- -y
 
 # Install Snapcast 0.34.0 from GitHub releases (requires at least 0.27)
 ARG SNAPCAST_VERSION=0.34.0

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -178,6 +178,7 @@ RUN set -x \
 
 # Install deno, required for Youtube Music provider
 RUN curl -fsSL https://deno.land/install.sh | sh -s -- -y
+ENV PATH="/root/.deno/bin:${PATH}"
 
 # Install Snapcast 0.34.0 from GitHub releases (requires at least 0.27)
 ARG SNAPCAST_VERSION=0.34.0


### PR DESCRIPTION
A JavaScript runtime is now required for the Youtube Music provider to work, deno is the recommended and the default setting on yt-dlp: https://github.com/yt-dlp/yt-dlp/wiki/EJS

This fixes https://github.com/music-assistant/support/issues/4348