### PR TITLE
Fix possible race conditions during HEOS startup

### DIFF
--- a/music_assistant/providers/heos/provider.py
+++ b/music_assistant/providers/heos/provider.py
@@ -43,6 +43,9 @@ class HeosPlayerProvider(PlayerProvider):
             ip_address = cast("str", ip_address)
             await self._setup_controller(ip_address)
 
+            # Explicitly discover players now
+            await self.discover_players()
+
     async def _setup_controller(self, controller_ip: str, connect_preferred: bool = False) -> None:
         """Set up the HEOS controller."""
         self.logger.debug("Attempting HEOS controller setup on IP %s", controller_ip)
@@ -67,6 +70,9 @@ class HeosPlayerProvider(PlayerProvider):
 
             if preferred_ips and controller_ip not in preferred_ips:
                 if connect_preferred:
+                    self.logger.debug(
+                        "Attempting to connect to preferred Host %s", preferred_ips[0]
+                    )
                     await self._heos.disconnect()
                     # Set up controller with preferred host instead
                     return await self._setup_controller(preferred_ips[0], connect_preferred=False)

--- a/music_assistant/providers/heos/provider.py
+++ b/music_assistant/providers/heos/provider.py
@@ -144,7 +144,7 @@ class HeosPlayerProvider(PlayerProvider):
 
     async def discover_players(self) -> None:
         """Discover players for this provider."""
-        if self._player_discovery_running or not self._heos:
+        if self._controller_discovery_running or self._player_discovery_running or not self._heos:
             return  # discovery already running or not set up
 
         try:

--- a/music_assistant/providers/heos/provider.py
+++ b/music_assistant/providers/heos/provider.py
@@ -82,8 +82,6 @@ class HeosPlayerProvider(PlayerProvider):
             self._heos.add_on_controller_event(self._handle_controller_event)
             await self._populate_sources()
 
-            # Explicitly discover players now, in case we are set up from discovery
-            await self.discover_players()
         except HeosError as e:
             self.logger.error(f"Unexpected error setting up HEOS controller: {e}")
             raise SetupFailedError("Unexpected error setting up HEOS controller") from e


### PR DESCRIPTION
While working on https://github.com/music-assistant/server/pull/3358, I noticed a race condition happening from time to time:

HEOS goes through this setup:
- 1 mDNS entry start controller setup
- Controller setup will grab system information (including players)
- As HEOS prefers using wired hosts, it's possible a re-connection needs to happen to the preferred host
- In the meantime, additional mDNS reports might trigger HEOS player discovery.

This results in 3 scenarios:
- controller setup is fully done before player discovery, no problem here
- Player discovery happens before the re-connection, everything works fine, there's just a minor blip in connectivity, but not noticable as it's still being setup
- Player discovery happens when the re-connection checks happen. The player discovery command fails here, sometimes being able to recover because the controller setup specifically calls the player discovery method. But sometimes failing totally due to command conflicts and timeouts.

This fix makes sure we have finished the controller setup (also the re-connection) before trying to discover any players.
Manual IP setup force player discovery after setup, discovery setup already runs player discovery after mDNS entry is handled (by MA itself)