### PR TITLE
Fix IPv6 address handling in bind config and ifaddr parsing

### DIFF
--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -281,10 +281,10 @@ class StreamsController(CoreController):
                 key=CONF_BIND_IP,
                 type=ConfigEntryType.STRING,
                 default_value="0.0.0.0",
-                options=[ConfigValueOption(x, x) for x in {"0.0.0.0", *ip_addresses}],
+                options=[ConfigValueOption(x, x) for x in {"0.0.0.0", "::", *ip_addresses}],
                 label="Bind to IP/interface",
                 description="Start the stream server on this specific interface. \n"
-                "Use 0.0.0.0 to bind to all interfaces, which is the default. \n"
+                "Use 0.0.0.0 or :: to bind to all interfaces, which is the default. \n"
                 "This is an advanced setting that should normally "
                 "not be adjusted in regular setups.",
                 category="generic",

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -226,10 +226,10 @@ class WebserverController(CoreController):
                 key=CONF_BIND_IP,
                 type=ConfigEntryType.STRING,
                 default_value="0.0.0.0",
-                options=[ConfigValueOption(x, x) for x in {"0.0.0.0", *ip_addresses}],
+                options=[ConfigValueOption(x, x) for x in {"0.0.0.0", "::", *ip_addresses}],
                 label="Bind to IP/interface",
                 description="Bind the (web)server to this specific interface. \n"
-                "Use 0.0.0.0 to bind to all interfaces. \n"
+                "Use 0.0.0.0 or :: to bind to all interfaces. \n"
                 "Set this address for example to a docker-internal network, "
                 "when you are running a reverse proxy to enhance security and "
                 "protect outside access to the webinterface and API. \n\n"

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -304,7 +304,8 @@ async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
             for ip in adapter.ips:
                 if ip.is_IPv6 and not include_ipv6:
                     continue
-                ip_str = str(ip.ip)
+                # ifaddr returns IPv6 addresses as (address, flowinfo, scope_id) tuples
+                ip_str = ip.ip[0] if isinstance(ip.ip, tuple) else ip.ip
                 if ip_str.startswith(("127", "169.254")):
                     # filter out IPv4 loopback/APIPA address
                     continue

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -94,7 +94,7 @@ class Webserver:
             self._webapp.router.add_route("*", "/{tail:.*}", self._handle_catch_all)
         await self._apprunner.setup()
         # set host to None to bind to all addresses on both IPv4 and IPv6
-        host = None if bind_ip == "0.0.0.0" else bind_ip
+        host = None if bind_ip in ("0.0.0.0", "::") else bind_ip
         try:
             self._tcp_site = web.TCPSite(
                 self._apprunner, host=host, port=bind_port, ssl_context=ssl_context


### PR DESCRIPTION
  - Fix `get_ip_addresses` to extract IPv6 address string from ifaddr tuples instead of stringifying the whole `(address, flowinfo, scope_id)` tuple
  - Add `::` (IPv6 all-interfaces) to bind IP options for both webserver and stream server
  - Treat `::` the same as `0.0.0.0` in webserver socket binding (map to `host=None`)

Follow-up to #3084