### PR TITLE
Add configuration for Zeroconf discovery interfaces

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -101,6 +101,7 @@ CONF_USE_SSL: Final[str] = "use_ssl"
 CONF_VERIFY_SSL: Final[str] = "verify_ssl"
 CONF_SSL_FINGERPRINT: Final[str] = "ssl_fingerprint"
 CONF_AUTH_ALLOW_SELF_REGISTRATION: Final[str] = "auth_allow_self_registration"
+CONF_ZEROCONF_INTERFACES: Final[str] = "zeroconf_interfaces"
 CONF_ENABLED: Final[str] = "enabled"
 
 # config default values
@@ -687,6 +688,25 @@ CONF_ENTRY_LIBRARY_SYNC_ARTISTS = ConfigEntry(
     "provider to the Music Assistant Library.",
     default_value=True,
     category="sync_options",
+)
+
+
+CONF_ENTRY_ZEROCONF_INTERFACES = ConfigEntry(
+    key=CONF_ZEROCONF_INTERFACES,
+    type=ConfigEntryType.STRING,
+    label="Mdns/Zeroconf discovery interface(s)",
+    description="In normal circumstances, Music Assistant will automatically "
+    "discover all players on the network using multicast discovery on the "
+    "(L2) local network, such as mDNS or UPNP.\n\n"
+    "By default, Music Assistant will only listen on the default interface. "
+    "If you have multiple network interfaces and you want to discover players "
+    "on all interfaces, you can change this setting to 'All interfaces'.",
+    options=[
+        ConfigValueOption("Default interface", "default"),
+        ConfigValueOption("All interfaces", "all"),
+    ],
+    default_value="default",
+    category="advanced",
 )
 CONF_ENTRY_LIBRARY_SYNC_ALBUMS = ConfigEntry(
     key="library_sync_albums",

--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -45,6 +45,7 @@ from music_assistant.constants import (
     CONF_ENTRY_ENABLE_ICY_METADATA,
     CONF_ENTRY_LOG_LEVEL,
     CONF_ENTRY_SUPPORT_GAPLESS_DIFFERENT_SAMPLE_RATES,
+    CONF_ENTRY_ZEROCONF_INTERFACES,
     CONF_HTTP_PROFILE,
     CONF_OUTPUT_CHANNELS,
     CONF_OUTPUT_CODEC,
@@ -294,6 +295,7 @@ class StreamsController(CoreController):
                 default_value="GLOBAL",
                 category="advanced",
             ),
+            CONF_ENTRY_ZEROCONF_INTERFACES,
         )
 
     async def setup(self, config: CoreConfig) -> None:


### PR DESCRIPTION
- Add `zeroconf_interfaces` setting to allow choosing between 'default' and 'all' network interfaces for mDNS discovery.
- Move ConfigController setup before AsyncZeroconf initialization in `MusicAssistant` to ensure config is available.
- Initialize `AsyncZeroconf` based on the configured interface choice (`InterfaceChoice.All` vs `InterfaceChoice.Default`).

Not being able to bind the zeroconf interface to all network interfaces breaks the setup of some people. This leaves the default setting to the default network interface, but allows a user to configure zeroconf to bind to all network interfaces.

As mentioned in https://github.com/music-assistant/server/pull/2100#issuecomment-2811884657