### PR TITLE
Fix squeezelite WAV playback

### DIFF
--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -1844,11 +1844,23 @@ class StreamsController(CoreController):
             output_sample_rate = min(48000, output_sample_rate)
         if output_format_str == "pcm":
             content_type = ContentType.from_bit_depth(output_bit_depth)
+        output_channels = 1 if output_channels_str != "stereo" else 2
+        # For WAV format, explicitly set output_format_str with PCM parameters.
+        # This is needed for slimproto players which parse these parameters from the
+        # Content-Type header to configure the correct bit depth for decoding.
+        if content_type == ContentType.WAV:
+            wav_output_format_str = (
+                f"wav;rate={output_sample_rate};bitrate={output_bit_depth};"
+                f"channels={output_channels}"
+            )
+        else:
+            wav_output_format_str = ""
         return AudioFormat(
             content_type=content_type,
             sample_rate=output_sample_rate,
             bit_depth=output_bit_depth,
-            channels=1 if output_channels_str != "stereo" else 2,
+            channels=output_channels,
+            output_format_str=wav_output_format_str,
         )
 
     async def _select_flow_format(


### PR DESCRIPTION
REQUIRES: https://github.com/music-assistant/aioslimproto/pull/512

Fixes: https://github.com/music-assistant/support/issues/4163

When streaming WAV audio to slimproto players (squeezelite), include sample rate, bit depth, and channels in the Content-Type header (e.g., audio/wav;rate=44100;bitrate=24;channels=2). Without these parameters, slimproto defaults to 16-bit regardless of the actual stream bit depth, causing audio distortion when playing higher bit depth content.