### PR TITLE
Add album year to track SQL query

### DIFF
--- a/music_assistant/controllers/media/tracks.py
+++ b/music_assistant/controllers/media/tracks.py
@@ -85,6 +85,7 @@ class TracksController(MediaControllerBase[Track]):
                     'name', albums.name,
                     'sort_name', albums.sort_name,
                     'media_type', 'album',
+                    'year', albums.year,
                     'disc_number', album_tracks.disc_number,
                     'track_number', album_tracks.track_number,
                     'images', json_extract(albums.metadata, '$.images')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "getmac==0.9.5",
   "mashumaro==3.18",
   "music-assistant-frontend==2.17.80",
-  "music-assistant-models==1.1.95",
+  "music-assistant-models==1.1.96",
   "mutagen==1.47.0",
   "orjson==3.11.5",
   "pillow==12.1.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -42,7 +42,7 @@ librosa==0.11.0
 lyricsgenius==3.7.5
 mashumaro==3.18
 music-assistant-frontend==2.17.80
-music-assistant-models==1.1.95
+music-assistant-models==1.1.96
 mutagen==1.47.0
 niconico.py-ma==2.1.0.post1
 orjson==3.11.5

--- a/tests/providers/jellyfin/__snapshots__/test_parsers.ambr
+++ b/tests/providers/jellyfin/__snapshots__/test_parsers.ambr
@@ -17,6 +17,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/e439648e08ade14e27d5de48fa97c88e',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,
@@ -112,6 +113,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/555b36f7d310d1b7405557a8775c6878',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,
@@ -207,6 +209,7 @@
         'translation_key': None,
         'uri': 'jellyfin://artist/[unknown]',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,
@@ -370,6 +373,7 @@
       'translation_key': None,
       'uri': 'xx-instance-id-xx://album/d42d74e134693184e7adc73106238e89',
       'version': '',
+      'year': None,
     }),
     'artists': list([
       dict({
@@ -386,6 +390,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/cc940aeb8a99149f159fe9794f136071',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,
@@ -474,6 +479,7 @@
       'translation_key': None,
       'uri': 'xx-instance-id-xx://album/70b7288088b42d318f75dbcc41fd0091',
       'version': '',
+      'year': None,
     }),
     'artists': list([
       dict({
@@ -490,6 +496,7 @@
         'translation_key': None,
         'uri': 'jellyfin://artist/[unknown]',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,
@@ -574,6 +581,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/94875b0dd58cbf5245a135982133651a',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,
@@ -662,6 +670,7 @@
       'translation_key': None,
       'uri': 'xx-instance-id-xx://album/32ed6a0091733dcff57eae67010f3d4b',
       'version': '',
+      'year': None,
     }),
     'artists': list([
       dict({
@@ -678,6 +687,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/a0c459294295710546c81c20a8d9abfc',
         'version': '',
+        'year': None,
       }),
       dict({
         'available': True,
@@ -693,6 +703,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/1952db245ddef4e41dcd016475379190',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,

--- a/tests/providers/opensubsonic/__snapshots__/test_parsers.ambr
+++ b/tests/providers/opensubsonic/__snapshots__/test_parsers.ambr
@@ -299,6 +299,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/91c3901ac465b9efc439e4be4270c2b6',
         'version': '',
+        'year': None,
       }),
       dict({
         'available': True,
@@ -314,6 +315,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/ar-1',
         'version': '',
+        'year': None,
       }),
       dict({
         'available': True,
@@ -329,6 +331,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/ar-2',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,
@@ -423,6 +426,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/91c3901ac465b9efc439e4be4270c2b6',
         'version': '',
+        'year': None,
       }),
       dict({
         'available': True,
@@ -438,6 +442,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/ar-1',
         'version': '',
+        'year': None,
       }),
       dict({
         'available': True,
@@ -453,6 +458,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/ar-2',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,
@@ -1644,6 +1650,7 @@
       'translation_key': None,
       'uri': 'xx-instance-id-xx://album/e8a0685e3f3ec6f251649af2b58b8617',
       'version': '',
+      'year': None,
     }),
     'artists': list([
       dict({
@@ -2001,6 +2008,7 @@
       'translation_key': None,
       'uri': 'xx-instance-id-xx://album/e8a0685e3f3ec6f251649af2b58b8617',
       'version': '',
+      'year': None,
     }),
     'artists': list([
       dict({
@@ -2358,6 +2366,7 @@
       'translation_key': None,
       'uri': 'xx-instance-id-xx://album/e8a0685e3f3ec6f251649af2b58b8617',
       'version': '',
+      'year': None,
     }),
     'artists': list([
       dict({
@@ -2374,6 +2383,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/97e0398acf63f9fb930d7d4ce209a52b',
         'version': '',
+        'year': None,
       }),
       dict({
         'available': True,
@@ -2389,6 +2399,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/ar-1',
         'version': '',
+        'year': None,
       }),
       dict({
         'available': True,
@@ -2404,6 +2415,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/ar-2',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,
@@ -2565,6 +2577,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/97e0398acf63f9fb930d7d4ce209a52b',
         'version': '',
+        'year': None,
       }),
       dict({
         'available': True,
@@ -2580,6 +2593,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/ar-1',
         'version': '',
+        'year': None,
       }),
       dict({
         'available': True,
@@ -2595,6 +2609,7 @@
         'translation_key': None,
         'uri': 'xx-instance-id-xx://artist/ar-2',
         'version': '',
+        'year': None,
       }),
     ]),
     'date_added': None,

--- a/tests/providers/tidal/__snapshots__/test_parsers.ambr
+++ b/tests/providers/tidal/__snapshots__/test_parsers.ambr
@@ -365,6 +365,7 @@
       'translation_key': None,
       'uri': 'tidal_instance://album/67890',
       'version': '',
+      'year': None,
     }),
     'artists': list([
       dict({


### PR DESCRIPTION
## Summary
- Add `year` field to track album data in SQL query
- Returns album year as part of track's album ItemMapping

## Related PRs
- Models: https://github.com/music-assistant/models/pull/164
- Frontend: sfortis/frontend#feat/album-year-display (pending)

Depends on models PR being merged first.