### PR TITLE
Disconnect sendspin clients to allow clean shutdown

### DIFF
--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -123,6 +123,3 @@ class SendspinProvider(PlayerProvider):
         for cb in self.unregister_cbs:
             cb()
         self.unregister_cbs = []
-        for player in self.players:
-            self.logger.debug("Unloading player %s", player.name)
-            await self.mass.players.unregister(player.player_id)

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -104,9 +104,18 @@ class SendspinProvider(PlayerProvider):
         :param is_removed: True when the provider is removed from the configuration.
         """
         # Disconnect all clients before stopping the server
-        for client in list(self.server_api.clients):
+        clients = list(self.server_api.clients)
+        disconnect_tasks = []
+        for client in clients:
             self.logger.debug("Disconnecting client %s", client.client_id)
-            await client.disconnect(retry_connection=False)
+            disconnect_tasks.append(client.disconnect(retry_connection=False))
+        if disconnect_tasks:
+            results = await asyncio.gather(*disconnect_tasks, return_exceptions=True)
+            for client, result in zip(clients, results):
+                if isinstance(result, Exception):
+                    self.logger.warning(
+                        "Error disconnecting client %s: %s", client.client_id, result
+                    )
 
         # Stop the Sendspin server
         await self.server_api.close()

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -103,6 +103,11 @@ class SendspinProvider(PlayerProvider):
 
         :param is_removed: True when the provider is removed from the configuration.
         """
+        # Disconnect all clients before stopping the server
+        for client in list(self.server_api.clients):
+            self.logger.debug("Disconnecting client %s", client.client_id)
+            await client.disconnect(retry_connection=False)
+
         # Stop the Sendspin server
         await self.server_api.close()
 

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -111,7 +111,7 @@ class SendspinProvider(PlayerProvider):
             disconnect_tasks.append(client.disconnect(retry_connection=False))
         if disconnect_tasks:
             results = await asyncio.gather(*disconnect_tasks, return_exceptions=True)
-            for client, result in zip(clients, results):
+            for client, result in zip(clients, results, strict=True):
                 if isinstance(result, Exception):
                     self.logger.warning(
                         "Error disconnecting client %s: %s", client.client_id, result


### PR DESCRIPTION
I was unable to do a clean shutdown in development when a Sendspin client was connected to the Sendspin server. This PR fixes it. 

STR
- Start MA
- Connect sendspin client (I was using sendspin-js)
- Shut down MA using ctrl+C
- Hangs

With this PR: shuts down cleanly