### PR TITLE
Fix race condition when transitioning from plugin source

### DIFF
--- a/music_assistant/controllers/players/player_controller.py
+++ b/music_assistant/controllers/players/player_controller.py
@@ -889,7 +889,7 @@ class PlayerController(CoreController):
             with suppress(PlayerCommandFailed, RuntimeError):
                 # just try to stop (regardless of state)
                 await self.cmd_stop(player_id)
-                await asyncio.sleep(0.5)  # small delay to allow stop to process
+                await asyncio.sleep(2)  # small delay to allow stop to process
         # check if source is a pluginsource
         # in that case the source id is the instance_id of the plugin provider
         if plugin_prov := self.mass.get_provider(source):


### PR DESCRIPTION
When transitioning from a plugin source to a different source, player state update was happening before the cleanup in the StreamsController plugin handler finished, resulting in the plugin source still showing as the player's active_source in the frontend.