### PR TITLE
Fix queue not proceeding to next track for squeezelite groups

### DIFF
--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -877,7 +877,7 @@ class StreamsController(CoreController):
         return f"{self.base_url}/announcement/{player_id}.{content_type.value}"
 
     def get_stream(
-        self, media: PlayerMedia, pcm_format: AudioFormat
+        self, media: PlayerMedia, pcm_format: AudioFormat, force_flow_mode: bool = False
     ) -> AsyncGenerator[bytes, None]:
         """
         Get a stream of the given media as raw PCM audio.
@@ -922,7 +922,11 @@ class StreamsController(CoreController):
                 audio_source = ugp_stream.subscribe_raw()
             else:
                 audio_source = ugp_stream.get_stream(output_format=pcm_format)
-        elif media.source_id and media.queue_item_id and media.media_type == MediaType.FLOW_STREAM:
+        elif (
+            media.source_id
+            and media.queue_item_id
+            and (media.media_type == MediaType.FLOW_STREAM or force_flow_mode)
+        ):
             # regular queue (flow) stream request
             queue = self.mass.player_queues.get(media.source_id)
             assert queue

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -244,7 +244,7 @@ class SqueezelitePlayer(Player):
             channels=2,
         )
 
-        # select audio source, we force flow mode 
+        # select audio source, we force flow mode
         # because multi-client streaming does not support enqueueing
         audio_source = self.mass.streams.get_stream(
             media, master_audio_format, force_flow_mode=True

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -244,8 +244,12 @@ class SqueezelitePlayer(Player):
             channels=2,
         )
 
-        # select audio source
-        audio_source = self.mass.streams.get_stream(media, master_audio_format)
+        # select audio source, we force flow mode because multi-client streaming does not support
+        # enqueueing
+        audio_source = self.mass.streams.get_stream(
+            media, master_audio_format, force_flow_mode=True
+        )
+
         # start the stream task
         self.multi_client_stream = stream = MultiClientStream(
             audio_source=audio_source, audio_format=master_audio_format

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -244,8 +244,8 @@ class SqueezelitePlayer(Player):
             channels=2,
         )
 
-        # select audio source, we force flow mode because multi-client streaming does not support
-        # enqueueing
+        # select audio source, we force flow mode 
+        # because multi-client streaming does not support enqueueing
         audio_source = self.mass.streams.get_stream(
             media, master_audio_format, force_flow_mode=True
         )


### PR DESCRIPTION
We need to enforce flow mode for the multi stream client, since a group simply does not support enqueueing.

Fixes: https://github.com/music-assistant/support/issues/4460