### PR TITLE
Fix sendspin mDNS name

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -6,7 +6,7 @@
   "description": "Sendspin is an audio playback, control and synchronization protocol developed by the Open Home Foundation and is the native playback protocol built into Music Assistant, used for playback to supported clients like the Music Assistant Web interface, supported (mobile) clients and supported hardware",
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
-  "requirements": ["aiosendspin==1.1.1"],
+  "requirements": ["aiosendspin==1.1.2"],
   "builtin": true,
   "allow_disable": false
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
 aiorun==2025.1.1
-aiosendspin==1.1.1
+aiosendspin==1.1.2
 aioslimproto==3.1.1
 aiosonos==0.1.9
 aiosqlite==0.21.0


### PR DESCRIPTION
Sendspin wasn't using the servers id, but only the non unique "Music Assistant" name before. Which resulted in conflicts with multiple MA instances.