### PR TITLE
Potential fix for code injection in github action

### DIFF
--- a/.github/workflows/auto-merge-dependency-updates.yml
+++ b/.github/workflows/auto-merge-dependency-updates.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Verify PR labels and source
         run: |
           LABELS="${{ join(github.event.pull_request.labels.*.name, ',') }}"
-          BRANCH="${{ github.event.pull_request.head.ref }}"
+          BRANCH="$BRANCH"
 
           if [[ "$LABELS" != *"dependencies"* ]]; then
             echo "❌ PR does not have 'dependencies' label"
@@ -61,6 +61,8 @@ jobs:
 
           echo "✅ PR has 'dependencies' label and valid branch name"
 
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
       # IMPORTANT: Checkout the PR's head to validate file changes
       # This is required for the git commands in security check 5
       - name: Checkout PR branch


### PR DESCRIPTION
Potential fix for [https://github.com/music-assistant/server/security/code-scanning/36](https://github.com/music-assistant/server/security/code-scanning/36)

The best way to fix this problem is to use an intermediate environment variable and reference it using plain shell syntax (`$BRANCH`), rather than interpolating the potentially malicious expression directly into the command. Specifically, assign the branch name to an environment variable in the `env:` section of the step, and then reference it in the shell using `$BRANCH`. Thus, change line 50 from

```bash
BRANCH="${{ github.event.pull_request.head.ref }}"
```
to

```bash
BRANCH="$BRANCH"
```

and add to the step's `env:` block:

```yaml
env:
  BRANCH: ${{ github.event.pull_request.head.ref }}
```

This ensures the variable assignment is not performed by shell interpolation, but by the actions infrastructure, reducing the risk of injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
