### PR TITLE
Fix race condition when calling stop/pause on an already stopped Universal Player

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3079,6 +3079,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         player = self.get_player(player_id, raise_unavailable=True)
         assert player is not None
+        if player.state.playback_state == PlaybackState.IDLE:
+            return
         player.mark_stop_called()
         # Delegate to active protocol player if one is active
         target_player = player
@@ -3176,6 +3178,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         player = self.get_player(player_id, raise_unavailable=True)
         assert player is not None
+        if player.state.playback_state == PlaybackState.IDLE:
+            return
         # Check if a plugin source is active with a pause callback
         if plugin_source := self._get_active_plugin_source(player):
             if plugin_source.can_play_pause and plugin_source.on_pause:


### PR DESCRIPTION
The race happens on VPEs that are added to MA as a universal player with the sendspin protocol. When a user calls pause twice (eg via HA), the current logic will ultimately call `stop()` on the Univeral Playing, resulting in the error:
`stop needs to be implemented when PlayerFeature.PLAY_MEDIA is set`

This PR implements an early return by checking if the player is IDLE in stop/pause to prevent the above from happening.

Related issue: https://github.com/music-assistant/support/issues/5125