### PR TITLE
Plex Connect: Ungroup player before starting playback

### DIFF
--- a/music_assistant/providers/plex_connect/player_remote.py
+++ b/music_assistant/providers/plex_connect/player_remote.py
@@ -13,7 +13,12 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from aiohttp import ClientTimeout, web
-from music_assistant_models.enums import EventType, PlayerType, QueueOption, RepeatMode
+from music_assistant_models.enums import (
+    EventType,
+    PlayerType,
+    QueueOption,
+    RepeatMode,
+)
 from plexapi.playqueue import PlayQueue
 
 from .gdm import PlexGDMAdvertiser
@@ -343,6 +348,24 @@ class PlexRemoteControlServer:
             },
         )
 
+    async def _ungroup_player_if_needed(self, player_id: str) -> None:
+        """Ungroup player before playback if it's part of a group/sync."""
+        player = self.provider.mass.players.get(player_id)
+        if not player or player.type == PlayerType.GROUP:
+            return
+
+        if not (player.synced_to or player.group_members or player.active_group):
+            return
+
+        LOGGER.debug("Ungrouping player %s before starting playback from Plex", player.display_name)
+        # Use set_members directly on the group to bypass static member check
+        if player.active_group and (group := self.provider.mass.players.get(player.active_group)):
+            await group.set_members(player_ids_to_remove=[player_id])
+        elif player.synced_to and (sync_leader := self.provider.mass.players.get(player.synced_to)):
+            await sync_leader.set_members(player_ids_to_remove=[player_id])
+        elif player.group_members:
+            await player.set_members(player_ids_to_remove=player.group_members)
+
     async def handle_play_media(self, request: web.Request) -> web.Response:
         """
         Handle playMedia command from Plex controller.
@@ -376,6 +399,10 @@ class PlexRemoteControlServer:
             player_id = self._ma_player_id
             if not player_id:
                 return web.Response(status=500, text="No player assigned to this server")
+
+            # Ungroup player if it's part of a group/sync
+            # User selected this specific player, so remove from any groups
+            await self._ungroup_player_if_needed(player_id)
 
             if container_key and "/playQueues/" in container_key:
                 # Extract play queue ID from container key
@@ -964,6 +991,8 @@ class PlexRemoteControlServer:
         self._updating_from_plex = True
         try:
             if self._ma_player_id:
+                # Ungroup player before resuming playback
+                await self._ungroup_player_if_needed(self._ma_player_id)
                 await self.provider.mass.players.cmd_play(self._ma_player_id)
             await self._broadcast_timeline()
             return web.Response(status=200)

--- a/music_assistant/providers/plex_connect/player_remote.py
+++ b/music_assistant/providers/plex_connect/player_remote.py
@@ -9,7 +9,6 @@ import re
 import time
 import uuid
 from collections.abc import Callable
-from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -21,7 +20,6 @@ from music_assistant_models.enums import (
     QueueOption,
     RepeatMode,
 )
-from music_assistant_models.errors import PlayerCommandFailed, UnsupportedFeaturedException
 from plexapi.playqueue import PlayQueue
 
 from .gdm import PlexGDMAdvertiser
@@ -367,18 +365,15 @@ class PlexRemoteControlServer:
             and (group := self.provider.mass.players.get(player.active_group))
             and group.supports_feature(PlayerFeature.SET_MEMBERS)
         ):
-            with suppress(UnsupportedFeaturedException, PlayerCommandFailed):
-                await group.set_members(player_ids_to_remove=[player_id])
+            await group.set_members(player_ids_to_remove=[player_id])
         elif (
             player.synced_to
             and (sync_leader := self.provider.mass.players.get(player.synced_to))
             and sync_leader.supports_feature(PlayerFeature.SET_MEMBERS)
         ):
-            with suppress(UnsupportedFeaturedException, PlayerCommandFailed):
-                await sync_leader.set_members(player_ids_to_remove=[player_id])
+            await sync_leader.set_members(player_ids_to_remove=[player_id])
         elif player.group_members and player.supports_feature(PlayerFeature.SET_MEMBERS):
-            with suppress(UnsupportedFeaturedException, PlayerCommandFailed):
-                await player.set_members(player_ids_to_remove=player.group_members)
+            await player.set_members(player_ids_to_remove=player.group_members)
 
     async def handle_play_media(self, request: web.Request) -> web.Response:
         """

--- a/music_assistant/providers/plex_connect/player_remote.py
+++ b/music_assistant/providers/plex_connect/player_remote.py
@@ -9,16 +9,19 @@ import re
 import time
 import uuid
 from collections.abc import Callable
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from aiohttp import ClientTimeout, web
 from music_assistant_models.enums import (
     EventType,
+    PlayerFeature,
     PlayerType,
     QueueOption,
     RepeatMode,
 )
+from music_assistant_models.errors import PlayerCommandFailed, UnsupportedFeaturedException
 from plexapi.playqueue import PlayQueue
 
 from .gdm import PlexGDMAdvertiser
@@ -359,12 +362,23 @@ class PlexRemoteControlServer:
 
         LOGGER.debug("Ungrouping player %s before starting playback from Plex", player.display_name)
         # Use set_members directly on the group to bypass static member check
-        if player.active_group and (group := self.provider.mass.players.get(player.active_group)):
-            await group.set_members(player_ids_to_remove=[player_id])
-        elif player.synced_to and (sync_leader := self.provider.mass.players.get(player.synced_to)):
-            await sync_leader.set_members(player_ids_to_remove=[player_id])
-        elif player.group_members:
-            await player.set_members(player_ids_to_remove=player.group_members)
+        if (
+            player.active_group
+            and (group := self.provider.mass.players.get(player.active_group))
+            and group.supports_feature(PlayerFeature.SET_MEMBERS)
+        ):
+            with suppress(UnsupportedFeaturedException, PlayerCommandFailed):
+                await group.set_members(player_ids_to_remove=[player_id])
+        elif (
+            player.synced_to
+            and (sync_leader := self.provider.mass.players.get(player.synced_to))
+            and sync_leader.supports_feature(PlayerFeature.SET_MEMBERS)
+        ):
+            with suppress(UnsupportedFeaturedException, PlayerCommandFailed):
+                await sync_leader.set_members(player_ids_to_remove=[player_id])
+        elif player.group_members and player.supports_feature(PlayerFeature.SET_MEMBERS):
+            with suppress(UnsupportedFeaturedException, PlayerCommandFailed):
+                await player.set_members(player_ids_to_remove=player.group_members)
 
     async def handle_play_media(self, request: web.Request) -> web.Response:
         """


### PR DESCRIPTION
When a user selects a specific player for playback in Plex, automatically remove it from any sync groups or permanent groups. This should improve UX by ensuring playback only happens on the selected player, not all grouped players.

- Added _ungroup_player_if_needed() helper method
- Calls set_members directly to bypass static member restrictions
- Applied to handle_play_media (new playback) and handle_play (resume)
- Works with temporary syncs, permanent groups, and dynamic groups