### PR TITLE
Fallback to stream.url if url_resolved is missing

### DIFF
--- a/music_assistant/providers/radiobrowser/__init__.py
+++ b/music_assistant/providers/radiobrowser/__init__.py
@@ -495,7 +495,7 @@ class RadioBrowserProvider(MusicProvider):
                 ),
                 media_type=MediaType.RADIO,
                 stream_type=StreamType.HTTP,
-                path=stream.url_resolved,
+                path=stream.url_resolved or stream.url,
                 can_seek=False,
                 allow_seek=False,
             )


### PR DESCRIPTION
Updated the RadioBrowserProvider to use stream.url as a fallback for the path if stream.url_resolved is not available. This ensures that a valid stream path is always provided and prevents those key errors people were talking about on discord

Fixes https://github.com/music-assistant/support/issues/4779