### PR TITLE
Fix race condition in Airplay stream cleanup

### DIFF
--- a/music_assistant/providers/airplay/protocols/airplay2.py
+++ b/music_assistant/providers/airplay/protocols/airplay2.py
@@ -159,4 +159,6 @@ class AirPlay2Stream(AirPlayProtocol):
             await asyncio.sleep(0)  # Yield to event loop
 
         # ensure we're cleaned up afterwards (this also logs the returncode)
-        await self.stop()
+        # Only call stop if not already stopped (prevents race with stream replacement)
+        if not self._stopped:
+            await self.stop()

--- a/music_assistant/providers/airplay/protocols/airplay2.py
+++ b/music_assistant/providers/airplay/protocols/airplay2.py
@@ -159,6 +159,5 @@ class AirPlay2Stream(AirPlayProtocol):
             await asyncio.sleep(0)  # Yield to event loop
 
         # ensure we're cleaned up afterwards (this also logs the returncode)
-        # Only call stop if not already stopped (prevents race with stream replacement)
         if not self._stopped:
             await self.stop()

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -198,4 +198,6 @@ class RaopStream(AirPlayProtocol):
 
         # ensure we're cleaned up afterwards (this also logs the returncode)
         logger.debug("CLIRaop stderr reader ended")
-        await self.stop()
+        # Only call stop if not already stopped (prevents race with stream replacement)
+        if not self._stopped:
+            await self.stop()

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -198,6 +198,5 @@ class RaopStream(AirPlayProtocol):
 
         # ensure we're cleaned up afterwards (this also logs the returncode)
         logger.debug("CLIRaop stderr reader ended")
-        # Only call stop if not already stopped (prevents race with stream replacement)
         if not self._stopped:
             await self.stop()


### PR DESCRIPTION
This PR fixes a race condition during the stream cleanup of Airplay. 

Fixes announcements causing Airplay players to go to IDLE in the UI, but still have audio playing.