### PR TITLE
Fix device_info not updating on Sendspin client reconnect

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1372,11 +1372,19 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
         if player.player_id in self._players:
             self._players[player.player_id] = player
-            player.update_state()
+            player.update_state(signal_event=False)
+            # Load and apply config so the new instance has audio format prefs etc.
+            player_config = await self.mass.config.get_player_config(player.player_id)
+            player.set_config(player_config)
+            player.update_state(signal_event=False)
+            await player.on_config_updated()
             # Re-evaluate protocol links so that universal player wrappers
             # pick up updated device_info (e.g. after a bridge version upgrade).
             if player.state.type == PlayerType.PROTOCOL:
                 self._evaluate_protocol_links(player)
+            # Mark the new instance as fully ready.
+            player.set_initialized()
+            player.update_state()
             # Also schedule update when replacing existing player
             self._schedule_update_all_players()
             return

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1373,6 +1373,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if player.player_id in self._players:
             self._players[player.player_id] = player
             player.update_state()
+            # Re-evaluate protocol links so that universal player wrappers
+            # pick up updated device_info (e.g. after a bridge version upgrade).
+            if player.state.type == PlayerType.PROTOCOL:
+                self._evaluate_protocol_links(player)
             # Also schedule update when replacing existing player
             self._schedule_update_all_players()
             return

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -460,23 +460,27 @@ class ProtocolLinkingMixin:
         self, universal_player: UniversalPlayer, protocol_player: Player
     ) -> None:
         """
-        Update universal player's device info from protocol player if needed.
+        Update universal player's device info from protocol player.
 
-        When a universal player is restored from config, it has generic device info
-        (model="Universal Player", manufacturer="Music Assistant"). This method
-        updates those values from a protocol player that has real device info.
+        Always syncs model and manufacturer from the protocol player so that
+        version upgrades (e.g. bridge firmware update) are reflected without
+        requiring an MA restart.
         """
-        # Check if universal player has generic device info (from restore)
         device_info = universal_player.device_info
         protocol_info = protocol_player.device_info
 
-        # Update model if universal player has generic value
-        if device_info.model in (None, "Universal Player") and protocol_info.model:
-            device_info.model = protocol_info.model
+        changed = False
 
-        # Update manufacturer if universal player has generic value
-        if device_info.manufacturer in (None, "Music Assistant") and protocol_info.manufacturer:
+        if protocol_info.model and device_info.model != protocol_info.model:
+            device_info.model = protocol_info.model
+            changed = True
+
+        if protocol_info.manufacturer and device_info.manufacturer != protocol_info.manufacturer:
             device_info.manufacturer = protocol_info.manufacturer
+            changed = True
+
+        if changed:
+            self._save_universal_player_data(universal_player)
 
     def _save_universal_player_data(self, universal_player: UniversalPlayer) -> None:
         """

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, cast
 
 from aiosendspin.server import ClientAddedEvent, ClientRemovedEvent, SendspinEvent, SendspinServer
 from music_assistant_models.enums import IdentifierType, ProviderFeature
-from music_assistant_models.errors import AlreadyRegisteredError
 
 from music_assistant.constants import CONF_ENABLED
 from music_assistant.mass import MusicAssistant
@@ -94,11 +93,7 @@ class SendspinProvider(PlayerProvider):
         else:
             self.logger.warning("Client %s hello not received within timeout", client_id)
             return
-        if self.mass.players.get_player(client_id) is not None:
-            self.logger.debug(
-                "Client %s already registered, skipping duplicate add event", client_id
-            )
-            return
+        existing = self.mass.players.get_player(client_id)
         if not self.mass.config.get_raw_player_config_value(client_id, CONF_ENABLED, True):
             self.logger.debug("Ignoring disabled sendspin client: %s", client_id)
             return
@@ -118,12 +113,16 @@ class SendspinProvider(PlayerProvider):
                 player._attr_name = (
                     hass_device["name_by_user"] or hass_device["name"] or player.name
                 )
-        try:
+        if existing is not None:
+            # Player reconnected (e.g. bridge restart / version upgrade).
+            # Update device_info in place so MA picks up new manufacturer,
+            # model, and software_version without requiring an MA restart.
+            self.logger.debug("Client %s reconnected, updating device info", client_id)
+            # Properly unload the old player instance to avoid leaking sessions and listeners.
+            await cast("SendspinPlayer", existing).on_unload()
+            await self.mass.players.register_or_update(player)
+        else:
             await self.mass.players.register(player)
-        except AlreadyRegisteredError:
-            self.logger.debug("Client %s already registered while handling add event", client_id)
-            player.unsub_event_cb()
-            player.unsub_group_event_cb()
 
     async def _handle_client_removed(self, client_id: str) -> None:
         """Handle a client disconnection asynchronously."""


### PR DESCRIPTION
## Summary

Fix `device_info` (model, manufacturer) not updating on universal player wrappers when a protocol player reconnects with new information.

## Problem

When a protocol player (e.g. Sendspin bridge) reconnects after a version upgrade or hostname change, the universal player wrapper retains stale `device_info`. Two issues caused this:

1. **Sendspin provider discarded reconnecting clients.** The early-return check in `_handle_client_added` (`if get_player(...) is not None: return`) skipped already-registered players, so fresh `DeviceInfo` from the new `client_hello` was never propagated.

2. **Universal player wrappers never refreshed device_info from protocol players:**
   - `_update_universal_device_info()` only overwrote model/manufacturer when they were defaults (`None`, `"Universal Player"`, `"Music Assistant"`). Once set to real values, they were never updated — even when the protocol player reported new ones.
   - `register_or_update()` did not call `_evaluate_protocol_links()`, so the universal player was never notified of updated protocol player info.

**Result:** `device_info.model` and `device_info.manufacturer` showed stale values indefinitely; only a full MA restart fixed it.

## Fix

### `sendspin/provider.py`
- Remove the early-return check that skipped already-registered players
- When the player already exists, call `on_unload()` on the old instance (to avoid leaking sessions/listeners), then `register_or_update()`
- When the player is new, call `register()` as before
- Remove unused `AlreadyRegisteredError` import

### `controllers/players/controller.py`
- In `register_or_update()`, call `_evaluate_protocol_links(player)` when the updated player is a `PROTOCOL` type — this triggers `_update_universal_device_info()` on the parent universal player

### `controllers/players/protocol_linking.py`
- `_update_universal_device_info()` now always syncs model and manufacturer from the protocol player (not only when current values are defaults)
- Persists updated device_info to config via `_save_universal_player_data()` so changes survive MA restarts

Closes music-assistant/support#5049
