### PR TITLE
Use streams server bind ip as spotify connect zeroconf bind interface

### DIFF
--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -678,6 +678,9 @@ class SpotifyConnectProvider(PluginProvider):
                 str(EVENTS_SCRIPT),
                 "--emit-sink-events",
             ]
+            bind_ip = self.mass.streams.bind_ip
+            if bind_ip and bind_ip != "0.0.0.0":
+                args.extend(["--zeroconf-interface", bind_ip])
             self._librespot_proc = librespot = AsyncProcess(
                 args, stdout=False, stderr=True, name=f"librespot[{self.name}]", env=env
             )


### PR DESCRIPTION
Bind librespot's zeroconf interface to the stream server's bind ip to make it discoverable.

Fixes: https://github.com/music-assistant/support/issues/3987