### PR TITLE
Fix: Handle non-UTF8 .lrc files gracefully to prevent playback blocking

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -995,8 +995,15 @@ class LocalFileSystemProvider(MusicProvider):
         assert file_item.ext is not None  # for type checking
         lrc_path = f"{file_item.absolute_path.removesuffix(file_item.ext)}lrc"
         if await self.exists(lrc_path):
-            async with aiofiles.open(lrc_path) as lrc_file:
-                track.metadata.lrc_lyrics = await lrc_file.read()
+            try:
+                async with aiofiles.open(lrc_path, encoding="utf-8") as lrc_file:
+                    track.metadata.lrc_lyrics = await lrc_file.read()
+            except Exception as err:
+                self.logger.warning(
+                    "Failed to read lyrics file %s: %s",
+                    lrc_path,
+                    str(err),
+                )
 
         return track
 


### PR DESCRIPTION
When a .lrc (lyrics) file associated with an MP3 has non-UTF8 encoding, the previous code would fail during file reading and potentially block playback. This fix:

1. Explicitly specifies UTF-8 encoding when opening .lrc files
2. Wraps .lrc file reading in try-except block
3. Logs a warning if the lyrics file cannot be read
4. Allows playback to continue even if lyrics parsing fails

This ensures that encoding issues in lyrics files are logged but do not prevent the audio file from playing.