### PR TITLE
Use floating point for `aiosendspin`'s internal audio data

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin==4.2.0", "av==16.1.0"],
+  "requirements": ["aiosendspin==4.3.0", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 # Same sample format expressed in both MA and Sendspin type systems.
 _PCM_FORMAT = AudioFormat(
-    content_type=ContentType.PCM_S32LE,
+    content_type=ContentType.PCM_F32LE,
     sample_rate=48000,
     bit_depth=32,
     channels=2,
@@ -36,6 +36,7 @@ _SENDSPIN_PCM_FORMAT = SendspinAudioFormat(
     sample_rate=48000,
     bit_depth=32,
     channels=2,
+    sample_type="float",
 )
 # Max PCM slice fed to the producer per iteration.
 _PRODUCER_SLICE_US = 100_000

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
 aiorun==2025.1.1
-aiosendspin==4.2.0
+aiosendspin==4.3.0
 aioslimproto==3.1.5
 aiosonos==0.1.9
 aiosqlite==0.22.1


### PR DESCRIPTION
`aiosendspin` now receives floating point (PCM_F32LE) instead of signed integer (PCM_S32LE) audio data for internal processing.