### PR TITLE
Fix builtin playlist genre display on refresh

### DIFF
--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -154,6 +154,13 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 yield track
             page += 1
 
+        # reset last_refresh on force_refresh so the metadata task
+        # will pick up this playlist and refresh genres + collage images
+        if force_refresh and library_item is not None:
+            library_item.metadata.last_refresh = None
+            await self.update_item_in_library(library_item.item_id, library_item)
+            self.mass.metadata.schedule_update_metadata(library_item)
+
     async def create_playlist(
         self,
         name: str,


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/3899 Builtin playlists (Random Album, etc.) not updating genres when refreshed.

Added genre counting during the track iteration when force_refresh=True. As we're already looping through every track to yield them, we grab the genre from each track (or its album if the track doesn't have one) and tally them up. At the end, we hand those counts off to metadata.save_playlist_genres().

I tried doing this the "proper" way through `_update_playlist_metadata` but that path has two problems:

1. It's behind a throttler (one call per 30 seconds) so the UI hangs waiting for it
2. It checks REFRESH_INTERVAL (90 days) and skips playlists that were recently refreshed

So I feel the genre collection needs to happen inline during the same iteration that's already happening. No extra iteration, no waiting on the throttler.

`metadata.py` - `save_playlist_genres() `

This takes the genre counts collected above and does the actual saving. It needs to do two things because I understand the UI reads genres from two places:

1. Write to genre_media_item_mapping table - this is what get_genres_for_media_item reads, which is what the UI actually calls to show genre tags
2. Update metadata.genres on the playlist object in the library DB - this fires MEDIA_ITEM_UPDATED which tells the UI to refresh

`metadata.py` - `_update_playlist_metadata()` genre filter improvement

The old filter (count > 5) was too aggressive for small playlists - a Random Album with 10 tracks might only have 1-2 genres with a count of 10. Now it keeps all genres for small playlists (<=20 total occurrences) and uses a proportional threshold for bigger ones. Also sorts by frequency and takes the top 8 rather than just grabbing an arbitrary set.