### PR TITLE
Add configurable in-library podcast feeds syncing time to the iTunes Podcast Provider

### DIFF
--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -385,15 +385,15 @@ class ITunesPodcastsProvider(MusicProvider):
         return parsed_podcast  # type: ignore[no-any-return]
 
     async def _cache_set_podcast(self, feed_url: str, parsed_podcast: dict[str, Any]) -> None:
-        # We cache for 12 hours. However, the user may overwrite the cache with a library sync. So
-        # 12 hours is only true for a non-library item, e.g. a search result not added to the
+        # We cache for 24 hours. However, the user may overwrite the cache with a library sync. So
+        # 24 hours is only true for a non-library item, e.g. a search result not added to the
         # library.
         await self.mass.cache.set(
             key=feed_url,
             provider=self.instance_id,
             category=CACHE_CATEGORY_PODCASTS,
             data=parsed_podcast,
-            expiration=60 * 60 * 12,  # 12h
+            expiration=60 * 60 * 24,  # 24h
         )
 
     async def _cache_set_top_podcasts(self, top_podcast_helper: TopPodcastsHelper) -> None:

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -231,15 +231,17 @@ class ITunesPodcastsProvider(MusicProvider):
             provider_instance=self.instance_id
         )
         for podcast in podcasts:
-            feed_url: str | None = None
+            our_provider_mapping: ProviderMapping | None = None
             for provider_mapping in podcast.provider_mappings:
                 if provider_mapping.provider_instance == self.instance_id:
-                    feed_url = provider_mapping.item_id
+                    our_provider_mapping = provider_mapping
                     break
-            if feed_url is None:
+            if our_provider_mapping is None:
                 # We should never end up here.
-                self.logger.error("Podcast %s lacks a feed url.", podcast.name)
+                self.logger.error("Podcast %s lacks a provider mapping.", podcast.name)
                 continue
+            feed_url = our_provider_mapping.item_id
+            parsed_podcast: dict[str, Any] | None = None
             try:
                 parsed_podcast = await get_podcastparser_dict(
                     session=self.mass.http_session,
@@ -249,9 +251,21 @@ class ITunesPodcastsProvider(MusicProvider):
                 await self._cache_set_podcast(feed_url=feed_url, parsed_podcast=parsed_podcast)
                 self.logger.debug("Synced podcast %s.", podcast.name)
             except MediaNotFoundError:
-                # We just keep what we have then, if the sync is unsuccessful.
+                # If we are not able to refresh the podcast, we must prevent the sync
+                # from deleting the podcast from the library - that is both a breaking change
+                # (pre March 2026) and certainly not desired just because of some downtime.
                 self.logger.warning("Was unable to sync podcast %s (%s).", podcast.name, feed_url)
-            yield (await self.get_podcast(feed_url))
+                podcast.item_id = feed_url
+                podcast.provider_mappings = {our_provider_mapping}
+                yield podcast
+
+            assert parsed_podcast is not None  # for type checking
+            yield parse_podcast(
+                feed_url=feed_url,
+                parsed_feed=parsed_podcast,
+                instance_id=self.instance_id,
+                domain=self.domain,
+            )
 
     async def get_podcast(self, prov_podcast_id: str) -> Podcast:
         """Get podcast."""

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -140,7 +140,7 @@ class ITunesPodcastsProvider(MusicProvider):
         # 20 requests per minute, be a bit below
         self.throttler = ThrottlerManager(rate_limit=18, period=60)
 
-    @use_cache(3600 * 12)  # Cache for 12 hours
+    @use_cache(3600 * 24 * 7)  # Cache for 7 days
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 10
     ) -> SearchResults:

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -30,6 +30,10 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.constants import (
+    CONF_ENTRY_LIBRARY_SYNC_PODCASTS,
+    CONF_ENTRY_PROVIDER_SYNC_INTERVAL_PODCASTS,
+)
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.podcast_parsers import (
     get_podcastparser_dict,
@@ -69,6 +73,22 @@ SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_PODCASTS,
 }
 
+CONF_ENTRY_LIBRARY_SYNC_PODCASTS_HIDDEN = ConfigEntry.from_dict(
+    {
+        **CONF_ENTRY_LIBRARY_SYNC_PODCASTS.to_dict(),
+        "hidden": True,
+        "default_value": True,
+    }
+)
+CONF_ENTRY_PROVIDER_SYNC_INTERVAL_PODCASTS_MOD = ConfigEntry.from_dict(
+    {
+        **CONF_ENTRY_PROVIDER_SYNC_INTERVAL_PODCASTS.to_dict(),
+        "label": "In-library podcast sync interval",
+        "description": "The interval at which the podcast feed added to the library are refreshed. "
+        "A podcast must have been either added to the library or favorited, to make this work.",
+    }
+)
+
 
 async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
@@ -97,6 +117,8 @@ async def get_config_entries(
 
     language_options = [ConfigValueOption(val, key.lower()) for key, val in country_codes.items()]
     return (
+        CONF_ENTRY_LIBRARY_SYNC_PODCASTS_HIDDEN,
+        CONF_ENTRY_PROVIDER_SYNC_INTERVAL_PODCASTS_MOD,
         ConfigEntry(
             key=CONF_LOCALE,
             type=ConfigEntryType.STRING,

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -140,7 +140,7 @@ class ITunesPodcastsProvider(MusicProvider):
         # 20 requests per minute, be a bit below
         self.throttler = ThrottlerManager(rate_limit=18, period=60)
 
-    @use_cache(3600 * 24 * 7)  # Cache for 7 days
+    @use_cache(3600 * 12)  # Cache for 12 hours
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 10
     ) -> SearchResults:

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -385,15 +385,23 @@ class ITunesPodcastsProvider(MusicProvider):
         return parsed_podcast  # type: ignore[no-any-return]
 
     async def _cache_set_podcast(self, feed_url: str, parsed_podcast: dict[str, Any]) -> None:
-        # We cache for 24 hours. However, the user may overwrite the cache with a library sync. So
-        # 24 hours is only true for a non-library item, e.g. a search result not added to the
-        # library.
+        # We cache just a couple minutes longer then our sync interval, if it is configured.
+        # Otherwise we cache for 12 hrs
+        # Keys are in music_assistant/constants
+        library_sync_time_minutes = int(
+            str(self.config.get_value("provider_sync_interval_podcasts"))
+        )
+        library_sync_enabled = bool(self.config.get_value("library_sync_podcasts"))
+        if library_sync_time_minutes == 0 or not library_sync_enabled:
+            cache_time = 60 * 60 * 12  # 12h
+        else:
+            cache_time = library_sync_time_minutes * 60 + 600  # 10 minutes extra cache
         await self.mass.cache.set(
             key=feed_url,
             provider=self.instance_id,
             category=CACHE_CATEGORY_PODCASTS,
             data=parsed_podcast,
-            expiration=60 * 60 * 24,  # 24h
+            expiration=cache_time,
         )
 
     async def _cache_set_top_podcasts(self, top_podcast_helper: TopPodcastsHelper) -> None:

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -258,6 +258,7 @@ class ITunesPodcastsProvider(MusicProvider):
                 podcast.item_id = feed_url
                 podcast.provider_mappings = {our_provider_mapping}
                 yield podcast
+                continue
 
             assert parsed_podcast is not None  # for type checking
             yield parse_podcast(

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -260,7 +260,6 @@ class ITunesPodcastsProvider(MusicProvider):
                 yield podcast
                 continue
 
-            assert parsed_podcast is not None  # for type checking
             yield parse_podcast(
                 feed_url=feed_url,
                 parsed_feed=parsed_podcast,

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -61,7 +61,13 @@ CACHE_CATEGORY_PODCASTS = 0
 CACHE_CATEGORY_RECOMMENDATIONS = 1
 CACHE_KEY_TOP_PODCASTS = "top-podcasts"
 
-SUPPORTED_FEATURES = {ProviderFeature.SEARCH, ProviderFeature.RECOMMENDATIONS}
+SUPPORTED_FEATURES = {
+    ProviderFeature.SEARCH,
+    ProviderFeature.RECOMMENDATIONS,
+    # This provider does not have a "real" library. Refer to method comment
+    # in get_library_podcasts
+    ProviderFeature.LIBRARY_PODCASTS,
+}
 
 
 async def setup(
@@ -212,6 +218,37 @@ class ITunesPodcastsProvider(MusicProvider):
             podcast.metadata.images = UniqueList(image_list)
             podcast_list.append(podcast)
         return podcast_list
+
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+        """Get library podcasts.
+
+        We use get_library_podcasts to sync all feeds which have been added to the MA library
+        by the user via the search function. The provider itself does not offer a real library.
+
+        The item_id corresponds to the feed_url.
+        """
+        podcasts = await self.mass.music.podcasts.get_library_items_by_prov_id(
+            provider_instance=self.instance_id
+        )
+        for podcast in podcasts:
+            feed_url: str | None = None
+            for provider_mapping in podcast.provider_mappings:
+                if provider_mapping.provider_instance == self.instance_id:
+                    feed_url = provider_mapping.item_id
+                    break
+            if feed_url is None:
+                self.logger.debug("Podcast %s lacks a feed url.", podcast.name)
+                continue
+            try:
+                parsed_podcast = await get_podcastparser_dict(
+                    session=self.mass.http_session,
+                    feed_url=feed_url,
+                    max_episodes=self.max_episodes,
+                )
+                await self._cache_set_podcast(feed_url=feed_url, parsed_podcast=parsed_podcast)
+            except MediaNotFoundError:
+                self.logger.warning("Was unable to sync podcast %s (%s).", podcast.name, feed_url)
+            yield (await self.get_podcast(feed_url))
 
     async def get_podcast(self, prov_podcast_id: str) -> Podcast:
         """Get podcast."""

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -237,7 +237,8 @@ class ITunesPodcastsProvider(MusicProvider):
                     feed_url = provider_mapping.item_id
                     break
             if feed_url is None:
-                self.logger.debug("Podcast %s lacks a feed url.", podcast.name)
+                # We should never end up here.
+                self.logger.error("Podcast %s lacks a feed url.", podcast.name)
                 continue
             try:
                 parsed_podcast = await get_podcastparser_dict(
@@ -247,6 +248,7 @@ class ITunesPodcastsProvider(MusicProvider):
                 )
                 await self._cache_set_podcast(feed_url=feed_url, parsed_podcast=parsed_podcast)
             except MediaNotFoundError:
+                # We just keep what we have then, if the sync is unsuccessful.
                 self.logger.warning("Was unable to sync podcast %s (%s).", podcast.name, feed_url)
             yield (await self.get_podcast(feed_url))
 
@@ -382,12 +384,15 @@ class ITunesPodcastsProvider(MusicProvider):
         return parsed_podcast  # type: ignore[no-any-return]
 
     async def _cache_set_podcast(self, feed_url: str, parsed_podcast: dict[str, Any]) -> None:
+        # We cache for 12 hours. However, the user may overwrite the cache with a library sync. So
+        # 12 hours is only true for a non-library item, e.g. a search result not added to the
+        # library.
         await self.mass.cache.set(
             key=feed_url,
             provider=self.instance_id,
             category=CACHE_CATEGORY_PODCASTS,
             data=parsed_podcast,
-            expiration=60 * 60 * 24,  # 1 day
+            expiration=60 * 60 * 12,  # 12h
         )
 
     async def _cache_set_top_podcasts(self, top_podcast_helper: TopPodcastsHelper) -> None:

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -247,6 +247,7 @@ class ITunesPodcastsProvider(MusicProvider):
                     max_episodes=self.max_episodes,
                 )
                 await self._cache_set_podcast(feed_url=feed_url, parsed_podcast=parsed_podcast)
+                self.logger.debug("Synced podcast %s.", podcast.name)
             except MediaNotFoundError:
                 # We just keep what we have then, if the sync is unsuccessful.
                 self.logger.warning("Was unable to sync podcast %s (%s).", podcast.name, feed_url)


### PR DESCRIPTION
This is per this issue / feature request https://github.com/music-assistant/support/issues/5029

I use the sync library method to allow feed syncing of in-library items. If the approach is fine, I'll add something to the docs too. I decreased the cache time of the search as well. 