### PR TITLE
Fix webserver base url not persisting

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -372,8 +372,7 @@ class WebserverController(CoreController):
 
     async def close(self) -> None:
         """Cleanup on exit."""
-        if self.remote_access.is_running:
-            await self.remote_access.close()
+        await self.remote_access.close()
         for client in set(self.clients):
             await client.disconnect()
         await self._server.close()

--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -85,6 +85,7 @@ class RemoteAccessManager:
         await self.stop()
         for unload_cb in self._on_unload_callbacks:
             unload_cb()
+        self._on_unload_callbacks.clear()
 
     async def _schedule_start(self) -> None:
         """Schedule a debounced gateway start, cancelling any existing connection first."""

--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -85,7 +85,6 @@ class RemoteAccessManager:
         await self.stop()
         for unload_cb in self._on_unload_callbacks:
             unload_cb()
-        self._on_unload_callbacks.clear()
 
     async def _schedule_start(self) -> None:
         """Schedule a debounced gateway start, cancelling any existing connection first."""


### PR DESCRIPTION
Fixes: https://github.com/music-assistant/support/issues/4547

We were conditionally cleaning up the remote access, even though we **always** add the api commands. This would cause an error: `Error handling message: config/core/save: Command remote_access/info is already registered`, causing the webserver reload to fail and thus not persisting the change.

Solution: Always call `close()` on the remote_access to cleanup the api commands.