### PR TITLE
Treat narrators as a distinguishing field to prevent merging different recordings

### DIFF
--- a/music_assistant/helpers/compare.py
+++ b/music_assistant/helpers/compare.py
@@ -319,6 +319,12 @@ def compare_audiobook(
         and not compare_strings(base_item.publisher, compare_item.publisher, strict=True)
     ):
         return False
+    # compare narrator(s) — different narrators indicate different recordings and must not be merged
+    if base_item.narrators and compare_item.narrators:
+        base_narrators = {create_safe_string(n) for n in base_item.narrators}
+        compare_narrators = {create_safe_string(n) for n in compare_item.narrators}
+        if base_narrators.isdisjoint(compare_narrators):
+            return False
     # compare author(s)
     for author in base_item.authors:
         author_safe = create_safe_string(author)


### PR DESCRIPTION
## Problem

Audiobooks with the same title and author but different narrators (e.g. the same Harry Potter title read by Stephen Fry and Jim Dale) are merged into a single library item by `compare_audiobook()`. This produces:

- Only one narrator retained in the merged item (the other is silently discarded)
- Chapter lists from all recordings concatenated, resulting in an incorrect (doubled) chapter count
- No supported API path for clients to retrieve per-recording metadata, since `music/audiobooks/get` also returns the merged item

## Root Cause

`compare_audiobook()` in `music_assistant/helpers/compare.py` compares name, version, publisher, and author, but **never checks narrator**. Two recordings of the same title by the same author with completely different narrators pass all checks and are treated as identical items.

## Fix

Add a narrator comparison before the author comparison. When both items have narrator metadata and no narrators are shared (disjoint sets), return `False` — the items are distinct recordings and should not be merged.

```python
# compare narrator(s) — different narrators indicate different recordings and must not be merged
if base_item.narrators and compare_item.narrators:
    base_narrators = {create_safe_string(n) for n in base_item.narrators}
    compare_narrators = {create_safe_string(n) for n in compare_item.narrators}
    if base_narrators.isdisjoint(compare_narrators):
        return False
```

The check is only applied when **both** items have narrator data, so items with missing narrator metadata fall through to the existing author-based comparison unchanged.

## Testing

Verified against an Audiobookshelf library containing two separate recordings of each Harry Potter title (Stephen Fry and Jim Dale narrations). Before this fix: 8 library items returned. Expected: 16 distinct library items, each with correct narrator and chapter count.