### PR TITLE
Add player control features to supported features set

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1771,6 +1771,14 @@ class Player(ABC):
                 for feature in protocol_player.supported_features:
                     if feature in PROTOCOL_FEATURES:
                         base_features.add(feature)
+        # Add features based on configured player controls
+        # (e.g. when mute/volume/power is delegated to an external entity)
+        if self.mute_control != PLAYER_CONTROL_NONE:
+            base_features.add(PlayerFeature.VOLUME_MUTE)
+        if self.volume_control != PLAYER_CONTROL_NONE:
+            base_features.add(PlayerFeature.VOLUME_SET)
+        if self.power_control != PLAYER_CONTROL_NONE:
+            base_features.add(PlayerFeature.POWER)
         return base_features
 
     @cached_property


### PR DESCRIPTION
## Summary
This change enhances the player feature detection logic to include features based on configured player controls, allowing delegated control mechanisms (such as external mute, volume, or power control) to be properly advertised as supported features.

## Key Changes
- Added logic to dynamically add `PlayerFeature.VOLUME_MUTE` when mute control is configured (not set to `PLAYER_CONTROL_NONE`)
- Added logic to dynamically add `PlayerFeature.VOLUME_SET` when volume control is configured
- Added logic to dynamically add `PlayerFeature.POWER` when power control is configured
- These features are now included in the `__final_supported_features` property alongside protocol-based features

## Implementation Details
The new code checks each control type (mute, volume, power) and adds the corresponding feature to the base features set if the control is not set to `PLAYER_CONTROL_NONE`. This ensures that when player controls are delegated to external entities, the player correctly advertises these capabilities as supported features, improving compatibility and feature discovery for downstream consumers.

https://claude.ai/code/session_012JNGc8qPasvTkpcqpyufHr