### PR TITLE
Spotify connect: Fix sudden volume change when session starts

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -1074,8 +1074,9 @@ class SpotifyProvider(MusicProvider):
                 raise ResourceTemporarilyUnavailable(backoff_time=30)
             response.raise_for_status()
 
-    async def _put_data_unthrottled(self, endpoint: str, data: Any = None, **kwargs: Any) -> None:
-        """Put data on api without throttling."""
+    @throttle_with_retries
+    async def _put_data(self, endpoint: str, data: Any = None, **kwargs: Any) -> None:
+        """Put data on api."""
         url = f"https://api.spotify.com/v1/{endpoint}"
         auth_info = kwargs.pop("auth_info", await self.login())
         headers = {"Authorization": f"Bearer {auth_info['access_token']}"}
@@ -1098,11 +1099,6 @@ class SpotifyProvider(MusicProvider):
             if response.status in (502, 503):
                 raise ResourceTemporarilyUnavailable(backoff_time=30)
             response.raise_for_status()
-
-    @throttle_with_retries
-    async def _put_data(self, endpoint: str, data: Any = None, **kwargs: Any) -> None:
-        """Put data on api with throttling."""
-        await self._put_data_unthrottled(endpoint, data, **kwargs)
 
     @throttle_with_retries
     async def _post_data(

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -1075,13 +1075,7 @@ class SpotifyProvider(MusicProvider):
             response.raise_for_status()
 
     async def _put_data_unthrottled(self, endpoint: str, data: Any = None, **kwargs: Any) -> None:
-        """
-        Put data on api without throttling.
-
-        :param endpoint: API endpoint to call.
-        :param data: Optional JSON data to send.
-        :param kwargs: Additional parameters for the request.
-        """
+        """Put data on api without throttling."""
         url = f"https://api.spotify.com/v1/{endpoint}"
         auth_info = kwargs.pop("auth_info", await self.login())
         headers = {"Authorization": f"Bearer {auth_info['access_token']}"}
@@ -1107,13 +1101,7 @@ class SpotifyProvider(MusicProvider):
 
     @throttle_with_retries
     async def _put_data(self, endpoint: str, data: Any = None, **kwargs: Any) -> None:
-        """
-        Put data on api with throttling.
-
-        :param endpoint: API endpoint to call.
-        :param data: Optional JSON data to send.
-        :param kwargs: Additional parameters for the request.
-        """
+        """Put data on api with throttling."""
         await self._put_data_unthrottled(endpoint, data, **kwargs)
 
     @throttle_with_retries

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -1074,9 +1074,14 @@ class SpotifyProvider(MusicProvider):
                 raise ResourceTemporarilyUnavailable(backoff_time=30)
             response.raise_for_status()
 
-    @throttle_with_retries
-    async def _put_data(self, endpoint: str, data: Any = None, **kwargs: Any) -> None:
-        """Put data on api."""
+    async def _put_data_unthrottled(self, endpoint: str, data: Any = None, **kwargs: Any) -> None:
+        """
+        Put data on api without throttling.
+
+        :param endpoint: API endpoint to call.
+        :param data: Optional JSON data to send.
+        :param kwargs: Additional parameters for the request.
+        """
         url = f"https://api.spotify.com/v1/{endpoint}"
         auth_info = kwargs.pop("auth_info", await self.login())
         headers = {"Authorization": f"Bearer {auth_info['access_token']}"}
@@ -1099,6 +1104,17 @@ class SpotifyProvider(MusicProvider):
             if response.status in (502, 503):
                 raise ResourceTemporarilyUnavailable(backoff_time=30)
             response.raise_for_status()
+
+    @throttle_with_retries
+    async def _put_data(self, endpoint: str, data: Any = None, **kwargs: Any) -> None:
+        """
+        Put data on api with throttling.
+
+        :param endpoint: API endpoint to call.
+        :param data: Optional JSON data to send.
+        :param kwargs: Additional parameters for the request.
+        """
+        await self._put_data_unthrottled(endpoint, data, **kwargs)
 
     @throttle_with_retries
     async def _post_data(

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -442,7 +442,46 @@ class SpotifyConnectProvider(PluginProvider):
         if self._connected_spotify_username:
             self.mass.create_task(self._check_spotify_provider_match())
 
-    async def _librespot_runner(self) -> None:  # noqa: PLR0915
+    def _process_librespot_stderr_line(self, line: str) -> None:
+        """
+        Process a single line from librespot stderr output.
+
+        :param line: A line from librespot's stderr output.
+        """
+        if (
+            not self._librespot_started.is_set()
+            and "Using StdoutSink (pipe) with format: S16" in line
+        ):
+            self._librespot_started.set()
+        if "error sending packet Os" in line:
+            return
+        if "dropping truncated packet" in line:
+            return
+        if "couldn't parse packet from " in line:
+            return
+        if "Authenticated as '" in line:
+            # Extract username from librespot authentication message
+            # Format: "Authenticated as 'username'"
+            try:
+                parts = line.split("Authenticated as '")
+                if len(parts) > 1:
+                    username_part = parts[1].split("'")
+                    if len(username_part) > 0 and username_part[0]:
+                        username = username_part[0]
+                        self._connected_spotify_username = username
+                        self.logger.debug("Authenticated to Spotify as: %s", username)
+                        # Check for provider match now that we have the username
+                        self.mass.create_task(self._check_spotify_provider_match())
+                    else:
+                        self.logger.warning("Could not parse Spotify username from line: %s", line)
+                else:
+                    self.logger.warning("Could not parse Spotify username from line: %s", line)
+            except Exception as err:
+                self.logger.warning("Error parsing Spotify username from line: %s - %s", line, err)
+            return
+        self.logger.debug(line)
+
+    async def _librespot_runner(self) -> None:
         """Run the spotify connect daemon in a background task."""
         assert self._librespot_bin
         self.logger.info("Starting Spotify Connect background daemon")
@@ -493,44 +532,7 @@ class SpotifyConnectProvider(PluginProvider):
 
             # keep reading logging from stderr until exit
             async for line in librespot.iter_stderr():
-                if (
-                    not self._librespot_started.is_set()
-                    and "Using StdoutSink (pipe) with format: S16" in line
-                ):
-                    self._librespot_started.set()
-                if "error sending packet Os" in line:
-                    continue
-                if "dropping truncated packet" in line:
-                    continue
-                if "couldn't parse packet from " in line:
-                    continue
-                if "Authenticated as '" in line:
-                    # Extract username from librespot authentication message
-                    # Format: "Authenticated as 'username'"
-                    try:
-                        parts = line.split("Authenticated as '")
-                        if len(parts) > 1:
-                            username_part = parts[1].split("'")
-                            if len(username_part) > 0 and username_part[0]:
-                                username = username_part[0]
-                                self._connected_spotify_username = username
-                                self.logger.debug("Authenticated to Spotify as: %s", username)
-                                # Check for provider match now that we have the username
-                                self.mass.create_task(self._check_spotify_provider_match())
-                            else:
-                                self.logger.warning(
-                                    "Could not parse Spotify username from line: %s", line
-                                )
-                        else:
-                            self.logger.warning(
-                                "Could not parse Spotify username from line: %s", line
-                            )
-                    except Exception as err:
-                        self.logger.warning(
-                            "Error parsing Spotify username from line: %s - %s", line, err
-                        )
-                    continue
-                self.logger.debug(line)
+                self._process_librespot_stderr_line(line)
         finally:
             await librespot.close()
             self.logger.info("Spotify Connect background daemon stopped for %s", self.name)

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -168,19 +168,18 @@ class SpotifyConnectProvider(PluginProvider):
         self._on_unload_callbacks: list[Callable[..., None]] = []
         self._runner_error_count = 0
         self._spotify_device_id: str | None = None
+        self._last_session_connected_time: float = 0
+        self._syncing_volume_to_ma: bool = False
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self._librespot_bin = await get_librespot_binary()
-        self.player = self.mass.players.get(self.mass_player_id)
-        if self.player:
-            self._setup_player_daemon()
 
         # Subscribe to events
         self._on_unload_callbacks.append(
             self.mass.subscribe(
                 self._on_mass_player_event,
-                (EventType.PLAYER_ADDED, EventType.PLAYER_REMOVED),
+                (EventType.PLAYER_ADDED, EventType.PLAYER_REMOVED, EventType.PLAYER_UPDATED),
                 id_filter=self.mass_player_id,
             )
         )
@@ -333,6 +332,33 @@ class SpotifyConnectProvider(PluginProvider):
             self.logger.warning("Failed to send seek command via Spotify Web API: %s", err)
             raise
 
+    async def _on_volume(self, volume: int) -> None:
+        """
+        Handle volume change from MA to sync to Spotify app.
+
+        :param volume: Volume level (0-100) from MA player.
+        """
+        # Don't sync if we're currently syncing from Spotify to MA (prevent feedback loop)
+        if self._syncing_volume_to_ma:
+            return
+
+        self.logger.debug("Syncing volume from MA to Spotify: %d%%", volume)
+
+        # Only sync via Web API if we have a Spotify provider
+        if not self._spotify_provider:
+            self.logger.debug("Cannot sync volume to Spotify - no matching Spotify music provider")
+            return
+
+        try:
+            # Spotify Web API expects volume as percentage (0-100)
+            # Use unthrottled version to avoid delays during rapid volume changes
+            await self._spotify_provider._put_data_unthrottled(
+                f"me/player/volume?volume_percent={volume}"
+            )
+        except Exception as err:
+            self.logger.debug("Failed to sync volume to Spotify via Web API: %s", err)
+            # Don't raise - volume sync is best-effort
+
     async def _get_spotify_device_id(self) -> str | None:
         """Get the Spotify Connect device ID for this instance.
 
@@ -414,6 +440,45 @@ class SpotifyConnectProvider(PluginProvider):
         if self._connected_spotify_username:
             self.mass.create_task(self._check_spotify_provider_match())
 
+    def _process_librespot_stderr_line(self, line: str) -> None:
+        """
+        Process a single line from librespot stderr output.
+
+        :param line: A line from librespot's stderr output.
+        """
+        if (
+            not self._librespot_started.is_set()
+            and "Using StdoutSink (pipe) with format: S16" in line
+        ):
+            self._librespot_started.set()
+        if "error sending packet Os" in line:
+            return
+        if "dropping truncated packet" in line:
+            return
+        if "couldn't parse packet from " in line:
+            return
+        if "Authenticated as '" in line:
+            # Extract username from librespot authentication message
+            # Format: "Authenticated as 'username'"
+            try:
+                parts = line.split("Authenticated as '")
+                if len(parts) > 1:
+                    username_part = parts[1].split("'")
+                    if len(username_part) > 0 and username_part[0]:
+                        username = username_part[0]
+                        self._connected_spotify_username = username
+                        self.logger.debug("Authenticated to Spotify as: %s", username)
+                        # Check for provider match now that we have the username
+                        self.mass.create_task(self._check_spotify_provider_match())
+                    else:
+                        self.logger.warning("Could not parse Spotify username from line: %s", line)
+                else:
+                    self.logger.warning("Could not parse Spotify username from line: %s", line)
+            except Exception as err:
+                self.logger.warning("Error parsing Spotify username from line: %s - %s", line, err)
+            return
+        self.logger.debug(line)
+
     async def _librespot_runner(self) -> None:
         """Run the spotify connect daemon in a background task."""
         assert self._librespot_bin
@@ -424,6 +489,11 @@ class SpotifyConnectProvider(PluginProvider):
         await check_output("mkfifo", self.named_pipe)
         await asyncio.sleep(0.1)
         try:
+            # Get initial volume from player, or use 100 as fallback
+            initial_volume = 100
+            if self.player and self.player.volume_level:
+                initial_volume = self.player.volume_level
+
             args: list[str] = [
                 self._librespot_bin,
                 "--name",
@@ -439,13 +509,13 @@ class SpotifyConnectProvider(PluginProvider):
                 self.named_pipe,
                 "--dither",
                 "none",
-                # disable volume control
+                # Enable volume control with linear scale for intuitive volume feel
                 "--mixer",
                 "softvol",
                 "--volume-ctrl",
-                "fixed",
+                "linear",
                 "--initial-volume",
-                f"{self.player.volume_level if self.player and self.player.volume_level else 100}",
+                str(initial_volume),
                 "--enable-volume-normalisation",
                 # forward events to the events script
                 "--onevent",
@@ -459,44 +529,7 @@ class SpotifyConnectProvider(PluginProvider):
 
             # keep reading logging from stderr until exit
             async for line in librespot.iter_stderr():
-                if (
-                    not self._librespot_started.is_set()
-                    and "Using StdoutSink (pipe) with format: S16" in line
-                ):
-                    self._librespot_started.set()
-                if "error sending packet Os" in line:
-                    continue
-                if "dropping truncated packet" in line:
-                    continue
-                if "couldn't parse packet from " in line:
-                    continue
-                if "Authenticated as '" in line:
-                    # Extract username from librespot authentication message
-                    # Format: "Authenticated as 'username'"
-                    try:
-                        parts = line.split("Authenticated as '")
-                        if len(parts) > 1:
-                            username_part = parts[1].split("'")
-                            if len(username_part) > 0 and username_part[0]:
-                                username = username_part[0]
-                                self._connected_spotify_username = username
-                                self.logger.debug("Authenticated to Spotify as: %s", username)
-                                # Check for provider match now that we have the username
-                                self.mass.create_task(self._check_spotify_provider_match())
-                            else:
-                                self.logger.warning(
-                                    "Could not parse Spotify username from line: %s", line
-                                )
-                        else:
-                            self.logger.warning(
-                                "Could not parse Spotify username from line: %s", line
-                            )
-                    except Exception as err:
-                        self.logger.warning(
-                            "Error parsing Spotify username from line: %s - %s", line, err
-                        )
-                    continue
-                self.logger.debug(line)
+                self._process_librespot_stderr_line(line)
         finally:
             await librespot.close()
             self.logger.info("Spotify Connect background daemon stopped for %s", self.name)
@@ -516,7 +549,7 @@ class SpotifyConnectProvider(PluginProvider):
         self._runner_task = self.mass.create_task(self._librespot_runner())
 
     def _on_mass_player_event(self, event: MassEvent) -> None:
-        """Handle incoming event from linked airplay player."""
+        """Handle incoming event from linked player."""
         if event.object_id != self.mass_player_id:
             return
         if event.event == EventType.PLAYER_REMOVED:
@@ -524,7 +557,13 @@ class SpotifyConnectProvider(PluginProvider):
             self.mass.create_task(self.unload())
             return
         if event.event == EventType.PLAYER_ADDED:
+            self.player = self.mass.players.get(self.mass_player_id)
             self._setup_player_daemon()
+            return
+        if event.event == EventType.PLAYER_UPDATED:
+            # Check for volume changes and sync to Spotify
+            if self.player and self.player.volume_level is not None:
+                self.mass.create_task(self._on_volume(self.player.volume_level))
             return
 
     async def _handle_custom_webservice(self, request: Request) -> Response:  # noqa: PLR0915
@@ -537,6 +576,8 @@ class SpotifyConnectProvider(PluginProvider):
         # handle session connected event
         # extract the connected username and check for matching Spotify provider
         if event_name == "session_connected":
+            # Track when session connected for volume event filtering
+            self._last_session_connected_time = time.time()
             username = json_data.get("user_name")
             self.logger.debug(
                 "Session connected event - username from event: %s, current username: %s",
@@ -549,6 +590,11 @@ class SpotifyConnectProvider(PluginProvider):
                 await self._check_spotify_provider_match()
             elif not username:
                 self.logger.warning("Session connected event received but no username in payload")
+
+            # Sync MA's current volume to Spotify to ensure MA is in control
+            player = self.mass.players.get(self.mass_player_id)
+            if player and player.volume_level is not None:
+                self.mass.create_task(self._on_volume(player.volume_level))
 
         # handle session disconnected event
         if event_name == "session_disconnected":
@@ -612,12 +658,29 @@ class SpotifyConnectProvider(PluginProvider):
                 self._source_details.metadata.elapsed_time_last_updated = int(time.time())
 
         if event_name == "volume_changed" and (volume := json_data.get("volume")):
-            # Spotify Connect volume is 0-65535
-            volume = int(int(volume) / 65535 * 100)
-            try:
-                await self.mass.players.cmd_volume_set(self.mass_player_id, volume)
-            except UnsupportedFeaturedException:
-                self.logger.debug(f"Player {self.mass_player_id} does not support volume control")
+            # Ignore volume_changed events that fire immediately after session_connect
+            # We want to use the volume from MA in that case
+            time_since_connect = time.time() - self._last_session_connected_time
+            if time_since_connect < 2.0:
+                self.logger.debug(
+                    "Ignoring initial volume_changed event (%.2fs after session_connect)",
+                    time_since_connect,
+                )
+            else:
+                # Spotify Connect volume is 0-65535
+                volume_percent = int(int(volume) / 65535 * 100)
+                self.logger.debug("Syncing volume from Spotify app to MA: %d%%", volume_percent)
+                try:
+                    # Set flag to prevent feedback loop
+                    self._syncing_volume_to_ma = True
+                    await self.mass.players.cmd_volume_set(self.mass_player_id, volume_percent)
+                except UnsupportedFeaturedException:
+                    self.logger.debug(
+                        "Player %s does not support volume control", self.mass_player_id
+                    )
+                finally:
+                    # Clear flag after syncing
+                    self._syncing_volume_to_ma = False
 
         # signal update to connected player
         if self._source_details.in_use_by:

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -353,10 +353,9 @@ class SpotifyConnectProvider(PluginProvider):
 
         try:
             # Spotify Web API expects volume as percentage (0-100)
-            # Use unthrottled version to avoid delays during rapid volume changes
-            await self._spotify_provider._put_data_unthrottled(
-                f"me/player/volume?volume_percent={volume}"
-            )
+            # Use throttler bypass to avoid delays when setting the volume
+            async with self._spotify_provider.throttler.bypass():
+                await self._spotify_provider._put_data(f"me/player/volume?volume_percent={volume}")
         except Exception as err:
             self.logger.debug("Failed to sync volume to Spotify via Web API: %s", err)
             # Don't raise - volume sync is best-effort

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -169,7 +169,6 @@ class SpotifyConnectProvider(PluginProvider):
         self._runner_error_count = 0
         self._spotify_device_id: str | None = None
         self._last_session_connected_time: float = 0
-        self._syncing_volume_to_ma: bool = False
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
@@ -181,7 +180,7 @@ class SpotifyConnectProvider(PluginProvider):
         self._on_unload_callbacks.append(
             self.mass.subscribe(
                 self._on_mass_player_event,
-                (EventType.PLAYER_ADDED, EventType.PLAYER_REMOVED, EventType.PLAYER_UPDATED),
+                (EventType.PLAYER_ADDED, EventType.PLAYER_REMOVED),
                 id_filter=self.mass_player_id,
             )
         )
@@ -334,32 +333,6 @@ class SpotifyConnectProvider(PluginProvider):
             self.logger.warning("Failed to send seek command via Spotify Web API: %s", err)
             raise
 
-    async def _on_volume(self, volume: int) -> None:
-        """
-        Handle volume change from MA to sync to Spotify app.
-
-        :param volume: Volume level (0-100) from MA player.
-        """
-        # Don't sync if we're currently syncing from Spotify to MA (prevent feedback loop)
-        if self._syncing_volume_to_ma:
-            return
-
-        self.logger.debug("Syncing volume from MA to Spotify: %d%%", volume)
-
-        # Only sync via Web API if we have a Spotify provider
-        if not self._spotify_provider:
-            self.logger.debug("Cannot sync volume to Spotify - no matching Spotify music provider")
-            return
-
-        try:
-            # Spotify Web API expects volume as percentage (0-100)
-            # Use throttler bypass to avoid delays when setting the volume
-            async with self._spotify_provider.throttler.bypass():
-                await self._spotify_provider._put_data(f"me/player/volume?volume_percent={volume}")
-        except Exception as err:
-            self.logger.debug("Failed to sync volume to Spotify via Web API: %s", err)
-            # Don't raise - volume sync is best-effort
-
     async def _get_spotify_device_id(self) -> str | None:
         """Get the Spotify Connect device ID for this instance.
 
@@ -490,7 +463,7 @@ class SpotifyConnectProvider(PluginProvider):
         await check_output("mkfifo", self.named_pipe)
         await asyncio.sleep(0.1)
         try:
-            # Get initial volume from player, or use 20 as fallback to prevent heart attacks
+            # Get initial volume from player, or use 20 as fallback
             initial_volume = 20
             _player = self.mass.players.get(self.mass_player_id)
             if _player and _player.volume_level:
@@ -511,11 +484,11 @@ class SpotifyConnectProvider(PluginProvider):
                 self.named_pipe,
                 "--dither",
                 "none",
-                # Enable volume control with linear scale for intuitive volume feel
+                # disable volume control
                 "--mixer",
                 "softvol",
                 "--volume-ctrl",
-                "linear",
+                "fixed",
                 "--initial-volume",
                 str(initial_volume),
                 "--enable-volume-normalisation",
@@ -561,12 +534,6 @@ class SpotifyConnectProvider(PluginProvider):
         if event.event == EventType.PLAYER_ADDED:
             self._setup_player_daemon()
             return
-        if event.event == EventType.PLAYER_UPDATED:
-            # Check for volume changes and sync to Spotify
-            _player = self.mass.players.get(self.mass_player_id)
-            if _player and _player.volume_level is not None:
-                self.mass.create_task(self._on_volume(_player.volume_level))
-            return
 
     async def _handle_custom_webservice(self, request: Request) -> Response:  # noqa: PLR0915
         """Handle incoming requests on the custom webservice."""
@@ -592,11 +559,6 @@ class SpotifyConnectProvider(PluginProvider):
                 await self._check_spotify_provider_match()
             elif not username:
                 self.logger.warning("Session connected event received but no username in payload")
-
-            # Sync MA's current volume to Spotify to ensure MA is in control
-            player = self.mass.players.get(self.mass_player_id)
-            if player and player.volume_level is not None:
-                self.mass.create_task(self._on_volume(player.volume_level))
 
         # handle session disconnected event
         if event_name == "session_disconnected":
@@ -659,7 +621,7 @@ class SpotifyConnectProvider(PluginProvider):
                 self._source_details.metadata.elapsed_time = int(json_data["position_ms"]) // 1000
                 self._source_details.metadata.elapsed_time_last_updated = int(time.time())
 
-        if event_name == "volume_changed" and (volume := json_data.get("volume")):
+        if event_name == "volume_changed" and json_data.get("volume"):
             # Ignore volume_changed events that fire immediately after session_connect
             # We want to use the volume from MA in that case
             time_since_connect = time.time() - self._last_session_connected_time
@@ -668,21 +630,6 @@ class SpotifyConnectProvider(PluginProvider):
                     "Ignoring initial volume_changed event (%.2fs after session_connect)",
                     time_since_connect,
                 )
-            else:
-                # Spotify Connect volume is 0-65535
-                volume_percent = int(int(volume) / 65535 * 100)
-                self.logger.debug("Syncing volume from Spotify app to MA: %d%%", volume_percent)
-                try:
-                    # Set flag to prevent feedback loop
-                    self._syncing_volume_to_ma = True
-                    await self.mass.players.cmd_volume_set(self.mass_player_id, volume_percent)
-                except UnsupportedFeaturedException:
-                    self.logger.debug(
-                        "Player %s does not support volume control", self.mass_player_id
-                    )
-                finally:
-                    # Clear flag after syncing
-                    self._syncing_volume_to_ma = False
 
         # signal update to connected player
         if self._source_details.in_use_by:

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -174,6 +174,8 @@ class SpotifyConnectProvider(PluginProvider):
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self._librespot_bin = await get_librespot_binary()
+        if self.mass.players.get(self.mass_player_id):
+            self._setup_player_daemon()
 
         # Subscribe to events
         self._on_unload_callbacks.append(
@@ -440,46 +442,7 @@ class SpotifyConnectProvider(PluginProvider):
         if self._connected_spotify_username:
             self.mass.create_task(self._check_spotify_provider_match())
 
-    def _process_librespot_stderr_line(self, line: str) -> None:
-        """
-        Process a single line from librespot stderr output.
-
-        :param line: A line from librespot's stderr output.
-        """
-        if (
-            not self._librespot_started.is_set()
-            and "Using StdoutSink (pipe) with format: S16" in line
-        ):
-            self._librespot_started.set()
-        if "error sending packet Os" in line:
-            return
-        if "dropping truncated packet" in line:
-            return
-        if "couldn't parse packet from " in line:
-            return
-        if "Authenticated as '" in line:
-            # Extract username from librespot authentication message
-            # Format: "Authenticated as 'username'"
-            try:
-                parts = line.split("Authenticated as '")
-                if len(parts) > 1:
-                    username_part = parts[1].split("'")
-                    if len(username_part) > 0 and username_part[0]:
-                        username = username_part[0]
-                        self._connected_spotify_username = username
-                        self.logger.debug("Authenticated to Spotify as: %s", username)
-                        # Check for provider match now that we have the username
-                        self.mass.create_task(self._check_spotify_provider_match())
-                    else:
-                        self.logger.warning("Could not parse Spotify username from line: %s", line)
-                else:
-                    self.logger.warning("Could not parse Spotify username from line: %s", line)
-            except Exception as err:
-                self.logger.warning("Error parsing Spotify username from line: %s - %s", line, err)
-            return
-        self.logger.debug(line)
-
-    async def _librespot_runner(self) -> None:
+    async def _librespot_runner(self) -> None:  # noqa: PLR0915
         """Run the spotify connect daemon in a background task."""
         assert self._librespot_bin
         self.logger.info("Starting Spotify Connect background daemon")
@@ -489,10 +452,11 @@ class SpotifyConnectProvider(PluginProvider):
         await check_output("mkfifo", self.named_pipe)
         await asyncio.sleep(0.1)
         try:
-            # Get initial volume from player, or use 100 as fallback
-            initial_volume = 100
-            if self.player and self.player.volume_level:
-                initial_volume = self.player.volume_level
+            # Get initial volume from player, or use 20 as fallback to prevent heart attacks
+            initial_volume = 20
+            _player = self.mass.players.get(self.mass_player_id)
+            if _player and _player.volume_level:
+                initial_volume = _player.volume_level
 
             args: list[str] = [
                 self._librespot_bin,
@@ -529,7 +493,44 @@ class SpotifyConnectProvider(PluginProvider):
 
             # keep reading logging from stderr until exit
             async for line in librespot.iter_stderr():
-                self._process_librespot_stderr_line(line)
+                if (
+                    not self._librespot_started.is_set()
+                    and "Using StdoutSink (pipe) with format: S16" in line
+                ):
+                    self._librespot_started.set()
+                if "error sending packet Os" in line:
+                    continue
+                if "dropping truncated packet" in line:
+                    continue
+                if "couldn't parse packet from " in line:
+                    continue
+                if "Authenticated as '" in line:
+                    # Extract username from librespot authentication message
+                    # Format: "Authenticated as 'username'"
+                    try:
+                        parts = line.split("Authenticated as '")
+                        if len(parts) > 1:
+                            username_part = parts[1].split("'")
+                            if len(username_part) > 0 and username_part[0]:
+                                username = username_part[0]
+                                self._connected_spotify_username = username
+                                self.logger.debug("Authenticated to Spotify as: %s", username)
+                                # Check for provider match now that we have the username
+                                self.mass.create_task(self._check_spotify_provider_match())
+                            else:
+                                self.logger.warning(
+                                    "Could not parse Spotify username from line: %s", line
+                                )
+                        else:
+                            self.logger.warning(
+                                "Could not parse Spotify username from line: %s", line
+                            )
+                    except Exception as err:
+                        self.logger.warning(
+                            "Error parsing Spotify username from line: %s - %s", line, err
+                        )
+                    continue
+                self.logger.debug(line)
         finally:
             await librespot.close()
             self.logger.info("Spotify Connect background daemon stopped for %s", self.name)
@@ -557,13 +558,13 @@ class SpotifyConnectProvider(PluginProvider):
             self.mass.create_task(self.unload())
             return
         if event.event == EventType.PLAYER_ADDED:
-            self.player = self.mass.players.get(self.mass_player_id)
             self._setup_player_daemon()
             return
         if event.event == EventType.PLAYER_UPDATED:
             # Check for volume changes and sync to Spotify
-            if self.player and self.player.volume_level is not None:
-                self.mass.create_task(self._on_volume(self.player.volume_level))
+            _player = self.mass.players.get(self.mass_player_id)
+            if _player and _player.volume_level is not None:
+                self.mass.create_task(self._on_volume(_player.volume_level))
             return
 
     async def _handle_custom_webservice(self, request: Request) -> Response:  # noqa: PLR0915

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -621,7 +621,7 @@ class SpotifyConnectProvider(PluginProvider):
                 self._source_details.metadata.elapsed_time = int(json_data["position_ms"]) // 1000
                 self._source_details.metadata.elapsed_time_last_updated = int(time.time())
 
-        if event_name == "volume_changed" and json_data.get("volume"):
+        if event_name == "volume_changed" and (volume := json_data.get("volume")):
             # Ignore volume_changed events that fire immediately after session_connect
             # We want to use the volume from MA in that case
             time_since_connect = time.time() - self._last_session_connected_time
@@ -630,6 +630,15 @@ class SpotifyConnectProvider(PluginProvider):
                     "Ignoring initial volume_changed event (%.2fs after session_connect)",
                     time_since_connect,
                 )
+            else:
+                # Spotify Connect volume is 0-65535
+                volume = int(int(volume) / 65535 * 100)
+                try:
+                    await self.mass.players.cmd_volume_set(self.mass_player_id, volume)
+                except UnsupportedFeaturedException:
+                    self.logger.debug(
+                        "Player %s does not support volume control", self.mass_player_id
+                    )
 
         # signal update to connected player
         if self._source_details.in_use_by:


### PR DESCRIPTION
This PR:
- Enables volume control from the Spotify app (e.g. your phone or the Spotify desktop app)
- Makes sure that the volume does not jump to 100% when a session starts
- Refactor stderr handling in a separate function to prevent `PLR0915`