### PR TITLE
Fix Sendspin playback stability issues

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin==4.3.3", "av==16.1.0"],
+  "requirements": ["aiosendspin==4.3.4", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -376,7 +376,7 @@ class SendspinPlaybackSession:
     async def add_member(self, player_id: str) -> None:
         """Add a member to the group with DSP-aware lifecycle handling."""
         async with self._state_lock:
-            if player_id in self._members or player_id in self.pending_join_members:
+            if player_id in self._members:
                 return
             self.pending_join_members.add(player_id)
             # Preserve any channel pre-resolved during add_client so join-time
@@ -384,18 +384,19 @@ class SendspinPlaybackSession:
             self._preassigned_channels.setdefault(player_id, uuid4())
         try:
             await self._start_join_catchup(player_id)
-            async with self._state_lock:
-                if player_id not in self.pending_join_members:
-                    # Concurrent remove_member/sync_members cancelled this join.
-                    return
-                self._members.add(player_id)
-                self._mapping_dirty = True
         except Exception:
-            await self._release_player_channel(player_id)
-            raise
-        finally:
             async with self._state_lock:
                 self.pending_join_members.discard(player_id)
+            await self._release_player_channel(player_id)
+            raise
+        # Promote to full member even if already pending to avoid losing
+        # the join when a cancelled task clears our pending flag.
+        async with self._state_lock:
+            if player_id not in self.pending_join_members:
+                return
+            self._members.add(player_id)
+            self._mapping_dirty = True
+            self.pending_join_members.discard(player_id)
 
     async def remove_member(self, player_id: str) -> None:
         """Remove a member from the group and clean up per-member playback state."""

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -280,6 +280,7 @@ class SendspinPlaybackSession:
         self._member_pipelines: dict[str, _MemberPipeline] = {}
         self._push_stream: PushStream | None = None
         self._playback_running = False
+        self._producer_eof_sent = False
         self._timeline_start_us: int | None = None
         self._first_commit_monotonic_us: int | None = None
         self._produced_audio_us = 0
@@ -584,6 +585,9 @@ class SendspinPlaybackSession:
         state.drainer_task.cancel()
         with suppress(asyncio.CancelledError, Exception):
             await state.drainer_task
+        if self._producer_eof_sent and pipeline.config.requires_transform:
+            with suppress(Exception):
+                await pipeline.processor.write_eof()
         if old_processor is not None and old_processor is not state.processor:
             with suppress(Exception):
                 await old_processor.close()
@@ -617,6 +621,7 @@ class SendspinPlaybackSession:
         async with self._state_lock:
             self._push_stream = push_stream
             self._playback_running = True
+            self._producer_eof_sent = False
             self._history.clear()
             self._produced_audio_us = 0
             self._timeline_start_us = None
@@ -742,6 +747,9 @@ class SendspinPlaybackSession:
             producer_stopped_cleanly = True
         finally:
             if producer_stopped_cleanly and not commit_task.done():
+                # Mark EOF so that catchup processors promoted after this
+                # point also get flushed (see _promote_join_catchup_processor).
+                self._producer_eof_sent = True
                 # Signal EOF to transform pipelines so ffmpeg flushes its
                 # internal buffers instead of blocking on the last read.
                 _, pipelines = await self._snapshot_active_pipelines()

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -370,28 +370,31 @@ class SendspinPlaybackSession:
     async def add_member(self, player_id: str) -> None:
         """Add a member to the group with DSP-aware lifecycle handling."""
         async with self._state_lock:
-            if player_id in self._members:
-                self.pending_join_members.discard(player_id)
+            if player_id in self._members or player_id in self.pending_join_members:
                 return
+            self.pending_join_members.add(player_id)
             # Preserve any channel pre-resolved during add_client so join-time
             # role requirements and prepared audio stay on the same channel.
             self._preassigned_channels.setdefault(player_id, uuid4())
-        self.pending_join_members.add(player_id)
         try:
             await self._start_join_catchup(player_id)
             async with self._state_lock:
+                if player_id not in self.pending_join_members:
+                    # Concurrent remove_member/sync_members cancelled this join.
+                    return
                 self._members.add(player_id)
                 self._mapping_dirty = True
         except Exception:
             await self._release_player_channel(player_id)
             raise
         finally:
-            self.pending_join_members.discard(player_id)
+            async with self._state_lock:
+                self.pending_join_members.discard(player_id)
 
     async def remove_member(self, player_id: str) -> None:
         """Remove a member from the group and clean up per-member playback state."""
-        self.pending_join_members.discard(player_id)
         async with self._state_lock:
+            self.pending_join_members.discard(player_id)
             self._members.discard(player_id)
             self._mapping_dirty = True
             self._pipeline_config_cache.pop(player_id, None)
@@ -403,6 +406,9 @@ class SendspinPlaybackSession:
         """Reconcile session members to exactly the provided set."""
         async with self._state_lock:
             current_members = set(self._members)
+            stale_pending = self.pending_join_members - member_ids
+        for player_id in stale_pending:
+            await self.remove_member(player_id)
         for player_id in current_members - member_ids:
             await self.remove_member(player_id)
         for player_id in member_ids - current_members:

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -79,6 +79,10 @@ class _BufferedFfmpegProcessor:
     async def push(self, pcm: bytes) -> None:
         await self._ffmpeg.write(pcm)
 
+    async def write_eof(self) -> None:
+        """Signal no more input, causing ffmpeg to flush its internal buffers."""
+        await self._ffmpeg.write_eof()
+
     @property
     def produced_output_us(self) -> int:
         """Return cumulative output duration currently drained from ffmpeg."""
@@ -94,6 +98,8 @@ class _BufferedFfmpegProcessor:
             missing = target_bytes - len(self._output_buffer)
             read_size = max(self._read_quantum_bytes, missing)
             chunk = await self._ffmpeg.readexactly(read_size)
+            if not chunk:
+                break
             self._output_buffer.extend(chunk)
 
         out = bytes(self._output_buffer[:target_bytes])
@@ -735,6 +741,13 @@ class SendspinPlaybackSession:
             producer_stopped_cleanly = True
         finally:
             if producer_stopped_cleanly and not commit_task.done():
+                # Signal EOF to transform pipelines so ffmpeg flushes its
+                # internal buffers instead of blocking on the last read.
+                _, pipelines = await self._snapshot_active_pipelines()
+                for _, pipeline in pipelines:
+                    if pipeline.processor is not None and pipeline.config.requires_transform:
+                        with suppress(Exception):
+                            await pipeline.processor.write_eof()
                 # Producer finished normally; send a None sentinel so the
                 # consumer exits cleanly.  The queue may be full, so retry
                 # with a deadline before falling back to cancellation.

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -416,7 +416,7 @@ class SendspinPlaybackSession:
 
     # -- Join catchup ----------------------------------------------------------
 
-    async def _start_join_catchup(self, player_id: str) -> None:
+    async def _start_join_catchup(self, player_id: str) -> None:  # noqa: PLR0915
         """Start dedicated join catchup processor fed from committed history."""
         async with self._state_lock:
             playback_active = self._playback_running and self._push_stream is not None
@@ -442,6 +442,11 @@ class SendspinPlaybackSession:
             await processor.close()
             return
         history_end_us = history_snapshot[-1].start_time_us + history_snapshot[-1].duration_us
+        writer_task: asyncio.Task[None] | None = None
+        drainer_task: asyncio.Task[None] | None = None
+        snapshot_task: asyncio.Task[None] | None = None
+        state: _JoinCatchupState | None = None
+        registered = False
 
         async def _writer() -> None:
             while True:
@@ -453,30 +458,43 @@ class SendspinPlaybackSession:
         async def _drainer() -> None:
             await processor.drain_forever()
 
-        writer_task = asyncio.create_task(_writer())
-        drainer_task = asyncio.create_task(_drainer())
-        self._attach_task_exception_logger(writer_task, f"join_writer:{player_id}")
-        self._attach_task_exception_logger(drainer_task, f"join_drainer:{player_id}")
+        try:
+            async with self._state_lock:
+                writer_task = asyncio.create_task(_writer())
+                drainer_task = asyncio.create_task(_drainer())
+                self._attach_task_exception_logger(writer_task, f"join_writer_{player_id}")
+                self._attach_task_exception_logger(drainer_task, f"join_drainer_{player_id}")
 
-        state = _JoinCatchupState(
-            processor=processor,
-            input_queue=input_queue,
-            writer_task=writer_task,
-            drainer_task=drainer_task,
-            history_end_us=history_end_us,
-        )
-        async with self._state_lock:
-            self._join_catchup[player_id] = state
-
-        async with self._state_lock:
-            current = self._join_catchup.get(player_id)
-            if current is not None and current.processor is processor:
-                current.snapshot_task = asyncio.create_task(
+                state = _JoinCatchupState(
+                    processor=processor,
+                    input_queue=input_queue,
+                    writer_task=writer_task,
+                    drainer_task=drainer_task,
+                    history_end_us=history_end_us,
+                )
+                self._join_catchup[player_id] = state
+                snapshot_task = asyncio.create_task(
                     self._feed_join_history(player_id, processor, history_snapshot)
                 )
-                self._attach_task_exception_logger(
-                    current.snapshot_task, f"join_snapshot:{player_id}"
-                )
+                self._attach_task_exception_logger(snapshot_task, f"join_snapshot_{player_id}")
+                state.snapshot_task = snapshot_task
+                registered = True
+        except BaseException:
+            if not registered:
+                # If registered, cleanup is handled via _stop_join_catchup/_clear_join_catchup.
+                async with self._state_lock:
+                    current = self._join_catchup.get(player_id)
+                    if current is state:
+                        self._join_catchup.pop(player_id, None)
+                for task in (snapshot_task, drainer_task, writer_task):
+                    if task is None:
+                        continue
+                    task.cancel()
+                    with suppress(asyncio.CancelledError, Exception):
+                        await task
+                with suppress(Exception):
+                    await processor.close()
+            raise
 
     async def _feed_join_history(
         self,
@@ -1129,7 +1147,9 @@ class SendspinPlaybackSession:
 
     def _stop_push_stream(self) -> None:
         """Stop the active PushStream."""
-        self.player.api.group.stop_stream()
+        ps = self._push_stream
+        if ps is not None and not ps.is_stopped:
+            ps.stop()
 
     def _resolve_channel_for_player(self, player_id: str) -> UUID:
         """Channel resolver callback for per-player routing."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -294,6 +294,14 @@ class SendspinPlayer(Player):
         )
         await self.playback_session.sync_members(set(desired_session_members))
 
+    def _schedule_membership_sync(self, group: SendspinGroup) -> None:
+        """Schedule a coalesced membership reconciliation task for this player."""
+        self.mass.create_task(
+            self._sync_membership_from_group(group),
+            task_id=f"sendspin_membership_sync_{self.player_id}",
+            abort_existing=True,
+        )
+
     def event_cb(self, client: SendspinClient, event: ClientEvent) -> None:
         """Event callback registered to the sendspin client."""
         match event:
@@ -321,7 +329,7 @@ class SendspinPlayer(Player):
                 # Update in case this is a newly created group
                 # GroupMemberAddedEvent or GroupMemberRemovedEvent will be fired before this
                 # so group members are already up to date at this point
-                self.mass.create_task(self._sync_membership_from_group(new_group))
+                self._schedule_membership_sync(new_group)
                 self.update_state()
 
     def group_event_cb(self, group: SendspinGroup, event: GroupEvent) -> None:
@@ -357,12 +365,10 @@ class SendspinPlayer(Player):
                 if client_id not in self._attr_group_members:
                     self._attr_group_members.append(client_id)
                     self.update_state()
-                self.mass.create_task(self.playback_session.add_member(client_id))
-                self.mass.create_task(self._sync_membership_from_group(group))
+                self._schedule_membership_sync(group)
             case GroupMemberRemovedEvent(client_id=client_id):
-                self.mass.create_task(self.playback_session.remove_member(client_id))
                 self.mass.create_task(self._handle_group_member_removed(group, client_id))
-                self.mass.create_task(self._sync_membership_from_group(group))
+                self._schedule_membership_sync(group)
             case GroupDeletedEvent():
                 pass
             case ControllerEvent() as controller_event:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
 aiorun==2025.1.1
-aiosendspin==4.3.3
+aiosendspin==4.3.4
 aioslimproto==3.1.7
 aiosonos==0.1.9
 aiosqlite==0.22.1


### PR DESCRIPTION
Several race conditions could cause Sendspin players to get stuck, immediately pause, or get out of sync, especially under rapid group membership changes and when DSP was enabled.

## aiosendspin 4.3.4

Bumps aiosendspin to [4.3.4](https://github.com/Sendspin/aiosendspin/releases/tag/4.3.4) which include these fixes:
- Reconnection loop after connection takeover
- Stale chunk log spam in the debug console after web player disconnects
- Out of sync playback when DSP clients join or reconnect

## Sendspin Provider fixes

- Prevent duplicate join attempts when multiple group events fire at once
- Cancel stale joins that no longer match the current group
- Clean up resources when a join fails partway through
- Stop the correct stream instance instead of tearing down the whole group
- Flush audio pipelines on track end so DSP players don't get stuck in "playing" state