### PR TITLE
Pin `av` to 16.1.0 for sendspin provider

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin==2.0.0"],
+  "requirements": ["aiosendspin==2.0.0", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -20,6 +20,7 @@ alexapy==1.29.10
 async-upnp-client==0.46.0
 audible==0.10.0
 auntie-sounds==1.1.7
+av==16.1.0
 awesomeversion>=24.6.0
 bidict==0.23.1
 certifi==2025.11.12


### PR DESCRIPTION
Pins PyAV to 16.1.0 to match the pre-built wheel in the base image. Without this pin, aiosendspin's `av>=16.0.0` constraint could resolve to a different version after av updates, causing Docker build failures.