### PR TITLE
Fix content type for Sqeezelite multiclient streams

### DIFF
--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -18,6 +18,7 @@ from aioslimproto.models import VisualisationType as SlimVisualisationType
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import (
     ConfigEntryType,
+    ContentType,
     PlaybackState,
     PlayerFeature,
     PlayerType,
@@ -34,7 +35,6 @@ from music_assistant.constants import (
     CONF_ENTRY_OUTPUT_CODEC,
     CONF_ENTRY_SUPPORT_GAPLESS_DIFFERENT_SAMPLE_RATES,
     CONF_ENTRY_SYNC_ADJUST,
-    INTERNAL_PCM_FORMAT,
     VERBOSE_LOG_LEVEL,
     create_sample_rates_config_entry,
 )
@@ -243,7 +243,7 @@ class SqueezelitePlayer(Player):
         # this is a syncgroup, we need to handle this with a multi client stream
         # Use a fixed 96kHz/24-bit format for syncgroup playback
         master_audio_format = AudioFormat(
-            content_type=INTERNAL_PCM_FORMAT.content_type,
+            content_type=ContentType.PCM_S24LE,
             sample_rate=96000,
             bit_depth=24,
             channels=2,

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -18,7 +18,6 @@ from aioslimproto.models import VisualisationType as SlimVisualisationType
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import (
     ConfigEntryType,
-    ContentType,
     PlaybackState,
     PlayerFeature,
     PlayerType,
@@ -35,6 +34,7 @@ from music_assistant.constants import (
     CONF_ENTRY_OUTPUT_CODEC,
     CONF_ENTRY_SUPPORT_GAPLESS_DIFFERENT_SAMPLE_RATES,
     CONF_ENTRY_SYNC_ADJUST,
+    INTERNAL_PCM_FORMAT,
     VERBOSE_LOG_LEVEL,
     create_sample_rates_config_entry,
 )
@@ -243,9 +243,9 @@ class SqueezelitePlayer(Player):
         # this is a syncgroup, we need to handle this with a multi client stream
         # Use a fixed 96kHz/24-bit format for syncgroup playback
         master_audio_format = AudioFormat(
-            content_type=ContentType.PCM_S24LE,
+            content_type=INTERNAL_PCM_FORMAT.content_type,
             sample_rate=96000,
-            bit_depth=24,
+            bit_depth=INTERNAL_PCM_FORMAT.bit_depth,
             channels=2,
         )
 


### PR DESCRIPTION
Incorrect content type caused the calculations for track time to be off, causing overflow. This PR fixes that.

Fixes:
- https://github.com/music-assistant/support/issues/4597