### PR TITLE
SyncGroupPlayer: Inherit MULTI_DEVICE_DSP feature from group members

### DIFF
--- a/music_assistant/controllers/players/sync_groups.py
+++ b/music_assistant/controllers/players/sync_groups.py
@@ -113,14 +113,14 @@ class SyncGroupPlayer(GroupPlayer):
     def supported_features(self) -> set[PlayerFeature]:
         """Return the supported features of the player."""
         members = self.group_members
-        p: Player | None = self.sync_leader or (
+        reference_player: Player | None = self.sync_leader or (
             self.mass.players.get(members[0]) if members else None
         )
-        if p:
+        if reference_player:
             base_features = self._attr_supported_features.copy()
             # add features supported by the sync leader
             for feature in OPTIONAL_FEATURES:
-                if feature in p.supported_features:
+                if feature in reference_player.supported_features:
                     base_features.add(feature)
             return base_features
         return self._attr_supported_features

--- a/music_assistant/controllers/players/sync_groups.py
+++ b/music_assistant/controllers/players/sync_groups.py
@@ -65,6 +65,7 @@ OPTIONAL_FEATURES = {
     PlayerFeature.SEEK,
     PlayerFeature.SELECT_SOURCE,
     PlayerFeature.VOLUME_MUTE,
+    PlayerFeature.MULTI_DEVICE_DSP,
 }
 
 
@@ -111,11 +112,15 @@ class SyncGroupPlayer(GroupPlayer):
     @property
     def supported_features(self) -> set[PlayerFeature]:
         """Return the supported features of the player."""
-        if self.sync_leader:
+        members = self.group_members
+        p: Player | None = self.sync_leader or (
+            self.mass.players.get(members[0]) if members else None
+        )
+        if p:
             base_features = self._attr_supported_features.copy()
             # add features supported by the sync leader
             for feature in OPTIONAL_FEATURES:
-                if feature in self.sync_leader.supported_features:
+                if feature in p.supported_features:
                     base_features.add(feature)
             return base_features
         return self._attr_supported_features


### PR DESCRIPTION
1. Add `PlayerFeature.MULTI_DEVICE_DSP` to `OPTIONAL_FEATURES` of `SyncGroupPlayer` so the feature is inherited from its group member players.
2. Allow reading supported features of a `SyncGroupPlayer` even when it is powered off (and therefore has no group leader yet) by inheriting supported features from the first player in its `group_members` list.
