### PR TITLE
Fix(chromecast): Support HTTP Range for WAV streams

### DIFF
--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -19,7 +19,11 @@ from typing import TYPE_CHECKING, Final, cast
 
 from aiofiles.os import wrap
 from aiohttp import web
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
+from music_assistant_models.config_entries import (
+    ConfigEntry,
+    ConfigValueOption,
+    ConfigValueType,
+)
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
@@ -65,9 +69,12 @@ from music_assistant.constants import (
 from music_assistant.controllers.players.player_controller import AnnounceData
 from music_assistant.controllers.streams.smart_fades import SmartFadesMixer
 from music_assistant.controllers.streams.smart_fades.analyzer import SmartFadesAnalyzer
-from music_assistant.controllers.streams.smart_fades.fades import SMART_CROSSFADE_DURATION
+from music_assistant.controllers.streams.smart_fades.fades import (
+    SMART_CROSSFADE_DURATION,
+)
 from music_assistant.helpers.audio import LOGGER as AUDIO_LOGGER
 from music_assistant.helpers.audio import (
+    create_wave_header,
     get_buffered_media_stream,
     get_chunksize,
     get_media_stream,
@@ -117,7 +124,9 @@ CONF_ALLOW_BUFFER_DEFAULT = TOTAL_SYSTEM_MEMORY_GB >= 8.0
 def parse_pcm_info(content_type: str) -> tuple[int, int, int]:
     """Parse PCM info from a codec/content_type string."""
     params = (
-        dict(urllib.parse.parse_qsl(content_type.replace(";", "&"))) if ";" in content_type else {}
+        dict(urllib.parse.parse_qsl(content_type.replace(";", "&")))
+        if ";" in content_type
+        else {}
     )
     sample_rate = int(params.get("rate", 44100))
     sample_size = int(params.get("bitrate", 16))
@@ -131,7 +140,9 @@ class CrossfadeData:
 
     data: bytes
     fade_in_size: int
-    pcm_format: AudioFormat  # Format of the 'data' bytes (current/previous track's format)
+    pcm_format: (
+        AudioFormat  # Format of the 'data' bytes (current/previous track's format)
+    )
     fade_in_pcm_format: AudioFormat  # Format for 'fade_in_size' (next track's format)
     queue_item_id: str
 
@@ -402,7 +413,9 @@ class StreamsController(CoreController):
             fmt = ContentType.WAV.value
         else:
             fmt = plugin_source.audio_format.content_type.value
-        return f"{self._server.base_url}/pluginsource/{plugin_source.id}/{player_id}.{fmt}"
+        return (
+            f"{self._server.base_url}/pluginsource/{plugin_source.id}/{player_id}.{fmt}"
+        )
 
     async def serve_queue_item_stream(self, request: web.Request) -> web.StreamResponse:
         """Stream single queueitem audio to a player."""
@@ -429,7 +442,9 @@ class StreamsController(CoreController):
                     "Failed to get streamdetails for QueueItem %s: %s", queue_item_id, e
                 )
                 queue_item.available = False
-                raise web.HTTPNotFound(reason=f"No streamdetails for Queue item: {queue_item_id}")
+                raise web.HTTPNotFound(
+                    reason=f"No streamdetails for Queue item: {queue_item_id}"
+                )
 
         # pick output format based on the streamdetails and player capabilities
         if not queue_player:
@@ -447,6 +462,25 @@ class StreamsController(CoreController):
             content_sample_rate=pcm_format.sample_rate,
             content_bit_depth=pcm_format.bit_depth,
         )
+
+        range_header = request.headers.get("Range")
+        if (
+            queue_player.provider.domain == "chromecast"
+            and output_format.content_type == ContentType.WAV
+            and (queue_item.streamdetails.duration or queue_item.duration)
+        ):
+            # Chromecast "Cast Lite" devices are known to aggressively buffer and then close the HTTP
+            # connection. They later reconnect with a Range request to continue downloading.
+            # For WAV (linear PCM), we can support Range requests by mapping byte offsets to PCM time.
+            return await self._serve_wav_queue_item_stream_with_range(
+                request=request,
+                queue=queue,
+                queue_item=queue_item,
+                queue_player=queue_player,
+                input_pcm_format=pcm_format,
+                wav_format=output_format,
+                range_header=range_header,
+            )
 
         # prepare request, add some DLNA/UPNP compatible headers
         headers = {
@@ -560,17 +594,41 @@ class StreamsController(CoreController):
                     # Player disconnected (unexpected) after receiving at least some data
                     # This could indicate buffering issues, network problems,
                     # or player-specific issues
-                    bytes_expected = get_chunksize(output_format, queue_item.duration or 3600)
-                    self.logger.warning(
-                        "Player %s disconnected prematurely from stream for %s (%s) - "
-                        "error: %s, sent %d bytes, expected (approx) bytes=%d",
-                        queue.display_name,
-                        queue_item.name,
-                        queue_item.uri,
-                        err.__class__.__name__,
-                        bytes_sent,
-                        bytes_expected,
+                    bytes_expected = get_chunksize(
+                        output_format, queue_item.duration or 3600
                     )
+                    user_agent = request.headers.get("User-Agent", "")
+                    is_cast_lite = (
+                        queue_player.provider.domain == "chromecast"
+                        and "Cast Lite" in user_agent
+                    )
+                    if is_cast_lite and output_format.content_type != ContentType.WAV:
+                        # Cast Lite devices are known to buffer aggressively and then close the HTTP
+                        # connection. They may later reconnect using HTTP Range requests to continue
+                        # downloading. Range support is currently only available for WAV streams.
+                        self.logger.warning(
+                            "Player %s closed %s stream early for %s (%s) - Cast Lite may resume "
+                            "with HTTP Range requests; enable WAV output codec to support this. "
+                            "error: %s, sent %d bytes, expected (approx) bytes=%d",
+                            queue.display_name,
+                            output_format.output_format_str,
+                            queue_item.name,
+                            queue_item.uri,
+                            err.__class__.__name__,
+                            bytes_sent,
+                            bytes_expected,
+                        )
+                    else:
+                        self.logger.warning(
+                            "Player %s disconnected prematurely from stream for %s (%s) - "
+                            "error: %s, sent %d bytes, expected (approx) bytes=%d",
+                            queue.display_name,
+                            queue_item.name,
+                            queue_item.uri,
+                            err.__class__.__name__,
+                            bytes_sent,
+                            bytes_expected,
+                        )
                 break
         if queue_item.streamdetails.stream_error:
             self.logger.error(
@@ -583,6 +641,218 @@ class StreamsController(CoreController):
             self.mass.call_later(5, self.mass.player_queues.next(queue_id))
         return resp
 
+    @staticmethod
+    def _parse_http_range(range_header: str, total_size: int) -> tuple[int, int] | None:
+        """Parse a single HTTP Range header (bytes=START-END) and clamp to total_size."""
+        if not range_header:
+            return None
+        if not range_header.startswith("bytes="):
+            return None
+        range_spec = range_header[6:].strip()
+        # only support a single range
+        if "," in range_spec:
+            return None
+        if range_spec.startswith("-"):
+            # suffix-length range: bytes=-N
+            try:
+                suffix_len = int(range_spec[1:])
+            except ValueError:
+                return None
+            if suffix_len <= 0:
+                return None
+            start = max(0, total_size - suffix_len)
+            return (start, total_size - 1)
+        if "-" not in range_spec:
+            return None
+        start_str, end_str = range_spec.split("-", 1)
+        if not start_str:
+            return None
+        try:
+            start = int(start_str)
+        except ValueError:
+            return None
+        if start < 0:
+            return None
+        if start >= total_size:
+            return None
+        if end_str:
+            try:
+                end = int(end_str)
+            except ValueError:
+                return None
+            if end < start:
+                return None
+            end = min(end, total_size - 1)
+        else:
+            end = total_size - 1
+        return (start, end)
+
+    async def _serve_wav_queue_item_stream_with_range(
+        self,
+        *,
+        request: web.Request,
+        queue: PlayerQueue,
+        queue_item: QueueItem,
+        queue_player: Player,
+        input_pcm_format: AudioFormat,
+        wav_format: AudioFormat,
+        range_header: str | None,
+    ) -> web.StreamResponse:
+        """Serve a WAV stream for a single queue item, with HTTP Range support."""
+        streamdetails = queue_item.streamdetails
+        assert streamdetails
+
+        base_seek = int(streamdetails.seek_position or 0)
+        duration_total = int(streamdetails.duration or queue_item.duration or 0)
+        duration_remaining = max(0, duration_total - base_seek) if duration_total else 0
+
+        wav_header = create_wave_header(
+            samplerate=wav_format.sample_rate,
+            channels=wav_format.channels,
+            bitspersample=wav_format.bit_depth,
+            duration=duration_remaining,
+        )
+        header_len = len(wav_header)
+        bytes_per_second = int(
+            wav_format.sample_rate * wav_format.channels * (wav_format.bit_depth // 8)
+        )
+        total_pcm_bytes = int(duration_remaining * bytes_per_second)
+        total_size = header_len + total_pcm_bytes
+
+        # Determine requested range (or full content).
+        start = 0
+        end = total_size - 1
+        status = 200
+        if range_header:
+            parsed = self._parse_http_range(range_header, total_size)
+            if parsed is None:
+                # Invalid or unsatisfiable range.
+                resp = web.StreamResponse(
+                    status=416, reason="Requested Range Not Satisfiable"
+                )
+                resp.headers["Content-Range"] = f"bytes */{total_size}"
+                resp.headers["Accept-Ranges"] = "bytes"
+                await resp.prepare(request)
+                return resp
+            start, end = parsed
+            status = 206
+
+        headers = {
+            **DEFAULT_STREAM_HEADERS,
+            "icy-name": queue_item.name,
+            "contentFeatures.dlna.org": "DLNA.ORG_OP=01;DLNA.ORG_FLAGS=01500000000000000000000000000000",  # noqa: E501
+            "Accept-Ranges": "bytes",
+            "Content-Type": "audio/wav",
+        }
+        if status == 206:
+            headers["Content-Range"] = f"bytes {start}-{end}/{total_size}"
+
+        reason = "Partial Content" if status == 206 else "OK"
+        resp = web.StreamResponse(status=status, reason=reason, headers=headers)
+        resp.content_type = "audio/wav"
+        resp.content_length = (end - start) + 1
+        await resp.prepare(request)
+
+        if request.method != "GET":
+            return resp
+
+        first_bytes_written = False
+
+        bytes_remaining = resp.content_length
+        bytes_sent = 0
+
+        # Send WAV header bytes (if range starts inside header).
+        if start < header_len and bytes_remaining:
+            header_end = min(header_len, start + bytes_remaining)
+            header_chunk = wav_header[start:header_end]
+            try:
+                await resp.write(header_chunk)
+                if not first_bytes_written:
+                    first_bytes_written = True
+                    self.mass.player_queues.track_loaded_in_buffer(
+                        queue_item.queue_id, queue_item.queue_item_id
+                    )
+                bytes_sent += len(header_chunk)
+                bytes_remaining -= len(header_chunk)
+                start += len(header_chunk)
+            except (BrokenPipeError, ConnectionResetError, ConnectionError):
+                return resp
+
+        # Send PCM data bytes.
+        if bytes_remaining and start >= header_len:
+            data_offset = start - header_len
+            skip_seconds, skip_bytes = divmod(data_offset, bytes_per_second)
+            seek_position = base_seek + int(skip_seconds)
+
+            out_pcm_content_type = ContentType.from_bit_depth(wav_format.bit_depth)
+            out_pcm_format = AudioFormat(
+                content_type=out_pcm_content_type,
+                sample_rate=wav_format.sample_rate,
+                bit_depth=wav_format.bit_depth,
+                channels=wav_format.channels,
+            )
+
+            audio_input = self.get_queue_item_stream(
+                queue_item=queue_item,
+                pcm_format=input_pcm_format,
+                seek_position=seek_position,
+            )
+            pcm_stream = get_ffmpeg_stream(
+                audio_input=audio_input,
+                input_format=input_pcm_format,
+                output_format=out_pcm_format,
+                filter_params=get_player_filter_params(
+                    self.mass,
+                    player_id=queue_player.player_id,
+                    input_format=input_pcm_format,
+                    output_format=out_pcm_format,
+                ),
+            )
+
+            first_chunk = True
+            # Range requests may start at arbitrary byte offsets within the PCM payload.
+            # Because ffmpeg yields chunks of (usually) ~64k, the initial byte offset may span
+            # multiple chunks. Keep discarding until we've skipped the requested byte count.
+            remaining_skip_bytes = skip_bytes
+            async for chunk in pcm_stream:
+                if not chunk:
+                    continue
+                if remaining_skip_bytes:
+                    if len(chunk) <= remaining_skip_bytes:
+                        remaining_skip_bytes -= len(chunk)
+                        continue
+                    chunk = chunk[remaining_skip_bytes:]
+                    remaining_skip_bytes = 0
+                if not chunk:
+                    continue
+                if len(chunk) > bytes_remaining:
+                    chunk = chunk[:bytes_remaining]
+                try:
+                    await resp.write(chunk)
+                    if not first_bytes_written:
+                        first_bytes_written = True
+                        self.mass.player_queues.track_loaded_in_buffer(
+                            queue_item.queue_id, queue_item.queue_item_id
+                        )
+                    bytes_sent += len(chunk)
+                    bytes_remaining -= len(chunk)
+                except (BrokenPipeError, ConnectionResetError, ConnectionError):
+                    break
+                if bytes_remaining <= 0:
+                    break
+
+        if range_header and bytes_sent and queue_player.provider.domain == "chromecast":
+            user_agent = request.headers.get("User-Agent")
+            if user_agent:
+                self.logger.debug(
+                    "WAV Range served to %s: ua=%s range=%s",
+                    queue.display_name,
+                    user_agent,
+                    range_header,
+                )
+
+        return resp
+
     async def serve_queue_flow_stream(self, request: web.Request) -> web.StreamResponse:
         """Stream Queue Flow audio to player."""
         self._log_request(request)
@@ -593,7 +863,9 @@ class StreamsController(CoreController):
         if not (queue_player := self.mass.players.get(queue_id)):
             raise web.HTTPNotFound(reason=f"Unknown Player: {queue_id}")
         start_queue_item_id = request.match_info["queue_item_id"]
-        start_queue_item = self.mass.player_queues.get_item(queue_id, start_queue_item_id)
+        start_queue_item = self.mass.player_queues.get_item(
+            queue_id, start_queue_item_id
+        )
         if not start_queue_item:
             raise web.HTTPNotFound(reason=f"Unknown Queue item: {start_queue_item_id}")
 
@@ -615,7 +887,10 @@ class StreamsController(CoreController):
             CONF_ENTRY_ENABLE_ICY_METADATA.key,
             CONF_ENTRY_ENABLE_ICY_METADATA.default_value,
         )
-        enable_icy = request.headers.get("Icy-MetaData", "") == "1" and icy_preference != "disabled"
+        enable_icy = (
+            request.headers.get("Icy-MetaData", "") == "1"
+            and icy_preference != "disabled"
+        )
         icy_meta_interval = 256000 if icy_preference == "full" else 16384
 
         # prepare request, add some DLNA/UPNP compatible headers
@@ -653,7 +928,9 @@ class StreamsController(CoreController):
         # this final ffmpeg process in the chain will convert the raw, lossless PCM audio into
         # the desired output format for the player including any player specific filter params
         # such as channels mixing, DSP, resampling and, only if needed, encoding to lossy formats
-        self.logger.debug("Start serving Queue flow audio stream for %s", queue.display_name)
+        self.logger.debug(
+            "Start serving Queue flow audio stream for %s", queue.display_name
+        )
 
         async for chunk in get_ffmpeg_stream(
             audio_input=self.get_queue_flow_stream(
@@ -672,7 +949,9 @@ class StreamsController(CoreController):
             # see for example: https://github.com/music-assistant/support/issues/3717
             # allow buffer ahead of 6 seconds and read rest in realtime
             extra_input_args=["-readrate", "1.0", "-readrate_initial_burst", "6"],
-            chunk_size=icy_meta_interval if enable_icy else get_chunksize(output_format),
+            chunk_size=(
+                icy_meta_interval if enable_icy else get_chunksize(output_format)
+            ),
         ):
             try:
                 await resp.write(chunk)
@@ -716,7 +995,9 @@ class StreamsController(CoreController):
             self.mass.create_task(self.mass.player_queues.next(queue_id))
         return web.FileResponse(SILENCE_FILE, headers={"icy-name": "Music Assistant"})
 
-    async def serve_announcement_stream(self, request: web.Request) -> web.StreamResponse:
+    async def serve_announcement_stream(
+        self, request: web.Request
+    ) -> web.StreamResponse:
         """Stream announcement audio to a player."""
         self._log_request(request)
         player_id = request.match_info["player_id"]
@@ -724,7 +1005,9 @@ class StreamsController(CoreController):
         if not player:
             raise web.HTTPNotFound(reason=f"Unknown Player: {player_id}")
         if not (announce_data := self.announcements.get(player_id)):
-            raise web.HTTPNotFound(reason=f"No pending announcements for Player: {player_id}")
+            raise web.HTTPNotFound(
+                reason=f"No pending announcements for Player: {player_id}"
+            )
 
         # work out output format/details
         fmt = request.match_info["fmt"]
@@ -790,7 +1073,9 @@ class StreamsController(CoreController):
 
         return resp
 
-    async def serve_plugin_source_stream(self, request: web.Request) -> web.StreamResponse:
+    async def serve_plugin_source_stream(
+        self, request: web.Request
+    ) -> web.StreamResponse:
         """Stream PluginSource audio to a player."""
         self._log_request(request)
         plugin_source_id = request.match_info["plugin_source"]
@@ -840,7 +1125,9 @@ class StreamsController(CoreController):
 
         # all checks passed, start streaming!
         if not plugin_source.audio_format:
-            raise InvalidDataError(f"No audio format for plugin source {plugin_source_id}")
+            raise InvalidDataError(
+                f"No audio format for plugin source {plugin_source_id}"
+            )
         async for chunk in self.get_plugin_source_stream(
             plugin_source_id=plugin_source_id,
             output_format=output_format,
@@ -910,7 +1197,9 @@ class StreamsController(CoreController):
         ):
             # special case: member player accessing UGP stream
             # Check URI to distinguish from the UGP accessing its own stream
-            ugp_player = cast("UniversalGroupPlayer", self.mass.players.get(media.source_id))
+            ugp_player = cast(
+                "UniversalGroupPlayer", self.mass.players.get(media.source_id)
+            )
             ugp_stream = ugp_player.stream
             assert ugp_stream is not None  # for type checker
             if ugp_stream.base_pcm_format == pcm_format:
@@ -937,7 +1226,9 @@ class StreamsController(CoreController):
             )
         elif media.source_id and media.queue_item_id:
             # single item stream (e.g. radio)
-            queue_item = self.mass.player_queues.get_item(media.source_id, media.queue_item_id)
+            queue_item = self.mass.player_queues.get_item(
+                media.source_id, media.queue_item_id
+            )
             assert queue_item
             audio_source = buffered(
                 self.get_queue_item_stream(
@@ -995,9 +1286,11 @@ class StreamsController(CoreController):
             "Start Queue Flow stream for Queue %s - crossfade: %s %s",
             queue.display_name,
             smart_fades_mode,
-            f"({standard_crossfade_duration}s)"
-            if smart_fades_mode == SmartFadesMode.STANDARD_CROSSFADE
-            else "",
+            (
+                f"({standard_crossfade_duration}s)"
+                if smart_fades_mode == SmartFadesMode.STANDARD_CROSSFADE
+                else ""
+            ),
         )
         total_bytes_sent = 0
         total_chunks_received = 0
@@ -1037,15 +1330,19 @@ class StreamsController(CoreController):
             )
             crossfade_buffer_duration = min(
                 crossfade_buffer_duration,
-                int(queue_track.streamdetails.duration / 2)
-                if queue_track.streamdetails.duration
-                else crossfade_buffer_duration,
+                (
+                    int(queue_track.streamdetails.duration / 2)
+                    if queue_track.streamdetails.duration
+                    else crossfade_buffer_duration
+                ),
             )
             # Ensure crossfade buffer size is aligned to frame boundaries
             # Frame size = bytes_per_sample * channels
             bytes_per_sample = pcm_format.bit_depth // 8
             frame_size = bytes_per_sample * pcm_format.channels
-            crossfade_buffer_size = int(pcm_format.pcm_sample_size * crossfade_buffer_duration)
+            crossfade_buffer_size = int(
+                pcm_format.pcm_sample_size * crossfade_buffer_duration
+            )
             # Round down to nearest frame boundary
             crossfade_buffer_size = (crossfade_buffer_size // frame_size) * frame_size
 
@@ -1069,7 +1366,10 @@ class StreamsController(CoreController):
                     self.mass.player_queues.track_loaded_in_buffer(
                         queue.queue_id, queue_track.queue_item_id
                     )
-                if total_chunks_received < 10 and smart_fades_mode != SmartFadesMode.DISABLED:
+                if (
+                    total_chunks_received < 10
+                    and smart_fades_mode != SmartFadesMode.DISABLED
+                ):
                     # we want a stream to start as quickly as possible
                     # so for the first 10 chunks we keep a very short buffer
                     req_buffer_size = pcm_format.pcm_sample_size
@@ -1193,7 +1493,9 @@ class StreamsController(CoreController):
             streamdetails.seconds_streamed = (
                 streamdetails.seconds_streamed or 0
             ) + last_part_seconds
-            streamdetails.duration = int((streamdetails.duration or 0) + last_part_seconds)
+            streamdetails.duration = int(
+                (streamdetails.duration or 0) + last_part_seconds
+            )
             last_fadeout_part = b""
         total_bytes_sent += bytes_written
         self.logger.info("Finished Queue Flow stream for Queue %s", queue.display_name)
@@ -1242,7 +1544,9 @@ class StreamsController(CoreController):
             if pre_announce:
                 async for chunk in get_ffmpeg_stream(
                     audio_input=pre_announce_url,
-                    input_format=AudioFormat(content_type=ContentType.try_parse(pre_announce_url)),
+                    input_format=AudioFormat(
+                        content_type=ContentType.try_parse(pre_announce_url)
+                    ),
                     output_format=pcm_format,
                     chunk_size=get_chunksize(pcm_format, 1),
                 ):
@@ -1250,7 +1554,10 @@ class StreamsController(CoreController):
             # pad silence while we're waiting for the announcement to be ready
             while announcement_data.empty():
                 yield b"\0" * int(
-                    pcm_format.sample_rate * (pcm_format.bit_depth / 8) * pcm_format.channels * 0.1
+                    pcm_format.sample_rate
+                    * (pcm_format.bit_depth / 8)
+                    * pcm_format.channels
+                    * 0.1
                 )
                 await asyncio.sleep(0.1)
             # stream announcement
@@ -1300,9 +1607,11 @@ class StreamsController(CoreController):
             async for chunk in get_ffmpeg_stream(
                 audio_input=cast(
                     "str | AsyncGenerator[bytes, None]",
-                    plugin_prov.get_audio_stream(player_id)
-                    if plugin_source.stream_type == StreamType.CUSTOM
-                    else plugin_source.path,
+                    (
+                        plugin_prov.get_audio_stream(player_id)
+                        if plugin_source.stream_type == StreamType.CUSTOM
+                        else plugin_source.path
+                    ),
                 ),
                 input_format=plugin_source.audio_format,
                 output_format=output_format,
@@ -1344,7 +1653,10 @@ class StreamsController(CoreController):
             filter_rule = f"loudnorm=I={streamdetails.target_loudness}:TP=-2.0:LRA=10.0:offset=0.0"
             filter_rule += ":print_format=json"
             filter_params.append(filter_rule)
-        elif streamdetails.volume_normalization_mode == VolumeNormalizationMode.FIXED_GAIN:
+        elif (
+            streamdetails.volume_normalization_mode
+            == VolumeNormalizationMode.FIXED_GAIN
+        ):
             # apply user defined fixed volume/gain correction
             config_key = (
                 CONF_VOLUME_NORMALIZATION_FIXED_GAIN_TRACKS
@@ -1356,7 +1668,10 @@ class StreamsController(CoreController):
             )
             gain_correct = round(gain_value, 2)
             filter_params.append(f"volume={gain_correct}dB")
-        elif streamdetails.volume_normalization_mode == VolumeNormalizationMode.MEASUREMENT_ONLY:
+        elif (
+            streamdetails.volume_normalization_mode
+            == VolumeNormalizationMode.MEASUREMENT_ONLY
+        ):
             # volume normalization with known loudness measurement
             # apply volume/gain correction
             target_loudness = (
@@ -1364,7 +1679,10 @@ class StreamsController(CoreController):
                 if streamdetails.target_loudness is not None
                 else 0.0
             )
-            if streamdetails.prefer_album_loudness and streamdetails.loudness_album is not None:
+            if (
+                streamdetails.prefer_album_loudness
+                and streamdetails.loudness_album is not None
+            ):
                 gain_correct = target_loudness - float(streamdetails.loudness_album)
             elif streamdetails.loudness is not None:
                 gain_correct = target_loudness - float(streamdetails.loudness)
@@ -1500,10 +1818,13 @@ class StreamsController(CoreController):
         if crossfade_data and streamdetails.seek_position > 0:
             # don't do crossfade when seeking into track
             crossfade_data = None
-        if crossfade_data and (crossfade_data.queue_item_id != queue_item.queue_item_id):
+        if crossfade_data and (
+            crossfade_data.queue_item_id != queue_item.queue_item_id
+        ):
             # edge case alert: the next item changed just while we were preloading/crossfading
             self.logger.warning(
-                "Skipping crossfade data for queue %s - next item changed!", queue.display_name
+                "Skipping crossfade data for queue %s - next item changed!",
+                queue.display_name,
             )
             crossfade_data = None
 
@@ -1528,15 +1849,19 @@ class StreamsController(CoreController):
         )
         crossfade_buffer_duration = min(
             crossfade_buffer_duration,
-            int(streamdetails.duration / 2)
-            if streamdetails.duration
-            else crossfade_buffer_duration,
+            (
+                int(streamdetails.duration / 2)
+                if streamdetails.duration
+                else crossfade_buffer_duration
+            ),
         )
         # Ensure crossfade buffer size is aligned to frame boundaries
         # Frame size = bytes_per_sample * channels
         bytes_per_sample = pcm_format.bit_depth // 8
         frame_size = bytes_per_sample * pcm_format.channels
-        crossfade_buffer_size = int(pcm_format.pcm_sample_size * crossfade_buffer_duration)
+        crossfade_buffer_size = int(
+            pcm_format.pcm_sample_size * crossfade_buffer_duration
+        )
         # Round down to nearest frame boundary
         crossfade_buffer_size = (crossfade_buffer_size // frame_size) * frame_size
         fade_out_data: bytes | None = None
@@ -1545,7 +1870,8 @@ class StreamsController(CoreController):
             # Calculate discard amount in seconds (format-independent)
             # Use fade_in_pcm_format because fade_in_size is in the next track's original format
             fade_in_duration_seconds = (
-                crossfade_data.fade_in_size / crossfade_data.fade_in_pcm_format.pcm_sample_size
+                crossfade_data.fade_in_size
+                / crossfade_data.fade_in_pcm_format.pcm_sample_size
             )
             discard_seconds = int(fade_in_duration_seconds) - 1
             # Calculate discard amounts in CURRENT track's format
@@ -1600,7 +1926,9 @@ class StreamsController(CoreController):
                         pcm_format,
                     )
                     if resampled_data:
-                        for _chunk in divide_chunks(resampled_data, pcm_format.pcm_sample_size):
+                        for _chunk in divide_chunks(
+                            resampled_data, pcm_format.pcm_sample_size
+                        ):
                             yield _chunk
                         bytes_written += len(resampled_data)
                     else:
@@ -1611,7 +1939,9 @@ class StreamsController(CoreController):
                             queue.display_name,
                         )
                 else:
-                    for _chunk in divide_chunks(crossfade_data.data, pcm_format.pcm_sample_size):
+                    for _chunk in divide_chunks(
+                        crossfade_data.data, pcm_format.pcm_sample_size
+                    ):
                         yield _chunk
                     bytes_written += len(crossfade_data.data)
                 # clear vars
@@ -1652,7 +1982,9 @@ class StreamsController(CoreController):
                     )
                     crossfade_data = None
             if crossfade_data:
-                for _chunk in divide_chunks(crossfade_data.data, pcm_format.pcm_sample_size):
+                for _chunk in divide_chunks(
+                    crossfade_data.data, pcm_format.pcm_sample_size
+                ):
                     yield _chunk
                 bytes_written += len(crossfade_data.data)
                 crossfade_data = None
@@ -1741,7 +2073,9 @@ class StreamsController(CoreController):
                 crossfade_bytes = await self._smart_fades_mixer.mix(
                     fade_in_part=buffer,
                     fade_out_part=fade_out_data,
-                    fade_in_streamdetails=cast("StreamDetails", next_queue_item.streamdetails),
+                    fade_in_streamdetails=cast(
+                        "StreamDetails", next_queue_item.streamdetails
+                    ),
                     fade_out_streamdetails=streamdetails,
                     pcm_format=pcm_format,
                     standard_crossfade_duration=standard_crossfade_duration,
@@ -1753,7 +2087,9 @@ class StreamsController(CoreController):
                 crossfade_second = crossfade_bytes[split_point:]
                 del crossfade_bytes
                 bytes_written += len(crossfade_first)
-                for _chunk in divide_chunks(crossfade_first, pcm_format.pcm_sample_size):
+                for _chunk in divide_chunks(
+                    crossfade_first, pcm_format.pcm_sample_size
+                ):
                     yield _chunk
                 # store the other half for the next track
                 # IMPORTANT: crossfade_second data is in CURRENT track's format (pcm_format)
@@ -1891,7 +2227,11 @@ class StreamsController(CoreController):
         supported_sample_rates = tuple(int(x[0]) for x in supported_rates_conf)
         # use highest supported rate within content rate
         output_sample_rate = max(
-            (r for r in supported_sample_rates if r <= streamdetails.audio_format.sample_rate),
+            (
+                r
+                for r in supported_sample_rates
+                if r <= streamdetails.audio_format.sample_rate
+            ),
             default=48000,  # sane/safe default
         )
         # work out pcm format based on streamdetails

--- a/music_assistant/providers/chromecast/constants.py
+++ b/music_assistant/providers/chromecast/constants.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType
 
 from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE,
-    CONF_ENTRY_OUTPUT_CODEC,
+    create_output_codec_config_entry,
     create_sample_rates_config_entry,
 )
 
@@ -22,8 +22,16 @@ CONF_SENDSPIN_CODEC = "sendspin_codec"
 DEFAULT_SENDSPIN_SYNC_DELAY = -300
 DEFAULT_SENDSPIN_CODEC = "flac"
 
+CONF_ENTRY_OUTPUT_CODEC_CAST = create_output_codec_config_entry(default_value="flac")
+CONF_ENTRY_OUTPUT_CODEC_CAST.options = [
+    ConfigValueOption("WAV (lossless, uncompressed, supports range requests)", "wav")
+    if opt.value == "wav"
+    else opt
+    for opt in (CONF_ENTRY_OUTPUT_CODEC_CAST.options or [])
+]
+
 CAST_PLAYER_CONFIG_ENTRIES = (
-    CONF_ENTRY_OUTPUT_CODEC,
+    CONF_ENTRY_OUTPUT_CODEC_CAST,
     CONF_ENTRY_HTTP_PROFILE,
     ConfigEntry(
         key=CONF_USE_MASS_APP,

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -785,6 +785,10 @@ class ChromecastPlayer(Player):
 
     def _create_cc_media_item(self, media: PlayerMedia) -> dict[str, Any]:
         """Create CC media item from MA PlayerMedia."""
+        uri = media.uri or ""
+        clean_uri = uri.split("?", 1)[0].split("#", 1)[0].lower()
+        content_type = "audio/wav" if clean_uri.endswith(".wav") else "audio/flac"
+
         if media.media_type == MediaType.TRACK:
             stream_type = STREAM_TYPE_BUFFERED
         else:
@@ -803,7 +807,7 @@ class ChromecastPlayer(Player):
                 "uri": media.uri,
                 "queue_item_id": media.uri,
             },
-            "contentType": "audio/flac",
+            "contentType": content_type,
             "streamType": stream_type,
             "metadata": metadata,
             "duration": media.duration,

--- a/scripts/cast_stream_debug.py
+++ b/scripts/cast_stream_debug.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""
+Minimal Chromecast HTTP-stream debug tool.
+
+This script starts a tiny HTTP server that serves 4 synthetic audio "tracks" and instructs a
+Chromecast device to play them as buffered queue items using the Default Media Receiver app.
+
+The 4 tracks intentionally use different HTTP behaviors to help reproduce buffering/disconnect
+issues in isolation:
+  1) Content-Length, send as fast as possible
+  2) Chunked, send as fast as possible
+  3) Content-Length, throttled to (near) realtime
+  4) Chunked, throttled to (near) realtime
+
+Run it inside the same environment/venv as Music Assistant (so PyChromecast is available):
+
+  python3 scripts/cast_stream_debug.py --cast-host 172.20.10.228
+
+Notes:
+- The Chromecast must be able to reach your machine over HTTP (same LAN).
+- If you have multiple interfaces, pass --publish-ip explicitly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import socket
+import struct
+import sys
+import threading
+import time
+from array import array
+from contextlib import suppress
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from uuid import UUID
+
+
+APP_MEDIA_RECEIVER = "CC1AD845"
+
+
+def _guess_publish_ip(target_host: str) -> str:
+    """Guess the local IP used to reach target_host."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.connect((target_host, 80))
+        return sock.getsockname()[0]
+    finally:
+        sock.close()
+
+
+def _wav_header(*, sample_rate: int, channels: int, bits_per_sample: int, frames: int) -> bytes:
+    """Generate a standard PCM WAV header for a fixed number of frames."""
+    block_align = channels * (bits_per_sample // 8)
+    byte_rate = sample_rate * block_align
+    data_size = frames * block_align
+    riff_size = 36 + data_size
+    return b"".join(
+        [
+            b"RIFF",
+            struct.pack("<I", riff_size),
+            b"WAVE",
+            b"fmt ",
+            struct.pack("<I", 16),  # fmt chunk size
+            struct.pack("<H", 1),  # PCM
+            struct.pack("<H", channels),
+            struct.pack("<I", sample_rate),
+            struct.pack("<I", byte_rate),
+            struct.pack("<H", block_align),
+            struct.pack("<H", bits_per_sample),
+            b"data",
+            struct.pack("<I", data_size),
+        ]
+    )
+
+
+def _pcm_s16le_1s(*, freq_hz: float, sample_rate: int, channels: int, amplitude: float) -> bytes:
+    """Generate 1 second of signed 16-bit PCM (little endian)."""
+    if channels not in (1, 2):
+        raise ValueError("Only mono/stereo supported for this debug script.")
+    if not (0.0 < amplitude <= 1.0):
+        raise ValueError("Amplitude must be in (0.0, 1.0].")
+    max_i16 = 32767
+    amp = int(max_i16 * amplitude)
+    two_pi_f = 2.0 * math.pi * freq_hz
+    samples = array("h")
+    for i in range(sample_rate):
+        val = int(amp * math.sin(two_pi_f * (i / sample_rate)))
+        if channels == 2:
+            samples.append(val)
+            samples.append(val)
+        else:
+            samples.append(val)
+    if sys.byteorder == "big":
+        samples.byteswap()
+    return samples.tobytes()
+
+
+@dataclass(frozen=True)
+class TrackSpec:
+    path: str
+    title: str
+    freq_hz: float
+    duration_s: int
+    chunked: bool
+    throttle: bool
+    sample_rate: int = 44100
+    channels: int = 2
+    bits_per_sample: int = 16
+    amplitude: float = 0.2
+    # For throttled streams: allow the client to buffer some seconds before enforcing realtime.
+    initial_burst_s: float = 6.0
+
+    @property
+    def bytes_per_second(self) -> int:
+        return self.sample_rate * self.channels * (self.bits_per_sample // 8)
+
+
+def _build_track_assets(track: TrackSpec) -> tuple[bytes, bytes, int]:
+    """Return (wav_header, pcm_1s_block, total_size_bytes)."""
+    pcm_1s = _pcm_s16le_1s(
+        freq_hz=track.freq_hz,
+        sample_rate=track.sample_rate,
+        channels=track.channels,
+        amplitude=track.amplitude,
+    )
+    if len(pcm_1s) != track.bytes_per_second:
+        raise RuntimeError("Internal error: pcm_1s size mismatch")
+    frames = track.sample_rate * track.duration_s
+    header = _wav_header(
+        sample_rate=track.sample_rate,
+        channels=track.channels,
+        bits_per_sample=track.bits_per_sample,
+        frames=frames,
+    )
+    total_size = len(header) + (track.duration_s * len(pcm_1s))
+    return header, pcm_1s, total_size
+
+
+class _CastDebugListener:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def new_connection_status(self, status: Any) -> None:  # pychromecast ConnectionStatus
+        with self._lock:
+            ts = time.strftime("%H:%M:%S")
+            print(f"[{ts}] CAST connection_status: {getattr(status, 'status', status)}")
+
+    def new_cast_status(self, status: Any) -> None:  # pychromecast CastStatus
+        with self._lock:
+            ts = time.strftime("%H:%M:%S")
+            app_id = getattr(status, "app_id", None)
+            vol = getattr(status, "volume_level", None)
+            print(f"[{ts}] CAST cast_status: app_id={app_id} volume={vol}")
+
+    def new_media_status(self, status: Any) -> None:  # pychromecast MediaStatus
+        with self._lock:
+            ts = time.strftime("%H:%M:%S")
+            state = getattr(status, "player_state", None)
+            content_id = getattr(status, "content_id", None)
+            cur = getattr(status, "current_time", None)
+            dur = getattr(status, "duration", None)
+            print(f"[{ts}] CAST media_status: state={state} t={cur}/{dur} content_id={content_id}")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        # quiet default http.server logging; we print custom lines instead.
+        return
+
+    def do_HEAD(self) -> None:  # noqa: N802 (stdlib naming)
+        self._handle(send_body=False)
+
+    def do_GET(self) -> None:  # noqa: N802 (stdlib naming)
+        self._handle(send_body=True)
+
+    def _handle(self, *, send_body: bool) -> None:
+        tracks: dict[str, TrackSpec] = self.server.tracks  # type: ignore[attr-defined]
+        if self.path.split("?", 1)[0] not in tracks:
+            self.send_error(404, "Not Found")
+            return
+
+        track = tracks[self.path.split("?", 1)[0]]
+        header, pcm_1s, total_size = self.server.track_assets[track.path]  # type: ignore[attr-defined]
+        advertise_range: bool = bool(getattr(self.server, "advertise_range", True))  # type: ignore[attr-defined]
+        honor_range: bool = bool(getattr(self.server, "honor_range", True))  # type: ignore[attr-defined]
+
+        ts = time.strftime("%H:%M:%S")
+        range_header = self.headers.get("Range")
+        user_agent = self.headers.get("User-Agent")
+        print(
+            f"[{ts}] HTTP {self.command} {self.path} from {self.client_address[0]} "
+            f"range={range_header!r} ua={user_agent!r}"
+        )
+        if range_header and not advertise_range:
+            print(
+                f"[{ts}] !!! CLIENT SENT Range header but server is NOT advertising range support "
+                f"(Accept-Ranges: none)"
+            )
+
+        # Parse optional Range header.
+        start = 0
+        end = total_size - 1
+        is_partial = False
+        if range_header and honor_range:
+            match = re.match(r"bytes=(\d+)-(\d+)?$", range_header.strip())
+            if match:
+                start = int(match.group(1))
+                if match.group(2) is not None:
+                    end = int(match.group(2))
+                end = min(end, total_size - 1)
+                if start <= end:
+                    is_partial = True
+        elif range_header and not honor_range:
+            print(f"[{ts}] !!! Server is configured to IGNORE Range requests (honor_range=false)")
+
+        if start > end:
+            self.send_response(416, "Requested Range Not Satisfiable")
+            self.send_header("Content-Range", f"bytes */{total_size}")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            return
+
+        content_len = (end - start) + 1
+        if is_partial:
+            self.send_response(206, "Partial Content")
+            self.send_header("Content-Range", f"bytes {start}-{end}/{total_size}")
+        else:
+            self.send_response(200, "OK")
+
+        self.send_header("Content-Type", "audio/wav")
+        self.send_header("Accept-Ranges", "bytes" if advertise_range else "none")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Connection", "close")
+        if track.chunked:
+            self.send_header("Transfer-Encoding", "chunked")
+        else:
+            self.send_header("Content-Length", str(content_len))
+        self.end_headers()
+
+        if not send_body:
+            return
+
+        def write(data: bytes) -> None:
+            if not data:
+                return
+            if track.chunked:
+                self.wfile.write(f"{len(data):X}\r\n".encode())
+                self.wfile.write(data)
+                self.wfile.write(b"\r\n")
+            else:
+                self.wfile.write(data)
+            self.wfile.flush()
+
+        data_start_time = time.monotonic()
+        header_bytes_sent = 0
+        pcm_bytes_sent = 0
+
+        header_len = len(header)
+        data_size = total_size - header_len
+        block_len = len(pcm_1s)  # == bytes_per_second
+
+        def maybe_throttle(pcm_chunk_len: int) -> None:
+            nonlocal pcm_bytes_sent
+            if not track.throttle:
+                return
+            if pcm_chunk_len <= 0:
+                return
+            seconds_sent = pcm_bytes_sent / block_len
+            target_elapsed = max(0.0, seconds_sent - track.initial_burst_s)
+            elapsed = time.monotonic() - data_start_time
+            if target_elapsed > elapsed:
+                time.sleep(target_elapsed - elapsed)
+
+        try:
+            # Serve header portion.
+            pos = start
+            if pos < header_len:
+                header_end = min(header_len, end + 1)
+                chunk = header[pos:header_end]
+                write(chunk)
+                header_bytes_sent += len(chunk)
+                pos = header_end
+
+            # Serve PCM data portion (repeating 1-second block).
+            if pos <= end:
+                data_pos = max(0, pos - header_len)
+                data_end = min(data_size, (end + 1) - header_len)  # exclusive
+                remaining = data_end - data_pos
+                block_index = data_pos // block_len
+                in_block_off = data_pos % block_len
+
+                # Fast-forward logical index without allocating anything.
+                _ = block_index
+
+                while remaining > 0:
+                    chunk = pcm_1s[in_block_off : min(block_len, in_block_off + remaining)]
+                    write(chunk)
+                    pcm_bytes_sent += len(chunk)
+                    maybe_throttle(len(chunk))
+                    remaining -= len(chunk)
+                    in_block_off = 0
+
+            if track.chunked:
+                # terminator
+                self.wfile.write(b"0\r\n\r\n")
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            ts2 = time.strftime("%H:%M:%S")
+            seconds_sent = pcm_bytes_sent / block_len if block_len else 0.0
+            print(
+                f"[{ts2}] HTTP client disconnected while streaming {track.path} "
+                f"(sent_header_bytes={header_bytes_sent} sent_pcm_seconds≈{seconds_sent:.1f})"
+            )
+
+
+def _start_http_server(
+    *,
+    bind: str,
+    port: int,
+    tracks: list[TrackSpec],
+) -> tuple[ThreadingHTTPServer, threading.Thread]:
+    server = ThreadingHTTPServer((bind, port), _Handler)
+    server.tracks = {t.path: t for t in tracks}  # type: ignore[attr-defined]
+    server.track_assets = {t.path: _build_track_assets(t) for t in tracks}  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True, name="http-server")
+    thread.start()
+    return server, thread
+
+
+def _launch_app(cast: Any, app_id: str, timeout: float = 10.0) -> None:
+    ev = threading.Event()
+
+    def launched_cb(success: bool, response: dict[str, Any] | None) -> None:  # noqa: ARG001
+        ev.set()
+
+    if getattr(cast, "app_id", None) == app_id:
+        return
+    cast.socket_client.receiver_controller.launch_app(  # type: ignore[attr-defined]
+        app_id, force_launch=True, callback_function=launched_cb
+    )
+    if not ev.wait(timeout):
+        raise TimeoutError("Timed out waiting for receiver app launch")
+
+
+def _cc_media_item(*, url: str, title: str, duration_s: int) -> dict[str, Any]:
+    # Keep it close to what Music Assistant sends.
+    return {
+        "contentId": url,
+        "customData": {"uri": url},
+        "contentType": "audio/wav",
+        "streamType": "BUFFERED",
+        "metadata": {
+            "metadataType": 3,
+            "title": title,
+        },
+        "duration": duration_s,
+    }
+
+
+def _wait_for_media_session_id(cast: Any, timeout: float = 15.0) -> int:
+    start = time.monotonic()
+    while True:
+        cast.media_controller.update_status()
+        msid = getattr(cast.media_controller.status, "media_session_id", None)
+        if msid is not None:
+            return int(msid)
+        if (time.monotonic() - start) > timeout:
+            raise TimeoutError("Timed out waiting for media_session_id")
+        time.sleep(0.25)
+
+
+def _connect_cast(pychromecast: Any, *, host: str, port: int) -> Any:
+    """Create a Chromecast object from a host/port across PyChromecast versions."""
+    # Older API: construct from host tuple.
+    if hasattr(pychromecast, "get_chromecast_from_host"):
+        try:
+            # Some versions accept (host, port).
+            return pychromecast.get_chromecast_from_host((host, port))  # type: ignore[attr-defined]
+        except Exception:
+            # Newer signature expects (ip, port, uuid, model_name, friendly_name).
+            dev_uuid: UUID = UUID(int=0)
+            model_name: str | None = None
+            friendly_name: str | None = None
+            try:
+                import pychromecast.dial as dial  # type: ignore
+
+                device_status = dial.get_device_info(host, services=None, timeout=5)  # type: ignore[arg-type]
+                if device_status:
+                    dev_uuid = getattr(device_status, "uuid", None) or dev_uuid
+                    model_name = getattr(device_status, "model_name", None)
+                    friendly_name = getattr(device_status, "friendly_name", None)
+            except Exception:
+                pass
+            return pychromecast.get_chromecast_from_host(  # type: ignore[attr-defined]
+                (host, port, dev_uuid, model_name, friendly_name)
+            )
+
+    # Very old fallback: Chromecast(host, port=...).
+    if hasattr(pychromecast, "Chromecast"):
+        return pychromecast.Chromecast(host, port=port)  # type: ignore[call-arg]
+
+    raise RuntimeError("Unsupported PyChromecast version: cannot create Chromecast object.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cast-host", required=True, help="Chromecast IP/hostname (e.g. 172.20.10.228)")
+    parser.add_argument("--cast-port", type=int, default=8009, help="Chromecast port (default: 8009)")
+    parser.add_argument("--bind", default="0.0.0.0", help="HTTP bind address (default: 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=0, help="HTTP port (0 chooses a random free port)")
+    parser.add_argument("--publish-ip", default="", help="IP to publish to Chromecast (default: auto)")
+    parser.add_argument("--duration", type=int, default=600, help="Duration per track in seconds (default: 600)")
+    parser.add_argument(
+        "--start-track",
+        type=int,
+        choices=[1, 2, 3, 4],
+        default=1,
+        help="Which track to LOAD first (default: 1)",
+    )
+    parser.add_argument(
+        "--no-queue",
+        action="store_true",
+        help="Only LOAD the start track (do not QUEUE_INSERT the remaining tracks)",
+    )
+    parser.add_argument(
+        "--preload-time",
+        type=int,
+        default=0,
+        help="Chromecast preloadTime for QUEUE_INSERT items (default: 0)",
+    )
+    parser.add_argument(
+        "--advertise-range",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Advertise byte range support via Accept-Ranges header (default: true).",
+    )
+    parser.add_argument(
+        "--honor-range",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Honor incoming Range requests (default: true).",
+    )
+    args = parser.parse_args()
+
+    publish_ip = args.publish_ip or _guess_publish_ip(args.cast_host)
+
+    tracks = [
+        TrackSpec(
+            path="/track1.wav",
+            title="Track 1 (Content-Length, fast)",
+            freq_hz=220.0,
+            duration_s=args.duration,
+            chunked=False,
+            throttle=False,
+        ),
+        TrackSpec(
+            path="/track2.wav",
+            title="Track 2 (Chunked, fast)",
+            freq_hz=330.0,
+            duration_s=args.duration,
+            chunked=True,
+            throttle=False,
+        ),
+        TrackSpec(
+            path="/track3.wav",
+            title="Track 3 (Content-Length, throttled)",
+            freq_hz=440.0,
+            duration_s=args.duration,
+            chunked=False,
+            throttle=True,
+        ),
+        TrackSpec(
+            path="/track4.wav",
+            title="Track 4 (Chunked, throttled)",
+            freq_hz=550.0,
+            duration_s=args.duration,
+            chunked=True,
+            throttle=True,
+        ),
+    ]
+
+    server, _thread = _start_http_server(bind=args.bind, port=args.port, tracks=tracks)
+    server.advertise_range = bool(args.advertise_range)  # type: ignore[attr-defined]
+    server.honor_range = bool(args.honor_range)  # type: ignore[attr-defined]
+    srv_host, srv_port = server.server_address[:2]
+    base_url = f"http://{publish_ip}:{srv_port}"
+    print(f"HTTP server listening on {srv_host}:{srv_port} (published as {base_url})")
+    print(
+        "Range settings:"
+        f" advertise_range={server.advertise_range} honor_range={server.honor_range}"  # type: ignore[attr-defined]
+    )
+    print("Track URLs:")
+    for t in tracks:
+        print(f"  - {base_url}{t.path}  [{t.title}]")
+
+    try:
+        import pychromecast  # type: ignore
+    except ImportError:
+        print("PyChromecast is not installed. Run this script inside the MA venv or install it:")
+        print("  python3 -m pip install PyChromecast")
+        return 2
+
+    cast: Any = _connect_cast(pychromecast, host=args.cast_host, port=args.cast_port)
+
+    # Start/attach listeners.
+    listener = _CastDebugListener()
+    try:
+        cast.register_status_listener(listener)
+        cast.socket_client.media_controller.register_status_listener(listener)
+        cast.register_connection_listener(listener)
+    except Exception:
+        # Not critical; depends on pychromecast internals.
+        pass
+
+    try:
+        cast.start()
+    except Exception:
+        pass
+
+    try:
+        cast.wait()
+    except TypeError:
+        cast.wait(10)
+
+    print(f"Connected to cast: {getattr(cast, 'name', None) or args.cast_host}")
+
+    # Launch Default Media Receiver app.
+    _launch_app(cast, APP_MEDIA_RECEIVER)
+
+    # Load first item.
+    media_controller = cast.media_controller
+    start_track = tracks[args.start_track - 1]
+    load_msg = {
+        "type": "LOAD",
+        "autoplay": True,
+        "currentTime": 0,
+        "media": _cc_media_item(
+            url=f"{base_url}{start_track.path}",
+            title=start_track.title,
+            duration_s=start_track.duration_s,
+        ),
+    }
+    media_controller.send_message(data=load_msg, inc_session_id=True)
+
+    if args.no_queue:
+        print(f"Loaded start track only (QUEUE_INSERT disabled): {start_track.title}")
+    else:
+        # Insert the remaining items into the Chromecast queue.
+        media_session_id = _wait_for_media_session_id(cast)
+        queue_tracks = [t for t in tracks if t != start_track]
+        insert_msg = {
+            "type": "QUEUE_INSERT",
+            "mediaSessionId": media_session_id,
+            "insertBefore": None,
+            "items": [
+                {
+                    "autoplay": True,
+                    "startTime": 0,
+                    "preloadTime": args.preload_time,
+                    "media": _cc_media_item(
+                        url=f"{base_url}{t.path}",
+                        title=t.title,
+                        duration_s=t.duration_s,
+                    ),
+                }
+                for t in queue_tracks
+            ],
+        }
+        media_controller.send_message(data=insert_msg, inc_session_id=True)
+        print(f"Queue loaded (preloadTime={args.preload_time}).")
+
+    print("Leave this running and watch for HTTP disconnects / cast socket drops.")
+    print("Press Ctrl+C to stop.")
+    try:
+        while True:
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Some Chromecast “UA=Cast Lite” devices (e.g. Samsung soundbars) buffer a large portion of a track,
close the HTTP connection intentionally, then reconnect later with `Range: bytes=...-` to fetch more.
Music Assistant’s `/single` streams didn’t support Range, so these devices stop mid-track. Short tracks happen to play, but common length/longer stop mid-track.

This MR adds HTTP Range support for Chromecast `/single` streams when the output codec is WAV. Similar feature for the compressed streams is significantly harder so I don't have that done. I'm satisfied with using WAV.

The 'Flow mode' is a workaround via only feeding the device bytes slowly, I wasn't satisfied with that solution since it feels like it misses out on the benefit of the buffering (playback stability); I felt the next/previous controls were not quite as responsive; I think I still saw some disconnects/music stopping (just very rarely).

## AI

This code was written by Codex (GP-5.2 Extra High) with me guiding it to discover the "bug" (via having it write cast_stream_debug.py) and then the implementation. Before removing the 'draft' flag I intend to read through the code and ensure it doesn't do anything I'd consider unreasonable. I've raised the (draft) MR now in case other people want to see it early, it took me a while to discover what the problem with the Soundbar was, and I hope this might help others use their device.

(AI written from here)

## Why WAV (and not FLAC) for Range
- WAV is linear PCM, so byte offsets map directly to time offsets (bytes/sec).
- FLAC is lossless but compressed; for MA’s on-the-fly encoding pipeline there is no stable
  byte-offset → time mapping without pre-encoding/caching the full encoded stream. I've been working on a 'cache the full encoded stream' but don't have it working yet in a way that my Samsung soundbar accepts.

Default output remains FLAC for bandwidth reasons; WAV is an opt-in per player for devices that require Range.

## Changes
- Add `Range` parsing and `206 Partial Content` responses for Chromecast `/single` WAV streams:
  - `Accept-Ranges: bytes`, `Content-Range`, and correct `Content-Length`
  - Map requested byte offsets into WAV header vs PCM payload
  - Seek by whole seconds and skip remaining bytes within the first chunk for byte accuracy
  - Return `416 Requested Range Not Satisfiable` for invalid/unsatisfiable ranges
- Update Chromecast player config UI label to indicate WAV “supports range requests” while keeping default FLAC.
- Ensure Cast `contentType` is `audio/wav` when the stream URL ends in `.wav`.
- Add `scripts/cast_stream_debug.py` to reproduce the buffering/disconnect/Range-reconnect behavior in isolation. This script clearly shows the soundbar disconnecting and then later coming back and asking for a range. I understand this is acceptable/common Chromecast behaviour (according to ChatGPT 5.2)

## Testing / Repro
- Run the debug tool:
  - `./.venv/bin/python scripts/cast_stream_debug.py --cast-host <ip>`
  - Observe the Chromecast reconnecting with `Range: bytes=...-` requests.
- In Music Assistant, set the affected Chromecast player’s output codec to WAV and verify playback continues
  through reconnects (server should respond with `206` for Range requests).

## Limitations
- Range support is implemented for WAV `/single` streams with known duration.
- FLAC Range support is not included (would require full-file encode/caching to guarantee byte-stable ranges).

