### PR TITLE
abs/ gpodder: add configurable user for playlog sync

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1166,23 +1166,26 @@ class MusicController(CoreController):
     async def mark_item_unplayed(
         self,
         media_item: MediaItemType,
+        userid: str | None = None,
         all_users: bool = False,
     ) -> None:
         """
         Mark item as unplayed in playlog.
 
         :param media_item: The media item to mark as unplayed.
+        :param userid: The user ID to mark the item as unplayed for (instead of the current user).
         :param all_users: If True, mark the item as unplayed for all users.
         """
         current_user = get_current_user()
-        user_id = current_user.user_id if current_user else "system"
+        if userid is None:
+            userid = current_user.user_id if current_user else "system"
         params = {
             "item_id": media_item.item_id,
             "provider": media_item.provider,
             "media_type": media_item.media_type.value,
         }
         if not all_users:
-            params["userid"] = user_id
+            params["userid"] = userid
         await self.database.delete(DB_TABLE_PLAYLOG, params)
         # forward to provider(s) to sync resume state (e.g. for audiobooks)
         for prov_mapping in media_item.provider_mappings:

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1173,19 +1173,20 @@ class MusicController(CoreController):
         Mark item as unplayed in playlog.
 
         :param media_item: The media item to mark as unplayed.
-        :param userid: The user ID to mark the item as unplayed for (instead of the current user).
+        :param userid: The user ID to mark the item as unplayed for. Required if all_users is False.
         :param all_users: If True, mark the item as unplayed for all users.
         """
-        current_user = get_current_user()
-        if userid is None:
-            userid = current_user.user_id if current_user else "system"
         params = {
             "item_id": media_item.item_id,
             "provider": media_item.provider,
             "media_type": media_item.media_type.value,
         }
         if not all_users:
-            params["userid"] = userid
+            if not userid:
+                current_user = get_current_user()
+                userid = current_user.user_id if current_user else None
+            if userid:
+                params["userid"] = userid
         await self.database.delete(DB_TABLE_PLAYLOG, params)
         # forward to provider(s) to sync resume state (e.g. for audiobooks)
         for prov_mapping in media_item.provider_mappings:

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -137,12 +137,14 @@ async def get_config_entries(
     ma_user_list = await mass.webserver.auth.list_users()  # excludes system users
     ma_user_list = [user for user in ma_user_list if user.enabled]
     ma_current_user = get_current_user()
-    assert ma_current_user is not None  # for type checking
     user_options = [
         ConfigValueOption(title=user.display_name or user.username, value=user.user_id)
         for user in ma_user_list
         if user.enabled
     ]
+    default_playlog_user_id = (
+        str(user_options[0].value) if not ma_current_user else ma_current_user.user_id
+    )
 
     # ruff: noqa: ARG001
     return (
@@ -190,7 +192,7 @@ async def get_config_entries(
             label="Music Assistant user to sync playlog with",
             type=ConfigEntryType.STRING,
             options=user_options,
-            default_value=ma_current_user.user_id,
+            default_value=default_playlog_user_id,
             description="The abs provider will sync its playlog, i.e. resume position,"
             " finished..., with this Music Assistant user.",
         ),

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -41,7 +41,12 @@ from aioaudiobookshelf.schema.shelf import (
 from aioaudiobookshelf.schema.shelf import ShelfId as AbsShelfId
 from aioaudiobookshelf.schema.shelf import ShelfType as AbsShelfType
 from aiohttp import web
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+from music_assistant_models.config_entries import (
+    ConfigEntry,
+    ConfigValueOption,
+    ConfigValueType,
+    ProviderConfig,
+)
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
@@ -62,6 +67,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.media_items.media_item import RecommendationFolder
 from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 
+from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.audiobookshelf.parsers import (
     parse_audiobook,
@@ -79,6 +85,7 @@ from .constants import (
     CONF_HIDE_EMPTY_PODCASTS,
     CONF_OLD_TOKEN,
     CONF_PASSWORD,
+    CONF_PLAYLOG_USER_ID,
     CONF_URL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
@@ -126,6 +133,17 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
+    # User options for playlog sync
+    ma_user_list = await mass.webserver.auth.list_users()  # excludes system users
+    ma_user_list = [user for user in ma_user_list if user.enabled]
+    ma_current_user = get_current_user()
+    assert ma_current_user is not None  # for type checking
+    user_options = [
+        ConfigValueOption(title=user.display_name or user.username, value=user.user_id)
+        for user in ma_user_list
+        if user.enabled
+    ]
+
     # ruff: noqa: ARG001
     return (
         ConfigEntry(
@@ -166,6 +184,15 @@ async def get_config_entries(
             description="Instead of using a username and password, "
             "you may provide an API key (ABS version >= 2.26). "
             "Please consult the docs.",
+        ),
+        ConfigEntry(
+            key=CONF_PLAYLOG_USER_ID,
+            label="Music Assistant user to sync playlog with",
+            type=ConfigEntryType.STRING,
+            options=user_options,
+            default_value=ma_current_user.user_id,
+            description="The abs provider will sync its playlog, i.e. resume position,"
+            " finished..., with this Music Assistant user.",
         ),
         ConfigEntry(
             key=CONF_OLD_TOKEN,
@@ -1404,6 +1431,29 @@ for more details.
 
         return known_ids
 
+    async def _mark_item_played(
+        self,
+        media_item: MediaItemType,
+        fully_played: bool,
+        seconds_played: int,
+    ) -> None:
+        """Mark item played and include configured playlog user."""
+        playlog_user_id = str(self.config.get_value(CONF_PLAYLOG_USER_ID))
+        await self.mass.music.mark_item_played(
+            media_item=media_item,
+            fully_played=fully_played,
+            seconds_played=seconds_played,
+            userid=playlog_user_id,
+        )
+
+    async def _mark_item_unplayed(
+        self,
+        media_item: MediaItemType,
+    ) -> None:
+        """Mark item unplayed and include configured playlog user."""
+        playlog_user_id = str(self.config.get_value(CONF_PLAYLOG_USER_ID))
+        await self.mass.music.mark_item_unplayed(media_item=media_item, userid=playlog_user_id)
+
     async def _set_playlog_from_user(self, user: User) -> None:
         """Update on user callback.
 
@@ -1467,14 +1517,14 @@ for more details.
                     provider_instance_id_or_domain=self.instance_id,
                 ):
                     self.progress_guard.add_progress(discarded_progress_id)
-                    await self.mass.music.mark_item_unplayed(discarded_item)
+                    await self._mark_item_unplayed(discarded_item)
             else:
                 with suppress(MediaNotFoundError):
                     discarded_item = await self.get_podcast_episode(
                         prov_episode_id=discarded_progress_id, add_progress=False
                     )
                     self.progress_guard.add_progress(*discarded_progress_id.split(" "))
-                    await self.mass.music.mark_item_unplayed(discarded_item)
+                    await self._mark_item_unplayed(discarded_item)
             self.logger.debug("Discarded item %s ", discarded_progress_id)
 
     async def _update_playlog_book(self, progress: MediaProgress) -> None:
@@ -1491,9 +1541,9 @@ for more details.
         if mass_audiobook is None:
             return
         if int(progress.current_time) == 0:
-            await self.mass.music.mark_item_unplayed(mass_audiobook)
+            await self._mark_item_unplayed(mass_audiobook)
         else:
-            await self.mass.music.mark_item_played(
+            await self._mark_item_played(
                 mass_audiobook,
                 fully_played=progress.is_finished,
                 seconds_played=int(progress.current_time),
@@ -1512,9 +1562,9 @@ for more details.
         except MediaNotFoundError:
             return
         if int(progress.current_time) == 0:
-            await self.mass.music.mark_item_unplayed(mass_episode)
+            await self._mark_item_unplayed(mass_episode)
         else:
-            await self.mass.music.mark_item_played(
+            await self._mark_item_played(
                 mass_episode,
                 fully_played=progress.is_finished,
                 seconds_played=int(progress.current_time),

--- a/music_assistant/providers/audiobookshelf/constants.py
+++ b/music_assistant/providers/audiobookshelf/constants.py
@@ -16,6 +16,7 @@ CONF_PASSWORD = "password"
 CONF_OLD_TOKEN = "token"
 CONF_API_TOKEN = "api_token"  # with jwt api token (>= v2.26)
 CONF_VERIFY_SSL = "verify_ssl"
+CONF_PLAYLOG_USER_ID = "playlog_user_id"
 # optionally hide podcasts with no episodes
 CONF_HIDE_EMPTY_PODCASTS = "hide_empty_podcasts"
 

--- a/music_assistant/providers/gpodder/__init__.py
+++ b/music_assistant/providers/gpodder/__init__.py
@@ -19,7 +19,12 @@ from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
 from aiohttp.client_exceptions import ClientError
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+from music_assistant_models.config_entries import (
+    ConfigEntry,
+    ConfigValueOption,
+    ConfigValueType,
+    ProviderConfig,
+)
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
@@ -36,6 +41,7 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import AudioFormat, MediaItemType, Podcast, PodcastEpisode
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.podcast_parsers import (
     get_podcastparser_dict,
     get_stream_url_and_guid_from_episode,
@@ -67,6 +73,7 @@ CONF_URL_NC = "url_nc"
 # General config
 CONF_VERIFY_SSL = "verify_ssl"
 CONF_MAX_NUM_EPISODES = "max_num_episodes"
+CONF_PLAYLOG_USER_ID = "playlog_user_id"
 
 
 CACHE_CATEGORY_PODCAST_ITEMS = 0  # the individual parsed podcast (dict from podcastparser)
@@ -133,6 +140,19 @@ async def get_config_entries(
         authenticated_nc = False
 
     using_gpodder = bool(values.get(CONF_USING_GPODDER, False))
+
+    # User options for playlog sync
+    ma_user_list = await mass.webserver.auth.list_users()  # excludes system users
+    ma_user_list = [user for user in ma_user_list if user.enabled]
+    ma_current_user = get_current_user()
+    user_options = [
+        ConfigValueOption(title=user.display_name or user.username, value=user.user_id)
+        for user in ma_user_list
+        if user.enabled
+    ]
+    default_playlog_user_id = (
+        str(user_options[0].value) if not ma_current_user else ma_current_user.user_id
+    )
 
     return (
         ConfigEntry(
@@ -211,6 +231,15 @@ async def get_config_entries(
             key="label_general",
             type=ConfigEntryType.LABEL,
             label="General config:",
+        ),
+        ConfigEntry(
+            key=CONF_PLAYLOG_USER_ID,
+            label="Music Assistant user to sync playlog with",
+            type=ConfigEntryType.STRING,
+            options=user_options,
+            default_value=default_playlog_user_id,
+            description="The gpodder provider will sync its playlog, i.e. resume position,"
+            " finished..., with this Music Assistant user.",
         ),
         ConfigEntry(
             key=CONF_MAX_NUM_EPISODES,
@@ -390,12 +419,16 @@ class GPodder(MusicProvider):
                         continue
                     match _action:
                         case EpisodeActionNew():
-                            await self.mass.music.mark_item_unplayed(mass_episode)
+                            await self.mass.music.mark_item_unplayed(
+                                mass_episode,
+                                userid=str(self.config.get_value(CONF_PLAYLOG_USER_ID)),
+                            )
                         case EpisodeActionPlay():
                             await self.mass.music.mark_item_played(
                                 mass_episode,
                                 fully_played=_action.position >= _action.total,
                                 seconds_played=_action.position,
+                                userid=str(self.config.get_value(CONF_PLAYLOG_USER_ID)),
                             )
 
             # cache
@@ -469,7 +502,7 @@ class GPodder(MusicProvider):
 
                         # propagate to playlog
                         await self.mass.music.mark_item_unplayed(
-                            mass_episode,
+                            mass_episode, userid=str(self.config.get_value(CONF_PLAYLOG_USER_ID))
                         )
                     elif isinstance(action, EpisodeActionPlay):
                         fully_played = action.position >= action.total
@@ -482,6 +515,7 @@ class GPodder(MusicProvider):
                             mass_episode,
                             fully_played=fully_played,
                             seconds_played=resume_position_s,
+                            userid=str(self.config.get_value(CONF_PLAYLOG_USER_ID)),
                         )
                     elif isinstance(action, EpisodeActionDelete):
                         for mapping in mass_episode.provider_mappings:


### PR DESCRIPTION
adds a config option to the audiobookshelf and gpodder provider, such that the playlog sync is possible in the background with the new user system