### PR TITLE
Fix multi disc audiobook

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1882,7 +1882,7 @@ class LocalFileSystemProvider(MusicProvider):
                     continue
                 chapters.append(
                     MediaItemChapter(
-                        position=position if use_alphabetical else (chapter_tags.track or position),
+                        position=position,
                         name=chapter_tags.title,
                         start=total_duration,
                         end=total_duration + chapter_tags.duration,


### PR DESCRIPTION
Fixes https://github.com/orgs/music-assistant/discussions/4956

Tested using a multi disc audio CD. Also verified the previous test audiobooks that I have for a previous PR were unaffected.

I didn't want to regress the changes from the last PR I had which fixed a number of audiobook issues. Claude's assessment is:

The fix from commit d6399d2 (supporting untagged multi-file audiobooks) is not regressed because:

The alphabetical fallback path (use_alphabetical=True) was already using position via the ternary condition
The embedded chapters path is completely separate code
Only the tagged files path changes, which is exactly where the multi-disc duplicate position bug lived