### PR TITLE
Add missing select_source method for HEOS provider

### DIFF
--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -128,7 +128,7 @@ class HeosPlayer(Player):
 
     async def _player_event_received(self, event: str) -> None:
         """Handle player device events."""
-        self.logger.debug("[%s] Event received: %s", self._device.name, event)
+        self.logger.log(5, "[%s] Event received: %s", self._device.name, event)
 
         match event:
             case const.EVENT_PLAYER_STATE_CHANGED:
@@ -300,6 +300,11 @@ class HeosPlayer(Player):
         else:
             await self._heos.set_group([int(player) for player in members])
         # group_members will be updated when group_changed event is handled
+
+    async def select_source(self, source: str) -> None:
+        """Handle SELECT SOURCE command on the player."""
+        self.logger.debug("[%s] Selecting source %s", self._device.name, source)
+        await self._device.play_input_source(source)
 
     async def get_config_entries(
         self,

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -128,7 +128,10 @@ class HeosPlayer(Player):
 
     async def _player_event_received(self, event: str) -> None:
         """Handle player device events."""
-        self.logger.log(5, "[%s] Event received: %s", self._device.name, event)
+        if event == const.EVENT_PLAYER_NOW_PLAYING_PROGRESS:
+            self.logger.log(5, "[%s] Event received: %s", self._device.name, event)
+        else:
+            self.logger.debug("[%s] Event received: %s", self._device.name, event)
 
         match event:
             case const.EVENT_PLAYER_STATE_CHANGED:

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from copy import copy
 from typing import TYPE_CHECKING, cast
 
@@ -10,7 +11,10 @@ from music_assistant_models.errors import SetupFailedError
 from music_assistant_models.player import DeviceInfo, PlayerSource
 from pyheos import Heos, const
 
-from music_assistant.constants import create_sample_rates_config_entry
+from music_assistant.constants import (
+    VERBOSE_LOG_LEVEL,
+    create_sample_rates_config_entry,
+)
 from music_assistant.models.player import Player, PlayerMedia
 from music_assistant.providers.heos.helpers import media_uri_from_now_playing_media
 
@@ -128,11 +132,16 @@ class HeosPlayer(Player):
 
     async def _player_event_received(self, event: str) -> None:
         """Handle player device events."""
-        if event == const.EVENT_PLAYER_NOW_PLAYING_PROGRESS:
-            self.logger.log(5, "[%s] Event received: %s", self._device.name, event)
-        else:
-            self.logger.debug("[%s] Event received: %s", self._device.name, event)
-
+        self.logger.log(
+            (
+                VERBOSE_LOG_LEVEL
+                if event == const.EVENT_PLAYER_NOW_PLAYING_PROGRESS
+                else logging.DEBUG
+            ),
+            "[%s] Event received: %s",
+            self._device.name,
+            event,
+        )
         match event:
             case const.EVENT_PLAYER_STATE_CHANGED:
                 self._update_player_state()


### PR DESCRIPTION
Seems the HEOS provider was missing the select_source method on the players.
I've added the debug logging in there to track sources being changed, in case some specific sources fail to get selected.

This should fix the problem where you can't resume content natively playing on the HEOS speakers from MA (https://github.com/music-assistant/support/issues/5036)

I also adjusted the logging level of received HEOS events. When something is playing, we get progress reports every 5 seconds, so this reduced the chatty logs. Other events are still logged as DEBUG.