### PR TITLE
Fix missing totalCount parameter in ARD Audiothek provider

### DIFF
--- a/music_assistant/providers/ard_audiothek/database_queries.py
+++ b/music_assistant/providers/ard_audiothek/database_queries.py
@@ -158,6 +158,7 @@ query Show($showId: ID!, $first: Int, $offset: Int, $filter: ItemFilter) {
     title
     showType
     items(first: $first, offset: $offset, filter: $filter) {
+      totalCount
       nodes {
         duration
         title


### PR DESCRIPTION
This fixes the issue of the missing totalCount parameter

https://github.com/music-assistant/support/issues/4541