### PR TITLE
fix(spotify_connect): reload provider on broken pipe errors

### DIFF
--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -606,6 +606,19 @@ class SpotifyConnectProvider(PluginProvider):
             and "Using StdoutSink (pipe) with format: S16" in line
         ):
             self._librespot_started.set()
+
+        # Librespot catches "Broken pipe" errors (os error 32) and transitions to
+        # Paused state without exiting. We must forcibly close it to trigger restart.
+        if "Broken pipe (os error 32)" in line:
+            self.logger.debug("[%s] %s", self.name, line)
+            self.logger.error(
+                "Librespot output pipe is broken (Zombie State). Restarting process..."
+            )
+            if self._librespot_proc:
+                # self._librespot_proc.close() is too polite; we don't end up restarting.
+                self.mass.create_task(self.mass.load_provider_config(self.config))
+            return
+
         if "error sending packet Os" in line:
             return
         if "dropping truncated packet" in line:


### PR DESCRIPTION
### Description
This PR fixes a "Zombie Process" issue where the `librespot` binary remains running but non-functional after a Broken Pipe (os error 32) event.

**The Fix:**
I have extended the stderr processor to trap this specific fatal error. When detected, the provider now triggers a self-reload via `self.mass.load_provider_config(self.config)`.

### Motivation and Context
* **The Problem:** `librespot` handles output pipe errors by pausing rather than crashing ("Sticky Sink"). Music Assistant sees the process as healthy (PID exists), but the named pipe to FFmpeg is permanently broken.
* **Why Reload?** Standard restart logic failed because `librespot` handles `SIGTERM` gracefully and exits with `Code 0`. Music Assistant interprets `Exit 0` as a user-initiated stop and **does not** restart the provider.
* **The Solution:** Triggering `load_provider_config` forces a complete unload/load cycle, ensuring the broken pipe and zombie process are cleaned up and a fresh session is established.

### Steps to Reproduce
1. Start playback on a Spotify Connect player.
2. On the host machine (outside the container), identify the ffmpeg process ID:
   `docker top music_assistant | grep ffmpeg`
3. Kill the process ID (PID) found in the previous step to force the pipe break:
   `kill <PID>`
4. Observe logs and player state.

### Verification

**1. Original Failure Mode (Zombie State)**
*The error occurs, the player pauses, and remains unavailable indefinitely. The process does not exit.*

```
2026-01-19 20:59:12.802 ERROR [librespot_core::session] Broken pipe (os error 32)
2026-01-19 20:59:13.843 DEBUG Spotify Connect paused, releasing player UI state...

# ... Process remains active (PID exists) but audio is permanently broken ...
```

**2. With Fix (Provider reload)**
*The error is detected immediately, the provider reloads, and the player becomes available again.*

```
2026-01-19 22:24:00.424 DEBUG [music_assistant.spotify_connect] [Spotify Connect [None]] [2026-01-19T22:24:00Z ERROR librespot_playback::player] Audio Sink Error On Write: <StdoutSink> Broken pipe (os error 32)
2026-01-19 22:24:00.424 ERROR (MainThread) [music_assistant.spotify_connect] Librespot output pipe is broken (Zombie State). Restarting process...
# ... Provider unloads and restarts, user is able to restart playback ...
2026-01-19 22:24:01.470 DEBUG (MainThread) [music_assistant.spotify_connect] Authenticated to Spotify as: prydie
2026-01-19 22:24:15.286 DEBUG (MainThread) [music_assistant.spotify_connect] Session connected event - username from event: prydie
```

*Note: Playback stops when the pipe breaks. Once the provider reloads (approx. 15s), the user must manually re-select the device/press play to resume, but a container restart is no longer required.*

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)