### PR TITLE
Only show non empty genres for media type in library views

### DIFF
--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -308,13 +308,12 @@ class GenreController(MediaControllerBase[Genre]):
         """Get genres in the library.
 
         :param genre: NOT SUPPORTED - Filtering genres by genres doesn't make sense.
-        :param hide_empty: Controls which genres are returned when media_type is not set.
-            True: only return genres that have media mappings.
+        :param hide_empty: Only applies when media_type is not set.
+            True: only return genres that have at least one media mapping.
             False: return all genres including unmapped ones.
             None (default): only return default genres (those with a translation_key).
-        :param media_type: When set, return ALL genres (including non-defaults) that have
-            at least one media item of this type mapped. Overrides hide_empty completely —
-            this is intended for library views that need type-scoped genre filters.
+        :param media_type: When set, return all genres (including non-defaults) that have
+            at least one mapping for this media type. Takes precedence over hide_empty.
         """
         if genre is not None:
             msg = "genre parameter is not supported for Genre.library_items()"
@@ -658,16 +657,10 @@ class GenreController(MediaControllerBase[Genre]):
         # that accumulated "pop" as a secondary alias.
         alias_to_genre, primary_name_to_genre = await self._build_genre_lookup()
 
-        # Extract all unique raw genre names from metadata across all media tables
-        # CASE WHEN json_valid(...) guards the json_extract inside json_each so that
-        # rows with malformed metadata produce no rows rather than raising an error.
-        # A WHERE-only json_valid guard is insufficient because SQLite evaluates the
-        # FROM clause before the WHERE filter.
         union_parts = [
             f"SELECT DISTINCT TRIM(g.value) AS raw_name "
             f"FROM {table}, "
-            f"json_each(CASE WHEN json_valid({table}.metadata) "
-            f"THEN json_extract({table}.metadata, '$.genres') END) AS g "
+            f"json_each(json_extract({table}.metadata, '$.genres')) AS g "
             f"WHERE TRIM(g.value) != ''"
             for table, _ in MEDIA_TABLES
         ]

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -326,14 +326,9 @@ class GenreController(MediaControllerBase[Genre]):
         extra_parts: list[str] = []
         if search:
             extra_params["search_raw"] = f"%{search.strip().lower()}%"
-        if hide_empty is None:
-            extra_parts.append(f"{self.db_table}.translation_key IS NOT NULL")
-        elif hide_empty:
-            gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
-            extra_parts.append(
-                f"EXISTS(SELECT 1 FROM {gm} gm WHERE gm.genre_id = {self.db_table}.item_id)"
-            )
         if media_type is not None:
+            # media_type implies non-empty: return all genres (including non-default) that
+            # have at least one mapping for the requested type.
             gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
             extra_parts.append(
                 f"EXISTS(SELECT 1 FROM {gm} gm_mt "
@@ -341,6 +336,13 @@ class GenreController(MediaControllerBase[Genre]):
                 "AND gm_mt.media_type = :filter_media_type)"
             )
             extra_params["filter_media_type"] = media_type.value
+        elif hide_empty is None:
+            extra_parts.append(f"{self.db_table}.translation_key IS NOT NULL")
+        elif hide_empty:
+            gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
+            extra_parts.append(
+                f"EXISTS(SELECT 1 FROM {gm} gm WHERE gm.genre_id = {self.db_table}.item_id)"
+            )
         return await self.get_library_items_by_query(
             favorite=favorite,
             search=search,

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -308,12 +308,13 @@ class GenreController(MediaControllerBase[Genre]):
         """Get genres in the library.
 
         :param genre: NOT SUPPORTED - Filtering genres by genres doesn't make sense.
-        :param hide_empty: Controls which genres are returned.
+        :param hide_empty: Controls which genres are returned when media_type is not set.
             True: only return genres that have media mappings.
             False: return all genres including unmapped ones.
             None (default): only return default genres (those with a translation_key).
-        :param media_type: When set, only return genres that have at least one
-            media mapping for this specific media type.
+        :param media_type: When set, return ALL genres (including non-defaults) that have
+            at least one media item of this type mapped. Overrides hide_empty completely —
+            this is intended for library views that need type-scoped genre filters.
         """
         if genre is not None:
             msg = "genre parameter is not supported for Genre.library_items()"
@@ -658,12 +659,16 @@ class GenreController(MediaControllerBase[Genre]):
         alias_to_genre, primary_name_to_genre = await self._build_genre_lookup()
 
         # Extract all unique raw genre names from metadata across all media tables
+        # CASE WHEN json_valid(...) guards the json_extract inside json_each so that
+        # rows with malformed metadata produce no rows rather than raising an error.
+        # A WHERE-only json_valid guard is insufficient because SQLite evaluates the
+        # FROM clause before the WHERE filter.
         union_parts = [
             f"SELECT DISTINCT TRIM(g.value) AS raw_name "
-            f"FROM {table}, json_each(json_extract({table}.metadata, '$.genres')) AS g "
-            f"WHERE json_valid({table}.metadata) = 1 "
-            f"AND json_extract({table}.metadata, '$.genres') IS NOT NULL "
-            f"AND json_extract({table}.metadata, '$.genres') != '[]'"
+            f"FROM {table}, "
+            f"json_each(CASE WHEN json_valid({table}.metadata) "
+            f"THEN json_extract({table}.metadata, '$.genres') END) AS g "
+            f"WHERE TRIM(g.value) != ''"
             for table, _ in MEDIA_TABLES
         ]
         unique_names_sql = " UNION ".join(union_parts)
@@ -740,11 +745,10 @@ class GenreController(MediaControllerBase[Genre]):
                     f"SELECT gl.genre_id, {table}.item_id, "
                     f"'{media_type.value}', TRIM(g.value) "
                     f"FROM {table}, "
-                    f"json_each(json_extract({table}.metadata, '$.genres')) AS g "
+                    f"json_each(CASE WHEN json_valid({table}.metadata) "
+                    f"THEN json_extract({table}.metadata, '$.genres') END) AS g "
                     f"JOIN genre_lookup gl ON gl.raw_name = LOWER(TRIM(g.value)) "
-                    f"WHERE json_valid({table}.metadata) = 1 "
-                    f"AND json_extract({table}.metadata, '$.genres') IS NOT NULL "
-                    f"AND json_extract({table}.metadata, '$.genres') != '[]' "
+                    f"WHERE TRIM(g.value) != '' "
                     f"AND NOT EXISTS ("
                     f"SELECT 1 FROM {excl} e "
                     f"WHERE e.genre_id = gl.genre_id "

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -661,7 +661,8 @@ class GenreController(MediaControllerBase[Genre]):
         union_parts = [
             f"SELECT DISTINCT TRIM(g.value) AS raw_name "
             f"FROM {table}, json_each(json_extract({table}.metadata, '$.genres')) AS g "
-            f"WHERE json_extract({table}.metadata, '$.genres') IS NOT NULL "
+            f"WHERE json_valid({table}.metadata) = 1 "
+            f"AND json_extract({table}.metadata, '$.genres') IS NOT NULL "
             f"AND json_extract({table}.metadata, '$.genres') != '[]'"
             for table, _ in MEDIA_TABLES
         ]
@@ -741,7 +742,8 @@ class GenreController(MediaControllerBase[Genre]):
                     f"FROM {table}, "
                     f"json_each(json_extract({table}.metadata, '$.genres')) AS g "
                     f"JOIN genre_lookup gl ON gl.raw_name = LOWER(TRIM(g.value)) "
-                    f"WHERE json_extract({table}.metadata, '$.genres') IS NOT NULL "
+                    f"WHERE json_valid({table}.metadata) = 1 "
+                    f"AND json_extract({table}.metadata, '$.genres') IS NOT NULL "
                     f"AND json_extract({table}.metadata, '$.genres') != '[]' "
                     f"AND NOT EXISTS ("
                     f"SELECT 1 FROM {excl} e "

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -302,6 +302,7 @@ class GenreController(MediaControllerBase[Genre]):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         hide_empty: bool | None = None,
+        media_type: MediaType | None = None,
         **kwargs: Any,
     ) -> list[Genre]:
         """Get genres in the library.
@@ -311,6 +312,8 @@ class GenreController(MediaControllerBase[Genre]):
             True: only return genres that have media mappings.
             False: return all genres including unmapped ones.
             None (default): only return default genres (those with a translation_key).
+        :param media_type: When set, only return genres that have at least one
+            media mapping for this specific media type.
         """
         if genre is not None:
             msg = "genre parameter is not supported for Genre.library_items()"
@@ -319,17 +322,25 @@ class GenreController(MediaControllerBase[Genre]):
         # the provider filter (the frontend always sends provider="library").
         # Pass raw lowered search for alias matching (search_raw),
         # since the normalized :search param strips spaces/special chars.
-        extra_params: dict[str, Any] | None = None
-        extra_parts: list[str] | None = None
+        extra_params: dict[str, Any] = {}
+        extra_parts: list[str] = []
         if search:
-            extra_params = {"search_raw": f"%{search.strip().lower()}%"}
+            extra_params["search_raw"] = f"%{search.strip().lower()}%"
         if hide_empty is None:
-            extra_parts = [f"{self.db_table}.translation_key IS NOT NULL"]
+            extra_parts.append(f"{self.db_table}.translation_key IS NOT NULL")
         elif hide_empty:
             gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
-            extra_parts = [
+            extra_parts.append(
                 f"EXISTS(SELECT 1 FROM {gm} gm WHERE gm.genre_id = {self.db_table}.item_id)"
-            ]
+            )
+        if media_type is not None:
+            gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
+            extra_parts.append(
+                f"EXISTS(SELECT 1 FROM {gm} gm_mt "
+                f"WHERE gm_mt.genre_id = {self.db_table}.item_id "
+                "AND gm_mt.media_type = :filter_media_type)"
+            )
+            extra_params["filter_media_type"] = media_type.value
         return await self.get_library_items_by_query(
             favorite=favorite,
             search=search,

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -2981,10 +2981,6 @@ class MusicController(CoreController):
             f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}_genre_alias_idx "
             f"on {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}(genre_id,alias);"
         )
-        await self.database.execute(
-            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}_genre_type_idx "
-            f"on {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}(genre_id,media_type);"
-        )
         # indexes on genre_media_item_exclusion table
         await self.database.execute(
             f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}_media_idx "

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -2981,6 +2981,10 @@ class MusicController(CoreController):
             f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}_genre_alias_idx "
             f"on {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}(genre_id,alias);"
         )
+        await self.database.execute(
+            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}_genre_type_idx "
+            f"on {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}(genre_id,media_type);"
+        )
         # indexes on genre_media_item_exclusion table
         await self.database.execute(
             f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}_media_idx "

--- a/tests/core/test_genres.py
+++ b/tests/core/test_genres.py
@@ -293,31 +293,80 @@ class TestGenreCRUD:
     ) -> None:
         """media_type filter returns all non-empty genres for that type, including non-defaults.
 
-        Default hide_empty=None (translation_key IS NOT NULL) is bypassed when media_type
-        is set, so non-default genres with mappings are included.
+        Verifies:
+        - Non-default genres (no translation_key) with mappings ARE returned — the default
+          translation_key IS NOT NULL filter is bypassed when media_type is set.
+        - Genres mapped only to another type are excluded.
+        - Default genres (with translation_key) that have no mapping for the type are excluded.
+        - A genre mapped to multiple types appears in results for each of those types.
+        - search composing with media_type works correctly.
+        - No mappings for the requested type returns an empty list.
         """
-        track_genre = await genre_ctrl.add_item_to_library(_make_genre("MediaTypeTrackGenre"))
-        album_genre = await genre_ctrl.add_item_to_library(_make_genre("MediaTypeAlbumGenre"))
+        track_genre = await genre_ctrl.add_item_to_library(_make_genre("MT_FilterTrackOnlyGenre"))
+        album_genre = await genre_ctrl.add_item_to_library(_make_genre("MT_FilterAlbumOnlyGenre"))
+        shared_genre = await genre_ctrl.add_item_to_library(_make_genre("MT_FilterSharedGenre"))
 
-        track = await _add_test_track(mass, "MT Track")
-        album = await _add_test_album(mass, "MT Album")
+        track = await _add_test_track(mass, "MT Filter Track")
+        album = await _add_test_album(mass, "MT Filter Album")
         await genre_ctrl.add_media_mapping(
-            int(track_genre.item_id), MediaType.TRACK, track.item_id, "MediaTypeTrackGenre"
+            int(track_genre.item_id), MediaType.TRACK, track.item_id, "MT_FilterTrackOnlyGenre"
         )
         await genre_ctrl.add_media_mapping(
-            int(album_genre.item_id), MediaType.ALBUM, album.item_id, "MediaTypeAlbumGenre"
+            int(album_genre.item_id), MediaType.ALBUM, album.item_id, "MT_FilterAlbumOnlyGenre"
+        )
+        # shared_genre is mapped to both tracks and albums
+        await genre_ctrl.add_media_mapping(
+            int(shared_genre.item_id), MediaType.TRACK, track.item_id, "MT_FilterSharedGenre"
+        )
+        await genre_ctrl.add_media_mapping(
+            int(shared_genre.item_id), MediaType.ALBUM, album.item_id, "MT_FilterSharedGenre"
         )
 
-        # Use default hide_empty (None) to confirm non-default genres are still returned
+        # Add a default genre (has translation_key) that has NO mappings for any type —
+        # it must not appear in media_type results even though hide_empty=None would normally
+        # include all defaults.
+        await genre_ctrl.restore_default_genres()
+
         track_results = await genre_ctrl.library_items(media_type=MediaType.TRACK)
         track_names = {g.name for g in track_results}
-        assert "MediaTypeTrackGenre" in track_names
-        assert "MediaTypeAlbumGenre" not in track_names
+        assert "MT_FilterTrackOnlyGenre" in track_names, (
+            "track-mapped genre missing from TRACK results"
+        )
+        assert "MT_FilterSharedGenre" in track_names, "shared genre missing from TRACK results"
+        assert "MT_FilterAlbumOnlyGenre" not in track_names, (
+            "album-only genre appeared in TRACK results"
+        )
+        # Unmapped default genres must not bleed through —
+        # media_type overrides the translation_key filter
+        default_genre_name = DEFAULT_GENRE_MAPPING[0]["genre"]
+        assert default_genre_name not in track_names, (
+            "unmapped default genre appeared in TRACK results"
+        )
 
         album_results = await genre_ctrl.library_items(media_type=MediaType.ALBUM)
         album_names = {g.name for g in album_results}
-        assert "MediaTypeAlbumGenre" in album_names
-        assert "MediaTypeTrackGenre" not in album_names
+        assert "MT_FilterAlbumOnlyGenre" in album_names, (
+            "album-mapped genre missing from ALBUM results"
+        )
+        assert "MT_FilterSharedGenre" in album_names, "shared genre missing from ALBUM results"
+        assert "MT_FilterTrackOnlyGenre" not in album_names, (
+            "track-only genre appeared in ALBUM results"
+        )
+
+        # search composes correctly with media_type
+        search_results = await genre_ctrl.library_items(
+            media_type=MediaType.TRACK, search="MT_FilterShared"
+        )
+        search_names = {g.name for g in search_results}
+        assert "MT_FilterSharedGenre" in search_names
+        assert "MT_FilterTrackOnlyGenre" not in search_names
+
+        # No mappings for the requested type returns an empty list
+        playlist_results = await genre_ctrl.library_items(media_type=MediaType.PLAYLIST)
+        playlist_names = {g.name for g in playlist_results}
+        assert "MT_FilterTrackOnlyGenre" not in playlist_names
+        assert "MT_FilterAlbumOnlyGenre" not in playlist_names
+        assert "MT_FilterSharedGenre" not in playlist_names
 
     async def test_library_count(self, genre_ctrl: GenreController) -> None:
         """Returns correct count; favorite_only=True filters."""

--- a/tests/core/test_genres.py
+++ b/tests/core/test_genres.py
@@ -288,6 +288,32 @@ class TestGenreCRUD:
         with pytest.raises(ValueError, match="genre parameter is not supported"):
             await genre_ctrl.library_items(genre=1)
 
+    async def test_library_items_media_type_filter(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """media_type filter returns only genres with a mapping for that specific type."""
+        track_genre = await genre_ctrl.add_item_to_library(_make_genre("MediaTypeTrackGenre"))
+        album_genre = await genre_ctrl.add_item_to_library(_make_genre("MediaTypeAlbumGenre"))
+
+        track = await _add_test_track(mass, "MT Track")
+        album = await _add_test_album(mass, "MT Album")
+        await genre_ctrl.add_media_mapping(
+            int(track_genre.item_id), MediaType.TRACK, track.item_id, "MediaTypeTrackGenre"
+        )
+        await genre_ctrl.add_media_mapping(
+            int(album_genre.item_id), MediaType.ALBUM, album.item_id, "MediaTypeAlbumGenre"
+        )
+
+        track_results = await genre_ctrl.library_items(hide_empty=True, media_type=MediaType.TRACK)
+        track_names = {g.name for g in track_results}
+        assert "MediaTypeTrackGenre" in track_names
+        assert "MediaTypeAlbumGenre" not in track_names
+
+        album_results = await genre_ctrl.library_items(hide_empty=True, media_type=MediaType.ALBUM)
+        album_names = {g.name for g in album_results}
+        assert "MediaTypeAlbumGenre" in album_names
+        assert "MediaTypeTrackGenre" not in album_names
+
     async def test_library_count(self, genre_ctrl: GenreController) -> None:
         """Returns correct count; favorite_only=True filters."""
         await genre_ctrl.add_item_to_library(_make_genre("CountA"))

--- a/tests/core/test_genres.py
+++ b/tests/core/test_genres.py
@@ -291,7 +291,11 @@ class TestGenreCRUD:
     async def test_library_items_media_type_filter(
         self, mass: MusicAssistant, genre_ctrl: GenreController
     ) -> None:
-        """media_type filter returns only genres with a mapping for that specific type."""
+        """media_type filter returns all non-empty genres for that type, including non-defaults.
+
+        Default hide_empty=None (translation_key IS NOT NULL) is bypassed when media_type
+        is set, so non-default genres with mappings are included.
+        """
         track_genre = await genre_ctrl.add_item_to_library(_make_genre("MediaTypeTrackGenre"))
         album_genre = await genre_ctrl.add_item_to_library(_make_genre("MediaTypeAlbumGenre"))
 
@@ -304,12 +308,13 @@ class TestGenreCRUD:
             int(album_genre.item_id), MediaType.ALBUM, album.item_id, "MediaTypeAlbumGenre"
         )
 
-        track_results = await genre_ctrl.library_items(hide_empty=True, media_type=MediaType.TRACK)
+        # Use default hide_empty (None) to confirm non-default genres are still returned
+        track_results = await genre_ctrl.library_items(media_type=MediaType.TRACK)
         track_names = {g.name for g in track_results}
         assert "MediaTypeTrackGenre" in track_names
         assert "MediaTypeAlbumGenre" not in track_names
 
-        album_results = await genre_ctrl.library_items(hide_empty=True, media_type=MediaType.ALBUM)
+        album_results = await genre_ctrl.library_items(media_type=MediaType.ALBUM)
         album_names = {g.name for g in album_results}
         assert "MediaTypeAlbumGenre" in album_names
         assert "MediaTypeTrackGenre" not in album_names


### PR DESCRIPTION
Backend filtering logic to allow library view genre filters to only display non empty genres per media type