### PR TITLE
fix(bbc_sounds): Handle library exception more gracefully

### DIFF
--- a/music_assistant/providers/bbc_sounds/__init__.py
+++ b/music_assistant/providers/bbc_sounds/__init__.py
@@ -797,7 +797,7 @@ class BBCSoundsProvider(MusicProvider):
                     success = await self.client.streaming.update_play_status(
                         pid=media_item.item_id, elapsed_time=position, action=action
                     )
-                    self.logger.info(f"Updated play status: {success}")
+                    self.logger.debug(f"Updated play status: {success}")
                 except exceptions.APIResponseError as err:
                     self.logger.error(f"Error updating play status: {err}")
         # Cancel now playing task

--- a/music_assistant/providers/bbc_sounds/__init__.py
+++ b/music_assistant/providers/bbc_sounds/__init__.py
@@ -793,10 +793,13 @@ class BBCSoundsProvider(MusicProvider):
                 action = PlayStatus.PAUSED
 
             if action:
-                success = await self.client.streaming.update_play_status(
-                    pid=media_item.item_id, elapsed_time=position, action=action
-                )
-                self.logger.info(f"Updated play status: {success}")
+                try:
+                    success = await self.client.streaming.update_play_status(
+                        pid=media_item.item_id, elapsed_time=position, action=action
+                    )
+                    self.logger.info(f"Updated play status: {success}")
+                except exceptions.APIResponseError as err:
+                    self.logger.error(f"Error updating play status: {err}")
         # Cancel now playing task
         if FEATURES["now_playing"] and not is_playing and self.current_task:
             self.current_task.cancel()

--- a/music_assistant/providers/bbc_sounds/manifest.json
+++ b/music_assistant/providers/bbc_sounds/manifest.json
@@ -8,7 +8,7 @@
     "@kieranhogg"
   ],
   "requirements": [
-    "auntie-sounds==1.1.1",
+    "auntie-sounds==1.1.3",
     "pytz==2025.2"
   ],
   "multi_instance": false

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -18,7 +18,7 @@ aiovban>=0.6.3
 alexapy==1.29.10
 async-upnp-client==0.45.0
 audible==0.10.0
-auntie-sounds==1.1.1
+auntie-sounds==1.1.3
 bidict==0.23.1
 certifi==2025.11.12
 chardet>=5.2.0


### PR DESCRIPTION
An unexpected json response from the heartbeat API endpoint wasn't checked for `TypeError`s, handle this in both the library and the MA provider