### PR TITLE
Fix operator precedence and inverted dedup logic in audiobooks playlog

### DIFF
--- a/music_assistant/controllers/media/audiobooks.py
+++ b/music_assistant/controllers/media/audiobooks.py
@@ -305,12 +305,12 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                 "provider": "library",
             },
         )
-        seconds_played = int(media_item.resume_position_ms or 0 / 1000)
+        seconds_played = int((media_item.resume_position_ms or 0) / 1000)
         # abort if nothing changed
         if (
             cur_entry
             and cur_entry["fully_played"] == media_item.fully_played
-            and abs((cur_entry["seconds_played"] or 0) - seconds_played) > 2
+            and abs((cur_entry["seconds_played"] or 0) - seconds_played) <= 2
         ):
             return
         await self.mass.music.database.insert(


### PR DESCRIPTION
Two bugs in the audiobook resume/playlog tracking:

1. `int(media_item.resume_position_ms or 0 / 1000)` never divides by 1000 because `/` binds tighter than `or`. The expression evaluates as `int(resume_position_ms or (0 / 1000))`, so non-zero values pass through as raw milliseconds instead of seconds.

2. The dedup check `abs(difference) > 2` skips the DB write when data HAS changed (difference > 2 seconds) and writes when it has NOT changed (difference <= 2 seconds). The comparison is inverted.