### PR TITLE
fix: Ensure playlist ID is a string in Soundcloud provider

### DIFF
--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -299,6 +299,8 @@ class SoundcloudMusicProvider(MusicProvider):
 
     async def _get_playlist_object(self, prov_playlist_id: str) -> dict[str, Any]:
         """Get playlist object from Soundcloud API based on playlist ID type."""
+        # Handle playlist id's which are actually numbers
+        prov_playlist_id = str(prov_playlist_id)
         if prov_playlist_id.startswith("soundcloud:system-playlists"):
             # Handle system playlists
             result = await self._soundcloud.get_system_playlist_details(prov_playlist_id)


### PR DESCRIPTION
Convert playlist ID to string to prevent an error on startsWith. Most of the playlist id's are just names but sometimes it's an actual id. This should fix that.

See discussion here: https://github.com/orgs/music-assistant/discussions/1160#discussioncomment-15449676