### PR TITLE
Fix base queries to work with provider mapping filters

### DIFF
--- a/music_assistant/controllers/media/albums.py
+++ b/music_assistant/controllers/media/albums.py
@@ -50,16 +50,16 @@ class AlbumsController(MediaControllerBase[Album]):
             albums.*,
             (SELECT JSON_GROUP_ARRAY(
                 json_object(
-                'item_id', provider_mappings.provider_item_id,
-                    'provider_domain', provider_mappings.provider_domain,
-                        'provider_instance', provider_mappings.provider_instance,
-                        'available', provider_mappings.available,
-                        'audio_format', json(provider_mappings.audio_format),
-                        'url', provider_mappings.url,
-                        'details', provider_mappings.details,
-                        'in_library', provider_mappings.in_library,
-                        'is_unique', provider_mappings.is_unique
-                )) FROM provider_mappings WHERE provider_mappings.item_id = albums.item_id AND media_type = 'album') AS provider_mappings,
+                'item_id', album_pm.provider_item_id,
+                    'provider_domain', album_pm.provider_domain,
+                        'provider_instance', album_pm.provider_instance,
+                        'available', album_pm.available,
+                        'audio_format', json(album_pm.audio_format),
+                        'url', album_pm.url,
+                        'details', album_pm.details,
+                        'in_library', album_pm.in_library,
+                        'is_unique', album_pm.is_unique
+                )) FROM provider_mappings album_pm WHERE album_pm.item_id = albums.item_id AND album_pm.media_type = 'album') AS provider_mappings,
             (SELECT JSON_GROUP_ARRAY(
                 json_object(
                 'item_id', artists.item_id,

--- a/music_assistant/controllers/media/audiobooks.py
+++ b/music_assistant/controllers/media/audiobooks.py
@@ -40,16 +40,16 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             audiobooks.*,
             (SELECT JSON_GROUP_ARRAY(
                 json_object(
-                'item_id', provider_mappings.provider_item_id,
-                    'provider_domain', provider_mappings.provider_domain,
-                        'provider_instance', provider_mappings.provider_instance,
-                        'available', provider_mappings.available,
-                        'audio_format', json(provider_mappings.audio_format),
-                        'url', provider_mappings.url,
-                        'details', provider_mappings.details,
-                        'in_library', provider_mappings.in_library,
-                        'is_unique', provider_mappings.is_unique
-                )) FROM provider_mappings WHERE provider_mappings.item_id = audiobooks.item_id AND media_type = 'audiobook') AS provider_mappings,
+                'item_id', audiobook_pm.provider_item_id,
+                    'provider_domain', audiobook_pm.provider_domain,
+                        'provider_instance', audiobook_pm.provider_instance,
+                        'available', audiobook_pm.available,
+                        'audio_format', json(audiobook_pm.audio_format),
+                        'url', audiobook_pm.url,
+                        'details', audiobook_pm.details,
+                        'in_library', audiobook_pm.in_library,
+                        'is_unique', audiobook_pm.is_unique
+                )) FROM provider_mappings audiobook_pm WHERE audiobook_pm.item_id = audiobooks.item_id AND audiobook_pm.media_type = 'audiobook') AS provider_mappings,
             playlog.fully_played AS fully_played,
             playlog.seconds_played AS seconds_played,
             playlog.seconds_played * 1000 as resume_position_ms

--- a/music_assistant/controllers/media/tracks.py
+++ b/music_assistant/controllers/media/tracks.py
@@ -58,16 +58,16 @@ class TracksController(MediaControllerBase[Track]):
             tracks.*,
             (SELECT JSON_GROUP_ARRAY(
                 json_object(
-                'item_id', provider_mappings.provider_item_id,
-                    'provider_domain', provider_mappings.provider_domain,
-                        'provider_instance', provider_mappings.provider_instance,
-                        'available', provider_mappings.available,
-                        'audio_format', json(provider_mappings.audio_format),
-                        'url', provider_mappings.url,
-                        'details', provider_mappings.details,
-                        'in_library', provider_mappings.in_library,
-                        'is_unique', provider_mappings.is_unique
-                )) FROM provider_mappings WHERE provider_mappings.item_id = tracks.item_id AND media_type = 'track') AS provider_mappings,
+                'item_id', track_pm.provider_item_id,
+                    'provider_domain', track_pm.provider_domain,
+                        'provider_instance', track_pm.provider_instance,
+                        'available', track_pm.available,
+                        'audio_format', json(track_pm.audio_format),
+                        'url', track_pm.url,
+                        'details', track_pm.details,
+                        'in_library', track_pm.in_library,
+                        'is_unique', track_pm.is_unique
+                )) FROM provider_mappings track_pm WHERE track_pm.item_id = tracks.item_id AND track_pm.media_type = 'track') AS provider_mappings,
 
             (SELECT JSON_GROUP_ARRAY(
                 json_object(


### PR DESCRIPTION
Use table aliases for base queries to avoid collisions with dynamic filters

Fixes: https://github.com/music-assistant/support/issues/4632