### PR TITLE
Fix race condition when Sendspin player reconnect

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -597,4 +597,3 @@ class SendspinPlayer(Player):
         await super().on_unload()
         self.unsub_event_cb()
         self.unsub_group_event_cb()
-        await self.api.disconnect()


### PR DESCRIPTION
Fixes a race condition where reconnecting Sendspin players would be removed shortly after being registered in Music Assistant.

When a client disconnects and quickly reconnects (which is usually the case due to the websocket time out), the slow `unregister()` from the disconnect event could complete after the new `register()` call, removing the newly registered player.

This PR fixes that issue by tracking pending unregister operations per client_id and waiting for them to complete before registering a reconnected player.