### PR TITLE
Add recently added tracks and albums playlist + recommendation

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -497,6 +497,11 @@ class MusicController(CoreController):
             )
         return result
 
+    @api_command("music/recently_added_tracks")
+    async def recently_added_tracks(self, limit: int = 10) -> list[Track]:
+        """Return a list of the last added tracks."""
+        return await self.tracks.library_items(limit=limit, order_by="timestamp_added_desc")
+
     @api_command("music/in_progress_items")
     async def in_progress_items(self, limit: int = 10) -> list[ItemMapping]:
         """Return a list of the Audiobooks and PodcastEpisodes that are in progress."""
@@ -1359,6 +1364,22 @@ class MusicController(CoreController):
                 translation_key="recently_played",
                 icon="mdi-motion-play",
                 items=await self.recently_played(limit=10),
+            ),
+            RecommendationFolder(
+                item_id="recently_added_tracks",
+                provider="library",
+                name="Recently added tracks",
+                translation_key="recently_added_tracks",
+                icon="music-note-plus",
+                items=await self.tracks.library_items(limit=10, order_by="timestamp_added_desc"),
+            ),
+            RecommendationFolder(
+                item_id="recently_added_albums",
+                provider="library",
+                name="Recently added albums",
+                translation_key="recently_added_albums",
+                icon="music-note-plus",
+                items=await self.albums.library_items(limit=10, order_by="timestamp_added_desc"),
             ),
             RecommendationFolder(
                 item_id="random_artists",

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -61,6 +61,7 @@ from .constants import (
     RANDOM_ALBUM,
     RANDOM_ARTIST,
     RANDOM_TRACKS,
+    RECENTLY_ADDED_TRACKS,
     RECENTLY_PLAYED,
     StoredItem,
 )
@@ -619,6 +620,14 @@ class BuiltinProvider(MusicProvider):
             result.append(track)
         return result
 
+    async def _get_builtin_playlist_recently_added_tracks(self) -> list[Track]:
+        result: list[Track] = []
+        recent_tracks = await self.mass.music.recently_added_tracks(100)
+        for idx, track in enumerate(recent_tracks, 1):
+            track.position = idx
+            result.append(track)
+        return result
+
     async def _get_builtin_playlist_tracks(
         self, builtin_playlist_id: str
     ) -> list[Track] | UniqueList[Track]:
@@ -630,6 +639,7 @@ class BuiltinProvider(MusicProvider):
                 RANDOM_ALBUM: self._get_builtin_playlist_random_album,
                 RANDOM_ARTIST: self._get_builtin_playlist_random_artist,
                 RECENTLY_PLAYED: self._get_builtin_playlist_recently_played,
+                RECENTLY_ADDED_TRACKS: self._get_builtin_playlist_recently_added_tracks,
             }[builtin_playlist_id]()
         except KeyError:
             raise MediaNotFoundError(f"No built in playlist: {builtin_playlist_id}")

--- a/music_assistant/providers/builtin/constants.py
+++ b/music_assistant/providers/builtin/constants.py
@@ -38,6 +38,7 @@ RANDOM_ARTIST = "random_artist"
 RANDOM_ALBUM = "random_album"
 RANDOM_TRACKS = "random_tracks"
 RECENTLY_PLAYED = "recently_played"
+RECENTLY_ADDED_TRACKS = "recently_added_tracks"
 
 BUILTIN_PLAYLISTS = {
     ALL_FAVORITE_TRACKS: "All favorited tracks",
@@ -45,6 +46,7 @@ BUILTIN_PLAYLISTS = {
     RANDOM_ALBUM: "Random Album (from library)",
     RANDOM_TRACKS: "500 Random tracks (from library)",
     RECENTLY_PLAYED: "Recently played tracks",
+    RECENTLY_ADDED_TRACKS: "Recently added tracks",
 }
 BUILTIN_PLAYLISTS_ENTRIES = [
     ConfigEntry(


### PR DESCRIPTION
Idea here is to add three things:
- A new built-in playlist containing the most recently added tracks
- A new recommendation (so the things on the home screen) that also displays the most recently added 10 tracks
- A new recommendation displaying the most recently added albums

Homescreen:
<img width="1164" height="668" alt="Screenshot 2025-11-27 at 21 56 47" src="https://github.com/user-attachments/assets/0a9c54a8-3d41-41f5-8708-1f1a5432c27f" />

Added Playlist:
<img width="1470" height="709" alt="Screenshot 2025-11-27 at 21 58 08" src="https://github.com/user-attachments/assets/f5f0644d-ced4-4bb6-8190-0fbd94855997" />