### PR TITLE
Retry sendspin proxy connection during startup race condition

### DIFF
--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -97,20 +97,27 @@ class SendspinProxyHandler:
         # The internal Sendspin server may not be ready yet during startup
         # (it starts in the provider load phase, after the webserver).
         # Retry a few times with backoff to handle this race condition.
-        internal_ws = None
-        for attempt in range(5):
-            try:
-                internal_ws = await self.mass.http_session.ws_connect(self.internal_sendspin_url)
-                break
-            except ClientConnectorError:
-                if attempt < 4:
-                    await asyncio.sleep(0.5 * (attempt + 1))
-                    continue
-                self.logger.exception("Failed to connect to internal Sendspin server")
-                await wsock.close(code=1011, message=b"Internal server error")
-                return wsock
-
-        assert internal_ws is not None  # ensured by retry loop above
+        try:
+            internal_ws = None
+            for attempt in range(5):
+                try:
+                    internal_ws = await self.mass.http_session.ws_connect(
+                        self.internal_sendspin_url
+                    )
+                    break
+                except ClientConnectorError:
+                    if attempt < 4:
+                        await asyncio.sleep(0.5 * (attempt + 1))
+                        continue
+                    self.logger.exception("Failed to connect to internal Sendspin server")
+                    await wsock.close(code=1011, message=b"Internal server error")
+                    return wsock
+            if internal_ws is None:
+                raise RuntimeError("Retry loop exited without connecting or returning")
+        except Exception:
+            self.logger.exception("Failed to connect to internal Sendspin server")
+            await wsock.close(code=1011, message=b"Internal server error")
+            return wsock
         self.logger.debug("Sendspin proxy authenticated and connected for %s", request.remote)
 
         try:

--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -13,7 +13,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from aiohttp import WSMsgType, web
+from aiohttp import ClientConnectorError, WSMsgType, web
 
 from music_assistant.constants import MASS_LOGGER_NAME
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
@@ -94,13 +94,23 @@ class SendspinProxyHandler:
                 await wsock.close(code=4001, message=b"Authentication error")
                 return wsock
 
-        try:
-            internal_ws = await self.mass.http_session.ws_connect(self.internal_sendspin_url)
-        except Exception:
-            self.logger.exception("Failed to connect to internal Sendspin server")
-            await wsock.close(code=1011, message=b"Internal server error")
-            return wsock
+        # The internal Sendspin server may not be ready yet during startup
+        # (it starts in the provider load phase, after the webserver).
+        # Retry a few times with backoff to handle this race condition.
+        internal_ws = None
+        for attempt in range(5):
+            try:
+                internal_ws = await self.mass.http_session.ws_connect(self.internal_sendspin_url)
+                break
+            except ClientConnectorError:
+                if attempt < 4:
+                    await asyncio.sleep(0.5 * (attempt + 1))
+                    continue
+                self.logger.exception("Failed to connect to internal Sendspin server")
+                await wsock.close(code=1011, message=b"Internal server error")
+                return wsock
 
+        assert internal_ws is not None  # ensured by retry loop above
         self.logger.debug("Sendspin proxy authenticated and connected for %s", request.remote)
 
         try:

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -101,7 +101,7 @@ class TestSendspinProxyRetry:
         assert result is mock_ws_response
 
     async def test_does_not_retry_on_other_exceptions(self, handler: SendspinProxyHandler) -> None:
-        """Verify non-connection errors are not retried."""
+        """Verify non-connection errors are not retried and websocket is closed cleanly."""
         mock_ws_response = AsyncMock(spec=web.WebSocketResponse)
         mock_ws_response.closed = False
 
@@ -118,7 +118,8 @@ class TestSendspinProxyRetry:
         ):
             mock_session.ws_connect = mock_ws_connect
             request = make_mocked_request("GET", "/sendspin")
-            with pytest.raises(TypeError, match="unexpected error"):
-                await handler.handle_sendspin_proxy(request)
+            result = await handler.handle_sendspin_proxy(request)
 
         assert mock_ws_connect.call_count == 1
+        mock_ws_response.close.assert_called_once_with(code=1011, message=b"Internal server error")
+        assert result is mock_ws_response

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -1,0 +1,124 @@
+"""Tests for the Sendspin WebSocket proxy handler."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import ClientConnectorError, web
+from aiohttp.test_utils import make_mocked_request
+
+from music_assistant.controllers.webserver.sendspin_proxy import SendspinProxyHandler
+
+
+@pytest.fixture
+def mock_webserver() -> MagicMock:
+    """Create a mock webserver controller."""
+    webserver = MagicMock()
+    webserver.mass = MagicMock()
+    webserver.mass.streams.bind_ip = "0.0.0.0"
+    webserver.mass.http_session = MagicMock()
+    return webserver
+
+
+@pytest.fixture
+def handler(mock_webserver: MagicMock) -> SendspinProxyHandler:
+    """Create a SendspinProxyHandler with mocked dependencies."""
+    return SendspinProxyHandler(mock_webserver)
+
+
+def _make_connector_error() -> ClientConnectorError:
+    """Create a realistic ClientConnectorError for testing."""
+    connection_key = MagicMock()
+    return ClientConnectorError(connection_key, OSError(111, "Connection refused"))
+
+
+class TestSendspinProxyRetry:
+    """Tests for the retry logic when connecting to the internal Sendspin server."""
+
+    async def test_retries_on_connection_refused(self, handler: SendspinProxyHandler) -> None:
+        """Verify the proxy retries on ClientConnectorError before giving up."""
+        mock_ws_response = AsyncMock(spec=web.WebSocketResponse)
+        mock_ws_response.closed = False
+
+        connector_error = _make_connector_error()
+
+        mock_internal_ws = AsyncMock()
+        mock_internal_ws.closed = False
+        mock_ws_connect = AsyncMock(
+            side_effect=[connector_error, connector_error, mock_internal_ws]
+        )
+
+        with (
+            patch.object(handler, "_authenticate", return_value=MagicMock()),
+            patch.object(handler, "_proxy_messages", new_callable=AsyncMock),
+            patch("aiohttp.web.WebSocketResponse", return_value=mock_ws_response),
+            patch.object(handler.mass, "http_session", create=True) as mock_session,
+            patch(
+                "music_assistant.controllers.webserver.sendspin_proxy.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep,
+            patch(
+                "music_assistant.controllers.webserver.sendspin_proxy.is_request_from_ingress",
+                return_value=False,
+            ),
+        ):
+            mock_session.ws_connect = mock_ws_connect
+            request = make_mocked_request("GET", "/sendspin")
+            await handler.handle_sendspin_proxy(request)
+
+        assert mock_ws_connect.call_count == 3
+        assert mock_sleep.call_count == 2
+        # Verify backoff: 0.5s, then 1.0s
+        mock_sleep.assert_any_call(0.5)
+        mock_sleep.assert_any_call(1.0)
+
+    async def test_gives_up_after_max_retries(self, handler: SendspinProxyHandler) -> None:
+        """Verify the proxy closes the client websocket after exhausting retries."""
+        mock_ws_response = AsyncMock(spec=web.WebSocketResponse)
+        mock_ws_response.closed = False
+
+        connector_error = _make_connector_error()
+        mock_ws_connect = AsyncMock(side_effect=connector_error)
+
+        with (
+            patch.object(handler, "_authenticate", return_value=MagicMock()),
+            patch("aiohttp.web.WebSocketResponse", return_value=mock_ws_response),
+            patch.object(handler.mass, "http_session", create=True) as mock_session,
+            patch(
+                "music_assistant.controllers.webserver.sendspin_proxy.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "music_assistant.controllers.webserver.sendspin_proxy.is_request_from_ingress",
+                return_value=False,
+            ),
+        ):
+            mock_session.ws_connect = mock_ws_connect
+            request = make_mocked_request("GET", "/sendspin")
+            result = await handler.handle_sendspin_proxy(request)
+
+        assert mock_ws_connect.call_count == 5
+        mock_ws_response.close.assert_called_once_with(code=1011, message=b"Internal server error")
+        assert result is mock_ws_response
+
+    async def test_does_not_retry_on_other_exceptions(self, handler: SendspinProxyHandler) -> None:
+        """Verify non-connection errors are not retried."""
+        mock_ws_response = AsyncMock(spec=web.WebSocketResponse)
+        mock_ws_response.closed = False
+
+        mock_ws_connect = AsyncMock(side_effect=TypeError("unexpected error"))
+
+        with (
+            patch.object(handler, "_authenticate", return_value=MagicMock()),
+            patch("aiohttp.web.WebSocketResponse", return_value=mock_ws_response),
+            patch.object(handler.mass, "http_session", create=True) as mock_session,
+            patch(
+                "music_assistant.controllers.webserver.sendspin_proxy.is_request_from_ingress",
+                return_value=False,
+            ),
+        ):
+            mock_session.ws_connect = mock_ws_connect
+            request = make_mocked_request("GET", "/sendspin")
+            with pytest.raises(TypeError, match="unexpected error"):
+                await handler.handle_sendspin_proxy(request)
+
+        assert mock_ws_connect.call_count == 1


### PR DESCRIPTION
The webserver starts before the Sendspin provider, so a client connecting immediately on startup hits ConnectionRefusedError when the proxy tries to reach the internal Sendspin server on port 8927. Add a retry loop with backoff (up to 5 attempts) catching only ClientConnectorError so programming errors still fail fast. 

Example log:
```
2026-03-05 17:29:12.533 DEBUG (MainThread) [music_assistant.webserver] Set sendspin player ma_companion_02f42c31-e167-4485-8dae-f24e187cc135 for websocket client of user handsomestdave
2026-03-05 17:29:12.533 DEBUG (MainThread) [music_assistant.sendspin_proxy] Registered sendspin player ma_companion_02f42c31-e167-4485-8dae-f24e187cc135 for user handsomestdave
2026-03-05 17:29:12.533 DEBUG (MainThread) [music_assistant.sendspin_proxy] Sendspin proxy authenticated user: handsomestdave
2026-03-05 17:29:12.583 ERROR (MainThread) [music_assistant.sendspin_proxy] Failed to connect to internal Sendspin server
Traceback (most recent call last):
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1298, in _wrap_create_connection
    sock = await aiohappyeyeballs.start_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohappyeyeballs/impl.py", line 122, in start_connection
    raise first_exception
  File "/app/venv/lib/python3.13/site-packages/aiohappyeyeballs/impl.py", line 73, in start_connection
    sock = await _connect_sock(
           ^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohappyeyeballs/impl.py", line 208, in _connect_sock
    await loop.sock_connect(sock, address)
  File "/usr/local/lib/python3.13/asyncio/selector_events.py", line 641, in sock_connect
    return await fut
           ^^^^^^^^^
  File "/usr/local/lib/python3.13/asyncio/selector_events.py", line 681, in _sock_connect_cb
    raise OSError(err, f'Connect call failed {address}')
ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 8927)
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/app/venv/lib/python3.13/site-packages/music_assistant/controllers/webserver/sendspin_proxy.py", line 98, in handle_sendspin_proxy
    internal_ws = await self.mass.http_session.ws_connect(self.internal_sendspin_url)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/client.py", line 1076, in _ws_connect
    resp = await self.request(
           ^^^^^^^^^^^^^^^^^^^
    ...<11 lines>...
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/client.py", line 779, in _request
    resp = await handler(req)
           ^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/client.py", line 734, in _connect_and_send_request
    conn = await self._connector.connect(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        req, traces=traces, timeout=real_timeout
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 672, in connect
    proto = await self._create_connection(req, traces, timeout)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1239, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1611, in _create_direct_connection
    raise last_exc
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1580, in _create_direct_connection
    transp, proto = await self._wrap_create_connection(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/app/venv/lib/python3.13/site-packages/aiohttp/connector.py", line 1321, in _wrap_create_connection
    raise client_error(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host 127.0.0.1:8927 ssl:default [Connect call failed ('127.0.0.1', 8927)]
2026-03-05 17:29:12.648 DEBUG (MainThread) [aiohttp.server] Ignored premature client disconnection.
```