### PR TITLE
Fix type error in load_provider_config

### DIFF
--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -88,9 +88,7 @@ class Provider:
                 self.instance_id,
             )
             task_id = f"provider_reload_{self.instance_id}"
-            self.mass.call_later(
-                1, self.mass.load_provider_config, config, self.instance_id, task_id=task_id
-            )
+            self.mass.call_later(1, self.mass.load_provider_config, config, task_id=task_id)
 
     async def on_mdns_service_state_change(
         self, name: str, state_change: ServiceStateChange, info: AsyncServiceInfo | None


### PR DESCRIPTION
Fixes a `TypeError `when reloading a provider config (e.g., changing settings on an existing provider):

TypeError: `MusicAssistant.load_provider_config()` takes 2 positional arguments but 3 were given

The `load_provider_config()` method only accepts the config object, but `self.instance_id` was incorrectly being passed as an extra argument.