### PR TITLE
fix(spotify_connect): ignore trailing sink event to prevent playback thrashing

### DIFF
--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -755,6 +755,14 @@ class SpotifyConnectProvider(PluginProvider):
         # this player has become the active spotify connect player
         # we need to start the playback
         if event_name in ("sink", "playing") and (not self._source_details.in_use_by):
+
+            # If we receive a 'sink' event but we are not officially connected
+            # (i.e. we just disconnected), ignore it to prevent accidental
+            # re-activation of this player (trailing event from dying session).
+            if event_name == "sink" and not self._connected_spotify_username:
+                self.logger.debug("Ignoring trailing sink event while disconnected")
+                return Response()
+
             # Check for matching Spotify provider now that playback is starting
             # This ensures the Spotify music provider has had time to initialize
             if not self._connected_spotify_username or not self._spotify_provider:

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -755,7 +755,6 @@ class SpotifyConnectProvider(PluginProvider):
         # this player has become the active spotify connect player
         # we need to start the playback
         if event_name in ("sink", "playing") and (not self._source_details.in_use_by):
-
             # If we receive a 'sink' event but we are not officially connected
             # (i.e. we just disconnected), ignore it to prevent accidental
             # re-activation of this player (trailing event from dying session).


### PR DESCRIPTION
### Description

Fixes a race condition when switching Spotify Connect players.

When a session disconnects, the `librespot` daemon appears to emit a trailing `sink` event (buffer flush) after the `session_disconnected` event. Currently, the disconnect handler clears the `in_use_by` state immediately on disconnect. Consequently, the `_handle_custom_webservice` logic misinterprets the trailing `sink` event as a fresh playback request and calls `select_source` on the disconnecting player.

This results in session thrashing where the old player attempts to steal the session back from the new target player.

### Fix
Added a guard clause to ignore `sink` events if `_connected_spotify_username` is not set.

### Logs

**Before (Bug behavior):**

The trailing `sink` event triggers a playback restart on the disconnecting player (`e0:8c...`), creating a conflict with the new playback request on the target player (`1c:db...`).

```text
2026-01-15 14:44:19.488 INFO Spotify Connect session disconnected
2026-01-15 14:44:19.488 DEBUG Playback ended on player 1c:db:d4:77:cc:ec, clearing active player
# State cleared (in_use_by = None)

2026-01-15 14:44:19.557 DEBUG Received metadata on webservice ... {'event': 'sink'}
# Bug: Misinterpreted as new playback request because in_use_by is None

2026-01-15 14:44:19.640 INFO Starting Spotify Connect playback ... on player 1c:db:d4:77:cc:ec
# ❌ CONFLICT: Old player re-activates immediately
```

**After (With fix):**

The trailing sink event is correctly identified and ignored. The disconnecting player remains stopped, allowing the new player (1c:db...) to acquire the session cleanly.

```
2026-01-15 15:06:00.557 INFO Spotify Connect session disconnected
2026-01-15 15:06:00.557 DEBUG Playback ended on player e0:8c:fe:6b:22:44, clearing active player

2026-01-15 15:06:00.576 DEBUG Received metadata on webservice ... {'event': 'sink'}

2026-01-15 15:06:00.577 DEBUG Ignoring trailing sink event while disconnected
# ✅ SUCCESS: Event ignored, no playback command issued

2026-01-15 15:06:00.730 INFO Starting Spotify Connect playback ... on player 1c:db:d4:77:cc:ec
# Handoff proceeds without conflict
```