### PR TITLE
Fix RuntimeError from dict/set mutation during iteration

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -202,7 +202,7 @@ class MusicController(CoreController):
     async def on_provider_unload(self, provider: MusicProvider) -> None:
         """Handle logic when a provider is (about to get) unloaded."""
         # make sure to stop any running sync tasks first
-        for sync_task in self.in_progress_syncs:
+        for sync_task in list(self.in_progress_syncs):
             if sync_task.provider_instance == provider.instance_id:
                 if sync_task.task:
                     sync_task.task.cancel()
@@ -1604,7 +1604,7 @@ class MusicController(CoreController):
             key = f"sync_{provider_instance_id}_{media_type.value}"
             self.mass.cancel_timer(key)
         # cancel any running sync tasks
-        for sync_task in self.in_progress_syncs:
+        for sync_task in list(self.in_progress_syncs):
             if sync_task.provider_instance == provider_instance_id:
                 sync_task.task.cancel()
 
@@ -1806,7 +1806,7 @@ class MusicController(CoreController):
     def _start_provider_sync(self, provider: MusicProvider, media_type: MediaType) -> None:
         """Start sync task on provider and track progress."""
         # check if we're not already running a sync task for this provider/mediatype
-        for sync_task in self.in_progress_syncs:
+        for sync_task in list(self.in_progress_syncs):
             if sync_task.provider_instance != provider.instance_id:
                 continue
             if sync_task.task.done():

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -191,7 +191,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         current_sendspin_player = get_sendspin_player_id()
         return [
             player
-            for player in self._players.values()
+            for player in list(self._players.values())
             if (player.state.available or return_unavailable)
             and (player.state.enabled or return_disabled)
             and (provider_filter is None or player.provider.instance_id == provider_filter)
@@ -303,7 +303,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         name_normalized = name.strip().lower()
         matches: list[Player] = []
 
-        for player in self._players.values():
+        for player in list(self._players.values()):
             if player.state.name.strip().lower() == name_normalized:
                 matches.append(player)
 
@@ -1653,7 +1653,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if self.mass.closing:
             return
         # update all players that are using this control
-        for player in self._players.values():
+        for player in list(self._players.values()):
             if control_id in (
                 player.state.power_control,
                 player.state.volume_control,

--- a/music_assistant/helpers/webserver.py
+++ b/music_assistant/helpers/webserver.py
@@ -192,7 +192,7 @@ class Webserver:
                 return await handler(request)
         # Try prefix match (for routes registered with /*)
         if self._dynamic_routes is not None:
-            for route_key, handler in self._dynamic_routes.items():
+            for route_key, handler in list(self._dynamic_routes.items()):
                 method, path = route_key.split(".", 1)
                 if method in (request.method, "*") and path.endswith("/*"):
                     prefix = path[:-2]

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -366,7 +366,7 @@ class MusicAssistant:
                 return None
             provider_instance_or_domain = prov.domain
         # fallback to match on domain
-        for prov in self._providers.values():
+        for prov in list(self._providers.values()):
             if prov.domain != provider_instance_or_domain:
                 continue
             if return_unavailable or prov.available:
@@ -409,7 +409,7 @@ class MusicAssistant:
             LOGGER.getChild("event").log(VERBOSE_LOG_LEVEL, "%s %s", event.value, object_id or "")
 
         event_obj = MassEvent(event=event, object_id=object_id, data=data)
-        for cb_func, event_filter, id_filter in self._subscribers:
+        for cb_func, event_filter, id_filter in list(self._subscribers):
             if not (event_filter is None or event in event_filter):
                 continue
             if not (id_filter is None or object_id in id_filter):
@@ -1037,7 +1037,7 @@ class MusicAssistant:
             service_type,
             state_change,
         )
-        for prov in self._providers.values():
+        for prov in list(self._providers.values()):
             if not prov.manifest.mdns_discovery:
                 continue
             if not prov.available:

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -207,7 +207,7 @@ class MusicAssistant:
         self.signal_event(EventType.SHUTDOWN)
         self.closing = True
         # cancel all running tasks
-        for task in self._tracked_tasks.values():
+        for task in list(self._tracked_tasks.values()):
             task.cancel()
         # cleanup all providers
         await asyncio.gather(
@@ -302,7 +302,7 @@ class MusicAssistant:
         )
         return [
             x
-            for x in self._providers.values()
+            for x in list(self._providers.values())
             if (provider_type is None or provider_type == x.type)
             # apply user provider filter
             and (
@@ -386,7 +386,7 @@ class MusicAssistant:
         """
         return [
             prov
-            for prov in self._providers.values()
+            for prov in list(self._providers.values())
             if (provider_type is None or provider_type == prov.type)
             and prov.domain == domain
             and (return_unavailable or prov.available)


### PR DESCRIPTION
Several collections are iterated while concurrent callbacks can modify them, causing "Set/dictionary changed size during iteration" RuntimeErrors:

- mass.py: _subscribers set iterated in signal_event() while subscribe/unsubscribe callbacks modify it
- mass.py: _providers dict iterated in get_provider() and _on_mdns_service_state_change() while providers load/unload
- player_controller.py: _players dict iterated in get_players(), get_player_by_name(), and update_player_control() while players register/unregister
- music.py: in_progress_syncs list iterated while done-callbacks call .remove() on it

Snapshot via list() before iterating in all affected locations.