### PR TITLE
Bump `aiosendspin` to 4.3.3

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin==4.3.2", "av==16.1.0"],
+  "requirements": ["aiosendspin==4.3.3", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
 aiorun==2025.1.1
-aiosendspin==4.3.2
+aiosendspin==4.3.3
 aioslimproto==3.1.7
 aiosonos==0.1.9
 aiosqlite==0.22.1


### PR DESCRIPTION
A couple of bugfixes for the sendspin provider.

Full list of changes: https://github.com/Sendspin/aiosendspin/releases/tag/4.3.3