### PR TITLE
Validate queue item ID in Sonos pause path

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2418,7 +2418,10 @@ class PlayerQueuesController(CoreController):
         ):
             if protocol_player.current_media.queue_item_id:
                 return protocol_player.current_media.queue_item_id
-            return protocol_player.current_media.uri.split(":")[-1]
+            current_item_id = protocol_player.current_media.uri.split(":")[-1]
+            if self.get_item(queue_id, current_item_id):
+                return current_item_id
+            return None
         # try to extract the item id from a mass stream url
         if (
             protocol_player.current_media.uri


### PR DESCRIPTION
There is an apparent race condition where after calling media_player.pause, the player's current media URI can become just 'mass:<queue_id>' (without the item ID suffix).   When this happens, Music Assistant loses its place in the queue when paused and starts over with the first item in the queue on resume.

get_item as used in the two code paths below this change validates correctly and returns None in this case.  Changing the code to be consistent with that approach seems to solve the queue reset on pause issue.

