### PR TITLE
Fix sync group losing child member across MA restarts

### DIFF
--- a/music_assistant/controllers/players/sync_groups.py
+++ b/music_assistant/controllers/players/sync_groups.py
@@ -423,8 +423,7 @@ class SyncGroupPlayer(GroupPlayer):
             if member.player_id == self.sync_leader.player_id:
                 # skip sync leader
                 continue
-            # Always add to members_to_sync to prevent them from being removed
-            # Even if already synced, we need them in the list for the removal logic below
+            # Always add to members_to_sync to prevent them from being removed below
             members_to_sync.append(member.player_id)
         for former_members in self.sync_leader.group_members:
             if (

--- a/music_assistant/controllers/players/sync_groups.py
+++ b/music_assistant/controllers/players/sync_groups.py
@@ -423,12 +423,8 @@ class SyncGroupPlayer(GroupPlayer):
             if member.player_id == self.sync_leader.player_id:
                 # skip sync leader
                 continue
-            if (
-                member.synced_to == self.sync_leader.player_id
-                and member.player_id in self.sync_leader.group_members
-            ):
-                # already synced
-                continue
+            # Always add to members_to_sync to prevent them from being removed
+            # Even if already synced, we need them in the list for the removal logic below
             members_to_sync.append(member.player_id)
         for former_members in self.sync_leader.group_members:
             if (


### PR DESCRIPTION
Based on the state, the previous solution would remove the child player from the underlying sync group 50% of the time. This fix ensures that only orphaned childs are removed as opposed to also child players that are part of the sync group.