### PR TITLE
Fix queue state loss on player re-register

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1329,6 +1329,10 @@ class PlayerQueuesController(CoreController):
             )
         self._queues.pop(player_id, None)
         self._queue_items.pop(player_id, None)
+        # Clear transient runtime state for this queue_id so a later re-register
+        # starts from restored cache state only (without stale compare/transition data).
+        self._prev_states.pop(player_id, None)
+        self._transitioning_players.discard(player_id)
 
     async def load_next_queue_item(
         self,

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1311,6 +1311,8 @@ class PlayerQueuesController(CoreController):
 
     def on_player_remove(self, player_id: str, permanent: bool) -> None:
         """Call when a player is removed from the registry."""
+        # cancel any pending play_index calls for this queue to prevent conflicts
+        self.mass.cancel_timer(f"queue_play_index_{player_id}")
         if permanent:
             # if the player is permanently removed, we also remove the cached queue data
             self.mass.create_task(

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1329,8 +1329,6 @@ class PlayerQueuesController(CoreController):
             )
         self._queues.pop(player_id, None)
         self._queue_items.pop(player_id, None)
-        # Clear transient runtime state for this queue_id so a later re-register
-        # starts from restored cache state only (without stale compare/transition data).
         self._prev_states.pop(player_id, None)
         self._transitioning_players.discard(player_id)
 


### PR DESCRIPTION
Fixes queues getting lost for players that get re-registered.
Particularly fixes the Sendspin Web Player loosing its queue.