### PR TITLE
Log expected API errors as warnings without tracebacks

### DIFF
--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -23,6 +23,7 @@ from music_assistant_models.errors import (
     InsufficientPermissions,
     InvalidCommand,
     InvalidToken,
+    MusicAssistantError,
 )
 
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER, VERBOSE_LOG_LEVEL
@@ -242,6 +243,12 @@ class WebsocketClientHandler:
             elif inspect.iscoroutine(result):
                 result = await result
             await self._send_message(SuccessResultMessage(msg.message_id, result))
+        except MusicAssistantError as err:
+            # Expected operational errors (player unavailable, queue empty, etc.)
+            # Log at warning level since these are normal error responses, not crashes.
+            self._logger.warning("%s: %s", msg.command, err)
+            err_msg = str(err) or err.__class__.__name__
+            await self._send_message(ErrorResultMessage(msg.message_id, err.error_code, err_msg))
         except Exception as err:
             if self._logger.isEnabledFor(logging.DEBUG):
                 self._logger.exception("Error handling message: %s", msg)


### PR DESCRIPTION
MusicAssistantError subclasses (player unavailable, queue empty, etc.) are normal operational errors, not crashes. Log them as clean one-line warnings instead of dumping full tracebacks at ERROR level.

Previous error message:

```
2026-02-27 13:08:15.953 ERROR (MainThread) [music_assistant.webserver] Error handling message: CommandMessage(message_id='fb3c742b-992b-449d-92a2-becefd7bc758', command='player_queues/play_media', args={'queue_id': 'upma_companion_e9c0c92333fa459cb04dc97e83a37312', 'media': ['library://album/124'], 'option': 'replace'})
Traceback (most recent call last):
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/webserver/websocket_client.py", line 243, in _run_handler
    result = await result
             ^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/player_queues.py", line 143, in wrapper
    return await func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/player_queues.py", line 497, in play_media
    queue_player = self.mass.players.get_player(queue_id, True)
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/players/controller.py", line 257, in get_player
    raise PlayerUnavailableError(msg)
music_assistant_models.errors.PlayerUnavailableError: Player upma_companion_e9c0c92333fa459cb04dc97e83a37312 is not available
```

Now:
```
WARNING: player_queues/play_media: Player upma_companion_e9c0c92333fa459cb04dc97e83a37312 is not available
```