### PR TITLE
Add support for dynamic playlists to the Queue controller

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -952,7 +952,9 @@ class PlayerQueuesController(CoreController):
         # debounce rapid next button presses using call_later
         self.mass.call_later(
             1,
-            self.play_index(queue_id, next_index),
+            self.play_index,
+            queue_id,
+            next_index,
             task_id=f"queue_play_index_{queue_id}",
         )
 

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -554,6 +554,18 @@ class PlayerQueuesController(CoreController):
                     # item is MediaItemType | ItemMapping at this point
                     media_item = item
 
+                if (
+                    isinstance(media_item, ItemMapping)
+                    and media_item.media_type == MediaType.PLAYLIST
+                ):
+                    # Resolve mapping once so playlist-specific logic can use
+                    # a full Playlist object without duplicating branches.
+                    with suppress(MusicAssistantError):
+                        media_item = await self.mass.music.playlists.get(
+                            media_item.item_id,
+                            media_item.provider,
+                        )
+
                 # Save requested media item to play on the queue so we can use it as a source
                 # for Don't stop the music. Use FIFO list to keep track of the last 10 played items
                 # Skip ItemMapping and BrowseFolder - only queue full MediaItemType objects
@@ -572,21 +584,6 @@ class PlayerQueuesController(CoreController):
                         media_item, "is_dynamic", False
                     ):
                         radio_source.append(media_item)
-                elif (
-                    isinstance(media_item, ItemMapping)
-                    and media_item.media_type == MediaType.PLAYLIST
-                ):
-                    # Resolve mapping to full playlist so dynamic playlists can hook into
-                    # existing radio_source refill behavior.
-                    try:
-                        mapped_playlist = await self.mass.music.playlists.get(
-                            media_item.item_id,
-                            media_item.provider,
-                        )
-                    except MusicAssistantError:
-                        mapped_playlist = None
-                    if mapped_playlist and getattr(mapped_playlist, "is_dynamic", False):
-                        radio_source.append(mapped_playlist)
 
                 # handle default enqueue option if needed
                 if option is None:

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2101,11 +2101,15 @@ class PlayerQueuesController(CoreController):
                     QueueItem.from_media_item(queue_id, x) for x in dynamic_tracks if x.available
                 ]
                 if queue_items:
+                    cur_index = self._queues[queue_id].current_index or 0
                     await self.load(
                         queue_id,
                         queue_items,
-                        insert_at_index=len(self._queue_items[queue_id]) + 1,
+                        insert_at_index=cur_index + 1,
+                        keep_remaining=False,
+                        keep_played=True,
                     )
+                    return
             except MusicAssistantError as err:
                 self.logger.warning(
                     "Failed to refill dynamic playlist %s for queue %s: %s",
@@ -2113,7 +2117,6 @@ class PlayerQueuesController(CoreController):
                     queue.display_name,
                     err,
                 )
-            return
         radio_tracks = await self._get_radio_tracks(queue_id=queue_id, is_initial_radio_mode=False)
         # fill queue - filter out unavailable items
         queue_items = [QueueItem.from_media_item(queue_id, x) for x in radio_tracks if x.available]
@@ -2883,10 +2886,11 @@ class PlayerQueuesController(CoreController):
                             if x.available
                         ]
                         if queue_items:
+                            cur_index = queue.current_index or 0
                             await self.load(
                                 queue.queue_id,
                                 queue_items,
-                                insert_at_index=len(self._queue_items[queue.queue_id]),
+                                insert_at_index=cur_index + 1,
                                 keep_remaining=False,
                                 keep_played=True,
                                 shuffle=False,

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1913,9 +1913,12 @@ class PlayerQueuesController(CoreController):
             "Fetching tracks to play for playlist %s",
             playlist.name,
         )
+        force_refresh = bool(getattr(playlist, "is_dynamic", False))
         # TODO: Handle other sort options etc.
         async for playlist_track in self.mass.music.playlists.tracks(
-            playlist.item_id, playlist.provider
+            playlist.item_id,
+            playlist.provider,
+            force_refresh=force_refresh,
         ):
             if not playlist_track.available:
                 continue
@@ -2825,6 +2828,39 @@ class PlayerQueuesController(CoreController):
                         )
                         await self.play_index(queue.queue_id, next_index)
                     return
+            # If the queue was started from a dynamic playlist, fetch fresh tracks and continue.
+            dynamic_playlist = next(
+                (
+                    item
+                    for item in reversed(queue.enqueued_media_items)
+                    if isinstance(item, Playlist) and getattr(item, "is_dynamic", False)
+                ),
+                None,
+            )
+            if dynamic_playlist is not None:
+                dynamic_tracks = await self.get_playlist_tracks(dynamic_playlist, start_item=None)
+                if dynamic_tracks:
+                    queue_items = [
+                        QueueItem.from_media_item(queue.queue_id, x)
+                        for x in dynamic_tracks
+                        if x.available
+                    ]
+                    if queue_items:
+                        await self.load(
+                            queue.queue_id,
+                            queue_items,
+                            insert_at_index=len(self._queue_items[queue.queue_id]),
+                            keep_remaining=False,
+                            keep_played=True,
+                            shuffle=False,
+                        )
+                        if queue.current_index is not None and (
+                            next_item := self.get_next_item(queue.queue_id, queue.current_index)
+                        ):
+                            next_index = self.index_by_id(queue.queue_id, next_item.queue_item_id)
+                            if next_index is not None:
+                                await self.play_index(queue.queue_id, next_index)
+                                return
             # If the last item was a radio station, continue playing instead of clearing.
             # For track-based radio (Apple Music Artist Radio etc.) this fetches the next
             # track from the station; for live radio it would reconnect to the stream.

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -568,6 +568,25 @@ class PlayerQueuesController(CoreController):
                     queue.enqueued_media_items.append(media_item)
                     if len(queue.enqueued_media_items) > 10:
                         queue.enqueued_media_items.pop(0)
+                    if isinstance(media_item, Playlist) and getattr(
+                        media_item, "is_dynamic", False
+                    ):
+                        radio_source.append(media_item)
+                elif (
+                    isinstance(media_item, ItemMapping)
+                    and media_item.media_type == MediaType.PLAYLIST
+                ):
+                    # Resolve mapping to full playlist so dynamic playlists can hook into
+                    # existing radio_source refill behavior.
+                    try:
+                        mapped_playlist = await self.mass.music.playlists.get(
+                            media_item.item_id,
+                            media_item.provider,
+                        )
+                    except MusicAssistantError:
+                        mapped_playlist = None
+                    if mapped_playlist and getattr(mapped_playlist, "is_dynamic", False):
+                        radio_source.append(mapped_playlist)
 
                 # handle default enqueue option if needed
                 if option is None:
@@ -782,8 +801,6 @@ class PlayerQueuesController(CoreController):
         queue.radio_source = []
         if queue.state != PlaybackState.IDLE and not skip_stop:
             self.mass.create_task(self.stop(queue_id))
-        self.mass.cancel_timer(f"queue_play_index_{queue_id}")
-        self._transitioning_players.discard(queue_id)
         queue.current_index = None
         queue.current_item = None
         queue.elapsed_time = 0
@@ -1409,16 +1426,6 @@ class PlayerQueuesController(CoreController):
         while True:
             next_index = self._get_next_index(queue_id, cur_index + idx)
             if next_index is None:
-                # For RADIO type items, treat them as a continuous source: clear the
-                # cached stream details and re-request the next track from the provider.
-                cur_item = self.get_item(queue_id, cur_index)
-                if cur_item is not None and cur_item.media_type == MediaType.RADIO:
-                    cur_item.streamdetails = None
-                    try:
-                        await self._load_item(cur_item, None)
-                    except (MediaNotFoundError, AudioError) as err:
-                        raise QueueEmpty("No more tracks available from radio station.") from err
-                    return cur_item
                 raise QueueEmpty("No more tracks left in the queue.")
             queue_item = self.get_item(queue_id, next_index)
             if queue_item is None:
@@ -1782,17 +1789,6 @@ class PlayerQueuesController(CoreController):
             media.album = (
                 album.name if (album := getattr(queue_item.media_item, "album", None)) else ""
             )
-            # For track-based radio stations (e.g. Apple Music Artist Radio)
-            # stream_metadata carries the currently playing track's artist/title.
-            if (
-                queue_item.media_type == MediaType.RADIO
-                and queue_item.streamdetails
-                and (sm := queue_item.streamdetails.stream_metadata)
-            ):
-                if sm.title:
-                    media.title = sm.title
-                if sm.artist:
-                    media.artist = sm.artist
             if queue_item.image:
                 # the image format needs to be 500x500 jpeg for maximum compatibility with players
                 # we prefer the imageproxy on the streamserver here because this request is sent
@@ -2089,9 +2085,38 @@ class PlayerQueuesController(CoreController):
             "Filling radio tracks for queue %s",
             queue_id,
         )
-        tracks = await self._get_radio_tracks(queue_id=queue_id, is_initial_radio_mode=False)
+        queue = self._queues[queue_id]
+        dynamic_playlist = next(
+            (
+                item
+                for item in reversed(queue.radio_source)
+                if isinstance(item, Playlist) and getattr(item, "is_dynamic", False)
+            ),
+            None,
+        )
+        if dynamic_playlist is not None:
+            try:
+                dynamic_tracks = await self.get_playlist_tracks(dynamic_playlist, start_item=None)
+                queue_items = [
+                    QueueItem.from_media_item(queue_id, x) for x in dynamic_tracks if x.available
+                ]
+                if queue_items:
+                    await self.load(
+                        queue_id,
+                        queue_items,
+                        insert_at_index=len(self._queue_items[queue_id]) + 1,
+                    )
+            except MusicAssistantError as err:
+                self.logger.warning(
+                    "Failed to refill dynamic playlist %s for queue %s: %s",
+                    getattr(dynamic_playlist, "name", repr(dynamic_playlist)),
+                    queue.display_name,
+                    err,
+                )
+            return
+        radio_tracks = await self._get_radio_tracks(queue_id=queue_id, is_initial_radio_mode=False)
         # fill queue - filter out unavailable items
-        queue_items = [QueueItem.from_media_item(queue_id, x) for x in tracks if x.available]
+        queue_items = [QueueItem.from_media_item(queue_id, x) for x in radio_tracks if x.available]
         await self.load(
             queue_id,
             queue_items,
@@ -2832,11 +2857,20 @@ class PlayerQueuesController(CoreController):
             dynamic_playlist = next(
                 (
                     item
-                    for item in reversed(queue.enqueued_media_items)
+                    for item in reversed(queue.radio_source)
                     if isinstance(item, Playlist) and getattr(item, "is_dynamic", False)
                 ),
                 None,
             )
+            if dynamic_playlist is None:
+                dynamic_playlist = next(
+                    (
+                        item
+                        for item in reversed(queue.enqueued_media_items)
+                        if isinstance(item, Playlist) and getattr(item, "is_dynamic", False)
+                    ),
+                    None,
+                )
             if dynamic_playlist is not None:
                 try:
                     dynamic_tracks = await self.get_playlist_tracks(
@@ -2873,16 +2907,6 @@ class PlayerQueuesController(CoreController):
                         queue.display_name,
                         err,
                     )
-            # If the last item was a radio station, continue playing instead of clearing.
-            # For track-based radio (Apple Music Artist Radio etc.) this fetches the next
-            # track from the station; for live radio it would reconnect to the stream.
-            if prev_item and prev_item.media_type == MediaType.RADIO:
-                current_index = self.index_by_id(queue.queue_id, prev_item.queue_item_id)
-                if current_index is not None and queue.state == PlaybackState.IDLE and queue.active:
-                    # clear cached stream details so the provider fetches a fresh track
-                    prev_item.streamdetails = None
-                    await self.play_index(queue.queue_id, current_index)
-                    return
             self.logger.info("End of queue reached, clearing items")
             self.clear(queue.queue_id)
 

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2838,29 +2838,41 @@ class PlayerQueuesController(CoreController):
                 None,
             )
             if dynamic_playlist is not None:
-                dynamic_tracks = await self.get_playlist_tracks(dynamic_playlist, start_item=None)
-                if dynamic_tracks:
-                    queue_items = [
-                        QueueItem.from_media_item(queue.queue_id, x)
-                        for x in dynamic_tracks
-                        if x.available
-                    ]
-                    if queue_items:
-                        await self.load(
-                            queue.queue_id,
-                            queue_items,
-                            insert_at_index=len(self._queue_items[queue.queue_id]),
-                            keep_remaining=False,
-                            keep_played=True,
-                            shuffle=False,
-                        )
-                        if queue.current_index is not None and (
-                            next_item := self.get_next_item(queue.queue_id, queue.current_index)
-                        ):
-                            next_index = self.index_by_id(queue.queue_id, next_item.queue_item_id)
-                            if next_index is not None:
-                                await self.play_index(queue.queue_id, next_index)
-                                return
+                try:
+                    dynamic_tracks = await self.get_playlist_tracks(
+                        dynamic_playlist, start_item=None
+                    )
+                    if dynamic_tracks:
+                        queue_items = [
+                            QueueItem.from_media_item(queue.queue_id, x)
+                            for x in dynamic_tracks
+                            if x.available
+                        ]
+                        if queue_items:
+                            await self.load(
+                                queue.queue_id,
+                                queue_items,
+                                insert_at_index=len(self._queue_items[queue.queue_id]),
+                                keep_remaining=False,
+                                keep_played=True,
+                                shuffle=False,
+                            )
+                            if queue.current_index is not None and (
+                                next_item := self.get_next_item(queue.queue_id, queue.current_index)
+                            ):
+                                next_index = self.index_by_id(
+                                    queue.queue_id, next_item.queue_item_id
+                                )
+                                if next_index is not None:
+                                    await self.play_index(queue.queue_id, next_index)
+                                    return
+                except MusicAssistantError as err:
+                    self.logger.warning(
+                        "Failed to refresh dynamic playlist %s for queue %s: %s",
+                        getattr(dynamic_playlist, "name", repr(dynamic_playlist)),
+                        queue.display_name,
+                        err,
+                    )
             # If the last item was a radio station, continue playing instead of clearing.
             # For track-based radio (Apple Music Artist Radio etc.) this fetches the next
             # track from the station; for live radio it would reconnect to the stream.

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -580,7 +580,11 @@ class PlayerQueuesController(CoreController):
                     queue.enqueued_media_items.append(media_item)
                     if len(queue.enqueued_media_items) > 10:
                         queue.enqueued_media_items.pop(0)
-                    if isinstance(media_item, Playlist) and media_item.is_dynamic:
+                    if (
+                        isinstance(media_item, Playlist)
+                        and media_item.is_dynamic
+                        and not radio_mode
+                    ):
                         radio_source.append(media_item)
 
                 # handle default enqueue option if needed

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -782,6 +782,8 @@ class PlayerQueuesController(CoreController):
         queue.radio_source = []
         if queue.state != PlaybackState.IDLE and not skip_stop:
             self.mass.create_task(self.stop(queue_id))
+        self.mass.cancel_timer(f"queue_play_index_{queue_id}")
+        self._transitioning_players.discard(queue_id)
         queue.current_index = None
         queue.current_item = None
         queue.elapsed_time = 0
@@ -1405,6 +1407,16 @@ class PlayerQueuesController(CoreController):
         while True:
             next_index = self._get_next_index(queue_id, cur_index + idx)
             if next_index is None:
+                # For RADIO type items, treat them as a continuous source: clear the
+                # cached stream details and re-request the next track from the provider.
+                cur_item = self.get_item(queue_id, cur_index)
+                if cur_item is not None and cur_item.media_type == MediaType.RADIO:
+                    cur_item.streamdetails = None
+                    try:
+                        await self._load_item(cur_item, None)
+                    except (MediaNotFoundError, AudioError) as err:
+                        raise QueueEmpty("No more tracks available from radio station.") from err
+                    return cur_item
                 raise QueueEmpty("No more tracks left in the queue.")
             queue_item = self.get_item(queue_id, next_index)
             if queue_item is None:
@@ -1768,6 +1780,17 @@ class PlayerQueuesController(CoreController):
             media.album = (
                 album.name if (album := getattr(queue_item.media_item, "album", None)) else ""
             )
+            # For track-based radio stations (e.g. Apple Music Artist Radio)
+            # stream_metadata carries the currently playing track's artist/title.
+            if (
+                queue_item.media_type == MediaType.RADIO
+                and queue_item.streamdetails
+                and (sm := queue_item.streamdetails.stream_metadata)
+            ):
+                if sm.title:
+                    media.title = sm.title
+                if sm.artist:
+                    media.artist = sm.artist
             if queue_item.image:
                 # the image format needs to be 500x500 jpeg for maximum compatibility with players
                 # we prefer the imageproxy on the streamserver here because this request is sent
@@ -2776,6 +2799,10 @@ class PlayerQueuesController(CoreController):
         if prev_state["current_item_id"] is None:
             return
 
+        # retrieve prev_item here so it's available in the _clear_or_resume_delayed closure
+        # regardless of which code path (flow mode or non-flow mode) creates the task
+        prev_item = prev_state["current_item"]
+
         async def _clear_or_resume_delayed() -> None:
             for _ in range(5):
                 await asyncio.sleep(1)
@@ -2796,6 +2823,16 @@ class PlayerQueuesController(CoreController):
                         )
                         await self.play_index(queue.queue_id, next_index)
                     return
+            # If the last item was a radio station, continue playing instead of clearing.
+            # For track-based radio (Apple Music Artist Radio etc.) this fetches the next
+            # track from the station; for live radio it would reconnect to the stream.
+            if prev_item and prev_item.media_type == MediaType.RADIO:
+                current_index = self.index_by_id(queue.queue_id, prev_item.queue_item_id)
+                if current_index is not None and queue.state == PlaybackState.IDLE and queue.active:
+                    # clear cached stream details so the provider fetches a fresh track
+                    prev_item.streamdetails = None
+                    await self.play_index(queue.queue_id, current_index)
+                    return
             self.logger.info("End of queue reached, clearing items")
             self.clear(queue.queue_id)
 
@@ -2812,7 +2849,6 @@ class PlayerQueuesController(CoreController):
             return
 
         # For non-flow mode, use prev_state values since queue state may have been updated/reset
-        prev_item = prev_state["current_item"]
         if prev_item and (streamdetails := prev_item.streamdetails):
             duration = streamdetails.duration or prev_item.duration or 24 * 3600
         elif prev_item:

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -580,9 +580,7 @@ class PlayerQueuesController(CoreController):
                     queue.enqueued_media_items.append(media_item)
                     if len(queue.enqueued_media_items) > 10:
                         queue.enqueued_media_items.pop(0)
-                    if isinstance(media_item, Playlist) and getattr(
-                        media_item, "is_dynamic", False
-                    ):
+                    if isinstance(media_item, Playlist) and media_item.is_dynamic:
                         radio_source.append(media_item)
 
                 # handle default enqueue option if needed
@@ -1906,7 +1904,7 @@ class PlayerQueuesController(CoreController):
             "Fetching tracks to play for playlist %s",
             playlist.name,
         )
-        force_refresh = bool(getattr(playlist, "is_dynamic", False))
+        force_refresh = playlist.is_dynamic
         # TODO: Handle other sort options etc.
         async for playlist_track in self.mass.music.playlists.tracks(
             playlist.item_id,
@@ -2087,7 +2085,7 @@ class PlayerQueuesController(CoreController):
             (
                 item
                 for item in reversed(queue.radio_source)
-                if isinstance(item, Playlist) and getattr(item, "is_dynamic", False)
+                if isinstance(item, Playlist) and item.is_dynamic
             ),
             None,
         )
@@ -2858,7 +2856,7 @@ class PlayerQueuesController(CoreController):
                 (
                     item
                     for item in reversed(queue.radio_source)
-                    if isinstance(item, Playlist) and getattr(item, "is_dynamic", False)
+                    if isinstance(item, Playlist) and item.is_dynamic
                 ),
                 None,
             )
@@ -2867,7 +2865,7 @@ class PlayerQueuesController(CoreController):
                     (
                         item
                         for item in reversed(queue.enqueued_media_items)
-                        if isinstance(item, Playlist) and getattr(item, "is_dynamic", False)
+                        if isinstance(item, Playlist) and item.is_dynamic
                     ),
                     None,
                 )

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -558,8 +558,8 @@ class PlayerQueuesController(CoreController):
                     isinstance(media_item, ItemMapping)
                     and media_item.media_type == MediaType.PLAYLIST
                 ):
-                    # Resolve mapping once so playlist-specific logic can use
-                    # a full Playlist object without duplicating branches.
+                    # Resolve ItemMapping for a playlist so the full Playlist object
+                    # so we have access to details such as 'is_dynamic'
                     with suppress(MusicAssistantError):
                         media_item = await self.mass.music.playlists.get(
                             media_item.item_id,


### PR DESCRIPTION
This PR extracts the provider-agnostic queue behavior improvements from the Apple Music work.

## Changes
- Treat RADIO items as continuous sources when no next index exists.
- Allow end-of-queue handling to continue RADIO playback instead of clearing immediately.
- Surface stream metadata title/artist for RADIO items in player media output.

## Why separate PR
These changes are controller-level and benefit any provider that uses track-based radio behavior, not only Apple Music.

## Related

The queue behavior here is a workaround for the lack of a first-class dynamic/endless track source type in MA. A proper solution is tracked in:
- **[music-assistant/models#192](https://github.com/music-assistant/models/pull/192)** — Draft PR adding `MediaType.DYNAMIC_PLAYLIST` and a `DynamicPlaylist` dataclass
- **[orgs/music-assistant/discussions/5129](https://github.com/orgs/music-assistant/discussions/5129)** — Design discussion

Once the models PR is released, this PR's workarounds may be superseded by a dedicated queue path for `DYNAMIC_PLAYLIST` items.
