### PR TITLE
Bump aiosendspin to 2.0.0

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin==1.1.4"],
+  "requirements": ["aiosendspin==2.0.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -92,7 +92,7 @@ class SendspinProvider(PlayerProvider):
         await self.server_api.start_server(
             port=8927,
             host=self.mass.streams.bind_ip,
-            advertise_host=cast("str", self.mass.streams.publish_ip),
+            advertise_addresses=[cast("str", self.mass.streams.publish_ip)],
         )
 
     async def unload(self, is_removed: bool = False) -> None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
 aiorun==2025.1.1
-aiosendspin==1.1.4
+aiosendspin==2.0.0
 aioslimproto==3.1.4
 aiosonos==0.1.9
 aiosqlite==0.22.1


### PR DESCRIPTION
## Summary

- Bump aiosendspin from 1.1.4 to 2.0.0
- Fix compatibility with sendspin-cli 2.0.0+ by accepting spec-compliant field names in the client/hello support object
- Update `start_server()` API call: `advertise_host` → `advertise_addresses` (breaking change from Sendspin/aiosendspin#117)