### PR TITLE
Allow Emoji in folder names

### DIFF
--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -303,6 +303,11 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
         options.append(f"cache={cache_mode}")
 
         # Case insensitive by default (standard for SMB) and other performance options
+        # Note: We intentionally do NOT set iocharset=utf8 because the NLS framework
+        # is limited to 16-bit Unicode (U+FFFF max) and cannot handle emoji or other
+        # characters above the Basic Multilingual Plane. Without iocharset, CIFS uses
+        # its native Unicode handling which supports the full Unicode range including
+        # surrogate pairs (4-byte UTF-8 sequences like emoji).
         options.extend(
             [
                 "nocase",
@@ -310,7 +315,6 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
                 "dir_mode=0755",
                 "uid=0",
                 "gid=0",
-                "iocharset=utf8",
                 "noperm",
                 "nobrl",
                 "mfsymlinks",

--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -303,11 +303,8 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
         options.append(f"cache={cache_mode}")
 
         # Case insensitive by default (standard for SMB) and other performance options
-        # Note: We intentionally do NOT set iocharset=utf8 because the NLS framework
-        # is limited to 16-bit Unicode (U+FFFF max) and cannot handle emoji or other
-        # characters above the Basic Multilingual Plane. Without iocharset, CIFS uses
-        # its native Unicode handling which supports the full Unicode range including
-        # surrogate pairs (4-byte UTF-8 sequences like emoji).
+        # Note: iocharset is omitted to allow CIFS native Unicode handling for emoji
+        # and other 4-byte UTF-8 characters.
         options.extend(
             [
                 "nocase",


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/4878

The problem was that the iocharset=utf8 mount option uses the Linux kernel's NLS (Native Language Support) framework, which is limited to 16-bit Unicode code points (U+FFFF maximum). This means it can only handle 3-byte UTF-8 sequences.

Emoji characters like 🌱 (U+1F331) and 🎧 (U+1F3A7) are above U+FFFF and require 4-byte UTF-8 sequences (surrogate pairs in UTF-16). When iocharset=utf8 is set, the kernel's NLS tables can't process these characters, resulting in EINVAL (Invalid argument) errors.

By removing the iocharset=utf8 option, CIFS uses its native Unicode handling which has special code to handle surrogate pairs and supports the full Unicode range, including emoji.

I reviewed:

https://www.spinics.net/lists/linux-cifs/msg18282.html
https://community.netapp.com/t5/ONTAP-Discussions/Failed-to-create-a-file-with-surrogate-pair-characters-UTF-16/m-p/151302
https://www.kernel.org/doc/html/v6.0/admin-guide/cifs/usage.html