### PR TITLE
Reduce FFmpeg cover-art storms

### DIFF
--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import itertools
 import os
 import random
 from base64 import b64decode
+from collections import OrderedDict
 from collections.abc import Iterable
 from io import BytesIO
 from typing import TYPE_CHECKING, cast
@@ -26,6 +28,43 @@ if TYPE_CHECKING:
     from PIL.Image import Image as ImageClass
 
     from music_assistant.mass import MusicAssistant
+
+
+# Thumbnail cache: on-disk (persistent) + small in-memory FIFO (hot path)
+_THUMB_CACHE_DIR = "thumbnails"
+_THUMB_MEMORY_CACHE_MAX = 50
+
+_thumb_memory_cache: OrderedDict[str, bytes] = OrderedDict()
+
+
+def _create_thumb_hash(provider: str, path_or_url: str) -> str:
+    """Create a safe filesystem hash from provider and image path."""
+    raw = f"{provider}/{path_or_url}"
+    return hashlib.sha256(raw.encode(), usedforsecurity=False).hexdigest()
+
+
+def _thumb_cache_filename(thumb_hash: str, size: int | None, image_format: str) -> str:
+    """Build the cache filename for a thumbnail."""
+    ext = image_format.lower()
+    if ext == "jpeg":
+        ext = "jpg"
+    return f"{thumb_hash}_{size or 0}.{ext}"
+
+
+def _get_from_memory_cache(key: str) -> bytes | None:
+    """Retrieve thumbnail from in-memory FIFO cache."""
+    if key in _thumb_memory_cache:
+        _thumb_memory_cache.move_to_end(key)
+        return _thumb_memory_cache[key]
+    return None
+
+
+def _put_in_memory_cache(key: str, data: bytes) -> None:
+    """Store thumbnail in in-memory FIFO cache."""
+    _thumb_memory_cache[key] = data
+    _thumb_memory_cache.move_to_end(key)
+    while len(_thumb_memory_cache) > _THUMB_MEMORY_CACHE_MAX:
+        _thumb_memory_cache.popitem(last=False)
 
 
 async def get_image_data(mass: MusicAssistant, path_or_url: str, provider: str) -> bytes:
@@ -67,41 +106,107 @@ async def get_image_thumb(
     provider: str,
     image_format: str = "PNG",
 ) -> bytes:
-    """Get (optimized) PNG thumbnail from image url."""
+    """Get (optimized) thumbnail from image url.
+
+    Uses a two-tier cache (in-memory FIFO + on-disk) keyed by a hash of
+    provider + path so that repeated requests never trigger ffmpeg or
+    PIL processing again.  Concurrent requests for the same thumbnail
+    are de-duplicated via create_task.
+
+    :param mass: The MusicAssistant instance.
+    :param path_or_url: Path or URL to the source image.
+    :param size: Target thumbnail size (square), or None for original.
+    :param provider: Provider identifier for the image source.
+    :param image_format: Output format (PNG or JPEG/JPG).
+    """
+    image_format = image_format.upper()
+    if image_format == "JPG":
+        image_format = "JPEG"
+
+    thumb_hash = _create_thumb_hash(provider, path_or_url)
+    cache_filename = _thumb_cache_filename(thumb_hash, size, image_format)
+
+    # 1. Check in-memory FIFO cache
+    if cached := _get_from_memory_cache(cache_filename):
+        return cached
+
+    # 2. Check on-disk cache
+    thumb_dir = os.path.join(mass.cache_path, _THUMB_CACHE_DIR)
+    cache_filepath = os.path.join(thumb_dir, cache_filename)
+    if await asyncio.to_thread(os.path.isfile, cache_filepath):
+        async with aiofiles.open(cache_filepath, "rb") as f:
+            thumb_data = cast("bytes", await f.read())
+        _put_in_memory_cache(cache_filename, thumb_data)
+        return thumb_data
+
+    # 3. Generate thumbnail (de-duplicated across concurrent requests)
+    task: asyncio.Task[bytes] = mass.create_task(
+        _generate_and_cache_thumb,
+        mass,
+        path_or_url,
+        size,
+        provider,
+        image_format,
+        cache_filepath,
+        task_id=f"thumb.{cache_filename}",
+        abort_existing=False,
+    )
+    thumb_data = await asyncio.shield(task)
+    _put_in_memory_cache(cache_filename, thumb_data)
+    return thumb_data
+
+
+async def _generate_and_cache_thumb(
+    mass: MusicAssistant,
+    path_or_url: str,
+    size: int | None,
+    provider: str,
+    image_format: str,
+    cache_filepath: str,
+) -> bytes:
+    """Generate a thumbnail, persist it on disk, and return the bytes.
+
+    :param mass: The MusicAssistant instance.
+    :param path_or_url: Path or URL to the source image.
+    :param size: Target thumbnail size (square), or None for original.
+    :param provider: Provider identifier for the image source.
+    :param image_format: Normalized output format (PNG or JPEG).
+    :param cache_filepath: Absolute path where the thumbnail will be stored.
+    """
     img_data = await get_image_data(mass, path_or_url, provider)
     if not img_data or not isinstance(img_data, bytes):
         raise FileNotFoundError(f"Image not found: {path_or_url}")
 
     if not size and image_format.encode() in img_data:
-        return img_data
+        thumb_data = img_data
+    else:
 
-    image_format = image_format.upper()
-    if image_format == "JPG":
-        image_format = "JPEG"
+        def _create_image() -> bytes:
+            data = BytesIO()
+            try:
+                img = Image.open(BytesIO(img_data))
+            except UnidentifiedImageError:
+                raise FileNotFoundError(f"Invalid image: {path_or_url}")
+            if size:
+                img.thumbnail((size, size), Image.Resampling.LANCZOS)
+            mode = "RGBA" if image_format == "PNG" else "RGB"
+            if image_format == "JPEG":
+                img.convert(mode).save(data, image_format, quality=95, optimize=False)
+            else:
+                img.convert(mode).save(data, image_format, optimize=False)
+            return data.getvalue()
 
-    def _create_image() -> bytes:
-        data = BytesIO()
-        try:
-            img = Image.open(BytesIO(img_data))
-        except UnidentifiedImageError:
-            raise FileNotFoundError(f"Invalid image: {path_or_url}")
-        if size:
-            # Use LANCZOS for high quality downsampling
-            img.thumbnail((size, size), Image.Resampling.LANCZOS)
+        thumb_data = await asyncio.to_thread(_create_image)
 
-        mode = "RGBA" if image_format == "PNG" else "RGB"
+    # Persist to disk cache (best-effort, don't fail on I/O errors)
+    try:
+        await asyncio.to_thread(os.makedirs, os.path.dirname(cache_filepath), exist_ok=True)
+        async with aiofiles.open(cache_filepath, "wb") as f:
+            await f.write(thumb_data)
+    except OSError:
+        pass
 
-        # Save with high quality settings
-        if image_format == "JPEG":
-            # For JPEG, use quality=95 for better quality
-            img.convert(mode).save(data, image_format, quality=95, optimize=False)
-        else:
-            # For PNG, disable optimize to preserve quality
-            img.convert(mode).save(data, image_format, optimize=False)
-        return data.getvalue()
-
-    image_format = image_format.upper()
-    return await asyncio.to_thread(_create_image)
+    return thumb_data
 
 
 async def create_collage(

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import itertools
 import os
 import random
+import time
+import weakref
 from base64 import b64decode
+from collections import OrderedDict
 from collections.abc import Iterable
+from dataclasses import dataclass, field
 from io import BytesIO
 from typing import TYPE_CHECKING, cast
 
@@ -28,9 +33,89 @@ if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
 
 
+_IMAGE_CACHE_TTL_SECONDS = 900
+_IMAGE_CACHE_MAX_ENTRIES = 256
+_MAX_CONCURRENT_EMBEDDED_IMAGE_EXTRACTIONS = 2
+
+
+@dataclass(slots=True)
+class _ImageHelperState:
+    """Runtime state for image helper cache/throttling."""
+
+    cache: OrderedDict[str, tuple[float, bytes]] = field(default_factory=OrderedDict)
+    embedded_image_semaphore: asyncio.Semaphore = field(
+        default_factory=lambda: asyncio.Semaphore(_MAX_CONCURRENT_EMBEDDED_IMAGE_EXTRACTIONS)
+    )
+
+
+_IMAGE_HELPER_STATES: weakref.WeakKeyDictionary[MusicAssistant, _ImageHelperState] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _get_helper_state(mass: MusicAssistant) -> _ImageHelperState:
+    """Return/create helper state for this Music Assistant instance."""
+    if state := _IMAGE_HELPER_STATES.get(mass):
+        return state
+    state = _ImageHelperState()
+    _IMAGE_HELPER_STATES[mass] = state
+    return state
+
+
+def _create_cache_key(provider: str, path_or_url: str) -> str:
+    """Create deterministic cache key for image requests."""
+    return f"{provider}.{path_or_url}"
+
+
+def _create_task_id(provider: str, path_or_url: str) -> str:
+    """Create compact task_id for in-flight request de-duplication."""
+    cache_key = _create_cache_key(provider, path_or_url)
+    cache_key_hash = hashlib.md5(cache_key.encode(), usedforsecurity=False).hexdigest()
+    return f"image_data.{cache_key_hash}"
+
+
+def _get_cached_image(state: _ImageHelperState, cache_key: str) -> bytes | None:
+    """Get image bytes from local memory cache."""
+    cache_entry = state.cache.get(cache_key)
+    if cache_entry is None:
+        return None
+    expires_at, image_data = cache_entry
+    if expires_at <= time.monotonic():
+        state.cache.pop(cache_key, None)
+        return None
+    state.cache.move_to_end(cache_key)
+    return image_data
+
+
+def _set_cached_image(state: _ImageHelperState, cache_key: str, image_data: bytes) -> None:
+    """Store image bytes in local memory cache."""
+    state.cache[cache_key] = (time.monotonic() + _IMAGE_CACHE_TTL_SECONDS, image_data)
+    state.cache.move_to_end(cache_key)
+    while len(state.cache) > _IMAGE_CACHE_MAX_ENTRIES:
+        state.cache.popitem(last=False)
+
+
 async def get_image_data(mass: MusicAssistant, path_or_url: str, provider: str) -> bytes:
     """Create thumbnail from image url."""
-    # TODO: add local cache here !
+    state = _get_helper_state(mass)
+    cache_key = _create_cache_key(provider, path_or_url)
+    if (cached_image := _get_cached_image(state, cache_key)) is not None:
+        return cached_image
+    task: asyncio.Task[bytes] = mass.create_task(
+        _get_image_data_uncached,
+        mass,
+        path_or_url,
+        provider,
+        task_id=_create_task_id(provider, path_or_url),
+        abort_existing=False,
+    )
+    image_data = await asyncio.shield(task)
+    _set_cached_image(state, cache_key, image_data)
+    return image_data
+
+
+async def _get_image_data_uncached(mass: MusicAssistant, path_or_url: str, provider: str) -> bytes:
+    """Fetch image bytes without using local cache."""
     if prov := mass.get_provider(provider):
         assert isinstance(prov, MusicProvider | MetadataProvider | PluginProvider)
         if resolved_image := await prov.resolve_image(path_or_url):
@@ -54,8 +139,11 @@ async def get_image_data(mass: MusicAssistant, path_or_url: str, provider: str) 
             async with aiofiles.open(path_or_url, "rb") as _file:
                 return cast("bytes", await _file.read())
     # use ffmpeg for embedded images
-    if is_safe_path(path_or_url) and (img_data := await get_embedded_image(path_or_url)):
-        return img_data
+    if is_safe_path(path_or_url):
+        state = _get_helper_state(mass)
+        async with state.embedded_image_semaphore:
+            if img_data := await get_embedded_image(path_or_url):
+                return img_data
     msg = f"Image not found: {path_or_url}"
     raise FileNotFoundError(msg)
 

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -3,16 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import itertools
 import os
 import random
-import time
-import weakref
 from base64 import b64decode
-from collections import OrderedDict
 from collections.abc import Iterable
-from dataclasses import dataclass, field
 from io import BytesIO
 from typing import TYPE_CHECKING, cast
 
@@ -33,89 +28,9 @@ if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
 
 
-_IMAGE_CACHE_TTL_SECONDS = 900
-_IMAGE_CACHE_MAX_ENTRIES = 256
-_MAX_CONCURRENT_EMBEDDED_IMAGE_EXTRACTIONS = 2
-
-
-@dataclass(slots=True)
-class _ImageHelperState:
-    """Runtime state for image helper cache/throttling."""
-
-    cache: OrderedDict[str, tuple[float, bytes]] = field(default_factory=OrderedDict)
-    embedded_image_semaphore: asyncio.Semaphore = field(
-        default_factory=lambda: asyncio.Semaphore(_MAX_CONCURRENT_EMBEDDED_IMAGE_EXTRACTIONS)
-    )
-
-
-_IMAGE_HELPER_STATES: weakref.WeakKeyDictionary[MusicAssistant, _ImageHelperState] = (
-    weakref.WeakKeyDictionary()
-)
-
-
-def _get_helper_state(mass: MusicAssistant) -> _ImageHelperState:
-    """Return/create helper state for this Music Assistant instance."""
-    if state := _IMAGE_HELPER_STATES.get(mass):
-        return state
-    state = _ImageHelperState()
-    _IMAGE_HELPER_STATES[mass] = state
-    return state
-
-
-def _create_cache_key(provider: str, path_or_url: str) -> str:
-    """Create deterministic cache key for image requests."""
-    return f"{provider}.{path_or_url}"
-
-
-def _create_task_id(provider: str, path_or_url: str) -> str:
-    """Create compact task_id for in-flight request de-duplication."""
-    cache_key = _create_cache_key(provider, path_or_url)
-    cache_key_hash = hashlib.md5(cache_key.encode(), usedforsecurity=False).hexdigest()
-    return f"image_data.{cache_key_hash}"
-
-
-def _get_cached_image(state: _ImageHelperState, cache_key: str) -> bytes | None:
-    """Get image bytes from local memory cache."""
-    cache_entry = state.cache.get(cache_key)
-    if cache_entry is None:
-        return None
-    expires_at, image_data = cache_entry
-    if expires_at <= time.monotonic():
-        state.cache.pop(cache_key, None)
-        return None
-    state.cache.move_to_end(cache_key)
-    return image_data
-
-
-def _set_cached_image(state: _ImageHelperState, cache_key: str, image_data: bytes) -> None:
-    """Store image bytes in local memory cache."""
-    state.cache[cache_key] = (time.monotonic() + _IMAGE_CACHE_TTL_SECONDS, image_data)
-    state.cache.move_to_end(cache_key)
-    while len(state.cache) > _IMAGE_CACHE_MAX_ENTRIES:
-        state.cache.popitem(last=False)
-
-
 async def get_image_data(mass: MusicAssistant, path_or_url: str, provider: str) -> bytes:
     """Create thumbnail from image url."""
-    state = _get_helper_state(mass)
-    cache_key = _create_cache_key(provider, path_or_url)
-    if (cached_image := _get_cached_image(state, cache_key)) is not None:
-        return cached_image
-    task: asyncio.Task[bytes] = mass.create_task(
-        _get_image_data_uncached,
-        mass,
-        path_or_url,
-        provider,
-        task_id=_create_task_id(provider, path_or_url),
-        abort_existing=False,
-    )
-    image_data = await asyncio.shield(task)
-    _set_cached_image(state, cache_key, image_data)
-    return image_data
-
-
-async def _get_image_data_uncached(mass: MusicAssistant, path_or_url: str, provider: str) -> bytes:
-    """Fetch image bytes without using local cache."""
+    # TODO: add local cache here !
     if prov := mass.get_provider(provider):
         assert isinstance(prov, MusicProvider | MetadataProvider | PluginProvider)
         if resolved_image := await prov.resolve_image(path_or_url):
@@ -139,11 +54,8 @@ async def _get_image_data_uncached(mass: MusicAssistant, path_or_url: str, provi
             async with aiofiles.open(path_or_url, "rb") as _file:
                 return cast("bytes", await _file.read())
     # use ffmpeg for embedded images
-    if is_safe_path(path_or_url):
-        state = _get_helper_state(mass)
-        async with state.embedded_image_semaphore:
-            if img_data := await get_embedded_image(path_or_url):
-                return img_data
+    if is_safe_path(path_or_url) and (img_data := await get_embedded_image(path_or_url)):
+        return img_data
     msg = f"Image not found: {path_or_url}"
     raise FileNotFoundError(msg)
 


### PR DESCRIPTION
## Background (my setup)

- Running a recent beta of Music Assistant server.
- Music library is local at home but accessed by the server over SMB.
- Many tracks have embedded cover art (and my playlist folders can mix tracks from different albums, each with its own artwork).
- When skipping/changing tracks, the server spawns many `ffmpeg` processes to extract the same embedded image repeatedly (same/similar tracks on every song change), causing high CPU usage and frequent interruptions in playback, changing song can take a few seconds.

## Flow (before)

- UI/client requests artwork via `GET /imageproxy`.
- `MetaDataController.handle_imageproxy` → `get_thumbnail` → `helpers/images.get_image_thumb`.
- `get_image_thumb` calls `helpers/images.get_image_data`.
- For local tracks where the image path points to the media file (embedded cover art):
  - `get_image_data` falls back to `helpers/tags.get_embedded_image`,
  - which spawns `ffmpeg` (`-vcodec mjpeg -f mjpeg -`) to extract the picture.

## Issue

- `helpers/images.get_image_data` had no local caching and no in-flight de-duplication [TODO in code]
- Result: every imageproxy request (and especially concurrent ones) could trigger a fresh embedded-art extraction.
- This caused bursts of `ffmpeg` processes for the same file, leading to significant slowdowns (amplified on slower I/O, e.g. SMB mounts).

## Fix (this PR)

- Add a small per-server in-memory cache for raw image bytes (TTL + max entries).
- De-duplicate concurrent requests for the same `(provider, path)` so only one extraction runs and other callers await the same task.
- Add a semaphore to cap concurrent embedded-art extractions, preventing `ffmpeg` bursts even across different files.

