### PR TITLE
Pin aiovban dependency to 0.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "librosa==0.11.0",
   "numpy==2.3.5",  # numpy 2.4.0+ uses X86_V2 CPU baseline (requires SSE4.2) which breaks older CPUs https://github.com/music-assistant/support/issues/5005#issuecomment-3972476728
   "gql[all]==4.0.0",
-  "aiovban>=0.6.3",
+  "aiovban==0.6.3",
   "aiortc>=1.6.0",
   "pyjwt[crypto]>=2.10.1",
 ]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -15,7 +15,7 @@ aiosendspin==4.3.2
 aioslimproto==3.1.7
 aiosonos==0.1.9
 aiosqlite==0.22.1
-aiovban>=0.6.3
+aiovban==0.6.3
 alexapy==1.29.17
 async-upnp-client==0.46.2
 audible==0.10.0


### PR DESCRIPTION
Errors appearing when using aiovban 0.8.0:

`WARNING (MainThread) [music_assistant] Error loading provider(instance) vban_receiver--yVw49aaS: 'coroutine' object has no attribute 'receive_stream`

Pinning to 0.6.3 until I have time to reconcile the changes.