### PR TITLE
Improve protocol linking reliability and restart resilience

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -118,6 +118,8 @@ CONF_LINKED_PROTOCOL_IDS: Final[str] = "linked_protocol_ids"  # cached for fast 
 CONF_PROTOCOL_PARENT_ID: Final[str] = (
     "protocol_parent_id"  # cached native player ID for protocol player
 )
+CONF_CACHED_ARP_MAC: Final[str] = "cached_arp_mac"  # cached ARP-resolved MAC for fast restart
+CONF_REPORTED_MAC: Final[str] = "reported_mac"  # original MAC reported by provider (before ARP)
 CONF_OUTPUT_CODEC: Final[str] = "output_codec"
 CONF_ALLOW_AUDIO_CACHE: Final[str] = "allow_audio_cache"
 CONF_SMART_FADES_MODE: Final[str] = "smart_fades_mode"

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -30,6 +30,7 @@ from music_assistant_models.constants import (
 )
 from music_assistant_models.enums import (
     EventType,
+    IdentifierType,
     MediaType,
     PlaybackState,
     PlayerFeature,
@@ -68,6 +69,7 @@ from music_assistant.constants import (
     ATTR_SUPPORTED_FEATURES,
     ATTR_VOLUME_CONTROL,
     CONF_AUTO_PLAY,
+    CONF_CACHED_ARP_MAC,
     CONF_ENTRY_ANNOUNCE_VOLUME,
     CONF_ENTRY_ANNOUNCE_VOLUME_MAX,
     CONF_ENTRY_ANNOUNCE_VOLUME_MIN,
@@ -77,6 +79,8 @@ from music_assistant.constants import (
     CONF_PLAYER_DSP,
     CONF_PLAYERS,
     CONF_PRE_ANNOUNCE_CHIME_URL,
+    CONF_PROTOCOL_PARENT_ID,
+    CONF_REPORTED_MAC,
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
@@ -88,6 +92,7 @@ from music_assistant.helpers.throttle_retry import Throttler
 from music_assistant.helpers.util import (
     TaskManager,
     enrich_device_mac_address,
+    is_valid_mac_address,
     validate_announcement_chime_url,
 )
 from music_assistant.models.core_controller import CoreController
@@ -152,6 +157,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     async def setup(self, config: CoreConfig) -> None:
         """Async initialize of module."""
+        self._cleanup_stale_protocol_parent_ids()
         self._poll_task = self.mass.create_task(self._poll_players())
 
     async def close(self) -> None:
@@ -1248,9 +1254,47 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             if not player.state.enabled:
                 return
 
+            # Save the original MAC reported by the provider (before ARP enrichment)
+            reported_mac = player.device_info.identifiers.get(IdentifierType.MAC_ADDRESS)
+
+            # Try to use cached ARP MAC from config for fast matching on restart.
+            # This allows protocol linking to work immediately even if ARP is slow/fails.
+            conf_base = f"{CONF_PLAYERS}/{player_id}/values"
+            cached_arp_mac: str | None = self.mass.config.get(
+                f"{conf_base}/{CONF_CACHED_ARP_MAC}", None
+            )
+            if cached_arp_mac and is_valid_mac_address(cached_arp_mac):
+                player.device_info.add_identifier(IdentifierType.MAC_ADDRESS, cached_arp_mac)
+
             # Enrich device MAC address via ARP if needed
             # (handles invalid MACs, locally-administered MACs, and missing MACs)
             await enrich_device_mac_address(player.device_info, self.logger)
+
+            # Cache the resolved MAC for fast matching on subsequent restarts
+            current_mac = player.device_info.identifiers.get(IdentifierType.MAC_ADDRESS)
+            if current_mac and is_valid_mac_address(current_mac) and current_mac != cached_arp_mac:
+                self.mass.config.set(f"{conf_base}/{CONF_CACHED_ARP_MAC}", current_mac)
+
+            # Store original reported MAC if it differs from the resolved MAC.
+            # This enables multi-MAC matching for devices with multiple interfaces
+            # (e.g., WiFi + Ethernet) where ARP resolves one interface but the
+            # protocol reports the other.
+            if (
+                reported_mac
+                and is_valid_mac_address(reported_mac)
+                and current_mac
+                and reported_mac.upper() != current_mac.upper()
+            ):
+                player.extra_data["reported_mac"] = reported_mac
+                self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", reported_mac)
+            else:
+                # Restore reported MAC from config on restart (when provider reports
+                # the ARP MAC directly because device_info was already enriched)
+                cached_reported_mac: str | None = self.mass.config.get(
+                    f"{conf_base}/{CONF_REPORTED_MAC}", None
+                )
+                if cached_reported_mac and is_valid_mac_address(cached_reported_mac):
+                    player.extra_data["reported_mac"] = cached_reported_mac
 
             # register throttler for this player
             self._player_throttlers[player_id] = Throttler(1, 0.05)
@@ -2073,6 +2117,31 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         elif prev_state == PlaybackState.PLAYING:
             # player was playing something before the announcement - try to resume that here
             await self._handle_cmd_resume(player.player_id, prev_source, prev_media)
+
+    def _cleanup_stale_protocol_parent_ids(self) -> None:
+        """Clean up stale protocol_parent_id values in config on startup.
+
+        Scans protocol player configs and clears parent_ids that point to
+        player configs that no longer exist (e.g., deleted universal players).
+        """
+        all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
+        for player_id, player_config in all_player_configs.items():
+            if player_config.get("player_type") != "protocol":
+                continue
+            values = player_config.get("values", {})
+            parent_id = values.get(CONF_PROTOCOL_PARENT_ID)
+            if not parent_id:
+                continue
+            # Check if parent config still exists
+            parent_config = all_player_configs.get(parent_id)
+            if not parent_config:
+                self.logger.debug(
+                    "Clearing stale protocol_parent_id %s for %s (parent config deleted)",
+                    parent_id,
+                    player_id,
+                )
+                conf_key = f"{CONF_PLAYERS}/{player_id}/values/{CONF_PROTOCOL_PARENT_ID}"
+                self.mass.config.set(conf_key, None)
 
     async def _poll_players(self) -> None:
         """Background task that polls players for updates."""

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1279,22 +1279,26 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             # This enables multi-MAC matching for devices with multiple interfaces
             # (e.g., WiFi + Ethernet) where ARP resolves one interface but the
             # protocol reports the other.
-            if (
-                reported_mac
-                and is_valid_mac_address(reported_mac)
-                and current_mac
-                and reported_mac.upper() != current_mac.upper()
-            ):
-                player.extra_data["reported_mac"] = reported_mac
-                self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", reported_mac)
-            else:
-                # Restore reported MAC from config on restart (when provider reports
-                # the ARP MAC directly because device_info was already enriched)
+            if reported_mac and is_valid_mac_address(reported_mac) and current_mac:
+                if reported_mac.upper() != current_mac.upper():
+                    player.extra_data["reported_mac"] = reported_mac
+                    self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", reported_mac)
+                else:
+                    # Provider's reported MAC matches the resolved MAC; clear any stale
+                    # stored reported MAC to avoid false-positive multi-MAC matches.
+                    self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", None)
+            elif not reported_mac or not is_valid_mac_address(reported_mac):
+                # Restore reported MAC from config on restart only when the provider
+                # did not supply a usable MAC address.
                 cached_reported_mac: str | None = self.mass.config.get(
                     f"{conf_base}/{CONF_REPORTED_MAC}", None
                 )
                 if cached_reported_mac and is_valid_mac_address(cached_reported_mac):
-                    player.extra_data["reported_mac"] = cached_reported_mac
+                    if current_mac and cached_reported_mac.upper() == current_mac.upper():
+                        # Cached value matches the resolved MAC; clear stale entry.
+                        self.mass.config.set(f"{conf_base}/{CONF_REPORTED_MAC}", None)
+                    else:
+                        player.extra_data["reported_mac"] = cached_reported_mac
 
             # register throttler for this player
             self._player_throttlers[player_id] = Throttler(1, 0.05)

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -317,16 +317,16 @@ class ProtocolLinkingMixin:
         if cached_parent_id and not self.get_player(cached_parent_id):
             # Previously linked to a native player that hasn't registered yet
             # Use longer delay to give native providers time to start up
-            delay = 30.0
+            delay = 45.0
             self.logger.debug(
-                "Protocol player %s waiting for cached parent %s (30s delay)",
+                "Protocol player %s waiting for cached parent %s (45s delay)",
                 player_id,
                 cached_parent_id,
             )
         else:
             # Standard delay for protocol player discovery
             # Allows time for other protocols and native players to register
-            delay = 10.0
+            delay = 15.0
 
         # Schedule evaluation after the delay
         handle = self.mass.loop.call_later(
@@ -791,8 +791,9 @@ class ProtocolLinkingMixin:
         # (only for non-universal players, as universal players handle this themselves)
         if native_player.provider.domain != "universal_player":
             self._save_linked_protocol_ids(native_player)
-            # Also save the parent ID on the protocol player for reverse lookup on restart
-            self._save_protocol_parent_id(protocol_player.player_id, native_player.player_id)
+        # Always save the parent ID on the protocol player for reverse lookup on restart
+        # (needed for both native and universal parents to enable fast restore)
+        self._save_protocol_parent_id(protocol_player.player_id, native_player.player_id)
 
     def _remove_protocol_link(
         self, native_player: Player, protocol_player_id: str, permanent: bool = False
@@ -819,14 +820,15 @@ class ProtocolLinkingMixin:
             if protocol_player.protocol_parent_id == native_player.player_id:
                 protocol_player.set_protocol_parent_id(None)
 
-        # Update persisted linked protocol IDs and clear cached parent
+        # Update persisted linked protocol IDs
         if native_player.provider.domain != "universal_player":
             if permanent:
                 # Permanently remove from cache (player config is being deleted)
                 self._remove_protocol_id_from_cache(native_player.player_id, protocol_player_id)
             # Note: we don't call _save_linked_protocol_ids here anymore for non-permanent
             # removals because the merge approach will preserve the ID in the cache
-            self._clear_protocol_parent_id(protocol_player_id)
+        # Always clear the cached parent ID (for both native and universal parents)
+        self._clear_protocol_parent_id(protocol_player_id)
 
     def _save_linked_protocol_ids(self, native_player: Player) -> None:
         """
@@ -1003,6 +1005,9 @@ class ProtocolLinkingMixin:
             }
             all_protocol_ids.update(self._get_cached_protocol_ids(player.player_id))
             for protocol_id in all_protocol_ids:
+                # Clear cached parent ID in config so protocol won't try to
+                # restore a link to the deleted player on next restart
+                self._clear_protocol_parent_id(protocol_id)
                 if protocol_player := self.get_player(protocol_id):
                     # Protocol player is available: clear parent and schedule re-evaluation
                     # so it can be matched to a new parent or a new universal player
@@ -1078,9 +1083,30 @@ class ProtocolLinkingMixin:
                 # where bit 1 of the first octet is set (e.g., 54:78:... vs 56:78:...)
                 val_a_norm = normalize_mac_for_matching(val_a)
                 val_b_norm = normalize_mac_for_matching(val_b)
-            else:
-                val_a_norm = val_a.lower().replace(":", "").replace("-", "")
-                val_b_norm = val_b.lower().replace(":", "").replace("-", "")
+
+                # Direct match on current MAC
+                if val_a_norm == val_b_norm:
+                    return True
+
+                # Multi-MAC matching: also check original reported MACs.
+                # Devices with multiple interfaces (WiFi + Ethernet) may have ARP
+                # resolve one MAC while the protocol reports a different one.
+                macs_a = {val_a_norm}
+                macs_b = {val_b_norm}
+                reported_a = player_a.extra_data.get("reported_mac")
+                reported_b = player_b.extra_data.get("reported_mac")
+                if reported_a and is_valid_mac_address(reported_a):
+                    macs_a.add(normalize_mac_for_matching(reported_a))
+                if reported_b and is_valid_mac_address(reported_b):
+                    macs_b.add(normalize_mac_for_matching(reported_b))
+                if macs_a & macs_b:
+                    return True
+
+                # No MAC match - continue to next identifier type
+                continue
+
+            val_a_norm = val_a.lower().replace(":", "").replace("-", "")
+            val_b_norm = val_b.lower().replace(":", "").replace("-", "")
 
             # Direct match
             if val_a_norm == val_b_norm:

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -416,12 +416,13 @@ class SendspinBridgeManager:
                 return
 
             # skip if the cast player's parent also has airplay linked
-            # (we prefer the airplay bridge due to better sync performance))
+            # (we prefer the airplay bridge due to better sync performance)
             if cast_player.protocol_parent_id:
                 parent_player = self.mass.players.get_player(cast_player.protocol_parent_id)
-                for protocol in parent_player.linked_output_protocols:
-                    if protocol.protocol_domain == "airplay":
-                        return
+                if parent_player:
+                    for protocol in parent_player.linked_output_protocols:
+                        if protocol.protocol_domain == "airplay":
+                            return
 
             # Resolve client_id from device MAC address
             bridge_client_id = get_bridge_client_id(cast_player)

--- a/tests/core/test_protocol_linking.py
+++ b/tests/core/test_protocol_linking.py
@@ -5570,3 +5570,314 @@ class TestNativePlayerSiblingLinking:
             for link in heos_player.linked_output_protocols
         )
         assert sendspin_linked, "Sendspin should be linked via sibling protocol matching"
+
+
+class TestMultiMACMatching:
+    """Tests for multi-MAC matching (reported MAC vs ARP MAC)."""
+
+    def test_match_on_reported_mac_when_arp_mac_differs(self, mock_mass: MagicMock) -> None:
+        """Two players match when one's reported MAC equals the other's ARP-resolved MAC."""
+        controller = PlayerController(mock_mass)
+
+        provider = MockProvider("test")
+        # Player A has ARP-resolved MAC in identifiers, reported MAC saved in extra_data
+        player_a = MockPlayer(
+            provider,
+            "player_a",
+            "Player A",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:01"},
+        )
+        player_a.extra_data["reported_mac"] = "AA:BB:CC:DD:EE:02"
+
+        # Player B has a MAC that matches player_a's reported MAC
+        player_b = MockPlayer(
+            provider,
+            "player_b",
+            "Player B",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:02"},
+        )
+
+        assert controller._identifiers_match(player_a, player_b) is True
+
+    def test_match_on_reported_mac_reverse(self, mock_mass: MagicMock) -> None:
+        """Match when player_b's reported MAC matches player_a's ARP MAC."""
+        controller = PlayerController(mock_mass)
+
+        provider = MockProvider("test")
+        player_a = MockPlayer(
+            provider,
+            "player_a",
+            "Player A",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:02"},
+        )
+
+        player_b = MockPlayer(
+            provider,
+            "player_b",
+            "Player B",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:01"},
+        )
+        player_b.extra_data["reported_mac"] = "AA:BB:CC:DD:EE:02"
+
+        assert controller._identifiers_match(player_a, player_b) is True
+
+    def test_no_match_when_both_macs_differ(self, mock_mass: MagicMock) -> None:
+        """No match when all MACs differ between players."""
+        controller = PlayerController(mock_mass)
+
+        provider = MockProvider("test")
+        player_a = MockPlayer(
+            provider,
+            "player_a",
+            "Player A",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:01"},
+        )
+        player_a.extra_data["reported_mac"] = "AA:BB:CC:DD:EE:02"
+
+        player_b = MockPlayer(
+            provider,
+            "player_b",
+            "Player B",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:03"},
+        )
+        player_b.extra_data["reported_mac"] = "AA:BB:CC:DD:EE:04"
+
+        assert controller._identifiers_match(player_a, player_b) is False
+
+    def test_match_reported_mac_with_la_bit_normalization(self, mock_mass: MagicMock) -> None:
+        """Reported MAC matching also applies LA bit normalization."""
+        controller = PlayerController(mock_mass)
+
+        provider = MockProvider("test")
+        # Player A has ARP MAC, reported MAC has LA bit set
+        player_a = MockPlayer(
+            provider,
+            "player_a",
+            "Player A",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:01"},
+        )
+        player_a.extra_data["reported_mac"] = "56:78:C9:E6:0D:A0"  # LA variant
+
+        # Player B has the hardware MAC
+        player_b = MockPlayer(
+            provider,
+            "player_b",
+            "Player B",
+            identifiers={IdentifierType.MAC_ADDRESS: "54:78:C9:E6:0D:A0"},  # real MAC
+        )
+
+        assert controller._identifiers_match(player_a, player_b) is True
+
+
+class TestProtocolParentIdPersistence:
+    """Tests for protocol_parent_id persistence for all parent types."""
+
+    def test_parent_id_saved_for_universal_parent(self, mock_mass: MagicMock) -> None:
+        """protocol_parent_id should be saved when linking to a universal player."""
+        controller = PlayerController(mock_mass)
+        mock_mass.config.get = MagicMock(return_value=[])
+
+        universal_provider = create_mock_universal_provider(mock_mass)
+        parent = UniversalPlayer(
+            provider=universal_provider,
+            player_id="up_test",
+            name="Test Universal",
+            device_info=DeviceInfo(),
+            protocol_player_ids=[],
+        )
+        parent.update_state(signal_event=False)
+
+        protocol_provider = MockProvider("airplay")
+        protocol_player = MockPlayer(
+            protocol_provider,
+            "airplay_test",
+            "AirPlay Test",
+            player_type=PlayerType.PROTOCOL,
+        )
+
+        controller._players = {
+            "up_test": parent,
+            "airplay_test": protocol_player,
+        }
+
+        controller._add_protocol_link(parent, protocol_player, "airplay")
+
+        # Verify _save_protocol_parent_id was called (config.set with parent ID)
+        config_set_calls = [
+            call
+            for call in mock_mass.config.set.call_args_list
+            if "protocol_parent_id" in str(call)
+        ]
+        assert len(config_set_calls) >= 1, (
+            "protocol_parent_id should be saved for universal player parents"
+        )
+
+    def test_parent_id_cleared_for_universal_parent(self, mock_mass: MagicMock) -> None:
+        """protocol_parent_id should be cleared when unlinking from a universal player."""
+        controller = PlayerController(mock_mass)
+        mock_mass.config.get = MagicMock(return_value=[])
+
+        universal_provider = create_mock_universal_provider(mock_mass)
+        parent = UniversalPlayer(
+            provider=universal_provider,
+            player_id="up_test",
+            name="Test Universal",
+            device_info=DeviceInfo(),
+            protocol_player_ids=["airplay_test"],
+        )
+        parent.update_state(signal_event=False)
+
+        protocol_provider = MockProvider("airplay")
+        protocol_player = MockPlayer(
+            protocol_provider,
+            "airplay_test",
+            "AirPlay Test",
+            player_type=PlayerType.PROTOCOL,
+        )
+        protocol_player.set_protocol_parent_id("up_test")
+
+        # Set up linked protocols
+        parent.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="airplay_test",
+                    name="AirPlay",
+                    protocol_domain="airplay",
+                    priority=10,
+                )
+            ]
+        )
+
+        controller._players = {
+            "up_test": parent,
+            "airplay_test": protocol_player,
+        }
+
+        controller._remove_protocol_link(parent, "airplay_test")
+
+        # Verify protocol_parent_id was cleared in config
+        config_set_calls = [
+            call
+            for call in mock_mass.config.set.call_args_list
+            if "protocol_parent_id" in str(call) and call.args[1] is None
+        ]
+        assert len(config_set_calls) >= 1, (
+            "protocol_parent_id should be cleared for universal player parents"
+        )
+
+
+class TestCleanupProtocolLinks:
+    """Tests for protocol link cleanup on player removal."""
+
+    def test_cleanup_clears_config_parent_id(self, mock_mass: MagicMock) -> None:
+        """When a universal player is removed, protocol parent_ids are cleared in config."""
+        controller = PlayerController(mock_mass)
+        mock_mass.config.get = MagicMock(return_value=[])
+
+        universal_provider = create_mock_universal_provider(mock_mass)
+        parent = UniversalPlayer(
+            provider=universal_provider,
+            player_id="up_test",
+            name="Test Universal",
+            device_info=DeviceInfo(),
+            protocol_player_ids=["airplay_test"],
+        )
+        parent.update_state(signal_event=False)
+
+        protocol_provider = MockProvider("airplay")
+        protocol_player = MockPlayer(
+            protocol_provider,
+            "airplay_test",
+            "AirPlay Test",
+            player_type=PlayerType.PROTOCOL,
+        )
+        protocol_player.set_protocol_parent_id("up_test")
+
+        parent.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="airplay_test",
+                    name="AirPlay",
+                    protocol_domain="airplay",
+                    priority=10,
+                )
+            ]
+        )
+
+        controller._players = {
+            "up_test": parent,
+            "airplay_test": protocol_player,
+        }
+        controller._player_throttlers = {k: Throttler(1, 0.05) for k in controller._players}
+
+        controller._cleanup_protocol_links(parent)
+
+        # Verify protocol_parent_id was cleared in config
+        config_set_calls = [
+            call
+            for call in mock_mass.config.set.call_args_list
+            if "airplay_test" in str(call) and "protocol_parent_id" in str(call)
+        ]
+        assert len(config_set_calls) >= 1, (
+            "protocol_parent_id should be cleared in config on parent removal"
+        )
+        # Verify in-memory parent cleared
+        assert protocol_player.protocol_parent_id is None
+
+
+class TestStaleConfigMigration:
+    """Tests for stale protocol_parent_id cleanup on startup."""
+
+    def test_clears_stale_parent_ids(self, mock_mass: MagicMock) -> None:
+        """Stale parent_ids pointing to deleted players are cleared on startup."""
+        controller = PlayerController(mock_mass)
+
+        # Set up config with a protocol player pointing to a deleted universal player
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "airplay_test": {
+                    "player_type": "protocol",
+                    "values": {
+                        "protocol_parent_id": "up_deleted_player",
+                    },
+                },
+                "heos_player": {
+                    "player_type": "player",
+                    "values": {},
+                },
+            }
+        )
+
+        controller._cleanup_stale_protocol_parent_ids()
+
+        # Verify the stale parent_id was cleared
+        mock_mass.config.set.assert_any_call(
+            "players/airplay_test/values/protocol_parent_id",
+            None,
+        )
+
+    def test_keeps_valid_parent_ids(self, mock_mass: MagicMock) -> None:
+        """Valid parent_ids pointing to existing players are preserved."""
+        controller = PlayerController(mock_mass)
+
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "airplay_test": {
+                    "player_type": "protocol",
+                    "values": {
+                        "protocol_parent_id": "up_valid_player",
+                    },
+                },
+                "up_valid_player": {
+                    "player_type": "group",
+                    "provider": "universal_player",
+                    "values": {},
+                },
+            }
+        )
+
+        controller._cleanup_stale_protocol_parent_ids()
+
+        # Verify no set calls were made to clear the parent_id
+        for call in mock_mass.config.set.call_args_list:
+            assert "protocol_parent_id" not in str(call), "Valid parent_id should not be cleared"


### PR DESCRIPTION
Another follow-up on the whole merged players concept.

Protocol players (AirPlay, DLNA, Chromecast, etc.) were sometimes incorrectly linked or failed to restore links after restart, causing wrong player merges and orphaned universal players.

**Root causes:**

- ARP-resolved MAC addresses were not cached, so matching broke when ARP failed on restart
- Only a single MAC was compared during matching, missing devices with multiple network interfaces
- protocol_parent_id was never saved for universal player parents, preventing fast restore
- Cleanup of removed universal players didn't clear config parent IDs, leaving stale references
- Evaluation delays too short for slower providers (MusicCast, HEOS)

**Changes:**

- Cache ARP-resolved and original reported MAC addresses in config for persistence across restarts
- Match on both reported and ARP-resolved MACs to handle multi-interface devices
- Always save/clear protocol_parent_id regardless of parent type (native or universal)
- Clear config parent IDs when cleaning up removed players
- Add startup migration to clean stale parent IDs pointing to deleted players
- Increase protocol evaluation delays (10s→15s, 30s→45s) for slower providers
- Fix null-safety in Chromecast bridge AirPlay exclusion check