### PR TITLE
Guard against trailing spaces in auth URLs

### DIFF
--- a/music_assistant/controllers/webserver/helpers/auth_providers.py
+++ b/music_assistant/controllers/webserver/helpers/auth_providers.py
@@ -554,7 +554,9 @@ class HomeAssistantOAuthProvider(LoginProvider):
 
         :return: External URL if available, otherwise None.
         """
-        ha_url = cast("str", self.config.get("ha_url")) if self.config.get("ha_url") else None
+        ha_url = (
+            cast("str", self.config.get("ha_url")).strip() if self.config.get("ha_url") else None
+        )
         if not ha_url:
             return None
 
@@ -591,7 +593,7 @@ class HomeAssistantOAuthProvider(LoginProvider):
                 internal_url = network_urls.get("internal")
 
                 # Use external URL first, then cloud, then internal
-                final_url = cast("str", external_url or cloud_url or internal_url)
+                final_url = cast("str", external_url or cloud_url or internal_url).strip()
                 if final_url:
                     self.logger.debug(
                         "Using HA URL for OAuth: %s (from network/url, configured: %s)",

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -81,7 +81,7 @@ async def get_config_entries(
     """
     # config flow auth action/step (authenticate button clicked)
     if action == CONF_ACTION_AUTH and values:
-        hass_url = values[CONF_URL]
+        hass_url = str(values[CONF_URL]).strip()
         async with AuthenticationHelper(mass, str(values["session_id"])) as auth_helper:
             client_id = base_url(auth_helper.callback_url)
             auth_url = get_auth_url(
@@ -501,7 +501,7 @@ class HomeAssistantProvider(PluginProvider):
             return
         if not (player_control := self._player_controls.get(entity_id)):
             return
-        entity_platform = entity_id.split(".")[0]
+        entity_platform = entity_id.split(".", maxsplit=1)[0]
         if "s" in state:
             # state changed
             if player_control.supports_power:

--- a/music_assistant/providers/hass/__init__.py
+++ b/music_assistant/providers/hass/__init__.py
@@ -501,7 +501,7 @@ class HomeAssistantProvider(PluginProvider):
             return
         if not (player_control := self._player_controls.get(entity_id)):
             return
-        entity_platform = entity_id.split(".", maxsplit=1)[0]
+        entity_platform = entity_id.split(".")[0]
         if "s" in state:
             # state changed
             if player_control.supports_power:


### PR DESCRIPTION
When users configure their Home Assistant URL with trailing whitespace (e.g. "https://ha.example.com "), the OAuth authorization URL becomes invalid (e.g. "https://ha.example.com /auth/authorize?..."). Strip whitespace from HA URLs at all points where they feed into auth URLs.

