### PR TITLE
fix: tracks tab not being populated

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -798,7 +798,10 @@ class PlexProvider(MusicProvider):
             available = True
             content = plex_track.media[0].container
         else:
-            available = False
+            # For Plex (local library provider), assume tracks are available by default
+            # even if media attribute is not populated in the initial response.
+            # This prevents tracks from being skipped during library sync.
+            available = True
             content = None
         track = Track(
             item_id=plex_track.key,


### PR DESCRIPTION
# Fix Plex provider: Tracks not syncing to library

## Summary

Fixes issue where tracks from Plex provider were not being synced to the Music Assistant library, leaving the Tracks tab empty while Albums and Artists tabs populated correctly.

## Problem
When syncing tracks from Plex, the provider incorrectly marked tracks as available=False when the media attribute wasn't populated in the track object. During bulk library sync operations using searchTracks(), Plex API often returns track objects without fully populated metadata (including the media attribute), even though the tracks are actually available in the library.

Fixes [this issue](https://github.com/orgs/music-assistant/discussions/4406#discussioncomment-14953882) @OzGav 