### PR TITLE
Fix spotify podcast thumb image quality

### DIFF
--- a/music_assistant/providers/spotify/parsers.py
+++ b/music_assistant/providers/spotify/parsers.py
@@ -266,8 +266,6 @@ def parse_podcast(podcast_obj: dict[str, Any], provider: SpotifyProvider) -> Pod
     if podcast_obj.get("description"):
         podcast.metadata.description = podcast_obj["description"]
 
-    provider.logger.debug(f"Podcast images from Spotify: {podcast_obj.get('images', [])}")
-
     podcast.metadata.images = parse_images(podcast_obj.get("images", []), provider.instance_id)
 
     if "explicit" in podcast_obj:

--- a/music_assistant/providers/spotify/parsers.py
+++ b/music_assistant/providers/spotify/parsers.py
@@ -45,9 +45,21 @@ def parse_images(
     if not filtered_images:
         return UniqueList([])
 
-    # Spotify orders images from largest to smallest (640x640, 300x300, 64x64)
-    # Select the largest (highest quality) image - the first one
-    best_image = filtered_images[0]
+    # Spotify images come in various sizes (typically 640x640, 300x300, 64x64)
+    # Prefer 640x640 for best quality, or find the largest available
+    best_image = None
+
+    # First, try to find 640x640 image
+    for img in filtered_images:
+        if img.get("height") == 640:
+            best_image = img
+            break
+
+    # If no 640x640 found, select the largest image by height
+    if best_image is None:
+        best_image = max(
+            filtered_images, key=lambda img: img.get("height", 0), default=filtered_images[0]
+        )
 
     return UniqueList(
         [
@@ -253,6 +265,8 @@ def parse_podcast(podcast_obj: dict[str, Any], provider: SpotifyProvider) -> Pod
     # Set metadata
     if podcast_obj.get("description"):
         podcast.metadata.description = podcast_obj["description"]
+
+    provider.logger.debug(f"Podcast images from Spotify: {podcast_obj.get('images', [])}")
 
     podcast.metadata.images = parse_images(podcast_obj.get("images", []), provider.instance_id)
 

--- a/music_assistant/providers/spotify/parsers.py
+++ b/music_assistant/providers/spotify/parsers.py
@@ -46,20 +46,10 @@ def parse_images(
         return UniqueList([])
 
     # Spotify images come in various sizes (typically 640x640, 300x300, 64x64)
-    # Prefer 640x640 for best quality, or find the largest available
-    best_image = None
-
-    # First, try to find 640x640 image
-    for img in filtered_images:
-        if img.get("height") == 640:
-            best_image = img
-            break
-
-    # If no 640x640 found, select the largest image by height
-    if best_image is None:
-        best_image = max(
-            filtered_images, key=lambda img: img.get("height", 0), default=filtered_images[0]
-        )
+    # Find the largest image available
+    best_image = max(
+        filtered_images, key=lambda img: img.get("height", 0), default=filtered_images[0]
+    )
 
     return UniqueList(
         [


### PR DESCRIPTION
Looks like Spotify changed the order images are delivered. Made the retrieval logic more robust to avoid this problem in the future.