### PR TITLE
Extract date_added from Deezer API for library items

### DIFF
--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -5,6 +5,7 @@ import uuid
 from asyncio import TaskGroup
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from math import ceil
 from typing import Any, Literal, cast
 
@@ -318,17 +319,26 @@ class DeezerProvider(MusicProvider):
     async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
         """Retrieve all library artists from Deezer."""
         async for artist in await self.client.get_user_artists():
-            yield self.parse_artist(artist=artist)
+            item = self.parse_artist(artist=artist)
+            if time_add := getattr(artist, "time_add", None):
+                item.date_added = datetime.fromtimestamp(int(time_add), tz=UTC)
+            yield item
 
     async def get_library_albums(self) -> AsyncGenerator[Album, None]:
         """Retrieve all library albums from Deezer."""
         async for album in await self.client.get_user_albums():
-            yield self.parse_album(album=album)
+            item = self.parse_album(album=album)
+            if time_add := getattr(album, "time_add", None):
+                item.date_added = datetime.fromtimestamp(int(time_add), tz=UTC)
+            yield item
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
         """Retrieve all library playlists from Deezer."""
         async for playlist in await self.user.get_playlists():
-            yield self.parse_playlist(playlist=playlist)
+            item = self.parse_playlist(playlist=playlist)
+            if time_add := getattr(playlist, "time_add", None):
+                item.date_added = datetime.fromtimestamp(int(time_add), tz=UTC)
+            yield item
 
     async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
         """Retrieve all library tracks from Deezer."""
@@ -1029,6 +1039,8 @@ class DeezerProvider(MusicProvider):
         )
         if isrc := getattr(track, "isrc", None):
             item.external_ids.add((ExternalID.ISRC, isrc))
+        if time_add := getattr(track, "time_add", None):
+            item.date_added = datetime.fromtimestamp(int(time_add), tz=UTC)
         return item
 
     def get_short_title(self, track: deezer.Track) -> str:


### PR DESCRIPTION
Fixes music-assistant/support#5094

The Deezer API returns a `time_add` field (Unix timestamp) for library items indicating when the user added them to favorites. This field was available on the deezer-python Resource objects but was never extracted.

Without this, all library items get `timestamp_added` set to the sync time (via SQLite column default), making "Sort by Recently Added" show sync order instead of the actual order the user favorited items.

This extracts `time_add` and sets `date_added` for tracks, albums, artists, and playlists. Tracks added individually at different times now sort correctly. Items added in bulk still share the same narrow time window (expected behavior from Deezer's side).

Tested with a Deezer account: confirmed `time_add` is present in API responses and timestamps are correctly stored in the database after sync.

Note: Spotify has a similar issue (`added_at` field in wrapper objects is discarded), but that is not addressed here.