### PR TITLE
Gpodder: Handle None value for position when manually marking episodes as played

### DIFF
--- a/music_assistant/providers/gpodder/__init__.py
+++ b/music_assistant/providers/gpodder/__init__.py
@@ -558,6 +558,10 @@ class GPodder(MusicProvider):
             return
         if time.time() - self.progress_guard_timestamp <= 5:
             return
+        if position is None and fully_played:
+            position = media_item.duration
+        elif position is None:
+            position = 0
         podcast_id, guid_or_stream_url = prov_item_id.split(" ")
         stream_url = await self._get_episode_stream_url(podcast_id, guid_or_stream_url)
         assert stream_url is not None


### PR DESCRIPTION
When manually marking an episode as played in the web interface, the `on_played` function is called with  `position` set to  `None`.
The subsequent call to `update_progress` will throw an error when it tries to [cast](https://github.com/music-assistant/server/blob/dev/music_assistant/providers/gpodder/client.py#L297) the `None` value to an `int` and the progress won't be updated.

Tested with Nextcloud gpodder sync app.