### PR TITLE
Fix issues with progress bar jumps and time overflow 

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -59,7 +59,7 @@ from music_assistant_models.media_items import (
     media_from_dict,
 )
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
-from music_assistant_models.player_queue import PlayerQueue, QueueTimeUpdate
+from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.constants import (
@@ -2217,10 +2217,10 @@ class PlayerQueuesController(CoreController):
                 self.mass.signal_event(
                     EventType.QUEUE_TIME_UPDATED,
                     object_id=queue_id,
-                    data=QueueTimeUpdate(
-                        elapsed_time=queue.elapsed_time,
-                        elapsed_time_last_updated=queue.elapsed_time_last_updated,
-                    ),
+                    data={
+                        "elapsed_time": queue.elapsed_time,
+                        "elapsed_time_last_updated": queue.elapsed_time_last_updated,
+                    },
                 )
                 # also signal update to the player itself so it can update its current_media
                 self.mass.players.trigger_player_update(queue_id)
@@ -2302,6 +2302,7 @@ class PlayerQueuesController(CoreController):
     ) -> tuple[int | None, int]:
         """Calculate current queue index and current track elapsed time when flow mode is active."""
         elapsed_time_queue_total = player.corrected_elapsed_time or 0
+
         if queue.current_index is None and not queue.flow_mode_stream_log:
             return queue.current_index, int(queue.elapsed_time)
 
@@ -2340,6 +2341,7 @@ class PlayerQueuesController(CoreController):
             # if the player is not playing, we can't be sure that the elapsed time is correct
             # so we just return the queue index and the elapsed time
             return queue.current_index, int(queue.elapsed_time)
+
         return queue_index, int(track_time)
 
     def _parse_player_current_item_id(self, queue_id: str, player: Player) -> str | None:

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -59,7 +59,7 @@ from music_assistant_models.media_items import (
     media_from_dict,
 )
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
-from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.player_queue import PlayerQueue, QueueTimeUpdate
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.constants import (
@@ -650,6 +650,7 @@ class PlayerQueuesController(CoreController):
         queue.current_index = None
         queue.current_item = None
         queue.elapsed_time = 0
+        queue.elapsed_time_last_updated = time.time()
         queue.index_in_buffer = None
         self.update_items(queue_id, [])
 
@@ -897,6 +898,7 @@ class PlayerQueuesController(CoreController):
         # this way the UI knows immediately that a new item is loading
         queue.current_item = self.get_item(queue_id, index)
         queue.elapsed_time = seek_position
+        queue.elapsed_time_last_updated = time.time()
         self.signal_update(queue_id)
         queue.index_in_buffer = index
         queue.flow_mode_stream_log = []
@@ -2109,6 +2111,7 @@ class PlayerQueuesController(CoreController):
                 and current_item.streamdetails.seek_position
             ):
                 elapsed_time += current_item.streamdetails.seek_position
+
             queue.elapsed_time = elapsed_time
             queue.elapsed_time_last_updated = time.time()
 
@@ -2214,7 +2217,10 @@ class PlayerQueuesController(CoreController):
                 self.mass.signal_event(
                     EventType.QUEUE_TIME_UPDATED,
                     object_id=queue_id,
-                    data=queue.elapsed_time,
+                    data=QueueTimeUpdate(
+                        elapsed_time=queue.elapsed_time,
+                        elapsed_time_last_updated=queue.elapsed_time_last_updated,
+                    ),
                 )
                 # also signal update to the player itself so it can update its current_media
                 self.mass.players.trigger_player_update(queue_id)

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -59,7 +59,7 @@ from music_assistant_models.media_items import (
     media_from_dict,
 )
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
-from music_assistant_models.player_queue import PlayerQueue, QueueTimeUpdate
+from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.constants import (
@@ -2216,10 +2216,7 @@ class PlayerQueuesController(CoreController):
                 self.mass.signal_event(
                     EventType.QUEUE_TIME_UPDATED,
                     object_id=queue_id,
-                    data=QueueTimeUpdate(
-                        elapsed_time=queue.elapsed_time,
-                        elapsed_time_last_updated=queue.elapsed_time_last_updated,
-                    ),
+                    data=queue.elapsed_time,
                 )
                 # also signal update to the player itself so it can update its current_media
                 self.mass.players.trigger_player_update(queue_id)

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -59,7 +59,7 @@ from music_assistant_models.media_items import (
     media_from_dict,
 )
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
-from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.player_queue import PlayerQueue, QueueTimeUpdate
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.constants import (
@@ -2217,10 +2217,10 @@ class PlayerQueuesController(CoreController):
                 self.mass.signal_event(
                     EventType.QUEUE_TIME_UPDATED,
                     object_id=queue_id,
-                    data={
-                        "elapsed_time": queue.elapsed_time,
-                        "elapsed_time_last_updated": queue.elapsed_time_last_updated,
-                    },
+                    data=QueueTimeUpdate(
+                        elapsed_time=queue.elapsed_time,
+                        elapsed_time_last_updated=queue.elapsed_time_last_updated,
+                    ),
                 )
                 # also signal update to the player itself so it can update its current_media
                 self.mass.players.trigger_player_update(queue_id)

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2111,7 +2111,6 @@ class PlayerQueuesController(CoreController):
                 and current_item.streamdetails.seek_position
             ):
                 elapsed_time += current_item.streamdetails.seek_position
-
             queue.elapsed_time = elapsed_time
             queue.elapsed_time_last_updated = time.time()
 
@@ -2302,7 +2301,6 @@ class PlayerQueuesController(CoreController):
     ) -> tuple[int | None, int]:
         """Calculate current queue index and current track elapsed time when flow mode is active."""
         elapsed_time_queue_total = player.corrected_elapsed_time or 0
-
         if queue.current_index is None and not queue.flow_mode_stream_log:
             return queue.current_index, int(queue.elapsed_time)
 
@@ -2341,7 +2339,6 @@ class PlayerQueuesController(CoreController):
             # if the player is not playing, we can't be sure that the elapsed time is correct
             # so we just return the queue index and the elapsed time
             return queue.current_index, int(queue.elapsed_time)
-
         return queue_index, int(track_time)
 
     def _parse_player_current_item_id(self, queue_id: str, player: Player) -> str | None:

--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -590,6 +590,9 @@ class StreamsController(CoreController):
         if not start_queue_item:
             raise web.HTTPNotFound(reason=f"Unknown Queue item: {start_queue_item_id}")
 
+        # make sure to start the stream with a fresh log
+        queue.flow_mode_stream_log = []
+
         # select the highest possible PCM settings for this player
         flow_pcm_format = await self._select_flow_format(queue_player)
 
@@ -1152,12 +1155,6 @@ class StreamsController(CoreController):
             # update duration details based on the actual pcm data we sent
             # this also accounts for crossfade and silence stripping
             seconds_streamed = bytes_written / pcm_sample_size
-
-            # Cap seconds_streamed to the actual remaining track duration to avoid overflow
-            # when there's extra silence or padding in the source
-            if queue_track.duration:
-                max_streamable = queue_track.duration - queue_track.streamdetails.seek_position
-                seconds_streamed = min(seconds_streamed, max_streamable)
 
             queue_track.streamdetails.seconds_streamed = seconds_streamed
             queue_track.streamdetails.duration = int(

--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -1011,12 +1011,6 @@ class StreamsController(CoreController):
                     queue_track.queue_item_id,
                 )
 
-            self.logger.debug(
-                "Start Streaming queue track: %s (%s) for queue %s",
-                queue_track.streamdetails.uri,
-                queue_track.name,
-                queue.display_name,
-            )
             # append to play log so the queue controller can work out which track is playing
             play_log_entry = PlayLogEntry(queue_track.queue_item_id)
             queue.flow_mode_stream_log.append(play_log_entry)
@@ -1158,6 +1152,13 @@ class StreamsController(CoreController):
             # update duration details based on the actual pcm data we sent
             # this also accounts for crossfade and silence stripping
             seconds_streamed = bytes_written / pcm_sample_size
+
+            # Cap seconds_streamed to the actual remaining track duration to avoid overflow
+            # when there's extra silence or padding in the source
+            if queue_track.duration:
+                max_streamable = queue_track.duration - queue_track.streamdetails.seek_position
+                seconds_streamed = min(seconds_streamed, max_streamable)
+
             queue_track.streamdetails.seconds_streamed = seconds_streamed
             queue_track.streamdetails.duration = int(
                 queue_track.streamdetails.seek_position + seconds_streamed
@@ -1165,12 +1166,6 @@ class StreamsController(CoreController):
             play_log_entry.seconds_streamed = seconds_streamed
             play_log_entry.duration = queue_track.streamdetails.duration
             total_bytes_sent += bytes_written
-            self.logger.debug(
-                "Finished Streaming queue track: %s (%s) on queue %s",
-                queue_track.streamdetails.uri,
-                queue_track.name,
-                queue.display_name,
-            )
         #### HANDLE END OF QUEUE FLOW STREAM
         # end of queue flow: make sure we yield the last_fadeout_part
         if last_fadeout_part:

--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -1013,6 +1013,7 @@ class StreamsController(CoreController):
                     "No Streamdetails known for queue item %s",
                     queue_track.queue_item_id,
                 )
+
             self.logger.debug(
                 "Start Streaming queue track: %s (%s) for queue %s",
                 queue_track.streamdetails.uri,
@@ -1166,13 +1167,13 @@ class StreamsController(CoreController):
             )
             play_log_entry.seconds_streamed = seconds_streamed
             play_log_entry.duration = queue_track.streamdetails.duration
+            total_bytes_sent += bytes_written
             self.logger.debug(
                 "Finished Streaming queue track: %s (%s) on queue %s",
                 queue_track.streamdetails.uri,
                 queue_track.name,
                 queue.display_name,
             )
-            total_bytes_sent += bytes_written
         #### HANDLE END OF QUEUE FLOW STREAM
         # end of queue flow: make sure we yield the last_fadeout_part
         if last_fadeout_part:

--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -1013,7 +1013,12 @@ class StreamsController(CoreController):
                     "No Streamdetails known for queue item %s",
                     queue_track.queue_item_id,
                 )
-
+            self.logger.debug(
+                "Start Streaming queue track: %s (%s) for queue %s",
+                queue_track.streamdetails.uri,
+                queue_track.name,
+                queue.display_name,
+            )
             # append to play log so the queue controller can work out which track is playing
             play_log_entry = PlayLogEntry(queue_track.queue_item_id)
             queue.flow_mode_stream_log.append(play_log_entry)
@@ -1155,13 +1160,18 @@ class StreamsController(CoreController):
             # update duration details based on the actual pcm data we sent
             # this also accounts for crossfade and silence stripping
             seconds_streamed = bytes_written / pcm_sample_size
-
             queue_track.streamdetails.seconds_streamed = seconds_streamed
             queue_track.streamdetails.duration = int(
                 queue_track.streamdetails.seek_position + seconds_streamed
             )
             play_log_entry.seconds_streamed = seconds_streamed
             play_log_entry.duration = queue_track.streamdetails.duration
+            self.logger.debug(
+                "Finished Streaming queue track: %s (%s) on queue %s",
+                queue_track.streamdetails.uri,
+                queue_track.name,
+                queue.display_name,
+            )
             total_bytes_sent += bytes_written
         #### HANDLE END OF QUEUE FLOW STREAM
         # end of queue flow: make sure we yield the last_fadeout_part

--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -590,7 +590,6 @@ class StreamsController(CoreController):
         if not start_queue_item:
             raise web.HTTPNotFound(reason=f"Unknown Queue item: {start_queue_item_id}")
 
-        # make sure to start the stream with a fresh log
         queue.flow_mode_stream_log = []
 
         # select the highest possible PCM settings for this player

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -132,7 +132,12 @@ class AirPlayPlayer(Player):
         """Return the corrected elapsed time accounting for stream session restarts."""
         if not self.stream or not self.stream.session:
             return super().corrected_elapsed_time or 0.0
-        return time.time() - self.stream.session.last_stream_started
+        session = self.stream.session
+        elapsed = time.time() - session.last_stream_started - session.total_pause_time
+        if session.last_paused is not None:
+            current_pause = time.time() - session.last_paused
+            elapsed -= current_pause
+        return max(0.0, elapsed)
 
     async def get_config_entries(
         self,
@@ -592,7 +597,16 @@ class AirPlayPlayer(Player):
     ) -> None:
         """Set the playback state from stream (RAOP or AirPlay2)."""
         if state is not None:
+            prev_state = self._attr_playback_state
             self._attr_playback_state = state
+            if self.stream and self.stream.session:
+                if prev_state == PlaybackState.PLAYING and state != PlaybackState.PLAYING:
+                    self.stream.session.last_paused = time.time()
+                elif prev_state != PlaybackState.PLAYING and state == PlaybackState.PLAYING:
+                    if self.stream.session.last_paused is not None:
+                        pause_duration = time.time() - self.stream.session.last_paused
+                        self.stream.session.total_pause_time += pause_duration
+                        self.stream.session.last_paused = None
         if elapsed_time is not None:
             self._attr_elapsed_time = elapsed_time
             self._attr_elapsed_time_last_updated = time.time()

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -65,6 +65,8 @@ class AirPlayStreamSession:
         # because we reuse an existing stream session for new play_media requests,
         # we need to track when the last stream was started
         self.last_stream_started: float = 0.0
+        self.total_pause_time: float = 0.0
+        self.last_paused: float | None = None
         self._clients_ready = asyncio.Event()
         self._first_chunk_received = asyncio.Event()
 
@@ -206,6 +208,8 @@ class AirPlayStreamSession:
             old_audio_source_task.cancel()
             self._audio_source_task = new_audio_source_task
         self.last_stream_started = time.time() + self.wait_start
+        self.total_pause_time = 0.0
+        self.last_paused = None
         for sync_client in self.sync_clients:
             sync_client.set_state_from_stream(state=None, elapsed_time=0)
         # ensure we cleanly wait for the old audio source task to finish

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -458,13 +458,20 @@ class SqueezelitePlayer(Player):
 
     def _handle_player_heartbeat(self) -> None:
         """Process SlimClient elapsed_time update."""
-        if self.client.state == SlimPlayerState.STOPPED:
+        if self.client.state in (SlimPlayerState.STOPPED, SlimPlayerState.PAUSED):
             # ignore server heartbeats when stopped
+            # Some players keep sending heartbeat with increasing elapsed time
+            # even when paused (e.g. WiiM)
             return
         # elapsed time change on the player will be auto picked up
         # by the player manager.
         self._attr_elapsed_time = self.client.elapsed_seconds
         self._attr_elapsed_time_last_updated = time.time()
+        self.logger.debug(
+            "Squeezelite player heartbeat: state %s, elapsed_time=%s",
+            self.client.state,
+            self._attr_elapsed_time,
+        )
 
         # handle sync
         if self.synced_to:

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -464,9 +464,8 @@ class SqueezelitePlayer(Player):
 
     def _handle_player_heartbeat(self) -> None:
         """Process SlimClient elapsed_time update."""
-        # if self.client.state in (SlimPlayerState.STOPPED, SlimPlayerState.PAUSED):
         if self.playback_state != PlaybackState.PLAYING:
-            # ignore server heartbeats when stopped
+            # ignore server heartbeats when not playing
             # Some players keep sending heartbeat with increasing elapsed time
             # even when paused (e.g. WiiM)
             return
@@ -478,10 +477,6 @@ class SqueezelitePlayer(Player):
         # handle sync
         if self.synced_to:
             self._handle_sync()
-
-        # update state to notify player queue controller of elapsed time change
-        # this is critical for flow mode to correctly transition between tracks
-        self.update_state()
 
     async def _handle_buffer_ready(self) -> None:
         """

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -369,6 +369,7 @@ class SqueezelitePlayer(Player):
         self._attr_available = self.client.connected
         self._attr_name = self.client.name
         self._attr_powered = self.client.powered
+        old_state = self._attr_playback_state
         self._attr_playback_state = STATE_MAP[self.client.state]
         self._attr_volume_level = self.client.volume_level
         self._attr_volume_muted = self.client.muted
@@ -377,8 +378,13 @@ class SqueezelitePlayer(Player):
             ip_address=self.client.device_address,
             manufacturer=self.client.device_type,
         )
-        self._attr_elapsed_time = self.client.elapsed_seconds
-        self._attr_elapsed_time_last_updated = time.time()
+        if (
+            old_state != PlaybackState.PLAYING
+            and self._attr_playback_state == PlaybackState.PLAYING
+        ):
+            # Invalidate elapsed time interpolation to avoid jumps when resuming from pause/stop
+            # We need this because some players (e.g. WiiM) keep sending increasing elapsed time
+            self._attr_elapsed_time_last_updated = time.time()
         # Update current media if available
         if self.client.current_media and (metadata := self.client.current_media.metadata):
             self._attr_current_media = PlayerMedia(
@@ -458,24 +464,24 @@ class SqueezelitePlayer(Player):
 
     def _handle_player_heartbeat(self) -> None:
         """Process SlimClient elapsed_time update."""
-        if self.client.state in (SlimPlayerState.STOPPED, SlimPlayerState.PAUSED):
+        # if self.client.state in (SlimPlayerState.STOPPED, SlimPlayerState.PAUSED):
+        if self.playback_state != PlaybackState.PLAYING:
             # ignore server heartbeats when stopped
             # Some players keep sending heartbeat with increasing elapsed time
             # even when paused (e.g. WiiM)
             return
         # elapsed time change on the player will be auto picked up
         # by the player manager.
-        self._attr_elapsed_time = self.client.elapsed_seconds
+        self._attr_elapsed_time = self.client._elapsed_milliseconds / 1000
         self._attr_elapsed_time_last_updated = time.time()
-        self.logger.debug(
-            "Squeezelite player heartbeat: state %s, elapsed_time=%s",
-            self.client.state,
-            self._attr_elapsed_time,
-        )
 
         # handle sync
         if self.synced_to:
             self._handle_sync()
+
+        # update state to notify player queue controller of elapsed time change
+        # this is critical for flow mode to correctly transition between tracks
+        self.update_state()
 
     async def _handle_buffer_ready(self) -> None:
         """

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -471,7 +471,7 @@ class SqueezelitePlayer(Player):
             return
         # elapsed time change on the player will be auto picked up
         # by the player manager.
-        self._attr_elapsed_time = self.client._elapsed_milliseconds / 1000
+        self._attr_elapsed_time = self.client.elapsed_seconds
         self._attr_elapsed_time_last_updated = time.time()
 
         # handle sync


### PR DESCRIPTION
This PR fixes a couple of issues that caused progress bar jumps and overflows:
- Clearing the playlog on a stream restart avoids duplicates in the playlog. This caused the overflow to happen in flow mode
- Send the server side 'elapsed_time_updated_at' as part of the QUEUE_TIME_UPDATED event ensures the frontend can accurately extrapolate elapsed_time. This avoids different elapsed_time with multiple browser open. [See Discord](https://discord.com/channels/753947050995089438/1458038874100994129)
- Pausing in Airplay caused the elapsed time to continue anyway. We now count the pause time to tackle this
- Pausing in Sqeezelite causes weird jumps because of inaccurate elapsed_time reported by some players. We now guard for this. 

Depends on PRs, will bump the frontend after its been merged:
- Frontend: https://github.com/music-assistant/frontend/pull/1364