### PR TITLE
fix: delay stream/end until client buffers drain at end of album

### DIFF
--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -735,6 +735,25 @@ class SendspinPlaybackSession:
                 commit_task.cancel()
                 with suppress(asyncio.CancelledError, Exception):
                     await commit_task
+            # On clean EOF, wait for clients to finish playing their
+            # buffered audio before sending stream/end (which clears
+            # client buffers per the SendSpin spec).  The sleep keeps
+            # _run_playback alive so MA still considers the track
+            # "playing" and the UI stays in sync with actual audio.
+            if producer_stopped_cleanly:
+                drain_wait_s = self._get_stream_end_delay_s()
+                if drain_wait_s > 0:
+                    self.player.logger.debug(
+                        "Waiting %.1fs for client buffer drain before stream/end",
+                        drain_wait_s,
+                    )
+                    try:
+                        await asyncio.sleep(drain_wait_s)
+                    except asyncio.CancelledError:
+                        # play_media → cancel() interrupted the drain.
+                        # Treat as non-clean stop so we skip group.stop()
+                        # and let the new playback handle the transition.
+                        producer_stopped_cleanly = False
             with suppress(Exception):
                 self._stop_push_stream()
             await self._clear_join_catchup()
@@ -748,11 +767,22 @@ class SendspinPlaybackSession:
                 self._history.clear()
                 # Drop cached DSP decisions so next playback reflects latest config.
                 self._pipeline_config_cache.clear()
-            # Only emit a group STOP when MA stream playback reached natural EOF.
-            # Skip this on cancellation/error paths to avoid stop-event races with transitions.
             if producer_stopped_cleanly:
-                with suppress(Exception):
-                    await self.player.api.group.stop()
+                # Check whether a track was enqueued during the drain
+                # (e.g. user pressed "play next" while the last track
+                # was finishing).  If so, start it instead of stopping.
+                next_result = self._peek_next_queue_index()
+                if next_result is not None:
+                    queue_id, next_index = next_result
+                    self.player.logger.debug(
+                        "New queue item detected after drain, resuming playback"
+                    )
+                    self.player.mass.create_task(
+                        self.player.mass.player_queues.play_index(queue_id, next_index)
+                    )
+                else:
+                    with suppress(Exception):
+                        await self.player.api.group.stop()
 
     # -- Join injection --------------------------------------------------------
 
@@ -1082,6 +1112,56 @@ class SendspinPlaybackSession:
     def _create_push_stream(self) -> PushStream:
         """Create PushStream with channel resolver for per-member routing."""
         return self.player.api.group.start_stream(channel_resolver=self._resolve_channel_for_player)
+
+    def _peek_next_queue_index(self) -> tuple[str, int] | None:
+        """Return (queue_id, index) of the next queue item, or None if unavailable."""
+        queue = self.player.mass.player_queues.get_active_queue(self.player.player_id)
+        if queue is None or queue.current_index is None:
+            return None
+        next_item = self.player.mass.player_queues.get_next_item(
+            queue.queue_id, queue.current_index
+        )
+        if next_item is None:
+            return None
+        index = self.player.mass.player_queues.index_by_id(queue.queue_id, next_item.queue_item_id)
+        if index is None:
+            return None
+        return (queue.queue_id, index)
+
+    def _get_stream_end_delay_s(self) -> float:
+        """Return seconds until the last committed audio finishes playing.
+
+        The push stream's channel timing tracks the server-clock end timestamp
+        of the last committed chunk for each channel.  Clients play audio at
+        server-clock time, so we wait until the server clock reaches that point
+        before sending stream/end (which clears client buffers per spec).
+
+        Only active audio channels are considered, matching the filter used by
+        ``sleep_to_limit_buffer`` to avoid stale channels from disconnected
+        members inflating the wait.
+        """
+        ps = self._push_stream
+        if ps is None:
+            return 0.0
+        try:
+            active_channels = ps._get_active_audio_channels()
+            timings = ps._channel_timing
+            active_timings = [t for ch, t in timings.items() if ch in active_channels]
+            if not active_timings:
+                return 0.0
+            last_us = max(active_timings)
+            now_us = ps._clock.now_us()
+            ahead_us = last_us - now_us
+            if ahead_us <= 0:
+                return 0.0
+            # Cap at the producer buffer limit as a safety bound.
+            return min(ahead_us / 1_000_000, _PRODUCER_BUFFER_LIMIT_US / 1_000_000)
+        except Exception:
+            self.player.logger.debug(
+                "Failed to compute stream end delay",
+                exc_info=True,
+            )
+            return 0.0
 
     def _stop_push_stream(self) -> None:
         """Stop the active PushStream."""

--- a/tests/providers/sendspin/__init__.py
+++ b/tests/providers/sendspin/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Sendspin player provider."""

--- a/tests/providers/sendspin/test_playback.py
+++ b/tests/providers/sendspin/test_playback.py
@@ -1,0 +1,213 @@
+"""Tests for SendspinPlaybackSession drain-delay helpers."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from music_assistant.providers.sendspin.playback import SendspinPlaybackSession
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CH_A = uuid4()
+CH_B = uuid4()
+CH_STALE = uuid4()  # channel for a disconnected member
+
+
+def _make_session(
+    *,
+    push_stream: object | None = None,
+) -> SendspinPlaybackSession:
+    """Build a minimal SendspinPlaybackSession with mocked player."""
+    player = MagicMock()
+    player.player_id = "test-player-1"
+    player.logger = logging.getLogger("test.sendspin.playback")
+
+    session = object.__new__(SendspinPlaybackSession)
+    session.player = player
+    session._push_stream = push_stream
+    return session
+
+
+def _make_push_stream(
+    *,
+    channel_timing: dict | None = None,
+    active_channels: set | None = None,
+    now_us: int = 0,
+) -> MagicMock:
+    """Build a mock PushStream with controllable timing internals."""
+    ps = MagicMock()
+    ps._channel_timing = channel_timing or {}
+    ps._get_active_audio_channels.return_value = active_channels or set()
+    ps._clock.now_us.return_value = now_us
+    return ps
+
+
+def _make_session_with_queue(
+    *,
+    queue: object | None = None,
+    next_item: object | None = None,
+    index_by_id_result: int | None = None,
+) -> SendspinPlaybackSession:
+    """Build a session with mocked queue API."""
+    session = _make_session()
+    pq = session.player.mass.player_queues
+    pq.get_active_queue.return_value = queue
+    pq.get_next_item.return_value = next_item
+    pq.index_by_id.return_value = index_by_id_result
+    return session
+
+
+# ---------------------------------------------------------------------------
+# _get_stream_end_delay_s
+# ---------------------------------------------------------------------------
+
+
+def test_delay_no_push_stream_returns_zero() -> None:
+    """No push stream means no delay."""
+    session = _make_session(push_stream=None)
+    assert session._get_stream_end_delay_s() == 0.0
+
+
+def test_delay_no_active_channels_returns_zero() -> None:
+    """Stale channels with no active audio should not produce a delay."""
+    ps = _make_push_stream(
+        channel_timing={CH_STALE: 5_000_000},
+        active_channels=set(),
+        now_us=0,
+    )
+    session = _make_session(push_stream=ps)
+    assert session._get_stream_end_delay_s() == 0.0
+
+
+def test_delay_clock_past_end_returns_zero() -> None:
+    """If the clock is past the last committed audio, no delay needed."""
+    ps = _make_push_stream(
+        channel_timing={CH_A: 10_000_000},
+        active_channels={CH_A},
+        now_us=12_000_000,
+    )
+    session = _make_session(push_stream=ps)
+    assert session._get_stream_end_delay_s() == 0.0
+
+
+def test_delay_clock_at_end_returns_zero() -> None:
+    """Exactly at the end timestamp — no wait required."""
+    ps = _make_push_stream(
+        channel_timing={CH_A: 10_000_000},
+        active_channels={CH_A},
+        now_us=10_000_000,
+    )
+    session = _make_session(push_stream=ps)
+    assert session._get_stream_end_delay_s() == 0.0
+
+
+def test_delay_basic_computation() -> None:
+    """2.7 seconds of buffered audio remaining."""
+    ps = _make_push_stream(
+        channel_timing={CH_A: 12_700_000},
+        active_channels={CH_A},
+        now_us=10_000_000,
+    )
+    session = _make_session(push_stream=ps)
+    assert session._get_stream_end_delay_s() == pytest.approx(2.7)
+
+
+def test_delay_multiple_channels_uses_max() -> None:
+    """With multiple channels, use the one that finishes last."""
+    ps = _make_push_stream(
+        channel_timing={CH_A: 11_000_000, CH_B: 13_000_000},
+        active_channels={CH_A, CH_B},
+        now_us=10_000_000,
+    )
+    session = _make_session(push_stream=ps)
+    assert session._get_stream_end_delay_s() == pytest.approx(3.0)
+
+
+def test_delay_stale_channels_excluded() -> None:
+    """Disconnected member channels should not inflate the wait."""
+    ps = _make_push_stream(
+        channel_timing={CH_A: 11_000_000, CH_STALE: 20_000_000},
+        active_channels={CH_A},
+        now_us=10_000_000,
+    )
+    session = _make_session(push_stream=ps)
+    assert session._get_stream_end_delay_s() == pytest.approx(1.0)
+
+
+def test_delay_capped_at_producer_buffer_limit() -> None:
+    """Delay should never exceed the 30s producer buffer limit."""
+    ps = _make_push_stream(
+        channel_timing={CH_A: 70_000_000},
+        active_channels={CH_A},
+        now_us=10_000_000,
+    )
+    session = _make_session(push_stream=ps)
+    assert session._get_stream_end_delay_s() == pytest.approx(30.0)
+
+
+def test_delay_exception_returns_zero() -> None:
+    """Graceful degradation: any exception falls back to 0.0."""
+    ps = _make_push_stream()
+    ps._get_active_audio_channels.side_effect = RuntimeError("boom")
+    session = _make_session(push_stream=ps)
+    assert session._get_stream_end_delay_s() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _peek_next_queue_index
+# ---------------------------------------------------------------------------
+
+
+def test_peek_no_active_queue() -> None:
+    """No active queue returns None."""
+    session = _make_session_with_queue(queue=None)
+    assert session._peek_next_queue_index() is None
+
+
+def test_peek_no_current_index() -> None:
+    """Queue with no current_index returns None."""
+    queue = SimpleNamespace(queue_id="q1", current_index=None)
+    session = _make_session_with_queue(queue=queue)
+    assert session._peek_next_queue_index() is None
+
+
+def test_peek_no_next_item() -> None:
+    """No next item in the queue returns None (end of album)."""
+    queue = SimpleNamespace(queue_id="q1", current_index=5)
+    session = _make_session_with_queue(queue=queue, next_item=None)
+    assert session._peek_next_queue_index() is None
+
+
+def test_peek_returns_queue_id_and_index() -> None:
+    """Happy path: next item exists, returns (queue_id, index) tuple."""
+    queue = SimpleNamespace(queue_id="q1", current_index=5)
+    next_item = SimpleNamespace(queue_item_id="item-6")
+    session = _make_session_with_queue(
+        queue=queue,
+        next_item=next_item,
+        index_by_id_result=6,
+    )
+    assert session._peek_next_queue_index() == ("q1", 6)
+    # Verify correct args were passed through
+    pq = session.player.mass.player_queues
+    pq.get_next_item.assert_called_once_with("q1", 5)
+    pq.index_by_id.assert_called_once_with("q1", "item-6")
+
+
+def test_peek_index_by_id_returns_none() -> None:
+    """Item existed but was removed before index_by_id — returns None."""
+    queue = SimpleNamespace(queue_id="q1", current_index=5)
+    next_item = SimpleNamespace(queue_item_id="item-gone")
+    session = _make_session_with_queue(
+        queue=queue,
+        next_item=next_item,
+        index_by_id_result=None,
+    )
+    assert session._peek_next_queue_index() is None

--- a/tests/providers/sendspin/test_playback.py
+++ b/tests/providers/sendspin/test_playback.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -22,7 +23,7 @@ CH_STALE = uuid4()  # channel for a disconnected member
 
 def _make_session(
     *,
-    push_stream: object | None = None,
+    push_stream: Any = None,
 ) -> SendspinPlaybackSession:
     """Build a minimal SendspinPlaybackSession with mocked player."""
     player = MagicMock()
@@ -37,8 +38,8 @@ def _make_session(
 
 def _make_push_stream(
     *,
-    channel_timing: dict | None = None,
-    active_channels: set | None = None,
+    channel_timing: dict[UUID, int] | None = None,
+    active_channels: set[UUID] | None = None,
     now_us: int = 0,
 ) -> MagicMock:
     """Build a mock PushStream with controllable timing internals."""
@@ -57,7 +58,7 @@ def _make_session_with_queue(
 ) -> SendspinPlaybackSession:
     """Build a session with mocked queue API."""
     session = _make_session()
-    pq = session.player.mass.player_queues
+    pq = cast("MagicMock", session.player.mass.player_queues)
     pq.get_active_queue.return_value = queue
     pq.get_next_item.return_value = next_item
     pq.index_by_id.return_value = index_by_id_result
@@ -196,7 +197,7 @@ def test_peek_returns_queue_id_and_index() -> None:
     )
     assert session._peek_next_queue_index() == ("q1", 6)
     # Verify correct args were passed through
-    pq = session.player.mass.player_queues
+    pq = cast("MagicMock", session.player.mass.player_queues)
     pq.get_next_item.assert_called_once_with("q1", 5)
     pq.index_by_id.assert_called_once_with("q1", "item-6")
 


### PR DESCRIPTION
When the last track in a queue finishes, the server must wait for clients to finish playing their buffered audio before sending stream/end (which clears client buffers per the SendSpin spec).

The drain sleep runs inline in _run_playback's finally block so MA still considers the track "playing" and the UI stays in sync with actual audio output. On cancellation (e.g. play_media starts a new track), the sleep is interrupted via CancelledError.

After the drain completes, the queue is checked for newly enqueued tracks (e.g. user pressed "play next" during the last track). If found, play_index is triggered instead of stopping — playback continues after the current track finishes naturally.

Also:
- Active channel filtering for stream end delay computation
- Debug logging for exception fallback in delay computation