### PR TITLE
Preserve Sendspin players queue across reconnects

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1373,6 +1373,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if player.player_id in self._players:
             self._players[player.player_id] = player
             player.update_state()
+            # Re-evaluate protocol links on protocol player updates so parent wrappers
+            # can refresh metadata (e.g. reconnect with updated device info).
+            if player.state.type == PlayerType.PROTOCOL:
+                self._evaluate_protocol_links(player)
             # Also schedule update when replacing existing player
             self._schedule_update_all_players()
             return

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -176,6 +176,7 @@ class ProtocolLinkingMixin:
                     for conn_type, value in protocol_player.device_info.identifiers.items():
                         parent_player.device_info.add_identifier(conn_type, value)
                     self._update_universal_device_info(parent_player, protocol_player)
+                    self._save_universal_player_data(parent_player)
                     # Check if this universal player should now be merged with another
                     # (e.g., DLNA brought a MAC via ARP that matches an AirPlay universal)
                     self._check_merge_universal_players(parent_player)
@@ -229,7 +230,7 @@ class ProtocolLinkingMixin:
                         # with empty identifiers
                         for conn_type, value in protocol_player.device_info.identifiers.items():
                             native_player.device_info.add_identifier(conn_type, value)
-                        # Update model/manufacturer if universal player has generic values
+                        # Update model/manufacturer from the active protocol player.
                         self._update_universal_device_info(native_player, protocol_player)
                         # Register newly matched protocol player with the universal player
                         if is_match:
@@ -439,7 +440,7 @@ class ProtocolLinkingMixin:
             universal_player.add_protocol_player(protocol_player.player_id)
             for conn_type, value in protocol_player.device_info.identifiers.items():
                 universal_player.device_info.add_identifier(conn_type, value)
-            # Update model/manufacturer if universal player has generic values
+            # Update model/manufacturer from the active protocol player.
             self._update_universal_device_info(universal_player, protocol_player)
 
             # Persist all player data (protocol IDs, identifiers, device info) to config
@@ -460,22 +461,18 @@ class ProtocolLinkingMixin:
         self, universal_player: UniversalPlayer, protocol_player: Player
     ) -> None:
         """
-        Update universal player's device info from protocol player if needed.
+        Update universal player's device info from protocol player.
 
-        When a universal player is restored from config, it has generic device info
-        (model="Universal Player", manufacturer="Music Assistant"). This method
-        updates those values from a protocol player that has real device info.
+        Keep universal wrappers in sync when a linked protocol player reconnects
+        and reports refreshed model/manufacturer data.
         """
-        # Check if universal player has generic device info (from restore)
         device_info = universal_player.device_info
         protocol_info = protocol_player.device_info
 
-        # Update model if universal player has generic value
-        if device_info.model in (None, "Universal Player") and protocol_info.model:
+        if protocol_info.model:
             device_info.model = protocol_info.model
 
-        # Update manufacturer if universal player has generic value
-        if device_info.manufacturer in (None, "Music Assistant") and protocol_info.manufacturer:
+        if protocol_info.manufacturer:
             device_info.manufacturer = protocol_info.manufacturer
 
     def _save_universal_player_data(self, universal_player: UniversalPlayer) -> None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable
+from contextlib import suppress
 from io import BytesIO
 from typing import TYPE_CHECKING, cast
 
@@ -134,8 +135,8 @@ class SendspinPlayer(Player):
     _attr_type = PlayerType.PROTOCOL
 
     api: SendspinClient
-    unsub_event_cb: Callable[[], None]
-    unsub_group_event_cb: Callable[[], None]
+    unsub_event_cb: Callable[[], None] | None
+    unsub_group_event_cb: Callable[[], None] | None
     last_sent_artwork_url: str | None = None
     last_sent_artist_artwork_url: str | None = None
     playback_session: SendspinPlaybackSession
@@ -152,17 +153,11 @@ class SendspinPlayer(Player):
         sendspin_client = provider.server_api.get_client(player_id)
         assert sendspin_client is not None
         self.api = sendspin_client
-        self.api.disconnect_behaviour = DisconnectBehaviour.STOP
-        self.unsub_event_cb = sendspin_client.add_event_listener(self.event_cb)
-        self.unsub_group_event_cb = sendspin_client.group.add_event_listener(self.group_event_cb)
-        if controller_role := self._controller_role:
-            controller_role.set_supported_commands(SUPPORTED_GROUP_COMMANDS)
-
+        self.unsub_event_cb = None
+        self.unsub_group_event_cb = None
         self.playback_session = SendspinPlaybackSession(self)
 
         self.logger = self.provider.logger.getChild(player_id)
-        # init some static variables
-        self._attr_name = sendspin_client.name
         self._attr_supported_features = {
             PlayerFeature.PLAY_MEDIA,
             PlayerFeature.SET_MEMBERS,
@@ -172,6 +167,38 @@ class SendspinPlayer(Player):
         }
         self._attr_can_group_with = {provider.instance_id}
         self._attr_power_control = PLAYER_CONTROL_NONE
+        self._refresh_client_info(sendspin_client)
+        self._subscribe_client_callbacks()
+
+    def _subscribe_client_callbacks(self) -> None:
+        """Subscribe to client and group events for the currently bound client."""
+        self.api.disconnect_behaviour = DisconnectBehaviour.STOP
+        self.unsub_event_cb = self.api.add_event_listener(self.event_cb)
+        self.unsub_group_event_cb = self.api.group.add_event_listener(self.group_event_cb)
+        if controller_role := self._controller_role:
+            controller_role.set_supported_commands(SUPPORTED_GROUP_COMMANDS)
+
+    def _unsubscribe_client_callbacks(self) -> None:
+        """Unsubscribe any active client and group listeners."""
+        if self.unsub_event_cb is not None:
+            with suppress(Exception):
+                self.unsub_event_cb()
+            self.unsub_event_cb = None
+        if self.unsub_group_event_cb is not None:
+            with suppress(Exception):
+                self.unsub_group_event_cb()
+            self.unsub_group_event_cb = None
+
+    def _refresh_client_info(
+        self,
+        sendspin_client: SendspinClient,
+        extra_identifiers: dict[IdentifierType, str] | None = None,
+    ) -> None:
+        """Refresh player attributes from a Sendspin client hello/info payload."""
+        # Capture existing identifiers before rebuilding DeviceInfo, so that identifiers
+        # added during previous connections (e.g. bridge UUIDs) are not lost.
+        preserved_identifiers = dict(self._attr_device_info.identifiers)
+        self._attr_name = sendspin_client.name
         if device_info := sendspin_client.info.device_info:
             self._attr_device_info = DeviceInfo(
                 model=device_info.product_name or "Unknown model",
@@ -194,12 +221,17 @@ class SendspinPlayer(Player):
         else:
             self._attr_device_info = DeviceInfo()
             self.is_web_player = False
+        for id_type, id_value in preserved_identifiers.items():
+            self._attr_device_info.add_identifier(id_type, id_value)
+        if extra_identifiers:
+            for id_type, id_value in extra_identifiers.items():
+                self._attr_device_info.add_identifier(id_type, id_value)
         # Add player_id as MAC identifier for protocol linking (if it's a valid MAC)
         # This enables linking with bridged players (e.g., AirPlay via Sendspin bridge)
-        if _mac := mac_from_bridge_client_id(player_id):
+        if _mac := mac_from_bridge_client_id(self.player_id):
             self._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, _mac)
-        elif is_valid_mac_address(player_id):
-            self._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, player_id)
+        elif is_valid_mac_address(self.player_id):
+            self._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, self.player_id)
         if sendspin_client.info.player_support:
             for role in sendspin_client.roles_by_family("player"):
                 volume = role.get_player_volume()
@@ -216,6 +248,49 @@ class SendspinPlayer(Player):
         # register web/app player as native player type because it doesn't need to be linked
         # every web/app player is just a standalone player.
         self._attr_type = PlayerType.PLAYER if self.is_web_player else PlayerType.PROTOCOL
+
+    def _sync_state_from_group(self) -> None:
+        """Sync immediate playback state from the currently bound Sendspin group."""
+        match self.api.group.state:
+            case PlaybackStateType.PLAYING:
+                self._attr_playback_state = PlaybackState.PLAYING
+            case PlaybackStateType.PAUSED:
+                self._attr_playback_state = PlaybackState.PAUSED
+            case PlaybackStateType.STOPPED:
+                self._attr_playback_state = PlaybackState.IDLE
+                self._attr_elapsed_time = 0
+                self._attr_elapsed_time_last_updated = time.time()
+
+    async def mark_unavailable(self, still_valid: Callable[[], bool] | None = None) -> None:
+        """Mark the player unavailable without unregistering it."""
+        if still_valid is not None and not still_valid():
+            return
+        self._unsubscribe_client_callbacks()
+        await self.playback_session.cancel("client disconnected")
+        if still_valid is not None and not still_valid():
+            return
+        self.last_sent_artwork_url = None
+        self.last_sent_artist_artwork_url = None
+        self._attr_available = False
+        self._attr_playback_state = PlaybackState.IDLE
+        self._attr_elapsed_time = 0
+        self._attr_elapsed_time_last_updated = time.time()
+        self.update_state()
+
+    async def reattach_client(
+        self,
+        sendspin_client: SendspinClient,
+        extra_identifiers: dict[IdentifierType, str] | None = None,
+    ) -> None:
+        """Rebind this player to a freshly connected Sendspin client."""
+        self._unsubscribe_client_callbacks()
+        self.api = sendspin_client
+        self._refresh_client_info(sendspin_client, extra_identifiers)
+        self._subscribe_client_callbacks()
+        self._sync_state_from_group()
+        await self._sync_membership_from_group(sendspin_client.group)
+        await self._apply_preferred_format()
+        self.update_state(force_update=True)
 
     @property
     def _artwork_role(self) -> ArtworkGroupRole | None:
@@ -302,7 +377,8 @@ class SendspinPlayer(Player):
                 self._attr_volume_muted = muted
                 self.update_state()
             case ClientGroupChangedEvent(new_group=new_group):
-                self.unsub_group_event_cb()
+                if self.unsub_group_event_cb is not None:
+                    self.unsub_group_event_cb()
                 self.unsub_group_event_cb = new_group.add_event_listener(self.group_event_cb)
                 if controller_role := self._controller_role:
                     controller_role.set_supported_commands(SUPPORTED_GROUP_COMMANDS)
@@ -683,5 +759,4 @@ class SendspinPlayer(Player):
         """Handle logic when the player is unloaded from the Player controller."""
         await self.playback_session.close()
         await super().on_unload()
-        self.unsub_event_cb()
-        self.unsub_group_event_cb()
+        self._unsubscribe_client_callbacks()

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -228,10 +228,12 @@ class SendspinPlayer(Player):
                 self._attr_device_info.add_identifier(id_type, id_value)
         # Add player_id as MAC identifier for protocol linking (if it's a valid MAC)
         # This enables linking with bridged players (e.g., AirPlay via Sendspin bridge)
-        if _mac := mac_from_bridge_client_id(self.player_id):
-            self._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, _mac)
-        elif is_valid_mac_address(self.player_id):
-            self._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, self.player_id)
+        # Skip if a MAC was already preserved (e.g. ARP-enriched) to avoid overwriting it.
+        if IdentifierType.MAC_ADDRESS not in self._attr_device_info.identifiers:
+            if _mac := mac_from_bridge_client_id(self.player_id):
+                self._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, _mac)
+            elif is_valid_mac_address(self.player_id):
+                self._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, self.player_id)
         if sendspin_client.info.player_support:
             for role in sendspin_client.roles_by_family("player"):
                 volume = role.get_player_volume()

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -135,7 +135,7 @@ class SendspinProvider(PlayerProvider):
                     existing_player._attr_name = (
                         hass_device["name_by_user"] or hass_device["name"] or existing_player.name
                     )
-                    existing_player.update_state(force_update=True)
+            await self.mass.players.register_or_update(existing_player)
             return
 
         player = SendspinPlayer(self, client_id)

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -27,8 +27,9 @@ class SendspinProvider(PlayerProvider):
 
     server_api: SendspinServer
     unregister_cbs: list[Callable[[], None]]
-    _pending_unregisters: dict[str, asyncio.Event]
     _bridge_identifiers: dict[str, dict[IdentifierType, str]]
+    _client_event_versions: dict[str, int]
+    _unloading: bool
 
     def __init__(
         self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
@@ -38,19 +39,37 @@ class SendspinProvider(PlayerProvider):
         self.server_api = SendspinServer(
             self.mass.loop, mass.server_id, "Music Assistant", self.mass.http_session
         )
-        self._pending_unregisters = {}
         self._bridge_identifiers = {}
+        self._client_event_versions = {}
+        self._unloading = False
         self.unregister_cbs = [
             self.server_api.add_event_listener(self.event_cb),
         ]
+
+    def _next_client_event_version(self, client_id: str) -> int:
+        """Increment and return the latest event version for a client id."""
+        version = self._client_event_versions.get(client_id, 0) + 1
+        self._client_event_versions[client_id] = version
+        return version
+
+    def _is_current_client_event(self, client_id: str, event_version: int) -> bool:
+        """Return True if the event version is still the latest for the client."""
+        return self._client_event_versions.get(client_id) == event_version
+
+    # _handle_client_added and _handle_client_removed are async and run concurrently as tasks.
+    # A fast reconnect can produce overlapping tasks: a remove task and an add task both in flight.
+    # Each event is assigned a monotonically increasing version; a task checks before acting whether
+    # its version is still the latest, and aborts if a newer event has superseded it.
 
     def event_cb(self, server: SendspinServer, event: SendspinEvent) -> None:
         """Event callback registered to the sendspin server."""
         match event:
             case ClientAddedEvent(client_id):
-                self.mass.create_task(self._handle_client_added(client_id))
+                event_version = self._next_client_event_version(client_id)
+                self.mass.create_task(self._handle_client_added(client_id, event_version))
             case ClientRemovedEvent(client_id):
-                self.mass.create_task(self._handle_client_removed(client_id))
+                event_version = self._next_client_event_version(client_id)
+                self.mass.create_task(self._handle_client_removed(client_id, event_version))
             case _:
                 self.logger.error("Unknown sendspin event: %s", event)
 
@@ -68,22 +87,18 @@ class SendspinProvider(PlayerProvider):
         """
         self._bridge_identifiers[client_id] = identifiers
 
-    async def _handle_client_added(self, client_id: str) -> None:
+    async def _handle_client_added(self, client_id: str, event_version: int) -> None:
         """Handle a new client connection asynchronously."""
+        if self._unloading:
+            return
         # Yield to allow any synchronous registration (like register_external_player) to complete
         # This is needed because ClientAddedEvent fires during get_or_create_client, before
         # preload_hello sets the client info
         await asyncio.sleep(0)
-        # Wait for any pending unregister to complete before registering
-        # This prevents a race condition where a slow unregister removes
-        # a newly registered player after a quick reconnect
-        if pending_event := self._pending_unregisters.get(client_id):
-            self.logger.debug("Waiting for pending unregister of %s before registering", client_id)
-            await pending_event.wait()
         # Check if client still exists (may have disconnected while waiting)
         sendspin_client = self.server_api.get_client(client_id)
         if sendspin_client is None:
-            self.logger.debug("Client %s gone after waiting for pending unregister", client_id)
+            self.logger.debug("Client %s disconnected before hello completed", client_id)
             return
         # Wait for client hello to be processed (info becomes available)
         # ClientAddedEvent fires before the hello handshake completes
@@ -94,18 +109,39 @@ class SendspinProvider(PlayerProvider):
         else:
             self.logger.warning("Client %s hello not received within timeout", client_id)
             return
-        if self.mass.players.get_player(client_id) is not None:
-            self.logger.debug(
-                "Client %s already registered, skipping duplicate add event", client_id
-            )
+        if not self._is_current_client_event(client_id, event_version):
+            self.logger.debug("Skipping stale add event for %s", client_id)
             return
         if not self.mass.config.get_raw_player_config_value(client_id, CONF_ENABLED, True):
             self.logger.debug("Ignoring disabled sendspin client: %s", client_id)
             return
+        extra_ids = self._bridge_identifiers.pop(client_id, None)
+        existing_player = self.mass.players.get_player(client_id)
+        if existing_player is not None:
+            if not isinstance(existing_player, SendspinPlayer):
+                self.logger.warning(
+                    "Skipping Sendspin reconnect for %s: registered player has unexpected type %s",
+                    client_id,
+                    type(existing_player).__name__,
+                )
+                return
+            await existing_player.reattach_client(sendspin_client, extra_ids)
+            self.logger.debug("Client %s reconnected", client_id)
+            if existing_player.device_info.manufacturer == "ESPHome" and (
+                hass := self.mass.get_provider("hass")
+            ):
+                hass = cast("HomeAssistantProvider", hass)
+                if hass_device := await hass.get_device_by_connection(client_id):
+                    existing_player._attr_name = (
+                        hass_device["name_by_user"] or hass_device["name"] or existing_player.name
+                    )
+                    existing_player.update_state(force_update=True)
+            return
+
         player = SendspinPlayer(self, client_id)
         # Apply any bridge identifiers that were pre-registered by the bridge manager.
         # This enables cross-protocol matching (e.g., Sendspin ↔ Chromecast via CAST_UUID).
-        if extra_ids := self._bridge_identifiers.pop(client_id, None):
+        if extra_ids:
             for id_type, id_value in extra_ids.items():
                 player.device_info.add_identifier(id_type, id_value)
         self.logger.debug("Client %s connected", client_id)
@@ -122,19 +158,28 @@ class SendspinProvider(PlayerProvider):
             await self.mass.players.register(player)
         except AlreadyRegisteredError:
             self.logger.debug("Client %s already registered while handling add event", client_id)
-            player.unsub_event_cb()
-            player.unsub_group_event_cb()
+            player._unsubscribe_client_callbacks()
 
-    async def _handle_client_removed(self, client_id: str) -> None:
+    async def _handle_client_removed(self, client_id: str, event_version: int) -> None:
         """Handle a client disconnection asynchronously."""
+        if self._unloading:
+            return
         self.logger.debug("Client %s disconnected", client_id)
-        unregister_event = asyncio.Event()
-        self._pending_unregisters[client_id] = unregister_event
-        try:
-            await self.mass.players.unregister(client_id)
-        finally:
-            self._pending_unregisters.pop(client_id, None)
-            unregister_event.set()
+        if not self._is_current_client_event(client_id, event_version):
+            self.logger.debug("Skipping stale remove event for %s", client_id)
+            return
+        if player := self.mass.players.get_player(client_id):
+            if isinstance(player, SendspinPlayer):
+                await player.mark_unavailable(
+                    still_valid=lambda: self._is_current_client_event(client_id, event_version)
+                )
+                return
+            self.logger.warning(
+                "Skipping Sendspin disconnect handling for %s: registered player has unexpected "
+                "type %s",
+                client_id,
+                type(player).__name__,
+            )
 
     @property
     def supported_features(self) -> set[ProviderFeature]:
@@ -162,6 +207,8 @@ class SendspinProvider(PlayerProvider):
 
         :param is_removed: True when the provider is removed from the configuration.
         """
+        self._unloading = True
+        player_ids = [player.player_id for player in self.players]
         # Disconnect all clients before stopping the server
         clients = list(self.server_api.clients)
         connected_clients = []
@@ -185,3 +232,10 @@ class SendspinProvider(PlayerProvider):
         for cb in self.unregister_cbs:
             cb()
         self.unregister_cbs = []
+        await asyncio.gather(
+            *(
+                self.mass.players.unregister(player_id, permanent=is_removed)
+                for player_id in player_ids
+            ),
+            return_exceptions=True,
+        )


### PR DESCRIPTION
## Summary
Do not unregister offline Sendspin players to keep the queue in memory.

With this PR, Sendspin players now remain registered and are only marked as unavailable, preserving the queue.

## Description

The Sendspin provider was previously calling `unregister` whenever a player/client went offline.
This had one major drawback: unregistering a player also deleted that player's queue.
While merged players created a Universal player, which solved this issue for most clients (since they have the type `PROTOCOL`), Sendspin-only clients are of type `PLAYER`.
This means that the clients most susceptible to network interruptions are also the ones whose queue gets cleared most often: the Web Player and Mobile Apps.

## Alternative Solutions

Alternatively, we could keep Sendspin using `unregister` for offline players and instead preserve queues after calling `PlayerController.unregister(permanent=False)`.
This would also fix the issue for other providers that unregister players, but it might introduce unexpected issues with dangling queues.