### PR TITLE
Subsonic: Reorder image metadata for artists

### DIFF
--- a/music_assistant/providers/opensubsonic/parsers.py
+++ b/music_assistant/providers/opensubsonic/parsers.py
@@ -221,6 +221,16 @@ def parse_artist(
     """Parse artist and artistInfo into a Music Assistant Artist."""
     metadata: MediaItemMetadata = MediaItemMetadata()
 
+    if sonic_artist.cover_art:
+        metadata.add_image(
+            MediaItemImage(
+                type=ImageType.THUMB,
+                path=sonic_artist.cover_art,
+                provider=instance_id,
+                remotely_accessible=False,
+            )
+        )
+
     if sonic_artist.artist_image_url:
         metadata.add_image(
             MediaItemImage(
@@ -231,15 +241,6 @@ def parse_artist(
             )
         )
 
-    if sonic_artist.cover_art:
-        metadata.add_image(
-            MediaItemImage(
-                type=ImageType.THUMB,
-                path=sonic_artist.cover_art,
-                provider=instance_id,
-                remotely_accessible=False,
-            )
-        )
     if sonic_info:
         if sonic_info.biography:
             metadata.description = sonic_info.biography

--- a/tests/providers/opensubsonic/__snapshots__/test_parsers.ambr
+++ b/tests/providers/opensubsonic/__snapshots__/test_parsers.ambr
@@ -823,15 +823,15 @@
       'grouping': None,
       'images': list([
         dict({
-          'path': 'https://demo.org/image.jpg',
-          'provider': 'xx-instance-id-xx',
-          'remotely_accessible': True,
-          'type': 'thumb',
-        }),
-        dict({
           'path': 'ar-37ec820ca7193e17040c98f7da7c4b51_0',
           'provider': 'xx-instance-id-xx',
           'remotely_accessible': False,
+          'type': 'thumb',
+        }),
+        dict({
+          'path': 'https://demo.org/image.jpg',
+          'provider': 'xx-instance-id-xx',
+          'remotely_accessible': True,
           'type': 'thumb',
         }),
       ]),
@@ -901,15 +901,15 @@
       'grouping': None,
       'images': list([
         dict({
-          'path': 'https://demo.org/image.jpg',
-          'provider': 'xx-instance-id-xx',
-          'remotely_accessible': True,
-          'type': 'thumb',
-        }),
-        dict({
           'path': 'ar-37ec820ca7193e17040c98f7da7c4b51_0',
           'provider': 'xx-instance-id-xx',
           'remotely_accessible': False,
+          'type': 'thumb',
+        }),
+        dict({
+          'path': 'https://demo.org/image.jpg',
+          'provider': 'xx-instance-id-xx',
+          'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
@@ -985,15 +985,15 @@
       'grouping': None,
       'images': list([
         dict({
-          'path': 'https://demo.org/image.jpg',
-          'provider': 'xx-instance-id-xx',
-          'remotely_accessible': True,
-          'type': 'thumb',
-        }),
-        dict({
           'path': 'ar-37ec820ca7193e17040c98f7da7c4b51_0',
           'provider': 'xx-instance-id-xx',
           'remotely_accessible': False,
+          'type': 'thumb',
+        }),
+        dict({
+          'path': 'https://demo.org/image.jpg',
+          'provider': 'xx-instance-id-xx',
+          'remotely_accessible': True,
           'type': 'thumb',
         }),
       ]),
@@ -1063,15 +1063,15 @@
       'grouping': None,
       'images': list([
         dict({
-          'path': 'https://demo.org/image.jpg',
-          'provider': 'xx-instance-id-xx',
-          'remotely_accessible': True,
-          'type': 'thumb',
-        }),
-        dict({
           'path': 'ar-37ec820ca7193e17040c98f7da7c4b51_0',
           'provider': 'xx-instance-id-xx',
           'remotely_accessible': False,
+          'type': 'thumb',
+        }),
+        dict({
+          'path': 'https://demo.org/image.jpg',
+          'provider': 'xx-instance-id-xx',
+          'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({


### PR DESCRIPTION
I am seeing a number of places where MA is asking the subsonic server for images using the full URL to lastfm. Reorder the insertion of images in these parsers to place the subsonic image first incase this encourages MA to use that entry instead.