### PR TITLE
Fix error when MA shutsdown

### DIFF
--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -240,15 +240,11 @@ class MusicAssistant:
         # cleanup cache and config
         await self.config.close()
         await self.cache.close()
-        # close/cleanup shared http session
-        if self._http_session:
-            self._http_session.detach()
-            if self._http_session.connector:
-                await self._http_session.connector.close()
-        if self._http_session_no_ssl:
-            self._http_session_no_ssl.detach()
-            if self._http_session_no_ssl.connector:
-                await self._http_session_no_ssl.connector.close()
+        # close/cleanup shared http sessions
+        if self._http_session and not self._http_session.closed:
+            await self._http_session.close()
+        if self._http_session_no_ssl and not self._http_session_no_ssl.closed:
+            await self._http_session_no_ssl.close()
         self._set_state(CoreState.STOPPED)
 
     @property
@@ -802,10 +798,14 @@ class MusicAssistant:
             for attr_name in dir(cls):
                 if attr_name.startswith("__"):
                     continue
+                # Skip properties to avoid triggering lazy initialization side effects
+                # (e.g. http_session creating an aiohttp connector during registration)
+                if isinstance(getattr(type(cls), attr_name, None), property):
+                    continue
                 try:
                     obj = getattr(cls, attr_name)
                 except (AttributeError, RuntimeError):
-                    # Skip properties that fail during initialization
+                    # Skip attributes that fail during initialization
                     continue
                 if hasattr(obj, "api_cmd"):
                     # method is decorated with our api decorator


### PR DESCRIPTION
Two issues in mass.py:

1. stop() called session.detach() which sets session._connector to None,
    then checked session.connector to close it — so the connector was
    never actually closed. Use session.close() which properly awaits
    connector.close() before clearing the reference.

2. _register_api_commands used getattr() on all attributes, triggering
    lazy property initialization (e.g. http_session) and creating an
    aiohttp ClientSession/connector as a side effect. Skip properties
    during registration since API commands are always methods.

Example log:

```
2026-03-05 16:37:33.223 DEBUG (MainThread) [music_assistant.controllers.config] Stopped.
2026-03-05 16:37:33.281 ERROR (MainThread) [music_assistant] Error doing job: Unclosed connector:   File "/app/venv/bin/mass", line 10, in <module>
    sys.exit(main())
  File "/app/venv/lib/python3.13/site-packages/music_assistant/__main__.py", line 254, in main
    run(
  File "/app/venv/lib/python3.13/site-packages/aiorun/__init__.py", line 257, in run
    loop.run_forever()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 683, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.13/asyncio/base_events.py", line 2042, in _run_once
    handle._run()
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
  File "/app/venv/lib/python3.13/site-packages/aiorun/__init__.py", line 223, in new_coro
    await coro
  File "/app/venv/lib/python3.13/site-packages/music_assistant/__main__.py", line 248, in start_mass
    await mass.start()
  File "/app/venv/lib/python3.13/site-packages/music_assistant/mass.py", line 205, in start
    self._register_api_commands()
  File "/app/venv/lib/python3.13/site-packages/music_assistant/mass.py", line 806, in _register_api_commands
    obj = getattr(cls, attr_name)
  File "/app/venv/lib/python3.13/site-packages/music_assistant/mass.py", line 279, in http_session
    self._http_session = create_clientsession(self, verify_ssl=True)
  File "/app/venv/lib/python3.13/site-packages/music_assistant/helpers/aiohttp_client.py", line 43, in create_clientsession
    connector=_get_connector(mass, verify_ssl),
  File "/app/venv/lib/python3.13/site-packages/music_assistant/helpers/aiohttp_client.py", line 174, in _get_connector
    return MusicAssistantTCPConnector(
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 993, in __init__
    super().__init__(
```