### PR TITLE
Ensure soundcloud playlist genre is added as a list

### DIFF
--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -459,7 +459,7 @@ class SoundcloudMusicProvider(MusicProvider):
                 ]
             )
         if playlist_obj.get("genre"):
-            playlist.metadata.genres = playlist_obj["genre"]
+            playlist.metadata.genres = {playlist_obj["genre"]}
         if playlist_obj.get("tag_list"):
             playlist.metadata.style = playlist_obj["tag_list"]
         return playlist


### PR DESCRIPTION
Similar fix was added for tracks here:
https://github.com/music-assistant/support/issues/3107
This fix addresses playlist genre parsing