### PR TITLE
Add build-system so uv run mass works on fresh checkouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,3 +263,7 @@ known-first-party = ["music_assistant"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 25
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add a setuptools build-system declaration to pyproject.toml
- let uv treat the server as a package when creating the project environment
- allow `uv run mass` to work without running uv pip install -e . first

## Why
The repo already declares the mass console script in [project.scripts], but without a build-system declaration uv treats the project as unpackaged during the initial environment sync and skips installing entry points. That means a fresh checkout cannot run `uv run mass` until the project has been manually installed.

With the build backend declared, uv can build/install the local project as part of uv run, so the `mass` entry point is available immediately.

## Verification
- uv build --wheel succeeds for the repository
- a fresh editable install creates the mass console script
