### PR TITLE
Use RAOP protocol for Juke Audio devices

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -88,5 +88,5 @@ AIRPLAY_2_DEFAULT_MODELS = (
     # Models that are known to work better with AirPlay 2 protocol instead of RAOP
     # These use the translated/friendly model names from get_model_info()
     ("Ubiquiti Inc.", "*"),
-    ("Juke Audio", "*"),
+    # ("Juke Audio", "*"),  # Disabled - RAOP works better with Shairport Sync
 )

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -88,5 +88,4 @@ AIRPLAY_2_DEFAULT_MODELS = (
     # Models that are known to work better with AirPlay 2 protocol instead of RAOP
     # These use the translated/friendly model names from get_model_info()
     ("Ubiquiti Inc.", "*"),
-    # ("Juke Audio", "*"),  # Disabled - RAOP works better with Shairport Sync
 )


### PR DESCRIPTION
## Summary
Juke Audio devices use Shairport Sync which has compatibility issues with the AirPlay 2 protocol implementation (cliap2 returns 400 Bad Request). The RAOP protocol (cliraop) works correctly after fixing the auth-setup crash in libraop.

## Changes
Remove Juke Audio from `AIRPLAY_2_DEFAULT_MODELS` so these devices default to RAOP instead of AirPlay 2.

## Related
- Depends on: https://github.com/music-assistant/libraop/pull/4
  - Fixes crash in cliraop when connecting to Shairport Sync
  - cliraop binaries need to be rebuilt after that PR merges

## Testing
Tested streaming to JukeAudio whole-house audio system running Shairport Sync 4.1.1 - playback works correctly with RAOP protocol.


closes: https://github.com/music-assistant/support/issues/4656
