### PR TITLE
Downgrade DLNA SSDP discovery socket errors to a warning

### DIFF
--- a/music_assistant/providers/dlna/provider.py
+++ b/music_assistant/providers/dlna/provider.py
@@ -88,10 +88,15 @@ class DLNAPlayerProvider(PlayerProvider):
                 await self._device_discovered(ssdp_udn, discovery_info["location"])
 
             # we iterate between using a regular and multicast search (if enabled)
-            if allow_network_scan and use_multicast:
-                await async_search(on_response, target=(str(IPv4Address("255.255.255.255")), 1900))
-            else:
-                await async_search(on_response)
+            try:
+                if allow_network_scan and use_multicast:
+                    await async_search(
+                        on_response, target=(str(IPv4Address("255.255.255.255")), 1900)
+                    )
+                else:
+                    await async_search(on_response)
+            except OSError as err:
+                self.logger.warning("DLNA SSDP discovery failed: %s", err)
 
         finally:
             self._discovery_running = False

--- a/tests/providers/dlna/__init__.py
+++ b/tests/providers/dlna/__init__.py
@@ -1,0 +1,1 @@
+"""DLNA provider tests."""

--- a/tests/providers/dlna/test_provider.py
+++ b/tests/providers/dlna/test_provider.py
@@ -1,0 +1,39 @@
+"""Tests for the DLNA player provider."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_assistant.providers.dlna.provider import DLNAPlayerProvider
+
+
+@pytest.fixture
+def provider() -> DLNAPlayerProvider:
+    """Return a minimal DLNA provider instance for discovery tests."""
+    prov = DLNAPlayerProvider.__new__(DLNAPlayerProvider)
+    prov._discovery_running = False
+    prov.config = MagicMock()
+    prov.config.get_value.return_value = False
+    prov.logger = MagicMock()
+    prov.mass = MagicMock()
+    prov.mass.create_task = MagicMock()
+    prov.mass.loop = MagicMock()
+    return prov
+
+
+async def test_discover_players_logs_warning_on_socket_error(
+    provider: DLNAPlayerProvider,
+) -> None:
+    """Socket setup failures during SSDP discovery should only log a warning."""
+    err = OSError(49, "Can't assign requested address")
+
+    with patch(
+        "music_assistant.providers.dlna.provider.async_search",
+        new=AsyncMock(side_effect=err),
+    ) as mock_async_search:
+        await provider.discover_players()
+
+    mock_async_search.assert_awaited_once()
+    provider.logger.warning.assert_called_once_with("DLNA SSDP discovery failed: %s", err)
+    provider.mass.loop.call_later.assert_called_once()
+    assert provider._discovery_running is False

--- a/tests/providers/dlna/test_provider.py
+++ b/tests/providers/dlna/test_provider.py
@@ -1,30 +1,21 @@
 """Tests for the DLNA player provider."""
 
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
 
 from music_assistant.providers.dlna.provider import DLNAPlayerProvider
 
 
-@pytest.fixture
-def provider() -> DLNAPlayerProvider:
-    """Return a minimal DLNA provider instance for discovery tests."""
-    prov = DLNAPlayerProvider.__new__(DLNAPlayerProvider)
-    prov._discovery_running = False
-    prov.config = MagicMock()
-    prov.config.get_value.return_value = False
-    prov.logger = MagicMock()
-    prov.mass = MagicMock()
-    prov.mass.create_task = MagicMock()
-    prov.mass.loop = MagicMock()
-    return prov
-
-
-async def test_discover_players_logs_warning_on_socket_error(
-    provider: DLNAPlayerProvider,
-) -> None:
+async def test_discover_players_logs_warning_on_socket_error() -> None:
     """Socket setup failures during SSDP discovery should only log a warning."""
+    provider = cast("Any", DLNAPlayerProvider.__new__(DLNAPlayerProvider))
+    provider._discovery_running = False
+    provider.config = MagicMock()
+    provider.config.get_value.return_value = False
+    provider.logger = MagicMock()
+    provider.mass = MagicMock()
+    provider.mass.create_task = MagicMock()
+    provider.mass.loop = MagicMock()
     err = OSError(49, "Can't assign requested address")
 
     with patch(


### PR DESCRIPTION
## Summary
- catch `OSError` from DLNA SSDP discovery so the recurring background task logs a warning instead of dumping an unhandled task traceback
- add a regression test for the discovery socket failure path

## Notes
This error is probably rare and mostly experienced during development, for example when the computer loses Wi-Fi or goes to sleep while the server is running.

## Testing
- `uv run --extra test pytest tests/providers/dlna/test_provider.py`
- `uv run --extra test ruff check music_assistant/providers/dlna/provider.py tests/providers/dlna/__init__.py tests/providers/dlna/test_provider.py`