### PR TITLE
Include nfs-common in Dockerfile.base

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -145,6 +145,7 @@ RUN set -x \
         # cifs utils and libnfs are needed for smb and nfs support (file provider)
         cifs-utils \
         libnfs13 \
+        nfs-common \
         # airplay libraries
         openssl \
         libssl-dev \


### PR DESCRIPTION
I believe this is necessary for the new NFS provider to work on Docker installs