### PR TITLE
Fix filtering and sorting within Artist, Album and Track views

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -859,9 +859,9 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         extra_join_parts: list[str] | None = None,
     ) -> list[ItemCls]:
         """Fetch MediaItem records from database by building the query."""
-        query_params = extra_query_params or {}
-        query_parts: list[str] = extra_query_parts or []
-        join_parts: list[str] = extra_join_parts or []
+        query_params = dict(extra_query_params) if extra_query_params else {}
+        query_parts: list[str] = list(extra_query_parts) if extra_query_parts else []
+        join_parts: list[str] = list(extra_join_parts) if extra_join_parts else []
         search = self._preprocess_search(search, query_params)
         # create special performant random query
         if order_by and order_by.startswith("random"):


### PR DESCRIPTION
When applying _both_ a provider filter _and_ a sort, this would result in an error: `ambiguous column name: provider_mappings.item_id`. This was due to the fact that we leaked dicts/list from the base_query, causing duplicate joins in the generated query.

Fixes: https://discordapp.com/channels/753947050995089438/1468913718367748146