### PR TITLE
Allow all special characters in passwords

### DIFF
--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -236,8 +236,8 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
                 server, username, password_str, share, subfolder
             )
         elif platform.system() == "Linux":
-            mount_cmd = self._build_linux_mount_cmd(
-                server, username, password_str, share, subfolder
+            mount_cmd, env_vars = self._build_linux_mount_cmd(
+                server, username, password_str, share, subfolder, env_vars
             )
         else:
             msg = f"SMB provider is not supported on {platform.system()}"
@@ -279,16 +279,39 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
         ]
 
     def _build_linux_mount_cmd(
-        self, server: str, username: str, password: str | None, share: str, subfolder: str
-    ) -> list[str]:
-        """Build mount command for Linux."""
+        self,
+        server: str,
+        username: str,
+        password: str | None,
+        share: str,
+        subfolder: str,
+        env_vars: dict[str, str],
+    ) -> tuple[list[str], dict[str, str]]:
+        """Build mount command for Linux.
+
+        Uses the PASSWD environment variable to handle passwords with special characters
+        (commas, etc.) that cannot be escaped on the command line.
+
+        :param server: The SMB server hostname or IP.
+        :param username: The username for authentication.
+        :param password: The password for authentication (can contain special chars).
+        :param share: The share name on the server.
+        :param subfolder: Optional subfolder path within the share.
+        :param env_vars: Environment variables dict to modify with PASSWD if needed.
+        :returns: Tuple of (mount command args, modified env vars).
+        """
         options = ["rw"]  # read-write access
 
         # Handle username and password
+        # We pass the password via the PASSWD environment variable instead of on the
+        # command line because passwords containing commas cannot be properly escaped
+        # on the command line - the comma is used as the option separator.
+        # See: https://bugs.launchpad.net/ubuntu/+source/cifs-utils/+bug/1069915
         if username and username.lower() != "guest":
             options.append(f"username={username}")
             if password:
-                options.append(f"password={password}")
+                # Pass password via environment variable to handle special characters
+                env_vars["PASSWD"] = password
         else:
             # Guest/anonymous access
             options.append("guest")
@@ -319,7 +342,7 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
             ]
         )
 
-        return [
+        mount_cmd = [
             "mount",
             "-t",
             "cifs",
@@ -328,6 +351,7 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
             f"//{server}/{share}{subfolder}",
             self.base_path,
         ]
+        return mount_cmd, env_vars
 
     async def unmount(self, ignore_error: bool = False) -> None:
         """Unmount the remote share."""

--- a/music_assistant/providers/filesystem_smb/__init__.py
+++ b/music_assistant/providers/filesystem_smb/__init__.py
@@ -302,15 +302,11 @@ class SMBFileSystemProvider(LocalFileSystemProvider):
         """
         options = ["rw"]  # read-write access
 
-        # Handle username and password
-        # We pass the password via the PASSWD environment variable instead of on the
-        # command line because passwords containing commas cannot be properly escaped
-        # on the command line - the comma is used as the option separator.
-        # See: https://bugs.launchpad.net/ubuntu/+source/cifs-utils/+bug/1069915
+        # We pass the password via the PASSWD environment variable to avoid
+        # improperly escaped passwords with special characters.
         if username and username.lower() != "guest":
             options.append(f"username={username}")
             if password:
-                # Pass password via environment variable to handle special characters
                 env_vars["PASSWD"] = password
         else:
             # Guest/anonymous access


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/4602 where SMB mounts would fail with mount error(22): Invalid argument when the password contains commas or other special characters.

The problem was that passwords were passed directly in the mount options string (-o username=x,password=y,...), where commas act as option separators. A password like pass,word would be incorrectly parsed as two separate options.

The fix passes the password via the PASSWD environment variable instead, which mount.cifs reads automatically and handles all special characters correctly.