### PR TITLE
Add 2 guards for queue missing after client disconnect

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1377,7 +1377,8 @@ class PlayerQueuesController(CoreController):
         """Get queue item by index or item_id."""
         if item_id_or_index is None:
             return None
-        queue_items = self._queue_items[queue_id]
+        if (queue_items := self._queue_items.get(queue_id)) is None:
+            return None
         if isinstance(item_id_or_index, int) and len(queue_items) > item_id_or_index:
             return queue_items[item_id_or_index]
         if isinstance(item_id_or_index, str):

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -544,6 +544,8 @@ class SendspinPlayer(Player):
 
     async def send_current_media_metadata(self) -> None:
         """Send the current media metadata to the sendspin group."""
+        if not self.available:
+            return
         current_media = self.current_media
         if current_media is None:
             return


### PR DESCRIPTION
When a sendspin client disconnected, the task to send metadata could still run, running into an exception.

- prevent sendspin from trying to send metadata
- guard in the queue get_item code for invalid queues

```
2025-12-24 13:55:42.910 INFO (MainThread) [aiosendspin.server.client.web-player-1e44bpou] Client disconnected
2025-12-24 13:55:42.910 INFO (MainThread) [aiosendspin.server.client.web-player-1e44bpou] Client disconnected
2025-12-24 13:55:42.916 INFO (MainThread) [music_assistant.players] Player unavailable: Sendspin Sample Player
2025-12-24 13:55:42.921 ERROR (MainThread) [music_assistant] Error doing task: Task exception was never retrieved
Traceback (most recent call last):
  File "/Users/paulus/dev/mass/server/music_assistant/providers/sendspin/player.py", line 555, in send_current_media_metadata
    queue_item = self.mass.player_queues.get_item(
        current_media.source_id, current_media.queue_item_id
    )
  File "/Users/paulus/dev/mass/server/music_assistant/controllers/player_queues.py", line 1380, in get_item
    queue_items = self._queue_items[queue_id]
                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'web-player-1e44bpou'
```