### PR TITLE
Prevent StreamDetails unnecessarily being loaded twice

### DIFF
--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -303,6 +303,8 @@ async def get_stream_details(
         else:
             preferred_providers = [x.provider_instance for x in media_item.provider_mappings]
         for allow_other_provider in (False, True):
+            if streamdetails:
+                break
             # sort by quality and check item's availability
             for prov_media in sorted(
                 media_item.provider_mappings, key=lambda x: x.quality or 0, reverse=True


### PR DESCRIPTION
The logic would only break out of the inner loop when a StreamDetails was found. So, even when a stream details was found in the first round of `for allow_other_provider in (False, True)`, it would still go a second round, causing the stream url to be resolved twice. This significantly affects slower providers such as YT Music and Apple Music.