### PR TITLE
Bump get-mac 0.9.2 to getmac 0.9.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "cryptography==46.0.3",
   "chardet>=5.2.0",
   "ifaddr==0.2.0",
-  "get-mac==0.9.2",
+  "getmac==0.9.5",
   "mashumaro==3.17",
   "music-assistant-frontend==2.17.62",
   "music-assistant-models==1.1.86",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -30,7 +30,7 @@ deezer-python-async==0.3.0
 defusedxml==0.7.1
 deno==2.6.3
 duration-parser==1.0.1
-get-mac==0.9.2
+getmac==0.9.5
 gql[all]==4.0.0
 hass-client==1.2.0
 ibroadcastaio==0.4.0


### PR DESCRIPTION
The get-mac name is an old (2018) alias for the getmac package.

https://github.com/GhostofGoes/getmac#background-and-history

https://github.com/GhostofGoes/getmac/releases/tag/0.9.3
https://github.com/GhostofGoes/getmac/releases/tag/0.9.4
https://github.com/GhostofGoes/getmac/releases/tag/0.9.5