### PR TITLE
Fix group volume mute in Sendspin provider

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -358,11 +358,16 @@ class SendspinPlayer(Player):
 
     async def volume_mute(self, muted: bool) -> None:
         """Handle VOLUME MUTE command on the player."""
-        if player_client := self.api.player:
-            if muted:
-                player_client.mute()
-            else:
-                player_client.unmute()
+        if self.synced_to is not None:
+            # This player is a group member — mute only this player
+            if player_client := self.api.player:
+                if muted:
+                    player_client.mute()
+                else:
+                    player_client.unmute()
+        else:
+            # This player is the leader (or solo) — mute the entire group
+            self.api.group.set_mute(muted)
 
     async def stop(self) -> None:
         """Stop command."""


### PR DESCRIPTION
## Summary
- Fix `volume_mute()` to propagate mute to all group members when called on the group leader
- Use `group.set_mute()` for leader/solo players (distributes to all members via aiosendspin)
- Use per-player `player.mute()`/`player.unmute()` for individual group members (`synced_to is not None`)

## Problem
When MA mutes a grouped player, `cmd_volume_mute()` calls `volume_mute()` on the leader only. The previous implementation called `player.mute()` which is per-player — only the leader was muted, other group members were unaffected.

## Fix
Check `self.synced_to` to distinguish the group leader from a member:
- **Leader or solo** (`synced_to is None`): call `group.set_mute(muted)` which iterates all players in the aiosendspin group
- **Group member** (`synced_to is not None`): call `player.mute()`/`player.unmute()` for individual control

## Test plan
- [x] Unit test with aiosendspin: 4 players grouped, `group.set_mute(True)` reaches all 4, `player.mute()` reaches only 1
- [x] End-to-end test: patched nightly Docker image with 4 Sendspin SDK clients — group mute/unmute works, individual member mute works

🤖 Generated with [Claude Code](https://claude.com/claude-code)