### PR TITLE
Fix Dashie Kiosk manual_players config validation error

### DIFF
--- a/music_assistant/providers/dashie_kiosk/__init__.py
+++ b/music_assistant/providers/dashie_kiosk/__init__.py
@@ -79,12 +79,11 @@ async def get_config_entries(
         ConfigEntry(
             key=CONF_MANUAL_PLAYERS,
             type=ConfigEntryType.STRING,
-            multi_value=True,
             label="Manual Dashie Kiosk addresses",
             required=False,
-            description="Manually add Dashie Kiosk tablets by IP address and port "
-            "(e.g. 192.168.1.100:2323). Use this if you don't have the "
-            "Dashie HA integration installed.",
+            description="Comma-separated IP:port addresses of Dashie Kiosk tablets "
+            "(e.g. 192.168.1.100:2323, 192.168.1.101:2323). "
+            "Use this if you don't have the Dashie HA integration installed.",
             advanced=True,
         ),
     )

--- a/music_assistant/providers/dashie_kiosk/provider.py
+++ b/music_assistant/providers/dashie_kiosk/provider.py
@@ -50,12 +50,10 @@ class DashieKioskProvider(PlayerProvider):
         player_ids = cast("list[str]", self.config.get_value(CONF_PLAYERS)) or []
         if player_ids and self.hass_prov:
             await self._setup_ha_players(player_ids)
-        # Set up manually configured players
-        manual_addresses = cast("list[str]", self.config.get_value(CONF_MANUAL_PLAYERS)) or []
-        for raw_address in manual_addresses:
-            address = raw_address.strip()
-            if not address:
-                continue
+        # Set up manually configured players (comma-separated string)
+        raw_manual = self.config.get_value(CONF_MANUAL_PLAYERS) or ""
+        manual_addresses = [a.strip() for a in str(raw_manual).split(",") if a.strip()]
+        for address in manual_addresses:
             success = await self._setup_manual_player(address)
             if not success:
                 self._pending_players[address] = None


### PR DESCRIPTION
## Summary

Fixes a config validation error when saving the Dashie Kiosk provider settings. The `manual_players` field used `multi_value=True` without predefined options, causing the frontend to send a plain string instead of a list. The backend then rejected the value with:

```
value for manual_players must be a list
```

**Changes:**
- `__init__.py`: Remove `multi_value=True` from the `manual_players` config entry. Users now enter comma-separated IP:port addresses in a plain string field.
- `provider.py`: Parse the comma-separated string into individual addresses.

The HA players multi-select field (which has predefined options) is unchanged and works correctly.

## Test plan

- [ ] Add Dashie Kiosk provider with only HA players selected — should save without error
- [ ] Add Dashie Kiosk provider with manual addresses (e.g. `192.168.1.100:2323`) — should save and connect
- [ ] Add multiple manual addresses comma-separated — should connect to all

Follows up on #3180.