### PR TITLE
Plex Connect: fix queue cap of 50

### DIFF
--- a/music_assistant/providers/plex_connect/player_remote.py
+++ b/music_assistant/providers/plex_connect/player_remote.py
@@ -558,7 +558,7 @@ class PlexRemoteControlServer:
 
             # Use plexapi to fetch the play queue
             def fetch_queue() -> PlayQueue:
-                return PlayQueue.get(self.provider._plex_server, playQueueID=queue_id)
+                return PlayQueue.get(self.provider._plex_server, playQueueID=queue_id, window=500)
 
             playqueue = await asyncio.to_thread(fetch_queue)
 
@@ -888,7 +888,9 @@ class PlexRemoteControlServer:
 
             # Use plexapi to fetch the updated play queue
             def fetch_queue() -> PlayQueue:
-                return PlayQueue.get(self.provider._plex_server, playQueueID=play_queue_id)
+                return PlayQueue.get(
+                    self.provider._plex_server, playQueueID=play_queue_id, window=500
+                )
 
             playqueue = await asyncio.to_thread(fetch_queue)
 


### PR DESCRIPTION
For now a very permissive cap has been set. I think it should fix most issues. A more evolved fix should use the pagination and build the queue while parcouring the pages. Let me defer that to a later PR.