### PR TITLE
Fix volume_up / down for group players

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -613,6 +613,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         if not (player := self.get_player(player_id)):
             return
+        if player.type == PlayerType.GROUP:
+            await self.cmd_group_volume_up(player_id)
+            return
         current_volume = player.state.volume_level or 0
         if current_volume < 10 or current_volume > 90:
             step_size = 1
@@ -631,6 +634,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         - player_id: player_id of the player to handle the command.
         """
         if not (player := self.get_player(player_id)):
+            return
+        if player.type == PlayerType.GROUP:
+            await self.cmd_group_volume_down(player_id)
             return
         current_volume = player.state.volume_level or 0
         if current_volume < 10 or current_volume > 90:


### PR DESCRIPTION
This PR fixes volume jumping to 0 or 1 when invoking `volume_up/down` on a group player.

Related issues
- https://github.com/music-assistant/support/issues/4659
- (likely) https://github.com/music-assistant/support/issues/4609