### PR TITLE
Fix glitch where the UI and the flow are out of sync

### DIFF
--- a/music_assistant/controllers/streams/streams_controller.py
+++ b/music_assistant/controllers/streams/streams_controller.py
@@ -1222,6 +1222,7 @@ class StreamsController(CoreController):
                 )
                 # Clean up and continue to next track
                 queue_track.streamdetails.stream_error = True
+                play_log_entry.seconds_streamed = 0
                 del buffer
                 continue
             if last_fadeout_part:


### PR DESCRIPTION
fix(streams): set seconds_streamed=0 for failed flow mode tracks

When a track fails to stream (no audio data received), its PlayLogEntry was left with seconds_streamed=None. The flow mode index calculation falls back to duration, then to 604800s (one week) when both are None. This permanently pins the queue to the failed track while audio continues playing subsequent tracks normally — a split-brain where the UI shows the wrong track indefinitely.

What that looked like in the server logs:

```
2026-03-18 11:54:14.912 DEBUG (MainThread) [music_assistant.streams] Start Streaming queue track: qobuz--ZLGtm3jb://track/341006810 (The Cranberries - Ode To My Family (Remastered 2020)) for queue Living Room Streamer
2026-03-18 11:54:27.041 ERROR (MainThread) [music_assistant.streams] AudioError while streaming queue item The Cranberries - Ode To My Family (Remastered 2020) (qobuz--ZLGtm3jb://track/341006810): Error while streaming: FFMpeg exited with code 251: [https @ 0xffff96b10000] Will reconnect at 1 in 7 second(s), error=Input/output error.
2026-03-18 11:54:27.042 WARNING (MainThread) [music_assistant.streams] Track The Cranberries - Ode To My Family (Remastered 2020) (qobuz--ZLGtm3jb://track/341006810) on queue Living Room Streamer produced no audio data - skipping
2026-03-18 11:54:27.376 DEBUG (MainThread) [music_assistant.streams] Start Streaming queue track: qobuz--ZLGtm3jb://track/45057190 (Great Big Sea - Sea of No Cares) for queue Living Room Streamer
<snip the queue continuing just fine>
```

But the UI was 'stuck' on The Cranberries until I manually hit 'play' (it looked paused, even though we'd moved on to other songs) then it reset and was in sync again.

```
<snip the songs between the Cranberries and now>
2026-03-18 12:32:02.046 DEBUG (MainThread) [music_assistant.streams] Start Streaming queue track: qobuz--ZLGtm3jb://track/212017566 (Say Hi - Elouise) for queue Living Room Streamer
2026-03-18 12:35:59.488 DEBUG (MainThread) [music_assistant.streams] Finished Streaming queue track: qobuz--ZLGtm3jb://track/212017566 (Say Hi - Elouise) on queue Living Room Streamer
2026-03-18 12:35:59.550 DEBUG (MainThread) [music_assistant.streams] Start Streaming queue track: qobuz--ZLGtm3jb://track/2467973 (Frou Frou - Let Go) for queue Living Room Streamer
2026-03-18 12:36:49.073 INFO (MainThread) [music_assistant.streams] Start Queue Flow stream for Queue Living Room Streamer - crossfade: disabled
2026-03-18 12:36:49.073 DEBUG (MainThread) [music_assistant.streams] Start Streaming queue track: qobuz--ZLGtm3jb://track/45057190 (Great Big Sea - Sea of No Cares) for queue Living Room Streamer
```