### PR TITLE
Fix Radioparadise image URL

### DIFF
--- a/music_assistant/providers/radioparadise/constants.py
+++ b/music_assistant/providers/radioparadise/constants.py
@@ -6,7 +6,7 @@ from music_assistant_models.enums import ContentType
 
 # Base URL for station icons
 STATION_ICONS_BASE_URL = (
-    "https://raw.githubusercontent.com/music-assistant/music-assistant.io/main/docs/assets/icons"
+    "https://raw.githubusercontent.com/music-assistant/music-assistant.io/main/public/assets/icons"
 )
 
 # Radio Paradise channel configurations with hardcoded channels


### PR DESCRIPTION
The change to the documentation repo moved the images