### PR TITLE
Fix invalid timeout value for TLS connections

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -736,7 +736,7 @@ async def resolve_radio_stream(mass: MusicAssistant, url: str) -> tuple[str, Str
         return (cache[0], StreamType(cache[1]))
     stream_type = StreamType.HTTP
     resolved_url = url
-    timeout = ClientTimeout(total=0, connect=10, sock_read=5)
+    timeout = ClientTimeout(total=None, connect=10, sock_read=5)
     try:
         async with mass.http_session_no_ssl.get(
             url, headers=HTTP_HEADERS_ICY, allow_redirects=True, timeout=timeout
@@ -788,7 +788,7 @@ async def get_icy_radio_stream(
     mass: MusicAssistant, url: str, streamdetails: StreamDetails
 ) -> AsyncGenerator[bytes, None]:
     """Get (radio) audio stream from HTTP, including ICY metadata retrieval."""
-    timeout = ClientTimeout(total=0, connect=30, sock_read=5 * 60)
+    timeout = ClientTimeout(total=None, connect=30, sock_read=5 * 60)
     LOGGER.debug("Start streaming radio with ICY metadata from url %s", url)
     async with mass.http_session_no_ssl.get(
         url, allow_redirects=True, headers=HTTP_HEADERS_ICY, timeout=timeout
@@ -837,7 +837,7 @@ async def get_hls_substream(
     url: str,
 ) -> PlaylistItem:
     """Select the (highest quality) HLS substream for given HLS playlist/URL."""
-    timeout = ClientTimeout(total=0, connect=30, sock_read=5 * 60)
+    timeout = ClientTimeout(total=None, connect=30, sock_read=5 * 60)
     # fetch master playlist and select (best) child playlist
     # https://datatracker.ietf.org/doc/html/draft-pantos-http-live-streaming-19#section-10
     async with mass.http_session_no_ssl.get(
@@ -897,7 +897,7 @@ async def get_http_stream(
             seek_supported = resp.headers.get("Accept-Ranges") == "bytes"
     # headers
     headers = {**HTTP_HEADERS}
-    timeout = ClientTimeout(total=0, connect=30, sock_read=5 * 60)
+    timeout = ClientTimeout(total=None, connect=30, sock_read=5 * 60)
     skip_bytes = 0
     if seek_position and streamdetails.size:
         assert streamdetails.duration is not None  # for type checking

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -497,7 +497,7 @@ class DeezerProvider(MusicProvider):
         """Return the audio stream for the provider item."""
         blowfish_key = self.get_blowfish_key(streamdetails.data["track_id"])
         chunk_index = 0
-        timeout = ClientTimeout(total=0, connect=30, sock_read=600)
+        timeout = ClientTimeout(total=None, connect=30, sock_read=600)
         headers: dict[str, str] = {}
         # if seek_position and streamdetails.size:
         #     chunk_count = ceil(streamdetails.size / 2048)


### PR DESCRIPTION
[`aiohttp/connector.py`](https://github.com/aio-libs/aiohttp/blob/8b919d30a2339d3b9dbc53e8958f745b0f9703ea/aiohttp/connector.py#L1320-L1337) uses the total timeout value as handshake timeout for TLS connections:

```python
tls_transport = await self._loop.start_tls(
    [...]
    ssl_handshake_timeout=timeout.total,
```

This causes an exception with Deezer on slow network connections:
> ssl_handshake_timeout should be a positive number, got 0

According to https://github.com/aio-libs/aiohttp/issues/11859#issuecomment-3677980105, a zero value for total is not supposed to be used, but None means no timeout.

Fix it in all occurences throughout the repository.