### PR TITLE
Fix index_in_buffer or current_index treating index 0 as unset

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -313,7 +313,9 @@ class PlayerQueuesController(CoreController):
             return  # no change
         queue.shuffle_enabled = shuffle_enabled
         queue_items = self._queue_items[queue_id]
-        cur_index = queue.index_in_buffer or queue.current_index
+        cur_index = (
+            queue.index_in_buffer if queue.index_in_buffer is not None else queue.current_index
+        )
         if cur_index is not None:
             next_index = cur_index + 1
             next_items = queue_items[next_index:]
@@ -522,7 +524,11 @@ class PlayerQueuesController(CoreController):
 
         # load the items into the queue
         if queue.state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
-            cur_index = queue.index_in_buffer or queue.current_index or 0
+            cur_index = (
+                queue.index_in_buffer
+                if queue.index_in_buffer is not None
+                else (queue.current_index if queue.current_index is not None else 0)
+            )
         else:
             cur_index = queue.current_index or 0
         insert_at_index = cur_index + 1


### PR DESCRIPTION
index_in_buffer and current_index are int | None where 0 is a valid value (first track in queue). Two locations use chained `or` to select between them:

- set_shuffle: `queue.index_in_buffer or queue.current_index`
- play_media_from_queue: `queue.index_in_buffer or queue.current_index or 0`

When index_in_buffer is 0 (first track buffered), Python's `or` treats it as falsy and falls through to current_index. This causes shuffle reshuffling and queue insertion to use the wrong position.

Replace with explicit `is not None` checks in both locations.