### PR TITLE
Improve Sendspin progress bar accuracy

### DIFF
--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -739,9 +739,9 @@ class SendspinPlaybackSession:
                     self._produced_audio_us += pending.duration_us
                     self._prune_history_locked(commit_now_us)
                 await self._fanout_history_chunk_to_join_processors(committed_history_chunk)
-                if self._first_commit_monotonic_us is not None:
+                if self._timeline_start_us is not None:
                     elapsed_real_s = max(
-                        0.0, (commit_now_us - self._first_commit_monotonic_us) / 1_000_000
+                        0.0, (commit_now_us - self._timeline_start_us) / 1_000_000
                     )
                     if elapsed_real_s - last_elapsed_update_s >= 1.0:
                         last_elapsed_update_s = elapsed_real_s

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -634,6 +634,7 @@ class SendspinPlaybackSession:
         # Shadow deque mirroring pending_chunks for join-catchup backlog peeking.
         pending_backlog: deque[_PendingChunk] = deque()
         pending_duration_us = 0
+        last_elapsed_update_us = 0
 
         async def _produce_pending_chunks() -> None:
             nonlocal pending_duration_us
@@ -678,7 +679,7 @@ class SendspinPlaybackSession:
                             )
 
         async def _commit_pending_chunks() -> None:
-            nonlocal pending_duration_us
+            nonlocal pending_duration_us, last_elapsed_update_us
             while True:
                 pending = await pending_chunks.get()
                 if pending is None:
@@ -736,8 +737,14 @@ class SendspinPlaybackSession:
                         self._first_commit_monotonic_us = commit_now_us
                     self._history.append(committed_history_chunk)
                     self._produced_audio_us += pending.duration_us
+                    produced_us = self._produced_audio_us
                     self._prune_history_locked(commit_now_us)
                 await self._fanout_history_chunk_to_join_processors(committed_history_chunk)
+                if produced_us - last_elapsed_update_us >= 1_000_000:
+                    last_elapsed_update_us = produced_us
+                    self.player._attr_elapsed_time = produced_us / 1_000_000
+                    self.player._attr_elapsed_time_last_updated = time.time()
+                    self.player.update_state()
 
         commit_task = asyncio.create_task(_commit_pending_chunks())
         self._attach_task_exception_logger(commit_task, "commit_pending_chunks")

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -740,9 +740,7 @@ class SendspinPlaybackSession:
                     self._prune_history_locked(commit_now_us)
                 await self._fanout_history_chunk_to_join_processors(committed_history_chunk)
                 if self._timeline_start_us is not None:
-                    elapsed_real_s = max(
-                        0.0, (commit_now_us - self._timeline_start_us) / 1_000_000
-                    )
+                    elapsed_real_s = max(0.0, (commit_now_us - self._timeline_start_us) / 1_000_000)
                     if elapsed_real_s - last_elapsed_update_s >= 1.0:
                         last_elapsed_update_s = elapsed_real_s
                         self.player._attr_elapsed_time = elapsed_real_s

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -634,7 +634,7 @@ class SendspinPlaybackSession:
         # Shadow deque mirroring pending_chunks for join-catchup backlog peeking.
         pending_backlog: deque[_PendingChunk] = deque()
         pending_duration_us = 0
-        last_elapsed_update_us = 0
+        last_elapsed_update_s = 0.0
 
         async def _produce_pending_chunks() -> None:
             nonlocal pending_duration_us
@@ -679,7 +679,7 @@ class SendspinPlaybackSession:
                             )
 
         async def _commit_pending_chunks() -> None:
-            nonlocal pending_duration_us, last_elapsed_update_us
+            nonlocal pending_duration_us, last_elapsed_update_s
             while True:
                 pending = await pending_chunks.get()
                 if pending is None:
@@ -737,14 +737,17 @@ class SendspinPlaybackSession:
                         self._first_commit_monotonic_us = commit_now_us
                     self._history.append(committed_history_chunk)
                     self._produced_audio_us += pending.duration_us
-                    produced_us = self._produced_audio_us
                     self._prune_history_locked(commit_now_us)
                 await self._fanout_history_chunk_to_join_processors(committed_history_chunk)
-                if produced_us - last_elapsed_update_us >= 1_000_000:
-                    last_elapsed_update_us = produced_us
-                    self.player._attr_elapsed_time = produced_us / 1_000_000
-                    self.player._attr_elapsed_time_last_updated = time.time()
-                    self.player.update_state()
+                if self._first_commit_monotonic_us is not None:
+                    elapsed_real_s = max(
+                        0.0, (commit_now_us - self._first_commit_monotonic_us) / 1_000_000
+                    )
+                    if elapsed_real_s - last_elapsed_update_s >= 1.0:
+                        last_elapsed_update_s = elapsed_real_s
+                        self.player._attr_elapsed_time = elapsed_real_s
+                        self.player._attr_elapsed_time_last_updated = time.time()
+                        self.player.update_state()
 
         commit_task = asyncio.create_task(_commit_pending_chunks())
         self._attach_task_exception_logger(commit_task, "commit_pending_chunks")

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -430,8 +430,8 @@ class SendspinPlayer(Player):
 
         # Update player state optimistically
         self._attr_current_media = media
-        self._attr_elapsed_time = 0
-        self._attr_elapsed_time_last_updated = time.time()
+        self._attr_elapsed_time = None
+        self._attr_elapsed_time_last_updated = None
         # playback_state will be set by the group state change event
 
         # Stop previous stream in case we were already playing something.

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -428,7 +428,7 @@ class SendspinPlayer(Player):
             "Received PLAY_MEDIA command on player %s with uri %s", self.display_name, media.uri
         )
 
-        # Update player state optimistically
+        # Set current media; elapsed_time will be updated once audio actually commits.
         self._attr_current_media = media
         self._attr_elapsed_time = None
         self._attr_elapsed_time_last_updated = None


### PR DESCRIPTION
This PR fixes the elapsed time tracking mechanism in the Sendspin playback provider by deferring elapsed time updates until audio chunks are actually committed, rather than initializing them optimistically at the start of playback.