### PR TITLE
Fix IndexError when Deezer track has no media available

### DIFF
--- a/music_assistant/providers/deezer/gw_client.py
+++ b/music_assistant/providers/deezer/gw_client.py
@@ -10,6 +10,7 @@ from http.cookies import BaseCookie, Morsel
 from typing import Any, cast
 
 from aiohttp import ClientSession, ClientTimeout
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.streamdetails import StreamDetails
 from yarl import URL
 
@@ -166,7 +167,11 @@ class GWClient:
             msg = "Received an error from API"
             raise DeezerGWError(msg, error)
 
-        return result_json["data"][0]["media"][0], song_data
+        media_list = result_json["data"][0].get("media", [])
+        if not media_list:
+            raise MediaNotFoundError(f"No media available for track {track_id}")
+
+        return media_list[0], song_data
 
     async def log_listen(
         self, next_track: str | None = None, last_track: StreamDetails | None = None


### PR DESCRIPTION
## Summary
- Raise `MediaNotFoundError` instead of crashing with `IndexError` when the Deezer API returns an empty media list
- This allows the player queue to gracefully skip unavailable tracks instead of stopping playback

## Test plan
- Tested locally by patching Music Assistant server
- Playback now skips unavailable tracks with a warning: `Skipping unplayable item...`

Fixes music-assistant/support#4860