### PR TITLE
Guard eventdata snapcast

### DIFF
--- a/music_assistant/providers/snapcast/control.py
+++ b/music_assistant/providers/snapcast/control.py
@@ -251,7 +251,7 @@ class MusicAssistantControl:
         # Event
         if "event" in data and data.get("object_id") == self.queue_id:
             event = data["event"]
-            if event == "queue_updated":
+            if event == "queue_updated" and data.get("data"):
                 properties = self._create_properties(data["data"])
                 self.send_snapcast_properties_notification(properties)
                 return

--- a/music_assistant/providers/snapcast/control.py
+++ b/music_assistant/providers/snapcast/control.py
@@ -251,7 +251,7 @@ class MusicAssistantControl:
         # Event
         if "event" in data and data.get("object_id") == self.queue_id:
             event = data["event"]
-            if event == "queue_updated" and data.get("data"):
+            if event == "queue_updated" and "data" in data:
                 properties = self._create_properties(data["data"])
                 self.send_snapcast_properties_notification(properties)
                 return

--- a/music_assistant/providers/snapcast/control.py
+++ b/music_assistant/providers/snapcast/control.py
@@ -251,7 +251,7 @@ class MusicAssistantControl:
         # Event
         if "event" in data and data.get("object_id") == self.queue_id:
             event = data["event"]
-            if event == "queue_updated" and "data" in data:
+            if event == "queue_updated" and data.get("data"):
                 properties = self._create_properties(data["data"])
                 self.send_snapcast_properties_notification(properties)
                 return


### PR DESCRIPTION
Should prevent the following race that might prevent the queue proceeding for snapcast:

`DEBUG (MainThread) [music_assistant.snapcast.snapserver] 2026-02-19 20-47-13.236 [Info] (PcmStream) Stream: Music Assistant - masckitchen, message: 2026-02-19 20:47:13,236 control INFO: Exception in socket loop: 'NoneType' object has no attribute 'get'[0m`

Related issue: https://github.com/music-assistant/support/issues/4945