### PR TITLE
Validate player control config references before using them

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -76,11 +76,14 @@ from music_assistant.constants import (
     CONF_ENTRY_ANNOUNCE_VOLUME_STRATEGY,
     CONF_ENTRY_TTS_PRE_ANNOUNCE,
     CONF_ENTRY_ZEROCONF_INTERFACES,
+    CONF_MUTE_CONTROL,
     CONF_PLAYER_DSP,
     CONF_PLAYERS,
+    CONF_POWER_CONTROL,
     CONF_PRE_ANNOUNCE_CHIME_URL,
     CONF_PROTOCOL_PARENT_ID,
     CONF_REPORTED_MAC,
+    CONF_VOLUME_CONTROL,
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
@@ -159,6 +162,13 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """Async initialize of module."""
         self._cleanup_stale_protocol_parent_ids()
         self._poll_task = self.mass.create_task(self._poll_players())
+        # schedule a one-time reconciliation of stale control configs
+        # after all providers have had time to register their players
+        self.mass.call_later(
+            30,
+            self._reconcile_stale_control_configs,
+            task_id="reconcile_stale_control_configs",
+        )
 
     async def close(self) -> None:
         """Cleanup on exit."""
@@ -2161,6 +2171,43 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 )
                 conf_key = f"{CONF_PLAYERS}/{player_id}/values/{CONF_PROTOCOL_PARENT_ID}"
                 self.mass.config.set(conf_key, None)
+
+    async def _reconcile_stale_control_configs(self) -> None:
+        """One-time post-startup pass to clear control configs that don't resolve.
+
+        Runs ~30 seconds after startup, by which time all providers (including
+        async ones like Sendspin) should have registered their players.
+        Any control config value that still doesn't resolve to a known constant,
+        registered player, or registered player control is cleared so that
+        auto-detection can take over.
+        """
+        known_constants = {PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE}
+        control_keys = (CONF_VOLUME_CONTROL, CONF_MUTE_CONTROL, CONF_POWER_CONTROL)
+        cleared = 0
+        for player in list(self._players.values()):
+            player_cleared = False
+            for conf_key in control_keys:
+                raw = self.mass.config.get_raw_player_config_value(player.player_id, conf_key)
+                if raw is None:
+                    continue
+                raw_str = str(raw)
+                if raw_str in known_constants:
+                    continue
+                if self.get_player(raw_str) or self.get_player_control(raw_str):
+                    continue
+                self.logger.info(
+                    "Clearing stale %s config '%s' for player %s (not resolved after startup)",
+                    conf_key,
+                    raw_str,
+                    player.player_id,
+                )
+                self.mass.config.set_raw_player_config_value(player.player_id, conf_key, None)
+                player_cleared = True
+                cleared += 1
+            if player_cleared:
+                player.update_state()
+        if cleared:
+            self.logger.info("Reconciliation complete: cleared %d stale control config(s)", cleared)
 
     async def _poll_players(self) -> None:
         """Background task that polls players for updates."""

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -756,30 +756,37 @@ class Player(ABC):
         return cast("str", self._config.get_value(CONF_ENTRY_PLAYER_ICON.key))
 
     def _resolve_control_config(self, conf_key: str) -> str | None:
-        """Validate a control config value references an existing player or control.
+        """Return the explicitly configured control value, or None if not set.
 
-        Returns the config value if it's a known constant or resolves to an existing
-        player/control, or None if stale (so the caller can fall through to auto-detection).
+        If a value is explicitly configured (raw value is not None), it is always returned
+        — even if it doesn't currently resolve to a registered player or control. This
+        handles the case where protocol players register asynchronously and the configured
+        player will appear shortly after startup.
+
+        Returns None only when no value has been explicitly configured, signaling the
+        caller to fall through to auto-detection.
 
         :param conf_key: The config key to look up (e.g. CONF_VOLUME_CONTROL).
         """
-        if conf := self.mass.config.get_raw_player_config_value(self.player_id, conf_key):
-            conf_str = str(conf)
-            if conf_str in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
-                return conf_str
-            if self.mass.players.get_player(conf_str) or self.mass.players.get_player_control(
-                conf_str
-            ):
-                return conf_str
-            # configured ID doesn't resolve to any known player or control
-            self.logger.warning(
-                "Configured %s value '%s' for player %s references a nonexistent "
-                "player/control, falling back to auto-detection",
+        conf = self.mass.config.get_raw_player_config_value(self.player_id, conf_key)
+        if conf is None:
+            return None
+        conf_str = str(conf)
+        if not conf_str:
+            return None
+        if (
+            conf_str not in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE)
+            and not self.mass.players.get_player(conf_str)
+            and not self.mass.players.get_player_control(conf_str)
+        ):
+            self.logger.debug(
+                "Configured %s value '%s' for player %s does not currently resolve "
+                "to a registered player/control",
                 conf_key,
                 conf_str,
                 self.player_id,
             )
-        return None
+        return conf_str
 
     @cached_property
     @final

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -755,12 +755,38 @@ class Player(ABC):
         """Return the player icon."""
         return cast("str", self._config.get_value(CONF_ENTRY_PLAYER_ICON.key))
 
+    def _resolve_control_config(self, conf_key: str) -> str | None:
+        """Validate a control config value references an existing player or control.
+
+        Returns the config value if it's a known constant or resolves to an existing
+        player/control, or None if stale (so the caller can fall through to auto-detection).
+
+        :param conf_key: The config key to look up (e.g. CONF_VOLUME_CONTROL).
+        """
+        if conf := self.mass.config.get_raw_player_config_value(self.player_id, conf_key):
+            conf_str = str(conf)
+            if conf_str in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
+                return conf_str
+            if self.mass.players.get_player(conf_str) or self.mass.players.get_player_control(
+                conf_str
+            ):
+                return conf_str
+            # configured ID doesn't resolve to any known player or control
+            self.logger.warning(
+                "Configured %s value '%s' for player %s references a nonexistent "
+                "player/control, falling back to auto-detection",
+                conf_key,
+                conf_str,
+                self.player_id,
+            )
+        return None
+
     @cached_property
     @final
     def power_control(self) -> str:
         """Return the power control type."""
-        if conf := self.mass.config.get_raw_player_config_value(self.player_id, CONF_POWER_CONTROL):
-            return str(conf)
+        if resolved := self._resolve_control_config(CONF_POWER_CONTROL):
+            return resolved
         # not explicitly set, use native if supported
         if PlayerFeature.POWER in self.supported_features:
             return PLAYER_CONTROL_NATIVE
@@ -773,10 +799,8 @@ class Player(ABC):
     @final
     def volume_control(self) -> str:
         """Return the volume control type."""
-        if conf := self.mass.config.get_raw_player_config_value(
-            self.player_id, CONF_VOLUME_CONTROL
-        ):
-            return str(conf)
+        if resolved := self._resolve_control_config(CONF_VOLUME_CONTROL):
+            return resolved
         # not explicitly set, use native if supported
         if PlayerFeature.VOLUME_SET in self.supported_features:
             return PLAYER_CONTROL_NATIVE
@@ -789,8 +813,8 @@ class Player(ABC):
     @final
     def mute_control(self) -> str:
         """Return the mute control type."""
-        if conf := self.mass.config.get_raw_player_config_value(self.player_id, CONF_MUTE_CONTROL):
-            return str(conf)
+        if resolved := self._resolve_control_config(CONF_MUTE_CONTROL):
+            return resolved
         # not explicitly set, use native if supported
         if PlayerFeature.VOLUME_MUTE in self.supported_features:
             return PLAYER_CONTROL_NATIVE

--- a/tests/core/test_player_control_config.py
+++ b/tests/core/test_player_control_config.py
@@ -1,13 +1,17 @@
-"""Tests for player control config validation (volume, mute, power).
+"""Tests for player control config resolution (volume, mute, power).
 
-Verifies that stale config values (referencing players/controls that no longer exist)
-fall through to auto-detection instead of being blindly trusted.
+Verifies that:
+- Explicitly configured values are always returned (even if not yet resolvable)
+- Only unset configs (raw value is None) trigger auto-detection fallthrough
+- Debug logging fires when a configured value doesn't currently resolve
+- Post-startup reconciliation clears stale configs
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from music_assistant_models.constants import (
@@ -18,7 +22,9 @@ from music_assistant_models.constants import (
 from music_assistant_models.enums import PlayerFeature
 from music_assistant_models.player import OutputProtocol
 
-from music_assistant.constants import CONF_VOLUME_CONTROL
+from music_assistant.constants import CONF_MUTE_CONTROL, CONF_POWER_CONTROL, CONF_VOLUME_CONTROL
+from music_assistant.controllers.players import PlayerController
+from music_assistant.helpers.throttle_retry import Throttler
 from tests.common import MockPlayer, MockProvider
 
 
@@ -52,10 +58,10 @@ def player(mock_mass: MagicMock) -> MockPlayer:
 
 
 class TestResolveControlConfig:
-    """Test _resolve_control_config validation logic."""
+    """Test _resolve_control_config resolution logic."""
 
     def test_returns_native_constant(self, player: MockPlayer, mock_mass: MagicMock) -> None:
-        """Known constants are returned directly without player lookup."""
+        """Known constants are returned directly."""
         mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_NATIVE
         assert player._resolve_control_config(CONF_VOLUME_CONTROL) == PLAYER_CONTROL_NATIVE
 
@@ -65,100 +71,90 @@ class TestResolveControlConfig:
         assert player._resolve_control_config(CONF_VOLUME_CONTROL) == PLAYER_CONTROL_FAKE
 
     def test_returns_none_constant(self, player: MockPlayer, mock_mass: MagicMock) -> None:
-        """NONE constant is returned directly."""
+        """NONE constant (the string, not Python None) is returned directly."""
         mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_NONE
         assert player._resolve_control_config(CONF_VOLUME_CONTROL) == PLAYER_CONTROL_NONE
 
     def test_returns_valid_player_id(self, player: MockPlayer, mock_mass: MagicMock) -> None:
-        """Config referencing an existing player is accepted."""
+        """Config referencing an existing player is returned."""
         mock_mass.config.get_raw_player_config_value.return_value = "other_player_id"
-        mock_mass.players.get_player.return_value = MagicMock()  # player exists
+        mock_mass.players.get_player.return_value = MagicMock()
         assert player._resolve_control_config(CONF_VOLUME_CONTROL) == "other_player_id"
 
     def test_returns_valid_player_control_id(
         self, player: MockPlayer, mock_mass: MagicMock
     ) -> None:
-        """Config referencing an existing player control is accepted."""
+        """Config referencing an existing player control is returned."""
         mock_mass.config.get_raw_player_config_value.return_value = "some_control_id"
         mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = MagicMock()  # control exists
+        mock_mass.players.get_player_control.return_value = MagicMock()
         assert player._resolve_control_config(CONF_VOLUME_CONTROL) == "some_control_id"
 
-    def test_stale_config_returns_none(self, player: MockPlayer, mock_mass: MagicMock) -> None:
-        """Config referencing a nonexistent player/control returns None."""
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_player_id"
+    def test_unresolvable_config_still_returned(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Explicitly set config is returned even if it doesn't currently resolve."""
+        mock_mass.config.get_raw_player_config_value.return_value = "not_yet_registered_player"
         mock_mass.players.get_player.return_value = None
         mock_mass.players.get_player_control.return_value = None
-        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) == "not_yet_registered_player"
 
     def test_no_config_returns_none(self, player: MockPlayer, mock_mass: MagicMock) -> None:
-        """No config value at all returns None."""
+        """No config value (raw None) returns None for auto-detection."""
         mock_mass.config.get_raw_player_config_value.return_value = None
         assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
 
-    def test_empty_string_config_returns_none(
-        self, player: MockPlayer, mock_mass: MagicMock
-    ) -> None:
-        """Empty string config is treated as unset (falsy walrus operator)."""
+    def test_empty_string_treated_as_unset(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """Empty string config is treated as unset, returning None for auto-detection."""
         mock_mass.config.get_raw_player_config_value.return_value = ""
         assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
 
-    def test_integer_config_treated_as_stale(
-        self, player: MockPlayer, mock_mass: MagicMock
-    ) -> None:
-        """Non-string config values are coerced via str() and treated as stale."""
-        mock_mass.config.get_raw_player_config_value.return_value = 42
-        mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = None
-        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
-
-    def test_bool_false_config_returns_none(self, player: MockPlayer, mock_mass: MagicMock) -> None:
-        """False is falsy, so the walrus operator skips it entirely."""
-        mock_mass.config.get_raw_player_config_value.return_value = False
-        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
-
-    def test_bool_true_config_treated_as_stale(
-        self, player: MockPlayer, mock_mass: MagicMock
-    ) -> None:
-        """True is truthy but str(True)='True' won't match any player."""
-        mock_mass.config.get_raw_player_config_value.return_value = True
-        mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = None
-        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
-
-    def test_stale_config_logs_warning(
+    def test_unresolvable_config_logs_debug(
         self, player: MockPlayer, mock_mass: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Stale config emits a WARNING-level log with the stale ID and player ID."""
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_chromecast_id"
+        """Unresolvable config emits a DEBUG-level log."""
+        mock_mass.config.get_raw_player_config_value.return_value = "spb_notregisteredyet"
         mock_mass.players.get_player.return_value = None
         mock_mass.players.get_player_control.return_value = None
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG):
             player._resolve_control_config(CONF_VOLUME_CONTROL)
-        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert len(warning_records) == 1
-        assert "deleted_chromecast_id" in warning_records[0].message
-        assert "test_player" in warning_records[0].message
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("spb_notregisteredyet" in r.message for r in debug_records)
+        assert any("test_player" in r.message for r in debug_records)
 
-
-class TestVolumeControlFallthrough:
-    """Test that volume_control falls through to auto-detection on stale config."""
-
-    def test_stale_config_falls_through_to_native(
-        self, player: MockPlayer, mock_mass: MagicMock
+    def test_resolvable_config_no_debug_log(
+        self, player: MockPlayer, mock_mass: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Stale volume config falls through to NATIVE when player supports VOLUME_SET."""
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_chromecast_id"
-        mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = None
+        """Config that resolves to an existing player does not log."""
+        mock_mass.config.get_raw_player_config_value.return_value = "existing_player"
+        mock_mass.players.get_player.return_value = MagicMock()
+        with caplog.at_level(logging.DEBUG):
+            player._resolve_control_config(CONF_VOLUME_CONTROL)
+        assert not any("does not currently resolve" in r.message for r in caplog.records)
+
+    def test_known_constant_no_debug_log(
+        self, player: MockPlayer, mock_mass: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Known constants do not trigger the debug log."""
+        mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_NATIVE
+        with caplog.at_level(logging.DEBUG):
+            player._resolve_control_config(CONF_VOLUME_CONTROL)
+        assert not any("does not currently resolve" in r.message for r in caplog.records)
+
+
+class TestVolumeControlAutoDetection:
+    """Test volume_control auto-detection when no config is set."""
+
+    def test_no_config_native_support(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """No config with native volume support auto-detects to NATIVE."""
+        mock_mass.config.get_raw_player_config_value.return_value = None
         assert player.volume_control == PLAYER_CONTROL_NATIVE
 
-    def test_stale_config_no_native_falls_to_protocol_player(
+    def test_no_config_protocol_player_fallthrough(
         self, player: MockPlayer, mock_mass: MagicMock
     ) -> None:
-        """Stale config without native support falls through to protocol player."""
-        player._attr_supported_features = set()  # no native volume
-        # set up a linked protocol player with volume support
+        """No config without native support falls through to protocol player."""
+        player._attr_supported_features = set()
         protocol_player = MagicMock()
         protocol_player.player_id = "ap_protocol_player"
         protocol_player.available = True
@@ -173,45 +169,43 @@ class TestVolumeControlFallthrough:
             ]
         )
         player._cache.clear()
-
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_player_id"
-        # stale ID returns None, but protocol player lookup returns the player
+        mock_mass.config.get_raw_player_config_value.return_value = None
         mock_mass.players.get_player.side_effect = (
             lambda pid: protocol_player if pid == "ap_protocol_player" else None
         )
-        mock_mass.players.get_player_control.return_value = None
-
         assert player.volume_control == "ap_protocol_player"
 
-    def test_stale_config_no_native_no_protocol_falls_to_none(
+    def test_no_config_no_native_no_protocol_falls_to_none(
         self, player: MockPlayer, mock_mass: MagicMock
     ) -> None:
-        """Stale config with no native support and no protocol player falls to NONE."""
+        """No config with no native support and no protocol player falls to NONE."""
         player._attr_supported_features = set()
         player._cache.clear()
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_player_id"
+        mock_mass.config.get_raw_player_config_value.return_value = None
         mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = None
         assert player.volume_control == PLAYER_CONTROL_NONE
 
-
-class TestMuteControlFallthrough:
-    """Test that mute_control falls through to auto-detection on stale config."""
-
-    def test_stale_config_falls_through_to_native(
-        self, player: MockPlayer, mock_mass: MagicMock
-    ) -> None:
-        """Stale mute config falls through to NATIVE when player supports VOLUME_MUTE."""
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+    def test_explicit_config_always_used(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """Explicitly set config is used even if the player doesn't exist yet."""
+        mock_mass.config.get_raw_player_config_value.return_value = "spb_notregisteredyet"
         mock_mass.players.get_player.return_value = None
         mock_mass.players.get_player_control.return_value = None
+        assert player.volume_control == "spb_notregisteredyet"
+
+
+class TestMuteControlAutoDetection:
+    """Test mute_control auto-detection when no config is set."""
+
+    def test_no_config_native_support(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """No config with native mute support auto-detects to NATIVE."""
+        mock_mass.config.get_raw_player_config_value.return_value = None
         assert player.mute_control == PLAYER_CONTROL_NATIVE
 
-    def test_stale_config_no_native_falls_to_protocol_player(
+    def test_no_config_protocol_player_fallthrough(
         self, player: MockPlayer, mock_mass: MagicMock
     ) -> None:
-        """Stale mute config without native support falls through to protocol player."""
-        player._attr_supported_features = set()  # no native mute
+        """No config without native support falls through to protocol player."""
+        player._attr_supported_features = set()
         protocol_player = MagicMock()
         protocol_player.player_id = "ap_protocol_player"
         protocol_player.available = True
@@ -226,56 +220,45 @@ class TestMuteControlFallthrough:
             ]
         )
         player._cache.clear()
-
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.config.get_raw_player_config_value.return_value = None
         mock_mass.players.get_player.side_effect = (
             lambda pid: protocol_player if pid == "ap_protocol_player" else None
         )
-        mock_mass.players.get_player_control.return_value = None
-
         assert player.mute_control == "ap_protocol_player"
 
-    def test_stale_config_no_native_no_protocol_falls_to_none(
+    def test_no_config_no_native_no_protocol_falls_to_none(
         self, player: MockPlayer, mock_mass: MagicMock
     ) -> None:
-        """Stale mute config with no native support and no protocol player falls to NONE."""
+        """No config with no native support and no protocol player falls to NONE."""
         player._attr_supported_features = set()
         player._cache.clear()
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.config.get_raw_player_config_value.return_value = None
         mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = None
         assert player.mute_control == PLAYER_CONTROL_NONE
 
 
-class TestPowerControlFallthrough:
-    """Test that power_control falls through to auto-detection on stale config."""
+class TestPowerControlAutoDetection:
+    """Test power_control auto-detection when no config is set."""
 
-    def test_stale_config_falls_through_to_none(
+    def test_no_config_no_native_falls_to_none(
         self, player: MockPlayer, mock_mass: MagicMock
     ) -> None:
-        """Stale power config falls through to NONE (no native power support)."""
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
-        mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = None
-        # MockPlayer doesn't have POWER feature by default
+        """No config without native power support falls to NONE."""
+        mock_mass.config.get_raw_player_config_value.return_value = None
         assert player.power_control == PLAYER_CONTROL_NONE
 
-    def test_stale_config_falls_through_to_native(
-        self, player: MockPlayer, mock_mass: MagicMock
-    ) -> None:
-        """Stale power config falls through to NATIVE when player supports POWER."""
+    def test_no_config_native_support(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """No config with native power support auto-detects to NATIVE."""
         player._attr_supported_features.add(PlayerFeature.POWER)
         player._cache.clear()
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
-        mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = None
+        mock_mass.config.get_raw_player_config_value.return_value = None
         assert player.power_control == PLAYER_CONTROL_NATIVE
 
-    def test_stale_config_ignores_protocol_player_with_power(
+    def test_no_config_ignores_protocol_player_with_power(
         self, player: MockPlayer, mock_mass: MagicMock
     ) -> None:
         """Power control deliberately skips protocol player fallthrough."""
-        player._attr_supported_features = set()  # no native power
+        player._attr_supported_features = set()
         protocol_player = MagicMock()
         protocol_player.player_id = "ap_protocol_player"
         protocol_player.available = True
@@ -290,72 +273,217 @@ class TestPowerControlFallthrough:
             ]
         )
         player._cache.clear()
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.config.get_raw_player_config_value.return_value = None
         mock_mass.players.get_player.side_effect = (
             lambda pid: protocol_player if pid == "ap_protocol_player" else None
         )
-        mock_mass.players.get_player_control.return_value = None
         assert player.power_control == PLAYER_CONTROL_NONE
 
 
 class TestCacheInvalidationLifecycle:
     """Test that cached properties re-evaluate correctly after cache invalidation."""
 
-    def test_stale_config_becomes_valid_after_cache_clear(
+    def test_unresolvable_config_resolves_after_player_registers(
         self, player: MockPlayer, mock_mass: MagicMock
     ) -> None:
-        """Config pointing to a not-yet-registered player resolves after cache clear."""
-        target_player = MagicMock()
-        mock_mass.config.get_raw_player_config_value.return_value = "other_player_id"
+        """Config pointing to a not-yet-registered player works once it registers."""
+        mock_mass.config.get_raw_player_config_value.return_value = "spb_bridge_player"
         mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = None
 
-        # first evaluation: player not registered yet, falls through to native
-        assert player.volume_control == PLAYER_CONTROL_NATIVE
+        # first evaluation: player not registered yet, but config is returned anyway
+        assert player.volume_control == "spb_bridge_player"
 
         # player registers, cache cleared (simulates update_state)
-        mock_mass.players.get_player.return_value = target_player
-        player._cache.clear()
-
-        # second evaluation: config now resolves
-        assert player.volume_control == "other_player_id"
-
-    def test_valid_config_becomes_stale_after_cache_clear(
-        self, player: MockPlayer, mock_mass: MagicMock
-    ) -> None:
-        """Config pointing to a removed player falls through after cache clear."""
-        target_player = MagicMock()
-        mock_mass.config.get_raw_player_config_value.return_value = "other_player_id"
-        mock_mass.players.get_player.return_value = target_player
-        mock_mass.players.get_player_control.return_value = None
-
-        # first evaluation: player exists, config resolves
-        assert player.volume_control == "other_player_id"
-
-        # player removed, cache cleared
-        mock_mass.players.get_player.return_value = None
-        player._cache.clear()
-
-        # second evaluation: falls through to native
-        assert player.volume_control == PLAYER_CONTROL_NATIVE
-
-    def test_cached_value_persists_without_clear(
-        self, player: MockPlayer, mock_mass: MagicMock
-    ) -> None:
-        """Cached property retains its value until cache is explicitly cleared."""
-        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
-        mock_mass.players.get_player.return_value = None
-        mock_mass.players.get_player_control.return_value = None
-
-        # first evaluation: stale, falls through to native
-        assert player.volume_control == PLAYER_CONTROL_NATIVE
-
-        # change mock to make it resolve, but DON'T clear cache
         mock_mass.players.get_player.return_value = MagicMock()
+        player._cache.clear()
 
-        # cached value persists (still NATIVE)
+        # second evaluation: same value, now resolvable
+        assert player.volume_control == "spb_bridge_player"
+
+    def test_no_config_auto_detects_then_persists(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """No config auto-detects to NATIVE and caches the result."""
+        mock_mass.config.get_raw_player_config_value.return_value = None
         assert player.volume_control == PLAYER_CONTROL_NATIVE
 
-        # only after clearing does it re-evaluate
+        # even if config changes underneath, cached value persists
+        mock_mass.config.get_raw_player_config_value.return_value = "new_player_id"
+        assert player.volume_control == PLAYER_CONTROL_NATIVE
+
+        # only after clearing does it pick up the new config
         player._cache.clear()
-        assert player.volume_control == "deleted_id"
+        assert player.volume_control == "new_player_id"
+
+
+class TestReconcileStaleControlConfigs:
+    """Test the controller's post-startup reconciliation of stale control configs."""
+
+    @pytest.fixture
+    def controller_with_player(
+        self, mock_mass: MagicMock, player: MockPlayer
+    ) -> tuple[PlayerController, MockPlayer]:
+        """Create a PlayerController with a registered player."""
+        ctrl = PlayerController(mock_mass)
+        ctrl._players = {player.player_id: player}
+        ctrl._player_throttlers = {player.player_id: Throttler(1, 0.05)}
+        mock_mass.players = ctrl
+        return ctrl, player
+
+    def test_clears_stale_volume_config(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """Stale volume config referencing a nonexistent player is cleared."""
+        ctrl, player = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_chromecast_id"
+        asyncio.run(ctrl._reconcile_stale_control_configs())
+        mock_mass.config.set_raw_player_config_value.assert_any_call(
+            player.player_id, CONF_VOLUME_CONTROL, None
+        )
+
+    def test_clears_all_three_stale_configs(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """All three control configs are cleared when all are stale."""
+        ctrl, _player = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = "nonexistent_player"
+        asyncio.run(ctrl._reconcile_stale_control_configs())
+        calls = mock_mass.config.set_raw_player_config_value.call_args_list
+        cleared_keys = {call.args[1] for call in calls}
+        assert cleared_keys == {CONF_VOLUME_CONTROL, CONF_MUTE_CONTROL, CONF_POWER_CONTROL}
+
+    def test_preserves_native_constant(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """NATIVE constant is not cleared."""
+        ctrl, _ = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_NATIVE
+        asyncio.run(ctrl._reconcile_stale_control_configs())
+        mock_mass.config.set_raw_player_config_value.assert_not_called()
+
+    def test_preserves_fake_constant(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """FAKE constant is not cleared."""
+        ctrl, _ = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_FAKE
+        asyncio.run(ctrl._reconcile_stale_control_configs())
+        mock_mass.config.set_raw_player_config_value.assert_not_called()
+
+    def test_preserves_none_constant(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """NONE constant (the string) is not cleared."""
+        ctrl, _ = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_NONE
+        asyncio.run(ctrl._reconcile_stale_control_configs())
+        mock_mass.config.set_raw_player_config_value.assert_not_called()
+
+    def test_preserves_resolvable_player_id(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """Config pointing to a registered player is not cleared."""
+        ctrl, _ = controller_with_player
+        other = MagicMock()
+        other.player_id = "other_player"
+        ctrl._players["other_player"] = other
+        mock_mass.config.get_raw_player_config_value.return_value = "other_player"
+        asyncio.run(ctrl._reconcile_stale_control_configs())
+        mock_mass.config.set_raw_player_config_value.assert_not_called()
+
+    def test_preserves_resolvable_player_control_id(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """Config pointing to a registered player control is not cleared."""
+        ctrl, _ = controller_with_player
+        ctrl._controls["some_control_id"] = MagicMock()
+        mock_mass.config.get_raw_player_config_value.return_value = "some_control_id"
+        asyncio.run(ctrl._reconcile_stale_control_configs())
+        mock_mass.config.set_raw_player_config_value.assert_not_called()
+
+    def test_preserves_unset_config(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """None (unset) config is left alone — auto-detection handles it."""
+        ctrl, _ = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = None
+        asyncio.run(ctrl._reconcile_stale_control_configs())
+        mock_mass.config.set_raw_player_config_value.assert_not_called()
+
+    def test_calls_update_state_on_affected_player(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """update_state is called on players that had stale configs cleared."""
+        ctrl, player = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = "stale_id"
+        with patch.object(player, "update_state") as mock_update:
+            asyncio.run(ctrl._reconcile_stale_control_configs())
+            mock_update.assert_called_once()
+
+    def test_no_update_state_when_nothing_cleared(
+        self, controller_with_player: tuple[PlayerController, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """update_state is not called when no configs were cleared."""
+        ctrl, player = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_NATIVE
+        with patch.object(player, "update_state") as mock_update:
+            asyncio.run(ctrl._reconcile_stale_control_configs())
+            mock_update.assert_not_called()
+
+    def test_logs_summary_when_configs_cleared(
+        self,
+        controller_with_player: tuple[PlayerController, MockPlayer],
+        mock_mass: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A summary log is emitted when stale configs are cleared."""
+        ctrl, _ = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = "stale_id"
+        with caplog.at_level(logging.INFO):
+            asyncio.run(ctrl._reconcile_stale_control_configs())
+        assert any("Reconciliation complete" in r.message for r in caplog.records)
+
+    def test_no_summary_log_when_nothing_cleared(
+        self,
+        controller_with_player: tuple[PlayerController, MockPlayer],
+        mock_mass: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No summary log when all configs are valid."""
+        ctrl, _ = controller_with_player
+        mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_NATIVE
+        with caplog.at_level(logging.INFO):
+            asyncio.run(ctrl._reconcile_stale_control_configs())
+        assert not any("Reconciliation complete" in r.message for r in caplog.records)
+
+    def test_only_affected_player_gets_update_state(self, mock_mass: MagicMock) -> None:
+        """With two players, update_state is called only on the one with stale config."""
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        stale_player = MockPlayer(provider, "stale_player", "Stale Player")
+        valid_player = MockPlayer(provider, "valid_player", "Valid Player")
+
+        ctrl = PlayerController(mock_mass)
+        ctrl._players = {
+            "stale_player": stale_player,
+            "valid_player": valid_player,
+        }
+        ctrl._player_throttlers = {
+            "stale_player": Throttler(1, 0.05),
+            "valid_player": Throttler(1, 0.05),
+        }
+        mock_mass.players = ctrl
+
+        def config_side_effect(player_id: str, _key: str) -> str | None:
+            if player_id == "stale_player":
+                return "deleted_chromecast_id"
+            return PLAYER_CONTROL_NATIVE
+
+        mock_mass.config.get_raw_player_config_value.side_effect = config_side_effect
+
+        with (
+            patch.object(stale_player, "update_state") as mock_stale_update,
+            patch.object(valid_player, "update_state") as mock_valid_update,
+        ):
+            asyncio.run(ctrl._reconcile_stale_control_configs())
+            mock_stale_update.assert_called_once()
+            mock_valid_update.assert_not_called()

--- a/tests/core/test_player_control_config.py
+++ b/tests/core/test_player_control_config.py
@@ -1,0 +1,361 @@
+"""Tests for player control config validation (volume, mute, power).
+
+Verifies that stale config values (referencing players/controls that no longer exist)
+fall through to auto-detection instead of being blindly trusted.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.constants import (
+    PLAYER_CONTROL_FAKE,
+    PLAYER_CONTROL_NATIVE,
+    PLAYER_CONTROL_NONE,
+)
+from music_assistant_models.enums import PlayerFeature
+from music_assistant_models.player import OutputProtocol
+
+from music_assistant.constants import CONF_VOLUME_CONTROL
+from tests.common import MockPlayer, MockProvider
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock MusicAssistant instance."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.loop = None
+    mass.config = MagicMock()
+    mass.config.get = MagicMock(return_value=[])
+    mass.config.get_raw_player_config_value = MagicMock(return_value=None)
+    mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")
+    mass.config.set = MagicMock()
+    mass.signal_event = MagicMock()
+    mass.get_providers = MagicMock(return_value=[])
+    mass.players = MagicMock()
+    mass.players.get_player = MagicMock(return_value=None)
+    mass.players.get_player_control = MagicMock(return_value=None)
+    return mass
+
+
+@pytest.fixture
+def player(mock_mass: MagicMock) -> MockPlayer:
+    """Create a mock player with volume support."""
+    provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+    p = MockPlayer(provider, "test_player", "Test Player")
+    p._attr_supported_features = {PlayerFeature.VOLUME_SET, PlayerFeature.VOLUME_MUTE}
+    p._cache.clear()
+    return p
+
+
+class TestResolveControlConfig:
+    """Test _resolve_control_config validation logic."""
+
+    def test_returns_native_constant(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """Known constants are returned directly without player lookup."""
+        mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_NATIVE
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) == PLAYER_CONTROL_NATIVE
+
+    def test_returns_fake_constant(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """FAKE constant is returned directly."""
+        mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_FAKE
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) == PLAYER_CONTROL_FAKE
+
+    def test_returns_none_constant(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """NONE constant is returned directly."""
+        mock_mass.config.get_raw_player_config_value.return_value = PLAYER_CONTROL_NONE
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) == PLAYER_CONTROL_NONE
+
+    def test_returns_valid_player_id(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """Config referencing an existing player is accepted."""
+        mock_mass.config.get_raw_player_config_value.return_value = "other_player_id"
+        mock_mass.players.get_player.return_value = MagicMock()  # player exists
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) == "other_player_id"
+
+    def test_returns_valid_player_control_id(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Config referencing an existing player control is accepted."""
+        mock_mass.config.get_raw_player_config_value.return_value = "some_control_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = MagicMock()  # control exists
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) == "some_control_id"
+
+    def test_stale_config_returns_none(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """Config referencing a nonexistent player/control returns None."""
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_player_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
+
+    def test_no_config_returns_none(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """No config value at all returns None."""
+        mock_mass.config.get_raw_player_config_value.return_value = None
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
+
+    def test_empty_string_config_returns_none(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Empty string config is treated as unset (falsy walrus operator)."""
+        mock_mass.config.get_raw_player_config_value.return_value = ""
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
+
+    def test_integer_config_treated_as_stale(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Non-string config values are coerced via str() and treated as stale."""
+        mock_mass.config.get_raw_player_config_value.return_value = 42
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
+
+    def test_bool_false_config_returns_none(self, player: MockPlayer, mock_mass: MagicMock) -> None:
+        """False is falsy, so the walrus operator skips it entirely."""
+        mock_mass.config.get_raw_player_config_value.return_value = False
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
+
+    def test_bool_true_config_treated_as_stale(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """True is truthy but str(True)='True' won't match any player."""
+        mock_mass.config.get_raw_player_config_value.return_value = True
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        assert player._resolve_control_config(CONF_VOLUME_CONTROL) is None
+
+    def test_stale_config_logs_warning(
+        self, player: MockPlayer, mock_mass: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Stale config emits a WARNING-level log with the stale ID and player ID."""
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_chromecast_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        with caplog.at_level(logging.WARNING):
+            player._resolve_control_config(CONF_VOLUME_CONTROL)
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warning_records) == 1
+        assert "deleted_chromecast_id" in warning_records[0].message
+        assert "test_player" in warning_records[0].message
+
+
+class TestVolumeControlFallthrough:
+    """Test that volume_control falls through to auto-detection on stale config."""
+
+    def test_stale_config_falls_through_to_native(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Stale volume config falls through to NATIVE when player supports VOLUME_SET."""
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_chromecast_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        assert player.volume_control == PLAYER_CONTROL_NATIVE
+
+    def test_stale_config_no_native_falls_to_protocol_player(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Stale config without native support falls through to protocol player."""
+        player._attr_supported_features = set()  # no native volume
+        # set up a linked protocol player with volume support
+        protocol_player = MagicMock()
+        protocol_player.player_id = "ap_protocol_player"
+        protocol_player.available = True
+        protocol_player.supported_features = {PlayerFeature.VOLUME_SET}
+        player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="ap_protocol_player",
+                    name="AirPlay",
+                    protocol_domain="airplay",
+                )
+            ]
+        )
+        player._cache.clear()
+
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_player_id"
+        # stale ID returns None, but protocol player lookup returns the player
+        mock_mass.players.get_player.side_effect = (
+            lambda pid: protocol_player if pid == "ap_protocol_player" else None
+        )
+        mock_mass.players.get_player_control.return_value = None
+
+        assert player.volume_control == "ap_protocol_player"
+
+    def test_stale_config_no_native_no_protocol_falls_to_none(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Stale config with no native support and no protocol player falls to NONE."""
+        player._attr_supported_features = set()
+        player._cache.clear()
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_player_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        assert player.volume_control == PLAYER_CONTROL_NONE
+
+
+class TestMuteControlFallthrough:
+    """Test that mute_control falls through to auto-detection on stale config."""
+
+    def test_stale_config_falls_through_to_native(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Stale mute config falls through to NATIVE when player supports VOLUME_MUTE."""
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        assert player.mute_control == PLAYER_CONTROL_NATIVE
+
+    def test_stale_config_no_native_falls_to_protocol_player(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Stale mute config without native support falls through to protocol player."""
+        player._attr_supported_features = set()  # no native mute
+        protocol_player = MagicMock()
+        protocol_player.player_id = "ap_protocol_player"
+        protocol_player.available = True
+        protocol_player.supported_features = {PlayerFeature.VOLUME_MUTE}
+        player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="ap_protocol_player",
+                    name="AirPlay",
+                    protocol_domain="airplay",
+                )
+            ]
+        )
+        player._cache.clear()
+
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.players.get_player.side_effect = (
+            lambda pid: protocol_player if pid == "ap_protocol_player" else None
+        )
+        mock_mass.players.get_player_control.return_value = None
+
+        assert player.mute_control == "ap_protocol_player"
+
+    def test_stale_config_no_native_no_protocol_falls_to_none(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Stale mute config with no native support and no protocol player falls to NONE."""
+        player._attr_supported_features = set()
+        player._cache.clear()
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        assert player.mute_control == PLAYER_CONTROL_NONE
+
+
+class TestPowerControlFallthrough:
+    """Test that power_control falls through to auto-detection on stale config."""
+
+    def test_stale_config_falls_through_to_none(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Stale power config falls through to NONE (no native power support)."""
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        # MockPlayer doesn't have POWER feature by default
+        assert player.power_control == PLAYER_CONTROL_NONE
+
+    def test_stale_config_falls_through_to_native(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Stale power config falls through to NATIVE when player supports POWER."""
+        player._attr_supported_features.add(PlayerFeature.POWER)
+        player._cache.clear()
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+        assert player.power_control == PLAYER_CONTROL_NATIVE
+
+    def test_stale_config_ignores_protocol_player_with_power(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Power control deliberately skips protocol player fallthrough."""
+        player._attr_supported_features = set()  # no native power
+        protocol_player = MagicMock()
+        protocol_player.player_id = "ap_protocol_player"
+        protocol_player.available = True
+        protocol_player.supported_features = {PlayerFeature.POWER}
+        player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id="ap_protocol_player",
+                    name="AirPlay",
+                    protocol_domain="airplay",
+                )
+            ]
+        )
+        player._cache.clear()
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.players.get_player.side_effect = (
+            lambda pid: protocol_player if pid == "ap_protocol_player" else None
+        )
+        mock_mass.players.get_player_control.return_value = None
+        assert player.power_control == PLAYER_CONTROL_NONE
+
+
+class TestCacheInvalidationLifecycle:
+    """Test that cached properties re-evaluate correctly after cache invalidation."""
+
+    def test_stale_config_becomes_valid_after_cache_clear(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Config pointing to a not-yet-registered player resolves after cache clear."""
+        target_player = MagicMock()
+        mock_mass.config.get_raw_player_config_value.return_value = "other_player_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+
+        # first evaluation: player not registered yet, falls through to native
+        assert player.volume_control == PLAYER_CONTROL_NATIVE
+
+        # player registers, cache cleared (simulates update_state)
+        mock_mass.players.get_player.return_value = target_player
+        player._cache.clear()
+
+        # second evaluation: config now resolves
+        assert player.volume_control == "other_player_id"
+
+    def test_valid_config_becomes_stale_after_cache_clear(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Config pointing to a removed player falls through after cache clear."""
+        target_player = MagicMock()
+        mock_mass.config.get_raw_player_config_value.return_value = "other_player_id"
+        mock_mass.players.get_player.return_value = target_player
+        mock_mass.players.get_player_control.return_value = None
+
+        # first evaluation: player exists, config resolves
+        assert player.volume_control == "other_player_id"
+
+        # player removed, cache cleared
+        mock_mass.players.get_player.return_value = None
+        player._cache.clear()
+
+        # second evaluation: falls through to native
+        assert player.volume_control == PLAYER_CONTROL_NATIVE
+
+    def test_cached_value_persists_without_clear(
+        self, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Cached property retains its value until cache is explicitly cleared."""
+        mock_mass.config.get_raw_player_config_value.return_value = "deleted_id"
+        mock_mass.players.get_player.return_value = None
+        mock_mass.players.get_player_control.return_value = None
+
+        # first evaluation: stale, falls through to native
+        assert player.volume_control == PLAYER_CONTROL_NATIVE
+
+        # change mock to make it resolve, but DON'T clear cache
+        mock_mass.players.get_player.return_value = MagicMock()
+
+        # cached value persists (still NATIVE)
+        assert player.volume_control == PLAYER_CONTROL_NATIVE
+
+        # only after clearing does it re-evaluate
+        player._cache.clear()
+        assert player.volume_control == "deleted_id"


### PR DESCRIPTION
Myself and at least one other person have seen that, post-universal player consolidation, our WiiM devices always show 'zero' as the volume, and any changes aren't reflected. I believe that's not anything WiiM-specific, but that we previously had DNLA/Chromecast/whatever entries that aren't used anymore, but *are* being referenced on start. This fixes that, at least for me locally (I've been testing it all day).

The volume_control, mute_control, and power_control properties trusted config values without verifying the referenced player or control still exists. After the universal player consolidation, stale config entries (e.g. old Chromecast player IDs) caused volume commands to silently fail.

Now validates that config IDs resolve to known constants or existing players/controls before using them, falling through to auto-detection otherwise.