### PR TITLE
Add album year from Deezer release_date

### DIFF
--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -622,6 +622,7 @@ class DeezerProvider(MusicProvider):
             provider=self.instance_id,
             name=name,
             version=version,
+            year=album.release_date.year if getattr(album, "release_date", None) else None,
             artists=UniqueList(
                 [
                     ItemMapping(


### PR DESCRIPTION
## Summary
- Parse `release_date` from Deezer API and populate album `year` field
- Uses safe access with `getattr()` for backwards compatibility

<img width="623" height="353" alt="image" src="https://github.com/user-attachments/assets/1d4bc200-05b5-459e-9209-73cd43903163" />


## Test plan
- [x] Tested locally on dev server
- [x] Verified year is saved to database
- [x] Verified year displays in UI for provider albums