### PR TITLE
Fix infinite recursion in `cmd_stop` ↔ `_handle_cmd_power`

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2600,7 +2600,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             and not player_was_synced
             and player_state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
         ):
-            await self.cmd_stop(player_id)
+            # stop the player directly to avoid recursion:
+            await player.stop()
             # short sleep: allow the stop command to process and prevent race conditions
             await asyncio.sleep(0.2)
 


### PR DESCRIPTION
## Bug
Calling `cmd_stop` on a player that has `auto_power` enabled triggers infinite recursion:

```
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/players/helpers.py", line 123, in execute
    await fn(self, *args, **kwargs)
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/players/controller.py", line 422, in cmd_stop
    await self._handle_cmd_stop(player.player_id)
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/players/controller.py", line 2885, in _handle_cmd_stop
    await self._handle_cmd_power(target_player.player_id, False)
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/players/controller.py", line 2603, in _handle_cmd_power
    await self.cmd_stop(player_id)
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/players/helpers.py", line 135, in wrapper
    await execute()
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/players/helpers.py", line 125, in execute
    raise PlayerCommandFailed(str(err)) from err
music_assistant_models.errors.PlayerCommandFailed: maximum recursion depth exceeded
```

This happens because `_handle_cmd_stop` calls `_handle_cmd_power(player_id, False)` to auto-power-off the player, and `_handle_cmd_power` calls `cmd_stop(player_id)` to stop playback before powering off. Since `player.powered` is still `True` at that point, the cycle repeats until Python hits the recursion limit.

## Fix

In `_handle_cmd_power`, when `powered=False`, replace `await self.cmd_stop(player_id)` with a direct `await player.stop()` call. This stops playback without going through `cmd_stop` → `_handle_cmd_stop` → `_handle_cmd_power` again, breaking the cycle.

## Impact

- Affects any player with `auto_power` enabled (e.g. Squeezelite)
- Without the fix, stop commands crash with `PlayerCommandFailed: maximum recursion depth exceeded`
- The fix is minimal and doesn't change behavior — playback is still stopped before power-off

## How to Reproduce

1. Have two players with `auto_power` enabled (e.g. Squeezelite)
2. Start playback on player A
3. Transfer the queue from player A to player B
4. Player A receives `cmd_stop` → triggers the recursion → `PlayerCommandFailed: maximum recursion depth exceeded`
