### PR TITLE
Improve json_dumps handling for nested plain dataclasses

### DIFF
--- a/music_assistant/helpers/json.py
+++ b/music_assistant/helpers/json.py
@@ -31,10 +31,16 @@ def get_serializable_value(obj: Any, raise_unhandled: bool = False) -> Any:
     if getattr(obj, "do_not_serialize", None):
         return None
 
-    # Convert dataclass *instances* to dicts so nested dataclasses get handled recursively.
+    # Convert plain dataclass *instances* (without custom to_dict / mashumaro mixin)
+    # to dicts so nested dataclasses get handled recursively.
     # `is_dataclass` can also return True for dataclass *types*, so ensure we only
     # pass instances to `asdict` to avoid type errors (mypy).
-    if is_dataclass(obj) and not isinstance(obj, type):
+    if (
+        is_dataclass(obj)
+        and not isinstance(obj, type)
+        and not hasattr(obj, "to_dict")
+        and not isinstance(obj, DataClassORJSONMixin)
+    ):
         return get_serializable_value(asdict(obj))
 
     # Handle plain dicts

--- a/music_assistant/helpers/json.py
+++ b/music_assistant/helpers/json.py
@@ -2,13 +2,17 @@
 
 import asyncio
 import base64
+import logging
 from _collections_abc import dict_keys, dict_values
+from dataclasses import asdict, is_dataclass
 from types import MethodType
 from typing import Any, TypeVar
 
 import aiofiles
 import orjson
 from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+LOGGER = logging.getLogger(__name__)
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
 JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
@@ -17,16 +21,44 @@ DO_NOT_SERIALIZE_TYPES = (MethodType, asyncio.Task)
 
 
 def get_serializable_value(obj: Any, raise_unhandled: bool = False) -> Any:
-    """Parse the value to its serializable equivalent."""
+    """Parse the value to its serializable equivalent.
+
+    This function will convert dataclasses, dicts and iterable containers into
+    JSON-serializable primitives. It intentionally returns primitives (lists,
+    dicts, strings, numbers) for any complex object that cannot be serialized
+    directly by orjson to avoid infinite recursion in the default serializer.
+    """
     if getattr(obj, "do_not_serialize", None):
         return None
+
+    # Convert dataclass *instances* to dicts so nested dataclasses get handled recursively.
+    # `is_dataclass` can also return True for dataclass *types*, so ensure we only
+    # pass instances to `asdict` to avoid type errors (mypy).
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return get_serializable_value(asdict(obj))
+
+    # Handle plain dicts
+    if isinstance(obj, dict):
+        return {k: get_serializable_value(v) for k, v in obj.items()}
+
+    # Handle iterable containers
     if (
-        isinstance(obj, list | set | filter | tuple | dict_values | dict_keys | dict_values)
-        or obj.__class__ == "dict_valueiterator"
+        isinstance(obj, list | set | filter | tuple | dict_values | dict_keys)
+        or type(obj).__name__ == "dict_valueiterator"
     ):
         return [get_serializable_value(x) for x in obj]
+
+    # If an object provides an explicit to_dict use that
     if hasattr(obj, "to_dict"):
         return obj.to_dict()
+
+    # Fallback to to_json if available
+    if hasattr(obj, "to_json"):
+        try:
+            return obj.to_json()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.debug("Failed to use to_json() for %s: %s", type(obj), exc)
+
     if isinstance(obj, bytes):
         return base64.b64encode(obj).decode("ascii")
     if isinstance(obj, DO_NOT_SERIALIZE_TYPES):

--- a/tests/test_json_serialization.py
+++ b/tests/test_json_serialization.py
@@ -1,0 +1,13 @@
+"""Tests for JSON serialization helpers."""
+
+from music_assistant_models.streamdetails import MultiPartPath
+
+from music_assistant.helpers.json import json_dumps
+
+
+def test_multipartpath_list_serializes() -> None:
+    """Ensure a list of MultiPartPath serializes to JSON."""
+    data = [MultiPartPath("http://a"), MultiPartPath("b", 12.3)]
+    json_str = json_dumps(data)
+    assert "http://a" in json_str
+    assert "12.3" in json_str


### PR DESCRIPTION
## Summary
Isolates JSON helper improvements and a focused regression test so they can be reviewed independently of other work.

## Changes
- **`get_serializable_value`**: Recursively convert dataclass instances via `asdict`, walk plain dicts, fix `dict_valueiterator` detection (compare `type(obj).__name__` instead of class to string), remove duplicate `dict_values` in `isinstance`, and add a defensive `to_json()` fallback with debug logging on failure.
- **Test**: `test_multipartpath_list_serializes` ensures `json_dumps` can serialize a list of `MultiPartPath` (plain `@dataclass`) without hitting orjson default recursion when using `OPT_PASSTHROUGH_DATACLASS`.

## Context
With `OPT_PASSTHROUGH_DATACLASS`, orjson defers dataclasses to the default serializer. Plain dataclasses without mashumaro mixins (e.g. `MultiPartPath`) previously caused recursion if they appeared inside structures passed to `json_dumps`.

Made with [Cursor](https://cursor.com)