### PR TITLE
Add API to handle playback speed

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -379,6 +379,31 @@ class PlayerQueuesController(CoreController):
             if next_item := self.get_next_item(queue_id, queue.index_in_buffer):
                 self._enqueue_next_item(queue_id, next_item)
 
+    @api_command("player_queues/set_playback_speed")
+    async def set_playback_speed(self, queue_id: str, speed: float) -> None:
+        """Set the playback speed for the given queue.
+
+        :param queue_id: queue_id of the queue to configure.
+        :param speed: playback speed multiplier (0.5 to 2.0). 1.0 = normal speed.
+        """
+        if not (0.5 <= speed <= 2.0):
+            raise InvalidDataError(f"Playback speed must be between 0.5 and 2.0, got {speed}")
+        queue = self._queues[queue_id]
+        current_speed = float(queue.extra_attributes.get("playback_speed") or 1.0)
+        if abs(current_speed - speed) < 0.001:
+            return  # no change
+        queue.extra_attributes["playback_speed"] = speed
+        self.signal_update(queue_id)
+        # If currently playing a seekable item, restart the stream at the current position
+        # so the new speed takes effect immediately without waiting for the next track.
+        if (
+            queue.state == PlaybackState.PLAYING
+            and queue.current_item
+            and queue.current_item.duration
+            and queue.current_index is not None
+        ):
+            await self.seek(queue_id, int(queue.corrected_elapsed_time))
+
     @api_command("player_queues/play_media")
     async def play_media(
         self,

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -394,15 +394,8 @@ class PlayerQueuesController(CoreController):
             return  # no change
         queue.extra_attributes["playback_speed"] = speed
         self.signal_update(queue_id)
-        # If currently playing a seekable item, restart the stream at the current position
-        # so the new speed takes effect immediately without waiting for the next track.
-        if (
-            queue.state == PlaybackState.PLAYING
-            and queue.current_item
-            and queue.current_item.duration
-            and queue.current_index is not None
-        ):
-            await self.seek(queue_id, int(queue.corrected_elapsed_time))
+        if queue.state == PlaybackState.PLAYING:
+            await self.resume(queue_id)
 
     @api_command("player_queues/play_media")
     async def play_media(

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -1459,6 +1459,12 @@ def get_player_filter_params(
     elif conf_channels == "right":
         filter_params.append("pan=mono|c0=FR")
 
+    # Apply playback speed via atempo filter if a non-default speed is set on the queue.
+    if _speed_queue := mass.player_queues.get_active_queue(player_id):
+        speed = float(_speed_queue.extra_attributes.get("playback_speed") or 1.0)
+        if speed != 1.0:
+            filter_params.append(f"atempo={speed:.4f}")
+
     # Add safety limiter at the end
     if limiter_enabled:
         filter_params.append("alimiter=limit=-2dB:level=false:asc=true")


### PR DESCRIPTION
Add handling of the custom speed set by the UI (see https://github.com/music-assistant/frontend/pull/1476).

A new `player_queues/set_playback_speed` API command stores the speed in `queue.extra_attributes["playback_speed"]`. `get_player_filter_params()` then applies an ffmpeg `atempo` filter at stream time, which changes tempo without affecting pitch.

If the queue is actively playing a seekable item, the stream is restarted at the current position so the new speed takes effect immediately. `extra_attributes` was chosen over player config because: it serialises automatically in `QUEUE_UPDATED` events (so the frontend gets live updates for free), it's cached and survives server restarts, and it's semantically tied to the queue/content context rather than the player hardware.