### PR TITLE
Add debug logging for scrobbled tracks

### DIFF
--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -129,6 +129,7 @@ class ListenBrainzEventHandler(ScrobblerHelper):
                 listen = self._make_listen(report)
                 listen.listened_at = int(time.time())
                 self._client.submit_single_listen(listen)
+                self.logger.debug(f"track {report.uri} scrobbled")
                 self._last_scrobbled = report.uri
             except Exception as err:
                 self.logger.exception(err)


### PR DESCRIPTION
Hello, ListenBrainz developer here :wave: 

We have had a couple of users [having issues](https://community.metabrainz.org/t/duplicates-in-listens-and-some-songs-not-scrobbled/785477/17) with their MusicAssistant + Sonos setup, and while helping them diagnose the problem I realized there is a debug trace for playing-now listens, but not for full scrobbles.

This would be useful to debug potential issues. In their case not all tracks that are marked as playing-now are actually scrobbled, and having this debug trace would be useful to try and identify a pattern.