### PR TITLE
Use `aiosendspin` for finding the `PyAV` version in the base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -116,10 +116,10 @@ COPY --from=ffmpeg-builder /usr/local/lib/pkgconfig/ /usr/local/lib/pkgconfig/
 RUN ldconfig
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
-# Resolve PyAV version from aioresonate's dependencies and build wheel
-RUN PYAV_VERSION=$(pip install --dry-run aioresonate 2>&1 | grep -oP 'av-\K[0-9.]+' | head -1) && \
+# Resolve PyAV version from aiosendspin's dependencies and build wheel
+RUN PYAV_VERSION=$(pip install --dry-run aiosendspin 2>&1 | grep -oP 'av-\K[0-9.]+' | head -1) && \
     if [ -z "$PYAV_VERSION" ]; then \
-        echo "ERROR: Failed to detect PyAV version from aioresonate dependencies" >&2; \
+        echo "ERROR: Failed to detect PyAV version from aiosendspin dependencies" >&2; \
         exit 1; \
     fi && \
     echo "Building PyAV version: ${PYAV_VERSION}" && \


### PR DESCRIPTION
`Dockerfile.base` still used the old package name `aioresonate` instead of `aiosendspin`.

Since no `PyAV` updates were released since then, we don't need to rebuild the base image.