### PR TITLE
Fix albums not being able to be added to playlists during playlist creation

### DIFF
--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -130,6 +130,10 @@ class PlaylistController(MediaControllerBase[Playlist]):
 
         # Default is track for backwards compatibility.
         media_types_set = {MediaType.TRACK} if not media_types else set(media_types)
+        if MediaType.ALBUM in media_types_set:
+            # an album is unwrapped, so we remove that and use tracks instead
+            media_types_set.remove(MediaType.ALBUM)
+            media_types_set.add(MediaType.TRACK)
         if not provider_instance_or_domain and not media_types_set:
             # builtin can handle all media_types
             media_types_set.update(
@@ -146,8 +150,6 @@ class PlaylistController(MediaControllerBase[Playlist]):
         ):
             # PLAYLIST_CREATE is deprecated
             supported_types.add(MediaType.TRACK)
-            # an album is unwrapped to individual tracks in self.add_playlist_tracks
-            supported_types.add(MediaType.ALBUM)
         if ProviderFeature.PLAYLIST_CREATE_AUDIOBOOKS in provider.supported_features:
             supported_types.add(MediaType.AUDIOBOOK)
         if ProviderFeature.PLAYLIST_CREATE_PODCAST_EPISODES in provider.supported_features:

--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -146,6 +146,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
         ):
             # PLAYLIST_CREATE is deprecated
             supported_types.add(MediaType.TRACK)
+            # an album is unwrapped to individual tracks in self.add_playlist_tracks
+            supported_types.add(MediaType.ALBUM)
         if ProviderFeature.PLAYLIST_CREATE_AUDIOBOOKS in provider.supported_features:
             supported_types.add(MediaType.AUDIOBOOK)
         if ProviderFeature.PLAYLIST_CREATE_PODCAST_EPISODES in provider.supported_features:


### PR DESCRIPTION
The frontend is not able to add albums to playlist anymore - I introduced that bug accidentally here https://github.com/music-assistant/server/pull/3216

If a playlist supports tracks, it supports albums too, as we acquire individual tracks for the playlist anyways.

Frontend PR: https://github.com/music-assistant/frontend/pull/1577