### PR TITLE
Clear internal HEOS queue before playing

### DIFF
--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -264,6 +264,8 @@ class HeosPlayer(Player):
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA command on given player."""
+        await self._device.clear_queue()
+
         url = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
         await self._device.play_url(url)
 


### PR DESCRIPTION
HEOS keeps an internal queue of all played items. When using the native app, this is populated by actual songs, as you would expect from a queue. However, when playing from any generic URL (like we do with MA, sending 1 continuous stream), this is added as URL stream as well to the queue.

Once MA's own queue is finished, HEOS continues to play the next entries in the queue. This results in seemingly random songs playing even though you started from MA itself. It will also attempt to play all the previous URL streams, originating from MA, which will all fail anyway as they don't anymore.

This PR clears the HEOS internal queue before playing anything from MA, resulting in a finished queue on MA actually finishing playback on the devices as well.