### PR TITLE
Add Version suffix config to scrobble providers

### DIFF
--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -122,9 +122,9 @@ class ScrobblerConfig:
                 type=ConfigEntryType.BOOLEAN,
                 label="Suffix version to track names",
                 required=True,
-                description="""Whether to add the version as suffix to track names,
-                    e.g. 'Amazing Track (Live)'.""",
-                default_value=False,
+                description="Whether to add the version as suffix to track names,"
+                "e.g. 'Amazing Track (Live)'.",
+                default_value=True,
                 value=values.get(CONF_VERSION_SUFFIX) if values else None,
             )
         ]
@@ -132,4 +132,4 @@ class ScrobblerConfig:
     @staticmethod
     def create_from_config(config: Config) -> ScrobblerConfig:
         """Extract relevant shared config values."""
-        return ScrobblerConfig(bool(config.get_value(CONF_VERSION_SUFFIX, False)))
+        return ScrobblerConfig(bool(config.get_value(CONF_VERSION_SUFFIX, True)))

--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -11,7 +11,6 @@ from music_assistant_models.config_entries import (
     ConfigValueType,
 )
 from music_assistant_models.enums import ConfigEntryType
-from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 
 if TYPE_CHECKING:
     from music_assistant_models.event import MassEvent

--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from music_assistant_models.config_entries import (
+    Config,
+    ConfigEntry,
+    ConfigValueType,
+)
+from music_assistant_models.enums import ConfigEntryType
+from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
+
 if TYPE_CHECKING:
     from music_assistant_models.event import MassEvent
     from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
@@ -14,16 +22,25 @@ class ScrobblerHelper:
     """Base class to aid scrobbling tracks."""
 
     logger: logging.Logger
+    config: ScrobblerConfig
     currently_playing: str | None = None
     last_scrobbled: str | None = None
 
-    def __init__(self, logger: logging.Logger) -> None:
+    def __init__(self, logger: logging.Logger, config: ScrobblerConfig | None = None) -> None:
         """Initialize."""
         self.logger = logger
+        self.config = config or ScrobblerConfig(suffix_version=False)
 
     def _is_configured(self) -> bool:
         """Override if subclass needs specific configuration."""
         return True
+
+    def get_name(self, report: MediaItemPlaybackProgressReport) -> str:
+        """Get the track name to use for scrobbling, possibly appended with version info."""
+        if self.config.suffix_version and report.version:
+            return f"{report.name} ({report.version})"
+
+        return report.name
 
     async def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:
         """Send a Now Playing update to the scrobbling service."""
@@ -85,3 +102,35 @@ class ScrobblerHelper:
         # the exact context in which the event was fired
         # we can only rely on fully_played for now
         return bool(report.fully_played)
+
+
+CONF_VERSION_SUFFIX = "suffix_version"
+
+
+class ScrobblerConfig:
+    """Shared configuration options for scrobblers."""
+
+    def __init__(self, suffix_version: bool) -> None:
+        """Initialize."""
+        self.suffix_version = suffix_version
+
+    @staticmethod
+    def get_shared_config_entries(values: dict[str, ConfigValueType] | None) -> list[ConfigEntry]:
+        """Shared config entries."""
+        return [
+            ConfigEntry(
+                key=CONF_VERSION_SUFFIX,
+                type=ConfigEntryType.BOOLEAN,
+                label="Suffix version to track names",
+                required=True,
+                description="""Whether to add the version as suffix to track names,
+                    e.g. 'Amazing Track (Live)'.""",
+                default_value=False,
+                value=values.get(CONF_VERSION_SUFFIX) if values else None,
+            )
+        ]
+
+    @staticmethod
+    def create_from_config(config: Config) -> ScrobblerConfig:
+        """Extract relevant shared config values."""
+        return ScrobblerConfig(bool(config.get_value(CONF_VERSION_SUFFIX, False)))


### PR DESCRIPTION
#2669 added version information to the PlaybackProgressReport

This MR adds the option for scrobblers (LastFM and ListenBrainz) to append that version information to track titles when scrobbling. The current default is disabled, as that would be backwards compatible. But if preferred I'd happily change it to enabled.