### PR TITLE
Fix corrupt players config when player deleted

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1349,6 +1349,20 @@ class ConfigController:
                 LOGGER.warning("Removed corrupt provider configuration: %s", instance_id)
                 changed = True
 
+        # Remove corrupt player configurations that are missing the required 'player_id' key
+        # This can happen when _clear_protocol_parent_id is called on an already-deleted player
+        # TODO: remove after 2.9 release
+        for player_id, player_config in list(self._data.get(CONF_PLAYERS, {}).items()):
+            if "player_id" not in player_config:
+                LOGGER.warning(
+                    "Removing corrupt player configuration (missing player_id): %s", player_id
+                )
+                self._data[CONF_PLAYERS].pop(player_id, None)
+                # Also remove any DSP config for this player
+                if CONF_PLAYER_DSP in self._data:
+                    self._data[CONF_PLAYER_DSP].pop(player_id, None)
+                changed = True
+
         # The background tasks controller originally persisted runtime state directly under
         # core/tasks, which could create a CoreConfig object without the required domain field.
         # Repair that single known corruption case on load.

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1354,9 +1354,6 @@ class ConfigController:
         # TODO: remove after 2.9 release
         for player_id, player_config in list(self._data.get(CONF_PLAYERS, {}).items()):
             if "player_id" not in player_config:
-                LOGGER.warning(
-                    "Removing corrupt player configuration (missing player_id): %s", player_id
-                )
                 self._data[CONF_PLAYERS].pop(player_id, None)
                 # Also remove any DSP config for this player
                 if CONF_PLAYER_DSP in self._data:

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1351,7 +1351,7 @@ class ConfigController:
 
         # Remove corrupt player configurations that are missing the required 'player_id' key
         # This can happen when _clear_protocol_parent_id is called on an already-deleted player
-        # TODO: remove after 2.9 release
+        # TODO: remove after 2.8 release
         for player_id, player_config in list(self._data.get(CONF_PLAYERS, {}).items()):
             if "player_id" not in player_config:
                 self._data[CONF_PLAYERS].pop(player_id, None)

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -891,6 +891,9 @@ class ProtocolLinkingMixin:
 
     def _clear_protocol_parent_id(self, protocol_player_id: str) -> None:
         """Clear the cached parent ID for a protocol player."""
+        # Only clear if the player config still exists to avoid creating partial entries
+        if not self.mass.config.get(f"{CONF_PLAYERS}/{protocol_player_id}"):
+            return
         conf_key = f"{CONF_PLAYERS}/{protocol_player_id}/values/{CONF_PROTOCOL_PARENT_ID}"
         self.mass.config.set(conf_key, None)
 

--- a/tests/core/test_protocol_linking.py
+++ b/tests/core/test_protocol_linking.py
@@ -5814,7 +5814,7 @@ class TestProtocolParentIdPersistence:
     def test_parent_id_cleared_for_universal_parent(self, mock_mass: MagicMock) -> None:
         """protocol_parent_id should be cleared when unlinking from a universal player."""
         controller = PlayerController(mock_mass)
-        mock_mass.config.get = MagicMock(return_value=[])
+        mock_mass.config.get = MagicMock(return_value={"enabled": True})
 
         universal_provider = create_mock_universal_provider(mock_mass)
         parent = UniversalPlayer(
@@ -5871,7 +5871,7 @@ class TestCleanupProtocolLinks:
     def test_cleanup_clears_config_parent_id(self, mock_mass: MagicMock) -> None:
         """When a universal player is removed, protocol parent_ids are cleared in config."""
         controller = PlayerController(mock_mass)
-        mock_mass.config.get = MagicMock(return_value=[])
+        mock_mass.config.get = MagicMock(return_value={"enabled": True})
 
         universal_provider = create_mock_universal_provider(mock_mass)
         parent = UniversalPlayer(


### PR DESCRIPTION
Fixes: https://github.com/music-assistant/support/issues/5112

After deleting an unavailable player from the UI, I was getting the following error and realised it was the same as the linked issue

```
ERROR (MainThread) [music_assistant.webserver] Error handling message: CommandMessage(message_id='...', command='config/players',
args={'include_values': False, 'include_unavailable': False, 'include_disabled': True})
Traceback (most recent call last):
  File ".../music_assistant/controllers/webserver/websocket_client.py", line 244, in _run_handler
    result = await result
  File ".../music_assistant/controllers/config.py", line 539, in get_player_configs
    player = self.mass.players.get_player(raw_conf["player_id"], False)
KeyError: 'player_id'
```

After some investigation, I found a corrupt entry in `settings.json` that looked like this:

```
"kodi_192.168.1.158_9090": {
  "values": {
    "protocol_parent_id": null
  }
}
```

I believe the root cause is in `_clear_protocol_parent_id()`. When a parent player is removed, this method is called to clear the `protocol_parent_id` from linked protocol players. However, if the protocol player's config has already been deleted, the `config.set()` call recreates a partial entry because `set()` uses `setdefault()` to create intermediate dictionaries.

So I did the following:

1. `protocol_linking.py`: Added a check in `_clear_protocol_parent_id()` to verify the player config exists before attempting to clear the value
2. `config.py`: Added a migration to clean up any existing corrupt player configs that are missing the `player_id` key (marked with a TODO to remove it after the 2.9 release - probably could do earlier?)