### PR TITLE
Fix issue with remote_progress if user not logged in

### DIFF
--- a/music_assistant/providers/ard_audiothek/__init__.py
+++ b/music_assistant/providers/ard_audiothek/__init__.py
@@ -291,6 +291,7 @@ class ARDAudiothek(MusicProvider):
 
     async def _update_progress(self) -> None:
         if not self.user_id:
+            self.remote_progress = {}
             return
 
         async with await self.get_client() as session:


### PR DESCRIPTION
This solves the problem, that a not logged in user cannot load or play any podcasts.

https://github.com/music-assistant/support/issues/4593