### PR TITLE
Apple Music radio stations and improved URL import support

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -216,7 +216,7 @@ CONFIGURABLE_CORE_CONTROLLERS = (
     "player_queues",
 )
 VERBOSE_LOG_LEVEL: Final[int] = 5
-PROVIDERS_WITH_SHAREABLE_URLS = ("spotify", "qobuz")
+PROVIDERS_WITH_SHAREABLE_URLS = ("spotify", "qobuz", "apple_music")
 
 
 ####### REUSABLE CONFIG ENTRIES #######

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -329,18 +329,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         provider_instance_id_or_domain: str,
     ) -> ItemCls:
         """Return (full) details for a single media item."""
-        # if item_id is a URL, resolve the actual provider and item_id via parse_uri
-        original_url: str | None = None
+        # if item_id is a provider share URL, resolve the actual provider and item_id
         if item_id.startswith(("http://", "https://")):
-            original_url = item_id
             with suppress(InvalidProviderURI):
-                resolved_media_type, provider_instance_id_or_domain, item_id = await parse_uri(
-                    item_id
-                )
-                if resolved_media_type not in {self.media_type, MediaType.UNKNOWN}:
-                    # URL resolves to a different media type — delegate to the correct controller
-                    ctrl = self.mass.music.get_controller(resolved_media_type)
-                    return cast("ItemCls", await ctrl.get(item_id, provider_instance_id_or_domain))
+                _, provider_instance_id_or_domain, item_id = await parse_uri(item_id)
         # always prefer the full library item if we have it
         if library_item := await self.get_library_item_by_prov_id(
             item_id,
@@ -352,19 +344,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             self.mass.metadata.schedule_update_metadata(library_item.uri)
             return library_item
         # grab full details from the provider
-        item = await self.get_provider_item(
+        return await self.get_provider_item(
             item_id,
             provider_instance_id_or_domain,
         )
-        # If the provider returned a fallback name (name equals the item id), try to derive
-        # a human-readable name from the URL slug (second-to-last path segment).
-        if original_url and item.name == item_id:
-            parts = original_url.rstrip("/").split("/")
-            if len(parts) >= 2:
-                slug = parts[-2].split("?")[0]
-                if slug and slug != item_id and "-" in slug:
-                    item.name = slug.replace("-", " ").title()
-        return item
 
     async def search(
         self,

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -332,7 +332,19 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         # if item_id is a provider share URL, resolve the actual provider and item_id
         if item_id.startswith(("http://", "https://")):
             with suppress(InvalidProviderURI):
-                _, provider_instance_id_or_domain, item_id = await parse_uri(item_id)
+                parsed_media_type, provider_instance_id_or_domain, item_id = await parse_uri(
+                    item_id
+                )
+                if (
+                    provider_instance_id_or_domain != "builtin"
+                    and parsed_media_type != self.media_type
+                ):
+                    return cast(
+                        "ItemCls",
+                        await self.mass.music.get_item(
+                            parsed_media_type, item_id, provider_instance_id_or_domain
+                        ),
+                    )
         # always prefer the full library item if we have it
         if library_item := await self.get_library_item_by_prov_id(
             item_id,

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast, final
 from music_assistant_models.enums import EventType, ExternalID, MediaType, ProviderFeature
 from music_assistant_models.errors import (
     InsufficientPermissions,
+    InvalidProviderURI,
     MediaNotFoundError,
     ProviderUnavailableError,
 )
@@ -35,6 +36,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import get_cu
 from music_assistant.helpers.compare import compare_media_item, create_safe_string
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
+from music_assistant.helpers.uri import parse_uri
 from music_assistant.helpers.util import guard_single_request, parse_optional_bool
 
 if TYPE_CHECKING:
@@ -327,6 +329,18 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         provider_instance_id_or_domain: str,
     ) -> ItemCls:
         """Return (full) details for a single media item."""
+        # if item_id is a URL, resolve the actual provider and item_id via parse_uri
+        original_url: str | None = None
+        if item_id.startswith(("http://", "https://")):
+            original_url = item_id
+            with suppress(InvalidProviderURI):
+                resolved_media_type, provider_instance_id_or_domain, item_id = await parse_uri(
+                    item_id
+                )
+                if resolved_media_type not in {self.media_type, MediaType.UNKNOWN}:
+                    # URL resolves to a different media type — delegate to the correct controller
+                    ctrl = self.mass.music.get_controller(resolved_media_type)
+                    return cast("ItemCls", await ctrl.get(item_id, provider_instance_id_or_domain))
         # always prefer the full library item if we have it
         if library_item := await self.get_library_item_by_prov_id(
             item_id,
@@ -338,10 +352,19 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             self.mass.metadata.schedule_update_metadata(library_item.uri)
             return library_item
         # grab full details from the provider
-        return await self.get_provider_item(
+        item = await self.get_provider_item(
             item_id,
             provider_instance_id_or_domain,
         )
+        # If the provider returned a fallback name (name equals the item id), try to derive
+        # a human-readable name from the URL slug (second-to-last path segment).
+        if original_url and item.name == item_id:
+            parts = original_url.rstrip("/").split("/")
+            if len(parts) >= 2:
+                slug = parts[-2].split("?")[0]
+                if slug and slug != item_id and "-" in slug:
+                    item.name = slug.replace("-", " ").title()
+        return item
 
     async def search(
         self,

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -920,6 +920,16 @@ class PlayerQueuesController(CoreController):
             return
         next_index = self._get_next_index(queue_id, idx, True)
         if next_index is None:
+            # For RADIO items there's no next index, but we can skip to the next
+            # station track by re-playing the same index (provider fetches a new track).
+            current_item = self.get_item(queue_id, idx)
+            if current_item is not None and current_item.media_type == MediaType.RADIO:
+                current_item.streamdetails = None
+                self.mass.call_later(
+                    1,
+                    self.play_index(queue_id, idx),
+                    task_id=f"queue_play_index_{queue_id}",
+                )
             return
 
         # immediately update current item so UI shows the new track right away
@@ -1357,6 +1367,16 @@ class PlayerQueuesController(CoreController):
         while True:
             next_index = self._get_next_index(queue_id, cur_index + idx)
             if next_index is None:
+                # For RADIO type items, treat them as a continuous source: clear the
+                # cached stream details and re-request the next track from the provider.
+                cur_item = self.get_item(queue_id, cur_index)
+                if cur_item is not None and cur_item.media_type == MediaType.RADIO:
+                    cur_item.streamdetails = None
+                    try:
+                        await self._load_item(cur_item, None)
+                    except (MediaNotFoundError, AudioError) as err:
+                        raise QueueEmpty("No more tracks available from radio station.") from err
+                    return cur_item
                 raise QueueEmpty("No more tracks left in the queue.")
             queue_item = self.get_item(queue_id, next_index)
             if queue_item is None:
@@ -1711,6 +1731,17 @@ class PlayerQueuesController(CoreController):
             media.album = (
                 album.name if (album := getattr(queue_item.media_item, "album", None)) else ""
             )
+            # For track-based radio stations (e.g. Apple Music Artist Radio)
+            # stream_metadata carries the currently playing track's artist/title.
+            if (
+                queue_item.media_type == MediaType.RADIO
+                and queue_item.streamdetails
+                and (sm := queue_item.streamdetails.stream_metadata)
+            ):
+                if sm.title:
+                    media.title = sm.title
+                if sm.artist:
+                    media.artist = sm.artist
             if queue_item.image:
                 # the image format needs to be 500x500 jpeg for maximum compatibility with players
                 # we prefer the imageproxy on the streamserver here because this request is sent
@@ -2678,6 +2709,10 @@ class PlayerQueuesController(CoreController):
         if prev_state["current_item_id"] is None:
             return
 
+        # retrieve prev_item here so it's available in the _clear_or_resume_delayed closure
+        # regardless of which code path (flow mode or non-flow mode) creates the task
+        prev_item = prev_state["current_item"]
+
         async def _clear_or_resume_delayed() -> None:
             for _ in range(5):
                 await asyncio.sleep(1)
@@ -2698,6 +2733,16 @@ class PlayerQueuesController(CoreController):
                         )
                         await self.play_index(queue.queue_id, next_index)
                     return
+            # If the last item was a radio station, continue playing instead of clearing.
+            # For track-based radio (Apple Music Artist Radio etc.) this fetches the next
+            # track from the station; for live radio it would reconnect to the stream.
+            if prev_item and prev_item.media_type == MediaType.RADIO:
+                current_index = self.index_by_id(queue.queue_id, prev_item.queue_item_id)
+                if current_index is not None and queue.state == PlaybackState.IDLE:
+                    # clear cached stream details so the provider fetches a fresh track
+                    prev_item.streamdetails = None
+                    await self.play_index(queue.queue_id, current_index)
+                    return
             self.logger.info("End of queue reached, clearing items")
             self.clear(queue.queue_id)
 
@@ -2714,7 +2759,6 @@ class PlayerQueuesController(CoreController):
             return
 
         # For non-flow mode, use prev_state values since queue state may have been updated/reset
-        prev_item = prev_state["current_item"]
         if prev_item and (streamdetails := prev_item.streamdetails):
             duration = streamdetails.duration or prev_item.duration or 24 * 3600
         elif prev_item:

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -930,6 +930,8 @@ class PlayerQueuesController(CoreController):
                     self.play_index(queue_id, idx),
                     task_id=f"queue_play_index_{queue_id}",
                 )
+            else:
+                self._transitioning_players.discard(queue_id)
             return
 
         # immediately update current item so UI shows the new track right away

--- a/music_assistant/helpers/uri.py
+++ b/music_assistant/helpers/uri.py
@@ -26,7 +26,7 @@ def valid_id(provider: str, item_id: str) -> bool:
     return True
 
 
-async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str, str]:
+async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str, str]:  # noqa: PLR0915
     """Try to parse URI to Mass identifiers.
 
     Returns Tuple: MediaType, provider_instance_id_or_domain, item_id
@@ -59,10 +59,22 @@ async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str
             parts = uri.rstrip("/").split("?")[0].split("/")
             # parts: ['https:', '', 'music.apple.com', '{sf}', '{type}', '{slug}', '{id}']
             # or:    ['https:', '', 'music.apple.com', '{sf}', '{type}', '{id}']  (no slug)
+            # Track share links are album URLs with a ?i=<track_id> query param
+            query = uri.split("?", 1)[1] if "?" in uri else ""
+            track_id_from_query = next(
+                (p.split("=", 1)[1] for p in query.split("&") if p.startswith("i=")),
+                None,
+            )
             if len(parts) >= 6:
                 apple_type = parts[4]
-                item_id = parts[-1]
-                if apple_type in _apple_type_map and item_id:
+                if apple_type == "album" and track_id_from_query:
+                    provider_instance_id_or_domain = "apple_music"
+                    media_type = MediaType.TRACK
+                    item_id = track_id_from_query
+                elif apple_type in _apple_type_map:
+                    item_id = parts[-1]
+                    if not item_id:
+                        raise KeyError
                     provider_instance_id_or_domain = "apple_music"
                     media_type = _apple_type_map[apple_type]
                 else:

--- a/music_assistant/helpers/uri.py
+++ b/music_assistant/helpers/uri.py
@@ -46,6 +46,29 @@ async def parse_uri(uri: str, validate_id: bool = False) -> tuple[MediaType, str
             media_type_str = uri.split("/")[4]
             media_type = MediaType(media_type_str)
             item_id = uri.split("/")[5].split("?")[0]
+        elif uri.startswith("https://music.apple.com/"):
+            # Apple Music share URL
+            # https://music.apple.com/{storefront}/{type}/{slug}/{id}
+            _apple_type_map = {
+                "station": MediaType.RADIO,
+                "playlist": MediaType.PLAYLIST,
+                "album": MediaType.ALBUM,
+                "artist": MediaType.ARTIST,
+                "song": MediaType.TRACK,
+            }
+            parts = uri.rstrip("/").split("?")[0].split("/")
+            # parts: ['https:', '', 'music.apple.com', '{sf}', '{type}', '{slug}', '{id}']
+            # or:    ['https:', '', 'music.apple.com', '{sf}', '{type}', '{id}']  (no slug)
+            if len(parts) >= 6:
+                apple_type = parts[4]
+                item_id = parts[-1]
+                if apple_type in _apple_type_map and item_id:
+                    provider_instance_id_or_domain = "apple_music"
+                    media_type = _apple_type_map[apple_type]
+                else:
+                    raise KeyError
+            else:
+                raise KeyError
         elif uri.startswith(("http://", "https://", "rtsp://", "rtmp://")):
             # Translate a plain URL to the builtin provider
             provider_instance_id_or_domain = "builtin"

--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -859,11 +859,16 @@ class AppleMusicProvider(MusicProvider):
             ]
         last_error: str = ""
         for data in attempts:
-            async with self.mass.http_session.post(
-                playback_url, headers=self._get_decryption_headers(), json=data, ssl=True
-            ) as response:
-                response.raise_for_status()
-                content = await response.json(loads=json_loads)
+            try:
+                async with self.mass.http_session.post(
+                    playback_url, headers=self._get_decryption_headers(), json=data, ssl=True
+                ) as response:
+                    response.raise_for_status()
+                    content = await response.json(loads=json_loads)
+            except ClientError as err:
+                raise MediaNotFoundError(
+                    f"Failed to get stream for radio station {station_id}: {err}"
+                ) from err
             if content.get("failureType"):
                 last_error = (
                     f"type={content.get('failureType')}, message={content.get('failureMessage')}"

--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -865,10 +865,15 @@ class AppleMusicProvider(MusicProvider):
                 ) as response:
                     response.raise_for_status()
                     content = await response.json(loads=json_loads)
-            except ClientError as err:
-                raise MediaNotFoundError(
-                    f"Failed to get stream for radio station {station_id}: {err}"
-                ) from err
+            except (ClientError, ValueError) as err:
+                last_error = str(err)
+                self.logger.debug(
+                    "Radio station %s HTTP error with params %s: %s",
+                    station_id,
+                    data,
+                    err,
+                )
+                continue
             if content.get("failureType"):
                 last_error = (
                     f"type={content.get('failureType')}, message={content.get('failureMessage')}"

--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -54,11 +54,12 @@ from music_assistant_models.media_items import (
     MediaItemType,
     Playlist,
     ProviderMapping,
+    Radio,
     SearchResults,
     Track,
     UniqueList,
 )
-from music_assistant_models.streamdetails import StreamDetails
+from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 from pywidevine import PSSH, Cdm, Device, DeviceTypes
 from pywidevine.license_protocol_pb2 import WidevinePsshData
 from shortuuid import uuid
@@ -303,14 +304,22 @@ class AppleMusicProvider(MusicProvider):
         # create random session id to use for decryption keys
         # to invalidate cached keys on each provider initialization
         self._session_id = str(uuid())
-        async with aiofiles.open(
-            os.path.join(WIDEVINE_BASE_PATH, DECRYPT_CLIENT_ID_FILENAME), "rb"
-        ) as _file:
-            self._decrypt_client_id = await _file.read()
-        async with aiofiles.open(
-            os.path.join(WIDEVINE_BASE_PATH, DECRYPT_PRIVATE_KEY_FILENAME), "rb"
-        ) as _file:
-            self._decrypt_private_key = await _file.read()
+        try:
+            async with aiofiles.open(
+                os.path.join(WIDEVINE_BASE_PATH, DECRYPT_CLIENT_ID_FILENAME), "rb"
+            ) as _file:
+                self._decrypt_client_id = await _file.read()
+            async with aiofiles.open(
+                os.path.join(WIDEVINE_BASE_PATH, DECRYPT_PRIVATE_KEY_FILENAME), "rb"
+            ) as _file:
+                self._decrypt_private_key = await _file.read()
+        except FileNotFoundError:
+            self.logger.warning(
+                "Widevine CDM files not found at %s. "
+                "Streaming of encrypted catalog tracks will not work. "
+                "Radio stations and unencrypted library tracks are still available.",
+                WIDEVINE_BASE_PATH,
+            )
 
     @use_cache()
     async def search(
@@ -458,6 +467,29 @@ class AppleMusicProvider(MusicProvider):
                 )
             elif item and item["id"]:
                 yield self._parse_playlist(item, is_favourite)
+
+    @use_cache(3600 * 24)
+    async def get_radio(self, prov_radio_id: str) -> Radio:
+        """Get full radio station details by id."""
+        endpoint = f"catalog/{self._storefront}/stations/{prov_radio_id}"
+        try:
+            response = await self._get_data(endpoint)
+            return self._parse_radio(response["data"][0])
+        except MediaNotFoundError:
+            pass
+        # Station not indexed in the user's storefront catalog but may still be streamable.
+        return Radio(
+            item_id=prov_radio_id,
+            provider=self.domain,
+            name=prov_radio_id,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=prov_radio_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                )
+            },
+        )
 
     @use_cache()
     async def get_artist(self, prov_artist_id) -> Artist:
@@ -642,6 +674,67 @@ class AppleMusicProvider(MusicProvider):
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Return the content details for the given track when it will be streamed."""
+        if media_type == MediaType.RADIO:
+            station_hash, is_live = await self._get_station_play_params(item_id)
+            if is_live:
+                try:
+                    stream_url = await self._fetch_radio_stream_url(item_id, station_hash)
+                    return StreamDetails(
+                        item_id=item_id,
+                        provider=self.instance_id,
+                        audio_format=AudioFormat(content_type=ContentType.UNKNOWN),
+                        media_type=MediaType.RADIO,
+                        stream_type=StreamType.HLS,
+                        path=stream_url,
+                        can_seek=False,
+                        allow_seek=False,
+                    )
+                except MediaNotFoundError:
+                    # webPlayback failed — station may be a curated track-based channel
+                    # (e.g. third-party stations like "Radio Bob Best of Rock") that are
+                    # served via next-tracks rather than a live HLS stream, so fall through.
+                    self.logger.debug(
+                        "Live stream unavailable for %s, trying track-based fallback", item_id
+                    )
+            # Track-based Artist Radio: fetch next track from the station and stream it
+            (
+                track_id,
+                artist_name,
+                track_title,
+                duration_secs,
+            ) = await self._fetch_next_station_track(item_id)
+            streamdetails = await self._get_track_stream_details(track_id)
+            if track_title:
+                streamdetails.stream_metadata = StreamMetadata(
+                    title=track_title,
+                    artist=artist_name,
+                )
+            if duration_secs:
+                streamdetails.duration = duration_secs
+            return streamdetails
+        return await self._get_track_stream_details(item_id)
+
+    async def _fetch_next_station_track(
+        self, station_id: str
+    ) -> tuple[str, str | None, str | None, int | None]:
+        """Fetch the next track for a track-based Apple Music radio station.
+
+        Returns a tuple of (track_id, artist_name, track_title, duration_seconds).
+        """
+        response = await self._post_data(f"me/stations/next-tracks/{station_id}")
+        tracks = response.get("data", [])
+        if not tracks:
+            raise MediaNotFoundError(f"No tracks available for station {station_id}")
+        track = tracks[0]
+        attributes = track.get("attributes", {})
+        title: str | None = attributes.get("name")
+        # artistName is always present as a plain-string attribute on catalog tracks
+        artist_name: str | None = attributes.get("artistName")
+        duration_ms: int | None = attributes.get("durationInMillis")
+        return track["id"], artist_name, title, int(duration_ms / 1000) if duration_ms else None
+
+    async def _get_track_stream_details(self, item_id: str) -> StreamDetails:
+        """Return StreamDetails for a single catalog or library track."""
         stream_metadata = await self._fetch_song_stream_metadata(item_id)
         if self.is_library_id(item_id):
             # Library items are not encrypted and do not need decryption keys
@@ -660,7 +753,12 @@ class AppleMusicProvider(MusicProvider):
                 can_seek=True,
                 allow_seek=True,
             )
-        # Continue to obtain decryption keys for catalog items
+        # Catalog track: needs Widevine decryption keys
+        if not self._decrypt_client_id or not self._decrypt_private_key:
+            raise MediaNotFoundError(
+                "Widevine CDM files are not available. "
+                "Cannot stream encrypted catalog tracks without them."
+            )
         license_url = stream_metadata["hls-key-server-url"]
         stream_url, uri = await self._parse_stream_url_and_uri(stream_metadata["assets"])
         if not stream_url or not uri:
@@ -691,6 +789,101 @@ class AppleMusicProvider(MusicProvider):
         else:
             endpoint = f"me/ratings/library-{item_type}/{prov_item_id}"
         await self._put_data(endpoint, data=data)
+
+    def _parse_radio(self, station_obj: dict[str, Any]) -> Radio:
+        """Parse a station object from the Apple Music API into a Radio model."""
+        attributes = station_obj.get("attributes", {})
+        station_id = station_obj["id"]
+        radio = Radio(
+            item_id=station_id,
+            provider=self.domain,
+            name=attributes.get("name", station_id),
+            provider_mappings={
+                ProviderMapping(
+                    item_id=station_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                    url=attributes.get("url"),
+                )
+            },
+        )
+        if artwork := attributes.get("artwork"):
+            url = artwork["url"]
+            if artwork.get("width") and artwork.get("height"):
+                url = url.format(
+                    w=min(artwork["width"], MAX_ARTWORK_DIMENSION),
+                    h=min(artwork["height"], MAX_ARTWORK_DIMENSION),
+                )
+            radio.metadata.add_image(
+                MediaItemImage(
+                    provider=self.instance_id,
+                    type=ImageType.THUMB,
+                    path=url,
+                    remotely_accessible=True,
+                )
+            )
+        if notes := attributes.get("editorialNotes"):
+            radio.metadata.description = notes.get("standard") or notes.get("short")
+        return radio
+
+    async def _get_station_play_params(self, station_id: str) -> tuple[str | None, bool]:
+        """Fetch playParams for a radio station. Returns (stationHash, isLive)."""
+        try:
+            endpoint = f"catalog/{self._storefront}/stations/{station_id}"
+            response = await self._get_data(endpoint)
+            attributes = response["data"][0].get("attributes", {})
+            play_params = attributes.get("playParams", {})
+            return play_params.get("stationHash"), attributes.get("isLive", True)
+        except Exception as exc:
+            self.logger.debug("Could not fetch play params for %s: %s", station_id, exc)
+            return None, True
+
+    async def _fetch_radio_stream_url(
+        self, station_id: str, station_hash: str | None = None
+    ) -> str:
+        """Fetch the live HLS stream URL for an Apple Music radio station."""
+        playback_url = "https://play.music.apple.com/WebObjects/MZPlay.woa/wa/webPlayback"
+        # Build a list of payloads to try in order.
+        # Sending stationHash can trigger a DRM-encrypted stream request (failing with 3077
+        # when Widevine is unavailable), so always try without it first.
+        numeric_id = station_id.removeprefix("ra.")
+        attempts: list[dict[str, str]] = [
+            {"stationId": station_id},
+            {"salableAdamId": numeric_id},
+        ]
+        if station_hash:
+            # Also try with stationHash in case it is required for some stations.
+            attempts += [
+                {"stationId": station_id, "stationHash": station_hash},
+                {"salableAdamId": numeric_id, "stationHash": station_hash},
+            ]
+        last_error: str = ""
+        for data in attempts:
+            async with self.mass.http_session.post(
+                playback_url, headers=self._get_decryption_headers(), json=data, ssl=True
+            ) as response:
+                response.raise_for_status()
+                content = await response.json(loads=json_loads)
+            if content.get("failureType"):
+                last_error = (
+                    f"type={content.get('failureType')}, message={content.get('failureMessage')}"
+                )
+                self.logger.debug(
+                    "Radio station %s stream failure with params %s - %s, full response: %s",
+                    station_id,
+                    data,
+                    last_error,
+                    content,
+                )
+                continue
+            station_info = content.get("songList", [{}])[0]
+            self.logger.debug("Radio stream metadata for %s: %s", station_id, station_info)
+            for key in ("hls-url", "URL", "url"):
+                if url := station_info.get(key):
+                    return url
+        raise MediaNotFoundError(
+            f"Failed to get stream for radio station {station_id}: {last_error}"
+        )
 
     def _parse_artist(self, artist_obj: dict[str, Any]) -> Artist:
         """Parse artist object to generic layout."""

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -157,3 +157,54 @@ async def test_uri_parsing() -> None:
     # test invalid uri
     with pytest.raises(MusicAssistantError):
         await uri.parse_uri("invalid://blah")
+
+
+async def test_apple_music_uri_parsing() -> None:
+    """Test parsing of Apple Music share URLs."""
+    # station
+    media_type, provider, item_id = await uri.parse_uri(
+        "https://music.apple.com/de/station/dead-sara-essentials/ra.331701075"
+    )
+    assert media_type == MediaType.RADIO
+    assert provider == "apple_music"
+    assert item_id == "ra.331701075"
+    # playlist
+    media_type, provider, item_id = await uri.parse_uri(
+        "https://music.apple.com/de/playlist/disturbed-essentials/pl.5d641aa29c5d4cc49b474d7d100996ec"
+    )
+    assert media_type == MediaType.PLAYLIST
+    assert provider == "apple_music"
+    assert item_id == "pl.5d641aa29c5d4cc49b474d7d100996ec"
+    # album
+    media_type, provider, item_id = await uri.parse_uri(
+        "https://music.apple.com/de/album/some-album/1234567890"
+    )
+    assert media_type == MediaType.ALBUM
+    assert provider == "apple_music"
+    assert item_id == "1234567890"
+    # artist
+    media_type, provider, item_id = await uri.parse_uri(
+        "https://music.apple.com/de/artist/dead-sara/123456789"
+    )
+    assert media_type == MediaType.ARTIST
+    assert provider == "apple_music"
+    assert item_id == "123456789"
+    # song
+    media_type, provider, item_id = await uri.parse_uri(
+        "https://music.apple.com/de/song/my-song/987654321"
+    )
+    assert media_type == MediaType.TRACK
+    assert provider == "apple_music"
+    assert item_id == "987654321"
+    # trailing slash stripped
+    media_type, provider, item_id = await uri.parse_uri(
+        "https://music.apple.com/de/station/some-station/ra.111222333/"
+    )
+    assert media_type == MediaType.RADIO
+    assert item_id == "ra.111222333"
+    # query string stripped
+    media_type, provider, item_id = await uri.parse_uri(
+        "https://music.apple.com/de/album/some-album/1234567890?itsct=music_box"
+    )
+    assert media_type == MediaType.ALBUM
+    assert item_id == "1234567890"

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -202,9 +202,22 @@ async def test_apple_music_uri_parsing() -> None:
     )
     assert media_type == MediaType.RADIO
     assert item_id == "ra.111222333"
-    # query string stripped
+    # query string stripped (non-track query params)
     media_type, provider, item_id = await uri.parse_uri(
         "https://music.apple.com/de/album/some-album/1234567890?itsct=music_box"
     )
     assert media_type == MediaType.ALBUM
     assert item_id == "1234567890"
+    # track share link: album URL with ?i=<track_id>
+    media_type, provider, item_id = await uri.parse_uri(
+        "https://music.apple.com/de/album/some-album/1234567890?i=987654321"
+    )
+    assert media_type == MediaType.TRACK
+    assert provider == "apple_music"
+    assert item_id == "987654321"
+    # track share link with additional query params
+    media_type, provider, item_id = await uri.parse_uri(
+        "https://music.apple.com/de/album/some-album/1234567890?itsct=music_box&i=111222333"
+    )
+    assert media_type == MediaType.TRACK
+    assert item_id == "111222333"


### PR DESCRIPTION
## Summary

This PR adds Apple Music Artist Radio station playback support and improves how Apple Music share URLs are handled throughout Music Assistant.

> **Note:** This feature was developed by @dmoo500 with the assistance of GitHub Copilot (AI). The author is not deeply familiar with all parts of the codebase — please review thoroughly before merging.

---

## What's new

### Apple Music Artist Radio stations via "Add URL"
Apple Music share URLs for (Artist Radio) stations can now be added using the "Add URL" dialog:
- Example: `https://music.apple.com/de/station/dead-sara-essentials/ra.331701075`

**Track-based Artist Radio stations** (e.g. "Dead Sara und ähnliche Künstler:innen", `ra.xxxxxxxxx`)
- Individual tracks fetched via `me/stations/next-tracks/{id}` API
- Auto-plays next track when current track ends (~5s gap)
- Skip button fetches a fresh track from the station
- Currently playing artist and track title shown on the player

### Improved Apple Music share URL routing
All Apple Music share URL types now resolve to the correct provider and media type:

| URL type | Example |
|---|---|
| Station | `…/station/…/ra.xxx` |
| Playlist | `…/playlist/…/pl.xxx` |
| Album | `…/album/…/12345` |
| Artist | `…/artist/…/12345` |
| Song | `…/song/…/12345` |

Previously only station URLs were handled; playlist/album/artist/song URLs fell through to the `builtin` provider and failed with ffprobe errors.

When a URL resolves to a different media type than the calling controller, it is now automatically delegated to the correct controller.

---

## Known limitations

### Live broadcast stations do not work
**Apple Music live broadcast stations** (Apple Music 1, Apple Music Country, third-party stations like Radio Bob, etc.) **cannot be streamed**. All attempts via the `webPlayback` endpoint return error **3077** (`MZCommerce.ItemNotFoundForFuse`). The `me/stations/next-tracks` endpoint also returns an empty list for those stations.

The Apple Music app likely uses internal mechanisms to stream live stations that are not accessible through the public API. There is currently no known workaround. For those stations, using an alternative source (e.g. Radio Browser provider, or the station's own direct stream URL) is recommended.

### No automatic library sync for radio stations
`LIBRARY_RADIOS` / `get_library_radios()` is **not implemented**. Radio stations must be added manually via "Add URL". An earlier attempt at auto-syncing Apple Music stations was unreliable and has been dropped from this PR.

---

## Files changed

- `music_assistant/providers/apple_music/__init__.py` — Main provider: radio stream logic, URL handling, metadata helpers
- `music_assistant/helpers/uri.py` — Apple Music URL parsing for all share URL types
- `music_assistant/controllers/media/base.py` — URL routing to correct controller; human-readable name from URL slug
- `music_assistant/controllers/player_queues.py` — Continuous playback, skip button, and artist/title display for track-based radio
