### PR TITLE
Fix album image missing from queue item responses

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -1109,8 +1109,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             if (album_images := track_album.get("images")) and (
                 album_thumb := next((x for x in album_images if x["type"] == "thumb"), None)
             ):
-                # copy album image to itemmapping single image
+                # copy album image to itemmapping single image (on the track)
                 db_row_dict["image"] = album_thumb
+                # also set image on the album dict for ItemMapping compatibility
+                track_album["image"] = album_thumb
                 if db_row_dict["metadata"].get("images"):
                     # merge album image with existing images
                     db_row_dict["metadata"]["images"] = [
@@ -1119,6 +1121,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                     ]
                 else:
                     db_row_dict["metadata"]["images"] = [album_thumb]
+
         return db_row_dict
 
     @final


### PR DESCRIPTION
Include artist image metadata in the SQL queries for tracks and albums so that ItemMapping objects have their image field populated. Also set the image field on the album dict in _parse_db_row for ItemMapping compatibility.

Previously, the artist subqueries in tracks.py and albums.py did not extract metadata, so artist images were always null. The album image was extracted into an images array but never set as a singular image field on the album dict itself.
This is to fix https://github.com/music-assistant/backlog/issues/40

@OzGav  I think this accomplishes the ask in that frontend issue, if you want to take a look.