### PR TITLE
Enable multi-instance support for Audible provider

### DIFF
--- a/music_assistant/providers/audible/manifest.json
+++ b/music_assistant/providers/audible/manifest.json
@@ -3,9 +3,10 @@
   "domain": "audible",
   "stage": "stable",
   "name": "Audible",
-  "description": "Access Audible’s extensive audiobook library and podcast catalogue — perfect for spoken-word listening.",
+  "description": "Access Audible's extensive audiobook library and podcast catalogue — perfect for spoken-word listening.",
   "codeowners": ["@ztripez"],
   "credits": ["[Audible library](https://github.com/mkb79/Audible)"],
   "requirements": ["audible==0.10.0"],
-  "documentation": "https://www.music-assistant.io/music-providers/audible"
+  "documentation": "https://www.music-assistant.io/music-providers/audible",
+  "multi_instance": true
 }


### PR DESCRIPTION
Allow users to add multiple Audible provider instances with separate logins. The provider implementation already supports this - just needed to add the multi_instance flag to the manifest. 

Fixes: music-assistant/discussions#862