### PR TITLE
Add stub for GenreController

### DIFF
--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -1,0 +1,60 @@
+"""Manage MediaItems of type Genre - Stub Implementation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Genre, Track
+
+from .base import MediaControllerBase
+
+# NOTE: Genre support is not yet fully implemented.
+# This is a stub controller to prevent errors when Genre MediaType is encountered.
+
+if TYPE_CHECKING:
+    from music_assistant import MusicAssistant
+
+
+class GenreController(MediaControllerBase[Genre]):
+    """Stub controller for Genre MediaType - not yet fully implemented."""
+
+    db_table = "genres"  # Not actually used yet
+    media_type = MediaType.GENRE
+    item_cls = Genre
+
+    def __init__(self, mass: MusicAssistant) -> None:
+        """Initialize class."""
+        super().__init__(mass)
+
+    async def _add_library_item(self, item: Genre, overwrite_existing: bool = False) -> int:
+        """Add a new item record to the database - stub implementation."""
+        raise NotImplementedError("Genre support is not yet implemented")
+
+    async def _update_library_item(
+        self, item_id: str | int, update: Genre, overwrite: bool = False
+    ) -> None:
+        """Update existing record in the database - stub implementation."""
+        raise NotImplementedError("Genre support is not yet implemented")
+
+    async def search(
+        self,
+        query: str,
+        provider_instance_id_or_domain: str | None = None,
+        limit: int = 25,
+    ) -> list[Genre]:
+        """Search for genres - stub implementation."""
+        return []
+
+    async def radio_mode_base_tracks(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+        limit: int = 25,
+    ) -> list[Track]:
+        """Get the list of base tracks from the controller - stub implementation."""
+        raise NotImplementedError("Genre support is not yet implemented")
+
+    async def match_providers(self, db_item: Genre) -> None:
+        """Try to find match on all providers - stub implementation."""
+        raise NotImplementedError("Genre support is not yet implemented")

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -77,6 +77,7 @@ from music_assistant.models.smart_fades import SmartFadesAnalysis, SmartFadesAna
 from .media.albums import AlbumsController
 from .media.artists import ArtistsController
 from .media.audiobooks import AudiobooksController
+from .media.genres import GenreController
 from .media.playlists import PlaylistController
 from .media.podcasts import PodcastsController
 from .media.radio import RadioController
@@ -115,6 +116,7 @@ class MusicController(CoreController):
         self.playlists = PlaylistController(self.mass)
         self.audiobooks = AudiobooksController(self.mass)
         self.podcasts = PodcastsController(self.mass)
+        self.genres = GenreController(self.mass)
         self.in_progress_syncs: list[SyncTask] = []
         self._database: DatabaseConnection | None = None
         self._sync_lock = asyncio.Lock()
@@ -247,9 +249,6 @@ class MusicController(CoreController):
         """
         if not media_types:
             media_types = MediaType.ALL
-        # TODO: Remove when we have implemented the GenreController
-        if MediaType.GENRE in media_types:
-            media_types.remove(MediaType.GENRE)
         # Check if the search query is a streaming provider public shareable URL
         try:
             media_type, provider_instance_id_or_domain, item_id = await parse_uri(
@@ -1251,6 +1250,7 @@ class MusicController(CoreController):
         | PlaylistController
         | AudiobooksController
         | PodcastsController
+        | GenreController
     ):
         """Return controller for MediaType."""
         if media_type == MediaType.ARTIST:
@@ -1269,6 +1269,8 @@ class MusicController(CoreController):
             return self.podcasts
         if media_type == MediaType.PODCAST_EPISODE:
             return self.podcasts
+        if media_type == MediaType.GENRE:
+            return self.genres
         raise NotImplementedError
 
     def get_unique_providers(self) -> set[str]:

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -247,6 +247,9 @@ class MusicController(CoreController):
         """
         if not media_types:
             media_types = MediaType.ALL
+        # TODO: Remove when we have implemented the GenreController
+        if MediaType.GENRE in media_types:
+            media_types.remove(MediaType.GENRE)
         # Check if the search query is a streaming provider public shareable URL
         try:
             media_type, provider_instance_id_or_domain, item_id = await parse_uri(


### PR DESCRIPTION
Searching in MA for 'all'' now fails with a 'Not Implemented error' now that `MediaType.GENRE` is part of `MediaType.ALL`. This PR adds a stub for the GenreController so that generic functionality remains working.

Fixes: https://github.com/music-assistant/support/issues/4474


CC: @jozefKruszynski 