### PR TITLE
Make pre-commit configuration cross-platform compatible using uv

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for all text files
+* text=auto eol=lf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,102 +1,119 @@
 repos:
   - repo: local
     hooks:
+      # gen_requirements_all modifies files so it has to be first
+      - id: gen_requirements_all
+        name: gen_requirements_all
+        entry: uv run -m scripts.gen_requirements_all
+        pass_filenames: false
+        language: system
+        types: [text]
+        files: ^(music_assistant/.+/manifest\.json|pyproject\.toml|\.pre-commit-config\.yaml|scripts/gen_requirements_all\.py)$
+
       - id: ruff-check
         name: 🐶 Ruff Linter
         language: system
         types: [python]
-        entry: scripts/run-in-env.sh ruff check --fix
+        entry: uv run ruff check --fix
         require_serial: true
         stages: [pre-commit, pre-push, manual]
+
       - id: ruff-format
         name: 🐶 Ruff Formatter
         language: system
         types: [python]
-        entry: scripts/run-in-env.sh ruff format
+        entry: uv run ruff format
         require_serial: true
         stages: [pre-commit, pre-push, manual]
+
       - id: check-ast
         name: 🐍 Check Python AST
         language: system
         types: [python]
-        entry: scripts/run-in-env.sh check-ast
+        entry: uv run check-ast
+
       - id: check-case-conflict
         name: 🔠 Check for case conflicts
         language: system
-        entry: scripts/run-in-env.sh check-case-conflict
+        entry: uv run check-case-conflict
+
       - id: check-docstring-first
         name: ℹ️  Check docstring is first
         language: system
         types: [python]
-        entry: scripts/run-in-env.sh check-docstring-first
+        entry: uv run check-docstring-first
+
       - id: check-executables-have-shebangs
         name: 🧐 Check that executables have shebangs
         language: system
         types: [text, executable]
-        entry: scripts/run-in-env.sh check-executables-have-shebangs
+        entry: uv run check-executables-have-shebangs
         stages: [pre-commit, pre-push, manual]
+
       - id: check-json
         name: ｛ Check JSON files
         language: system
         types: [json]
-        entry: scripts/run-in-env.sh check-json
+        entry: uv run check-json
         files: ^(music_assistant/.+/manifest\.json)|(tests/providers/.+/fixtures/.+\.json)$
+
       - id: check-merge-conflict
         name: 💥 Check for merge conflicts
         language: system
         types: [text]
-        entry: scripts/run-in-env.sh check-merge-conflict
+        entry: uv run check-merge-conflict
+
       - id: check-symlinks
         name: 🔗 Check for broken symlinks
         language: system
         types: [symlink]
-        entry: scripts/run-in-env.sh check-symlinks
+        entry: uv run check-symlinks
+
       - id: check-toml
         name: ✅ Check TOML files
         language: system
         types: [toml]
-        entry: scripts/run-in-env.sh check-toml
+        entry: uv run check-toml
+
       - id: codespell
         name: ✅ Check code for common misspellings
         language: system
         types: [text]
-        entry: scripts/run-in-env.sh codespell
+        entry: uv run codespell
+
       - id: detect-private-key
-        name: 🕵️  Detect Private Keys
+        name: 🕵️ Detect Private Keys
         language: system
         types: [text]
-        entry: scripts/run-in-env.sh detect-private-key
+        entry: uv run detect-private-key
+
       - id: end-of-file-fixer
-        name: ⮐  Fix End of Files
+        name: ⮐ Fix End of Files
         language: system
         types: [text]
-        entry: scripts/run-in-env.sh end-of-file-fixer
+        entry: uv run end-of-file-fixer
         stages: [pre-commit, pre-push, manual]
+
       - id: no-commit-to-branch
         name: 🛑 Don't commit to stable branch
         language: system
-        entry: scripts/run-in-env.sh no-commit-to-branch
+        entry: uv run no-commit-to-branch
         pass_filenames: false
         always_run: true
         args:
           - --branch=stable
+
       - id: trailing-whitespace
-        name: ✄  Trim Trailing Whitespace
+        name: ✄ Trim Trailing Whitespace
         language: system
         types: [text]
-        entry: scripts/run-in-env.sh trailing-whitespace-fixer
+        entry: uv run trailing-whitespace-fixer
         stages: [pre-commit, pre-push, manual]
+
       - id: mypy
         name: mypy
-        entry: scripts/run-in-env.sh mypy
-        language: script
+        entry: uv run mypy
+        language: system
         types: [python]
         require_serial: true
         pass_filenames: false
-      - id: gen_requirements_all
-        name: gen_requirements_all
-        entry: scripts/run-in-env.sh python3 -m scripts.gen_requirements_all
-        pass_filenames: false
-        language: script
-        types: [text]
-        files: ^(music_assistant/.+/manifest\.json|pyproject\.toml|\.pre-commit-config\.yaml|scripts/gen_requirements_all\.py)$

--- a/scripts/gen_requirements_all.py
+++ b/scripts/gen_requirements_all.py
@@ -80,7 +80,8 @@ def main() -> int:
     for req_key in sorted(final_requirements):
         req_str = final_requirements[req_key]
         content += f"{req_str}\n"
-    Path("requirements_all.txt").write_text(content)
+    # Always use LF line endings for cross-platform compatibility
+    Path("requirements_all.txt").write_text(content, newline="\n")
 
     return 0
 


### PR DESCRIPTION
This PR updates the pre-commit configuration with minimal changes to work consistently on both Linux and Windows, replacing shell script wrappers with direct `uv run` commands and ensuring proper line ending handling.
This PR is based on the digressions part of https://github.com/music-assistant/server/pull/2871

Music Assistant Server **can** be developed on Windows, or, should I say, on any OS. But there are caveats that can be easily fixed
  - The pre-commit config uses `scripts/run-in-env.sh`. This is unneeded due to `uv`. `uv run pre-commit run` executes the same calls but on any OS.
  - The pre-commit config uses `python3 -m ...` which should also be substituted by `uv run -m ...`
  - (Optional) Many pre-commit checks can be replaced with the "official" ones from [uv](https://github.com/astral-sh/uv-pre-commit), [ruff](https://github.com/astral-sh/ruff-pre-commit), [pre-commit](https://github.com/pre-commit/pre-commit-hooks), [mypy](https://github.com/pre-commit/mirrors-mypy).
  - In pre-commit fixes, the end of lines is taken from the system. It should be fixed as `LF` in `pyproject.toml` and `.gitattributes` to allow for development on any OS.
  - WSL2 is not needed to either develop or test the project. Everything I tested works natively on Windows.


__Changes:__

1. __`.gitattributes`__ (new file):

   - Added `* text=auto eol=lf` to enforce LF line endings for all text files across platforms to ensure LF endings on the git client's side
   - This file does not prevent `requirements_all.txt` from showing as modified on Windows due to CRLF conversion, as `gen_requirements_all` is responsible for the endings

2. __`.pre-commit-config.yaml`__:

   - Replaced `scripts/run-in-env.sh <command>` with `uv run <command>` for all hooks to get rid of Linux Shell usage and for `uv` usage consistency.
   - Changed hook execution from `language: script` to `language: system` for `mypy` and `gen_requirements_all`
   - Reordered `gen_requirements_all` hook to run first as it modifies files.

3. __`scripts/gen_requirements_all.py`__:

   - Added explicit `newline="\n"` parameter to `Path.write_text()` to ensure LF line endings regardless of OS

__Benefits:__

- Pre-commit hooks work on Windows
- Pre-commit hooks work identically on Linux and Windows
- No more spurious diffs from line ending differences on Windows
- Simpler configuration using `uv` directly without wrapper scripts
