### PR TITLE
Handle empty stream URL in metadata refresh for Alexa player provider

### DIFF
--- a/music_assistant/providers/alexa/__init__.py
+++ b/music_assistant/providers/alexa/__init__.py
@@ -451,6 +451,9 @@ class AlexaPlayer(Player):
         to the configured Music Assistant / Alexa API so the Alexa side can
         display/update the playing item.
         """
+        if self._last_stream_url is None:
+            return
+
         media = self.state.current_media
 
         async def _upload_metadata() -> None:


### PR DESCRIPTION
Users reported an empty stream URL being pushed to the Alexa API