### PR TITLE
Use internal time in socket based progress updates in Audiobookshelf.

### DIFF
--- a/music_assistant/providers/audiobookshelf/helpers.py
+++ b/music_assistant/providers/audiobookshelf/helpers.py
@@ -96,15 +96,7 @@ class ProgressGuard:
         mass external updates. Here, we compare this property against a potential
         stored one.
         """
-        item_id = abs_progress.library_item_id
-        episode_id = abs_progress.episode_id
-        stored_progress = self._get_progress(item_id=item_id, episode_id=episode_id)
-        if stored_progress is None:
-            return True
-        return (
-            int(time.time() * 1000) - stored_progress.last_update_ms
-            >= self._min_time_between_updates_ms
-        )
+        return self.guard_ok_mass(abs_progress.library_item_id, abs_progress.episode_id)
 
     def guard_ok_mass(self, item_id: str, episode_id: str | None = None) -> bool:
         """Check, if we may update against a mass internal item.

--- a/music_assistant/providers/audiobookshelf/helpers.py
+++ b/music_assistant/providers/audiobookshelf/helpers.py
@@ -56,9 +56,9 @@ class ProgressGuard:
         """Init."""
         self._progresses: list[_ProgressHelper] = []
         self._max_progresses = 100
-        # 12s have to have passed before we accept an external progress update
-        # abs updates every 15 s
-        self._min_time_between_updates_ms = 12000
+        # 8s have to have passed before we accept an external progress update
+        # abs updates every 10 s
+        self._min_time_between_updates_ms = 8000
 
     def _get_progress(self, item_id: str, episode_id: str | None = None) -> _ProgressHelper | None:
         """Get a helper progress."""
@@ -101,8 +101,8 @@ class ProgressGuard:
         stored_progress = self._get_progress(item_id=item_id, episode_id=episode_id)
         if stored_progress is None:
             return True
-        return bool(
-            abs_progress.last_update - stored_progress.last_update_ms
+        return (
+            int(time.time() * 1000) - stored_progress.last_update_ms
             >= self._min_time_between_updates_ms
         )
 


### PR DESCRIPTION
Fixes an edge case, where the abs server and ma server are not synced in time. The progress update via socket then occurs a bit unpredictably. Solved by using the internal time.

Also, abs updates every 10s now, so I adjusted the minimum time required to pass between updates.