### PR TITLE
abs: remove use_cache decorator

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -62,7 +62,6 @@ from music_assistant_models.media_items import (
 from music_assistant_models.media_items.media_item import RecommendationFolder
 from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 
-from music_assistant.controllers.cache import use_cache
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.audiobookshelf.parsers import (
     parse_audiobook,
@@ -418,7 +417,6 @@ for more details.
 
         return abs_podcast
 
-    @use_cache(3600)
     @handle_refresh_token
     async def get_podcast(self, prov_podcast_id: str) -> Podcast:
         """Get single podcast."""
@@ -531,7 +529,6 @@ for more details.
 
         return abs_audiobook
 
-    @use_cache(3600)
     @handle_refresh_token
     async def get_audiobook(self, prov_audiobook_id: str) -> Audiobook:
         """Get a single audiobook.


### PR DESCRIPTION
As discussed, another go at music-assistant/support#4394

abs is self-hosted, no strict need for extending caching.