### PR TITLE
abs: fix: remove playlog sync during provider load

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -323,10 +323,6 @@ for more details.
         # progress guard
         self.progress_guard = ProgressGuard()
 
-        # update playlog information if just started
-        user = await self._client.get_my_user()
-        await self._set_playlog_from_user(user)
-
         # safe guard reauthentication
         self.reauthenticate_lock = asyncio.Lock()
         self.reauthenticate_last = 0.0


### PR DESCRIPTION
This is a leftover from the very early provider stage, and causes sometimes issues with new user system - userid is still none. We do not need that anymore, the playlog sync is triggered on regular provider syncs as well, here without issues.