### PR TITLE
Add configurable max size for metadata thumbnail cache

### DIFF
--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -203,8 +203,6 @@ class MetaDataController(CoreController):
                 default_value=DEFAULT_THUMB_CACHE_MAX_SIZE_MB,
                 range=(50, 5000),
                 description="Maximum total size in megabytes for the on-disk thumbnail cache.\n\n"
-                "Thumbnails are generated from album art and other images to avoid "
-                "repeated processing (e.g. ffmpeg extractions for embedded cover art). "
                 "Oldest thumbnails are automatically removed when this limit is exceeded.",
             ),
         )

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -59,9 +59,15 @@ from music_assistant.controllers.tasks.context import (
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.datetime import local_clock_time_to_utc
-from music_assistant.helpers.images import create_collage, get_image_data, get_image_thumb
+from music_assistant.helpers.images import (
+    cleanup_thumb_cache,
+    create_collage,
+    get_image_data,
+    get_image_thumb,
+)
 from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.throttle_retry import Throttler
+from music_assistant.helpers.util import try_parse_int
 from music_assistant.models.core_controller import CoreController
 from music_assistant.models.music_provider import MusicProvider
 
@@ -129,8 +135,11 @@ REFRESH_INTERVAL = 60 * 60 * 24 * 90  # 90 days
 CONF_ENABLE_ONLINE_METADATA = "enable_online_metadata"
 MISSING_ARTIST_ARTWORK_SCAN_TASK_ID = "metadata_missing_artist_artwork_scan"
 PLAYLIST_METADATA_SCAN_TASK_ID = "metadata_playlist_metadata_scan"
+THUMB_CACHE_CLEANUP_TASK_ID = "metadata_thumb_cache_cleanup"
 METADATA_LOOKUP_TASK_ID_PREFIX = "metadata_lookup"
 METADATA_SCAN_BATCH_SIZE = 5
+CONF_THUMB_CACHE_MAX_SIZE = "thumb_cache_max_size"
+DEFAULT_THUMB_CACHE_MAX_SIZE_MB = 500
 
 
 class MetaDataController(CoreController):
@@ -185,6 +194,18 @@ class MetaDataController(CoreController):
                 "The retrieval of additional rich metadata is a process that is executed slowly "
                 "in the background to not overload these free services with requests. "
                 "You can speedup the process by storing the images and other metadata locally.",
+            ),
+            ConfigEntry(
+                key=CONF_THUMB_CACHE_MAX_SIZE,
+                type=ConfigEntryType.INTEGER,
+                label="Maximum thumbnail cache size (MB)",
+                required=False,
+                default_value=DEFAULT_THUMB_CACHE_MAX_SIZE_MB,
+                range=(50, 5000),
+                description="Maximum total size in megabytes for the on-disk thumbnail cache.\n\n"
+                "Thumbnails are generated from album art and other images to avoid "
+                "repeated processing (e.g. ffmpeg extractions for embedded cover art). "
+                "Oldest thumbnails are automatically removed when this limit is exceeded.",
             ),
         )
 
@@ -1005,6 +1026,15 @@ class MetaDataController(CoreController):
             metadata={"task_domain": "metadata_playlist_metadata_scan"},
             allow_retry=True,
         )
+        self.mass.tasks.register_scheduled_task(
+            task_id=THUMB_CACHE_CLEANUP_TASK_ID,
+            name="Cleanup thumbnail cache",
+            handler=self._cleanup_thumb_cache,
+            schedule=desired_schedule,
+            translation_key="background_task.cleanup_thumbnail_cache",
+            metadata={"task_domain": "metadata_thumb_cache_cleanup"},
+            allow_retry=True,
+        )
 
     @staticmethod
     def _get_metadata_lookup_task_id(uri: str) -> str:
@@ -1080,3 +1110,15 @@ class MetaDataController(CoreController):
                     exc_info=err if self.logger.isEnabledFor(10) else None,
                 )
         update_current_task_progress(100, f"Processed {len(playlists)} playlist(s)")
+
+    async def _cleanup_thumb_cache(self) -> None:
+        """Remove oldest thumbnails when the cache folder exceeds the configured limit."""
+        max_size_mb = (
+            try_parse_int(
+                self.config.get_value(CONF_THUMB_CACHE_MAX_SIZE), DEFAULT_THUMB_CACHE_MAX_SIZE_MB
+            )
+            or DEFAULT_THUMB_CACHE_MAX_SIZE_MB
+        )
+        removed = await cleanup_thumb_cache(self.mass.cache_path, max_size_mb * 1024 * 1024)
+        if removed:
+            self.logger.debug("Thumbnail cache cleanup: removed %s file(s)", removed)

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -12,6 +12,7 @@ from base64 import b64decode
 from collections import OrderedDict
 from collections.abc import Iterable
 from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import aiofiles
@@ -273,6 +274,40 @@ async def _generate_and_cache_thumb(
         pass
 
     return thumb_data
+
+
+async def cleanup_thumb_cache(cache_path: str, max_size_bytes: int) -> int:
+    """Remove oldest cached thumbnails when total size exceeds the limit.
+
+    :param cache_path: The base cache directory (mass.cache_path).
+    :param max_size_bytes: Maximum allowed total size in bytes.
+    :returns: Number of files removed.
+    """
+    thumb_dir = os.path.join(cache_path, _THUMB_CACHE_DIR)
+
+    def _cleanup() -> int:
+        if not os.path.isdir(thumb_dir):
+            return 0
+        entries = []
+        for entry in os.scandir(thumb_dir):
+            if entry.is_file():
+                stat = entry.stat()
+                entries.append((entry.path, stat.st_size, stat.st_mtime))
+        entries.sort(key=lambda e: e[2])
+        total_size = sum(e[1] for e in entries)
+        removed = 0
+        for filepath, file_size, _ in entries:
+            if total_size <= max_size_bytes:
+                break
+            try:
+                Path(filepath).unlink()
+                total_size -= file_size
+                removed += 1
+            except OSError:
+                pass
+        return removed
+
+    return await asyncio.to_thread(_cleanup)
 
 
 async def create_collage(


### PR DESCRIPTION
Add a "Maximum thumbnail cache size (MB)" setting to the metadata controller (default 500 MB). A background task runs at startup and every 24 hours, evicting the oldest cached thumbnails when the folder exceeds the configured limit.