### PR TITLE
Add album scanning to periodic metadata refresh

### DIFF
--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -43,6 +43,7 @@ from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import (
     CONF_LANGUAGE,
+    DB_TABLE_ALBUMS,
     DB_TABLE_ARTISTS,
     DB_TABLE_PLAYLISTS,
     VARIOUS_ARTISTS_MBID,
@@ -981,6 +982,20 @@ class MetaDataController(CoreController):
         ):
             if artist.uri:
                 self.schedule_update_metadata(artist.uri)
+            await asyncio.sleep(30)
+
+        # Scan for missing album images
+        self.logger.debug("Start lookup for missing album images...")
+        query = (
+            f"json_extract({DB_TABLE_ALBUMS}.metadata,'$.last_refresh') ISNULL "
+            f"AND (json_extract({DB_TABLE_ALBUMS}.metadata,'$.images') ISNULL "
+            f"OR json_extract({DB_TABLE_ALBUMS}.metadata,'$.images') = '[]')"
+        )
+        for album in await self.mass.music.albums.get_library_items_by_query(
+            limit=5, order_by="random", extra_query_parts=[query]
+        ):
+            if album.uri:
+                self.schedule_update_metadata(album.uri)
             await asyncio.sleep(30)
 
         # Force refresh playlist metadata every refresh interval


### PR DESCRIPTION
## Summary

Albums were excluded from the periodic metadata scan in `_scan_missing_metadata()`, causing albums added via playlist tracks (as ItemMappings) to never receive cover artwork automatically.

This adds album scanning alongside the existing artist and playlist scans, using the same pattern and rate limits.

## Changes

- Added `DB_TABLE_ALBUMS` import to constants
- Added album scan block in `_scan_missing_metadata()` between artist and playlist scans
- Uses same parameters as existing scans: `limit=5`, `order_by="random"`, `asyncio.sleep(30)`

## Test plan

- [x] Tested on Music Assistant v2.7.3 Docker instance
- [x] Tested on Music Assistant v2.8.0.dev Docker instance  
- [x] Verified albums without images are detected and scheduled for metadata refresh
- [x] Confirmed album artwork is fetched after periodic scan runs

Fixes: music-assistant/support#4787