### PR TITLE
Fix AttributeError when provider is temporarily unavailable

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -865,7 +865,7 @@ class MusicController(CoreController):
             if not prov_mapping.in_library:
                 continue
             provider = self.mass.get_provider(prov_mapping.provider_instance)
-            if not provider.library_edit_supported(full_item.media_type):
+            if not provider or not provider.library_edit_supported(full_item.media_type):
                 continue
             if not provider.library_sync_back_enabled(full_item.media_type):
                 continue
@@ -899,7 +899,7 @@ class MusicController(CoreController):
         # add to provider(s) library first
         for prov_mapping in full_item.provider_mappings:
             provider = self.mass.get_provider(prov_mapping.provider_instance)
-            if not provider.library_edit_supported(full_item.media_type):
+            if not provider or not provider.library_edit_supported(full_item.media_type):
                 continue
             if not provider.library_sync_back_enabled(full_item.media_type):
                 continue


### PR DESCRIPTION
get_provider() can return None when a provider is temporarily unavailable (e.g., during reload or network issues). Both remove_item_from_library() and add_item_to_library() call .library_edit_supported() on the result without a None check, causing an AttributeError that surfaces as a 500 error.

I wasn't able to figure out how to make a test for this one, sorry. :-/ To break down the exact scenario this is an attempted fix for:

1. Provider starts unavailable

models/provider.py:39 — every provider initializes with self.available = False

2. Only set to True after successful async init

mass.py:838 — provider.available = True is set only after handle_async_init() succeeds at line 829

3. On unload, provider is removed entirely

mass.py:698 — self._providers.pop(instance_id, None) removes the provider from the dict

4. During reload, there's a window where available = False

When a provider is reloaded (unload then load), it goes through:
  - Unload: removed from _providers (line 698)
  - Load: re-added to _providers at line 832, but with available = False (from constructor, line 39)
  - Only after handle_async_init() completes does it become available = True (line 838)

5. get_provider() filters on available

mass.py:360 — the check if return_unavailable or prov.available means if prov.available is False (and return_unavailable defaults to False), the provider is not returned, and the method returns None at line 364 or 372.


Ergo, if any code calls get_provider("some_instance_id") during that window between lines 832 and 838 — where the provider object exists in  _providers but available is still False — it gets None back, and then we have the 500 error.