### PR TITLE
Handle HEOS internal queue timeouts

### DIFF
--- a/music_assistant/providers/heos/__init__.py
+++ b/music_assistant/providers/heos/__init__.py
@@ -6,9 +6,11 @@ from typing import TYPE_CHECKING
 
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
+from pyheos.const import DEFAULT_TIMEOUT
 
 from music_assistant.constants import CONF_IP_ADDRESS
 
+from .constants import CONF_TIMEOUT
 from .provider import HeosPlayerProvider
 
 if TYPE_CHECKING:
@@ -53,6 +55,20 @@ async def get_config_entries(
             description="Hostname or IP address of the HEOS device "
             "to be used as the main controller. It is recommended to use a "
             "wired device as the main controller.",
-            category="advanced",
+            advanced=True,
+            requires_reload=True,
+        ),
+        ConfigEntry(
+            key=CONF_TIMEOUT,
+            type=ConfigEntryType.INTEGER,
+            default_value=DEFAULT_TIMEOUT,
+            label="Command timeout value",
+            required=False,
+            range=(10, 60),
+            requires_reload=True,
+            description="Set the timeout value to use when sending commands to the HEOS system. "
+            "Some devices could reply slower to commands, if you are seeing Command timeout logs, "
+            "try increasing this value.",
+            advanced=True,
         ),
     )

--- a/music_assistant/providers/heos/constants.py
+++ b/music_assistant/providers/heos/constants.py
@@ -1,5 +1,7 @@
 """Constants for HEOS Player Provider."""
 
+from typing import Final
+
 from music_assistant_models.enums import MediaType, PlaybackState
 from pyheos import MediaType as HeosMediaType
 from pyheos import PlayState as HeosPlayState
@@ -26,3 +28,6 @@ HEOS_PLAY_STATE_TO_PLAYBACK_STATE: dict[HeosPlayState | None, PlaybackState] = {
 }
 
 HEOS_PASSIVE_SOURCES = [const.MUSIC_SOURCE_AUX_INPUT]
+
+
+CONF_TIMEOUT: Final[str] = "timeout"

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -276,9 +276,24 @@ class HeosPlayer(Player):
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA command on given player."""
-        queue_items = await self._device.get_queue(range_start=0, range_end=1)
-        if queue_items:
-            await self._device.clear_queue()
+        self.logger.debug(
+            "[%s] Received PLAY_MEDIA command with media_type=%s uri=%s",
+            self._device.name,
+            media.media_type,
+            media.uri,
+        )
+
+        try:
+            queue_items = await self._device.get_queue(range_start=0, range_end=1)
+        except Exception as err:
+            self.logger.warning(
+                "[%s] Failed to fetch HEOS queue before play_media, continuing: %s",
+                self._device.name,
+                err,
+            )
+        else:
+            if queue_items:
+                await self._device.clear_queue()
 
         url = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
         await self._device.play_url(url)

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 from music_assistant_models.enums import MediaType, PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.errors import SetupFailedError
 from music_assistant_models.player import DeviceInfo, PlayerSource
-from pyheos import Heos, const
+from pyheos import Heos, HeosError, const
 
 from music_assistant.constants import (
     VERBOSE_LOG_LEVEL,
@@ -285,15 +285,15 @@ class HeosPlayer(Player):
 
         try:
             queue_items = await self._device.get_queue(range_start=0, range_end=1)
-        except Exception as err:
+
+            if queue_items:
+                await self._device.clear_queue()
+        except HeosError as err:
             self.logger.warning(
                 "[%s] Failed to fetch HEOS queue before play_media, continuing: %s",
                 self._device.name,
                 err,
             )
-        else:
-            if queue_items:
-                await self._device.clear_queue()
 
         url = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
         await self._device.play_url(url)

--- a/music_assistant/providers/heos/provider.py
+++ b/music_assistant/providers/heos/provider.py
@@ -15,6 +15,7 @@ from music_assistant.helpers.util import get_primary_ip_address_from_zeroconf
 from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.providers.heos.constants import HEOS_PASSIVE_SOURCES
 
+from .constants import CONF_TIMEOUT
 from .player import HeosPlayer
 
 if TYPE_CHECKING:
@@ -45,7 +46,15 @@ class HeosPlayerProvider(PlayerProvider):
     async def _setup_controller(self, controller_ip: str, connect_preferred: bool = False) -> None:
         """Set up the HEOS controller."""
         self.logger.debug("Attempting HEOS controller setup on IP %s", controller_ip)
-        self._heos = Heos(HeosOptions(controller_ip, auto_reconnect=True, auto_failover=True))
+
+        self._heos = Heos(
+            HeosOptions(
+                controller_ip,
+                timeout=cast("int", self.config.get_value(CONF_TIMEOUT)),
+                auto_reconnect=True,
+                auto_failover=True,
+            )
+        )
 
         try:
             await self._heos.connect()


### PR DESCRIPTION
In previous PRs, we made sure the internal HEOS queue gets cleared when starting a new stream from MA.

It seems in some cases, the `get_queue` command takes longer to respond than the default 15 seconds timeout. 
Catching this exception, skipping the queue clearing and continuing to send a new stream to the device, makes sure the devices still are able to play.
I do not know yet how the devices get into this bad state where `get_queue` commands are delayed. But I had it happen on 1 of my devices, where I tested this fix with.

Additionally, I've added a timeout configuration to the provider. This could reduce these errors if they occur very often. When running a full HEOS network wirelessly, it might increase response times on all commands, allow to tweak this can help reduce these issues.
I also fixed the config entry for the manually configured IP, as it wasn't showing up anymore.