### PR TITLE
Adjust musicbranz log message formatting

### DIFF
--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -973,9 +973,7 @@ class MetaDataController(CoreController):
         ref_albums_str = "/".join(x.name for x in ref_albums) or "none"
         ref_tracks_str = "/".join(x.name for x in ref_tracks) or "none"
         self.logger.debug(
-            "Unable to get musicbrainz ID for artist %s\n"
-            " - using lookup-album(s): %s\n"
-            " - using lookup-track(s): %s\n",
+            "Unable to get musicbrainz ID for artist %s (albums: %s, tracks: %s)",
             artist.name,
             ref_albums_str,
             ref_tracks_str,


### PR DESCRIPTION
Replace multiline log message (with embedded newlines) in _get_artist_musicbrainz_id with single-line format. This prevents continuation lines from appearing without timestamps or source info in log output.

Previous example output:

```
2026-03-10 16:49:46.600 DEBUG (MainThread) [music_assistant.metadata] Unable to get musicbrainz ID for artist Robin Pecknold
 - using lookup-album(s): none
 - using lookup-track(s): Be Fearless, Fortuna!/Meeting Spirit & Main Title/You Look Just Like Your Mom/You're the One/Fireflies/Stay Wild, Brave One/Wranglers/Spirit's Herd/Be Yourself/Silver Dagger
2026-03-10 16:49:46.621 DEBUG (MainThread) [music_assistant.music.artist] updated Robin Pecknold in database: 2433
2026-03-10 16:49:46.628 DEBUG (MainThread) [music_assistant.music.artist] updated Robin Pecknold in database: (id 2433)
```

I tagged this with `bugfix` but "very minor nitpick" would be more precise. This came from me staring at logs looking into something else and getting distracted by the 'bare' log lines flashing by in a different color than everything else.