### PR TITLE
Check if HEOS queue exists before clearing

### DIFF
--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -264,7 +264,9 @@ class HeosPlayer(Player):
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA command on given player."""
-        await self._device.clear_queue()
+        queue_items = await self._device.get_queue(range_start=0, range_end=1)
+        if queue_items:
+            await self._device.clear_queue()
 
         url = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
         await self._device.play_url(url)


### PR DESCRIPTION
I recently added internal HEOS queue clearing when we start playing media from MA (otherwise the HEOS players start playing older content after a stream finishes). However, it seems HEOS can't handle the clear command when the queue is empty, throwing `Requested data not available (4)` errors.
This became more clear with the merge player providers, as playing from Airplay already clears the internal HEOS queue, thus resulting in not being able to start playing anything on the native provider anymore. 

With the PR we first check if there is anything in the queue, only then do we clear it.