### PR TITLE
Fix HEOS source switching back to Local Music after starting stream

### DIFF
--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -63,7 +63,7 @@ class HeosPlayer(Player):
     async def setup(self) -> None:
         """Set up the player."""
         self.set_device_info()
-        self.set_dynamic_attributes()
+        self.set_dynamic_attributes(update_media=True)
 
         await self.mass.players.register_or_update(self)
 
@@ -143,6 +143,12 @@ class HeosPlayer(Player):
             case const.EVENT_PLAYER_VOLUME_CHANGED:
                 self._update_player_volume()
 
+            case const.EVENT_PLAYER_PLAYBACK_ERROR:
+                self.logger.error(
+                    "[%s] Playback error: %s", self._device.name, self._device.playback_error
+                )
+                self.set_dynamic_attributes()
+
             case _:
                 # Update everything on other events
                 self.set_dynamic_attributes()
@@ -214,11 +220,14 @@ class HeosPlayer(Player):
             else None
         )
 
-    def set_dynamic_attributes(self) -> None:
+    def set_dynamic_attributes(self, update_media: bool = False) -> None:
         """Update all player dynamic attributes."""
         self._update_player_volume()
         self._update_player_state()
-        self._update_player_current_media()
+
+        if update_media:
+            self._update_player_current_media()
+
         self._update_player_playing_progress()
 
     async def volume_set(self, volume_level: int) -> None:


### PR DESCRIPTION
Fix for a reported issue on Discord. 
When an external source is active, then start playing from MA, the UI briefly shows the correct metadata (from MA's queue).
Then the player switches it's source back to Local Music and just shows URL Stream.

The problem is that HEOS sends an event that there internal queue changed, AFTER it sends it's event that the playing media was changed. Because HEOS doesn't distinguish between different local sources, we shouldn't update the active source and media on those queue change events, as we can't properly check the source ID.

Additionally, we specifically log the errors on a playback error event now, helping the debug process if that event occurs.