### PR TITLE
Fix DLNA players not reconnecting

### DIFF
--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -86,6 +86,10 @@ class DLNAPlayer(Player):
         self.last_seen = time.time()
         self.last_command = time.time()
 
+    def set_available(self, available: bool) -> None:
+        """Set the availability of the player."""
+        self._attr_available = available
+
     async def _device_connect(self) -> None:
         """Connect DLNA/DMR Device."""
         self.logger.debug("Connecting to device at %s", self.description_url)

--- a/music_assistant/providers/dlna/provider.py
+++ b/music_assistant/providers/dlna/provider.py
@@ -125,7 +125,7 @@ class DLNAPlayerProvider(PlayerProvider):
             dlna_player.device.on_event = None
             old_device = dlna_player.device
             dlna_player.device = None
-            dlna_player._attr_available = False
+            dlna_player.set_available(False)
             await old_device.async_unsubscribe_services()
 
     async def _device_discovered(self, udn: str, description_url: str) -> None:

--- a/music_assistant/providers/dlna/provider.py
+++ b/music_assistant/providers/dlna/provider.py
@@ -103,11 +103,11 @@ class DLNAPlayerProvider(PlayerProvider):
         finally:
             self._discovery_running = False
 
-        def reschedule() -> None:
-            self.mass.create_task(self.discover_players(use_multicast=not use_multicast))
+            def reschedule() -> None:
+                self.mass.create_task(self.discover_players(use_multicast=not use_multicast))
 
-        # reschedule self once finished
-        self.mass.loop.call_later(300, reschedule)
+            # reschedule self once finished
+            self.mass.loop.call_later(300, reschedule)
 
     async def _device_disconnect(self, dlna_player: DLNAPlayer) -> None:
         """
@@ -125,6 +125,7 @@ class DLNAPlayerProvider(PlayerProvider):
             dlna_player.device.on_event = None
             old_device = dlna_player.device
             dlna_player.device = None
+            dlna_player._attr_available = False
             await old_device.async_unsubscribe_services()
 
     async def _device_discovered(self, udn: str, description_url: str) -> None:


### PR DESCRIPTION
This PR fixes a few left overs from the player refactor:
- Sets 'available' explicitly to `False` when a device disconnects, allowing it to be picked up again
- Moves the reschedule logic to the `finally` to ensure a discover is retriggered even when an exception occurs during discovery.

Fixes: https://github.com/music-assistant/support/issues/3823
Might fix: https://github.com/music-assistant/support/issues/4753