### PR TITLE
Fix HTTP proxy URL parsing for wss:// WebSocket URLs

### DIFF
--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -14,6 +14,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import aiohttp
 from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection, RTCSessionDescription
@@ -629,8 +630,6 @@ class WebRTCGateway:
 
         # Build local HTTP URL from the WebSocket URL.
         # Handle both ws:// and wss:// schemes.
-        from urllib.parse import urlparse
-
         parsed = urlparse(self.local_ws_url)
         http_scheme = "https" if parsed.scheme == "wss" else "http"
         local_http_url = f"{http_scheme}://{parsed.netloc}{path}"

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -627,11 +627,13 @@ class WebRTCGateway:
         path = request_data.get("path", "/")
         headers = request_data.get("headers", {})
 
-        # Build local HTTP URL
-        # Extract host and port from local_ws_url (ws://localhost:8095/ws)
-        ws_url_parts = self.local_ws_url.replace("ws://", "").split("/")
-        host_port = ws_url_parts[0]  # localhost:8095
-        local_http_url = f"http://{host_port}{path}"
+        # Build local HTTP URL from the WebSocket URL.
+        # Handle both ws:// and wss:// schemes.
+        from urllib.parse import urlparse
+
+        parsed = urlparse(self.local_ws_url)
+        http_scheme = "https" if parsed.scheme == "wss" else "http"
+        local_http_url = f"{http_scheme}://{parsed.netloc}{path}"
 
         self.logger.debug("HTTP proxy request: %s %s", method, local_http_url)
 


### PR DESCRIPTION
## Summary
- Fix broken HTTP proxy URL construction when `local_ws_url` uses `wss://` scheme
- The previous code used `.replace("ws://", "")` which doesn't match `wss://`, producing URLs like `http://wss:/imageproxy?...` that fail with DNS errors
- Use `urllib.parse.urlparse` to correctly handle both `ws://` and `wss://` schemes

## Test plan
- [x] Verify image proxy works with SSL-enabled MA server (wss:// WebSocket URL)
- [x] Verify image proxy still works with plain ws:// WebSocket URL