### PR TITLE
Fix group mute for protocol-synced players

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -706,7 +706,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         player = self.get_player(player_id, True)
         assert player is not None  # for type checker
-        if player.type == PlayerType.GROUP or player.group_members:
+        if player.state.type == PlayerType.GROUP or player.state.group_members:
             # dedicated group player or sync leader
             coros = []
             for child_player in self.iter_group_members(

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -584,13 +584,16 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     @api_command("players/cmd/volume_set")
     @handle_player_command
-    async def cmd_volume_set(self, player_id: str, volume_level: int) -> None:
+    async def cmd_volume_set(
+        self, player_id: str, volume_level: int, preserve_mute: bool = False
+    ) -> None:
         """Send VOLUME_SET command to given player.
 
         :param player_id: player_id of the player to handle the command.
         :param volume_level: volume level (0..100) to set on the player.
+        :param preserve_mute: if True, do not auto-unmute the player.
         """
-        await self._handle_cmd_volume_set(player_id, volume_level)
+        await self._handle_cmd_volume_set(player_id, volume_level, preserve_mute=preserve_mute)
 
     @api_command("players/cmd/volume_up")
     @handle_player_command
@@ -714,6 +717,13 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             ):
                 coros.append(self.cmd_volume_mute(child_player.player_id, muted))
             await asyncio.gather(*coros)
+            return
+        if player.synced_to and (sync_leader := self.get_player(player.synced_to)):
+            # redirect to sync leader
+            await self.cmd_group_volume_mute(sync_leader.player_id, muted)
+            return
+        # treat as normal player mute
+        await self.cmd_volume_mute(player_id, muted)
 
     @api_command("players/cmd/volume_mute")
     @handle_player_command

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -584,16 +584,13 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     @api_command("players/cmd/volume_set")
     @handle_player_command
-    async def cmd_volume_set(
-        self, player_id: str, volume_level: int, preserve_mute: bool = False
-    ) -> None:
+    async def cmd_volume_set(self, player_id: str, volume_level: int) -> None:
         """Send VOLUME_SET command to given player.
 
         :param player_id: player_id of the player to handle the command.
         :param volume_level: volume level (0..100) to set on the player.
-        :param preserve_mute: if True, do not auto-unmute the player.
         """
-        await self._handle_cmd_volume_set(player_id, volume_level, preserve_mute=preserve_mute)
+        await self._handle_cmd_volume_set(player_id, volume_level)
 
     @api_command("players/cmd/volume_up")
     @handle_player_command
@@ -717,9 +714,6 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             ):
                 coros.append(self.cmd_volume_mute(child_player.player_id, muted))
             await asyncio.gather(*coros)
-            return
-        # treat as normal player mute
-        await self.cmd_volume_mute(player_id, muted)
 
     @api_command("players/cmd/volume_mute")
     @handle_player_command

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -718,10 +718,6 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 coros.append(self.cmd_volume_mute(child_player.player_id, muted))
             await asyncio.gather(*coros)
             return
-        if player.synced_to and (sync_leader := self.get_player(player.synced_to)):
-            # redirect to sync leader
-            await self.cmd_group_volume_mute(sync_leader.player_id, muted)
-            return
         # treat as normal player mute
         await self.cmd_volume_mute(player_id, muted)
 


### PR DESCRIPTION
## Summary

- Fix `cmd_group_volume_mute` using `player.group_members` (raw property) instead of `player.state.group_members` (computed state with protocol-translated members)
- For protocol-synced players (e.g., Sendspin), the raw `group_members` is empty because syncing happens at the protocol level — `state.group_members` includes the translated visible player IDs

## Context

This is a follow-up fix to #3034 (merged). After rebasing the frontend PR (music-assistant/frontend#1404) onto the latest upstream, group mute stopped working for protocol-synced players.

The root cause: `cmd_group_volume_mute` used `player.group_members` (raw) while the existing `cmd_group_volume` correctly uses `player.state.group_members` (computed). The protocol linking refactor changed the contract — raw properties may be empty for protocol-synced players while computed state includes protocol-translated members.

### Change

```python
# Before (bug):
if player.type == PlayerType.GROUP or player.group_members:

# After (fix — matches cmd_group_volume pattern):
if player.state.type == PlayerType.GROUP or player.state.group_members:
```

## Related

- Frontend PR: music-assistant/frontend#1404
- Original server PR: #3034 (merged)

## Test plan

- [x] Click group mute button on Sendspin group → all members mute
- [x] Click group mute button again → all members unmute
- [x] Individual child mute/unmute still works
- [x] Group mute icon correctly reflects aggregate state

🤖 Generated with [Claude Code](https://claude.com/claude-code)