### PR TITLE
Fix snapcast crash by disabling controlscript feature

### DIFF
--- a/music_assistant/providers/snapcast/player.py
+++ b/music_assistant/providers/snapcast/player.py
@@ -3,7 +3,6 @@
 import asyncio
 import random
 import time
-import urllib.parse
 from contextlib import suppress
 from typing import TYPE_CHECKING, cast
 
@@ -25,7 +24,6 @@ from music_assistant.helpers.ffmpeg import FFMpeg
 from music_assistant.models.player import Player
 from music_assistant.providers.snapcast.constants import (
     CONF_ENTRY_SAMPLE_RATES_SNAPCAST,
-    CONTROL_SCRIPT,
     DEFAULT_SNAPCAST_FORMAT,
     MASS_ANNOUNCEMENT_POSTFIX,
     MASS_STREAM_PREFIX,
@@ -349,18 +347,12 @@ class SnapCastPlayer(Player):
         if stream := self._get_snapstream(stream_name):
             return stream
 
-        # The control script is used only for music streams in the builtin server
-        # (queue_id is None only for announcement streams).
-        if self.provider._use_builtin_server and queue_id:
-            extra_args = (
-                f"&controlscript={urllib.parse.quote_plus(str(CONTROL_SCRIPT))}"
-                f"&controlscriptparams=--queueid={urllib.parse.quote_plus(queue_id)}%20"
-                f"--api-port={self.mass.webserver.publish_port}%20"
-                f"--streamserver-ip={self.mass.streams.publish_ip}%20"
-                f"--streamserver-port={self.mass.streams.publish_port}"
-            )
-        else:
-            extra_args = ""
+        # Note: The control script feature is currently disabled because snapserver requires
+        # controlscripts to be in /usr/share/snapserver/plug-ins/ but the script is in the
+        # Python package directory. This feature was non-functional from beta 7-15 due to a bug
+        # and needs proper implementation before re-enabling.
+        # See: https://github.com/music-assistant/server/issues/XXXX
+        extra_args = ""
 
         attempts = 50
         while attempts:


### PR DESCRIPTION
The typing fixes in commit 7aa4438 inadvertently exposed a bug where the snapcast controlscript path wasn't in the required /usr/share/snapserver/plug-ins/ directory, causing the built-in snapserver to reject stream creation and crash.

Before 7aa4438, there was a duplicate `extra_args = ""` assignment that meant the controlscript was never actually used (from beta 7-15), so everything worked fine. The typing fixes removed this duplicate, which was correct code-wise, but exposed the path issue.

Since the controlscript feature has been non-functional since at least beta 7 without user complaints, this commit disables it entirely to restore the working beta 7-15 behavior. A proper fix would require:
- Copying the script to /usr/share/snapserver/plug-ins/ during setup, or
- Using a different control integration approach

Fixes the KeyError crash in snapcast protocol.data_received() when attempting to add a stream with an invalid controlscript path.