### PR TITLE
Fix cache check for expire

### DIFF
--- a/music_assistant/controllers/cache.py
+++ b/music_assistant/controllers/cache.py
@@ -122,7 +122,7 @@ class CacheController(CoreController):
             db_row := await self.database.get_row(
                 DB_TABLE_CACHE, {"category": category, "provider": provider, "key": key}
             )
-        ) and (not checksum or (db_row["checksum"] == checksum and db_row["expires"] >= cur_time)):
+        ) and db_row["expires"] >= cur_time and (not checksum or db_row["checksum"] == checksum):
             try:
                 data = await async_json_loads(db_row["data"])
             except Exception as exc:

--- a/music_assistant/controllers/cache.py
+++ b/music_assistant/controllers/cache.py
@@ -119,10 +119,14 @@ class CacheController(CoreController):
             return cache_data[0]
         # fall back to db cache
         if (
-            db_row := await self.database.get_row(
-                DB_TABLE_CACHE, {"category": category, "provider": provider, "key": key}
+            (
+                db_row := await self.database.get_row(
+                    DB_TABLE_CACHE, {"category": category, "provider": provider, "key": key}
+                )
             )
-        ) and db_row["expires"] >= cur_time and (not checksum or db_row["checksum"] == checksum):
+            and db_row["expires"] >= cur_time
+            and (not checksum or db_row["checksum"] == checksum)
+        ):
             try:
                 data = await async_json_loads(db_row["data"])
             except Exception as exc:


### PR DESCRIPTION
`CacheController.get` checks to see if a query is expired or not when reading from cache. Crucially, it ignores the expiration time if no `checksum` is passed. This can cause unintended effects, like those raised in https://github.com/orgs/music-assistant/discussions/4865#discussioncomment-15683763. This simple fix has the `CacheController` always check `db_row["expires"]`. 