### PR TITLE
Fix deprecation warnings for asyncio.iscoroutinefunction

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import html
+import inspect
 import os
 import urllib.parse
 from collections.abc import Awaitable, Callable
@@ -574,7 +575,7 @@ class WebserverController(CoreController):
             if hasattr(result, "__anext__"):
                 # handle async generator (for really large listings)
                 result = [item async for item in result]
-            elif asyncio.iscoroutine(result):
+            elif inspect.iscoroutine(result):
                 result = await result
             return web.json_response(result, dumps=json_dumps)
         except Exception as e:

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from concurrent import futures
 from contextlib import suppress
@@ -238,7 +239,7 @@ class WebsocketClientHandler:
                         )
                         items = []
                 result = items
-            elif asyncio.iscoroutine(result):
+            elif inspect.iscoroutine(result):
                 result = await result
             await self._send_message(SuccessResultMessage(msg.message_id, result))
         except Exception as err:

--- a/music_assistant/helpers/logging.py
+++ b/music_assistant/helpers/logging.py
@@ -9,7 +9,6 @@ All rights reserved.
 
 from __future__ import annotations
 
-import asyncio
 import inspect
 import logging
 import logging.handlers
@@ -130,7 +129,7 @@ def catch_log_exception(
         check_func = check_func.func
 
     wrapper_func: Callable[..., None] | Callable[..., Coroutine[Any, Any, None]]
-    if asyncio.iscoroutinefunction(check_func):
+    if inspect.iscoroutinefunction(check_func):
         async_func = cast("Callable[..., Coroutine[Any, Any, None]]", func)
 
         @wraps(async_func)

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import os
 import pathlib
@@ -412,7 +413,7 @@ class MusicAssistant:
                 continue
             if not (id_filter is None or object_id in id_filter):
                 continue
-            if asyncio.iscoroutinefunction(cb_func):
+            if inspect.iscoroutinefunction(cb_func):
                 if TYPE_CHECKING:
                     cb_func = cast("Callable[[MassEvent], Coroutine[Any, Any, None]]", cb_func)
                 self.create_task(cb_func, event_obj)
@@ -466,10 +467,10 @@ class MusicAssistant:
                 return existing
         self.verify_event_loop_thread("create_task")
 
-        if asyncio.iscoroutinefunction(target):
+        if inspect.iscoroutinefunction(target):
             # coroutine function
             task = self.loop.create_task(target(*args, **kwargs))
-        elif asyncio.iscoroutine(target):
+        elif inspect.iscoroutine(target):
             # coroutine
             task = self.loop.create_task(target)
         elif callable(target):
@@ -526,7 +527,7 @@ class MusicAssistant:
             self._tracked_timers.pop(task_id)
             self.create_task(_target, *args, task_id=task_id, abort_existing=True, **kwargs)
 
-        if asyncio.iscoroutinefunction(target) or asyncio.iscoroutine(target):
+        if inspect.iscoroutinefunction(target) or inspect.iscoroutine(target):
             # coroutine function
             if TYPE_CHECKING:
                 target = cast("Coroutine[Any, Any, _R]", target)

--- a/music_assistant/providers/snapcast/socket_server.py
+++ b/music_assistant/providers/snapcast/socket_server.py
@@ -7,6 +7,7 @@ and Music Assistant, avoiding the need to expose the WebSocket API to the contro
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 from contextlib import suppress
@@ -169,7 +170,7 @@ class SnapcastSocketServer:
 
         # Execute the handler
         result = handler.target(**args)
-        if asyncio.iscoroutine(result):
+        if inspect.iscoroutine(result):
             result = await result
         return result
 


### PR DESCRIPTION
Fix warnings such as
```
2026-01-29 15:19:44.335 WARNING (MainThread) [py.warnings] /Users/marvin/git/music-assistant/server/music_assistant/mass.py:416: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
  if asyncio.iscoroutinefunction(cb_func):
```