### PR TITLE
Add genre exclusion feature to media items

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -159,6 +159,7 @@ DB_TABLE_LOUDNESS_MEASUREMENTS: Final[str] = "loudness_measurements"
 DB_TABLE_SMART_FADES_ANALYSIS: Final[str] = "smart_fades_analysis"
 DB_TABLE_GENRES: Final[str] = "genres"
 DB_TABLE_GENRE_MEDIA_ITEM_MAPPING: Final[str] = "genre_media_item_mapping"
+DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION: Final[str] = "genre_media_item_exclusion"
 
 
 def load_genre_mapping() -> list[dict[str, Any]]:

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -25,6 +25,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.constants import (
+    DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
     DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
     DB_TABLE_PLAYLOG,
     DB_TABLE_PROVIDER_MAPPINGS,
@@ -237,6 +238,11 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                     "provider": prov_mapping.provider_instance,
                 },
             )
+        # delete genre exclusions for this media item
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
+            {"media_type": self.media_type.value, "media_id": db_id},
+        )
         # NOTE: this does not delete any references to this item in other records,
         # this is handled/overridden in the mediatype specific controllers
         self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, library_item.uri, library_item)

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -24,6 +24,7 @@ from music_assistant.constants import (
     DB_TABLE_ALBUMS,
     DB_TABLE_ARTISTS,
     DB_TABLE_AUDIOBOOKS,
+    DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
     DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
     DB_TABLE_GENRES,
     DB_TABLE_PLAYLISTS,
@@ -141,6 +142,20 @@ class GenreController(MediaControllerBase[Genre]):
         self.mass.register_api_command(
             "music/genres/genres_for_media_item",
             self.get_genres_for_media_item,
+        )
+        self.mass.register_api_command(
+            "music/genres/genre_exclusions_for_media_item",
+            self.get_genre_exclusions_for_media_item,
+        )
+        self.mass.register_api_command(
+            "music/genres/exclude_genre_from_media_item",
+            self.exclude_genre_from_media_item,
+            required_role="admin",
+        )
+        self.mass.register_api_command(
+            "music/genres/remove_genre_exclusion",
+            self.remove_genre_exclusion,
+            required_role="admin",
         )
         self.mass.register_api_command(
             "music/genres/merge",
@@ -436,6 +451,32 @@ class GenreController(MediaControllerBase[Genre]):
             },
         )
 
+    async def get_genre_exclusions_for_media_item(
+        self, media_type: MediaType, media_id: str | int
+    ) -> list[Genre]:
+        """Return all genres excluded from a given media item.
+
+        :param media_type: The type of media item.
+        :param media_id: The database ID of the media item.
+        """
+        try:
+            media_id_int = int(media_id)
+        except (ValueError, TypeError):
+            return []
+        excl = DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION
+        query = (
+            f"EXISTS(SELECT 1 FROM {excl} e "
+            f"WHERE e.genre_id = {self.db_table}.item_id "
+            "AND e.media_type = :media_type AND e.media_id = :media_id)"
+        )
+        return await self.get_library_items_by_query(
+            extra_query_parts=[query],
+            extra_query_params={
+                "media_type": media_type.value,
+                "media_id": media_id_int,
+            },
+        )
+
     async def get_radio_mode_base_tracks(
         self,
         item_id: str,
@@ -663,6 +704,7 @@ class GenreController(MediaControllerBase[Genre]):
             )
             cte = f"WITH genre_lookup(raw_name, genre_id) AS (VALUES {cte_values})"
 
+            excl = DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION
             for table, media_type in MEDIA_TABLES:
                 full_query = (
                     f"{cte} INSERT OR REPLACE INTO {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}"
@@ -673,7 +715,12 @@ class GenreController(MediaControllerBase[Genre]):
                     f"json_each(json_extract({table}.metadata, '$.genres')) AS g "
                     f"JOIN genre_lookup gl ON gl.raw_name = LOWER(TRIM(g.value)) "
                     f"WHERE json_extract({table}.metadata, '$.genres') IS NOT NULL "
-                    f"AND json_extract({table}.metadata, '$.genres') != '[]'"
+                    f"AND json_extract({table}.metadata, '$.genres') != '[]' "
+                    f"AND NOT EXISTS ("
+                    f"SELECT 1 FROM {excl} e "
+                    f"WHERE e.genre_id = gl.genre_id "
+                    f"AND e.media_id = {table}.item_id "
+                    f"AND e.media_type = '{media_type.value}')"
                 )
                 await db.execute(full_query)
             await db.commit()
@@ -722,6 +769,7 @@ class GenreController(MediaControllerBase[Genre]):
         # orphaned playlog rows pointing to genres that no longer exist.
         # 'WHERE translation_key IS NULL' is used because it is only set for default genres, so this
         # keeps all default genres even if they become unmapped/empty.
+        excl = DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION
         await db.delete_where_query(
             DB_TABLE_PLAYLOG,
             f"media_type = '{MediaType.GENRE.value}' "
@@ -730,6 +778,9 @@ class GenreController(MediaControllerBase[Genre]):
             f"  WHERE translation_key IS NULL "
             f"  AND NOT EXISTS ("
             f"    SELECT 1 FROM {gm} WHERE {gm}.genre_id = {DB_TABLE_GENRES}.item_id"
+            f"  ) "
+            f"  AND NOT EXISTS ("
+            f"    SELECT 1 FROM {excl} WHERE {excl}.genre_id = {DB_TABLE_GENRES}.item_id"
             f"  )"
             f")",
         )
@@ -739,6 +790,9 @@ class GenreController(MediaControllerBase[Genre]):
             f"translation_key IS NULL "
             f"AND NOT EXISTS ("
             f"  SELECT 1 FROM {gm} WHERE {gm}.genre_id = {DB_TABLE_GENRES}.item_id"
+            f") "
+            f"AND NOT EXISTS ("
+            f"  SELECT 1 FROM {excl} WHERE {excl}.genre_id = {DB_TABLE_GENRES}.item_id"
             f")",
         )
         genres_deleted = genres_before - await db.get_count(DB_TABLE_GENRES)
@@ -838,6 +892,7 @@ class GenreController(MediaControllerBase[Genre]):
         )
         cte = f"WITH genre_lookup(raw_name, genre_id) AS (VALUES {cte_values})"
 
+        excl = DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION
         count_before = await db.get_count(gm)
         for table, media_type in MEDIA_TABLES:
             full_query = (
@@ -854,7 +909,12 @@ class GenreController(MediaControllerBase[Genre]):
                 f"SELECT 1 FROM {gm} ex "
                 f"WHERE ex.genre_id = gl.genre_id "
                 f"AND ex.media_id = {table}.item_id "
-                f"AND ex.media_type = '{media_type.value}')"
+                f"AND ex.media_type = '{media_type.value}') "
+                f"AND NOT EXISTS ("
+                f"SELECT 1 FROM {excl} e "
+                f"WHERE e.genre_id = gl.genre_id "
+                f"AND e.media_id = {table}.item_id "
+                f"AND e.media_type = '{media_type.value}')"
             )
             await db.execute(full_query)
         await db.commit()
@@ -962,6 +1022,50 @@ class GenreController(MediaControllerBase[Genre]):
         """
         await self.mass.music.database.delete(
             DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+            {
+                "genre_id": int(genre_id),
+                "media_id": int(media_id),
+                "media_type": media_type.value,
+            },
+        )
+
+    async def exclude_genre_from_media_item(
+        self,
+        genre_id: str | int,
+        media_type: MediaType,
+        media_id: str | int,
+    ) -> None:
+        """Permanently exclude a genre from being mapped to a media item.
+
+        Records the exclusion so the scanner will never re-add this mapping.
+        Any existing mapping for this genre/media pair is removed immediately.
+
+        :param genre_id: Database ID of the genre.
+        :param media_type: Type of media item (track, album, artist, etc.).
+        :param media_id: Database ID of the media item.
+        """
+        match = {
+            "genre_id": int(genre_id),
+            "media_id": int(media_id),
+            "media_type": media_type.value,
+        }
+        await self.mass.music.database.insert_or_replace(DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION, match)
+        await self.mass.music.database.delete(DB_TABLE_GENRE_MEDIA_ITEM_MAPPING, match)
+
+    async def remove_genre_exclusion(
+        self,
+        genre_id: str | int,
+        media_type: MediaType,
+        media_id: str | int,
+    ) -> None:
+        """Remove a genre exclusion, allowing the scanner to re-map it on the next run.
+
+        :param genre_id: Database ID of the genre.
+        :param media_type: Type of media item (track, album, artist, etc.).
+        :param media_id: Database ID of the media item.
+        """
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
             {
                 "genre_id": int(genre_id),
                 "media_id": int(media_id),

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -1044,13 +1044,25 @@ class GenreController(MediaControllerBase[Genre]):
         :param media_type: Type of media item (track, album, artist, etc.).
         :param media_id: Database ID of the media item.
         """
-        match = {
+        params = {
             "genre_id": int(genre_id),
             "media_id": int(media_id),
             "media_type": media_type.value,
         }
-        await self.mass.music.database.insert_or_replace(DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION, match)
-        await self.mass.music.database.delete(DB_TABLE_GENRE_MEDIA_ITEM_MAPPING, match)
+        db = self.mass.music.database
+        # Run both statements without committing between them so the exclusion insert
+        # and the mapping delete are committed atomically.
+        await db.execute(
+            f"INSERT OR REPLACE INTO {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}"
+            "(genre_id, media_id, media_type) VALUES (:genre_id, :media_id, :media_type)",
+            params,
+        )
+        await db.execute(
+            f"DELETE FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "WHERE genre_id = :genre_id AND media_id = :media_id AND media_type = :media_type",
+            params,
+        )
+        await db.commit()
 
     async def remove_genre_exclusion(
         self,

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -552,6 +552,7 @@ class GenreController(MediaControllerBase[Genre]):
         if full_restore:
             self.logger.warning("Performing FULL restore - deleting all existing genres")
             await self.mass.music.database.delete(DB_TABLE_GENRE_MEDIA_ITEM_MAPPING)
+            await self.mass.music.database.delete(DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION)
             await self.mass.music.database.delete(
                 DB_TABLE_PLAYLOG, {"media_type": MediaType.GENRE.value}
             )
@@ -927,6 +928,9 @@ class GenreController(MediaControllerBase[Genre]):
         db_id = int(item_id)
         await self.mass.music.database.delete(
             DB_TABLE_GENRE_MEDIA_ITEM_MAPPING, {"genre_id": db_id}
+        )
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION, {"genre_id": db_id}
         )
         await super().remove_item_from_library(item_id, recursive)
 

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -2498,6 +2498,7 @@ class MusicController(CoreController):
                 [genre_id] INTEGER NOT NULL,
                 [media_id] INTEGER NOT NULL,
                 [media_type] TEXT NOT NULL,
+                FOREIGN KEY([genre_id]) REFERENCES [genres]([item_id]) ON DELETE CASCADE,
                 UNIQUE(genre_id, media_id, media_type)
                 );"""
             )
@@ -2721,6 +2722,7 @@ class MusicController(CoreController):
             [genre_id] INTEGER NOT NULL,
             [media_id] INTEGER NOT NULL,
             [media_type] TEXT NOT NULL,
+            FOREIGN KEY([genre_id]) REFERENCES [genres]([item_id]) ON DELETE CASCADE,
             UNIQUE(genre_id, media_id, media_type)
             );"""
         )

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -102,7 +102,7 @@ CONF_RESET_DB = "reset_db"
 DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
-DB_SCHEMA_VERSION: Final[int] = 32
+DB_SCHEMA_VERSION: Final[int] = 31
 
 CACHE_CATEGORY_LAST_SYNC: Final[int] = 9
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -102,7 +102,7 @@ CONF_RESET_DB = "reset_db"
 DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
-DB_SCHEMA_VERSION: Final[int] = 31
+DB_SCHEMA_VERSION: Final[int] = 32
 
 CACHE_CATEGORY_LAST_SYNC: Final[int] = 9
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10
@@ -2490,7 +2490,7 @@ class MusicController(CoreController):
                 " json DEFAULT '[\"track\"]' NOT NULL"
             )
 
-        if prev_version <= 30:
+        if prev_version <= 31:
             # create the genre_media_item_exclusion table (new in schema 31)
             await self._database.execute(
                 f"""

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -2498,7 +2498,7 @@ class MusicController(CoreController):
                 [genre_id] INTEGER NOT NULL,
                 [media_id] INTEGER NOT NULL,
                 [media_type] TEXT NOT NULL,
-                FOREIGN KEY([genre_id]) REFERENCES [genres]([item_id]) ON DELETE CASCADE,
+                FOREIGN KEY([genre_id]) REFERENCES [genres]([item_id]),
                 UNIQUE(genre_id, media_id, media_type)
                 );"""
             )
@@ -2722,7 +2722,7 @@ class MusicController(CoreController):
             [genre_id] INTEGER NOT NULL,
             [media_id] INTEGER NOT NULL,
             [media_type] TEXT NOT NULL,
-            FOREIGN KEY([genre_id]) REFERENCES [genres]([item_id]) ON DELETE CASCADE,
+            FOREIGN KEY([genre_id]) REFERENCES [genres]([item_id]),
             UNIQUE(genre_id, media_id, media_type)
             );"""
         )

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -102,7 +102,7 @@ CONF_RESET_DB = "reset_db"
 DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
-DB_SCHEMA_VERSION: Final[int] = 31
+DB_SCHEMA_VERSION: Final[int] = 32
 
 CACHE_CATEGORY_LAST_SYNC: Final[int] = 9
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -51,6 +51,7 @@ from music_assistant.constants import (
     DB_TABLE_ALBUMS,
     DB_TABLE_ARTISTS,
     DB_TABLE_AUDIOBOOKS,
+    DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
     DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
     DB_TABLE_GENRES,
     DB_TABLE_LOUDNESS_MEASUREMENTS,
@@ -101,7 +102,7 @@ CONF_RESET_DB = "reset_db"
 DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
-DB_SCHEMA_VERSION: Final[int] = 30
+DB_SCHEMA_VERSION: Final[int] = 31
 
 CACHE_CATEGORY_LAST_SYNC: Final[int] = 9
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10
@@ -2489,6 +2490,26 @@ class MusicController(CoreController):
                 " json DEFAULT '[\"track\"]' NOT NULL"
             )
 
+        if prev_version <= 30:
+            # create the genre_media_item_exclusion table (new in schema 31)
+            await self._database.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(
+                [genre_id] INTEGER NOT NULL,
+                [media_id] INTEGER NOT NULL,
+                [media_type] TEXT NOT NULL,
+                UNIQUE(genre_id, media_id, media_type)
+                );"""
+            )
+            await self._database.execute(
+                f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}_media_idx "
+                f"on {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(media_id,media_type);"
+            )
+            await self._database.execute(
+                f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}_genre_idx "
+                f"on {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(genre_id);"
+            )
+
         # save changes
         await self._database.commit()
 
@@ -2696,6 +2717,15 @@ class MusicController(CoreController):
         )
         await self.database.execute(
             f"""
+            CREATE TABLE IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(
+            [genre_id] INTEGER NOT NULL,
+            [media_id] INTEGER NOT NULL,
+            [media_type] TEXT NOT NULL,
+            UNIQUE(genre_id, media_id, media_type)
+            );"""
+        )
+        await self.database.execute(
+            f"""
             CREATE TABLE IF NOT EXISTS {DB_TABLE_ALBUM_TRACKS}(
             [id] INTEGER PRIMARY KEY AUTOINCREMENT,
             [track_id] INTEGER NOT NULL,
@@ -2889,6 +2919,15 @@ class MusicController(CoreController):
         await self.database.execute(
             f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}_genre_alias_idx "
             f"on {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}(genre_id,alias);"
+        )
+        # indexes on genre_media_item_exclusion table
+        await self.database.execute(
+            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}_media_idx "
+            f"on {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(media_id,media_type);"
+        )
+        await self.database.execute(
+            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}_genre_idx "
+            f"on {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(genre_id);"
         )
         # unique index on playlog table
         await self.database.execute(

--- a/tests/core/test_genres.py
+++ b/tests/core/test_genres.py
@@ -1424,3 +1424,81 @@ class TestGenreExclusion:
             limit=0,
         )
         assert len(mapping_rows) == 0
+
+    async def test_cleanup_preserves_genre_with_exclusion(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """_cleanup_stale_genre_mappings keeps a genre that has an exclusion but no mappings.
+
+        Verifies both that the genre row survives and that a playlog entry for it is
+        also preserved (the playlog DELETE uses the same exclusion guard).
+        """
+        genre = await genre_ctrl.add_item_to_library(_make_genre("CleanupPreservedGenre"))
+        track = await _add_test_track(mass, "CleanupPreserved Track")
+        genre_id = int(genre.item_id)
+        track_id = int(track.item_id)
+
+        # Exclude the genre from the track (also removes any mapping that might exist)
+        await genre_ctrl.exclude_genre_from_media_item(genre_id, MediaType.TRACK, track_id)
+
+        # Insert a playlog entry for the genre so we can confirm it is also kept
+        cols = (
+            "(item_id, provider, media_type, name, fully_played, seconds_played, timestamp, userid)"
+        )
+        await mass.music.database.execute(
+            f"INSERT OR IGNORE INTO {DB_TABLE_PLAYLOG} {cols} "
+            "VALUES (:item_id, 'library', 'genre', :name, 0, 0, 0, 'testuser')",
+            {"item_id": str(genre_id), "name": "CleanupPreservedGenre"},
+        )
+        await mass.music.database.commit()
+
+        await genre_ctrl._cleanup_stale_genre_mappings()
+
+        genre_row = await mass.music.database.get_row(DB_TABLE_GENRES, {"item_id": genre_id})
+        assert genre_row is not None, "genre with an exclusion must not be deleted by cleanup"
+
+        playlog_rows = await mass.music.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_PLAYLOG} WHERE media_type = 'genre' AND item_id = :id",
+            {"id": str(genre_id)},
+            limit=0,
+        )
+        assert len(playlog_rows) == 1, "playlog entry for an excluded genre must not be deleted"
+
+    async def test_get_genre_exclusions_for_media_item(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """Returns genres excluded from a specific media item."""
+        genre1 = await genre_ctrl.add_item_to_library(_make_genre("ExclQueryGenre1"))
+        genre2 = await genre_ctrl.add_item_to_library(_make_genre("ExclQueryGenre2"))
+        track = await _add_test_track(mass, "ExclQuery Track")
+        await genre_ctrl.exclude_genre_from_media_item(
+            genre1.item_id, MediaType.TRACK, track.item_id
+        )
+        await genre_ctrl.exclude_genre_from_media_item(
+            genre2.item_id, MediaType.TRACK, track.item_id
+        )
+        result = await genre_ctrl.get_genre_exclusions_for_media_item(
+            MediaType.TRACK, track.item_id
+        )
+        names = {g.name for g in result}
+        assert "ExclQueryGenre1" in names
+        assert "ExclQueryGenre2" in names
+
+    async def test_get_genre_exclusions_for_media_item_empty(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """Returns empty list when no genres are excluded from the media item."""
+        track = await _add_test_track(mass, "ExclQuery No Exclusions Track")
+        result = await genre_ctrl.get_genre_exclusions_for_media_item(
+            MediaType.TRACK, track.item_id
+        )
+        assert result == []
+
+    async def test_get_genre_exclusions_for_media_item_non_integer_id(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """Returns empty list for non-integer media IDs."""
+        result = await genre_ctrl.get_genre_exclusions_for_media_item(
+            MediaType.ALBUM, "3957198221-190478553"
+        )
+        assert result == []

--- a/tests/core/test_genres.py
+++ b/tests/core/test_genres.py
@@ -22,6 +22,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import (
+    DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
     DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
     DB_TABLE_GENRES,
     DB_TABLE_PLAYLOG,
@@ -1283,3 +1284,143 @@ class TestCleanupStaleMappings:
             limit=0,
         )
         assert len(playlog_rows) == 0
+
+
+# ===================================================================
+# Group L: Genre Exclusion (5 tests)
+# ===================================================================
+
+
+class TestGenreExclusion:
+    """Tests for exclude_genre_from_media_item and remove_genre_exclusion."""
+
+    async def test_exclude_inserts_row(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """exclude_genre_from_media_item inserts a row into the exclusion table."""
+        genre = await genre_ctrl.add_item_to_library(_make_genre("ExclGenre1"))
+        track = await _add_test_track(mass, "ExclTrack1")
+        genre_id = int(genre.item_id)
+        track_id = int(track.item_id)
+
+        await genre_ctrl.exclude_genre_from_media_item(genre_id, MediaType.TRACK, track_id)
+
+        rows = await mass.music.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION} "
+            "WHERE genre_id = :gid AND media_id = :mid AND media_type = :mt",
+            {"gid": genre_id, "mid": track_id, "mt": "track"},
+            limit=0,
+        )
+        assert len(rows) == 1
+
+    async def test_exclude_removes_existing_mapping(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """exclude_genre_from_media_item immediately deletes any existing mapping."""
+        genre = await genre_ctrl.add_item_to_library(_make_genre("ExclGenre2"))
+        track = await _add_test_track(mass, "ExclTrack2")
+        genre_id = int(genre.item_id)
+        track_id = int(track.item_id)
+
+        await genre_ctrl.add_media_mapping(genre_id, MediaType.TRACK, track_id, "ExclGenre2")
+        pre_rows = await mass.music.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "WHERE genre_id = :gid AND media_id = :mid",
+            {"gid": genre_id, "mid": track_id},
+            limit=0,
+        )
+        assert len(pre_rows) == 1
+
+        await genre_ctrl.exclude_genre_from_media_item(genre_id, MediaType.TRACK, track_id)
+
+        post_rows = await mass.music.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "WHERE genre_id = :gid AND media_id = :mid",
+            {"gid": genre_id, "mid": track_id},
+            limit=0,
+        )
+        assert len(post_rows) == 0
+
+    async def test_exclude_idempotent(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """Calling exclude_genre_from_media_item twice is idempotent."""
+        genre = await genre_ctrl.add_item_to_library(_make_genre("ExclGenre3"))
+        track = await _add_test_track(mass, "ExclTrack3")
+        genre_id = int(genre.item_id)
+        track_id = int(track.item_id)
+
+        await genre_ctrl.exclude_genre_from_media_item(genre_id, MediaType.TRACK, track_id)
+        await genre_ctrl.exclude_genre_from_media_item(genre_id, MediaType.TRACK, track_id)
+
+        rows = await mass.music.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION} "
+            "WHERE genre_id = :gid AND media_id = :mid AND media_type = :mt",
+            {"gid": genre_id, "mid": track_id, "mt": "track"},
+            limit=0,
+        )
+        assert len(rows) == 1
+
+    async def test_remove_exclusion_deletes_row(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """remove_genre_exclusion deletes the exclusion row."""
+        genre = await genre_ctrl.add_item_to_library(_make_genre("ExclGenre4"))
+        track = await _add_test_track(mass, "ExclTrack4")
+        genre_id = int(genre.item_id)
+        track_id = int(track.item_id)
+
+        await genre_ctrl.exclude_genre_from_media_item(genre_id, MediaType.TRACK, track_id)
+        await genre_ctrl.remove_genre_exclusion(genre_id, MediaType.TRACK, track_id)
+
+        rows = await mass.music.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION} "
+            "WHERE genre_id = :gid AND media_id = :mid",
+            {"gid": genre_id, "mid": track_id},
+            limit=0,
+        )
+        assert len(rows) == 0
+
+    async def test_scanner_respects_exclusion(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """_bulk_scan_unmapped_genres does not create a mapping for an excluded pair."""
+        genre = await genre_ctrl.add_item_to_library(_make_genre("ExclScanGenre"))
+        track = await _add_test_track(mass, "ExclScan Track")
+        genre_id = int(genre.item_id)
+        track_id = int(track.item_id)
+
+        await _set_track_genres(mass, track_id, ["ExclScanGenre"])
+        await genre_ctrl.add_alias(genre_id, "ExclScanGenre")
+        await genre_ctrl.exclude_genre_from_media_item(genre_id, MediaType.TRACK, track_id)
+        await genre_ctrl._bulk_scan_unmapped_genres()
+
+        mapping_rows = await mass.music.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "WHERE genre_id = :gid AND media_id = :mid",
+            {"gid": genre_id, "mid": track_id},
+            limit=0,
+        )
+        assert len(mapping_rows) == 0
+
+    async def test_full_scanner_respects_exclusion(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """_bulk_scan_media_genres does not create a mapping for an excluded pair."""
+        genre = await genre_ctrl.add_item_to_library(_make_genre("ExclFullScanGenre"))
+        track = await _add_test_track(mass, "ExclFullScan Track")
+        genre_id = int(genre.item_id)
+        track_id = int(track.item_id)
+
+        await _set_track_genres(mass, track_id, ["ExclFullScanGenre"])
+        await genre_ctrl.add_alias(genre_id, "ExclFullScanGenre")
+        await genre_ctrl.exclude_genre_from_media_item(genre_id, MediaType.TRACK, track_id)
+        await genre_ctrl._bulk_scan_media_genres()
+
+        mapping_rows = await mass.music.database.get_rows_from_query(
+            f"SELECT * FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "WHERE genre_id = :gid AND media_id = :mid",
+            {"gid": genre_id, "mid": track_id},
+            limit=0,
+        )
+        assert len(mapping_rows) == 0


### PR DESCRIPTION
This allows a user to exclude discovered genres from a mapped media item ensuring that it does not get remapped during background genre sync