### PR TITLE
Detect stale streams after server restart in player queue controller

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2725,8 +2725,6 @@ class PlayerQueuesController(CoreController):
             return
         # wait briefly for the player to settle after detection
         await asyncio.sleep(3)
-        if not queue.active:  # type: ignore[unreachable]
-            return
         self.logger.info(
             "Resuming stale queue for %s",
             queue.display_name,

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2690,11 +2690,48 @@ class PlayerQueuesController(CoreController):
             path_parts = protocol_player.current_media.uri[len(base_url) :].strip("/").split("/")
             # path_parts: [mode, session_id, queue_id, queue_item_id, player_id.fmt]
             if len(path_parts) >= 5:
+                url_session_id = path_parts[1]
+                queue = self._queues.get(queue_id)
+                if queue and queue.session_id and url_session_id != queue.session_id:
+                    # player is still playing a stream from a previous MA session
+                    self.logger.info(
+                        "Stale stream detected on %s (session %s != %s), triggering resume",
+                        queue.display_name,
+                        url_session_id,
+                        queue.session_id,
+                    )
+                    self.mass.create_task(
+                        self._resume_stale_queue(queue_id),
+                        task_id=f"resume_stale_{queue_id}",
+                    )
+                    return None
                 current_item_id = path_parts[3]
                 if self.get_item(queue_id, current_item_id):
                     return current_item_id
 
         return None
+
+    async def _resume_stale_queue(self, queue_id: str) -> None:
+        """Resume a queue that is still playing a stream from a previous MA session.
+
+        After MA restarts, players may still be streaming audio from the old session.
+        This method waits briefly for the player state to settle, then triggers a resume
+        so the queue picks up from where it left off with a fresh stream.
+
+        :param queue_id: The queue to resume.
+        """
+        queue = self._queues.get(queue_id)
+        if not queue or not queue.active:
+            return
+        # wait briefly for the player to settle after detection
+        await asyncio.sleep(3)
+        if not queue.active:  # type: ignore[unreachable]
+            return
+        self.logger.info(
+            "Resuming stale queue for %s",
+            queue.display_name,
+        )
+        await self.resume(queue_id)
 
     def _handle_end_of_queue(
         self, queue: PlayerQueue, prev_state: CompareState, new_state: CompareState

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2692,10 +2692,11 @@ class PlayerQueuesController(CoreController):
             if len(path_parts) >= 5:
                 url_session_id = path_parts[1]
                 queue = self._queues.get(queue_id)
-                if queue and queue.session_id and url_session_id != queue.session_id:
+                if queue and (not queue.session_id or url_session_id != queue.session_id):
                     # player is still playing a stream from a previous MA session
+                    # (session_id is None after restore, or mismatches the current session)
                     self.logger.info(
-                        "Stale stream detected on %s (session %s != %s), triggering resume",
+                        "Stale stream detected on %s (url session %s, queue session %s)",
                         queue.display_name,
                         url_session_id,
                         queue.session_id,
@@ -2725,11 +2726,22 @@ class PlayerQueuesController(CoreController):
             return
         # wait briefly for the player to settle after detection
         await asyncio.sleep(3)
+        # re-fetch queue state after the delay
+        queue = self._queues.get(queue_id)
+        if not queue or not queue.active:
+            return
         self.logger.info(
             "Resuming stale queue for %s",
             queue.display_name,
         )
-        await self.resume(queue_id)
+        try:
+            await self.resume(queue_id)
+        except Exception as err:
+            self.logger.warning(
+                "Failed to resume stale queue for %s: %s",
+                queue.display_name,
+                err,
+            )
 
     def _handle_end_of_queue(
         self, queue: PlayerQueue, prev_state: CompareState, new_state: CompareState


### PR DESCRIPTION
After MA restarts, some players (e.g. DLNA devices) keep reporting PLAYING with a flow URL from the previous session. The stream is dead but the player has no way to know.

This adds session ID comparison in _parse_player_current_item_id(): if the URL's session ID doesn't match the current queue session, it triggers a delayed resume so playback continues seamlessly with a fresh stream. Uses create_task(task_id=...) for deduplication so repeated poll cycles don't spawn multiple resume attempts.

Works at the controller level so all player providers benefit, not just DLNA.

Related: #3376 (review comment by @MarvinSchenkel suggesting controller-level implementation)