### PR TITLE
Improve player drift detection + Airplay elapsed time improvements

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1330,7 +1330,6 @@ class PlayerQueuesController(CoreController):
         if player_elapsed is None:
             return
         now = time.time()
-        # Significant drift detected — correct the queue's timing base
         if queue.flow_mode:
             # in flow mode the player reports cumulative stream elapsed time,
             _, elapsed_time = self._get_flow_queue_stream_index(queue, player)
@@ -1339,12 +1338,6 @@ class PlayerQueuesController(CoreController):
             if queue.current_item and queue.current_item.streamdetails:
                 if seek_pos := queue.current_item.streamdetails.seek_position:
                     elapsed_time += seek_pos
-        self.logger.warning(
-            "Correcting elapsed_time for player %s from %.1f to %.1f seconds",
-            queue_id,
-            queue.elapsed_time,
-            elapsed_time,
-        )
         queue.elapsed_time = elapsed_time
         queue.elapsed_time_last_updated = now
         self.mass.signal_event(

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1339,6 +1339,12 @@ class PlayerQueuesController(CoreController):
             if queue.current_item and queue.current_item.streamdetails:
                 if seek_pos := queue.current_item.streamdetails.seek_position:
                     elapsed_time += seek_pos
+        self.logger.warning(
+            "Correcting elapsed_time for player %s from %.1f to %.1f seconds",
+            queue_id,
+            queue.elapsed_time,
+            elapsed_time,
+        )
         queue.elapsed_time = elapsed_time
         queue.elapsed_time_last_updated = now
         self.mass.signal_event(

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1504,7 +1504,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             return
 
         # to prevent spamming the eventbus on small changes (e.g. elapsed time),
-        # we check if there are only changes in the elapsed time
+        # we check if there are only changes in the elapsed time and send
+        # a lightweight event.
         clean_changed_keys = set(changed_values.keys()) - {
             "current_media.elapsed_time",
             "elapsed_time_last_updated",
@@ -1517,17 +1518,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 (elapsed[0] or 0) + (now - (updated[0] or now)),
                 (elapsed[1] or 0) + (now - (updated[1] or now)),
             )
-            if (drift := abs(prev_corrected - new_corrected)) > 1.0:
-                self.logger.warning(
-                    "Player: %s. Corrected elapsed drift: %.1f -> %.1f (%.1fs)",
-                    player_id,
-                    prev_corrected,
-                    new_corrected,
-                    drift,
-                )
+            if abs(prev_corrected - new_corrected) > 1.0:
                 self.mass.player_queues.on_player_elapsed_time_corrected(player)
-            if player.protocol_parent_id:
-                self.trigger_player_update(player.protocol_parent_id)
+                if player.protocol_parent_id:
+                    self.trigger_player_update(player.protocol_parent_id)
             return
 
         # signal update to the playerqueue

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1511,20 +1511,23 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         }
         if clean_changed_keys == {ATTR_ELAPSED_TIME} and not force_update:
             now = time.time()
-            prev_elapsed = changed_values[ATTR_ELAPSED_TIME][0] or 0
-            new_elapsed = changed_values[ATTR_ELAPSED_TIME][1] or 0
-            last_updated = changed_values.get("elapsed_time_last_updated", (now, now))
-            prev_corrected = prev_elapsed + (now - (last_updated[0] or now))
-            new_corrected = new_elapsed + (now - (last_updated[1] or now))
-            self.logger.warning(
-                "Player: %s. Corrected elapsed: %s -> %s, drift: %s",
-                player_id,
-                prev_corrected,
-                new_corrected,
-                abs(prev_corrected - new_corrected),
+            elapsed = changed_values[ATTR_ELAPSED_TIME]
+            updated = changed_values.get("elapsed_time_last_updated", (now, now))
+            prev_corrected, new_corrected = (
+                (elapsed[0] or 0) + (now - (updated[0] or now)),
+                (elapsed[1] or 0) + (now - (updated[1] or now)),
             )
-            if abs(prev_corrected - new_corrected) > 1.0:
+            if (drift := abs(prev_corrected - new_corrected)) > 1.0:
+                self.logger.warning(
+                    "Player: %s. Corrected elapsed drift: %.1f -> %.1f (%.1fs)",
+                    player_id,
+                    prev_corrected,
+                    new_corrected,
+                    drift,
+                )
                 self.mass.player_queues.on_player_elapsed_time_corrected(player)
+            if player.protocol_parent_id:
+                self.trigger_player_update(player.protocol_parent_id)
             return
 
         # signal update to the playerqueue

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1505,12 +1505,25 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
         # to prevent spamming the eventbus on small changes (e.g. elapsed time),
         # we check if there are only changes in the elapsed time
-        clean_changed_keys = set(changed_values.keys()) - {"current_media.elapsed_time"}
+        clean_changed_keys = set(changed_values.keys()) - {
+            "current_media.elapsed_time",
+            "elapsed_time_last_updated",
+        }
         if clean_changed_keys == {ATTR_ELAPSED_TIME} and not force_update:
-            # ignore small changes in elapsed time
-            prev_value = changed_values[ATTR_ELAPSED_TIME][0] or 0
-            new_value = changed_values[ATTR_ELAPSED_TIME][1] or 0
-            if abs(prev_value - new_value) > 1.0:
+            now = time.time()
+            prev_elapsed = changed_values[ATTR_ELAPSED_TIME][0] or 0
+            new_elapsed = changed_values[ATTR_ELAPSED_TIME][1] or 0
+            last_updated = changed_values.get("elapsed_time_last_updated", (now, now))
+            prev_corrected = prev_elapsed + (now - (last_updated[0] or now))
+            new_corrected = new_elapsed + (now - (last_updated[1] or now))
+            self.logger.warning(
+                "Player: %s. Corrected elapsed: %s -> %s, drift: %s",
+                player_id,
+                prev_corrected,
+                new_corrected,
+                abs(prev_corrected - new_corrected),
+            )
+            if abs(prev_corrected - new_corrected) > 1.0:
                 self.mass.player_queues.on_player_elapsed_time_corrected(player)
             return
 

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1512,12 +1512,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         }
         if clean_changed_keys == {ATTR_ELAPSED_TIME} and not force_update:
             now = time.time()
-            elapsed = changed_values[ATTR_ELAPSED_TIME]
-            updated = changed_values.get("elapsed_time_last_updated", (now, now))
-            prev_corrected, new_corrected = (
-                (elapsed[0] or 0) + (now - (updated[0] or now)),
-                (elapsed[1] or 0) + (now - (updated[1] or now)),
-            )
+            prev_elapsed, new_elapsed = changed_values[ATTR_ELAPSED_TIME]
+            prev_updated, new_updated = changed_values.get("elapsed_time_last_updated", (now, now))
+            prev_corrected = (prev_elapsed or 0) + (now - (prev_updated or now))
+            new_corrected = (new_elapsed or 0) + (now - (new_updated or now))
             if abs(prev_corrected - new_corrected) > 1.0:
                 self.mass.player_queues.on_player_elapsed_time_corrected(player)
                 if player.protocol_parent_id:

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1178,7 +1178,6 @@ class Player(ABC):
                 1, self._on_player_media_updated, task_id=f"player_media_updated_{self.player_id}"
             )
         # ignore some values that are not relevant for the state
-        changed_values.pop("elapsed_time_last_updated", None)
         changed_values.pop("extra_attributes.seq_no", None)
         changed_values.pop("extra_attributes.last_poll", None)
         changed_values.pop("current_media.elapsed_time_last_updated", None)

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -118,7 +118,12 @@ class RaopStream(AirPlayProtocol):
                 # this is received more or less every second while playing
                 millis = int(line.split("elapsed milliseconds: ")[1])
                 silence_ms = (self.session.silence_padding * 1000) if self.session else 0
-                elapsed_time = max(0, (millis - silence_ms) / 1000)
+                adjusted_millis = millis - silence_ms
+                if adjusted_millis < 0:
+                    # we need to ignore updates until we have passed the initial silence padding,
+                    # otherwise the player will not correct drift
+                    continue
+                elapsed_time = adjusted_millis / 1000
                 player.set_state_from_stream(elapsed_time=elapsed_time)
             elif "Password required, but none supplied." in line:
                 logger.error(

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -123,6 +123,7 @@ class RaopStream(AirPlayProtocol):
                     # we need to ignore updates until we have passed the initial silence padding,
                     # otherwise the player will not correct drift
                     continue
+                # note that this represents the total elapsed time of the streaming session
                 elapsed_time = adjusted_millis / 1000
                 player.set_state_from_stream(elapsed_time=elapsed_time)
             elif "Password required, but none supplied." in line:

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -117,8 +117,8 @@ class RaopStream(AirPlayProtocol):
             elif "elapsed milliseconds:" in line:
                 # this is received more or less every second while playing
                 millis = int(line.split("elapsed milliseconds: ")[1])
-                # note that this represents the total elapsed time of the streaming session
-                elapsed_time = millis / 1000
+                silence_ms = (self.session.silence_padding * 1000) if self.session else 0
+                elapsed_time = max(0, (millis - silence_ms) / 1000)
                 player.set_state_from_stream(elapsed_time=elapsed_time)
             elif "Password required, but none supplied." in line:
                 logger.error(

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -255,18 +255,21 @@ class AirPlayStreamSession:
         silence_inserted = 0.0
 
         await asyncio.sleep(grace_period)
-        while not self._first_chunk_received.is_set() and silence_inserted < max_silence_padding:
-            silence_duration = 0.1
-            silence_bytes = int(pcm_sample_size * silence_duration)
-            silence_chunk = bytes(silence_bytes)
-            has_running_clients = await self._write_chunk_to_all_players(silence_chunk)
-            if not has_running_clients:
-                break
-            self.seconds_streamed += silence_duration
-            silence_inserted += silence_duration
-            await asyncio.sleep(0.05)
-
-        self.silence_padding = silence_inserted
+        try:
+            while (
+                not self._first_chunk_received.is_set() and silence_inserted < max_silence_padding
+            ):
+                silence_duration = 0.1
+                silence_bytes = int(pcm_sample_size * silence_duration)
+                silence_chunk = bytes(silence_bytes)
+                has_running_clients = await self._write_chunk_to_all_players(silence_chunk)
+                if not has_running_clients:
+                    break
+                self.seconds_streamed += silence_duration
+                silence_inserted += silence_duration
+                await asyncio.sleep(0.05)
+        finally:
+            self.silence_padding = silence_inserted
         if silence_inserted > 0:
             self.prov.logger.warning(
                 "Inserted %.1fs silence padding while waiting for audio source",

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -55,6 +55,7 @@ class AirPlayStreamSession:
         self.start_time: float = 0.0
         self.wait_start: float = 0.0
         self.seconds_streamed: float = 0
+        self.silence_padding: float = 0.0
         self._first_chunk_received = asyncio.Event()
         # Ring buffer for late joiners: stores (chunk_data, seconds_offset) tuples
         # Chunks from streams controller are ~1 second each (pcm_sample_size bytes)
@@ -265,6 +266,7 @@ class AirPlayStreamSession:
             silence_inserted += silence_duration
             await asyncio.sleep(0.05)
 
+        self.silence_padding = silence_inserted
         if silence_inserted > 0:
             self.prov.logger.warning(
                 "Inserted %.1fs silence padding while waiting for audio source",


### PR DESCRIPTION
Couple of improvements for drift detection:
- We now use the actual elapsed_time_last_updated to detect the actual drift. We were sometimes missing events before because we were doing a different check than inside `on_player_elapsed_time_corrected`
- Fixes elapsed_time reporting for Airplay. We weren't accounting for the silence padding, causing the lyrics in karaoke mode to be off. This also fixes the player progress bar jumping when pressing pause/play.
- Also update the parent player in case we are playing through a protocol (e.g. airplay on Sonos)