### PR TITLE
Workaround for "Youtube Music playlist stalls on uploaded music" music-assistant/support#4469

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -337,7 +337,7 @@ class YoutubeMusicProvider(MusicProvider):
     @use_cache(3600 * 24 * 30)  # Cache for 30 days
     async def get_album(self, prov_album_id) -> Album:
         """Get full album details by id."""
-        if album_obj := await get_album(prov_album_id=prov_album_id, language=self.language):
+        if album_obj := await get_album(headers=self._headers, prov_album_id=prov_album_id, language=self.language, user=self._yt_user):
             return self._parse_album(album_obj=album_obj, album_id=prov_album_id)
         msg = f"Item {prov_album_id} not found"
         raise MediaNotFoundError(msg)
@@ -345,7 +345,7 @@ class YoutubeMusicProvider(MusicProvider):
     @use_cache(3600 * 24 * 30)  # Cache for 30 days
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get album tracks for given album id."""
-        album_obj = await get_album(prov_album_id=prov_album_id, language=self.language)
+        album_obj = await get_album(headers=self._headers, prov_album_id=prov_album_id, language=self.language, user=self._yt_user)
         if not album_obj.get("tracks"):
             return []
         tracks = []

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -337,7 +337,12 @@ class YoutubeMusicProvider(MusicProvider):
     @use_cache(3600 * 24 * 30)  # Cache for 30 days
     async def get_album(self, prov_album_id) -> Album:
         """Get full album details by id."""
-        if album_obj := await get_album(headers=self._headers, prov_album_id=prov_album_id, language=self.language, user=self._yt_user):
+        if album_obj := await get_album(
+            headers=self._headers,
+            prov_album_id=prov_album_id,
+            language=self.language,
+            user=self._yt_user,
+        ):
             return self._parse_album(album_obj=album_obj, album_id=prov_album_id)
         msg = f"Item {prov_album_id} not found"
         raise MediaNotFoundError(msg)
@@ -345,7 +350,12 @@ class YoutubeMusicProvider(MusicProvider):
     @use_cache(3600 * 24 * 30)  # Cache for 30 days
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get album tracks for given album id."""
-        album_obj = await get_album(headers=self._headers, prov_album_id=prov_album_id, language=self.language, user=self._yt_user)
+        album_obj = await get_album(
+            headers=self._headers,
+            prov_album_id=prov_album_id,
+            language=self.language,
+            user=self._yt_user,
+        )
         if not album_obj.get("tracks"):
             return []
         tracks = []

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -41,12 +41,21 @@ async def get_album(headers: dict[str, str], prov_album_id: str, language: str =
     """Async wrapper around the ytmusicapi get_album function."""
 
     def _get_album():
-        ytm = ytmusicapi.YTMusic(language=language)
-        album = ytm.get_album(browseId=prov_album_id)
+        if prov_album_id.startswith("FEmusic_library_privately_owned_release"):
+            ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
+            album = ytm.get_library_upload_album(browseId=prov_album_id)
+        else:
+            ytm = ytmusicapi.YTMusic(language=language)
+            album = ytm.get_album(browseId=prov_album_id)
+
         if "audioPlaylistId" in album:
             # Track id's from album tracks do not match with actual album tracks. E.g. a track
             # points to the videoId of the original version, while we want the album version
-            album_playlist = ytm.get_playlist(playlistId=album["audioPlaylistId"], limit=None)
+            try:
+                album_playlist = ytm.get_playlist(playlistId=album["audioPlaylistId"], limit=None)
+            except ytmusicapi.YTMusicError:
+                return album
+
             # Do some basic checks
             if len(album_playlist.get("tracks", [])) != len(album.get("tracks", [])):
                 return album
@@ -57,8 +66,7 @@ async def get_album(headers: dict[str, str], prov_album_id: str, language: str =
                     album_track["videoId"] = playlist_track["videoId"]
                     album_track["isAvailable"] = playlist_track.get("isAvailable", True)
                     album_track["likeStatus"] = playlist_track.get("likeStatus", "INDIFFERENT")
-            return album
-        return ytm.get_album(browseId=prov_album_id)
+        return album
 
     return await asyncio.to_thread(_get_album)
 

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -37,7 +37,9 @@ async def get_artist(
     return await asyncio.to_thread(_get_artist)
 
 
-async def get_album(headers: dict[str, str], prov_album_id: str, language: str = "en", user: str | None = None) -> dict[str, str]:
+async def get_album(
+    headers: dict[str, str], prov_album_id: str, language: str = "en", user: str | None = None
+) -> dict[str, str]:
     """Async wrapper around the ytmusicapi get_album function."""
 
     def _get_album():

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -37,7 +37,7 @@ async def get_artist(
     return await asyncio.to_thread(_get_artist)
 
 
-async def get_album(prov_album_id: str, language: str = "en") -> dict[str, str]:
+async def get_album(headers: dict[str, str], prov_album_id: str, language: str = "en", user: str | None = None) -> dict[str, str]:
     """Async wrapper around the ytmusicapi get_album function."""
 
     def _get_album():
@@ -238,7 +238,7 @@ async def library_add_remove_album(
     headers: dict[str, str], prov_item_id: str, add: bool = True, user: str | None = None
 ) -> bool:
     """Add or remove an album or playlist to the user's library."""
-    album = await get_album(prov_album_id=prov_item_id)
+    album = await get_album(headers=headers, prov_album_id=prov_item_id, user=user)
 
     def _library_add_remove_album():
         ytm = ytmusicapi.YTMusic(auth=headers, user=user)


### PR DESCRIPTION
This is a workaround for the "stalling" aspect of music-assistant/support#4469

MA tries to resolve albums providing the `prov_album_id` of the form `FEmusic_library_privately_owned_release_detailb_po_<probably private_letters_and_numbers_id>` which triggers an exception in `ytmusic.get_album()` as it checks that the ID `.startswith('MPRE')`.

The handling of the exception seems to lead to playback stalling in this case.  Catching and returning `None` (presumably like "not found") instead leads to a warning as follows, but playback doesn't stall.

```
2026-02-13 23:05:25.159 WARNING (MainThread) [music_assistant.music.track] Unable to fetch album details for ytmusic--xxxxxxx://track/JB2LoK_zfD4 - album://FEmusic_library_privately_owned_release_detailb_po_xxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx not found on provider ytmusic--xxxxxxx
```

This may not resolve the base issues:

1. Why do we have a providerID for the album that cannot be looked up - has the wrong field been stored somewhere?
2. Why does reloading MA often allow that album to be played successfully (though I don't see calls to `get_album()` in that case)

----

Approach:

I preferred to catch the exception rather than check the prefix, in case `ytmusicapi` resolves the issue and allows non MPRE prefixes in the future.

Since the Exception is a generic `UserError` type I specifically check the message and propagate any other exceptions..

----

Additionally I removed a duplicate lookup rather than expand the `try` block further.