### PR TITLE
Rewrite tidal stream behaviour to avoid premature cutoff

### DIFF
--- a/music_assistant/providers/tidal/constants.py
+++ b/music_assistant/providers/tidal/constants.py
@@ -42,3 +42,7 @@ DEFAULT_LIMIT: Final[int] = 50
 CACHE_CATEGORY_DEFAULT: Final[int] = 0
 CACHE_CATEGORY_RECOMMENDATIONS: Final[int] = 1
 CACHE_CATEGORY_ISRC_MAP: Final[int] = 2
+# Playback info (DASH manifest / direct URL) per track+quality. CDN tokens observed to be
+# valid for ~60 minutes, so 20 minutes gives a safe window without stale data.
+CACHE_CATEGORY_PLAYBACK_INFO: Final[int] = 3
+CACHE_TTL_PLAYBACK_INFO: Final[int] = 1200  # 20 minutes

--- a/music_assistant/providers/tidal/streaming.py
+++ b/music_assistant/providers/tidal/streaming.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import uuid
 from collections.abc import Callable, Coroutine
 from sqlite3 import OperationalError
@@ -105,7 +106,22 @@ class TidalStreamingManager:
             # manifest XML from MA's in-memory stream server so that ffmpeg receives a proper
             # HTTP URL. ffmpeg then connects directly to Tidal's CDN for all audio segments
             # without MA acting as a proxy for the audio data.
-            manifest_bytes = base64.b64decode(stream_data["manifest"])
+            try:
+                manifest_bytes = base64.b64decode(stream_data["manifest"])
+            except (binascii.Error, TypeError, ValueError) as err:
+                self.provider.logger.warning(
+                    "Invalid DASH manifest for track %s, evicting cache entry: %s",
+                    track.item_id,
+                    err,
+                )
+                await self.mass.cache.delete(
+                    cache_key,
+                    provider=self.provider.instance_id,
+                    category=CACHE_CATEGORY_PLAYBACK_INFO,
+                )
+                raise MediaNotFoundError(
+                    f"Invalid DASH manifest for track {track.item_id}"
+                ) from err
             manifest_id = uuid.uuid4().hex
             route_path = f"/tidal-dash/{manifest_id}.mpd"
             unregister = self.mass.streams.register_dynamic_route(

--- a/music_assistant/providers/tidal/streaming.py
+++ b/music_assistant/providers/tidal/streaming.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import uuid
+from collections.abc import Callable, Coroutine
 from sqlite3 import OperationalError
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from aiohttp import web
 from music_assistant_models.enums import ContentType, ExternalID, StreamType
 from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
-from .constants import CACHE_CATEGORY_ISRC_MAP, CONF_QUALITY
+from .constants import (
+    CACHE_CATEGORY_ISRC_MAP,
+    CACHE_CATEGORY_PLAYBACK_INFO,
+    CACHE_TTL_PLAYBACK_INFO,
+    CONF_QUALITY,
+)
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import Track
@@ -40,29 +50,87 @@ class TidalStreamingManager:
                 raise MediaNotFoundError(f"Track {item_id} not found")
 
         quality = self.provider.config.get_value(CONF_QUALITY)
+        cache_key = f"{track.item_id}:{quality}"
 
-        # 3. Get playback info
-        async with self.api.throttler.bypass():
-            api_result = await self.api.get(
-                f"tracks/{track.item_id}/playbackinfopostpaywall",
-                params={
-                    "playbackmode": "STREAM",
-                    "assetpresentation": "FULL",
-                    "audioquality": quality,
-                },
+        # 3. Get playback info (cached to avoid repeated API calls and reduce CDN token churn)
+        stream_data: dict[str, Any] | None = await self.mass.cache.get(
+            cache_key,
+            provider=self.provider.instance_id,
+            category=CACHE_CATEGORY_PLAYBACK_INFO,
+        )
+        if stream_data is None:
+            self.provider.logger.debug(
+                "Playback info cache miss for track %s (quality=%s) - fetching from API",
+                track.item_id,
+                quality,
             )
-
-        stream_data = api_result[0] if isinstance(api_result, tuple) else api_result
+            async with self.api.throttler.bypass():
+                api_result = await self.api.get(
+                    f"tracks/{track.item_id}/playbackinfopostpaywall",
+                    params={
+                        "playbackmode": "STREAM",
+                        "assetpresentation": "FULL",
+                        "audioquality": quality,
+                    },
+                )
+            stream_data = api_result[0] if isinstance(api_result, tuple) else api_result
+            await self.mass.cache.set(
+                cache_key,
+                stream_data,
+                provider=self.provider.instance_id,
+                category=CACHE_CATEGORY_PLAYBACK_INFO,
+                expiration=CACHE_TTL_PLAYBACK_INFO,
+            )
+        else:
+            self.provider.logger.debug(
+                "Playback info cache hit for track %s (quality=%s)",
+                track.item_id,
+                quality,
+            )
 
         # 4. Parse stream URL
         manifest_type = stream_data.get("manifestMimeType", "")
+        self.provider.logger.debug(
+            "Tidal playback info for track %s: manifestMimeType=%s audioQuality=%s codec=%s",
+            track.item_id,
+            manifest_type,
+            stream_data.get("audioQuality"),
+            stream_data.get("codec"),
+        )
         if "dash+xml" in manifest_type and "manifest" in stream_data:
-            url = f"data:application/dash+xml;base64,{stream_data['manifest']}"
+            # Tidal returns the DASH manifest as inline base64 content. Passing a data: URI
+            # directly to ffmpeg is unreliable — its DASH demuxer stops processing after
+            # buffering an initial batch of segments and never fetches the rest, resulting in
+            # only a fraction of the track being played. We therefore serve the decoded
+            # manifest XML from MA's in-memory stream server so that ffmpeg receives a proper
+            # HTTP URL. ffmpeg then connects directly to Tidal's CDN for all audio segments
+            # without MA acting as a proxy for the audio data.
+            manifest_bytes = base64.b64decode(stream_data["manifest"])
+            manifest_id = uuid.uuid4().hex
+            route_path = f"/tidal-dash/{manifest_id}.mpd"
+            unregister = self.mass.streams.register_dynamic_route(
+                route_path,
+                self._make_manifest_handler(manifest_bytes, self.provider.logger, track.item_id),
+                method="GET",
+            )
+            url = f"{self.mass.streams.base_url}{route_path}"
+            self.provider.logger.debug(
+                "Using DASH manifest (stream server route %s) for track %s",
+                route_path,
+                track.item_id,
+            )
+            # Unregister the route once the track duration has elapsed.
+            self.mass.create_task(
+                self._async_unregister_manifest_route(
+                    unregister, route_path, (track.duration or 600) + 60
+                )
+            )
         else:
             urls = stream_data.get("urls", [])
             if not urls:
                 raise MediaNotFoundError("No stream URL found")
             url = urls[0]
+            self.provider.logger.debug("Using direct URL for track %s", track.item_id)
 
         # 5. Determine format
         audio_quality = stream_data.get("audioQuality")
@@ -98,6 +166,31 @@ class TidalStreamingManager:
             can_seek=True,
             allow_seek=True,
         )
+
+    @staticmethod
+    def _make_manifest_handler(
+        manifest_bytes: bytes,
+        logger: Any,
+        track_id: str,
+    ) -> Callable[[web.Request], Coroutine[Any, Any, web.Response]]:
+        """Return an aiohttp request handler that serves the given manifest bytes."""
+
+        async def _handler(_request: web.Request) -> web.Response:
+            logger.debug("Serving DASH manifest to ffmpeg for track %s", track_id)
+            return web.Response(
+                body=manifest_bytes,
+                content_type="application/dash+xml",
+            )
+
+        return _handler
+
+    async def _async_unregister_manifest_route(
+        self, unregister: Callable[[], None], route_path: str, delay: float
+    ) -> None:
+        """Call unregister after delay seconds to clean up the temporary manifest route."""
+        await asyncio.sleep(delay)
+        unregister()
+        self.provider.logger.debug("Unregistered DASH manifest route %s", route_path)
 
     async def _async_update_provider_mapping_audio_format(
         self,

--- a/tests/providers/tidal/test_api_client.py
+++ b/tests/providers/tidal/test_api_client.py
@@ -98,7 +98,10 @@ async def test_get_429_error(api_client: TidalAPIClient, provider_mock: Mock) ->
 
     # Patch sleep in the throttle_retry module so retries don't cause real delays.
     with (
-        patch("music_assistant.helpers.throttle_retry.asyncio.sleep"),
+        patch(
+            "music_assistant.helpers.throttle_retry.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
         pytest.raises(RetriesExhausted),
     ):
         await api_client.get("test/endpoint")

--- a/tests/providers/tidal/test_api_client.py
+++ b/tests/providers/tidal/test_api_client.py
@@ -11,6 +11,7 @@ from music_assistant_models.errors import (
     RetriesExhausted,
 )
 
+from music_assistant.helpers.throttle_retry import ThrottlerManager
 from music_assistant.providers.tidal.api_client import TidalAPIClient
 
 
@@ -33,7 +34,11 @@ def provider_mock() -> Mock:
 @pytest.fixture
 def api_client(provider_mock: Mock) -> TidalAPIClient:
     """Return a TidalAPIClient instance."""
-    return TidalAPIClient(provider_mock)
+    client = TidalAPIClient(provider_mock)
+    # The class-level throttler is shared across all test instances; replace it with a
+    # fast instance-level one so tests don't accumulate real throttle delays.
+    client.throttler = ThrottlerManager(rate_limit=1000, period=0.001)
+    return client
 
 
 async def test_get_success(api_client: TidalAPIClient, provider_mock: Mock) -> None:
@@ -83,8 +88,7 @@ async def test_get_404_error(api_client: TidalAPIClient, provider_mock: Mock) ->
 
 async def test_get_429_error(api_client: TidalAPIClient, provider_mock: Mock) -> None:
     """Test GET request with 429 error."""
-    with patch("asyncio.sleep"):
-        response = AsyncMock(spec=ClientResponse)
+    response = AsyncMock(spec=ClientResponse)
     response.status = 429
     response.headers = {"Retry-After": "10"}
 
@@ -92,7 +96,11 @@ async def test_get_429_error(api_client: TidalAPIClient, provider_mock: Mock) ->
     request_ctx.__aenter__.return_value = response
     provider_mock.mass.http_session.request = MagicMock(return_value=request_ctx)
 
-    with pytest.raises(RetriesExhausted):
+    # Patch sleep in the throttle_retry module so retries don't cause real delays.
+    with (
+        patch("music_assistant.helpers.throttle_retry.asyncio.sleep"),
+        pytest.raises(RetriesExhausted),
+    ):
         await api_client.get("test/endpoint")
 
 

--- a/tests/providers/tidal/test_streaming.py
+++ b/tests/providers/tidal/test_streaming.py
@@ -1,9 +1,10 @@
 """Test Tidal Streaming Manager."""
 
+import base64
 from collections.abc import Coroutine
 from sqlite3 import OperationalError
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from music_assistant_models.enums import ContentType, ExternalID, StreamType
@@ -38,6 +39,8 @@ def provider_mock() -> Mock:
     provider.mass.cache.set = AsyncMock()
     provider.mass.cache.delete = AsyncMock()
     provider.mass.music.tracks.get_library_item_by_prov_id = AsyncMock(return_value=None)
+    provider.mass.streams.base_url = "http://localhost:8095"
+    provider.mass.streams.register_dynamic_route = Mock(return_value=Mock())
 
     return provider
 
@@ -117,11 +120,13 @@ async def test_get_stream_details_hires(
 async def test_get_stream_details_with_dash_manifest(
     streaming_manager: TidalStreamingManager, provider_mock: Mock, mock_track: Mock
 ) -> None:
-    """Test get_stream_details with DASH manifest."""
+    """Test get_stream_details with DASH manifest serves via HTTP route, not data: URI."""
     provider_mock.get_track.return_value = mock_track
+    manifest_xml = b"<MPD>dummy manifest</MPD>"
+    manifest_b64 = base64.b64encode(manifest_xml).decode()
     provider_mock.api.get.return_value = {
         "manifestMimeType": "application/dash+xml",
-        "manifest": "base64encodedmanifestdata",
+        "manifest": manifest_b64,
         "audioQuality": "HIGH",
         "sampleRate": 44100,
         "bitDepth": 16,
@@ -130,8 +135,15 @@ async def test_get_stream_details_with_dash_manifest(
     stream_details = await streaming_manager.get_stream_details("123")
 
     assert isinstance(stream_details.path, str)
-    assert stream_details.path.startswith("data:application/dash+xml;base64,")
-    assert "base64encodedmanifestdata" in stream_details.path
+    assert stream_details.path.startswith("http://localhost:8095/tidal-dash/")
+    assert stream_details.path.endswith(".mpd")
+    assert "data:" not in stream_details.path
+
+    # Route must be registered with the streams server.
+    provider_mock.mass.streams.register_dynamic_route.assert_called_once()
+    call_args = provider_mock.mass.streams.register_dynamic_route.call_args
+    assert call_args[0][0].startswith("/tidal-dash/")
+    assert call_args[1]["method"] == "GET"
 
 
 async def test_get_stream_details_with_codec(
@@ -554,3 +566,93 @@ async def test_async_update_provider_mapping_audio_format_unexpected_error_logs_
     )
 
     provider_mock.logger.exception.assert_called()
+
+
+async def test_get_stream_details_dash_schedules_cleanup_task(
+    streaming_manager: TidalStreamingManager, provider_mock: Mock, mock_track: Mock
+) -> None:
+    """Verify a cleanup task is scheduled to unregister the DASH manifest route."""
+    provider_mock.get_track.return_value = mock_track
+    manifest_b64 = base64.b64encode(b"<MPD/>").decode()
+    provider_mock.api.get.return_value = {
+        "manifestMimeType": "application/dash+xml",
+        "manifest": manifest_b64,
+        "audioQuality": "HIGH",
+        "sampleRate": 44100,
+        "bitDepth": 16,
+    }
+
+    captured: list[Any] = []
+    provider_mock.mass.create_task = Mock(side_effect=captured.append)
+
+    await streaming_manager.get_stream_details("123")
+
+    # create_task is called twice: once for the mapping update, once for route cleanup.
+    assert provider_mock.mass.create_task.call_count == 2
+
+
+async def test_make_manifest_handler_serves_manifest_bytes() -> None:
+    """Verify _make_manifest_handler returns an async handler that serves the given bytes."""
+    manifest_bytes = b"<MPD>test manifest</MPD>"
+    logger = Mock()
+    handler = TidalStreamingManager._make_manifest_handler(manifest_bytes, logger, "track_42")
+
+    response = await handler(MagicMock())
+
+    assert response.body == manifest_bytes
+    assert "dash+xml" in response.content_type
+    logger.debug.assert_called()
+
+
+async def test_async_unregister_manifest_route_calls_unregister(
+    streaming_manager: TidalStreamingManager,
+) -> None:
+    """Verify the route unregister callable is called after the delay."""
+    unregister = Mock()
+    with patch("music_assistant.providers.tidal.streaming.asyncio.sleep", new_callable=AsyncMock):
+        await streaming_manager._async_unregister_manifest_route(
+            unregister, "/tidal-dash/test.mpd", 300.0
+        )
+    unregister.assert_called_once()
+
+
+async def test_get_stream_details_playback_info_cache_hit(
+    streaming_manager: TidalStreamingManager, provider_mock: Mock, mock_track: Mock
+) -> None:
+    """Verify no API call is made when playback info is already cached."""
+    provider_mock.get_track.return_value = mock_track
+    provider_mock.mass.cache.get.return_value = {
+        "manifestMimeType": "application/vnd.tidal.bts",
+        "urls": ["https://cdn.tidal.com/stream.flac"],
+        "audioQuality": "LOSSLESS",
+        "sampleRate": 44100,
+        "bitDepth": 16,
+    }
+
+    stream_details = await streaming_manager.get_stream_details("123")
+
+    assert stream_details.path == "https://cdn.tidal.com/stream.flac"
+    provider_mock.api.get.assert_not_called()
+    provider_mock.mass.cache.set.assert_not_called()
+
+
+async def test_get_stream_details_playback_info_cache_miss_sets_cache(
+    streaming_manager: TidalStreamingManager, provider_mock: Mock, mock_track: Mock
+) -> None:
+    """Verify the API response is stored in cache on a cache miss."""
+    provider_mock.get_track.return_value = mock_track
+    provider_mock.mass.cache.get.return_value = None
+    api_response = {
+        "manifestMimeType": "application/vnd.tidal.bts",
+        "urls": ["https://cdn.tidal.com/stream.flac"],
+        "audioQuality": "LOSSLESS",
+        "sampleRate": 44100,
+        "bitDepth": 16,
+    }
+    provider_mock.api.get.return_value = api_response
+
+    await streaming_manager.get_stream_details("123")
+
+    provider_mock.mass.cache.set.assert_called_once()
+    set_call = provider_mock.mass.cache.set.call_args
+    assert set_call[0][1] == api_response  # second positional arg is the data


### PR DESCRIPTION
Closes https://github.com/music-assistant/support/issues/5077

decode dash xml and serve as internal http endpoint. Cache manifest details for short term replays of a given track