### PR TITLE
Deezer: Add Genre and mood flows

### DIFF
--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -102,28 +102,6 @@ TOP_CHARTS_PLAYLIST_ID = "top_charts"
 RADIO_PLAYLIST_PREFIX = "radio_"
 MOOD_FLOW_PREFIX = "mood_flow_"
 
-# Mood-based Flow variants (personalized, always available)
-MOOD_FLOWS = [
-    ("happy", "Flow: Happy"),
-    ("motivation", "Flow: Motivation"),
-    ("party", "Flow: Party"),
-    ("chill", "Flow: Chill"),
-    ("melancholy", "Flow: Melancholy"),
-    ("you_and_me", "Flow: Love"),
-    ("focus", "Flow: Focus"),
-]
-
-# Genre-based Flow variants (may vary by region/user)
-GENRE_FLOWS = [
-    ("genre-rock", "Flow: Rock"),
-    ("genre-metal", "Flow: Metal"),
-    ("genre-electronic", "Flow: Electronic"),
-    ("genre-classical", "Flow: Classical"),
-    ("genre-danceedm", "Flow: Dance & EDM"),
-    ("genre-house", "Flow: House"),
-    ("genre-lofi", "Flow: Lofi"),
-]
-
 # Curated Deezer radio station IDs
 CURATED_RADIO_IDS = [
     37151,  # Hits
@@ -268,6 +246,26 @@ class DeezerProvider(MusicProvider):
         """
         return await self.gw_client.get_user_radio(config_id)
 
+    @use_cache(3600 * 24)  # Cache for 24 hours
+    async def _get_available_flows(self) -> list[tuple[str, str, str | None]]:
+        """Discover available mood/genre Flow variants from the Deezer home page.
+
+        Genre flows have config_ids starting with 'genre-'.
+        Returns a list of (config_id, display_name, cover_url) tuples.
+        """
+        items = await self.gw_client.get_home_flows()
+        flows: list[tuple[str, str, str | None]] = []
+        for item in items:
+            config_id = item["data"]["id"]
+            if config_id == "default":
+                continue
+            title = f"Flow: {item['title']}"
+            cover_url = None
+            if pictures := item.get("pictures"):
+                cover_url = f"https://e-cdns-images.dzcdn.net/images/misc/{pictures[0]['md5']}/264x264-000000-80-0-0.jpg"
+            flows.append((config_id, title, cover_url))
+        return flows
+
     @use_cache(3600 * 24 * 7)  # Cache for 7 days
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 5
@@ -397,9 +395,10 @@ class DeezerProvider(MusicProvider):
                 raise MediaNotFoundError(f"Radio {prov_playlist_id} not found on Deezer") from err
         if prov_playlist_id.startswith(MOOD_FLOW_PREFIX):
             config_id = prov_playlist_id.removeprefix(MOOD_FLOW_PREFIX)
-            flow_names = dict(MOOD_FLOWS + GENRE_FLOWS)
-            display_name = flow_names.get(config_id, f"Flow: {config_id}")
-            return self._create_virtual_playlist(prov_playlist_id, display_name)
+            all_flows = await self._get_available_flows()
+            flow_info = {cid: (name, cover) for cid, name, cover in all_flows}
+            name, cover_url = flow_info.get(config_id, (f"Flow: {config_id}", None))
+            return self._create_virtual_playlist(prov_playlist_id, name, image_url=cover_url)
         try:
             return self.parse_playlist(
                 playlist=await self.client.get_playlist(playlist_id=int(prov_playlist_id)),
@@ -610,44 +609,54 @@ class DeezerProvider(MusicProvider):
         )
 
         # Recommended albums
-        recommended_albums = list(await self.client.get_user_recommended_albums())
-        if recommended_albums:
-            result.append(
-                RecommendationFolder(
-                    item_id="recommended_albums",
-                    provider=self.instance_id,
-                    name="Recommended albums",
-                    items=UniqueList(
-                        [self.parse_album(album=album) for album in recommended_albums]
-                    ),
+        try:
+            recommended_albums = list(await self.client.get_user_recommended_albums())
+            if recommended_albums:
+                result.append(
+                    RecommendationFolder(
+                        item_id="recommended_albums",
+                        provider=self.instance_id,
+                        name="Recommended albums",
+                        items=UniqueList(
+                            [self.parse_album(album=album) for album in recommended_albums]
+                        ),
+                    )
                 )
-            )
+        except Exception as err:
+            self.logger.debug("Failed to get recommended albums: %s", err)
 
         # Recommended artists
-        recommended_artists = list(await self.client.get_user_recommended_artists())
-        if recommended_artists:
-            result.append(
-                RecommendationFolder(
-                    item_id="recommended_artists",
-                    provider=self.instance_id,
-                    name="Recommended artists",
-                    items=UniqueList(
-                        [self.parse_artist(artist=artist) for artist in recommended_artists]
-                    ),
+        try:
+            recommended_artists = list(await self.client.get_user_recommended_artists())
+            if recommended_artists:
+                result.append(
+                    RecommendationFolder(
+                        item_id="recommended_artists",
+                        provider=self.instance_id,
+                        name="Recommended artists",
+                        items=UniqueList(
+                            [self.parse_artist(artist=artist) for artist in recommended_artists]
+                        ),
+                    )
                 )
-            )
+        except Exception as err:
+            self.logger.debug("Failed to get recommended artists: %s", err)
 
-        # Deezer Mood and Genre Flows - personalized playlists
+        # Deezer Mood and Genre Flows - personalized playlists (dynamically discovered)
+        all_flows = await self._get_available_flows()
+        mood_flows = [(c, n, img) for c, n, img in all_flows if not c.startswith("genre-")]
+        genre_flows = [(c, n, img) for c, n, img in all_flows if c.startswith("genre-")]
         for folder_id, folder_name, flows in [
-            ("mood_flows", "Deezer Mood Flows", MOOD_FLOWS),
-            ("genre_flows", "Deezer Genre Flows", GENRE_FLOWS),
+            ("mood_flows", "Deezer Mood Flows", mood_flows),
+            ("genre_flows", "Deezer Genre Flows", genre_flows),
         ]:
             flow_playlists = [
                 self._create_virtual_playlist(
                     item_id=f"{MOOD_FLOW_PREFIX}{config_id}",
                     name=display_name,
+                    image_url=cover_url,
                 )
-                for config_id, display_name in flows
+                for config_id, display_name, cover_url in flows
             ]
             if flow_playlists:
                 result.append(

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -985,8 +985,6 @@ class DeezerProvider(MusicProvider):
     def _parse_gw_track(self, gw_track: dict[str, Any]) -> Track:
         """Parse a raw GW API track dict directly to a Music Assistant track.
 
-        This avoids individual REST API calls for each track (e.g. from Flow responses).
-
         :param gw_track: Raw track dict from the GW API with keys like SNG_ID, SNG_TITLE, etc.
         """
         track_id = str(gw_track["SNG_ID"])

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -100,6 +100,29 @@ FLOW_PLAYLIST_ID = "flow"
 RECOMMENDED_TRACKS_PLAYLIST_ID = "recommended_tracks"
 TOP_CHARTS_PLAYLIST_ID = "top_charts"
 RADIO_PLAYLIST_PREFIX = "radio_"
+MOOD_FLOW_PREFIX = "mood_flow_"
+
+# Mood-based Flow variants (personalized, always available)
+MOOD_FLOWS = [
+    ("happy", "Flow: Happy"),
+    ("motivation", "Flow: Motivation"),
+    ("party", "Flow: Party"),
+    ("chill", "Flow: Chill"),
+    ("melancholy", "Flow: Melancholy"),
+    ("you_and_me", "Flow: Love"),
+    ("focus", "Flow: Focus"),
+]
+
+# Genre-based Flow variants (may vary by region/user)
+GENRE_FLOWS = [
+    ("genre-rock", "Flow: Rock"),
+    ("genre-metal", "Flow: Metal"),
+    ("genre-electronic", "Flow: Electronic"),
+    ("genre-classical", "Flow: Classical"),
+    ("genre-danceedm", "Flow: Dance & EDM"),
+    ("genre-house", "Flow: House"),
+    ("genre-lofi", "Flow: Lofi"),
+]
 
 # Curated Deezer radio station IDs
 CURATED_RADIO_IDS = [
@@ -237,6 +260,14 @@ class DeezerProvider(MusicProvider):
         chart = await self.client.get_chart()
         return list(chart.tracks[:100]) if chart.tracks else []
 
+    @use_cache(3600)  # Cache for 1 hour
+    async def _get_mood_flow_tracks(self, config_id: str) -> list[dict[str, Any]]:
+        """Get cached mood/genre Flow tracks from the GW API.
+
+        :param config_id: The Flow config identifier (e.g. "happy", "chill", "genre-rock").
+        """
+        return await self.gw_client.get_user_radio(config_id)
+
     @use_cache(3600 * 24 * 7)  # Cache for 7 days
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 5
@@ -364,6 +395,11 @@ class DeezerProvider(MusicProvider):
             except Exception as err:
                 self.logger.warning("Failed getting radio %s: %s", radio_id, err)
                 raise MediaNotFoundError(f"Radio {prov_playlist_id} not found on Deezer") from err
+        if prov_playlist_id.startswith(MOOD_FLOW_PREFIX):
+            config_id = prov_playlist_id.removeprefix(MOOD_FLOW_PREFIX)
+            flow_names = dict(MOOD_FLOWS + GENRE_FLOWS)
+            display_name = flow_names.get(config_id, f"Flow: {config_id}")
+            return self._create_virtual_playlist(prov_playlist_id, display_name)
         try:
             return self.parse_playlist(
                 playlist=await self.client.get_playlist(playlist_id=int(prov_playlist_id)),
@@ -422,6 +458,11 @@ class DeezerProvider(MusicProvider):
             except Exception as err:
                 self.logger.debug("Failed to get radio tracks %s: %s", radio_id, err)
                 return []
+
+        if prov_playlist_id.startswith(MOOD_FLOW_PREFIX):
+            config_id = prov_playlist_id.removeprefix(MOOD_FLOW_PREFIX)
+            gw_tracks = await self._get_mood_flow_tracks(config_id)
+            return [await self.get_track(track["SNG_ID"]) for track in gw_tracks]
 
         # Regular Deezer playlists (cached separately)
         return await self._get_regular_playlist_tracks(prov_playlist_id)
@@ -595,6 +636,28 @@ class DeezerProvider(MusicProvider):
                     ),
                 )
             )
+
+        # Deezer Mood and Genre Flows - personalized playlists
+        for folder_id, folder_name, flows in [
+            ("mood_flows", "Deezer Mood Flows", MOOD_FLOWS),
+            ("genre_flows", "Deezer Genre Flows", GENRE_FLOWS),
+        ]:
+            flow_playlists = [
+                self._create_virtual_playlist(
+                    item_id=f"{MOOD_FLOW_PREFIX}{config_id}",
+                    name=display_name,
+                )
+                for config_id, display_name in flows
+            ]
+            if flow_playlists:
+                result.append(
+                    RecommendationFolder(
+                        item_id=folder_id,
+                        provider=self.instance_id,
+                        name=folder_name,
+                        items=UniqueList(flow_playlists),
+                    )
+                )
 
         # Deezer Radios - curated selection (as virtual playlists in one folder)
         radio_playlists: list[Playlist] = []

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -461,7 +461,7 @@ class DeezerProvider(MusicProvider):
         if prov_playlist_id.startswith(MOOD_FLOW_PREFIX):
             config_id = prov_playlist_id.removeprefix(MOOD_FLOW_PREFIX)
             gw_tracks = await self._get_mood_flow_tracks(config_id)
-            return [self._parse_gw_track(track) for track in gw_tracks]
+            return [await self.get_track(track["SNG_ID"]) for track in gw_tracks]
 
         # Regular Deezer playlists (cached separately)
         return await self._get_regular_playlist_tracks(prov_playlist_id)
@@ -981,68 +981,6 @@ class DeezerProvider(MusicProvider):
             is_editable=False,
             owner="Deezer",
         )
-
-    def _parse_gw_track(self, gw_track: dict[str, Any]) -> Track:
-        """Parse a raw GW API track dict directly to a Music Assistant track.
-
-        :param gw_track: Raw track dict from the GW API with keys like SNG_ID, SNG_TITLE, etc.
-        """
-        track_id = str(gw_track["SNG_ID"])
-        title = gw_track.get("SNG_TITLE", "")
-        name, version = parse_title_and_version(title)
-        duration = int(gw_track.get("DURATION", 0))
-
-        artist: ItemMapping | None = None
-        if art_id := gw_track.get("ART_ID"):
-            artist = ItemMapping(
-                media_type=MediaType.ARTIST,
-                item_id=str(art_id),
-                provider=self.instance_id,
-                name=gw_track.get("ART_NAME", ""),
-            )
-
-        album: ItemMapping | None = None
-        if alb_id := gw_track.get("ALB_ID"):
-            album = ItemMapping(
-                media_type=MediaType.ALBUM,
-                item_id=str(alb_id),
-                provider=self.instance_id,
-                name=gw_track.get("ALB_TITLE", ""),
-            )
-
-        # Build cover image from ALB_PICTURE md5 hash
-        images: UniqueList[MediaItemImage] = UniqueList()
-        if alb_picture := gw_track.get("ALB_PICTURE"):
-            images.append(
-                MediaItemImage(
-                    type=ImageType.THUMB,
-                    path=f"https://e-cdns-images.dzcdn.net/images/cover/{alb_picture}/500x500-000000-80-0-0.jpg",
-                    provider=self.instance_id,
-                    remotely_accessible=True,
-                )
-            )
-
-        item = Track(
-            item_id=track_id,
-            provider=self.instance_id,
-            name=name,
-            version=version,
-            duration=duration,
-            artists=UniqueList([artist]) if artist else UniqueList(),
-            album=album,
-            provider_mappings={
-                ProviderMapping(
-                    item_id=track_id,
-                    provider_domain=self.domain,
-                    provider_instance=self.instance_id,
-                    available=True,
-                )
-            },
-            metadata=MediaItemMetadata(images=images) if images else MediaItemMetadata(),
-        )
-        if isrc := gw_track.get("ISRC"):
-            item.external_ids.add((ExternalID.ISRC, isrc))
-        return item
 
     def parse_track(self, track: deezer.Track, user_country: str, position: int = 0) -> Track:
         """Parse the deezer-python track to a Music Assistant track."""

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -461,7 +461,7 @@ class DeezerProvider(MusicProvider):
         if prov_playlist_id.startswith(MOOD_FLOW_PREFIX):
             config_id = prov_playlist_id.removeprefix(MOOD_FLOW_PREFIX)
             gw_tracks = await self._get_mood_flow_tracks(config_id)
-            return [await self.get_track(track["SNG_ID"]) for track in gw_tracks]
+            return [self._parse_gw_track(track) for track in gw_tracks]
 
         # Regular Deezer playlists (cached separately)
         return await self._get_regular_playlist_tracks(prov_playlist_id)
@@ -622,7 +622,7 @@ class DeezerProvider(MusicProvider):
                         ),
                     )
                 )
-        except Exception as err:
+        except deezer_exceptions.DeezerErrorResponse as err:
             self.logger.debug("Failed to get recommended albums: %s", err)
 
         # Recommended artists
@@ -639,7 +639,7 @@ class DeezerProvider(MusicProvider):
                         ),
                     )
                 )
-        except Exception as err:
+        except deezer_exceptions.DeezerErrorResponse as err:
             self.logger.debug("Failed to get recommended artists: %s", err)
 
         # Deezer Mood and Genre Flows - personalized playlists (dynamically discovered)
@@ -981,6 +981,70 @@ class DeezerProvider(MusicProvider):
             is_editable=False,
             owner="Deezer",
         )
+
+    def _parse_gw_track(self, gw_track: dict[str, Any]) -> Track:
+        """Parse a raw GW API track dict directly to a Music Assistant track.
+
+        This avoids individual REST API calls for each track (e.g. from Flow responses).
+
+        :param gw_track: Raw track dict from the GW API with keys like SNG_ID, SNG_TITLE, etc.
+        """
+        track_id = str(gw_track["SNG_ID"])
+        title = gw_track.get("SNG_TITLE", "")
+        name, version = parse_title_and_version(title)
+        duration = int(gw_track.get("DURATION", 0))
+
+        artist: ItemMapping | None = None
+        if art_id := gw_track.get("ART_ID"):
+            artist = ItemMapping(
+                media_type=MediaType.ARTIST,
+                item_id=str(art_id),
+                provider=self.instance_id,
+                name=gw_track.get("ART_NAME", ""),
+            )
+
+        album: ItemMapping | None = None
+        if alb_id := gw_track.get("ALB_ID"):
+            album = ItemMapping(
+                media_type=MediaType.ALBUM,
+                item_id=str(alb_id),
+                provider=self.instance_id,
+                name=gw_track.get("ALB_TITLE", ""),
+            )
+
+        # Build cover image from ALB_PICTURE md5 hash
+        images: UniqueList[MediaItemImage] = UniqueList()
+        if alb_picture := gw_track.get("ALB_PICTURE"):
+            images.append(
+                MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=f"https://e-cdns-images.dzcdn.net/images/cover/{alb_picture}/500x500-000000-80-0-0.jpg",
+                    provider=self.instance_id,
+                    remotely_accessible=True,
+                )
+            )
+
+        item = Track(
+            item_id=track_id,
+            provider=self.instance_id,
+            name=name,
+            version=version,
+            duration=duration,
+            artists=UniqueList([artist]) if artist else UniqueList(),
+            album=album,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=track_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                    available=True,
+                )
+            },
+            metadata=MediaItemMetadata(images=images) if images else MediaItemMetadata(),
+        )
+        if isrc := gw_track.get("ISRC"):
+            item.external_ids.add((ExternalID.ISRC, isrc))
+        return item
 
     def parse_track(self, track: deezer.Track, user_country: str, position: int = 0) -> Track:
         """Parse the deezer-python track to a Music Assistant track."""

--- a/music_assistant/providers/deezer/gw_client.py
+++ b/music_assistant/providers/deezer/gw_client.py
@@ -36,6 +36,7 @@ class GWClient:
     _gw_csrf_token: str | None
     _license: str | None
     _license_expiration_timestamp: int
+    _user_id: int
     session: ClientSession
     formats: list[dict[str, str]] = [
         {"cipher": "BF_CBC_STRIPE", "format": "MP3_128"},
@@ -67,6 +68,7 @@ class GWClient:
             raise DeezerGWError(msg)
 
         self._gw_csrf_token = user_data["results"]["checkForm"]
+        self._user_id = int(user_data["results"]["USER"]["USER_ID"])
         self._license = user_data["results"]["USER"]["OPTIONS"]["license_token"]
         self._license_expiration_timestamp = user_data["results"]["USER"]["OPTIONS"][
             "expiration_timestamp"
@@ -126,6 +128,17 @@ class GWClient:
             msg = "Failed to call GW-API"
             raise DeezerGWError(msg, result_json["error"])
         return cast("dict[str, Any]", result_json)
+
+    async def get_user_radio(self, config_id: str) -> list[dict[str, Any]]:
+        """Get personalized Flow tracks for a specific mood or genre.
+
+        :param config_id: The Flow config identifier (e.g. "happy", "chill", "genre-rock").
+        """
+        result = await self._gw_api_call(
+            "radio.getUserRadio",
+            args={"config_id": config_id, "user_id": self._user_id},
+        )
+        return cast("list[dict[str, Any]]", result["results"]["data"])
 
     async def get_song_data(self, track_id: str) -> dict[str, Any]:
         """Get data such as the track token for a given track."""

--- a/music_assistant/providers/deezer/gw_client.py
+++ b/music_assistant/providers/deezer/gw_client.py
@@ -139,13 +139,12 @@ class GWClient:
             "radio.getUserRadio",
             args={"config_id": config_id, "user_id": self._user_id},
         )
+        if "data" not in result["results"]:
+            return []
         return cast("list[dict[str, Any]]", result["results"]["data"])
 
     async def get_home_flows(self) -> list[dict[str, Any]]:
-        """Discover available Flow variants from the Deezer home page.
-
-        :param: None
-        """
+        """Discover available Flow variants from the Deezer home page."""
         gateway_input = json_module.dumps(
             {
                 "PAGE": "home",
@@ -157,7 +156,8 @@ class GWClient:
             "page.get",
             params={"gateway_input": gateway_input},
         )
-        for section in result["results"]["sections"]:
+        sections = result["results"].get("sections", [])
+        for section in sections:
             if section.get("layout") == "filterable-grid":
                 return cast("list[dict[str, Any]]", section["items"])
         return []

--- a/music_assistant/providers/deezer/gw_client.py
+++ b/music_assistant/providers/deezer/gw_client.py
@@ -5,6 +5,7 @@ cookie based on the api_token.
 """
 
 import datetime
+import json as json_module
 from collections.abc import Mapping
 from http.cookies import BaseCookie, Morsel
 from typing import Any, cast
@@ -139,6 +140,27 @@ class GWClient:
             args={"config_id": config_id, "user_id": self._user_id},
         )
         return cast("list[dict[str, Any]]", result["results"]["data"])
+
+    async def get_home_flows(self) -> list[dict[str, Any]]:
+        """Discover available Flow variants from the Deezer home page.
+
+        :param: None
+        """
+        gateway_input = json_module.dumps(
+            {
+                "PAGE": "home",
+                "VERSION": "2.5",
+                "SUPPORT": {"filterable-grid": ["flow"]},
+            }
+        )
+        result = await self._gw_api_call(
+            "page.get",
+            params={"gateway_input": gateway_input},
+        )
+        for section in result["results"]["sections"]:
+            if section.get("layout") == "filterable-grid":
+                return cast("list[dict[str, Any]]", section["items"])
+        return []
 
     async def get_song_data(self, track_id: str) -> dict[str, Any]:
         """Get data such as the track token for a given track."""

--- a/music_assistant/providers/deezer/gw_client.py
+++ b/music_assistant/providers/deezer/gw_client.py
@@ -5,7 +5,7 @@ cookie based on the api_token.
 """
 
 import datetime
-import json as json_module
+import json
 from collections.abc import Mapping
 from http.cookies import BaseCookie, Morsel
 from typing import Any, cast
@@ -145,7 +145,7 @@ class GWClient:
 
     async def get_home_flows(self) -> list[dict[str, Any]]:
         """Discover available Flow variants from the Deezer home page."""
-        gateway_input = json_module.dumps(
+        gateway_input = json.dumps(
             {
                 "PAGE": "home",
                 "VERSION": "2.5",


### PR DESCRIPTION
## Summary

Extends the Deezer provider with mood and genre Flow playlists (Happy, Chill, Focus, Party, Rock, Metal, etc.) building on top of #3077.

These Flow variants are only available through Deezer's unofficial GW API (`radio.getUserRadio`), so the changes go into `gw_client.py` and `__init__.py`.

Available Flows are discovered dynamically via the `page.get` GW endpoint instead of being hardcoded, so user-specific variations are picked up automatically.

The recommendations view now includes two new folders:
- **Deezer Mood Flows**: Happy, Chill, Focus, Melancholy, Party, Love, Motivation
- **Deezer Genre Flows**: Rock, Metal, Electronic, Classical, etc. (varies by user)

<img width="1420" height="667" alt="image" src="https://github.com/user-attachments/assets/5ab5c92b-a840-48fb-907c-4333b6f634ab" />

Also wraps `get_user_recommended_albums` and `get_user_recommended_artists` in try/except since the Deezer API occasionally returns errors on those endpoints, which would otherwise prevent all recommendations from loading.

## Test Plan

- Tested locally, mood and genre Flows show up in recommendations and play back correctly
- Verified that recommendations still load when `get_user_recommended_artists` returns an error

Suggested label: `enhancement`