### PR TITLE
feat(subsonic): allow self-signed certificates

### DIFF
--- a/music_assistant/providers/opensubsonic/__init__.py
+++ b/music_assistant/providers/opensubsonic/__init__.py
@@ -12,6 +12,7 @@ from music_assistant.constants import CONF_PASSWORD, CONF_PATH, CONF_PORT, CONF_
 from .sonic_provider import (
     CONF_BASE_URL,
     CONF_ENABLE_LEGACY_AUTH,
+    CONF_ALLOW_INSECURE_CONN,
     CONF_ENABLE_PODCASTS,
     CONF_NEW_ALBUMS,
     CONF_OVERRIDE_OFFSET,
@@ -115,6 +116,14 @@ async def get_config_entries(
             label="Enable Legacy Auth",
             required=True,
             description='Enable OpenSubsonic "legacy" auth support',
+            default_value=False,
+        ),
+        ConfigEntry(
+            key=CONF_ALLOW_INSECURE_CONN,
+            type=ConfigEntryType.BOOLEAN,
+            label="Allow Insecure Connection",
+            required=True,
+            description='This will allow you to use self signed certificates',
             default_value=False,
         ),
         ConfigEntry(

--- a/music_assistant/providers/opensubsonic/__init__.py
+++ b/music_assistant/providers/opensubsonic/__init__.py
@@ -10,9 +10,9 @@ from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 from music_assistant.constants import CONF_PASSWORD, CONF_PATH, CONF_PORT, CONF_USERNAME
 
 from .sonic_provider import (
+    CONF_ALLOW_INSECURE_CONN,
     CONF_BASE_URL,
     CONF_ENABLE_LEGACY_AUTH,
-    CONF_ALLOW_INSECURE_CONN,
     CONF_ENABLE_PODCASTS,
     CONF_NEW_ALBUMS,
     CONF_OVERRIDE_OFFSET,
@@ -123,7 +123,7 @@ async def get_config_entries(
             type=ConfigEntryType.BOOLEAN,
             label="Allow Insecure Connection",
             required=True,
-            description='This will allow you to use self signed certificates',
+            description="This will allow you to use self signed certificates",
             default_value=False,
         ),
         ConfigEntry(

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
 CONF_BASE_URL = "baseURL"
 CONF_ENABLE_PODCASTS = "enable_podcasts"
 CONF_ENABLE_LEGACY_AUTH = "enable_legacy_auth"
+CONF_ALLOW_INSECURE_CONN = "allow_insecure_conn"
 CONF_OVERRIDE_OFFSET = "override_transcode_offest"
 CONF_RECO_FAVES = "recommend_favorites"
 CONF_NEW_ALBUMS = "recommend_new"
@@ -112,6 +113,7 @@ class OpenSonicProvider(MusicProvider):
             username=str(self.config.get_value(CONF_USERNAME)),
             password=str(self.config.get_value(CONF_PASSWORD)),
             legacy_auth=bool(self.config.get_value(CONF_ENABLE_LEGACY_AUTH)),
+            insecure=bool(self.config.get_value(CONF_ALLOW_INSECURE_CONN)),
             port=port,
             server_path=str(path),
             app_name="Music Assistant",


### PR DESCRIPTION
Hi :wave:,

## Summary

this pull request (PR) adds support for self-signed certificates for the Subsonic provider. The `insecure` parameter is documented [here](https://github.com/khers/py-opensonic/blob/master/src/libopensonic/connection.py#L96).

Let me know if you want anything changed or have questions about the PR.

## Motivation

I have a self-signed certificate in my homelab for `*.home.internal` and host my services behind a reverse proxy. The change allows me to use: `https://navidrome.home.internal` as URL for the Subsonic provider.

## Type of Change

- [ ]  Bug fix
- [x] New feature
- [ ] Breaking change