### PR TITLE
Handle connection errors in the Audiobookshelf provider gracefully during provider unload

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -49,6 +49,7 @@ from aioaudiobookshelf.schema.shelf import (
 from aioaudiobookshelf.schema.shelf import ShelfId as AbsShelfId
 from aioaudiobookshelf.schema.shelf import ShelfType as AbsShelfType
 from aiohttp import web
+from aiohttp.client_exceptions import ClientError
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueType,
@@ -361,8 +362,11 @@ for more details.
         Called when provider is deregistered (e.g. MA exiting or config reloading).
         is_removed will be set to True when the provider is removed from the configuration.
         """
-        await self._client.logout()
-        await self._client_socket.logout()
+        try:
+            await self._client.logout()
+            await self._client_socket.logout()
+        except ClientError as err:
+            self.logger.debug("Ignoring error during logout: %s", err)
         for callback in self._on_unload_callbacks:
             callback()
 


### PR DESCRIPTION
I was watching my MA logs, as one does, and saw some huge tracebacks. Turns out my Audiobookshelf server was unavailable (good to know) but I figured we could clean up the logging. Set to debug level as errors talking to an unavailable server is expected, but I might be missing some context and would be happy to set the level higher.

Example of what I was seeing:

```
2026-02-27 13:03:53.128 WARNING (MainThread) [music_assistant] Error while unloading provider Audiobookshelf: Cannot connect to host foo.example.com:443 ssl:default [Connect call failed ('x.x.x.x', 443)]
Traceback (most recent call last):
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1298, in _wrap_create_connection
    sock = await aiohappyeyeballs.start_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohappyeyeballs/impl.py", line 122, in start_connection
    raise first_exception
  File "/app/venv/lib/python3.13/site-packages/aiohappyeyeballs/impl.py", line 73, in start_connection
    sock = await _connect_sock(
           ^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohappyeyeballs/impl.py", line 208, in _connect_sock
    await loop.sock_connect(sock, address)
  File "/usr/local/lib/python3.13/asyncio/selector_events.py", line 641, in sock_connect
    return await fut
           ^^^^^^^^^
  File "/usr/local/lib/python3.13/asyncio/selector_events.py", line 681, in _sock_connect_cb
    raise OSError(err, f'Connect call failed {address}')
ConnectionRefusedError: [Errno 111] Connect call failed ('x.x.x.x', 443)
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/app/venv/lib/python3.13/site-packages/music_assistant/mass.py", line 741, in unload_provider
    await provider.unload(is_removed)
  File "/app/venv/lib/python3.13/site-packages/music_assistant/providers/audiobookshelf/__init__.py", line 256, in wrapper
    return await method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/music_assistant/providers/audiobookshelf/__init__.py", line 392, in unload
    await self._client_socket.logout()
  File "/app/venv/lib/python3.13/site-packages/aioaudiobookshelf/client/__init__.py", line 179, in shutdown
    await self.client.shutdown()
  File "/app/venv/lib/python3.13/site-packages/socketio/async_client.py", line 346, in shutdown
    await self._reconnect_task
  File "/app/venv/lib/python3.13/site-packages/socketio/async_client.py", line 531, in _handle_reconnect
    await self.connect(self.connection_url,
    ...<5 lines>...
                       retry=False)
  File "/app/venv/lib/python3.13/site-packages/socketio/async_client.py", line 157, in connect
    await self._trigger_event(
        'connect_error', n,
        exc.args[1] if len(exc.args) > 1 else exc.args[0])
  File "/app/venv/lib/python3.13/site-packages/socketio/async_client.py", line 472, in _trigger_event
    ret = await handler(*args)
          ^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/aioaudiobookshelf/client/__init__.py", line 200, in _on_connect_error
    await self.session_config.refresh()
  File "/app/venv/lib/python3.13/site-packages/aioaudiobookshelf/client/session_configuration.py", line 75, in refresh
    response = await self.session.post(
               ^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/client.py", line 779, in _request
    resp = await handler(req)
           ^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/client.py", line 734, in _connect_and_send_request
    conn = await self._connector.connect(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        req, traces=traces, timeout=real_timeout
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 672, in connect
    proto = await self._create_connection(req, traces, timeout)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1239, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1611, in _create_direct_connection
    raise last_exc
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1580, in _create_direct_connection
    transp, proto = await self._wrap_create_connection(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1321, in _wrap_create_connection
    raise client_error(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host foo.example.com:443 ssl:default [Connect call failed ('x.x.x.x', 443)]
```