### PR TITLE
When the DI webserver replies 403, try the next URL in the list before giving up

### DIFF
--- a/music_assistant/providers/digitally_incorporated/__init__.py
+++ b/music_assistant/providers/digitally_incorporated/__init__.py
@@ -634,16 +634,49 @@ class DigitallyIncorporatedProvider(MusicProvider):
             for i, url in enumerate(playlist):
                 self.logger.debug("%s: Available stream URL %d: %s", self.domain, i + 1, url)
 
-            # Use the first URL - Digitally Incorporated typically returns them in priority order
-            stream_url: str = str(playlist[0])
-            self.logger.debug("%s: Selected stream URL: %s", self.domain, stream_url)
-
-            # Validate the stream URL
-            if not stream_url or not isinstance(stream_url, str):
-                msg = f"{self.domain}: Invalid stream URL received: {stream_url}"
+            # Try each URL until one responds without 403 (forbidden)
+            candidate_urls = [str(url) for url in playlist if isinstance(url, str) and str(url).strip()]
+            if not candidate_urls:
+                msg = f"{self.domain}: No valid stream URLs received from Digitally Incorporated API"
                 raise MediaNotFoundError(msg)
 
-            return stream_url
+            total_candidates = len(candidate_urls)
+            for idx, stream_url in enumerate(candidate_urls, start=1):
+                try:
+                    timeout = aiohttp.ClientTimeout(total=10)
+                    async with self.mass.http_session.head(
+                        stream_url, allow_redirects=True, timeout=timeout
+                    ) as resp:
+                        if resp.status == 403:
+                            self.logger.warning(
+                                "%s: Stream URL %s returned 403 (candidate %d/%d), trying next",
+                                self.domain,
+                                stream_url,
+                                idx,
+                                total_candidates,
+                            )
+                            continue
+                        resp.raise_for_status()
+                        self.logger.debug(
+                            "%s: Selected stream URL %d/%d: %s",
+                            self.domain,
+                            idx,
+                            total_candidates,
+                            stream_url,
+                        )
+                        return stream_url
+
+                except aiohttp.ClientError as err:
+                    self.logger.debug(
+                        "%s: Stream URL %s check failed (%s), trying next",
+                        self.domain,
+                        stream_url,
+                        err,
+                    )
+                    continue
+
+            msg = f"{self.domain}: Unable to get working stream URL after {total_candidates} attempts"
+            raise MediaNotFoundError(msg)
 
         except (ProviderUnavailableError, MediaNotFoundError):
             # Re-raise provider/media errors as-is (they already have domain prefix)


### PR DESCRIPTION
Example log:

```
2026-01-16 17:57:56.856 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Digitally Incorporated playlist returned 3 URLs
2026-01-16 17:57:56.856 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Available stream URL 1: http://prem2.classicalradio.com:80/bach?<<PLAYER_KEY>>
2026-01-16 17:57:56.856 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Available stream URL 2: http://prem4.classicalradio.com:80/bach?<<PLAYER_KEY>>
2026-01-16 17:57:56.856 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Available stream URL 3: http://prem1.classicalradio.com:80/bach?<<PLAYER_KEY>>
2026-01-16 17:57:57.036 WARNING (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Stream URL http://prem2.classicalradio.com:80/bach?<<PLAYER_KEY>> returned 403 (candidate 1/3), trying next
2026-01-16 17:57:57.054 DEBUG (MainThread) [aiosendspin.server.group] Sending server state to client ma_5ba8ksckpi
2026-01-16 17:57:57.054 DEBUG (MainThread) [aiosendspin.server.client.ma_5ba8ksckpi] Enqueueing message: ServerStateMessage
2026-01-16 17:57:57.221 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Selected stream URL 2/3: http://prem4.classicalradio.com:80/bach?<<PLAYER_KEY>>
2026-01-16 17:57:57.223 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Getting stream URL for classicalradio:bach
2026-01-16 17:57:57.242 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Digitally Incorporated playlist returned 3 URLs
2026-01-16 17:57:57.242 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Available stream URL 1: http://prem2.classicalradio.com:80/bach?<<PLAYER_KEY>>
2026-01-16 17:57:57.242 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Available stream URL 2: http://prem4.classicalradio.com:80/bach?<<PLAYER_KEY>>
2026-01-16 17:57:57.242 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Available stream URL 3: http://prem1.classicalradio.com:80/bach?<<PLAYER_KEY>>
2026-01-16 17:57:57.312 WARNING (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Stream URL http://prem2.classicalradio.com:80/bach?<<PLAYER_KEY>> returned 403 (candidate 1/3), trying next
2026-01-16 17:57:57.344 DEBUG (MainThread) [music_assistant.streams] stream aborted for digitally_incorporated://radio/classicalradio:21stcentury in 34.83 seconds - seconds streamed/buffered: 36.00
2026-01-16 17:57:57.483 DEBUG (MainThread) [music_assistant.digitally_incorporated] digitally_incorporated: Selected stream URL 2/3: http://prem4.classicalradio.com:80/bach?<<PLAYER_KEY>>
2026-01-16 17:57:57.737 DEBUG (MainThread) [music_assistant.audio] retrieved streamdetails for library://radio/254 in 1217 milliseconds
2026-01-16 17:57:57.842 DEBUG (MainThread) [music_assistant.players] Handling command play_media for player Web (Safari on Mac) (by user j.smith)
2026-01-16 17:57:57.843 DEBUG (MainThread) [music_assistant.sendspin.ma_5ba8ksckpi] Received PLAY_MEDIA command on player Web (Safari on Mac) with uri http://192.168.1.50:8097/single/K2M5DnN3/ma_5ba8ksckpi/9118d0aa43af4ca99b8db1f462457791.flac
2026-01-16 17:57:57.844 DEBUG (MainThread) [music_assistant.providers.sendspin.timed_client_stream] New subscriber joining: buffer is empty, starting at current_position=0.000s
2026-01-16 17:57:57.844 DEBUG (MainThread) [aiosendspin.server.group] Starting play_media with play_start_time_us=None
2026-01-16 17:57:57.844 INFO (MainThread) [aiosendspin.server.stream] Player ma_5ba8ksckpi assigned to main channel
2026-01-16 17:57:57.845 DEBUG (MainThread) [aiosendspin.server.group] Sending stream start message to client ma_5ba8ksckpi
2026-01-16 17:57:57.845 DEBUG (MainThread) [aiosendspin.server.client.ma_5ba8ksckpi] Enqueueing message: StreamStartMessage
2026-01-16 17:57:57.846 DEBUG (MainThread) [aiosendspin.server.client.ma_5ba8ksckpi] Enqueueing message: GroupUpdateServerMessage
2026-01-16 17:57:57.846 DEBUG (MainThread) [aiosendspin.server.client.ma_5ba8ksckpi] Enqueueing message: ServerStateMessage
2026-01-16 17:57:57.852 DEBUG (MainThread) [music_assistant.sendspin.ma_5ba8ksckpi] Received GroupEvent: GroupStateChangedEvent(state=<PlaybackStateType.PLAYING: 'playing'>)
2026-01-16 17:57:57.853 DEBUG (MainThread) [music_assistant.sendspin.ma_5ba8ksckpi] Group state changed to: PlaybackStateType.PLAYING
2026-01-16 17:57:57.860 DEBUG (MainThread) [music_assistant.streams] Starting queue item stream for Bach (digitally_incorporated://radio/classicalradio:bach) - using buffer: False - using fade-in: False - using volume normalization: fixed_gain
2026-01-16 17:57:57.898 DEBUG (MainThread) [music_assistant.audio.media_stream] Started media stream for digitally_incorporated://radio/classicalradio:bach - using streamtype: icy - pcm format: f32le - ffmpeg PID: 49696
2026-01-16 17:57:57.909 DEBUG (MainThread) [music_assistant.audio] Start streaming radio with ICY metadata from url http://prem4.classicalradio.com:80/bach?<<PLAYER_KEY>>
2026-01-16 17:57:58.279 DEBUG (MainThread) [music_assistant.audio.media_stream] First chunk received after 0.38 seconds (codec detected: mp3)
2026-01-16 17:57:58.279 DEBUG (MainThread) [music_assistant.streams] First audio chunk received for Bach (digitally_incorporated://radio/classicalradio:bach) after 0.42 seconds
```

Patch written by Codex and then read by me and adjusted again with Codex.