### PR TITLE
Bump aiosendspin to fix metadata clear edge case

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin==1.1.2"],
+  "requirements": ["aiosendspin==1.1.3"],
   "builtin": true,
   "allow_disable": false
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
 aiorun==2025.1.1
-aiosendspin==1.1.2
+aiosendspin==1.1.3
 aioslimproto==3.1.2
 aiosonos==0.1.9
 aiosqlite==0.21.0


### PR DESCRIPTION
Fixes an edge case for metadata clients: Send a message to clear metadata when a client switches to a new group without metadata.