### PR TITLE
Fix DSP not applying for AirPlay and Sendspin players

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -1402,10 +1402,18 @@ def get_player_filter_params(
     """Get player specific filter parameters for ffmpeg (if any)."""
     filter_params = []
 
-    dsp = mass.config.get_player_dsp_config(player_id)
+    # In case this is a protocol player, their DSP config is stored
+    # under the parent (native or universal) player that wraps them.
+    dsp_player_id = player_id
+    if (player := mass.players.get_player(player_id)) and (
+        player.type == PlayerType.PROTOCOL and player.protocol_parent_id
+    ):
+        dsp_player_id = player.protocol_parent_id
+
+    dsp = mass.config.get_player_dsp_config(dsp_player_id)
     limiter_enabled = True
 
-    if player := mass.players.get_player(player_id):
+    if player:
         if is_grouping_preventing_dsp(player):
             # We can not correctly apply DSP to a grouped player without multi-device DSP support,
             # so we disable it.

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -1402,14 +1402,12 @@ def get_player_filter_params(
     """Get player specific filter parameters for ffmpeg (if any)."""
     filter_params = []
 
+    player = mass.players.get_player(player_id)
     # In case this is a protocol player, their DSP config is stored
     # under the parent (native or universal) player that wraps them.
     dsp_player_id = player_id
-    if (player := mass.players.get_player(player_id)) and (
-        player.type == PlayerType.PROTOCOL and player.protocol_parent_id
-    ):
+    if player and player.protocol_parent_id:
         dsp_player_id = player.protocol_parent_id
-
     dsp = mass.config.get_player_dsp_config(dsp_player_id)
     limiter_enabled = True
 


### PR DESCRIPTION
DSP config is stored on the parent player, but was being looked up by the protocol player ID. Resolving to the parent player fixes DSP for AirPlay and Sendspin.