### PR TITLE
abs: fix: do not add cover url if no cover present

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -35,6 +35,9 @@ from aioaudiobookshelf.schema.library import (
 from aioaudiobookshelf.schema.library import LibraryMediaType as AbsLibraryMediaType
 from aioaudiobookshelf.schema.session import DeviceInfo as AbsDeviceInfo
 from aioaudiobookshelf.schema.shelf import (
+    LibraryItemMinifiedPodcast as ShelfLibraryItemMinifiedPodcast,
+)
+from aioaudiobookshelf.schema.shelf import (
     SeriesShelf,
     ShelfAuthors,
     ShelfBook,
@@ -497,6 +500,7 @@ for more details.
                 token=self._client.token,
                 base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
                 media_progress=progress,
+                add_cover=bool(abs_podcast.media.cover_path or False),
             )
             yield mass_episode
             episode_cnt += 1
@@ -525,6 +529,7 @@ for more details.
                     token=self._client.token,
                     base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
                     media_progress=progress,
+                    add_cover=bool(abs_podcast.media.cover_path or False),
                 )
 
             episode_cnt += 1
@@ -876,6 +881,7 @@ for more details.
         library_id: str,
         items_by_shelf_id: dict[AbsShelfId, list[list[MediaItemType | BrowseFolder]]],
     ) -> None:
+        # ruff: noqa: PLR0915
         for shelf in shelves:
             media_type: MediaType
             match shelf.type_:
@@ -916,6 +922,9 @@ for more details.
                             podcast_id = entity.id_
                             if entity.recent_episode is None:
                                 continue
+                            _add_cover = False
+                            if isinstance(entity, ShelfLibraryItemMinifiedPodcast):
+                                _add_cover = bool(entity.media.cover_path or False)
                             # we only have a PodcastEpisode here, with limited information
                             item = parse_podcast_episode(
                                 episode=entity.recent_episode,
@@ -924,6 +933,7 @@ for more details.
                                 domain=self.domain,
                                 token=self._client.token,
                                 base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
+                                add_cover=_add_cover,
                             )
                         if item is not None:
                             items.append(item)

--- a/music_assistant/providers/audiobookshelf/parsers.py
+++ b/music_assistant/providers/audiobookshelf/parsers.py
@@ -66,7 +66,7 @@ def parse_podcast(
         },
     )
     mass_podcast.metadata.description = abs_podcast.media.metadata.description
-    if token is not None:
+    if token is not None and abs_podcast.media.cover_path is not None:
         image_url = f"{base_url}/api/items/{abs_podcast.id_}/cover?token={token}"
         mass_podcast.metadata.images = UniqueList(
             [MediaItemImage(type=ImageType.THUMB, path=image_url, provider=instance_id)]
@@ -102,6 +102,7 @@ def parse_podcast_episode(
     token: str | None,
     base_url: str,
     media_progress: AbsMediaProgress | None = None,
+    add_cover: bool = False,
 ) -> MassPodcastEpisode:
     """Translate ABSPodcastEpisode to MassPodcastEpisode.
 
@@ -167,7 +168,7 @@ def parse_podcast_episode(
     mass_episode.metadata.release_date = release_date
 
     # cover image
-    if token is not None:
+    if token is not None and add_cover:
         url_api = f"/api/items/{prov_podcast_id}/cover?token={token}"
         url_cover = f"{base_url}{url_api}"
         mass_episode.metadata.images = UniqueList(
@@ -234,7 +235,7 @@ def parse_audiobook(
     mass_audiobook.metadata.explicit = abs_audiobook.media.metadata.explicit
 
     # cover
-    if token is not None:
+    if token is not None and abs_audiobook.media.cover_path is not None:
         api_url = f"/api/items/{abs_audiobook.id_}/cover?token={token}"
         cover_url = f"{base_url}{api_url}"
         mass_audiobook.metadata.images = UniqueList(


### PR DESCRIPTION
Small fix, I always added the url to a cover, even if the media item at abs has no cover set. Fixed here. 