### PR TITLE
Fix inverted track_number condition in Bandcamp converter

### DIFF
--- a/music_assistant/providers/bandcamp/converters.py
+++ b/music_assistant/providers/bandcamp/converters.py
@@ -190,7 +190,7 @@ class BandcampConverters:
                 )
             },
         )
-        if output.track_number is not None:
+        if track.track_number is not None:
             output.track_number = track.track_number
 
         if album_id:


### PR DESCRIPTION
The condition checked output.track_number instead of track.track_number, meaning track numbers from the API were only applied when the output already had a non-None default.