### PR TITLE
Fix podcast episode retrieval in builtin playlist tracks

### DIFF
--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -392,9 +392,12 @@ class BuiltinProvider(MusicProvider):
                     # controller's own media_type, which is wrong for podcast
                     # episodes (controller has PODCAST, not PODCAST_EPISODE).
                     item_prov = self.mass.get_provider(provider_instance_id_or_domain)
-                    if item_prov:
-                        item_prov = cast("MusicProvider", item_prov)
-                        media_item = await item_prov.get_item(media_type, item_id)
+                    if not item_prov:
+                        raise ProviderUnavailableError(
+                            f"{provider_instance_id_or_domain} is not available"
+                        )
+                    item_prov = cast("MusicProvider", item_prov)
+                    media_item = await item_prov.get_item(media_type, item_id)
                 if media_item is not None and media_item.media_type in PLAYLIST_MEDIA_TYPES:
                     playlist_item = cast("PlaylistPlayableItem", media_item)
                     playlist_item.position = index

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -24,13 +24,11 @@ from music_assistant_models.errors import (
 )
 from music_assistant_models.media_items import (
     Artist,
-    Audiobook,
     AudioFormat,
     MediaItemImage,
     MediaItemMetadata,
     MediaItemType,
     Playlist,
-    PodcastEpisode,
     ProviderMapping,
     Radio,
     Track,
@@ -40,6 +38,7 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import (
     MASS_LOGO,
+    PLAYLIST_MEDIA_TYPES,
     VARIOUS_ARTISTS_FANART,
     PlaylistPlayableItem,
 )
@@ -396,9 +395,10 @@ class BuiltinProvider(MusicProvider):
                     if item_prov:
                         item_prov = cast("MusicProvider", item_prov)
                         media_item = await item_prov.get_item(media_type, item_id)
-                    if isinstance(media_item, (Track, Radio, PodcastEpisode, Audiobook)):
-                        media_item.position = index
-                        result.append(media_item)
+                if media_item is not None and media_item.media_type in PLAYLIST_MEDIA_TYPES:
+                    playlist_item = cast("PlaylistPlayableItem", media_item)
+                    playlist_item.position = index
+                    result.append(playlist_item)
                 else:
                     self.logger.warning(
                         "Unsupported media type in playlist %s: %s",

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -380,22 +380,30 @@ class BuiltinProvider(MusicProvider):
                 media_type, provider_instance_id_or_domain, item_id = await parse_uri(uri)
                 media_controller = self.mass.music.get_controller(media_type)
                 # prefer item already in the db
-                track = await media_controller.get_library_item_by_prov_id(
+                media_item: (
+                    MediaItemType | None
+                ) = await media_controller.get_library_item_by_prov_id(
                     item_id, provider_instance_id_or_domain
                 )
-                if track is None:
-                    # get the provider item and not the full track from a regular 'get' call
-                    # as we only need basic track info here
-                    track = await media_controller.get_provider_item(
-                        item_id, provider_instance_id_or_domain
-                    )
-                if isinstance(track, get_args(PlaylistPlayableItem)):
-                    playlist_item = cast("PlaylistPlayableItem", track)
+                if media_item is None:
+                    # Call provider.get_item directly with the correct media_type.
+                    # Using media_controller.get_provider_item would pass the
+                    # controller's own media_type, which is wrong for podcast
+                    # episodes (controller has PODCAST, not PODCAST_EPISODE).
+                    item_prov = self.mass.get_provider(provider_instance_id_or_domain)
+                    if item_prov:
+                        media_item = await cast("MusicProvider", item_prov).get_item(
+                            media_type, item_id
+                        )
+                if isinstance(media_item, get_args(PlaylistPlayableItem)):
+                    playlist_item = cast("PlaylistPlayableItem", media_item)
                     playlist_item.position = index
                     result.append(playlist_item)
                 else:
                     self.logger.warning(
-                        "Unsupported media type in playlist %s: %s", prov_playlist_id, type(track)
+                        "Unsupported media type in playlist %s: %s",
+                        prov_playlist_id,
+                        type(media_item),
                     )
             except (MediaNotFoundError, InvalidDataError, ProviderUnavailableError) as err:
                 self.logger.warning(

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Final, cast, get_args
+from typing import TYPE_CHECKING, Final, cast
 
 import aiofiles
 import shortuuid
@@ -24,11 +24,13 @@ from music_assistant_models.errors import (
 )
 from music_assistant_models.media_items import (
     Artist,
+    Audiobook,
     AudioFormat,
     MediaItemImage,
     MediaItemMetadata,
     MediaItemType,
     Playlist,
+    PodcastEpisode,
     ProviderMapping,
     Radio,
     Track,
@@ -392,13 +394,11 @@ class BuiltinProvider(MusicProvider):
                     # episodes (controller has PODCAST, not PODCAST_EPISODE).
                     item_prov = self.mass.get_provider(provider_instance_id_or_domain)
                     if item_prov:
-                        media_item = await cast("MusicProvider", item_prov).get_item(
-                            media_type, item_id
-                        )
-                if isinstance(media_item, get_args(PlaylistPlayableItem)):
-                    playlist_item = cast("PlaylistPlayableItem", media_item)
-                    playlist_item.position = index
-                    result.append(playlist_item)
+                        item_prov = cast("MusicProvider", item_prov)
+                        media_item = await item_prov.get_item(media_type, item_id)
+                    if isinstance(media_item, (Track, Radio, PodcastEpisode, Audiobook)):
+                        media_item.position = index
+                        result.append(media_item)
                 else:
                     self.logger.warning(
                         "Unsupported media type in playlist %s: %s",


### PR DESCRIPTION
When loading playlist tracks, the builtin provider used media_controller.get_provider_item() which passes the controller's own media_type to the provider. For podcast episodes, get_controller() returns PodcastsController (media_type=PODCAST), causing get_podcast() to be called instead of get_podcast_episode() - resulting in a RuntimeError.

Fix by calling provider.get_item() directly with the correct media_type parsed from the URI.