### PR TITLE
Use /playlists/{id}/items endpoint (Spotify Feb 2026 API change)

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -588,7 +588,7 @@ class SpotifyProvider(MusicProvider):
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """Get playlist tracks."""
         is_liked_songs = prov_playlist_id == self._get_liked_songs_playlist_id()
-        uri = "me/tracks" if is_liked_songs else f"playlists/{prov_playlist_id}/tracks"
+        uri = "me/tracks" if is_liked_songs else f"playlists/{prov_playlist_id}/items"
 
         # Liked songs always require global session
         # For other playlists, call get_playlist first to trigger the fallback logic
@@ -682,7 +682,7 @@ class SpotifyProvider(MusicProvider):
         """Add track(s) to playlist."""
         track_uris = [f"spotify:track:{track_id}" for track_id in prov_track_ids]
         data = {"uris": track_uris}
-        await self._post_data(f"playlists/{prov_playlist_id}/tracks", data=data)
+        await self._post_data(f"playlists/{prov_playlist_id}/items", data=data)
 
     async def remove_playlist_tracks(
         self, prov_playlist_id: str, positions_to_remove: tuple[int, ...]
@@ -690,14 +690,14 @@ class SpotifyProvider(MusicProvider):
         """Remove track(s) from playlist."""
         track_uris = []
         for pos in positions_to_remove:
-            uri = f"playlists/{prov_playlist_id}/tracks"
+            uri = f"playlists/{prov_playlist_id}/items"
             spotify_result = await self._get_data(uri, limit=1, offset=pos - 1)
             for item in spotify_result["items"]:
                 if not (item and item["track"] and item["track"]["id"]):
                     continue
                 track_uris.append({"uri": f"spotify:track:{item['track']['id']}"})
         data = {"tracks": track_uris}
-        await self._delete_data(f"playlists/{prov_playlist_id}/tracks", data=data)
+        await self._delete_data(f"playlists/{prov_playlist_id}/items", data=data)
 
     async def create_playlist(self, name: str, media_types: set[MediaType]) -> Playlist:
         """Create a new playlist on provider with given name."""


### PR DESCRIPTION
## Summary

Spotify removed `GET/POST/DELETE /playlists/{id}/tracks` in their [February 2026 API changes](https://developer.spotify.com/documentation/web-api/references/changes/february-2026) and replaced them with `/playlists/{id}/items`.

This causes 403 Forbidden errors on all playlist operations (fetch tracks, add to playlist, remove from playlist). Individual track playback is unaffected.

## Changes

4 endpoint references updated in `providers/spotify/provider.py`:
- `get_playlist_tracks` (line 591): GET `/tracks` → `/items`
- `add_playlist_tracks` (line 685): POST `/tracks` → `/items`
- `remove_playlist_tracks` (line 693): GET `/tracks` → `/items` (position lookup)
- `remove_playlist_tracks` (line 700): DELETE `/tracks` → `/items`

The response format is unchanged — the new `/items` endpoint still returns objects with a `track` field, so no parser changes needed.

## Note

There are additional deprecated endpoints in the Spotify provider that will need migration in a follow-up (`/playlists/{id}/followers`, `/users/{id}/playlists`, `me/albums`, `me/tracks`, etc. → consolidated `me/library`). This PR focuses only on the playlist fix since it's the most impactful breakage.

Fixes music-assistant/support#4978