### PR TITLE
Prevent cache with media_item=None

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1040,7 +1040,8 @@ class PlayerQueuesController(CoreController):
     async def on_player_register(self, player: Player) -> None:
         """Register PlayerQueue for given player/queue id."""
         queue_id = player.player_id
-        queue = None
+        queue: PlayerQueue | None = None
+        queue_items: list[QueueItem] = []
         # try to restore previous state
         if prev_state := await self.mass.cache.get(
             key=queue_id,
@@ -1055,7 +1056,20 @@ class PlayerQueuesController(CoreController):
                     category=CACHE_CATEGORY_PLAYER_QUEUE_ITEMS,
                     default=[],
                 )
-                queue_items = [QueueItem.from_cache(x) for x in prev_items]
+                queue_items = []
+                for idx, item_data in enumerate(prev_items):
+                    qi = QueueItem.from_cache(item_data)
+                    if not qi.media_item:
+                        # Skip items with missing media_item - this can happen if
+                        # MA was killed during shutdown while cache was being written
+                        self.logger.debug(
+                            "Skipping queue item %s (index %d) restored from cache "
+                            "without media_item",
+                            qi.name,
+                            idx,
+                        )
+                        continue
+                    queue_items.append(qi)
                 if queue.enqueued_media_items:
                     # we need to restore the MediaItem objects for the enqueued media items
                     # Items from cache may be dicts that need deserialization
@@ -1076,6 +1090,9 @@ class PlayerQueuesController(CoreController):
                     player.display_name,
                     str(err),
                 )
+                # Reset to clean state on failure
+                queue = None
+                queue_items = []
         if queue is None:
             queue = PlayerQueue(
                 queue_id=queue_id,
@@ -1085,7 +1102,6 @@ class PlayerQueuesController(CoreController):
                 dont_stop_the_music_enabled=False,
                 items=0,
             )
-            queue_items = []
 
         self._queues[queue_id] = queue
         self._queue_items[queue_id] = queue_items
@@ -1389,11 +1405,14 @@ class PlayerQueuesController(CoreController):
         queue = self._queues[queue_id]
         if items_changed:
             self.mass.signal_event(EventType.QUEUE_ITEMS_UPDATED, object_id=queue_id, data=queue)
-            # save items in cache
+            # save items in cache - only cache items with valid media_item
+            cache_data = [
+                x.to_cache() for x in self._queue_items[queue_id] if x.media_item is not None
+            ]
             self.mass.create_task(
                 self.mass.cache.set(
                     key=queue_id,
-                    data=[x.to_cache() for x in self._queue_items[queue_id]],
+                    data=cache_data,
                     provider=self.domain,
                     category=CACHE_CATEGORY_PLAYER_QUEUE_ITEMS,
                 )


### PR DESCRIPTION
In dev, I am currently unable to do a clean shutdown. This ends up with having items in cache where media_item=None. When these get restored, the player is unable to continue playing.

Below fix was created together with Claude. It does fix my issue but want to make sure Marcel verifies it.

The original issue was a warning, which I turned into exception to generate below log:

```
2025-12-24 13:20:10.943 ERROR (MainThread) [music_assistant.player_queues] Skipping unplayable item ABBA - I Have a Dream (4ce6b28a00a04f17bb5dd982710fb950)
Traceback (most recent call last):
  File "/Users/paulus/dev/mass/server/music_assistant/controllers/player_queues.py", line 922, in _play_index
    await self._load_item(
    ...<5 lines>...
    )
  File "/Users/paulus/dev/mass/server/music_assistant/controllers/player_queues.py", line 1296, in _load_item
    queue_item.streamdetails = await get_stream_details(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/Users/paulus/dev/mass/server/music_assistant/helpers/audio.py", line 252, in get_stream_details
    raise MediaNotFoundError(
        f"Unable to retrieve streamdetails for {queue_item.name} ({queue_item.uri})"
    )
music_assistant_models.errors.MediaNotFoundError: Unable to retrieve streamdetails for ABBA - I Have a Dream (4ce6b28a00a04f17bb5dd982710fb950)
```