### PR TITLE
Remove unused Sendspin Player Options

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -29,6 +29,7 @@ from aiosendspin.server.group import (
 )
 from aiosendspin.server.metadata import Metadata
 from aiosendspin.server.stream import AudioCodec, MediaStream
+from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.constants import PLAYER_CONTROL_NONE
 from music_assistant_models.enums import (
     ContentType,
@@ -45,6 +46,9 @@ from PIL import Image
 
 from music_assistant.constants import (
     CONF_ENTRY_FLOW_MODE_ENFORCED,
+    CONF_ENTRY_HTTP_PROFILE_HIDDEN,
+    CONF_ENTRY_OUTPUT_CODEC_HIDDEN,
+    CONF_ENTRY_SAMPLE_RATES,
     CONF_OUTPUT_CODEC,
     INTERNAL_PCM_FORMAT,
 )
@@ -69,7 +73,7 @@ SUPPORTED_GROUP_COMMANDS = [
 
 if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
-    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
+    from music_assistant_models.config_entries import ConfigValueType
     from music_assistant_models.event import MassEvent
     from music_assistant_models.queue_item import QueueItem
 
@@ -590,6 +594,9 @@ class SendspinPlayer(Player):
         return [
             *default_entries,
             CONF_ENTRY_FLOW_MODE_ENFORCED,
+            CONF_ENTRY_OUTPUT_CODEC_HIDDEN,
+            CONF_ENTRY_HTTP_PROFILE_HIDDEN,
+            ConfigEntry.from_dict({**CONF_ENTRY_SAMPLE_RATES.to_dict(), "hidden": True}),
         ]
 
     async def on_unload(self) -> None:


### PR DESCRIPTION
Sendspin players sample rate and codec are selected internally by `aiosendspin` and can currently not be changed manually.
Hide those and the http profile options from the preferences.