### PR TITLE
Fix tracks from Sonos not being reported as played

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2794,7 +2794,7 @@ class PlayerQueuesController(CoreController):
             # we have a new item, so we need report the previous one
             is_current_item = False
             item_to_report = prev_state["current_item"]
-            seconds_played = int(prev_state["elapsed_time"])
+            seconds_played = int(prev_state["last_playing_elapsed_time"])
         else:
             # report on current item
             is_current_item = True


### PR DESCRIPTION
The race:
  1. Track A is playing at 298s/300s. prev_state = {item: A, elapsed: 298, last_playing: 298}
  2. Sonos sends playbackStatus websocket message: positionMillis=0 (new track started)
  3. GROUP_UPDATED fires → update_attributes() reads position=0 + metadata still says Track A
  4. _update_queue_from_player runs: same item A, elapsed_time=0 → saves prev_state = {item: A, elapsed: 0, last_playing: max(0, 298)=298}
  5. Sonos sends metadataStatus websocket message: currentItem=Track B
  6. GROUP_UPDATED fires → update_attributes() reads position=~0.5 + metadata now says Track B
  7. _update_queue_from_player runs: track change detected (A→B)
  8. Line 2797: seconds_played = prev_state["elapsed_time"] = 0
  9. Line 2821: 0 < 5 → return. Track A is never reported as played.

Related issues:
- https://github.com/music-assistant/support/issues/4125
- https://github.com/music-assistant/support/issues/5096