### PR TITLE
Do not report progress on ffmpeg streaming error 

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2484,6 +2484,13 @@ class PlayerQueuesController(CoreController):
             return
         assert media_item.uri is not None  # uri is set in __post_init__
 
+        if item_to_report.streamdetails and item_to_report.streamdetails.stream_error:
+            self.logger.debug(
+                "There was an error while streaming %s. Playback progress is not processed",
+                item_to_report.name,
+            )
+            return
+
         if item_to_report.streamdetails and item_to_report.streamdetails.duration:
             duration = int(item_to_report.streamdetails.duration)
         else:

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2485,10 +2485,7 @@ class PlayerQueuesController(CoreController):
         assert media_item.uri is not None  # uri is set in __post_init__
 
         if item_to_report.streamdetails and item_to_report.streamdetails.stream_error:
-            self.logger.debug(
-                "There was an error while streaming %s. Playback progress is not processed",
-                item_to_report.name,
-            )
+            #  Ignore items that had a stream error
             return
 
         if item_to_report.streamdetails and item_to_report.streamdetails.duration:


### PR DESCRIPTION
Related to music-assistant/support#4754

This should prevent progress reporting if ffmpeg reports an error while streaming. What the actual problem in music-assistant/support#4754 is, is still not clear to me.