### PR TITLE
Plex: Fix collision in cache keys

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -127,7 +127,7 @@ async def setup(
 
 async def get_config_entries(  # noqa: PLR0915
     mass: MusicAssistant,
-    instance_id: str | None = None,  # noqa: ARG001
+    instance_id: str | None = None,
     action: str | None = None,
     values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
@@ -277,6 +277,7 @@ async def get_config_entries(  # noqa: PLR0915
                     server_http_ip,
                     server_http_port,
                     server_http_verify_cert,
+                    instance_id,
                 )
             ):
                 msg = "Unable to retrieve Servers and/or Music Libraries"

--- a/music_assistant/providers/plex/helpers.py
+++ b/music_assistant/providers/plex/helpers.py
@@ -22,11 +22,20 @@ async def get_libraries(
     local_server_ip: str,
     local_server_port: str,
     local_server_verify_cert: bool,
+    instance_id: str | None = None,
 ) -> list[str]:
     """
     Get all music libraries for all plex servers.
 
     Returns a dict of Library names in format {'servername / library name':'baseurl'}
+
+    :param mass: MusicAssistant instance.
+    :param auth_token: Authentication token for Plex server.
+    :param local_server_ssl: Whether to use SSL/HTTPS.
+    :param local_server_ip: IP address of the Plex server.
+    :param local_server_port: Port of the Plex server.
+    :param local_server_verify_cert: Whether to verify SSL certificate.
+    :param instance_id: Provider instance ID to use for cache isolation.
     """
     cache_key = "plex_libraries"
 
@@ -54,12 +63,20 @@ async def get_libraries(
             all_libraries.append(f"{plex_server.friendlyName} / {media_section.title}")
         return all_libraries
 
-    if cache := await mass.cache.get(cache_key, checksum=auth_token):
+    if cache := await mass.cache.get(
+        cache_key, checksum=auth_token, provider=instance_id or "default"
+    ):
         return cast("list[str]", cache)
 
     result = await asyncio.to_thread(_get_libraries)
     # use short expiration for in-memory cache
-    await mass.cache.set(cache_key, result, checksum=auth_token, expiration=3600)
+    await mass.cache.set(
+        cache_key,
+        result,
+        checksum=auth_token,
+        expiration=3600,
+        provider=instance_id or "default",
+    )
     return result
 
 

--- a/music_assistant/providers/plex/helpers.py
+++ b/music_assistant/providers/plex/helpers.py
@@ -64,7 +64,7 @@ async def get_libraries(
         return all_libraries
 
     if cache := await mass.cache.get(
-        cache_key, checksum=auth_token, provider=instance_id or "default"
+        cache_key, checksum=auth_token, provider=instance_id or local_server_ip
     ):
         return cast("list[str]", cache)
 

--- a/music_assistant/providers/plex/helpers.py
+++ b/music_assistant/providers/plex/helpers.py
@@ -27,7 +27,7 @@ async def get_libraries(
     """
     Get all music libraries for all plex servers.
 
-    Returns a dict of Library names in format {'servername / library name':'baseurl'}
+    Returns a list of Library names in format ['servername / library name', ...]
 
     :param mass: MusicAssistant instance.
     :param auth_token: Authentication token for Plex server.


### PR DESCRIPTION
Fixes Cache key collision caused Server 2 to show Server 1's libraries when both used the same MyPlex account.

Fixes [this issue](https://github.com/music-assistant/support/issues/2308), sorry for the delay @OzGav, I was busy implementing the remote control feature.