### PR TITLE
Fix library items not deleted after all providers have removed them 

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -46,6 +46,7 @@ from music_assistant_models.provider import SyncTask
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import (
+    CONF_PROVIDERS,
     DB_TABLE_ALBUM_ARTISTS,
     DB_TABLE_ALBUM_TRACKS,
     DB_TABLE_ALBUMS,
@@ -74,7 +75,7 @@ from music_assistant.helpers.tags import split_artists
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.helpers.util import TaskManager, parse_title_and_version
 from music_assistant.models.core_controller import CoreController
-from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.music_provider import CACHE_CATEGORY_PREV_LIBRARY_IDS, MusicProvider
 from music_assistant.models.smart_fades import SmartFadesAnalysis, SmartFadesAnalysisFragment
 
 from .media.albums import AlbumsController
@@ -98,7 +99,7 @@ CONF_RESET_DB = "reset_db"
 DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
-DB_SCHEMA_VERSION: Final[int] = 26
+DB_SCHEMA_VERSION: Final[int] = 27
 
 CACHE_CATEGORY_LAST_SYNC: Final[int] = 9
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10
@@ -1803,6 +1804,49 @@ class MusicController(CoreController):
             )
             return []
 
+    async def _process_sync_deletions(
+        self,
+        provider_instance_id: str,
+        media_type: MediaType,
+        prev_library_items: list[int],
+    ) -> None:
+        """Hard-delete library items that are no longer in any provider's library.
+
+        This method checks if the item should be hard-deleted
+        from the DB (when no other provider has it in their library).
+
+        :param provider_instance_id: The provider instance that just synced.
+        :param media_type: The media type that was synced.
+        :param prev_library_items: DB IDs from previous sync cycle.
+        """
+        cur_db_ids_list: list[int] | None = await self.mass.cache.get(
+            key=media_type.value,
+            provider=provider_instance_id,
+            category=CACHE_CATEGORY_PREV_LIBRARY_IDS,
+        )
+        cur_db_ids = set(cur_db_ids_list) if cur_db_ids_list else set()
+        controller = self.get_controller(media_type)
+        for db_id in prev_library_items:
+            if db_id in cur_db_ids:
+                continue
+            try:
+                library_item = await controller.get_library_item(db_id)
+            except MediaNotFoundError:
+                continue
+
+            # check if any other provider mappings have this item in library
+            remaining_providers_in_library = {
+                x.provider_instance
+                for x in library_item.provider_mappings
+                if x.provider_instance != provider_instance_id and x.in_library
+            }
+
+            # if not, hard-delete from DB
+            if not remaining_providers_in_library:
+                await controller.remove_item_from_library(db_id)
+
+            await asyncio.sleep(0)
+
     def _start_provider_sync(self, provider: MusicProvider, media_type: MediaType) -> None:
         """Start sync task on provider and track progress."""
         # check if we're not already running a sync task for this provider/mediatype
@@ -1823,7 +1867,16 @@ class MusicController(CoreController):
             # Wrap the provider sync into a lock to prevent
             # race conditions when multiple providers are syncing at the same time.
             async with self._sync_lock:
+                prev_library_items: list[int] | None = await self.mass.cache.get(
+                    key=media_type.value,
+                    provider=provider.instance_id,
+                    category=CACHE_CATEGORY_PREV_LIBRARY_IDS,
+                )
                 await provider.sync_library(media_type)
+                if prev_library_items:
+                    await self._process_sync_deletions(
+                        provider.instance_id, media_type, prev_library_items
+                    )
 
         # we keep track of running sync tasks
         task = self.mass.create_task(run_sync())
@@ -2221,6 +2274,89 @@ class MusicController(CoreController):
                 f"DELETE FROM {DB_TABLE_PROVIDER_MAPPINGS} "
                 "WHERE media_type = 'playlist' AND in_library = 0;"
             )
+
+        if prev_version <= 27:
+            # Hard-delete items that were previously soft-deleted (all provider_mappings
+            # have in_library=0) and are exclusively from sync-back-enabled providers.
+            # Items from sync-back-disabled providers are kept (could be manually added).
+            sync_back_disabled: set[str] = set()
+            raw_providers = self.mass.config.get(CONF_PROVIDERS, {})
+            for instance_id in raw_providers:
+                if not self.mass.config.get_raw_provider_config_value(
+                    instance_id, "library_sync_back", True
+                ):
+                    sync_back_disabled.add(instance_id)
+
+            for table, media_type_str in (
+                (DB_TABLE_TRACKS, "track"),
+                (DB_TABLE_ALBUMS, "album"),
+                (DB_TABLE_ARTISTS, "artist"),
+                (DB_TABLE_PLAYLISTS, "playlist"),
+                (DB_TABLE_RADIOS, "radio"),
+                (DB_TABLE_AUDIOBOOKS, "audiobook"),
+                (DB_TABLE_PODCASTS, "podcast"),
+            ):
+                # find items with no in_library=1 mapping
+                items_query = (
+                    f"SELECT item_id FROM {table} WHERE item_id NOT IN ("
+                    f"  SELECT DISTINCT item_id FROM provider_mappings"
+                    f"  WHERE media_type = '{media_type_str}' AND in_library = 1"
+                    f")"
+                )
+                # exclude items that have a mapping from a sync-back-disabled provider
+                if sync_back_disabled:
+                    placeholders = ",".join(f"'{p}'" for p in sync_back_disabled)
+                    items_query += (
+                        f" AND item_id NOT IN ("
+                        f"  SELECT DISTINCT item_id FROM provider_mappings"
+                        f"  WHERE media_type = '{media_type_str}'"
+                        f"  AND provider_instance IN ({placeholders})"
+                        f")"
+                    )
+
+                rows = await self._database.get_rows_from_query(items_query)
+                if not rows:
+                    continue
+                ids_to_delete = ",".join(str(row["item_id"]) for row in rows)
+
+                # clean up join tables
+                if table == DB_TABLE_TRACKS:
+                    await self._database.execute(
+                        f"DELETE FROM {DB_TABLE_TRACK_ARTISTS} WHERE track_id IN ({ids_to_delete})"
+                    )
+                    await self._database.execute(
+                        f"DELETE FROM {DB_TABLE_ALBUM_TRACKS} WHERE track_id IN ({ids_to_delete})"
+                    )
+                elif table == DB_TABLE_ALBUMS:
+                    await self._database.execute(
+                        f"DELETE FROM {DB_TABLE_ALBUM_TRACKS} WHERE album_id IN ({ids_to_delete})"
+                    )
+                    await self._database.execute(
+                        f"DELETE FROM {DB_TABLE_ALBUM_ARTISTS} WHERE album_id IN ({ids_to_delete})"
+                    )
+                elif table == DB_TABLE_ARTISTS:
+                    await self._database.execute(
+                        f"DELETE FROM {DB_TABLE_ALBUM_ARTISTS} WHERE artist_id IN ({ids_to_delete})"
+                    )
+                    await self._database.execute(
+                        f"DELETE FROM {DB_TABLE_TRACK_ARTISTS} WHERE artist_id IN ({ids_to_delete})"
+                    )
+
+                # delete provider_mappings and playlog entries
+                await self._database.execute(
+                    f"DELETE FROM {DB_TABLE_PROVIDER_MAPPINGS}"
+                    f" WHERE media_type = '{media_type_str}'"
+                    f" AND item_id IN ({ids_to_delete})"
+                )
+                await self._database.execute(
+                    f"DELETE FROM {DB_TABLE_PLAYLOG}"
+                    f" WHERE media_type = '{media_type_str}'"
+                    f" AND item_id IN ({ids_to_delete})"
+                )
+                # delete the items themselves
+                await self._database.execute(
+                    f"DELETE FROM {table} WHERE item_id IN ({ids_to_delete})"
+                )
 
         # save changes
         await self._database.commit()

--- a/tests/controllers/__init__.py
+++ b/tests/controllers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Music Assistants controllers."""

--- a/tests/controllers/test_music.py
+++ b/tests/controllers/test_music.py
@@ -1,0 +1,231 @@
+"""Tests for sync deletion logic: hard-delete vs soft-delete behavior."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.media_items import ProviderMapping, Track
+
+from music_assistant.controllers.music import MusicController
+
+
+def _make_track(
+    db_id: int,
+    provider_mappings: set[ProviderMapping],
+    favorite: bool = False,
+) -> Track:
+    """Create a Track with the given provider mappings for testing."""
+    return Track(
+        item_id=str(db_id),
+        provider="library",
+        name=f"Track {db_id}",
+        provider_mappings=provider_mappings,
+        favorite=favorite,
+    )
+
+
+def _make_prov_mapping(
+    item_id: str,
+    provider_domain: str,
+    provider_instance: str,
+    in_library: bool | None = None,
+) -> ProviderMapping:
+    """Create a ProviderMapping for testing."""
+    return ProviderMapping(
+        item_id=item_id,
+        provider_domain=provider_domain,
+        provider_instance=provider_instance,
+        in_library=in_library,
+    )
+
+
+@pytest.fixture
+def media_controller() -> AsyncMock:
+    """Return a mock media type controller (e.g. TracksController)."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def music_controller(media_controller: AsyncMock) -> MusicController:
+    """Return a MusicController wired to use the mock media_controller."""
+    mass = MagicMock()
+    mass.config.get_raw_core_config_value.return_value = "GLOBAL"
+    ctrl = MusicController(mass)
+    ctrl.get_controller = lambda _media_type: media_controller  # type: ignore[assignment]
+    return ctrl
+
+
+async def test_sync_removes_synced_item_hard_delete(
+    music_controller: MusicController,
+    media_controller: AsyncMock,
+) -> None:
+    """Provider sync removes a synced item -> hard-deleted from DB.
+
+    Item was synced (prov_map.in_library=True), then removed from provider.
+    After soft-delete sets in_library=False, _process_sync_deletions should
+    call remove_item_from_library().
+    """
+    track = _make_track(
+        db_id=1,
+        provider_mappings={
+            _make_prov_mapping("sp_track_1", "spotify", "spotify_1", in_library=False),
+        },
+    )
+    # spotify_1 no longer has this item after sync
+    music_controller.mass.cache.get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    # DB still has the item with its (now soft-deleted) provider mapping
+    media_controller.get_library_item = AsyncMock(return_value=track)
+
+    await music_controller._process_sync_deletions(
+        provider_instance_id="spotify_1",
+        media_type=MediaType.TRACK,
+        prev_library_items=[1],
+    )
+
+    media_controller.remove_item_from_library.assert_called_once_with(1)
+
+
+async def test_manually_added_item_not_in_prev_ids(
+    music_controller: MusicController,
+    media_controller: AsyncMock,
+) -> None:
+    """Manually-added items (in_library=False) are never in prev_library_items.
+
+    Items added via MA search have in_library=0. They're never in the provider's
+    library, so they never appear in cur_db_ids or prev_library_items.
+    The sync deletion logic never processes them.
+    """
+    # spotify_1 has no items after sync
+    music_controller.mass.cache.get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    await music_controller._process_sync_deletions(
+        provider_instance_id="spotify_1",
+        media_type=MediaType.TRACK,
+        prev_library_items=[],
+    )
+
+    media_controller.get_library_item.assert_not_called()
+    media_controller.remove_item_from_library.assert_not_called()
+
+
+async def test_manually_added_item_none_in_library(
+    music_controller: MusicController,
+    media_controller: AsyncMock,
+) -> None:
+    """Same as above but with in_library=None (default for new ProviderMapping)."""
+    # spotify_1 has no items after sync
+    music_controller.mass.cache.get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    await music_controller._process_sync_deletions(
+        provider_instance_id="spotify_1",
+        media_type=MediaType.TRACK,
+        prev_library_items=[],
+    )
+
+    media_controller.remove_item_from_library.assert_not_called()
+
+
+async def test_multi_provider_removal_from_one_keeps_item(
+    music_controller: MusicController,
+    media_controller: AsyncMock,
+) -> None:
+    """Multi-provider: removal from one provider, still in another -> item stays.
+
+    Item has mappings from spotify_1 (already soft-deleted) and tidal_1 (in_library=True).
+    _process_sync_deletions should NOT hard-delete because tidal_1 still has it.
+    """
+    track = _make_track(
+        db_id=1,
+        provider_mappings={
+            _make_prov_mapping("sp_track_1", "spotify", "spotify_1", in_library=False),
+            _make_prov_mapping("td_track_1", "tidal", "tidal_1", in_library=True),
+        },
+    )
+    # spotify_1 removed this item from its library after sync
+    music_controller.mass.cache.get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    # DB has the item with mappings from both providers
+    media_controller.get_library_item = AsyncMock(return_value=track)
+
+    await music_controller._process_sync_deletions(
+        provider_instance_id="spotify_1",
+        media_type=MediaType.TRACK,
+        prev_library_items=[1],
+    )
+
+    media_controller.remove_item_from_library.assert_not_called()
+
+
+async def test_multi_provider_removal_from_last_deletes_item(
+    music_controller: MusicController,
+    media_controller: AsyncMock,
+) -> None:
+    """Multi-provider: removal from last provider -> hard-delete.
+
+    Item had both providers, but spotify already set in_library=False.
+    Now tidal also removes it (soft-deleted to in_library=False) -> should hard-delete.
+    """
+    track = _make_track(
+        db_id=1,
+        provider_mappings={
+            _make_prov_mapping("sp_track_1", "spotify", "spotify_1", in_library=False),
+            _make_prov_mapping("td_track_1", "tidal", "tidal_1", in_library=False),
+        },
+    )
+    # tidal_1 removed this item from its library after sync
+    music_controller.mass.cache.get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    # DB has the item, but both providers have in_library=False
+    media_controller.get_library_item = AsyncMock(return_value=track)
+
+    await music_controller._process_sync_deletions(
+        provider_instance_id="tidal_1",
+        media_type=MediaType.TRACK,
+        prev_library_items=[1],
+    )
+
+    media_controller.remove_item_from_library.assert_called_once_with(1)
+
+
+async def test_item_already_deleted_from_db_is_skipped(
+    music_controller: MusicController,
+    media_controller: AsyncMock,
+) -> None:
+    """If the item is already deleted from the DB, skip it gracefully."""
+    # spotify_1 no longer has this item after sync
+    music_controller.mass.cache.get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    # Item is already gone from the DB
+    media_controller.get_library_item = AsyncMock(side_effect=MediaNotFoundError("not found"))
+
+    await music_controller._process_sync_deletions(
+        provider_instance_id="spotify_1",
+        media_type=MediaType.TRACK,
+        prev_library_items=[1],
+    )
+
+    media_controller.remove_item_from_library.assert_not_called()
+
+
+async def test_items_still_in_provider_not_processed(
+    music_controller: MusicController,
+    media_controller: AsyncMock,
+) -> None:
+    """Items still in the provider (in cur_db_ids) are not processed for deletion."""
+    track = _make_track(
+        db_id=1,
+        provider_mappings={
+            _make_prov_mapping("sp_track_1", "spotify", "spotify_1", in_library=True),
+        },
+    )
+    # spotify_1 still has item 1 in its library after sync
+    music_controller.mass.cache.get = AsyncMock(return_value=[1])  # type: ignore[method-assign]
+    # DB has the item (but it should never be looked up)
+    media_controller.get_library_item = AsyncMock(return_value=track)
+
+    await music_controller._process_sync_deletions(
+        provider_instance_id="spotify_1",
+        media_type=MediaType.TRACK,
+        prev_library_items=[1],
+    )
+
+    media_controller.get_library_item.assert_not_called()
+    media_controller.remove_item_from_library.assert_not_called()


### PR DESCRIPTION
This PR 

- Fixes hanging library items when all providers have removed that item by checking if there are any prov_mappings left with in_library=1 after a sync
- This makes sure that MediaItems that were added to the MA library via search are still kept, as they are not included in the sync process
- The migration logic cleans up any library items that should have been deleted, with 1 exclusion: providers without 2 ways sync could have a valid db item entry with a provider_mapping.in_library = 0, since they might have been added via the search.