### PR TITLE
Remove legacy logic for radiobrowser item copying

### DIFF
--- a/music_assistant/providers/radiobrowser/__init__.py
+++ b/music_assistant/providers/radiobrowser/__init__.py
@@ -130,7 +130,6 @@ class RadioBrowserProvider(MusicProvider):
         except RadioBrowserError as err:
             raise ProviderUnavailableError(f"RadioBrowser API unavailable: {err}") from err
 
-
     @use_cache(3600 * 24 * 14)  # Cache for 14 days
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 10

--- a/music_assistant/providers/radiobrowser/__init__.py
+++ b/music_assistant/providers/radiobrowser/__init__.py
@@ -130,14 +130,6 @@ class RadioBrowserProvider(MusicProvider):
         except RadioBrowserError as err:
             raise ProviderUnavailableError(f"RadioBrowser API unavailable: {err}") from err
 
-        # copy the radiobrowser items that were added to the library
-        # TODO: remove this logic after version 2.3.0 or later
-        if not self.config.get_value(CONF_STORED_RADIOS) and self.mass.music.database:
-            async for db_row in self.mass.music.database.iter_items(
-                "provider_mappings",
-                {"media_type": "radio", "provider_domain": "radiobrowser"},
-            ):
-                await self.library_add(await self.get_radio(db_row["provider_item_id"]))
 
     @use_cache(3600 * 24 * 14)  # Cache for 14 days
     async def search(


### PR DESCRIPTION
Removed outdated logic for copying radiobrowser items added to the library, which is marked for removal after version 2.3.0.