### PR TITLE
Add name back to abs/itunes recommendation folders

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -819,8 +819,6 @@ for more details.
             # newest-episodes
             # etc
             name = f"{shelf_id.capitalize().replace('-', ' ')}"
-            if ABS_SHELF_ID_TRANSLATION_KEY.get(shelf_id):
-                name = ""  # use translation key if available
             folders.append(
                 RecommendationFolder(
                     item_id=f"{shelf_id}",
@@ -859,7 +857,7 @@ for more details.
         folders.append(
             RecommendationFolder(
                 item_id="browse",
-                name="",  # use translation key
+                name="Libraries",
                 icon="mdi-bookshelf",
                 translation_key=translation_key,
                 items=UniqueList(browse_items),

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -262,7 +262,7 @@ class ITunesPodcastsProvider(MusicProvider):
         return [
             RecommendationFolder(
                 item_id="itunes-top-podcasts",
-                name="",
+                name="Trending Podcasts",
                 icon="mdi-trending-up",
                 translation_key="trending_podcasts",
                 items=UniqueList(podcast_list),


### PR DESCRIPTION
I don't know why I did that, but it doesn't make much sense. E.g. the mobile app, currently not using the translation keys, doesn't show a name at all...