### PR TITLE
BBC Sounds: Fix Radio 4 station

### DIFF
--- a/music_assistant/providers/bbc_sounds/adaptor.py
+++ b/music_assistant/providers/bbc_sounds/adaptor.py
@@ -229,10 +229,7 @@ class StationConverter(BaseConverter):
 
     async def get_stream_details(self, source_obj: Station | LiveStation) -> StreamDetails | None:
         """Convert the source object to a stream."""
-        from music_assistant.providers.bbc_sounds import (  # noqa: PLC0415
-            FEATURES,
-            _Constants,
-        )
+        from music_assistant.providers.bbc_sounds import FEATURES, _Constants  # noqa: PLC0415
 
         # TODO: can't seek this stream
         station = await self.convert(source_obj)
@@ -288,14 +285,14 @@ class StationConverter(BaseConverter):
         image_url = self._get_attr(station, "image_url")
 
         radio = Radio(
-            item_id=station.item_id,
+            item_id=station.id,
             # Add BBC prefix back to station to help identify station within MA
             name=f"BBC {self._get_attr(station, 'title', 'Unknown')}",
             provider=self.context.provider_domain,
             metadata=ImageProvider.create_metadata_with_image(
                 image_url, self.context.provider_domain
             ),
-            provider_mappings={self._create_provider_mapping(station.item_id)},
+            provider_mappings={self._create_provider_mapping(station.id)},
         )
         if station.stream:
             radio.uri = station.stream.uri
@@ -303,18 +300,17 @@ class StationConverter(BaseConverter):
 
     def _convert_live_station(self, station: LiveStation) -> Radio:
         """Convert LiveStation object."""
-        network_id = self._get_attr(station, "network.id")
         name = self._get_attr(station, "network.short_title", "Unknown")
         image_url = self._get_attr(station, "network.logo_url")
 
         return Radio(
-            item_id=network_id,
+            item_id=station.id,
             name=f"BBC {name}",
             provider=self.context.provider_domain,
             metadata=ImageProvider.create_metadata_with_image(
                 image_url, self.context.provider_domain
             ),
-            provider_mappings={self._create_provider_mapping(network_id)},
+            provider_mappings={self._create_provider_mapping(station.id)},
         )
 
     def _convert_station_search_result(self, station: StationSearchResult) -> Radio:

--- a/music_assistant/providers/bbc_sounds/manifest.json
+++ b/music_assistant/providers/bbc_sounds/manifest.json
@@ -8,7 +8,7 @@
     "@kieranhogg"
   ],
   "requirements": [
-    "auntie-sounds==1.1.3",
+    "auntie-sounds==1.1.4",
     "pytz==2025.2"
   ],
   "multi_instance": false

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -18,7 +18,7 @@ aiovban>=0.6.3
 alexapy==1.29.10
 async-upnp-client==0.45.0
 audible==0.10.0
-auntie-sounds==1.1.3
+auntie-sounds==1.1.4
 bidict==0.23.1
 certifi==2025.11.12
 chardet>=5.2.0


### PR DESCRIPTION
Most stations have a couple of IDs that are identical. Radio 4 has two different ones, but only one can be used to request a stream, so switch to using that one.