### PR TITLE
Fix MA not starting on some older CPU models

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -7,6 +7,7 @@ import functools
 import importlib
 import logging
 import os
+import platform
 import re
 import shutil
 import socket
@@ -54,6 +55,35 @@ HA_WHEELS = "https://wheels.home-assistant.io/musllinux/"
 
 T = TypeVar("T")
 CALLBACK_TYPE = Callable[[], None]
+
+
+def check_x86_64_v2_support() -> bool | None:
+    """Check if the CPU supports the x86-64-v2 microarchitecture level.
+
+    :return: True if supported, False if not, None if not applicable (non-x86_64).
+    """
+    if platform.machine() not in ("x86_64", "AMD64"):
+        return None
+
+    try:
+        cpuinfo = Path("/proc/cpuinfo").read_text()
+    except (FileNotFoundError, PermissionError):
+        return None
+
+    flags: set[str] = set()
+    for line in cpuinfo.splitlines():
+        if line.startswith("flags"):
+            flags.update(line.split())
+            break
+
+    if not flags:
+        return None
+
+    # x86-64-v2 requires: CMPXCHG16B, LAHF/SAHF, POPCNT, SSE3, SSSE3, SSE4.1, SSE4.2
+    # SSE3 may appear as "pni" (Prescott New Instructions) on older kernels
+    required = {"cx16", "lahf_lm", "popcnt", "sse4_1", "sse4_2", "ssse3"}
+    has_sse3 = bool({"sse3", "pni"} & flags)
+    return required.issubset(flags) and has_sse3
 
 
 def get_total_system_memory() -> float:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -57,7 +57,7 @@ T = TypeVar("T")
 CALLBACK_TYPE = Callable[[], None]
 
 
-def check_x86_64_v2_support() -> bool | None:
+async def check_x86_64_v2_support() -> bool | None:
     """Check if the CPU supports the x86-64-v2 microarchitecture level.
 
     :return: True if supported, False if not, None if not applicable (non-x86_64).
@@ -65,25 +65,28 @@ def check_x86_64_v2_support() -> bool | None:
     if platform.machine() not in ("x86_64", "AMD64"):
         return None
 
-    try:
-        cpuinfo = Path("/proc/cpuinfo").read_text()
-    except (FileNotFoundError, PermissionError):
-        return None
+    def _check() -> bool | None:
+        try:
+            cpuinfo = Path("/proc/cpuinfo").read_text()
+        except (FileNotFoundError, PermissionError):
+            return None
 
-    flags: set[str] = set()
-    for line in cpuinfo.splitlines():
-        if line.startswith("flags"):
-            flags.update(line.split())
-            break
+        flags: set[str] = set()
+        for line in cpuinfo.splitlines():
+            if line.startswith("flags"):
+                flags.update(line.split())
+                break
 
-    if not flags:
-        return None
+        if not flags:
+            return None
 
-    # x86-64-v2 requires: CMPXCHG16B, LAHF/SAHF, POPCNT, SSE3, SSSE3, SSE4.1, SSE4.2
-    # SSE3 may appear as "pni" (Prescott New Instructions) on older kernels
-    required = {"cx16", "lahf_lm", "popcnt", "sse4_1", "sse4_2", "ssse3"}
-    has_sse3 = bool({"sse3", "pni"} & flags)
-    return required.issubset(flags) and has_sse3
+        # x86-64-v2 requires: CMPXCHG16B, LAHF/SAHF, POPCNT, SSE3, SSSE3, SSE4.1, SSE4.2
+        # SSE3 may appear as "pni" (Prescott New Instructions) on older kernels
+        required = {"cx16", "lahf_lm", "popcnt", "sse4_1", "sse4_2", "ssse3"}
+        has_sse3 = bool({"sse3", "pni"} & flags)
+        return required.issubset(flags) and has_sse3
+
+    return await asyncio.to_thread(_check)
 
 
 def get_total_system_memory() -> float:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -57,13 +57,13 @@ T = TypeVar("T")
 CALLBACK_TYPE = Callable[[], None]
 
 
-async def check_x86_64_v2_support() -> bool | None:
-    """Check if the CPU supports the x86-64-v2 microarchitecture level.
+async def warn_if_missing_x86_64_v2(logger: logging.Logger) -> None:
+    """Log a deprecation warning if the CPU lacks x86-64-v2 support.
 
-    :return: True if supported, False if not, None if not applicable (non-x86_64).
+    :param logger: Logger instance to write the warning to.
     """
     if platform.machine() not in ("x86_64", "AMD64"):
-        return None
+        return
 
     def _check() -> bool | None:
         try:
@@ -86,7 +86,32 @@ async def check_x86_64_v2_support() -> bool | None:
         has_sse3 = bool({"sse3", "pni"} & flags)
         return required.issubset(flags) and has_sse3
 
-    return await asyncio.to_thread(_check)
+    if await asyncio.to_thread(_check) is False:
+        logger.warning(
+            "\n\n"
+            "########################################################"
+            "########################\n"
+            "###               CPU DEPRECATION WARNING"
+            "                                    ###\n"
+            "########################################################"
+            "########################\n"
+            "\n"
+            "Your CPU does not support the x86-64-v2 instruction "
+            "set, which will be\n"
+            "required starting with Music Assistant 2.9.\n"
+            "\n"
+            "If you are running in a virtual machine (e.g. Proxmox),"
+            " change the CPU type\n"
+            "to 'host' or select a more modern CPU type preset "
+            "(e.g. x86-64-v2 or newer).\n"
+            "\n"
+            "If your physical CPU predates 2009, you will likely "
+            "need to upgrade\n"
+            "your hardware before updating Music Assistant to 2.9.\n"
+            "\n"
+            "########################################################"
+            "########################\n"
+        )
 
 
 def get_total_system_memory() -> float:

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -56,11 +56,11 @@ from music_assistant.helpers.api import APICommandHandler, api_command
 from music_assistant.helpers.images import get_icon_string
 from music_assistant.helpers.util import (
     TaskManager,
-    check_x86_64_v2_support,
     get_ip_pton,
     get_package_version,
     is_hass_supervisor,
     load_provider_module,
+    warn_if_missing_x86_64_v2,
 )
 from music_assistant.models import ProviderInstanceType
 from music_assistant.models.music_provider import MusicProvider
@@ -174,24 +174,7 @@ class MusicAssistant:
             self.running_as_hass_addon,
             self.safe_mode,
         )
-        if await check_x86_64_v2_support() is False:
-            LOGGER.warning(
-                "\n\n"
-                "################################################################################\n"
-                "###               CPU DEPRECATION WARNING                                    ###\n"
-                "################################################################################\n"
-                "\n"
-                "Your CPU does not support the x86-64-v2 instruction set, which will be\n"
-                "required starting with Music Assistant 2.9.\n"
-                "\n"
-                "If you are running in a virtual machine (e.g. Proxmox), change the CPU type\n"
-                "to 'host' or select a more modern CPU type preset (e.g. x86-64-v2 or newer).\n"
-                "\n"
-                "If your physical CPU predates 2009, you will likely need to upgrade\n"
-                "your hardware before updating Music Assistant to 2.9.\n"
-                "\n"
-                "################################################################################\n"
-            )
+        await warn_if_missing_x86_64_v2(LOGGER)
         # setup other core controllers
         self.cache = CacheController(self)
         self.webserver = WebserverController(self)

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -56,6 +56,7 @@ from music_assistant.helpers.api import APICommandHandler, api_command
 from music_assistant.helpers.images import get_icon_string
 from music_assistant.helpers.util import (
     TaskManager,
+    check_x86_64_v2_support,
     get_ip_pton,
     get_package_version,
     is_hass_supervisor,
@@ -173,6 +174,24 @@ class MusicAssistant:
             self.running_as_hass_addon,
             self.safe_mode,
         )
+        if check_x86_64_v2_support() is False:
+            LOGGER.warning(
+                "\n\n"
+                "################################################################################\n"
+                "###               CPU DEPRECATION WARNING                                    ###\n"
+                "################################################################################\n"
+                "\n"
+                "Your CPU does not support the x86-64-v2 instruction set, which will be\n"
+                "required starting with Music Assistant 2.9.\n"
+                "\n"
+                "If you are running in a virtual machine (e.g. Proxmox), change the CPU type\n"
+                "to 'host' or select a more modern CPU type preset (e.g. x86-64-v2 or newer).\n"
+                "\n"
+                "If your physical CPU predates 2009, you will likely need to upgrade\n"
+                "your hardware before updating Music Assistant to 2.9.\n"
+                "\n"
+                "################################################################################\n"
+            )
         # setup other core controllers
         self.cache = CacheController(self)
         self.webserver = WebserverController(self)

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -174,7 +174,7 @@ class MusicAssistant:
             self.running_as_hass_addon,
             self.safe_mode,
         )
-        if check_x86_64_v2_support() is False:
+        if await check_x86_64_v2_support() is False:
             LOGGER.warning(
                 "\n\n"
                 "################################################################################\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "zeroconf==0.148.0",
   "uv>=0.8.0",
   "librosa==0.11.0",
+  "numpy==2.3.5",  # numpy 2.4.0+ uses X86_V2 CPU baseline (requires SSE4.2) which breaks older CPUs https://github.com/music-assistant/support/issues/5005#issuecomment-3972476728
   "gql[all]==4.0.0",
   "aiovban>=0.6.3",
   "aiortc>=1.6.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -45,6 +45,7 @@ music-assistant-frontend==2.17.100
 music-assistant-models==1.1.102
 mutagen==1.47.0
 niconico.py-ma==2.1.0.post1
+numpy==2.3.5
 orjson==3.11.5
 pillow==12.1.1
 pkce==1.0.3


### PR DESCRIPTION
Pin numpy to 2.3.5 and display a deprecation warning for older CPU models