### PR TITLE
fix(tidal): auth refresh time diff

### DIFF
--- a/music_assistant/providers/tidal/auth_manager.py
+++ b/music_assistant/providers/tidal/auth_manager.py
@@ -6,7 +6,6 @@ import time
 import urllib
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import timedelta
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
@@ -24,6 +23,8 @@ if TYPE_CHECKING:
 TOKEN_TYPE = "Bearer"
 AUTH_URL = "https://auth.tidal.com/v1/oauth2"
 REDIRECT_URI = "https://tidal.com/android/login/auth"
+
+TOKEN_REFRESH_BUFFER = 60 * 7  # 7 minutes
 
 
 @dataclass
@@ -126,7 +127,7 @@ class TidalAuthManager:
 
         # Check if token is expired
         expires_at = self._auth_info.get("expires_at", 0)  # type: ignore[unreachable]
-        if expires_at > time.time() - timedelta(minutes=60).total_seconds():
+        if expires_at > time.time() + TOKEN_REFRESH_BUFFER:
             return True
 
         # Need to refresh token

--- a/music_assistant/providers/tidal/auth_manager.py
+++ b/music_assistant/providers/tidal/auth_manager.py
@@ -6,6 +6,7 @@ import time
 import urllib
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import timedelta
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
@@ -125,7 +126,7 @@ class TidalAuthManager:
 
         # Check if token is expired
         expires_at = self._auth_info.get("expires_at", 0)  # type: ignore[unreachable]
-        if expires_at > time.time() - 60:
+        if expires_at > time.time() - timedelta(minutes=60).total_seconds():
             return True
 
         # Need to refresh token


### PR DESCRIPTION
Auth expiration check was inverted and using 60 seconds, fixed the inversion and added buffer of 7 minutes

Closes [#4425](https://github.com/music-assistant/support/issues/4425)