### PR TITLE
Accept alternative genre tag separators

### DIFF
--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -357,7 +357,7 @@ class AudioTags:
     @property
     def genres(self) -> tuple[str, ...]:
         """Return (all) genres, if any."""
-        return split_items(self.tags.get("genre"))
+        return split_items(self.tags.get("genre"), allow_unsafe_splitters=True)
 
     @property
     def disc(self) -> int | None:


### PR DESCRIPTION
## Summary
- Enable fallback splitter logic (`, ` and ` / `) for genre tags when the default semicolon separator is not found
- Unlike artist names (e.g. AC/DC), genre names don't contain slashes, so these alternative splitters are safe to use
- Users who tag genres as `Rock / Pop` or `Rock, Pop` will now have them properly split

## Test plan
- [x] Verify genres tagged with `;` separator still work correctly (takes priority)
- [x] Verify genres tagged with `, ` separator are now properly split
- [x] Verify genres tagged with `/` separator are now properly split
- [x] Trigger a library resync to confirm corrected genres appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)