### PR TITLE
Handle HEAD requests on root route

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -257,6 +257,7 @@ class WebserverController(CoreController):
         # add index (with onboarding check)
         self._index_path = os.path.join(frontend_dir, "index.html")
         routes.append(("GET", "/", self._handle_index))
+        routes.append(("HEAD", "/", self._handle_index))
         # add logo
         logo_path = str(RESOURCES_DIR.joinpath("logo.png"))
         handler = partial(self._server.serve_static, logo_path)


### PR DESCRIPTION
The webserver only registered GET for "/", so HEAD requests fell through to the catch-all handler which logged a warning that happened every time the companion app connected, since it uses a HEAD request as part of its auto-reconnect logic.

asyncio handles HEAD requests for us, strips the body, etc., so this one line change should be all we need to stop these sorts of logs:

2026-02-20 18:39:10.397 WARNING (MainThread) [music_assistant.webserver] Received unhandled HEAD request to / from 192.168.1.149
headers: <CIMultiDictProxy('Host': '192.168.1.126:8095', 'Connection': 'keep-alive', 'Accept': '*/*', 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)', 'Accept-Language': 'en-US,en;q=0.9', 'Referer': 'http://127.0.0.1:1430/', 'Accept-Encoding': 'gzip, deflate')>