### PR TITLE
Add favorite status sync for Emby library items

### DIFF
--- a/music_assistant/providers/emby/const.py
+++ b/music_assistant/providers/emby/const.py
@@ -1,5 +1,7 @@
 """Constants for Emby provider."""
 
+from typing import Final
+
 # Emby API item keys
 AUTH_ACCESS_TOKEN = "AccessToken"
 AUTH_USER = "User"
@@ -25,6 +27,9 @@ ITEM_KEY_TYPE = "Type"
 ITEM_KEY_CONTAINER = "Container"
 ITEM_KEY_INDEX_NUMBER = "IndexNumber"
 ITEM_KEY_PARENT_INDEX_NUMBER = "ParentIndexNumber"
+ITEM_KEY_USER_DATA: Final = "UserData"
+
+USER_DATA_KEY_IS_FAVORITE: Final = "IsFavorite"
 
 AUDIO_STREAM_CODEC = "Codec"
 AUDIO_STREAM_SAMPLE_RATE = "SampleRate"

--- a/music_assistant/providers/emby/parsers.py
+++ b/music_assistant/providers/emby/parsers.py
@@ -35,6 +35,8 @@ from music_assistant.providers.emby.const import (
     ITEM_KEY_PRODUCTION_YEAR,
     ITEM_KEY_RUNTIME_TICKS,
     ITEM_KEY_TYPE,
+    ITEM_KEY_USER_DATA,
+    USER_DATA_KEY_IS_FAVORITE,
 )
 
 if TYPE_CHECKING:
@@ -133,6 +135,9 @@ def parse_track(
             )
         )
 
+    user_data = item.get(ITEM_KEY_USER_DATA, {})
+    track.favorite = user_data.get(USER_DATA_KEY_IS_FAVORITE, False)
+
     return track
 
 
@@ -171,6 +176,9 @@ def parse_artist(
                 remotely_accessible=True,
             )
         )
+
+    user_data = item.get(ITEM_KEY_USER_DATA, {})
+    artist.favorite = user_data.get(USER_DATA_KEY_IS_FAVORITE, False)
 
     return artist
 
@@ -236,6 +244,9 @@ def parse_album(
             )
         )
 
+    user_data = item.get(ITEM_KEY_USER_DATA, {})
+    album.favorite = user_data.get(USER_DATA_KEY_IS_FAVORITE, False)
+
     return album
 
 
@@ -273,5 +284,8 @@ def parse_playlist(
                 remotely_accessible=True,
             )
         )
+
+    user_data = item.get(ITEM_KEY_USER_DATA, {})
+    playlist.favorite = user_data.get(USER_DATA_KEY_IS_FAVORITE, False)
 
     return playlist


### PR DESCRIPTION
Parses and maps the `IsFavorite` flag from Emby's user data for tracks, artists, albums, and playlists.

## How to Test
1. Mark tracks, artists, albums, or playlists as favorites in Emby.
2. Sync the Emby provider in Music Assistant.
3. Verify favorited items appear as favorites in Music Assistant.