### PR TITLE
Subsonic Fixes

### DIFF
--- a/music_assistant/controllers/media/artists.py
+++ b/music_assistant/controllers/media/artists.py
@@ -234,7 +234,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             return []
         prov = cast("MusicProvider", prov)
         if ProviderFeature.ARTIST_TOPTRACKS in prov.supported_features:
-            return await prov.get_artist_toptracks(item_id)
+            return await prov.get_artist_top_tracks(item_id)
         # fallback implementation using the library db
         if db_artist := await self.mass.music.artists.get_library_item_by_prov_id(
             item_id,

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -130,7 +130,7 @@ class MusicProvider(Provider):
         """
         raise NotImplementedError
 
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get a list of most popular tracks for the given artist.
 
         Only called if provider supports ProviderFeature.ARTIST_TOPTRACKS.

--- a/music_assistant/providers/_demo_music_provider/__init__.py
+++ b/music_assistant/providers/_demo_music_provider/__init__.py
@@ -327,7 +327,7 @@ class MyDemoMusicprovider(MusicProvider):
         # You can use the @use_cache decorator from music_assistant.controllers.cache
         # to easily apply caching to this method.
 
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:  # type: ignore[empty-body]
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:  # type: ignore[empty-body]
         """Get a list of most popular tracks for the given artist."""
         # Get a list of most popular tracks for the given artist.
         # Mandatory only if you reported ARTIST_TOPTRACKS in the supported_features.

--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -548,7 +548,7 @@ class AppleMusicProvider(MusicProvider):
         return albums
 
     @use_cache(3600 * 24 * 7)  # cache for 7 days
-    async def get_artist_toptracks(self, prov_artist_id) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id) -> list[Track]:
         """Get a list of 10 most popular tracks for the given artist."""
         endpoint = f"catalog/{self._storefront}/artists/{prov_artist_id}/view/top-songs"
         try:

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -349,7 +349,7 @@ class DeezerProvider(MusicProvider):
         return [self.parse_album(album=album) async for album in await artist.get_albums()]
 
     @use_cache(3600 * 24 * 7)  # Cache for 7 days
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get top 50 tracks of an artist."""
         artist = await self.client.get_artist(artist_id=int(prov_artist_id))
         return [

--- a/music_assistant/providers/internet_archive/provider.py
+++ b/music_assistant/providers/internet_archive/provider.py
@@ -681,7 +681,7 @@ class InternetArchiveProvider(MusicProvider):
         return albums
 
     @use_cache(expiration=86400 * 7)  # Cache for 1 week
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """
         Get top tracks for a specific artist.
 

--- a/music_assistant/providers/nicovideo/provider_mixins/artist.py
+++ b/music_assistant/providers/nicovideo/provider_mixins/artist.py
@@ -48,7 +48,7 @@ class NicovideoMusicProviderArtistMixin(NicovideoMusicProviderMixinBase):
 
     @override
     @use_cache(3600 * 24 * 14)  # Cache for 14 days
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get newest 50 tracks of an artist."""
         return await self.service_manager.video.get_user_videos(
             prov_artist_id,

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -15,6 +15,7 @@ from libopensonic.errors import (
     ParameterError,
     SonicError,
 )
+from mashumaro.exceptions import InvalidFieldValue
 from music_assistant_models.enums import ContentType, MediaType, StreamType
 from music_assistant_models.errors import (
     ActionUnavailable,
@@ -425,13 +426,20 @@ class OpenSonicProvider(MusicProvider):
                     )
                 },
             )
-
+        sonic_info = None
         try:
-            sonic_artist: SonicArtist = await self._run_async(
-                self.conn.get_artist, artist_id=prov_artist_id
-            )
-            sonic_info = await self._run_async(self.conn.get_artist_info2, aid=prov_artist_id)
-        except (ParameterError, DataNotFoundError) as e:
+            sonic_artist: SonicArtist = await self._run_async(self.conn.get_artist, artist_id=prov_artist_id)
+            try:
+                sonic_info = await self._run_async(self.conn.get_artist_info2, aid=prov_artist_id)
+            except HTTPError as e:
+                if e.response.status_code != 404:
+                    # If the user didn't activate last.fm connection it has 404 response code and it must be ignored
+                    raise e
+            except KeyError as e:
+                if e.args[0] != "":
+                    # If the user didn't activate last.fm connection it has an empty tuple and it must be ignored
+                    raise e
+        except (ParameterError, DataNotFoundError, Exception) as e:
             msg = f"Artist {prov_artist_id} not found"
             raise MediaNotFoundError(msg) from e
         return parse_artist(self.instance_id, sonic_artist, sonic_info)
@@ -457,11 +465,14 @@ class OpenSonicProvider(MusicProvider):
         if prov_artist_id == UNKNOWN_ARTIST_ID or prov_artist_id.startswith(NAVI_VARIOUS_PREFIX):
             return []
 
-        try:
-            sonic_artist: SonicArtist = await self._run_async(self.conn.get_artist, prov_artist_id)
-        except (ParameterError, DataNotFoundError) as e:
-            msg = f"Album {prov_artist_id} not found"
-            raise MediaNotFoundError(msg) from e
+        sonic_artist: Artist = await self.get_artist(prov_artist_id=prov_artist_id)
+        # try:
+        #     sonic_artist: SonicArtist = await self._run_async(self.conn.get_artist, prov_artist_id)
+        # except (ParameterError, DataNotFoundError) as e:
+        #     msg = f"Album {prov_artist_id} not found"
+        #     raise MediaNotFoundError(msg) from e
+        # except InvalidFieldValue as e:
+        #
         albums = []
         if sonic_artist.album:
             for entry in sonic_artist.album:

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -37,6 +37,7 @@ from music_assistant_models.media_items import (
     Track,
 )
 from music_assistant_models.streamdetails import StreamDetails
+from requests import HTTPError
 
 from music_assistant.constants import (
     CONF_PASSWORD,
@@ -365,9 +366,16 @@ class OpenSonicProvider(MusicProvider):
 
     async def get_album(self, prov_album_id: str) -> Album:
         """Return the requested Album."""
+        sonic_album: SonicAlbum
+        sonic_info = None
         try:
-            sonic_album: SonicAlbum = await self._run_async(self.conn.get_album, prov_album_id)
-            sonic_info = await self._run_async(self.conn.get_album_info2, aid=prov_album_id)
+            sonic_album = await self._run_async(self.conn.get_album, prov_album_id)
+            try:
+                sonic_info = await self._run_async(self.conn.get_album_info2, aid=prov_album_id)
+            except HTTPError as e:
+                # If the user didn't activate last.fm connection it has 404 response code and must be ignored
+                if e.response.status_code != 404:
+                    raise e
         except (ParameterError, DataNotFoundError) as e:
             msg = f"Album {prov_album_id} not found"
             raise MediaNotFoundError(msg) from e

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -567,7 +567,7 @@ class OpenSonicProvider(MusicProvider):
             result.append(track)
         return result
 
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get the top listed tracks for a specified artist."""
         # We have seen top tracks requested for the UNKNOWN_ARTIST ID, protect against that
         if prov_artist_id == UNKNOWN_ARTIST_ID or prov_artist_id.startswith(NAVI_VARIOUS_PREFIX):

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -466,13 +466,7 @@ class OpenSonicProvider(MusicProvider):
             return []
 
         sonic_artist: Artist = await self.get_artist(prov_artist_id=prov_artist_id)
-        # try:
-        #     sonic_artist: SonicArtist = await self._run_async(self.conn.get_artist, prov_artist_id)
-        # except (ParameterError, DataNotFoundError) as e:
-        #     msg = f"Album {prov_artist_id} not found"
-        #     raise MediaNotFoundError(msg) from e
-        # except InvalidFieldValue as e:
-        #
+        
         albums = []
         if sonic_artist.album:
             for entry in sonic_artist.album:

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -197,7 +197,7 @@ class PhishInProvider(MusicProvider):
             raise ProviderUnavailableError(f"Artist albums error: {err}") from err
 
     @use_cache(expiration=2592000)  # 30 days - Top tracks won't change that often as its voted on
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get a list of most popular tracks for the given artist."""
         if prov_artist_id != PHISH_ARTIST_ID:
             raise MediaNotFoundError(f"Artist {prov_artist_id} not found")

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -1118,7 +1118,7 @@ class PlexProvider(MusicProvider):
         return []
 
     @use_cache(3600 * 3)  # Cache for 3 hours
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get top tracks for the given artist using Plex artist radio/station."""
         if prov_artist_id.startswith(FAKE_ARTIST_PREFIX):
             return []

--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -351,7 +351,7 @@ class QobuzProvider(MusicProvider):
         ]
 
     @use_cache(3600 * 24 * 14)  # Cache for 14 days
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get a list of most popular tracks for the given artist."""
         result = await self._get_data(
             "artist/get",

--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -336,7 +336,7 @@ class SoundcloudMusicProvider(MusicProvider):
         return result
 
     @use_cache(3600 * 24 * 14)  # Cache for 14 days
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get a list of (max 500) tracks for the given artist."""
         tracks_obj = await self._soundcloud.get_tracks_from_user(prov_artist_id, 500)
 

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -630,7 +630,7 @@ class SpotifyProvider(MusicProvider):
         ]
 
     @use_cache(86400 * 14)  # 14 days
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get a list of 10 most popular tracks for the given artist."""
         artist = await self.get_artist(prov_artist_id)
         endpoint = f"artists/{prov_artist_id}/top-tracks"

--- a/music_assistant/providers/tidal/provider.py
+++ b/music_assistant/providers/tidal/provider.py
@@ -173,7 +173,7 @@ class TidalProvider(MusicProvider):
         return await self.media.get_artist_albums(prov_artist_id)
 
     @use_cache(3600 * 24 * 7)
-    async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id: str) -> list[Track]:
         """Get a list of 10 most popular tracks for the given artist."""
         return await self.media.get_artist_toptracks(prov_artist_id)
 

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -457,7 +457,7 @@ class YoutubeMusicProvider(MusicProvider):
         return []
 
     @use_cache(3600 * 24 * 7)  # Cache for 7 days
-    async def get_artist_toptracks(self, prov_artist_id) -> list[Track]:
+    async def get_artist_top_tracks(self, prov_artist_id) -> list[Track]:
         """Get a list of 25 most popular tracks for the given artist."""
         artist_obj = await get_artist(prov_artist_id=prov_artist_id, headers=self._headers)
         if artist_obj.get("songs") and artist_obj["songs"].get("browseId"):

--- a/tests/providers/tidal/test_provider.py
+++ b/tests/providers/tidal/test_provider.py
@@ -210,7 +210,7 @@ async def test_get_artist_toptracks_delegates_to_media(provider: TidalProvider) 
     with patch.object(provider.media, "get_artist_toptracks", new_callable=AsyncMock) as mock_get:
         mock_get.return_value = []
 
-        await provider.get_artist_toptracks("123")
+        await provider.get_artist_top_tracks("123")
 
         mock_get.assert_called_with("123")
 


### PR DESCRIPTION
What's changed (for Subsonic Provider):

* Refactor name of _get_artist_toptracks_ to _get_artist_top_tracks_ as now it respects the snake case
* When getting artist using _artistInfo2_, server returned an empty object or 404 error, so it is now ignored as when the server doesn't use a service like last.fm it returns empty object or a 404 error.
*  While getting _albumInfo2_ for an album view, it could returns error 404 if no last.fm like services is used on server. So it is ignored and data can be shown on screen. This error makes music assistant unable to play music from impacted albums even if music's data was returned by the server before that query.

(I hope I was clear on what I did).

Thanks for this project, I use it to stream on my IOT objects at home :D