### PR TITLE
Fix resolve stream URL in squeezelite and handle missing sample_rates config

### DIFF
--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -1793,8 +1793,18 @@ class StreamsController(CoreController):
             )
             queue_player = self.mass.players.get_player(queue.queue_id)
             assert queue_player is not None
+            # Resolve to protocol player which has CONF_SAMPLE_RATES registered;
+            # the queue player (universal) is just a wrapper and does not carry that config entry.
+            pcm_player = queue_player
+            if (
+                queue_player.active_output_protocol
+                and queue_player.active_output_protocol != "native"
+            ):
+                _proto = self.mass.players.get_player(queue_player.active_output_protocol)
+                if _proto is not None:
+                    pcm_player = _proto
             next_queue_item_pcm_format = await self._select_pcm_format(
-                player=queue_player,
+                player=pcm_player,
                 streamdetails=next_queue_item.streamdetails,
                 smartfades_enabled=True,
             )

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -297,9 +297,10 @@ class SqueezelitePlayer(Player):
 
     async def enqueue_next_media(self, media: PlayerMedia) -> None:
         """Handle enqueuing next media item."""
+        stream_url = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
         await self._handle_play_url_for_slimplayer(
             self.client,
-            url=media.uri,
+            url=stream_url,
             media=media,
             enqueue=True,
             send_flush=False,


### PR DESCRIPTION
Fixes two related bugs that cause playback to break after ~7 seconds when using Squeezelite via Universal Player.

## Bug 1: `UnsupportedContentType: Invalid URL: library://track/...`

`enqueue_next_media` in the Squeezelite player passes `media.uri` directly to `_handle_play_url_for_slimplayer`, but `media.uri` can be a logical `library://` URI that aioslimproto cannot handle. The adjacent `play_media` method correctly calls `resolve_stream_url` first — `enqueue_next_media` was missing this step.

**Fix:** Call `resolve_stream_url` before passing the URL, matching the existing pattern in `play_media`.

## Bug 2: `Config key sample_rates not found for player`

In `get_queue_item_stream_with_smartfade`, the queue player (e.g. a Universal Player) is passed to `_select_pcm_format`. However, `CONF_SAMPLE_RATES` is only registered by protocol-level providers (Squeezelite, etc.), so the lookup fails with `KeyError` when the queue player differs from the protocol player. This crashes the stdin feeder task and kills the audio stream.

## Reproduction

1. Configure a Squeezelite player behind a Universal Player
2. Play any track from a music provider
3. Wait for the track to finish or for crossfade preparation → both errors appear, playback stops