### PR TITLE
Fix squeezelite UnboundLocalError exception when playing a plugin source.

### DIFF
--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -407,6 +407,7 @@ class SqueezelitePlayer(Player):
             "source_id": media.source_id,
             "queue_item_id": media.queue_item_id,
         }
+        queue = None
         if media.source_id and (queue := self.mass.player_queues.get(media.source_id)):
             self.extra_data["playlist repeat"] = REPEATMODE_MAP[queue.repeat_mode]
             self.extra_data["playlist shuffle"] = int(queue.shuffle_enabled)


### PR DESCRIPTION
```
 File "/opt/git/ma/server/squeezelite-queue-unbound/music_assistant/providers/squeezelite/player.py", line 429, in _handle_play_url_for_slimplayer
    if queue and queue.repeat_mode == RepeatMode.ONE:
       ^^^^^
UnboundLocalError: cannot access local variable 'queue' where it is not associated with a value
```