### PR TITLE
Fix Cast autoplay

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2677,11 +2677,17 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # fallback: just try to resume queue playback
         await self.mass.player_queues.resume(player.player_id)
 
-    async def _handle_cmd_power(self, player_id: str, powered: bool) -> None:
+    async def _handle_cmd_power(
+        self, player_id: str, powered: bool, skip_auto_play: bool = False
+    ) -> None:
         """
         Handle player power on/off command.
 
         Skips the permission checks (internal use only).
+
+        :param player_id: The player ID to power on/off.
+        :param powered: True to power on, False to power off.
+        :param skip_auto_play: If True, skip auto-play on power on.
         """
         player = self.get_player(player_id, True)
         assert player is not None  # for type checking
@@ -2769,7 +2775,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
         # handle 'auto play on power on' feature
         if (
-            not player_state.active_group
+            not skip_auto_play
+            and not player_state.active_group
             and not player_state.synced_to
             and powered
             and player.config.get_value(CONF_AUTO_PLAY)
@@ -2867,9 +2874,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if media.source_id:
             player.set_active_mass_source(media.source_id)
 
-        # power on the player if needed
+        # power on the player if needed (skip auto-play since we're about to start playback)
         if not player.state.powered and player.state.power_control != PLAYER_CONTROL_NONE:
-            await self._handle_cmd_power(player.player_id, True)
+            await self._handle_cmd_power(player.player_id, True, skip_auto_play=True)
 
         # Determine output protocol to use:
         # If player already has an active protocol set, prefer that.
@@ -2904,12 +2911,12 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             )
             player.set_active_output_protocol(output_protocol.output_protocol_id)
             # if the (protocol)player has power control and is currently powered off,
-            # we need to power it on before playback
+            # we need to power it on before playback (skip auto-play since we're starting playback)
             if (
                 target_player.state.powered is False
                 and target_player.power_control != PLAYER_CONTROL_NONE
             ):
-                await self._handle_cmd_power(target_player.player_id, True)
+                await self._handle_cmd_power(target_player.player_id, True, skip_auto_play=True)
             # forward play media command to protocol player
             await target_player.play_media(media)
             # notify the native player that protocol playback started

--- a/tests/core/test_player_controller.py
+++ b/tests/core/test_player_controller.py
@@ -184,7 +184,9 @@ class TestGroupUngroup:
         leader.set_members = mock_set_members  # type: ignore[method-assign]
 
         # Mock power handling to skip power control (focus is on grouping logic)
-        async def mock_handle_cmd_power(player_id: str, powered: bool) -> None:
+        async def mock_handle_cmd_power(
+            player_id: str, powered: bool, skip_auto_play: bool = False
+        ) -> None:
             pass
 
         controller._handle_cmd_power = mock_handle_cmd_power  # type: ignore[method-assign]


### PR DESCRIPTION
While investigating https://github.com/music-assistant/support/issues/4574 I wasn't able to recreate that problem but I discovered a different problem associated with the auto power on feature.

When the "Automatically play/resume on power on" setting is enabled for a Chromecast player, starting playback via `media_player.media_play` (or  from the MA interface) while the player is powered off causes playback to fail. The player shows a spinning circle indefinitely and never starts playing. Logs show two play_media commands being issued ~2 seconds apart for the same track.

Looking at the cast provider I believe the code path is:
1. cmd_play() → player_queues.resume() → play_index() → play_media() → _handle_play_media()
2. _handle_play_media() powers on the player by calling _handle_cmd_power()
3. At the end of _handle_cmd_power(), the auto-play feature checks if it should start playback - but it doesn't know that playback was already being initiated by the caller
4. This triggers a second player_queues.resume() call, causing two concurrent playback attempts that interfere with each other

I have fixed this by adding a `skip_auto_play` parameter to `_handle_cmd_power()`. When` _handle_play_media()` powers on the player as part of starting playback, it now passes `skip_auto_play=True` to prevent the redundant auto-play from triggering.

This may also resolve the intermittent "await wasn't used with future" errors reported in #4574, but as I said I couldnt recreate it to test...?