### PR TITLE
[Draft] Rebuild Snapcast external Snapserver integration

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -196,8 +196,8 @@ RUN set -x \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Snapcast 0.34.0 from GitHub releases (requires at least 0.27)
-ARG SNAPCAST_VERSION=0.34.0
+# Install Snapcast 0.35.0 from GitHub releases (requires at least 0.27)
+ARG SNAPCAST_VERSION=0.35.0
 ARG TARGETARCH
 RUN set -x \
     && if [ "$TARGETARCH" = "arm64" ]; then \

--- a/docs/snapcast-controller-plan.en.md
+++ b/docs/snapcast-controller-plan.en.md
@@ -1,0 +1,45 @@
+# Standalone Snapcast Controller Hardening
+
+## Summary
+
+The standalone Snapcast bridge for external Snapserver setups continues to use a
+name-first contract through `--stream=<stream_display_name>`. The provider resolves
+that stream reference to an active Music Assistant queue, after which `mass_bridge.py`
+translates metadata and transport commands bidirectionally between Snapcast and
+Music Assistant.
+
+This iteration hardens that path so only real queue-backed playback is treated as
+controllable. Streams without an active queue remain read-only and do not publish a
+misleading control state.
+
+## Key Changes
+
+- Keep `snapcast/resolve_control_stream(stream: str)` as the single authoritative resolver.
+- Match on internal stream name, Snapcast stream id, and visible stream name.
+- Only return queue data when the matching stream is linked to a real active queue.
+- Treat unresolved streams in `mass_bridge.py` as read-only:
+  `canControl=False`, no active queue id, and transport commands rejected.
+- Process `queue_time_updated` so the published position in Snapcast stays current
+  without a full re-resolve.
+- Keep the existing mapping for `next`, `previous`, `play`, `pause`, `playPause`,
+  `stop`, `setPosition`, `seek`, `shuffle`, and `loopStatus`.
+
+## Tests
+
+- Resolver returns `None` for streams without active queue-backed playback.
+- Resolver returns queue, player, and stream details for valid queue-backed streams.
+- `mass_bridge.py` stays read-only when a stream matches but does not return a queue.
+- `queue_time_updated` only refreshes the position.
+- Unresolved transport commands are rejected.
+- Retry logic for a visible old `idle` Snapcast stream remains intact.
+
+## Assumptions
+
+- The external Snapserver variant remains the primary scope; the built-in Unix socket
+  bridge does not change functionally.
+- `queue_id` and `player_id` are still the same in Music Assistant, but both remain
+  explicitly present in the resolve response.
+- Access tokens continue to be supplied externally through `--ma-access-token` or
+  `MASS_ACCESS_TOKEN`.
+- The external Snapserver host must be able to execute `mass_bridge.py` and have the
+  Python dependency `websocket-client` available.

--- a/docs/snapcast-plugin-rebuild-plan.en.md
+++ b/docs/snapcast-plugin-rebuild-plan.en.md
@@ -1,0 +1,237 @@
+# Snapcast Plugin-Only Rebuild Plan
+
+## Goal
+
+This document describes a clean rebuild of the Snapcast integration with the
+goal of avoiding broad core changes in modules such as `sync_group` or other
+generic player logic.
+
+The target design gives the external bridge, proposed as `mass_bridge.py`, a
+larger role while keeping the Snapcast provider responsible for live Snapserver
+state, stream lifecycle, and restart recovery.
+
+## Current Status
+
+The `dev` rebuild is now functionally in place and has been validated live
+against an external Snapserver setup.
+
+### What Works
+
+- Plugin-level stream registry for lookup by:
+  - internal stream name
+  - Snapstream id
+  - visible stream name
+  - `source_id`
+  - `queue_id`
+- External bridge through `snapserver/mass_bridge.py`
+  - Music Assistant WebSocket authentication
+  - queue resolution by visible stream name such as `broadcast`
+  - read-only behavior while no queue is active
+  - property and metadata sync towards Snapcast
+  - transport command translation from Snapcast to Music Assistant
+- Idempotent stream lifecycle
+  - existing idle Snapstreams are reused
+  - duplicate stream-name storms are fixed
+  - non-retryable duplicate errors no longer trigger endless new-port retries
+- Dynamic sync-group pre-materialization
+  - as soon as the first Snapcast member is added to an MA sync group such as
+    `broadcast`, an idle native Snapcast stream is created immediately
+  - extra members can join before playback starts
+- Plugin-level group restore
+  - existing live Snapcast groups can be mapped back to an MA sync group after
+    an MA restart without adding persistence logic to `sync_group`
+- Dedicated fallback group for external Snapserver
+  - for example `Media`
+  - removed members fall back to that group
+  - the fallback group is excluded as a restore source
+- Empty sync-group cleanup
+  - when `broadcast` becomes empty, the idle Snapcast stream is removed again
+  - the last leader no longer remains behind as an orphan group
+
+### Important Nuance
+
+The original rebuild target was fully plugin-only. The current `dev` state is
+very close, but not fully there yet:
+
+- there is now one small targeted change in `sync_group/player.py`
+  to make last-leader removal end in a truly empty runtime group
+
+That change is small and tested, but in a final cleanup pass it would ideally
+be pulled back into the Snapcast plugin itself.
+
+### Live-Validated Scenarios
+
+- create a new dynamic `broadcast` group
+- add the first member and immediately materialize a native stream
+- add extra members
+- start playback on `broadcast`
+- `mass_bridge.py` authentication and control resolution
+- `play`, `pause`, `next`, `seek`
+- MA restart with existing Snapserver state
+- member removal back to the configured fallback group
+- last-leader removal without leaving an orphan group behind
+- full cleanup flow:
+  - stop or clear playback
+  - remove members
+  - remove the group
+  - remove the idle `broadcast` stream again
+
+### Known Remaining Point
+
+Leader handoff during an active regroup is still not fully atomic. In live
+tests there is still a short double-`broadcast` transition of roughly 300 ms
+before the old leader falls back to the fallback group and the new leader takes
+over completely.
+
+For the current Snap.Net client this has proven acceptable:
+
+- the client follows the handoff correctly
+- the client no longer gets stuck during leader handoff
+- the final native state is correct
+
+### Practical Transport Nuance
+
+For the external Snapserver TCP stream, the transport model is effectively
+`playing` or `idle`. A true transport-level `paused` state does not exist
+there. In the current working setup, `pause` therefore means:
+
+- Music Assistant still handles a real pause command
+- the Snapcast TCP feed is intentionally stopped afterwards
+- Snapserver sees the stream fall back to `idle`
+
+That behavior matches the capabilities of the TCP stream plugin and is no
+longer treated as a bug.
+
+## Principles
+
+- Avoid broad core changes in Music Assistant.
+- External Snapserver is the primary use case.
+- `mass_bridge.py` is the main bridge for control and metadata.
+- Snapserver remains the source of truth for native Snapcast groups, clients,
+  and streams.
+- Music Assistant remains the source of truth for queue, playback state, and
+  metadata.
+- Restarting Music Assistant must not create duplicate Snapstreams.
+- An existing Snapcast stream such as `broadcast` must be safely reusable.
+
+## Non-Goals
+
+- No initial focus on the built-in Snapserver variant.
+- No new persistence logic in `sync_group`.
+- No attempt to make the Snapcast and Music Assistant grouping models fully
+  identical.
+- No large UI rebuild in this phase.
+
+## Safe Reference Layout
+
+Do not place the old plugin as `music_assistant/providers/snapcast-old`.
+Provider discovery scans directories under `music_assistant/providers` for
+`manifest.json` and loads modules by provider domain.
+
+Recommended archive location:
+
+- `/home/thaghostnl/MusicAssistant/_archive/snapcast_old`
+
+or, if it must stay inside the repo:
+
+- `/home/thaghostnl/MusicAssistant/music_assistant/providers/.snapcast_old`
+
+The active work directory remains:
+
+- `/home/thaghostnl/MusicAssistant/music_assistant/providers/snapcast`
+
+## Target Architecture
+
+### Responsibilities
+
+#### Snapserver
+
+- Manages clients, groups, and streams.
+- Remains the source of truth for live grouping state.
+- Starts and manages the external bridge per stream through a control script.
+
+#### `mass_bridge.py`
+
+- Connects to the Music Assistant WebSocket API.
+- Authenticates with an access token.
+- Resolves `--stream=<stream_display_name>` to the active MA queue.
+- Translates Snapcast JSON-RPC control calls into MA queue commands.
+- Translates MA queue and player events into Snapcast properties and metadata.
+- Stays read-only while the stream does not resolve to an active queue.
+- Recovers independently after MA reconnects.
+
+#### Snapcast Provider
+
+- Connects to Snapserver control.
+- Turns Snapclients into Music Assistant players.
+- Maintains mapping between:
+  - MA player id
+  - Snapclient id
+  - internal stream name
+  - Snapstream id
+  - stream display name
+- Reuses existing Snapserver streams by visible name.
+- Reconstructs runtime state after restart from live Snapserver data.
+- Reconnects existing Snapcast groups back to MA sync groups without core
+  persistence changes.
+
+## Source-of-Truth Model
+
+### Native Snapcast State
+
+- group membership
+- group leader
+- `stream_id`
+- client connectivity
+
+This data comes from Snapserver and is read by the provider.
+
+### Music Assistant Playback State
+
+- active queue
+- playback status
+- position
+- shuffle
+- repeat
+- metadata
+
+This data comes from Music Assistant and is pushed to Snapcast through
+`mass_bridge.py`.
+
+## File Layout
+
+```text
+music_assistant/providers/snapcast/
+├── __init__.py
+├── constants.py
+├── provider.py
+├── player.py
+├── ma_stream.py
+├── socket_server.py
+├── stream_registry.py
+├── group_restore.py
+├── group_materialize.py
+└── snapserver/
+    └── mass_bridge.py
+```
+
+## Acceptance Criteria
+
+- No duplicate `broadcast` stream creation storms.
+- Existing grouped Snapcast clients stay visible in the MA UI.
+- An existing MA sync group can reconnect to live Snapcast groups after restart.
+- `mass_bridge.py` stays read-only while no active queue resolves.
+- Snapcast transport commands work again once the queue does resolve.
+- Removed members fall back to the configured dedicated fallback group when set.
+- The dedicated fallback group is never used as a restore source.
+- Removing the last leader does not leave an orphan native Snapcast group behind.
+- Leader handoff may still have a short transition, as long as:
+  - the final state is correct
+  - the old leader falls back cleanly
+  - Snap.Net or other clients do not get stuck during the handoff
+
+## Recommended Next Step
+
+Keep validating the current `dev` implementation against the external
+Snapserver setup and only pull remaining cleanup into the plugin once the live
+behavior is stable enough to replace the temporary `sync_group` assist.

--- a/music_assistant/providers/snapcast/__init__.py
+++ b/music_assistant/providers/snapcast/__init__.py
@@ -17,6 +17,7 @@ from music_assistant.mass import MusicAssistant
 from music_assistant.models import ProviderInstanceType
 from music_assistant.providers.snapcast.constants import (
     CONF_CATEGORY_BUILT_IN,
+    CONF_EXTERNAL_DEDICATED_FALLBACK_GROUP,
     CONF_HELP_LINK,
     CONF_SERVER_BUFFER_SIZE,
     CONF_SERVER_CHUNK_MS,
@@ -180,6 +181,19 @@ async def get_config_entries(
             required=False,
             depends_on=CONF_USE_EXTERNAL_SERVER,
             advanced=local_snapserver_present,
+        ),
+        ConfigEntry(
+            key=CONF_EXTERNAL_DEDICATED_FALLBACK_GROUP,
+            type=ConfigEntryType.STRING,
+            default_value="",
+            label="Dedicated fallback group",
+            required=False,
+            depends_on=CONF_USE_EXTERNAL_SERVER,
+            advanced=True,
+            description=(
+                "Optional existing Snapserver group name to move removed clients back to "
+                "(for example: Media). Leave empty to disable."
+            ),
         ),
         ConfigEntry(
             key=CONF_STREAM_IDLE_THRESHOLD,

--- a/music_assistant/providers/snapcast/constants.py
+++ b/music_assistant/providers/snapcast/constants.py
@@ -10,6 +10,7 @@ from music_assistant.constants import create_sample_rates_config_entry
 CONF_SERVER_HOST = "snapcast_server_host"
 CONF_SERVER_CONTROL_PORT = "snapcast_server_control_port"
 CONF_USE_EXTERNAL_SERVER = "snapcast_use_external_server"
+CONF_EXTERNAL_DEDICATED_FALLBACK_GROUP = "snapcast_external_dedicated_fallback_group"
 CONF_SERVER_BUFFER_SIZE = "snapcast_server_built_in_buffer_size"
 CONF_SERVER_CHUNK_MS = "snapcast_server_built_in_chunk_ms"
 CONF_SERVER_INITIAL_VOLUME = "snapcast_server_built_in_initial_volume"

--- a/music_assistant/providers/snapcast/control.py
+++ b/music_assistant/providers/snapcast/control.py
@@ -360,7 +360,7 @@ if __name__ == "__main__":
 
     log_format_stderr = "%(asctime)s %(module)s %(levelname)s: %(message)s"
     log_level = logging.INFO
-    logger = logging.getLogger("meta_mass")
+    logger = logging.getLogger("snapcast_control")
     logger.propagate = False
     logger.setLevel(log_level)
 

--- a/music_assistant/providers/snapcast/group_materialize.py
+++ b/music_assistant/providers/snapcast/group_materialize.py
@@ -1,0 +1,242 @@
+"""Helpers for proactively materializing MA sync groups into live Snapcast state."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from music_assistant_models.enums import PlaybackState
+
+from music_assistant.providers.sync_group.constants import SGP_PREFIX
+
+if TYPE_CHECKING:
+    from .ma_stream import SnapcastMAStream
+    from .provider import SnapCastProvider
+    from .snap_cntrl_proto import SnapgroupProto
+
+
+@dataclass(slots=True)
+class SnapcastGroupMaterializeTarget:
+    """Desired native Snapcast state for one MA sync group."""
+
+    sync_group_player_id: str
+    sync_group_name: str
+    sync_leader_id: str
+    member_player_ids: list[str]
+
+
+class SnapcastGroupMaterializer:
+    """Materialize MA sync-group runtime state into native Snapcast groups/streams."""
+
+    def __init__(self, provider: SnapCastProvider) -> None:
+        """Initialize the materializer."""
+        self._provider = provider
+        self._logger = provider.logger.getChild("group_materialize")
+
+    async def materialize(self, sync_group_player_id: str) -> None:
+        """Materialize one MA sync-group into native Snapcast state."""
+        if self._provider.mass.closing:
+            return
+
+        sync_group_player = self._provider.mass.players.get_player(
+            sync_group_player_id, raise_unavailable=False
+        )
+        if sync_group_player is None or not sync_group_player_id.startswith(SGP_PREFIX):
+            return
+
+        if getattr(sync_group_player, "playback_state", None) == PlaybackState.PLAYING:
+            self._logger.debug(
+                "Skipping pre-materialization for sync group '%s' while it is actively playing",
+                getattr(getattr(sync_group_player, "config", None), "name", sync_group_player_id),
+            )
+            return
+
+        target = self._collect_target(sync_group_player)
+        if target is None:
+            await self._cleanup_target(sync_group_player)
+            return
+
+        idle_stream = await self._provider.ensure_sync_group_idle_stream(sync_group_player)
+        if idle_stream is None or idle_stream.stream_id is None:
+            return
+
+        await self._materialize_target(sync_group_player, target, idle_stream)
+
+    async def _cleanup_target(self, sync_group_player: Any) -> None:
+        """Remove previously materialized idle Snapcast state for an empty sync group."""
+        idle_stream = self._provider.get_snap_ma_stream(sync_group_player.player_id)
+        if idle_stream is None or idle_stream.queue_id is not None:
+            return
+
+        if idle_stream.stream_id is not None:
+            for snap_group in self._provider._snapserver.groups:
+                if getattr(snap_group, "stream", None) != idle_stream.stream_id:
+                    continue
+                for snap_client_id in getattr(snap_group, "clients", []):
+                    with suppress(AssertionError, KeyError, ValueError):
+                        player_id = self._provider._get_ma_id(snap_client_id)
+                        await self._provider.move_player_to_fallback_group(player_id)
+
+        await self._provider.delete_ma_stream(idle_stream.stream_name)
+        self._logger.info(
+            "Removed idle Snapcast stream '%s' for empty MA sync group '%s'",
+            idle_stream.stream_display_name,
+            getattr(
+                getattr(sync_group_player, "config", None),
+                "name",
+                sync_group_player.player_id,
+            ),
+        )
+        self._provider._update_group_callbacks(poke=True)
+
+    def _collect_target(self, sync_group_player: Any) -> SnapcastGroupMaterializeTarget | None:
+        """Collect the desired native Snapcast target state for a sync group."""
+        member_player_ids = list(
+            dict.fromkeys(
+                member_id
+                for member_id in getattr(sync_group_player, "group_members", [])
+                if member_id != getattr(sync_group_player, "player_id", "")
+                and self._provider.get_snap_client(player_id=member_id) is not None
+            )
+        )
+        if not member_player_ids:
+            return None
+
+        leader_player_id = self._resolve_sync_leader_id(sync_group_player, member_player_ids)
+        if leader_player_id is None:
+            return None
+
+        ordered_member_ids = [
+            leader_player_id,
+            *[member_id for member_id in member_player_ids if member_id != leader_player_id],
+        ]
+        return SnapcastGroupMaterializeTarget(
+            sync_group_player_id=sync_group_player.player_id,
+            sync_group_name=getattr(getattr(sync_group_player, "config", None), "name", ""),
+            sync_leader_id=leader_player_id,
+            member_player_ids=ordered_member_ids,
+        )
+
+    def _resolve_sync_leader_id(
+        self, sync_group_player: Any, member_player_ids: list[str]
+    ) -> str | None:
+        """Resolve a deterministic Snapcast leader for the sync group."""
+        current_leader = cast(
+            "str | None",
+            getattr(getattr(sync_group_player, "sync_leader", None), "player_id", None),
+        )
+        if current_leader in member_player_ids:
+            return current_leader
+        return member_player_ids[0] if member_player_ids else None
+
+    async def _materialize_target(
+        self,
+        sync_group_player: Any,
+        target: SnapcastGroupMaterializeTarget,
+        idle_stream: SnapcastMAStream,
+    ) -> None:
+        """Apply the desired native Snapcast target state."""
+        stream_ref = self._provider._get_stable_stream_reference(idle_stream.stream_id)
+        leader_group = await self._provider.ensure_player_owned_group(
+            target.sync_leader_id, set_stream_id=stream_ref
+        )
+        if leader_group is None:
+            return
+
+        leader_group.set_callback(None)
+        await self._move_stale_stream_members_to_fallback(
+            target,
+            idle_stream.stream_id,
+            exclude_group_id=getattr(leader_group, "identifier", None),
+        )
+        current_member_ids = self._resolve_group_member_player_ids(leader_group)
+        changes_applied = False
+
+        for member_player_id in current_member_ids:
+            if member_player_id == target.sync_leader_id:
+                continue
+            if member_player_id in target.member_player_ids:
+                continue
+            moved_to_fallback = await self._provider.move_player_to_fallback_group(member_player_id)
+            if not moved_to_fallback:
+                await self._provider.isolate_player_to_dedicated_group(
+                    member_player_id, target_stream_id=stream_ref
+                )
+            changes_applied = True
+
+        for member_player_id in target.member_player_ids:
+            if member_player_id == target.sync_leader_id:
+                continue
+            if member_player_id in current_member_ids:
+                continue
+            with suppress(AssertionError, KeyError, ValueError):
+                await leader_group.add_client(self._provider._get_snapclient_id(member_player_id))
+                changes_applied = True
+
+        if getattr(leader_group, "stream", None) != idle_stream.stream_id:
+            await leader_group.set_stream(stream_ref)
+            changes_applied = True
+
+        leader_changed = False
+        if leader_player := self._provider.mass.players.get_player(
+            target.sync_leader_id, raise_unavailable=False
+        ):
+            if getattr(getattr(sync_group_player, "sync_leader", None), "player_id", None) != (
+                leader_player.player_id
+            ):
+                sync_group_player_any = cast("Any", sync_group_player)
+                sync_group_player_any.sync_leader = leader_player
+                leader_changed = True
+
+        if not changes_applied and not leader_changed:
+            return
+
+        self._logger.info(
+            "Materialized MA sync group '%s' to native Snapcast leader=%s members=%s stream=%s",
+            target.sync_group_name or target.sync_group_player_id,
+            target.sync_leader_id,
+            target.member_player_ids,
+            idle_stream.stream_display_name,
+        )
+        self._provider.mass.players.trigger_player_update(
+            target.sync_group_player_id, force_update=True, debounce_delay=0
+        )
+        self._provider._update_group_callbacks(poke=True)
+
+    async def _move_stale_stream_members_to_fallback(
+        self,
+        target: SnapcastGroupMaterializeTarget,
+        stream_id: str | None,
+        exclude_group_id: str | None,
+    ) -> None:
+        """Move stale clients on the same sync-group stream back to the fallback group."""
+        if stream_id is None:
+            return
+
+        snapserver = getattr(self._provider, "_snapserver", None)
+        if snapserver is None:
+            return
+
+        for snap_group in snapserver.groups:
+            if getattr(snap_group, "identifier", None) == exclude_group_id:
+                continue
+            if getattr(snap_group, "stream", None) != stream_id:
+                continue
+            for snap_client_id in getattr(snap_group, "clients", []):
+                player_id: str | None = None
+                with suppress(AssertionError, KeyError, ValueError):
+                    player_id = self._provider._get_ma_id(snap_client_id)
+                if not player_id:
+                    continue
+                if player_id in target.member_player_ids:
+                    continue
+                await self._provider.move_player_to_fallback_group(player_id)
+
+    def _resolve_group_member_player_ids(self, snap_group: SnapgroupProto) -> list[str]:
+        """Translate a live Snapcast group's client ids to MA player ids."""
+        member_player_ids: list[str] = []
+        for snap_client_id in getattr(snap_group, "clients", []):
+            with suppress(AssertionError, KeyError, ValueError):
+                member_player_ids.append(self._provider._get_ma_id(snap_client_id))
+        return member_player_ids

--- a/music_assistant/providers/snapcast/group_restore.py
+++ b/music_assistant/providers/snapcast/group_restore.py
@@ -1,0 +1,238 @@
+"""Helpers for restoring live Snapcast groups to MA sync-group runtime state."""
+
+from __future__ import annotations
+
+import urllib.parse
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from music_assistant_models.enums import PlayerFeature
+
+from music_assistant.providers.sync_group.constants import SGP_PREFIX
+
+if TYPE_CHECKING:
+    from .provider import SnapCastProvider
+    from .snap_cntrl_proto import SnapgroupProto, SnapstreamProto
+
+
+@dataclass(slots=True)
+class SnapcastGroupRestoreTarget:
+    """Resolved restore target for one live Snapcast group."""
+
+    sync_group_player_id: str
+    sync_group_name: str
+    stream_display_name: str
+    sync_leader_id: str
+    member_player_ids: list[str]
+
+
+class SnapcastGroupRestorer:
+    """Restore live Snapcast grouping into MA sync-group runtime state."""
+
+    def __init__(self, provider: SnapCastProvider) -> None:
+        """Initialize the restorer."""
+        self._provider = provider
+        self._logger = provider.logger.getChild("group_restore")
+
+    async def restore(self) -> None:
+        """Restore all matching live Snapcast groups into MA sync-group runtime state."""
+        if self._provider.mass.closing:
+            return
+
+        for target in self._collect_restore_targets():
+            await self._restore_target(target)
+
+    def _collect_restore_targets(self) -> list[SnapcastGroupRestoreTarget]:
+        """Collect restore targets from live Snapcast groups."""
+        targets: list[SnapcastGroupRestoreTarget] = []
+        seen_sync_groups: set[str] = set()
+        fallback_group_name = getattr(self._provider, "dedicated_fallback_group_name", None)
+        for snap_group in self._provider._snapserver.groups:
+            if fallback_group_name and getattr(snap_group, "name", None) == fallback_group_name:
+                self._logger.debug(
+                    "Skipping dedicated fallback group '%s' during restore",
+                    fallback_group_name,
+                )
+                continue
+
+            member_player_ids = self._resolve_group_member_player_ids(snap_group)
+            if len(member_player_ids) < 2:
+                continue
+
+            stream_display_name = self._resolve_group_stream_display_name(snap_group.stream)
+            if not stream_display_name or stream_display_name == "default":
+                continue
+
+            sync_group_player = self._provider.resolve_sync_group_player(stream_display_name)
+            if sync_group_player is None:
+                self._logger.debug(
+                    "No matching MA sync group found for live Snapcast stream '%s'",
+                    stream_display_name,
+                )
+                continue
+
+            if sync_group_player.player_id in seen_sync_groups:
+                self._logger.debug(
+                    "Skipping duplicate restore target for sync group %s",
+                    sync_group_player.player_id,
+                )
+                continue
+
+            if not self._supports_dynamic_restore(sync_group_player):
+                self._logger.debug(
+                    "Skipping sync group %s because it does not support dynamic member restore",
+                    sync_group_player.player_id,
+                )
+                continue
+
+            sync_leader_id = self._resolve_sync_leader_id(snap_group, member_player_ids)
+            if not sync_leader_id:
+                continue
+
+            ordered_member_ids = [
+                sync_leader_id,
+                *[member_id for member_id in member_player_ids if member_id != sync_leader_id],
+            ]
+            targets.append(
+                SnapcastGroupRestoreTarget(
+                    sync_group_player_id=sync_group_player.player_id,
+                    sync_group_name=getattr(sync_group_player.config, "name", stream_display_name),
+                    stream_display_name=stream_display_name,
+                    sync_leader_id=sync_leader_id,
+                    member_player_ids=ordered_member_ids,
+                )
+            )
+            seen_sync_groups.add(sync_group_player.player_id)
+        return targets
+
+    async def _restore_target(self, target: SnapcastGroupRestoreTarget) -> None:
+        """Restore one live Snapcast group into the matching MA sync-group runtime."""
+        sync_group_player = self._provider.mass.players.get_player(target.sync_group_player_id)
+        if sync_group_player is None:
+            return
+
+        current_members = [
+            member_id
+            for member_id in getattr(sync_group_player, "group_members", [])
+            if member_id != sync_group_player.player_id
+        ]
+        target_members = list(dict.fromkeys(target.member_player_ids))
+        static_members = set(getattr(sync_group_player, "static_group_members", []))
+        player_ids_to_add = [
+            member_id for member_id in target_members if member_id not in current_members
+        ]
+        player_ids_to_remove = [
+            member_id
+            for member_id in current_members
+            if member_id not in target_members and member_id not in static_members
+        ]
+
+        if player_ids_to_add or player_ids_to_remove:
+            self._logger.info(
+                "Restoring MA sync group '%s' from live Snapcast group members=%s",
+                target.sync_group_name,
+                target_members,
+            )
+            await self._provider.mass.players.cmd_set_members(
+                target.sync_group_player_id,
+                player_ids_to_add=player_ids_to_add or None,
+                player_ids_to_remove=player_ids_to_remove or None,
+            )
+
+        if sync_leader := self._provider.mass.players.get_player(target.sync_leader_id):
+            sync_group_player_any = cast("Any", sync_group_player)
+            sync_group_player_any.sync_leader = sync_leader
+
+        self._provider.mass.players.trigger_player_update(
+            target.sync_group_player_id, force_update=True, debounce_delay=0
+        )
+
+    def _resolve_group_member_player_ids(self, snap_group: SnapgroupProto) -> list[str]:
+        """Translate a live Snapcast group's client ids to MA player ids."""
+        member_player_ids: list[str] = []
+        for snap_client_id in getattr(snap_group, "clients", []):
+            with suppress(AssertionError, KeyError, ValueError):
+                member_player_ids.append(self._provider._get_ma_id(snap_client_id))
+        return member_player_ids
+
+    def _resolve_group_stream_display_name(self, stream_ref: str | None) -> str | None:
+        """Resolve the visible stream name for a live Snapcast group."""
+        if not stream_ref:
+            return None
+
+        if ma_stream := self._provider._get_stream_registry().resolve(stream_ref):
+            return ma_stream.stream_display_name or ma_stream.stream_id or ma_stream.stream_name
+
+        snap_stream = self._find_snapstream(stream_ref)
+        if snap_stream is None:
+            return None if stream_ref == "default" else stream_ref
+
+        return (
+            self._get_snapstream_visible_name(snap_stream)
+            or getattr(snap_stream, "friendly_name", None)
+            or getattr(snap_stream, "identifier", None)
+        )
+
+    def _find_snapstream(self, stream_ref: str) -> SnapstreamProto | None:
+        """Find a live Snapserver stream by id or visible name reference."""
+        with suppress(KeyError, AttributeError):
+            snap_stream = self._provider._snapserver.stream(stream_ref)
+            if snap_stream is not None:
+                return snap_stream
+
+        for snap_stream in getattr(self._provider._snapserver, "streams", []):
+            if getattr(snap_stream, "identifier", None) == stream_ref:
+                return cast("SnapstreamProto", snap_stream)
+            if getattr(snap_stream, "friendly_name", None) == stream_ref:
+                return cast("SnapstreamProto", snap_stream)
+            if self._get_snapstream_visible_name(snap_stream) == stream_ref:
+                return cast("SnapstreamProto", snap_stream)
+        return None
+
+    def _get_snapstream_visible_name(self, snap_stream: SnapstreamProto) -> str | None:
+        """Extract the visible stream name from a live Snapserver stream."""
+        stream_meta = cast("dict[str, Any]", getattr(snap_stream, "_stream", {}))
+        uri_meta = cast("dict[str, Any]", stream_meta.get("uri", {}))
+        raw_uri = cast("str | None", uri_meta.get("raw"))
+        if not raw_uri:
+            return None
+        parsed = urllib.parse.urlparse(raw_uri)
+        name = urllib.parse.parse_qs(parsed.query).get("name")
+        if not name:
+            return None
+        return urllib.parse.unquote_plus(name[0])
+
+    def _resolve_sync_leader_id(
+        self, snap_group: SnapgroupProto, member_player_ids: list[str]
+    ) -> str | None:
+        """Resolve the MA sync leader player id for a live Snapcast group."""
+        candidate_refs = [
+            getattr(snap_group, "name", None),
+            getattr(snap_group, "identifier", None),
+        ]
+        for candidate_ref in candidate_refs:
+            if not candidate_ref:
+                continue
+            candidate_ref = cast("str", candidate_ref)
+            if candidate_ref in member_player_ids:
+                return candidate_ref
+            with suppress(AssertionError, KeyError, ValueError):
+                candidate_player_id = self._provider._get_ma_id(candidate_ref)
+                if candidate_player_id in member_player_ids:
+                    return candidate_player_id
+        return member_player_ids[0] if member_player_ids else None
+
+    def _supports_dynamic_restore(self, sync_group_player: Any) -> bool:
+        """Return True if the sync-group player supports runtime member restore."""
+        if not getattr(sync_group_player, "player_id", "").startswith(SGP_PREFIX):
+            return False
+        state = getattr(sync_group_player, "state", None)
+        supported_features = cast(
+            "set[PlayerFeature] | None", getattr(state, "supported_features", None)
+        )
+        if supported_features is None:
+            supported_features = cast(
+                "set[PlayerFeature]", getattr(sync_group_player, "supported_features", set())
+            )
+        return PlayerFeature.SET_MEMBERS in supported_features

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -11,11 +11,12 @@ Snapcast control script (used by the built-in Snapcast server integration).
 from __future__ import annotations
 
 import asyncio
+import os
 import random
 import time
 import urllib.parse
 from contextlib import suppress
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from music_assistant.helpers.audio import get_player_filter_params
 from music_assistant.helpers.ffmpeg import FFMpeg
@@ -46,12 +47,16 @@ class SnapcastMAStream:
     control script to communicate with Music Assistant.
     """
 
+    StreamLifecycleState = Literal["created", "attached", "unresolved", "destroyed"]
+
     def __init__(
         self,
         provider: SnapCastProvider,
         media: PlayerMedia,
         stream_name: str,
+        stream_display_name: str | None = None,
         source_id: str | None = None,
+        queue_id: str | None = None,
         filter_settings_owner: str | None = None,
         use_cntrl_script: bool = False,
         destroy_on_stop: bool = False,
@@ -68,14 +73,16 @@ class SnapcastMAStream:
         """
         self.media = media
         self.stream_name = stream_name
+        self.stream_display_name = stream_display_name or stream_name
         self.snap_stream: SnapstreamProto | None = None
 
         self._provider = provider
         self._logger = provider.logger
         self._mass = provider.mass
         self._source_id = source_id
+        self._queue_id = queue_id
         self._use_cntrl_script = use_cntrl_script
-        self._cntrl_queue_id = source_id if use_cntrl_script else None
+        self._cntrl_queue_id = queue_id if use_cntrl_script else None
         self._filter_settings_owner = filter_settings_owner
         self._destroy_on_stop = destroy_on_stop
 
@@ -83,6 +90,7 @@ class SnapcastMAStream:
         self._destroyed = False
         self._setup_done = False
         self._is_streaming = False
+        self._is_paused = False
         self._restart_requested: bool = False
         self._stop_requested: bool = False
         self._streaming_started_at: float | None = None
@@ -95,11 +103,17 @@ class SnapcastMAStream:
         self._stop_timer: asyncio.Handle | None = None
         self._stop_timer_started_at: float | None = None
         self._filter_settings: list[str] | None = None
+        self._lifecycle_state: SnapcastMAStream.StreamLifecycleState | None = None
 
     @property
     def source_id(self) -> str | None:
         """Return the source id this stream was created for."""
         return self._source_id
+
+    @property
+    def queue_id(self) -> str | None:
+        """Return the queue id this stream was created for, if queue-backed."""
+        return self._queue_id
 
     @property
     def stream_id(self) -> str | None:
@@ -112,6 +126,16 @@ class SnapcastMAStream:
     def is_streaming(self) -> bool:
         """Return True if the FFmpeg streaming task is currently running."""
         return self._is_streaming
+
+    @property
+    def is_paused(self) -> bool:
+        """Return True if the stream is intentionally paused."""
+        return self._is_paused
+
+    @property
+    def lifecycle_state(self) -> SnapcastMAStream.StreamLifecycleState | None:
+        """Return the latest high-level Snapcast stream lifecycle state."""
+        return self._lifecycle_state
 
     @property
     def playback_started_at(self) -> float | None:
@@ -138,7 +162,7 @@ class SnapcastMAStream:
         async with self._lifecycle_lock:
             if self._destroyed:
                 raise RuntimeError("Session is destroyed")
-            if self._setup_done:
+            if self._setup_done and not await self._reset_incompatible_registration_if_needed():
                 return
             if self._provider._snapserver is None:
                 raise RuntimeError("Snapserver needs to be setup first")
@@ -164,6 +188,7 @@ class SnapcastMAStream:
         await self.wait_for_stopped()
         await self._remove_snap_source()
         await self._stop_socket_server()
+        self._set_lifecycle_state("destroyed")
 
     async def start_stream(self, allow_restart: bool = False) -> None:
         """Start streaming the configured media to the Snapcast source.
@@ -181,6 +206,7 @@ class SnapcastMAStream:
 
             self._stop_requested = False
             self._restart_requested = False
+            self._is_paused = False
             self._stop_streamer_evt.clear()
             self._streamer_started_evt.clear()
             self._streamer_task = self._mass.create_task(self._streamer_task_impl())
@@ -228,13 +254,27 @@ class SnapcastMAStream:
         This is cooperative: the streamer task will stop when it observes the stop event.
         Any pending inactivity stop timer is canceled.
         """
+        self._is_paused = False
+        self._request_stream_end()
+
+    def request_pause_stream(self) -> None:
+        """Request the streamer task to pause while preserving resume state."""
+        self._is_paused = True
+        self._request_stream_end()
+
+    def _request_stream_end(self) -> None:
+        """Request the current streamer run to end."""
         self._stop_requested = True
         self._restart_requested = False  # explicit stop cancels any pending restart
         self._stop_streamer_evt.set()
+        self._cancel_stop_timer()
 
+    def _cancel_stop_timer(self) -> None:
+        """Cancel any pending inactivity stop timer."""
         self._stop_timer_started_at = None
         if self._stop_timer:
             self._stop_timer.cancel()
+            self._stop_timer = None
 
     def set_in_use(self, in_use: bool) -> None:
         """Mark the stream as in-use or idle.
@@ -294,10 +334,10 @@ class SnapcastMAStream:
                 DEFAULT_SNAPCAST_FORMAT,
                 DEFAULT_SNAPCAST_FORMAT,
             )
-        audio_source = self._mass.streams.get_stream(
-            self.media, DEFAULT_SNAPCAST_FORMAT, self._filter_settings_owner
-        )
         try:
+            audio_source = self._mass.streams.get_stream(
+                self.media, DEFAULT_SNAPCAST_FORMAT, self._filter_settings_owner
+            )
             async with FFMpeg(
                 audio_input=audio_source,
                 input_format=DEFAULT_SNAPCAST_FORMAT,
@@ -346,7 +386,9 @@ class SnapcastMAStream:
                 while True:
                     stream_is_idle = False
                     with suppress(KeyError):
-                        snap_stream = self._provider._snapserver.stream(self.stream_name)
+                        if self.snap_stream is None:
+                            break
+                        snap_stream = self._provider._snapserver.stream(self.snap_stream.identifier)
                         stream_is_idle = snap_stream.status == "idle"
                     if self._mass.closing or stream_is_idle:
                         break
@@ -425,22 +467,19 @@ class SnapcastMAStream:
         """Create a Snapcast TCP source for this stream (or reuse an existing one)."""
         # prefer to reuse existing stream if possible
         if self.snap_stream:
+            self._set_lifecycle_state("attached", detail="reusing registered stream reference")
             return
 
-        # The control script is used only for music streams in the builtin server
-        extra_args = ""
-        if (cntrl_queue_id := self._cntrl_queue_id) is not None:
-            # Create socket server for control script communication
-            socket_path = self._socket_path
-            if socket_path is None:
-                raise RuntimeError("socket_path needs to be set if cntrl_queue_id is set")
-            extra_args = (
-                f"&controlscript={urllib.parse.quote_plus('control.py')}"
-                f"&controlscriptparams=--queueid={urllib.parse.quote_plus(cntrl_queue_id)}%20"
-                f"--socket={urllib.parse.quote_plus(socket_path)}%20"
-                f"--streamserver-ip={self._mass.streams.publish_ip}%20"
-                f"--streamserver-port={self._mass.streams.publish_port}"
-            )
+        if existing_stream := self._find_existing_snapstream(require_idle=True):
+            if self._snapstream_matches_expected_registration(existing_stream):
+                self._attach_existing_snapstream(
+                    existing_stream,
+                    detail="reused idle Snapserver stream",
+                )
+                return
+            await self._remove_conflicting_snapstream(existing_stream)
+
+        extra_args = self._build_control_script_query_args()
 
         attempts = 50
         while attempts:
@@ -453,37 +492,97 @@ class SnapcastMAStream:
                 # (like 24 bits bit depth) does not seem to work at all!
                 f"tcp://0.0.0.0:{port}?sampleformat=48000:16:2"
                 f"&idle_threshold={self._provider._snapcast_stream_idle_threshold}"
-                f"{extra_args}&name={self.stream_name}"
+                f"{extra_args}&name={urllib.parse.quote_plus(self.stream_display_name)}"
             )
             if result is None or "id" not in result:
-                # if the port is already taken, the result will be an error
-                self._logger.warning(result)
-                continue
-            ## Do we need to synchronize the snapserver repr first?
-            self.snap_stream = self._provider._snapserver.stream(result["id"])
+                error_msg = self._extract_stream_add_error(result)
+                if self._is_duplicate_stream_name_error(error_msg):
+                    if existing_stream := self._find_existing_snapstream():
+                        if self._snapstream_matches_expected_registration(existing_stream):
+                            self._attach_existing_snapstream(
+                                existing_stream,
+                                detail="attached after duplicate stream-name response",
+                            )
+                            return
+                    self._set_lifecycle_state("unresolved", detail=error_msg)
+                    raise RuntimeError(error_msg)
+                if self._is_retryable_stream_add_error(error_msg):
+                    self._logger.warning(
+                        "Retryable Snapcast stream create failure for %s (%s): %s",
+                        self.stream_name,
+                        self.stream_display_name,
+                        error_msg,
+                    )
+                    continue
+                self._set_lifecycle_state("unresolved", detail=error_msg)
+                raise RuntimeError(error_msg)
+            self.snap_stream = None
+            if hasattr(self._provider._snapserver, "stream"):
+                self.snap_stream = self._provider._snapserver.stream(result["id"])
+            if self.snap_stream is None:
+                self.snap_stream = self._find_existing_snapstream(stream_ref=result["id"])
+            if self.snap_stream is None:
+                error_msg = f"Unable to attach created Snapcast stream {result['id']}"
+                self._set_lifecycle_state("unresolved", detail=error_msg)
+                raise RuntimeError(error_msg)
             self.snap_stream.set_callback(self._snap_on_stream_update)
+            self._set_lifecycle_state("created", snap_stream=self.snap_stream)
             return
 
         if self._socket_server:
             await self._stop_socket_server()
 
         msg = "Unable to create stream - No free port found?"
+        self._set_lifecycle_state("unresolved", detail=msg)
         raise RuntimeError(msg)
+
+    def _build_control_script_query_args(self) -> str:
+        """Build optional Snapserver control script query parameters for this stream."""
+        if (cntrl_queue_id := self._cntrl_queue_id) is not None:
+            socket_path = self._socket_path
+            if socket_path is None:
+                raise RuntimeError("socket_path needs to be set if cntrl_queue_id is set")
+            return (
+                f"&controlscript={urllib.parse.quote_plus('control.py')}"
+                f"&controlscriptparams=--queueid={urllib.parse.quote_plus(cntrl_queue_id)}%20"
+                f"--socket={urllib.parse.quote_plus(socket_path)}%20"
+                f"--streamserver-ip={self._mass.streams.publish_ip}%20"
+                f"--streamserver-port={self._mass.streams.publish_port}"
+            )
+
+        if self._queue_id is not None and not self._provider._use_builtin_server:
+            return (
+                f"&controlscript={urllib.parse.quote_plus('mass_bridge.py')}"
+                f"&controlscriptparams=--stream={urllib.parse.quote_plus(self.stream_display_name)}"
+            )
+
+        return ""
+
+    async def _reset_incompatible_registration_if_needed(self) -> bool:
+        """Remove an existing Snapserver registration if it no longer matches this stream."""
+        if self.snap_stream is None:
+            return False
+        if self._snapstream_matches_expected_registration(self.snap_stream):
+            return False
+        await self._remove_conflicting_snapstream(self.snap_stream)
+        self.snap_stream = None
+        self._setup_done = False
+        return True
 
     async def _remove_snap_source(self) -> None:
         """Remove the Snapcast source created for this stream and detach groups."""
         if self._mass.closing or self.snap_stream is None:
             return
 
-        for snap_group in self._provider._snapserver.groups:
-            if snap_group.stream != self.snap_stream.identifier:
-                continue
-            self._logger.debug(f"Set stream of group {snap_group.name} to default.")
-            await snap_group.set_stream("default")
+        if self._provider._use_builtin_server:
+            for snap_group in self._provider._snapserver.groups:
+                if snap_group.stream != self.snap_stream.identifier:
+                    continue
+                self._logger.debug(f"Set stream of group {snap_group.name} to default.")
+                await snap_group.set_stream("default")
 
         with suppress(KeyError, AttributeError):
-            snap_stream = self._provider._snapserver.stream(self.stream_name)
-            await self._provider._snapserver.stream_remove_stream(snap_stream.identifier)
+            await self._provider._snapserver.stream_remove_stream(self.snap_stream.identifier)
 
         if self._socket_server:
             await self._stop_socket_server()
@@ -510,6 +609,138 @@ class SnapcastMAStream:
             if snap_group.stream != self.snap_stream.identifier:
                 continue
             self._provider.poke_group_members(snap_group)
+
+    def _find_existing_snapstream(
+        self,
+        stream_ref: str | None = None,
+        require_idle: bool = False,
+    ) -> SnapstreamProto | None:
+        """Find an existing Snapserver stream by id or visible stream name."""
+        candidate_refs = {
+            ref
+            for ref in (stream_ref, self.stream_name, self.stream_display_name)
+            if ref is not None
+        }
+        for snap_stream in getattr(self._provider._snapserver, "streams", []):
+            if require_idle and getattr(snap_stream, "status", None) != "idle":
+                continue
+            visible_name = self._get_snapstream_visible_name(snap_stream)
+            if (
+                getattr(snap_stream, "identifier", None) in candidate_refs
+                or getattr(snap_stream, "friendly_name", None) in candidate_refs
+                or visible_name in candidate_refs
+            ):
+                return cast("SnapstreamProto", snap_stream)
+        return None
+
+    async def _remove_conflicting_snapstream(self, snap_stream: SnapstreamProto) -> None:
+        """Remove an incompatible existing Snapserver stream registration."""
+        if self._provider._use_builtin_server:
+            for snap_group in self._provider._snapserver.groups:
+                if snap_group.stream != getattr(snap_stream, "identifier", None):
+                    continue
+                await snap_group.set_stream("default")
+
+        with suppress(KeyError, AttributeError):
+            await self._provider._snapserver.stream_remove_stream(snap_stream.identifier)
+
+    def _snapstream_matches_expected_registration(self, snap_stream: SnapstreamProto) -> bool:
+        """Return True if an existing Snapserver stream matches this stream's control config."""
+        return (
+            self._get_snapstream_control_script_name(snap_stream)
+            == self._expected_control_script_name()
+        )
+
+    def _expected_control_script_name(self) -> str | None:
+        """Return the expected control script basename for this stream, if any."""
+        if self._cntrl_queue_id is not None:
+            return "control.py"
+        if self._queue_id is not None and not self._provider._use_builtin_server:
+            return "mass_bridge.py"
+        return None
+
+    def _get_snapstream_control_script_name(self, snap_stream: SnapstreamProto) -> str | None:
+        """Extract the configured control script basename from a Snapserver stream."""
+        raw_uri = getattr(snap_stream, "_stream", {}).get("uri", {}).get("raw")
+        if not raw_uri:
+            return None
+        parsed = urllib.parse.urlparse(raw_uri)
+        controlscript = urllib.parse.parse_qs(parsed.query).get("controlscript")
+        if not controlscript:
+            return None
+        return os.path.basename(urllib.parse.unquote_plus(controlscript[0]))
+
+    def _attach_existing_snapstream(
+        self,
+        snap_stream: SnapstreamProto,
+        *,
+        detail: str | None = None,
+    ) -> None:
+        """Attach this MA stream to an already existing Snapserver stream."""
+        self.snap_stream = snap_stream
+        self.snap_stream.set_callback(self._snap_on_stream_update)
+        self._set_lifecycle_state("attached", snap_stream=snap_stream, detail=detail)
+
+    def _set_lifecycle_state(
+        self,
+        state: StreamLifecycleState,
+        *,
+        snap_stream: SnapstreamProto | None = None,
+        detail: str | None = None,
+    ) -> None:
+        """Persist and log a human-readable lifecycle transition."""
+        self._lifecycle_state = state
+        stream_id = getattr(snap_stream or self.snap_stream, "identifier", None)
+        detail_suffix = f" ({detail})" if detail else ""
+        self._logger.info(
+            "Snapcast stream lifecycle=%s stream_name=%s display_name=%s stream_id=%s%s",
+            state,
+            self.stream_name,
+            self.stream_display_name,
+            stream_id,
+            detail_suffix,
+        )
+
+    def _extract_stream_add_error(self, result: Any) -> str:
+        """Normalize an add-stream error payload into a single readable message."""
+        if result is None:
+            return "Empty response from Snapserver while creating stream"
+        if isinstance(result, dict):
+            parts = [
+                str(result.get("message") or "").strip(),
+                str(result.get("data") or "").strip(),
+            ]
+            error_msg = " ".join(part for part in parts if part)
+            return error_msg or str(result)
+        return str(result)
+
+    def _is_duplicate_stream_name_error(self, error_msg: str) -> bool:
+        """Return True if the add-stream error indicates a duplicate visible stream name."""
+        error_msg = error_msg.lower()
+        return "already exists" in error_msg and "stream" in error_msg
+
+    def _is_retryable_stream_add_error(self, error_msg: str) -> bool:
+        """Return True if the add-stream failure is retryable on another random port."""
+        error_msg = error_msg.lower()
+        retryable_markers = (
+            "address already in use",
+            "bind failed",
+            "eaddrinuse",
+            "port is already in use",
+            "failed to bind",
+        )
+        return any(marker in error_msg for marker in retryable_markers)
+
+    def _get_snapstream_visible_name(self, snap_stream: SnapstreamProto) -> str | None:
+        """Extract the configured visible name from a Snapserver stream object."""
+        raw_uri = getattr(snap_stream, "_stream", {}).get("uri", {}).get("raw")
+        if not raw_uri:
+            return None
+        parsed = urllib.parse.urlparse(raw_uri)
+        name = urllib.parse.parse_qs(parsed.query).get("name")
+        if not name:
+            return None
+        return urllib.parse.unquote_plus(name[0])
 
     async def _start_socket_server(self) -> str:
         """Get or create a socket server for the given queue.

--- a/music_assistant/providers/snapcast/player.py
+++ b/music_assistant/providers/snapcast/player.py
@@ -191,11 +191,24 @@ class SnapCastPlayer(Player):
         # not guaranteed that the client respects it
         await self.snap_client.set_volume(volume_level)
 
+    async def play(self) -> None:
+        """Send PLAY (unpause) command to given player."""
+        await self.mass.players._handle_cmd_resume(
+            self.player_id, self.active_source, self.current_media
+        )
+
+    async def pause(self) -> None:
+        """Send PAUSE command to given player."""
+        if ma_stream := self.active_snap_ma_stream:
+            ma_stream.request_stop_stream()
+        self.poke_player_update()
+
     async def stop(self) -> None:
         """Send STOP command to given player."""
         player_group = await self.snap_provider.ensure_player_owned_group(self.player_id)
         assert player_group is not None  # for type checking
-        await player_group.set_stream("default")
+        stable_stream_ref = self.snap_provider._get_stable_stream_reference(player_group.stream)
+        await player_group.set_stream(stable_stream_ref)
         if ma_stream := self.active_snap_ma_stream:
             ma_stream.request_stop_stream()
             return
@@ -235,6 +248,7 @@ class SnapCastPlayer(Player):
         ]
 
         curr_stream_id = player_group.stream
+        stable_stream_ref = self.snap_provider._get_stable_stream_reference(curr_stream_id)
         sync_group_player: Player | None = None
         if curr_ma_stream := self.snap_provider.get_snap_ma_stream(curr_stream_id):
             media = curr_ma_stream.media
@@ -257,25 +271,50 @@ class SnapCastPlayer(Player):
                     id_to_remove in curr_ma_player_ids
                     and id_to_remove not in sync_group_player.group_members
                 ):
-                    await self.snap_provider.isolate_player_to_dedicated_group(
-                        id_to_remove, target_stream_id="default"
+                    moved_to_fallback = await self.snap_provider.move_player_to_fallback_group(
+                        id_to_remove
                     )
+                    if not moved_to_fallback:
+                        await self.snap_provider.isolate_player_to_dedicated_group(
+                            id_to_remove, target_stream_id=stable_stream_ref
+                        )
 
             # split remaining group into individual groups,
             # keeps the current stream, set this group to default stream
             await self.snap_provider.isolate_player_to_dedicated_group(
                 target_player_id=self.player_id,
                 target_stream_id="default",
-                others_stream_id=curr_stream_id,
+                others_stream_id=stable_stream_ref,
             )
+            await self.snap_provider.move_player_to_fallback_group(self.player_id)
         else:
+            leader_handoff = bool(
+                sync_group_player and self.player_id not in sync_group_player.group_members
+            )
             for player_id in player_ids_to_remove or []:
                 if player_id not in curr_ma_player_ids:
                     continue
-                await self.snap_provider.isolate_player_to_dedicated_group(
-                    player_id, target_stream_id="default"
+                keep_on_current_stream = bool(
+                    sync_group_player
+                    and player_id in sync_group_player.group_members
+                    and player_id != self.player_id
                 )
+                if keep_on_current_stream:
+                    await self.snap_provider.isolate_player_to_dedicated_group(
+                        player_id, target_stream_id=stable_stream_ref
+                    )
+                else:
+                    moved_to_fallback = await self.snap_provider.move_player_to_fallback_group(
+                        player_id
+                    )
+                    if not moved_to_fallback:
+                        await self.snap_provider.isolate_player_to_dedicated_group(
+                            player_id, target_stream_id=stable_stream_ref
+                        )
                 curr_ma_player_ids.remove(player_id)
+
+            if leader_handoff:
+                await self.snap_provider.move_player_to_fallback_group(self.player_id)
 
         for ma_id in player_ids_to_add or []:
             if (

--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-import re
 import shutil
 import socket
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from bidict import bidict
-from music_assistant_models.enums import MediaType, PlaybackState
+from music_assistant_models.enums import EventType, MediaType, PlaybackState
 from music_assistant_models.errors import SetupFailedError
+from music_assistant_models.player import PlayerMedia
 from snapcast.control.server import CONTROL_PORT, Snapserver
 from zeroconf import NonUniqueNameException
 from zeroconf.asyncio import AsyncServiceInfo
@@ -25,6 +25,7 @@ from music_assistant.helpers.process import AsyncProcess
 from music_assistant.helpers.util import get_ip_pton
 from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.providers.snapcast.constants import (
+    CONF_EXTERNAL_DEDICATED_FALLBACK_GROUP,
     CONF_SERVER_BUFFER_SIZE,
     CONF_SERVER_CHUNK_MS,
     CONF_SERVER_CONTROL_PORT,
@@ -43,12 +44,16 @@ from music_assistant.providers.snapcast.constants import (
     SHIPPED_SNAPSERVER_CONFIG_FILE,
     SNAPWEB_DIR,
 )
+from music_assistant.providers.snapcast.group_materialize import SnapcastGroupMaterializer
+from music_assistant.providers.snapcast.group_restore import SnapcastGroupRestorer
 from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
 from music_assistant.providers.snapcast.player import SnapCastPlayer
+from music_assistant.providers.snapcast.stream_registry import SnapcastStreamRegistry
+from music_assistant.providers.sync_group.constants import SGP_PREFIX
 from music_assistant.providers.universal_group.constants import UGP_PREFIX
 
 if TYPE_CHECKING:
-    from music_assistant_models.player import PlayerMedia
+    from music_assistant_models.event import MassEvent
 
     from .snap_cntrl_proto import SnapclientProto, SnapgroupProto, SnapserverProto
 
@@ -79,6 +84,19 @@ class SnapCastProvider(PlayerProvider):
     _controlscript_available: bool
     _snapcast_ma_streams: dict[str, SnapcastMAStream]
     _snapcast_ma_streams_lock: asyncio.Lock
+    _stream_registry: SnapcastStreamRegistry
+    _unregister_resolve_api_command: Any
+    _group_restore_lock: asyncio.Lock
+    _external_dedicated_fallback_group: str | None
+    _unsub_syncgroup_event_listener: Any
+
+    def _get_stream_registry(self) -> SnapcastStreamRegistry:
+        """Return the central stream registry, lazily initializing it when needed."""
+        if not hasattr(self, "_stream_registry"):
+            existing_streams = getattr(self, "_snapcast_ma_streams", {})
+            self._stream_registry = SnapcastStreamRegistry(existing_streams)
+            self._snapcast_ma_streams = self._stream_registry.streams_by_name
+        return self._stream_registry
 
     @property
     def queue_control_available(self) -> bool:
@@ -101,6 +119,8 @@ class SnapCastProvider(PlayerProvider):
         self._use_builtin_server = not self.config.get_value(CONF_USE_EXTERNAL_SERVER)
         self._stop_called = False
         self._controlscript_available = False
+        self._unregister_resolve_api_command = None
+        self._unsub_syncgroup_event_listener = None
         if self._use_builtin_server:
             if Path(DEFAULT_SNAPSERVER_CONFIG_FILE).exists():
                 self._snapcast_server_config_file = DEFAULT_SNAPSERVER_CONFIG_FILE
@@ -127,11 +147,19 @@ class SnapCastProvider(PlayerProvider):
             self._snapcast_server_control_port = int(
                 str(self.config.get_value(CONF_SERVER_CONTROL_PORT))
             )
+        fallback_group_name = str(
+            self.config.get_value(CONF_EXTERNAL_DEDICATED_FALLBACK_GROUP) or ""
+        ).strip()
+        self._external_dedicated_fallback_group = (
+            fallback_group_name if fallback_group_name and not self._use_builtin_server else None
+        )
         self._snapcast_stream_idle_threshold = self.config.get_value(CONF_STREAM_IDLE_THRESHOLD)
         self._ids_map = bidict({})
 
-        self._snapcast_ma_streams = {}
+        self._stream_registry = SnapcastStreamRegistry()
+        self._snapcast_ma_streams = self._stream_registry.streams_by_name
         self._snapcast_ma_streams_lock = asyncio.Lock()
+        self._group_restore_lock = asyncio.Lock()
 
         if self._use_builtin_server:
             await self._start_builtin_server()
@@ -160,12 +188,32 @@ class SnapCastProvider(PlayerProvider):
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
         await super().loaded_in_mass()
+        if self._unregister_resolve_api_command is None:
+            self._unregister_resolve_api_command = self.mass.register_api_command(
+                "snapcast/resolve_control_stream", self._api_resolve_control_stream
+            )
+        if self._unsub_syncgroup_event_listener is None:
+            self._unsub_syncgroup_event_listener = self.mass.subscribe(
+                self._on_mass_player_event,
+                (EventType.PLAYER_ADDED, EventType.PLAYER_UPDATED, EventType.PLAYER_REMOVED),
+            )
         # initial load of players
         self._handle_update()
+        self.mass.call_later(
+            1,
+            self._restore_group_runtime_state,
+            task_id=f"snapcast_group_restore_{self.instance_id}",
+        )
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle close/cleanup of the provider."""
         self._stop_called = True
+        if self._unregister_resolve_api_command is not None:
+            self._unregister_resolve_api_command()
+            self._unregister_resolve_api_command = None
+        if self._unsub_syncgroup_event_listener is not None:
+            self._unsub_syncgroup_event_listener()
+            self._unsub_syncgroup_event_listener = None
 
         for snap_client in self._snapserver.clients:
             player_id = self._get_ma_id(snap_client.identifier)
@@ -175,7 +223,7 @@ class SnapCastProvider(PlayerProvider):
                 continue
             await player.stop()
 
-        for stream_name in list(self._snapcast_ma_streams):
+        for stream_name in self._get_stream_registry().names():
             await self.delete_ma_stream(stream_name)
 
         self._snapserver.stop()
@@ -316,9 +364,9 @@ class SnapCastProvider(PlayerProvider):
                 # The snapserver doesn't always cleanup the control script processes
                 # properly. We do it explicitly when closing a socket server.
                 # Should be fixed on the server side, though.
-                for stream_name in list(self._snapcast_ma_streams):
+                for stream_name in self._get_stream_registry().names():
                     await self.delete_ma_stream(stream_name)
-                self._snapcast_ma_streams.clear()
+                self._get_stream_registry().clear()
                 raise
 
             finally:
@@ -343,7 +391,7 @@ class SnapCastProvider(PlayerProvider):
     def _generate_and_register_id(self, snap_client_id: str) -> str:
         search_dict = self._ids_map.inverse
         if snap_client_id not in search_dict:
-            new_id = "ma_" + str(re.sub(r"\W+", "", snap_client_id))
+            new_id = snap_client_id
             self._ids_map[new_id] = snap_client_id
             return new_id
         return self._get_ma_id(snap_client_id)
@@ -377,6 +425,10 @@ class SnapCastProvider(PlayerProvider):
                 self.logger.warning(
                     "Detected Snapclient %s without identifier, skipping", snap_client.friendly_name
                 )
+                continue
+            self._generate_and_register_id(snap_client.identifier)
+        for snap_client in self._snapserver.clients:
+            if not snap_client.identifier:
                 continue
             if ma_player := self._handle_player_init(snap_client):
                 snap_client.set_callback(ma_player._handle_player_update)
@@ -420,6 +472,53 @@ class SnapCastProvider(PlayerProvider):
             grp.set_callback(self.poke_group_members)
             if poke:
                 self.poke_group_members(grp)
+
+    @property
+    def dedicated_fallback_group_name(self) -> str | None:
+        """Return the configured external Snapserver fallback group name."""
+        return self._external_dedicated_fallback_group
+
+    def get_snap_group(
+        self, *, group_id: str | None = None, group_name: str | None = None
+    ) -> SnapgroupProto | None:
+        """Return a Snapcast group by identifier or by visible group name."""
+        if group_id is not None:
+            with suppress(KeyError):
+                return self._snapserver.group(group_id)
+
+        if group_name is None:
+            return None
+
+        for snap_group in self._snapserver.groups:
+            if getattr(snap_group, "name", None) == group_name:
+                return snap_group
+        return None
+
+    async def move_player_to_fallback_group(self, target_player_id: str) -> bool:
+        """Move a player to the configured dedicated fallback group if available."""
+        fallback_group_name = self.dedicated_fallback_group_name
+        if not fallback_group_name:
+            return False
+
+        fallback_group = self.get_snap_group(group_name=fallback_group_name)
+        if fallback_group is None:
+            self.logger.warning(
+                "Configured Snapcast fallback group '%s' does not exist; "
+                "falling back to dedicated isolate flow",
+                fallback_group_name,
+            )
+            return False
+
+        target_client = self.get_snap_client(player_id=target_player_id)
+        if target_client is None:
+            return False
+
+        current_group = getattr(target_client, "group", None)
+        if current_group is not None and current_group.identifier == fallback_group.identifier:
+            return True
+
+        await fallback_group.add_client(target_client.identifier)
+        return True
 
     async def ensure_player_owned_group(
         self, ma_player_id: str, set_stream_id: str | None = None
@@ -482,7 +581,7 @@ class SnapCastProvider(PlayerProvider):
         self,
         target_player_id: str,
         target_stream_id: str | None = None,
-        others_stream_id: str | None = "default",
+        others_stream_id: str | None = None,
     ) -> None:
         """Isolate a player into a dedicated Snapcast group.
 
@@ -512,6 +611,9 @@ class SnapCastProvider(PlayerProvider):
         if target_group is None:
             return
 
+        if others_stream_id is None:
+            others_stream_id = self._get_stable_stream_reference(target_group.stream)
+
         target_group.set_callback(None)
         group_members = list(target_group.clients)
         group_members.remove(this_client_id)
@@ -536,6 +638,51 @@ class SnapCastProvider(PlayerProvider):
 
         if target_stream_id is not None:
             await target_group.set_stream(target_stream_id)
+
+    async def ensure_sync_group_idle_stream(
+        self, sync_group_player: Any
+    ) -> SnapcastMAStream | None:
+        """Ensure an idle Snapcast stream exists for a dynamic MA sync group."""
+        stream_display_name = getattr(getattr(sync_group_player, "config", None), "name", None)
+        if not stream_display_name:
+            return None
+
+        stream_name = create_safe_string(sync_group_player.player_id, lowercase=False)
+        stream_name = f"{MASS_STREAM_PREFIX}idle_{stream_name}"
+        idle_media = PlayerMedia(
+            uri=f"snapcast-syncgroup://{sync_group_player.player_id}",
+            media_type=MediaType.PLUGIN_SOURCE,
+            title=stream_display_name,
+            custom_data={
+                "provider": self.instance_id,
+                "source_id": sync_group_player.player_id,
+                "player_id": sync_group_player.player_id,
+            },
+        )
+        async with self._snapcast_ma_streams_lock:
+            stream = self._get_stream_registry().get_by_stream_name(stream_name)
+            if (
+                stream is not None
+                and stream.stream_display_name != stream_display_name
+                and not stream.is_streaming
+            ):
+                await stream.destroy()
+                self._get_stream_registry().unregister(stream_name)
+                stream = None
+            if stream is None:
+                stream = SnapcastMAStream(
+                    provider=self,
+                    media=idle_media,
+                    stream_name=stream_name,
+                    stream_display_name=stream_display_name,
+                    source_id=sync_group_player.player_id,
+                    destroy_on_stop=False,
+                )
+                self._get_stream_registry().register(stream)
+            else:
+                stream.update_media(idle_media)
+        await stream.setup()
+        return stream
 
     async def get_snapcast_media_stream(
         self,
@@ -593,8 +740,20 @@ class SnapCastProvider(PlayerProvider):
 
         stream_name = create_safe_string(stream_name, lowercase=False)
         stream_name = f"{MASS_STREAM_PREFIX}{stream_name}{name_suffix}"
+        stream_display_name = self._get_sync_group_stream_display_name(media) or stream_name
+        stream_registry = self._get_stream_registry()
         async with self._snapcast_ma_streams_lock:
-            if not (stream := self._snapcast_ma_streams.get(stream_name)):
+            stream = stream_registry.get_by_stream_name(stream_name)
+            if (
+                stream is not None
+                and stream.stream_display_name != stream_display_name
+                and not stream.is_streaming
+            ):
+                await stream.destroy()
+                stream_registry.unregister(stream_name)
+                stream = None
+
+            if stream is None:
                 if existing_only:
                     return None
 
@@ -602,12 +761,14 @@ class SnapCastProvider(PlayerProvider):
                     provider=self,
                     media=media,
                     stream_name=stream_name,
+                    stream_display_name=stream_display_name,
                     filter_settings_owner=filter_settings_owner,
                     source_id=source_id,
+                    queue_id=queue_id,
                     use_cntrl_script=bool(queue_id) and self.queue_control_available,
                     destroy_on_stop=destroy_on_stop,
                 )
-                self._snapcast_ma_streams[stream_name] = stream
+                stream_registry.register(stream)
             else:
                 stream.update_media(media)
         await stream.setup()
@@ -622,7 +783,22 @@ class SnapCastProvider(PlayerProvider):
         Returns:
             The corresponding ``SnapcastMAStream`` instance, or ``None`` if not found.
         """
-        return self._snapcast_ma_streams.get(stream_name)
+        matches = self._get_stream_registry().resolve_all(stream_name)
+        if not matches:
+            return None
+
+        return max(
+            matches,
+            key=lambda stream: (
+                getattr(stream, "stream_name", None) == stream_name,
+                getattr(stream, "queue_id", None) == stream_name,
+                getattr(stream, "stream_id", None) == stream_name,
+                getattr(stream, "source_id", None) == stream_name,
+                getattr(stream, "stream_display_name", None) == stream_name,
+                bool(getattr(stream, "is_streaming", False)),
+                getattr(stream, "queue_id", None) is not None,
+            ),
+        )
 
     async def delete_ma_stream(self, stream_name: str) -> None:
         """Remove and destroy a Music Assistant Snapcast stream.
@@ -635,7 +811,7 @@ class SnapCastProvider(PlayerProvider):
             stream_name: Snapcast stream name to delete.
         """
         async with self._snapcast_ma_streams_lock:
-            stream = self._snapcast_ma_streams.pop(stream_name, None)
+            stream = self._get_stream_registry().unregister(stream_name)
 
         if not stream:
             return
@@ -654,19 +830,20 @@ class SnapCastProvider(PlayerProvider):
         This method should be called whenever group or stream assignments change
         on the Snapcast server.
         """
-        unused_streams = set(self._snapcast_ma_streams.keys())
+        stream_registry = self._get_stream_registry()
+        unused_streams = set(stream_registry.names())
         for grp in self._snapserver.groups:
-            stream_id = grp.stream
-            if stream_id in self._snapcast_ma_streams:
-                ma_stream = self._snapcast_ma_streams[stream_id]
+            matching_streams = stream_registry.resolve_all(grp.stream)
+            for ma_stream in matching_streams:
                 ma_stream.set_in_use(True)
-                unused_streams.discard(stream_id)
+                unused_streams.discard(ma_stream.stream_name)
 
             if not unused_streams:
                 break
 
         for stream_id in unused_streams:
-            self._snapcast_ma_streams[stream_id].set_in_use(False)
+            if unused_stream := stream_registry.get_by_stream_name(stream_id):
+                unused_stream.set_in_use(False)
 
     def get_snap_client(
         self, *, client_id: str | None = None, player_id: str | None = None
@@ -700,3 +877,94 @@ class SnapCastProvider(PlayerProvider):
             return ma_player
 
         return None
+
+    def resolve_sync_group_player(self, ref: str) -> Any | None:
+        """Resolve a sync-group player by player id or configured sync-group name."""
+        if player := self.mass.players.get_player(ref, raise_unavailable=False):
+            if getattr(player, "player_id", "").startswith(SGP_PREFIX):
+                return player
+
+        lookup_name = ref.removeprefix(SGP_PREFIX) if ref.startswith(SGP_PREFIX) else ref
+        all_players = getattr(self.mass.players, "all_players", None)
+        players_iter = iter(all_players()) if callable(all_players) else iter(self.mass.players)
+
+        for player in players_iter:
+            if not getattr(player, "player_id", "").startswith(SGP_PREFIX):
+                continue
+            if getattr(getattr(player, "config", None), "name", None) == lookup_name:
+                return player
+        return None
+
+    async def _restore_group_runtime_state(self) -> None:
+        """Restore MA sync-group runtime state from live Snapcast groups."""
+        async with self._group_restore_lock:
+            await SnapcastGroupRestorer(self).restore()
+
+    async def _materialize_sync_group_runtime_state(self, sync_group_player_id: str) -> None:
+        """Materialize MA sync-group runtime state into native Snapcast state."""
+        async with self._group_restore_lock:
+            await SnapcastGroupMaterializer(self).materialize(sync_group_player_id)
+
+    def _get_sync_group_stream_display_name(self, media: PlayerMedia) -> str | None:
+        """Resolve the visible Snapcast stream name for sync-group backed playback."""
+        player_ref: str | None = None
+        if media.media_type == MediaType.PLUGIN_SOURCE:
+            player_ref = (media.custom_data or {}).get("player_id")
+        elif media.source_id:
+            player_ref = media.source_id
+
+        if not player_ref or not player_ref.startswith(SGP_PREFIX):
+            return None
+
+        if sync_group_player := self.resolve_sync_group_player(player_ref):
+            return getattr(getattr(sync_group_player, "config", None), "name", None)
+        return None
+
+    def _get_stable_stream_reference(self, stream_ref: str | None) -> str:
+        """Return the most stable human-visible reference for a Snapcast stream."""
+        if not stream_ref:
+            return "default"
+        if stream_ref == "default":
+            return stream_ref
+        if ma_stream := self._get_stream_registry().resolve(stream_ref):
+            return ma_stream.stream_display_name or ma_stream.stream_id or ma_stream.stream_name
+        return stream_ref
+
+    def resolve_control_stream(self, stream: str) -> dict[str, Any] | None:
+        """Resolve a visible Snapcast stream reference to the active MA queue payload."""
+        for ma_stream in self._get_stream_registry().resolve_all(stream):
+            if not ma_stream.queue_id:
+                continue
+
+            if not (queue := self.mass.player_queues.get(ma_stream.queue_id)):
+                continue
+
+            return {
+                "player_id": queue.queue_id,
+                "queue_id": queue.queue_id,
+                "queue": queue.to_dict(),
+                "stream_id": ma_stream.stream_id,
+                "stream_name": ma_stream.stream_name,
+                "stream_display_name": ma_stream.stream_display_name,
+            }
+        return None
+
+    async def _api_resolve_control_stream(self, stream: str) -> dict[str, Any] | None:
+        """Async API wrapper for resolving a visible Snapcast stream reference."""
+        return self.resolve_control_stream(stream)
+
+    async def _on_mass_player_event(self, event: MassEvent) -> None:
+        """Track sync-group membership changes and materialize native Snapcast state."""
+        player_id = event.object_id
+        if not player_id or not player_id.startswith(SGP_PREFIX):
+            return
+
+        if event.event == EventType.PLAYER_REMOVED:
+            return
+
+        self.mass.call_later(
+            0.25,
+            self._materialize_sync_group_runtime_state,
+            player_id,
+            task_id=f"snapcast_group_materialize_{self.instance_id}_{player_id}",
+        )

--- a/music_assistant/providers/snapcast/snapserver/__init__.py
+++ b/music_assistant/providers/snapcast/snapserver/__init__.py
@@ -1,0 +1,1 @@
+"""Snapserver helper package for the Snapcast provider."""

--- a/music_assistant/providers/snapcast/snapserver/mass_bridge.py
+++ b/music_assistant/providers/snapcast/snapserver/mass_bridge.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""Standalone Snapcast bridge for Music Assistant."""
+
+# This file is part of the snapcast ecosystem (https://github.com/badaix/snapcast).
+#
+# Author            : ThaGhostNL <github.com/ThaGhostNL/snapserver/plugin/>
+# Maintainer        : ThaGhostNL
+# Provides          : Bridge between Snapcast and Music Assistant for playback
+#                     control and status updates
+# Version           : 1.2.0
+# Short-Description : Music Assistant control script for Snapcast plugin
+# Description       : This script bridges the Snapcast plugin and Music Assistant.
+#                     It listens for JSON-RPC requests on stdin, forwards control
+#                     commands over the Music Assistant WebSocket API, and sends
+#                     updated playback properties back to Snapcast.
+# Usage             : This script is intended to be run as part of the Snapcast
+#                     plugin setup and must be placed
+#                     inside the external SnapServer plugin directory.
+#                     For a single server setup, use the user configuration
+#                     parameters within this script.
+#                     For multiple server setups, use the command line arguments.
+# Extra Info        : This variant does not rely on the local Unix socket bridge
+#                     used by the built-in Snapserver integration. Instead it
+#                     talks to the Music Assistant WebSocket API and resolves the
+#                     active queue for a Snapcast stream through a provider-side
+#                     API command.
+# CmdLine options   : Run `mass_bridge.py --help` to see all available options.
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+import sys
+import threading
+import urllib.parse
+import urllib.request
+import uuid
+from collections.abc import Callable
+from contextlib import suppress
+from typing import Any, TypedDict, cast
+
+import websocket
+
+__version__ = "1.2.0"
+__git_version__ = ""
+
+# To get a token, create a new API token in Music Assistant
+# ("/settings/profile") and copy it, then either paste it here, read it from a
+# file, or set it via the environment variables MASS_ACCESS_TOKEN or
+# MASS_ACCESS_TOKEN_FILE. It is recommended to use a token file or environment
+# variable to avoid accidentally committing a token to version control.
+MassToken = ""
+MassTokenFile = ""
+
+# User-configurable defaults for standalone/external Snapserver setups.
+# CLI arguments override these values, and MASS_ACCESS_TOKEN can also supply
+# the Music Assistant access token if this field is left empty.
+RuntimeParams = TypedDict(
+    "RuntimeParams",
+    {
+        "progname": str,
+        "snapcast-host": str,
+        "snapcast-port": int,
+        "ma-websocket-ip": str,
+        "ma-websocket-port": int,
+        "ma-access-token": str,
+        "ma-access-token-file": str,
+        "stream": str | None,
+    },
+)
+
+params: dict[str, str | int | None] = {
+    "progname": sys.argv[0],
+    "snapcast-host": None,
+    "snapcast-port": None,
+    "ma-websocket-ip": None,
+    "ma-websocket-port": None,
+    "ma-access-token": MassToken,
+    "ma-access-token-file": MassTokenFile,
+    "stream": None,
+}
+
+LOOP_STATUS_MAP = {
+    "all": "playlist",
+    "one": "track",
+    "off": "none",
+}
+LOOP_STATUS_MAP_REVERSE = {v: k for k, v in LOOP_STATUS_MAP.items()}
+
+MessageCallback = Callable[[dict[str, Any] | None], None]
+
+
+def _read_token_file(token_file_path: str | None) -> str:
+    """Read a Music Assistant access token from a text file."""
+    if not token_file_path:
+        return ""
+
+    try:
+        with open(token_file_path, encoding="utf-8") as file_handle:
+            return file_handle.read().strip()
+    except OSError as err:
+        logger.warning("Unable to read Music Assistant token file '%s': %s", token_file_path, err)
+        return ""
+
+
+def _resolve_runtime_params(
+    argv: list[str], environ: dict[str, str] | None = None
+) -> RuntimeParams:
+    """Resolve effective runtime parameters from defaults, env vars, and CLI args."""
+    runtime_params: dict[str, str | int | None] = {
+        "progname": params["progname"],
+        "snapcast-host": params["snapcast-host"],
+        "snapcast-port": params["snapcast-port"],
+        "ma-websocket-ip": params["ma-websocket-ip"],
+        "ma-websocket-port": params["ma-websocket-port"],
+        "ma-access-token": params["ma-access-token"],
+        "ma-access-token-file": params["ma-access-token-file"],
+        "stream": params["stream"],
+    }
+    runtime_params["progname"] = argv[0] if argv else runtime_params["progname"]
+    cli_overrides: dict[str, str] = {}
+
+    for arg in argv[1:]:
+        if not arg.startswith("--") or "=" not in arg:
+            continue
+        key, value = arg[2:].split("=", 1)
+        if key in runtime_params:
+            cli_overrides[key] = value
+            runtime_params[key] = value
+
+    env = environ or os.environ
+    snapcast_host = str(runtime_params["snapcast-host"] or "127.0.0.1")
+    snapcast_port = int(runtime_params["snapcast-port"] or 1780)
+    ma_websocket_ip = str(runtime_params["ma-websocket-ip"] or "127.0.0.1")
+    ma_websocket_port = int(runtime_params["ma-websocket-port"] or 8095)
+
+    token = ""
+    token_file = ""
+    if cli_overrides.get("ma-access-token"):
+        token = cli_overrides["ma-access-token"]
+    elif cli_overrides.get("ma-access-token-file"):
+        token_file = cli_overrides["ma-access-token-file"]
+    elif runtime_params["ma-access-token"]:
+        token = str(runtime_params["ma-access-token"])
+    elif runtime_params["ma-access-token-file"]:
+        token_file = str(runtime_params["ma-access-token-file"])
+    elif env.get("MASS_ACCESS_TOKEN"):
+        token = env["MASS_ACCESS_TOKEN"]
+    else:
+        token_file = env.get("MASS_ACCESS_TOKEN_FILE", "")
+
+    return {
+        "progname": str(runtime_params["progname"]),
+        "snapcast-host": snapcast_host,
+        "snapcast-port": snapcast_port,
+        "ma-websocket-ip": ma_websocket_ip,
+        "ma-websocket-port": ma_websocket_port,
+        "ma-access-token": token or _read_token_file(token_file),
+        "ma-access-token-file": token_file,
+        "stream": cast("str | None", runtime_params["stream"]),
+    }
+
+
+def send(json_msg: dict[str, Any]) -> None:
+    """Send a JSON message to stdout."""
+    sys.stdout.write(json.dumps(json_msg))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def send_error(message_id: str, code: int, message: str) -> None:
+    """Send a JSON-RPC error response."""
+    send(
+        {
+            "jsonrpc": "2.0",
+            "error": {"code": code, "message": message},
+            "id": message_id,
+        }
+    )
+
+
+class MusicAssistantControl:
+    """Bridge between Snapcast JSON-RPC and the Music Assistant API."""
+
+    def __init__(
+        self,
+        stream: str,
+        snapcast_host: str,
+        snapcast_port: int,
+        ma_websocket_ip: str,
+        ma_websocket_port: int,
+        ma_access_token: str,
+    ) -> None:
+        """Initialize the bridge."""
+        self.stream = stream
+        self.snapcast_host = snapcast_host
+        self.snapcast_port = snapcast_port
+        self.ma_websocket_ip = ma_websocket_ip
+        self.ma_websocket_port = ma_websocket_port
+        self.ma_access_token = ma_access_token
+
+        self._metadata: dict[str, Any] = {}
+        self._properties: dict[str, Any] = self._default_properties()
+        self._request_callbacks: dict[str, MessageCallback] = {}
+        self._ws: Any = None
+        self._authenticated = False
+        self._stopped = False
+        self._shutdown_event = threading.Event()
+        self._send_lock = threading.Lock()
+        self._callback_lock = threading.Lock()
+        self._resolve_retry_lock = threading.Lock()
+        self._current_queue_id: str | None = None
+        self._current_player_id: str | None = None
+        self._resolve_retry_timer: threading.Timer | None = None
+        self._ws_thread = threading.Thread(target=self._ws_loop, name="massBridgeWS")
+        self._ws_thread.daemon = True
+        self._ws_thread.start()
+
+    def _default_properties(self) -> dict[str, Any]:
+        """Return the default unresolved Snapcast property set."""
+        return {
+            "canGoNext": False,
+            "canGoPrevious": False,
+            "canPlay": False,
+            "canPause": False,
+            "canSeek": False,
+            "canControl": False,
+            "playbackStatus": "stopped",
+            "loopStatus": "none",
+            "shuffle": False,
+            "volume": 0,
+            "mute": False,
+            "rate": 1.0,
+            "position": 0.0,
+            "metadata": {},
+        }
+
+    def _create_properties(self, mass_queue_details: dict[str, Any]) -> dict[str, Any]:
+        """Create Snapcast properties from Music Assistant queue details."""
+        current_queue_item: dict[str, Any] | None = mass_queue_details.get("current_item")
+        next_queue_item: dict[str, Any] | None = mass_queue_details.get("next_item")
+        current_index: int = mass_queue_details.get("current_index") or 0
+        properties: dict[str, Any] = {
+            "canGoNext": bool(next_queue_item is not None),
+            "canGoPrevious": bool(current_index > 0),
+            "canPlay": bool(current_queue_item is not None),
+            "canPause": bool(current_queue_item is not None),
+            "canSeek": bool(current_queue_item and current_queue_item.get("duration") is not None),
+            "canControl": bool(current_queue_item is not None),
+            "playbackStatus": mass_queue_details.get("state", "stopped"),
+            "loopStatus": LOOP_STATUS_MAP.get(mass_queue_details.get("repeat_mode", "off"), "none"),
+            "shuffle": mass_queue_details.get("shuffle_enabled", False),
+            "volume": 0,
+            "mute": False,
+            "rate": 1.0,
+            "position": mass_queue_details.get("elapsed_time", 0.0),
+            "metadata": {},
+        }
+        image_url: str | None = None
+        if current_queue_item and (media_item := current_queue_item.get("media_item")):
+            if image_path := current_queue_item.get("image", {}).get("path"):
+                image_path_encoded = urllib.parse.quote_plus(image_path)
+                image_url = (
+                    f"http://{self.ma_websocket_ip}:{self.ma_websocket_port}/imageproxy"
+                    f"?path={image_path_encoded}"
+                    f"&provider={current_queue_item['image']['provider']}"
+                    "&size=512"
+                )
+            properties["metadata"] = {
+                "trackId": media_item.get("uri") or current_queue_item.get("queue_item_id"),
+                "duration": media_item.get("duration"),
+                "title": media_item.get("name") or current_queue_item.get("name"),
+                "artUrl": image_url,
+            }
+            if "artists" in media_item:
+                properties["metadata"]["artist"] = [x["name"] for x in media_item["artists"]]
+                properties["metadata"]["artistSort"] = [
+                    x["sort_name"] for x in media_item["artists"]
+                ]
+            if media_item.get("album"):
+                properties["metadata"]["album"] = media_item["album"]["name"]
+                properties["metadata"]["albumSort"] = media_item["album"]["sort_name"]
+        elif current_queue_item:
+            properties["metadata"] = {
+                "title": current_queue_item.get("name"),
+                "trackId": current_queue_item.get("queue_item_id"),
+                "artUrl": image_url,
+            }
+        return properties
+
+    def _clear_resolved_state(self) -> None:
+        """Reset the bridge to its unresolved read-only state."""
+        self._current_queue_id = None
+        self._current_player_id = None
+        self._properties = self._default_properties()
+
+    def _ws_url(self) -> str:
+        """Return the Music Assistant websocket URL."""
+        return f"ws://{self.ma_websocket_ip}:{self.ma_websocket_port}/ws"
+
+    def _handle_auth_result(self, result: dict[str, Any] | None) -> None:
+        """Handle the response to the MA websocket auth command."""
+        authenticated = bool(result and result.get("authenticated"))
+        self._authenticated = authenticated
+        if not authenticated:
+            logger.warning("Authentication with Music Assistant WebSocket API failed")
+            self._clear_resolved_state()
+            self.send_snapcast_properties_notification(self._properties)
+            if self._ws is not None:
+                with suppress(Exception):
+                    self._ws.close()
+            return
+
+        logger.info("Authenticated with Music Assistant WebSocket API")
+        if self._ws is not None:
+            with suppress(Exception):
+                # After the initial handshake/auth completes we want a blocking recv loop.
+                # The connect timeout is still useful for establishing the websocket, but
+                # leaving the socket timeout at 10 seconds causes healthy idle connections
+                # to be treated as failures.
+                self._ws.settimeout(None)
+        self._resolve_stream_state(notify=True)
+
+    def _disconnect_websocket(self, reason: str, *, notify: bool) -> None:
+        """Transition the bridge to a disconnected read-only state."""
+        if self._authenticated or self._ws is not None:
+            logger.info("Music Assistant websocket disconnected: %s", reason)
+        self._authenticated = False
+        self._cancel_stream_state_retry()
+        self._clear_resolved_state()
+        with self._callback_lock:
+            self._request_callbacks.clear()
+        ws = self._ws
+        self._ws = None
+        if ws is not None:
+            with suppress(Exception):
+                ws.close()
+        if notify:
+            self.send_snapcast_properties_notification(self._properties)
+
+    def _reconnect_delay(self, attempt: int) -> float:
+        """Return an exponential reconnect delay with bounded jitter."""
+        base_delay = min(30.0, float(2 ** max(attempt - 1, 0)))
+        return max(1.0, base_delay + random.uniform(0.0, 0.5))
+
+    def _ws_loop(self) -> None:
+        """Maintain the Music Assistant websocket connection."""
+        logger.info("Started Music Assistant websocket loop")
+        attempt = 0
+        while not self._stopped:
+            try:
+                self._connect_and_read()
+                attempt = 0
+            except Exception as err:
+                attempt += 1
+                self._disconnect_websocket(str(err), notify=True)
+                delay = self._reconnect_delay(attempt)
+                logger.warning("WebSocket loop error: %s. Reconnecting in %.1f seconds", err, delay)
+                if self._shutdown_event.wait(delay):
+                    break
+
+    def _connect_and_read(self) -> None:
+        """Connect to the MA websocket and read messages until disconnect."""
+        ws_url = self._ws_url()
+        logger.info("Connecting to Music Assistant WebSocket: %s", ws_url)
+        ws = websocket.create_connection(ws_url, timeout=10, enable_multithread=True)
+        self._ws = ws
+        self._authenticated = False
+        self.send_request("auth", callback=self._handle_auth_result, token=self.ma_access_token)
+
+        while not self._stopped:
+            message = ws.recv()
+            if message is None:
+                raise ConnectionError("WebSocket closed by server")
+            if message == "":
+                raise ConnectionError("Empty websocket frame received")
+            self._handle_ws_message(str(message))
+
+    def _fetch_snapcast_server_status(self) -> dict[str, Any] | None:
+        """Fetch the current Snapserver status via HTTP JSON-RPC."""
+        request_data = json.dumps(
+            {"id": 1, "jsonrpc": "2.0", "method": "Server.GetStatus"}
+        ).encode()
+        request = urllib.request.Request(
+            f"http://{self.snapcast_host}:{self.snapcast_port}/jsonrpc",
+            data=request_data,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:  # noqa: S310
+                payload = json.loads(response.read().decode())
+        except Exception as err:
+            logger.debug("Unable to fetch Snapserver status: %s", err)
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+        result = payload.get("result")
+        if isinstance(result, dict) and "server" in result:
+            server_payload = result["server"]
+            return cast(
+                "dict[str, Any] | None",
+                server_payload if isinstance(server_payload, dict) else None,
+            )
+        if isinstance(result, dict):
+            return cast("dict[str, Any]", result)
+        return None
+
+    def _has_existing_inactive_snapcast_stream(self) -> bool:
+        """Return True if a matching idle Snapcast stream is still visible on the server."""
+        if not (status := self._fetch_snapcast_server_status()):
+            return False
+
+        candidate_names = {self.stream}
+        for snap_stream in status.get("streams", []):
+            if snap_stream.get("status") != "idle":
+                continue
+            if snap_stream.get("id") in candidate_names:
+                return True
+            raw_uri = snap_stream.get("uri", {}).get("raw", "")
+            if not raw_uri:
+                continue
+            parsed = urllib.parse.urlparse(raw_uri)
+            stream_name = urllib.parse.parse_qs(parsed.query).get("name", [None])[0]
+            if stream_name and urllib.parse.unquote_plus(stream_name) in candidate_names:
+                return True
+        return False
+
+    def _schedule_stream_state_retry(self) -> None:
+        """Schedule a delayed resolve retry after reconnect or stale stream state."""
+        with self._resolve_retry_lock:
+            if self._resolve_retry_timer is not None:
+                return
+            timer = threading.Timer(2.0, self._retry_resolve_stream_state)
+            timer.daemon = True
+            self._resolve_retry_timer = timer
+            timer.start()
+
+    def _retry_resolve_stream_state(self) -> None:
+        """Run the deferred stream-state retry."""
+        with self._resolve_retry_lock:
+            self._resolve_retry_timer = None
+        self._resolve_stream_state(notify=True)
+
+    def _cancel_stream_state_retry(self) -> None:
+        """Cancel any pending stream-state retry timer."""
+        with self._resolve_retry_lock:
+            if self._resolve_retry_timer is not None:
+                self._resolve_retry_timer.cancel()
+                self._resolve_retry_timer = None
+
+    def _resolve_stream_state(self, notify: bool = True) -> None:
+        """Resolve the current visible Snapcast stream to a MA queue."""
+
+        def handle_result(result: dict[str, Any] | None) -> None:
+            if not result or not result.get("queue"):
+                logger.info("Resolve miss for Snapcast stream '%s'", self.stream)
+                self._clear_resolved_state()
+                if result is None and self._has_existing_inactive_snapcast_stream():
+                    self._schedule_stream_state_retry()
+                else:
+                    self._cancel_stream_state_retry()
+                if notify:
+                    logger.info("Snapcast stream '%s' remains in read-only state", self.stream)
+                    self.send_snapcast_properties_notification(self._properties)
+                return
+
+            self._cancel_stream_state_retry()
+            self._current_queue_id = result.get("queue_id")
+            self._current_player_id = result.get("player_id")
+            self._properties = self._create_properties(result["queue"])
+            if notify:
+                self.send_snapcast_properties_notification(self._properties)
+
+        if not self.send_request(
+            "snapcast/resolve_control_stream", callback=handle_result, stream=self.stream
+        ):
+            self._clear_resolved_state()
+            if notify:
+                self.send_snapcast_properties_notification(self._properties)
+
+    def send_request(
+        self, command: str, callback: MessageCallback | None = None, **args: str | float | bool
+    ) -> bool:
+        """Send a request to Music Assistant via the websocket connection."""
+        if self._ws is None:
+            logger.debug("Cannot send request - websocket not connected")
+            return False
+        if command != "auth" and not self._authenticated:
+            logger.debug("Cannot send request - websocket not authenticated")
+            return False
+
+        request_id = uuid.uuid4().hex[:10]
+        payload = {
+            "message_id": request_id,
+            "command": command,
+            "args": args,
+        }
+        if callback:
+            with self._callback_lock:
+                self._request_callbacks[request_id] = callback
+        with self._send_lock:
+            try:
+                self._ws.send(json.dumps(payload))
+            except Exception as err:
+                logger.warning("Failed to send websocket request: %s", err)
+                with self._callback_lock:
+                    self._request_callbacks.pop(request_id, None)
+                return False
+        return True
+
+    def send_snapcast_log_notification(self, message: str, severity: str = "Info") -> None:
+        """Send a log message back to Snapcast."""
+        send(
+            {
+                "jsonrpc": "2.0",
+                "method": "Plugin.Stream.Log",
+                "params": {"severity": severity, "message": message},
+            }
+        )
+
+    def send_snapcast_properties_notification(self, properties: dict[str, Any]) -> None:
+        """Publish updated player properties to Snapcast."""
+        send(
+            {
+                "jsonrpc": "2.0",
+                "method": "Plugin.Stream.Player.Properties",
+                "params": properties,
+            }
+        )
+
+    def send_snapcast_stream_ready_notification(self) -> None:
+        """Notify Snapcast that the bridge is ready."""
+        send({"jsonrpc": "2.0", "method": "Plugin.Stream.Ready"})
+
+    def _handle_ws_message(self, message: str) -> None:
+        """Handle an incoming Music Assistant websocket message."""
+        try:
+            data = json.loads(message)
+        except json.JSONDecodeError as err:
+            logger.warning("Invalid websocket payload: %s", err)
+            return
+
+        if "message_id" in data:
+            message_id = data["message_id"]
+            with self._callback_lock:
+                callback = self._request_callbacks.pop(message_id, None)
+            if callback:
+                callback(data.get("result"))
+            return
+
+        if data.get("event") == "queue_updated" and data.get("object_id") == self._current_queue_id:
+            if queue_data := data.get("data"):
+                self._properties = self._create_properties(queue_data)
+                self.send_snapcast_properties_notification(self._properties)
+            return
+
+        if (
+            data.get("event") == "queue_time_updated"
+            and data.get("object_id") == self._current_queue_id
+        ):
+            updated_properties = {
+                **self._properties,
+                "position": float(data.get("data") or 0.0),
+            }
+            self._properties = updated_properties
+            self.send_snapcast_properties_notification(updated_properties)
+            return
+
+        if data.get("event") == "player_updated":
+            self._resolve_stream_state(notify=True)
+
+    def handle_snapcast_request(self, request: dict[str, Any]) -> None:
+        """Handle a Snapcast JSON-RPC request from stdin."""
+        message_id = request["id"]
+        interface, cmd = request["method"].rsplit(".", 1)
+
+        if interface != "Plugin.Stream.Player" or cmd not in (
+            "Control",
+            "SetProperty",
+            "GetProperties",
+        ):
+            send_error(message_id, -32601, "Method not found")
+            return
+
+        if cmd == "GetProperties":
+            send({"jsonrpc": "2.0", "result": self._properties, "id": message_id})
+            return
+
+        if self._current_queue_id is None:
+            self._resolve_stream_state(notify=False)
+        if self._current_queue_id is None:
+            send_error(
+                message_id,
+                -32000,
+                f"No active Music Assistant queue resolved for stream '{self.stream}'",
+            )
+            return
+
+        queue_id = self._current_queue_id
+
+        if cmd == "Control":
+            command = request["params"]["command"]
+            control_params = request["params"].get("params", {})
+            if command == "next":
+                self.send_request("player_queues/next", queue_id=queue_id)
+            elif command == "previous":
+                self.send_request("player_queues/previous", queue_id=queue_id)
+            elif command == "play":
+                self.send_request("player_queues/play", queue_id=queue_id)
+            elif command == "pause":
+                self.send_request("player_queues/pause", queue_id=queue_id)
+            elif command == "playPause":
+                self.send_request("player_queues/play_pause", queue_id=queue_id)
+            elif command == "stop":
+                self.send_request("player_queues/stop", queue_id=queue_id)
+            elif command == "setPosition":
+                self.send_request(
+                    "player_queues/seek",
+                    queue_id=queue_id,
+                    position=float(control_params["position"]),
+                )
+            elif command == "seek":
+                self.send_request(
+                    "player_queues/skip",
+                    queue_id=queue_id,
+                    seconds=float(control_params["offset"]),
+                )
+        elif cmd == "SetProperty":
+            properties = request["params"]
+            if "shuffle" in properties:
+                self.send_request(
+                    "player_queues/shuffle",
+                    queue_id=queue_id,
+                    shuffle_enabled=properties["shuffle"],
+                )
+            if "loopStatus" in properties:
+                self.send_request(
+                    "player_queues/repeat",
+                    queue_id=queue_id,
+                    repeat_mode=LOOP_STATUS_MAP_REVERSE[properties["loopStatus"]],
+                )
+
+        send({"jsonrpc": "2.0", "result": "ok", "id": message_id})
+
+    def stop(self) -> None:
+        """Stop the bridge."""
+        self._stopped = True
+        self._cancel_stream_state_retry()
+        self._disconnect_websocket("stop requested", notify=False)
+        ws_thread = getattr(self, "_ws_thread", None)
+        if ws_thread is not None and threading.current_thread() is not ws_thread:
+            ws_thread.join(timeout=2)
+        self._shutdown_event.set()
+
+
+def main() -> None:
+    """Run the standalone bridge entrypoint."""
+    runtime_params = _resolve_runtime_params(sys.argv)
+    stream = runtime_params["stream"]
+
+    if not stream:
+        print(  # noqa: T201
+            f"Usage: {runtime_params['progname']} --stream=<stream_display_name>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    ctrl = MusicAssistantControl(
+        stream=stream,
+        snapcast_host=runtime_params["snapcast-host"],
+        snapcast_port=runtime_params["snapcast-port"],
+        ma_websocket_ip=runtime_params["ma-websocket-ip"],
+        ma_websocket_port=runtime_params["ma-websocket-port"],
+        ma_access_token=runtime_params["ma-access-token"],
+    )
+    ctrl.send_snapcast_stream_ready_notification()
+
+    try:
+        while not ctrl._shutdown_event.is_set():
+            line = sys.stdin.readline()
+            if not line:
+                break
+            ctrl.handle_snapcast_request(json.loads(line))
+    finally:
+        ctrl.stop()
+
+
+log_format_stderr = "%(asctime)s %(module)s %(levelname)s: %(message)s"
+logger = logging.getLogger("mass_bridge")
+logger.propagate = False
+logger.setLevel(logging.INFO)
+if not logger.handlers:
+    log_handler = logging.StreamHandler()
+    log_handler.setFormatter(logging.Formatter(log_format_stderr))
+    logger.addHandler(log_handler)
+
+
+if __name__ == "__main__":
+    main()

--- a/music_assistant/providers/snapcast/stream_registry.py
+++ b/music_assistant/providers/snapcast/stream_registry.py
@@ -1,0 +1,76 @@
+"""Central registry for Music Assistant managed Snapcast streams."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .ma_stream import SnapcastMAStream
+
+
+class SnapcastStreamRegistry:
+    """Central lookup for Snapcast MA streams by internal and external references."""
+
+    def __init__(self, streams_by_name: dict[str, SnapcastMAStream] | None = None) -> None:
+        """Initialize the registry."""
+        self._streams_by_name = streams_by_name if streams_by_name is not None else {}
+
+    @property
+    def streams_by_name(self) -> dict[str, SnapcastMAStream]:
+        """Return the underlying stream mapping keyed by internal stream name."""
+        return self._streams_by_name
+
+    def register(self, stream: SnapcastMAStream) -> None:
+        """Register or replace a stream by its internal stream name."""
+        self._streams_by_name[stream.stream_name] = stream
+
+    def unregister(self, stream_name: str) -> SnapcastMAStream | None:
+        """Remove a stream from the registry by its internal stream name."""
+        return self._streams_by_name.pop(stream_name, None)
+
+    def clear(self) -> None:
+        """Remove all tracked streams from the registry."""
+        self._streams_by_name.clear()
+
+    def get_by_stream_name(self, stream_name: str) -> SnapcastMAStream | None:
+        """Return a tracked stream by its internal stream name."""
+        return self._streams_by_name.get(stream_name)
+
+    def resolve(self, ref: str | None) -> SnapcastMAStream | None:
+        """Resolve any known stream reference to a tracked stream."""
+        matches = self.resolve_all(ref)
+        return matches[0] if matches else None
+
+    def resolve_all(self, ref: str | None) -> tuple[SnapcastMAStream, ...]:
+        """Resolve all tracked streams matching the given reference."""
+        if ref is None:
+            return ()
+
+        matches: list[SnapcastMAStream] = []
+
+        if stream := self._streams_by_name.get(ref):
+            matches.append(stream)
+
+        for stream in self._streams_by_name.values():
+            if stream in matches:
+                continue
+            if getattr(stream, "stream_id", None) == ref:
+                matches.append(stream)
+                continue
+            if getattr(stream, "stream_display_name", None) == ref:
+                matches.append(stream)
+                continue
+            if getattr(stream, "source_id", None) == ref:
+                matches.append(stream)
+                continue
+            if getattr(stream, "queue_id", None) == ref:
+                matches.append(stream)
+        return tuple(matches)
+
+    def all(self) -> tuple[SnapcastMAStream, ...]:
+        """Return all tracked streams."""
+        return tuple(self._streams_by_name.values())
+
+    def names(self) -> tuple[str, ...]:
+        """Return the internal names of all tracked streams."""
+        return tuple(self._streams_by_name.keys())

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -424,6 +424,7 @@ class SyncGroupPlayer(Player):
                 )
             if self.sync_leader and member_id == self.sync_leader.player_id:
                 leader_removed = True
+                self._attr_group_members.remove(member_id)
                 continue
             if member_id == self.player_id:
                 raise PlayerCommandFailed(
@@ -435,7 +436,6 @@ class SyncGroupPlayer(Player):
         if self.sync_leader and leader_removed and self._attr_group_members:
             # we removed the current sync leader, but we still have members in the group
             # we need to select a new leader and re-form the syncgroup with it
-            old_leader_id = self.sync_leader.player_id
             self.logger.info(
                 "Removing current sync leader %s from group %s while it is active, "
                 "dissolving the current syncgroup and will re-form it with a new leader",
@@ -445,9 +445,6 @@ class SyncGroupPlayer(Player):
             await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
             await asyncio.sleep(1)
             await self._dissolve_syncgroup()
-            # remove the old leader from the group members list so it won't be re-selected
-            if old_leader_id in self._attr_group_members:
-                self._attr_group_members.remove(old_leader_id)
             if was_playing and self._attr_group_members:
                 await asyncio.sleep(2)
                 await self.play()

--- a/tests/core/test_sync_group_player.py
+++ b/tests/core/test_sync_group_player.py
@@ -1,0 +1,83 @@
+"""Tests for SyncGroupPlayer edge cases."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import PlaybackState
+
+from music_assistant.constants import CONF_DYNAMIC_GROUP_MEMBERS, CONF_GROUP_MEMBERS
+from music_assistant.providers.sync_group.constants import CONF_MEMBERS_FILTER, SGP_PREFIX
+from music_assistant.providers.sync_group.player import SyncGroupPlayer
+from tests.common import MockProvider
+
+
+def _create_dynamic_sync_group_player() -> tuple[SyncGroupPlayer, MagicMock]:
+    """Create a minimal dynamic SyncGroupPlayer for unit tests."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.config = MagicMock()
+    mass.signal_event = MagicMock()
+    mass.create_task = MagicMock()
+
+    config = MagicMock()
+    config.name = "broadcast"
+    config.default_name = "broadcast"
+    config.enabled = True
+
+    def _get_value(key: str, default: object | None = None) -> object | None:
+        if key == CONF_DYNAMIC_GROUP_MEMBERS:
+            return True
+        if key in (CONF_GROUP_MEMBERS, CONF_MEMBERS_FILTER):
+            return []
+        return default
+
+    config.get_value.side_effect = _get_value
+    mass.config.get_base_player_config.return_value = config
+    mass.config.create_default_player_config = MagicMock()
+    mass.players = MagicMock()
+    mass.players._handle_cmd_stop = AsyncMock()
+    mass.players.cmd_set_members = AsyncMock()
+    mass.players.trigger_player_update = MagicMock()
+
+    provider = cast("Any", MockProvider("sync_group", instance_id="sync_group", mass=mass))
+    player = SyncGroupPlayer(provider, f"{SGP_PREFIX}abc12345")
+    return player, mass
+
+
+@pytest.mark.asyncio
+async def test_remove_last_sync_leader_clears_runtime_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing the final sync leader should leave the dynamic group empty."""
+    player, mass = _create_dynamic_sync_group_player()
+    player._attr_group_members = ["thor-speakers"]
+    player._attr_static_group_members = []
+    cast("Any", player).sync_leader = SimpleNamespace(
+        player_id="thor-speakers",
+        display_name="Thor",
+        state=SimpleNamespace(
+            playback_state=PlaybackState.IDLE,
+            can_group_with=set(),
+            group_members=["thor-speakers"],
+        ),
+    )
+
+    async def _skip_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "music_assistant.providers.sync_group.player.asyncio.sleep",
+        _skip_sleep,
+    )
+
+    await player.set_members(player_ids_to_remove=["thor-speakers"])
+
+    assert player._attr_group_members == []
+    assert player.sync_leader is None
+    mass.players._handle_cmd_stop.assert_awaited_once_with("thor-speakers")
+    mass.players.cmd_set_members.assert_not_awaited()
+    mass.players.trigger_player_update.assert_called_once_with(player.player_id)

--- a/tests/providers/snapcast/__init__.py
+++ b/tests/providers/snapcast/__init__.py
@@ -1,0 +1,1 @@
+"""Snapcast provider tests."""

--- a/tests/providers/snapcast/test_group_materialize.py
+++ b/tests/providers/snapcast/test_group_materialize.py
@@ -1,0 +1,242 @@
+"""Tests for plugin-only Snapcast group materialization."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import PlaybackState
+
+from music_assistant.providers.snapcast.group_materialize import SnapcastGroupMaterializer
+from music_assistant.providers.sync_group.constants import SGP_PREFIX
+
+
+@pytest.mark.asyncio
+async def test_materialize_creates_native_idle_group_for_first_snapcast_member() -> None:
+    """The first Snapcast member in a dynamic MA sync group should materialize native state."""
+    sync_group_player = SimpleNamespace(
+        player_id=f"{SGP_PREFIX}abc12345",
+        config=SimpleNamespace(name="broadcast"),
+        group_members=["thor-speakers"],
+        sync_leader=None,
+        playback_state=PlaybackState.IDLE,
+    )
+    leader_player = SimpleNamespace(player_id="thor-speakers")
+    idle_stream = SimpleNamespace(stream_id="broadcast", stream_display_name="broadcast")
+    leader_group = SimpleNamespace(
+        clients=["snap-thor"],
+        stream="default",
+        set_callback=MagicMock(),
+        add_client=AsyncMock(),
+        set_stream=AsyncMock(),
+    )
+    players = SimpleNamespace(trigger_player_update=MagicMock())
+    players.get_player = MagicMock(
+        side_effect=lambda ref, raise_unavailable=False: {  # noqa: ARG005
+            sync_group_player.player_id: sync_group_player,
+            "thor-speakers": leader_player,
+        }.get(ref)
+    )
+    provider = SimpleNamespace(
+        logger=MagicMock(),
+        mass=SimpleNamespace(closing=False, players=players),
+        get_snap_client=MagicMock(return_value=SimpleNamespace(identifier="snap-thor")),
+        ensure_sync_group_idle_stream=AsyncMock(return_value=idle_stream),
+        ensure_player_owned_group=AsyncMock(return_value=leader_group),
+        move_player_to_fallback_group=AsyncMock(return_value=False),
+        isolate_player_to_dedicated_group=AsyncMock(),
+        _get_stable_stream_reference=MagicMock(return_value="broadcast"),
+        _get_ma_id=MagicMock(return_value="thor-speakers"),
+        _get_snapclient_id=MagicMock(return_value="snap-thor"),
+        _update_group_callbacks=MagicMock(),
+    )
+
+    await SnapcastGroupMaterializer(provider).materialize(sync_group_player.player_id)  # type: ignore[arg-type]
+
+    provider.ensure_sync_group_idle_stream.assert_awaited_once_with(sync_group_player)
+    provider.ensure_player_owned_group.assert_awaited_once_with(
+        "thor-speakers", set_stream_id="broadcast"
+    )
+    leader_group.set_stream.assert_awaited_once_with("broadcast")
+    assert sync_group_player.sync_leader is leader_player
+    players.trigger_player_update.assert_called_once_with(
+        sync_group_player.player_id, force_update=True, debounce_delay=0
+    )
+    provider._update_group_callbacks.assert_called_once_with(poke=True)
+
+
+@pytest.mark.asyncio
+async def test_materialize_skips_when_sync_group_is_playing() -> None:
+    """Active queue-backed playback should not be overridden by idle pre-materialization."""
+    sync_group_player = SimpleNamespace(
+        player_id=f"{SGP_PREFIX}abc12345",
+        config=SimpleNamespace(name="broadcast"),
+        group_members=["thor-speakers"],
+        sync_leader=SimpleNamespace(player_id="thor-speakers"),
+        playback_state=PlaybackState.PLAYING,
+    )
+    players = SimpleNamespace()
+    players.get_player = MagicMock(return_value=sync_group_player)
+    provider = SimpleNamespace(
+        logger=MagicMock(),
+        mass=SimpleNamespace(closing=False, players=players),
+        ensure_sync_group_idle_stream=AsyncMock(),
+    )
+
+    await SnapcastGroupMaterializer(provider).materialize(sync_group_player.player_id)  # type: ignore[arg-type]
+
+    provider.ensure_sync_group_idle_stream.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_materialize_is_noop_when_native_state_already_matches() -> None:
+    """Repeated materialization should not log or re-trigger updates when nothing changed."""
+    leader_player = SimpleNamespace(player_id="thor-speakers")
+    sync_group_player = SimpleNamespace(
+        player_id=f"{SGP_PREFIX}abc12345",
+        config=SimpleNamespace(name="broadcast"),
+        group_members=["thor-speakers"],
+        sync_leader=leader_player,
+        playback_state=PlaybackState.IDLE,
+    )
+    idle_stream = SimpleNamespace(stream_id="broadcast", stream_display_name="broadcast")
+    leader_group = SimpleNamespace(
+        clients=["snap-thor"],
+        stream="broadcast",
+        set_callback=MagicMock(),
+        add_client=AsyncMock(),
+        set_stream=AsyncMock(),
+    )
+    logger = MagicMock()
+    players = SimpleNamespace(trigger_player_update=MagicMock())
+    players.get_player = MagicMock(
+        side_effect=lambda ref, raise_unavailable=False: {  # noqa: ARG005
+            sync_group_player.player_id: sync_group_player,
+            "thor-speakers": leader_player,
+        }.get(ref)
+    )
+    provider = SimpleNamespace(
+        logger=logger,
+        mass=SimpleNamespace(closing=False, players=players),
+        get_snap_client=MagicMock(return_value=SimpleNamespace(identifier="snap-thor")),
+        ensure_sync_group_idle_stream=AsyncMock(return_value=idle_stream),
+        ensure_player_owned_group=AsyncMock(return_value=leader_group),
+        move_player_to_fallback_group=AsyncMock(return_value=False),
+        isolate_player_to_dedicated_group=AsyncMock(),
+        _get_stable_stream_reference=MagicMock(return_value="broadcast"),
+        _get_ma_id=MagicMock(return_value="thor-speakers"),
+        _get_snapclient_id=MagicMock(return_value="snap-thor"),
+        _update_group_callbacks=MagicMock(),
+    )
+
+    await SnapcastGroupMaterializer(provider).materialize(sync_group_player.player_id)  # type: ignore[arg-type]
+
+    leader_group.add_client.assert_not_awaited()
+    leader_group.set_stream.assert_not_awaited()
+    players.trigger_player_update.assert_not_called()
+    provider._update_group_callbacks.assert_not_called()
+    logger.getChild.return_value.info.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_materialize_removes_idle_stream_when_sync_group_becomes_empty() -> None:
+    """An empty sync group should clean up its previously materialized idle Snapcast stream."""
+    sync_group_player = SimpleNamespace(
+        player_id=f"{SGP_PREFIX}abc12345",
+        config=SimpleNamespace(name="broadcast"),
+        group_members=[],
+        sync_leader=None,
+        playback_state=PlaybackState.IDLE,
+    )
+    idle_stream = SimpleNamespace(
+        stream_name="Music Assistant - idle_syncgroupabc12345",
+        stream_display_name="broadcast",
+        stream_id="broadcast",
+        queue_id=None,
+    )
+    snap_group = SimpleNamespace(
+        stream="broadcast",
+        clients=["PC_VAIO_2"],
+    )
+    logger = MagicMock()
+    players = SimpleNamespace()
+    players.get_player = MagicMock(return_value=sync_group_player)
+    provider = SimpleNamespace(
+        logger=logger,
+        mass=SimpleNamespace(closing=False, players=players),
+        _snapserver=SimpleNamespace(groups=[snap_group]),
+        _get_ma_id=MagicMock(return_value="PC_VAIO_2"),
+        get_snap_ma_stream=MagicMock(return_value=idle_stream),
+        move_player_to_fallback_group=AsyncMock(return_value=True),
+        delete_ma_stream=AsyncMock(),
+        _update_group_callbacks=MagicMock(),
+    )
+
+    await SnapcastGroupMaterializer(provider).materialize(sync_group_player.player_id)  # type: ignore[arg-type]
+
+    provider.move_player_to_fallback_group.assert_awaited_once_with("PC_VAIO_2")
+    provider.delete_ma_stream.assert_awaited_once_with(idle_stream.stream_name)
+    provider._update_group_callbacks.assert_called_once_with(poke=True)
+    logger.getChild.return_value.info.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_materialize_moves_stale_old_leader_off_shared_stream() -> None:
+    """Leader handoff should evict stale clients that still linger on the old broadcast group."""
+    sync_group_player = SimpleNamespace(
+        player_id=f"{SGP_PREFIX}abc12345",
+        config=SimpleNamespace(name="broadcast"),
+        group_members=["PC_VAIO_2"],
+        sync_leader=None,
+        playback_state=PlaybackState.IDLE,
+    )
+    leader_player = SimpleNamespace(player_id="PC_VAIO_2")
+    idle_stream = SimpleNamespace(stream_id="broadcast", stream_display_name="broadcast")
+    leader_group = SimpleNamespace(
+        identifier="group-new-leader",
+        clients=["snap-pc"],
+        stream="broadcast",
+        set_callback=MagicMock(),
+        add_client=AsyncMock(),
+        set_stream=AsyncMock(),
+    )
+    stale_group = SimpleNamespace(
+        identifier="group-old-leader",
+        clients=["snap-thor"],
+        stream="broadcast",
+    )
+    players = SimpleNamespace(trigger_player_update=MagicMock())
+    players.get_player = MagicMock(
+        side_effect=lambda ref, raise_unavailable=False: {  # noqa: ARG005
+            sync_group_player.player_id: sync_group_player,
+            "PC_VAIO_2": leader_player,
+        }.get(ref)
+    )
+    provider = SimpleNamespace(
+        logger=MagicMock(),
+        mass=SimpleNamespace(closing=False, players=players),
+        _snapserver=SimpleNamespace(groups=[leader_group, stale_group]),
+        get_snap_client=MagicMock(
+            side_effect=lambda player_id=None, **kwargs: (  # noqa: ARG005
+                SimpleNamespace(identifier="snap-pc") if player_id == "PC_VAIO_2" else None
+            )
+        ),
+        ensure_sync_group_idle_stream=AsyncMock(return_value=idle_stream),
+        ensure_player_owned_group=AsyncMock(return_value=leader_group),
+        move_player_to_fallback_group=AsyncMock(return_value=True),
+        isolate_player_to_dedicated_group=AsyncMock(),
+        _get_stable_stream_reference=MagicMock(return_value="broadcast"),
+        _get_ma_id=MagicMock(
+            side_effect=lambda client_id: {
+                "snap-pc": "PC_VAIO_2",
+                "snap-thor": "thor-speakers",
+            }[client_id]
+        ),
+        _get_snapclient_id=MagicMock(return_value="snap-pc"),
+        _update_group_callbacks=MagicMock(),
+    )
+
+    await SnapcastGroupMaterializer(provider).materialize(sync_group_player.player_id)  # type: ignore[arg-type]
+
+    provider.move_player_to_fallback_group.assert_awaited_once_with("thor-speakers")

--- a/tests/providers/snapcast/test_group_restore.py
+++ b/tests/providers/snapcast/test_group_restore.py
@@ -1,0 +1,182 @@
+"""Tests for plugin-only Snapcast group restore."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import PlayerFeature
+
+from music_assistant.providers.snapcast.group_restore import SnapcastGroupRestorer
+from music_assistant.providers.snapcast.stream_registry import SnapcastStreamRegistry
+from music_assistant.providers.sync_group.constants import SGP_PREFIX
+
+
+def test_collect_restore_targets_matches_live_snapcast_group_to_sync_group_name() -> None:
+    """A live Snapcast group should resolve to the matching MA sync group by stream name."""
+    sync_group_player = SimpleNamespace(
+        player_id=f"{SGP_PREFIX}abc12345",
+        config=SimpleNamespace(name="broadcast"),
+        state=SimpleNamespace(supported_features={PlayerFeature.SET_MEMBERS}),
+    )
+    mass = SimpleNamespace(
+        closing=False,
+        players=SimpleNamespace(
+            get_player=MagicMock(
+                side_effect=lambda ref, raise_unavailable=False: (  # noqa: ARG005
+                    sync_group_player if ref == sync_group_player.player_id else None
+                )
+            ),
+            __iter__=MagicMock(return_value=iter([sync_group_player])),
+        ),
+    )
+    snap_stream = SimpleNamespace(
+        identifier="snap-stream-123",
+        friendly_name="broadcast",
+        _stream={"uri": {"raw": "tcp://0.0.0.0:4978?name=broadcast"}},
+    )
+    snap_group = SimpleNamespace(
+        identifier="group-1",
+        name="PC_VAIO_2",
+        clients=["PC_VAIO_2", "thor-speakers"],
+        stream="snap-stream-123",
+    )
+    provider: Any = SimpleNamespace(
+        logger=MagicMock(),
+        mass=mass,
+        _snapserver=SimpleNamespace(
+            groups=[snap_group],
+            streams=[snap_stream],
+            stream=MagicMock(return_value=snap_stream),
+        ),
+        _get_stream_registry=MagicMock(return_value=SnapcastStreamRegistry()),
+        _get_ma_id=MagicMock(
+            side_effect=lambda snap_id: {
+                "PC_VAIO_2": "PC_VAIO_2",
+                "thor-speakers": "thor-speakers",
+            }[snap_id]
+        ),
+        resolve_sync_group_player=MagicMock(return_value=sync_group_player),
+        dedicated_fallback_group_name=None,
+    )
+
+    targets = SnapcastGroupRestorer(provider)._collect_restore_targets()
+
+    assert len(targets) == 1
+    assert targets[0].sync_group_player_id == sync_group_player.player_id
+    assert targets[0].sync_group_name == "broadcast"
+    assert targets[0].stream_display_name == "broadcast"
+    assert targets[0].sync_leader_id == "PC_VAIO_2"
+    assert targets[0].member_player_ids == ["PC_VAIO_2", "thor-speakers"]
+
+
+def test_collect_restore_targets_skips_configured_fallback_group() -> None:
+    """The external dedicated fallback group must never be restored as an MA sync group."""
+    sync_group_player = SimpleNamespace(
+        player_id=f"{SGP_PREFIX}abc12345",
+        config=SimpleNamespace(name="broadcast"),
+        state=SimpleNamespace(supported_features={PlayerFeature.SET_MEMBERS}),
+    )
+    mass = SimpleNamespace(
+        closing=False,
+        players=SimpleNamespace(
+            get_player=MagicMock(
+                side_effect=lambda ref, raise_unavailable=False: (  # noqa: ARG005
+                    sync_group_player if ref == sync_group_player.player_id else None
+                )
+            ),
+            __iter__=MagicMock(return_value=iter([sync_group_player])),
+        ),
+    )
+    snap_stream = SimpleNamespace(
+        identifier="snap-stream-123",
+        friendly_name="broadcast",
+        _stream={"uri": {"raw": "tcp://0.0.0.0:4978?name=broadcast"}},
+    )
+    fallback_group = SimpleNamespace(
+        identifier="group-media",
+        name="Media",
+        clients=["PC_VAIO_2", "thor-speakers"],
+        stream="default",
+    )
+    broadcast_group = SimpleNamespace(
+        identifier="group-1",
+        name="PC_VAIO_2",
+        clients=["PC_VAIO_2", "thor-speakers"],
+        stream="snap-stream-123",
+    )
+    provider: Any = SimpleNamespace(
+        logger=MagicMock(),
+        mass=mass,
+        dedicated_fallback_group_name="Media",
+        _snapserver=SimpleNamespace(
+            groups=[fallback_group, broadcast_group],
+            streams=[snap_stream],
+            stream=MagicMock(return_value=snap_stream),
+        ),
+        _get_stream_registry=MagicMock(return_value=SnapcastStreamRegistry()),
+        _get_ma_id=MagicMock(
+            side_effect=lambda snap_id: {
+                "PC_VAIO_2": "PC_VAIO_2",
+                "thor-speakers": "thor-speakers",
+            }[snap_id]
+        ),
+        resolve_sync_group_player=MagicMock(return_value=sync_group_player),
+    )
+
+    targets = SnapcastGroupRestorer(provider)._collect_restore_targets()
+
+    assert len(targets) == 1
+    assert targets[0].sync_group_name == "broadcast"
+
+
+@pytest.mark.asyncio
+async def test_restore_updates_runtime_members_and_sync_leader() -> None:
+    """Restoring a live group should use public set-members flow and set the runtime leader."""
+    sync_group_player = SimpleNamespace(
+        player_id=f"{SGP_PREFIX}abc12345",
+        config=SimpleNamespace(name="broadcast"),
+        state=SimpleNamespace(supported_features={PlayerFeature.SET_MEMBERS}),
+        group_members=[],
+        static_group_members=[],
+        sync_leader=None,
+    )
+    leader_player = SimpleNamespace(
+        player_id="PC_VAIO_2",
+        state=SimpleNamespace(group_members=["PC_VAIO_2", "thor-speakers"]),
+    )
+    member_player = SimpleNamespace(player_id="thor-speakers")
+    players = SimpleNamespace(
+        cmd_set_members=AsyncMock(),
+        trigger_player_update=MagicMock(),
+    )
+    players.get_player = MagicMock(
+        side_effect=lambda ref, raise_unavailable=False: {  # noqa: ARG005
+            sync_group_player.player_id: sync_group_player,
+            "PC_VAIO_2": leader_player,
+            "thor-speakers": member_player,
+        }.get(ref)
+    )
+    mass = SimpleNamespace(closing=False, players=players)
+    provider: Any = SimpleNamespace(logger=MagicMock(), mass=mass)
+    target: Any = SimpleNamespace(
+        sync_group_player_id=sync_group_player.player_id,
+        sync_group_name="broadcast",
+        stream_display_name="broadcast",
+        sync_leader_id="PC_VAIO_2",
+        member_player_ids=["PC_VAIO_2", "thor-speakers"],
+    )
+
+    await SnapcastGroupRestorer(provider)._restore_target(target)
+
+    players.cmd_set_members.assert_awaited_once_with(
+        sync_group_player.player_id,
+        player_ids_to_add=["PC_VAIO_2", "thor-speakers"],
+        player_ids_to_remove=None,
+    )
+    assert sync_group_player.sync_leader is leader_player
+    players.trigger_player_update.assert_called_once_with(
+        sync_group_player.player_id, force_update=True, debounce_delay=0
+    )

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -1,0 +1,334 @@
+"""Tests for Snapcast MA stream registration behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.player import PlayerMedia
+
+from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
+
+
+def _create_provider(snapserver: object) -> object:
+    """Create a lightweight provider stub for SnapcastMAStream tests."""
+    return SimpleNamespace(
+        logger=MagicMock(),
+        mass=SimpleNamespace(closing=False),
+        _snapserver=snapserver,
+        _snapcast_server_host="192.168.10.3",
+        _snapcast_stream_idle_threshold=60000,
+        _use_builtin_server=False,
+        poke_group_members=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_reuses_existing_idle_snapserver_stream_by_display_name() -> None:
+    """Existing idle external streams should be reused after an MA restart."""
+    existing_stream = SimpleNamespace(
+        identifier="broadcast",
+        friendly_name="broadcast",
+        status="idle",
+        path="tcp://0.0.0.0:4978",
+        _stream={"uri": {"host": "0.0.0.0:4978"}},
+        set_callback=MagicMock(),
+    )
+    snapserver = SimpleNamespace(
+        streams=[existing_stream],
+        stream_add_stream=AsyncMock(),
+    )
+    stream = SnapcastMAStream(
+        provider=_create_provider(snapserver),  # type: ignore[arg-type]
+        media=PlayerMedia(uri="queue:broadcast"),
+        stream_name="mass_stream_broadcast",
+        stream_display_name="broadcast",
+    )
+
+    await stream.setup()
+
+    assert stream.snap_stream is existing_stream
+    assert stream.lifecycle_state == "attached"
+    existing_stream.set_callback.assert_called_once()
+    snapserver.stream_add_stream.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_setup_attaches_existing_stream_after_duplicate_stream_name_error() -> None:
+    """A duplicate-name response should attach to the already existing Snapserver stream."""
+    existing_stream = SimpleNamespace(
+        identifier="broadcast",
+        friendly_name="broadcast",
+        status="playing",
+        path="tcp://0.0.0.0:4978",
+        _stream={"uri": {"host": "0.0.0.0:4978"}},
+        set_callback=MagicMock(),
+    )
+    snapserver = SimpleNamespace(
+        streams=[existing_stream],
+        stream_add_stream=AsyncMock(
+            return_value={
+                "code": -32603,
+                "data": "Stream with name 'broadcast' already exists",
+                "message": "Internal error",
+            }
+        ),
+    )
+    stream = SnapcastMAStream(
+        provider=_create_provider(snapserver),  # type: ignore[arg-type]
+        media=PlayerMedia(uri="queue:broadcast"),
+        stream_name="mass_stream_broadcast",
+        stream_display_name="broadcast",
+    )
+
+    await stream.setup()
+
+    assert stream.snap_stream is existing_stream
+    assert stream.lifecycle_state == "attached"
+    assert snapserver.stream_add_stream.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_setup_stops_retrying_on_duplicate_name_without_attachable_stream() -> None:
+    """Duplicate stream names should fail fast instead of retrying 50 random ports."""
+    snapserver = SimpleNamespace(
+        streams=[],
+        stream_add_stream=AsyncMock(
+            return_value={
+                "code": -32603,
+                "data": "Stream with name 'broadcast' already exists",
+                "message": "Internal error",
+            }
+        ),
+    )
+    stream = SnapcastMAStream(
+        provider=_create_provider(snapserver),  # type: ignore[arg-type]
+        media=PlayerMedia(uri="queue:broadcast"),
+        stream_name="mass_stream_broadcast",
+        stream_display_name="broadcast",
+    )
+
+    with pytest.raises(RuntimeError, match="already exists"):
+        await stream.setup()
+
+    assert stream.lifecycle_state == "unresolved"
+    assert snapserver.stream_add_stream.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_setup_stops_retrying_on_non_retryable_error() -> None:
+    """Non-retryable add-stream failures should fail immediately."""
+    snapserver = SimpleNamespace(
+        streams=[],
+        stream_add_stream=AsyncMock(
+            return_value={
+                "code": -32603,
+                "data": "Unhandled Snapserver failure",
+                "message": "Internal error",
+            }
+        ),
+    )
+    stream = SnapcastMAStream(
+        provider=_create_provider(snapserver),  # type: ignore[arg-type]
+        media=PlayerMedia(uri="queue:broadcast"),
+        stream_name="mass_stream_broadcast",
+        stream_display_name="broadcast",
+    )
+
+    with pytest.raises(RuntimeError, match="Unhandled Snapserver failure"):
+        await stream.setup()
+
+    assert stream.lifecycle_state == "unresolved"
+    assert snapserver.stream_add_stream.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_setup_retries_on_retryable_port_conflict_then_marks_created() -> None:
+    """Retryable bind/port conflicts should retry and mark the final stream as created."""
+    created_stream = SimpleNamespace(
+        identifier="snap-stream-123",
+        friendly_name="broadcast",
+        status="idle",
+        path="tcp://0.0.0.0:4978",
+        _stream={"uri": {"host": "0.0.0.0:4978"}},
+        set_callback=MagicMock(),
+    )
+    snapserver = SimpleNamespace(
+        streams=[],
+        stream_add_stream=AsyncMock(
+            side_effect=[
+                {
+                    "code": -32603,
+                    "data": "Address already in use",
+                    "message": "Bind failed",
+                },
+                {"id": "snap-stream-123"},
+            ]
+        ),
+        stream=MagicMock(return_value=created_stream),
+    )
+    stream = SnapcastMAStream(
+        provider=_create_provider(snapserver),  # type: ignore[arg-type]
+        media=PlayerMedia(uri="queue:broadcast"),
+        stream_name="mass_stream_broadcast",
+        stream_display_name="broadcast",
+    )
+
+    await stream.setup()
+
+    assert stream.snap_stream is created_stream
+    assert stream.lifecycle_state == "created"
+    assert snapserver.stream_add_stream.await_count == 2
+    created_stream.set_callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_external_queue_backed_stream_adds_mass_bridge_controlscript() -> None:
+    """External queue-backed streams should start the standalone mass_bridge control script."""
+    created_stream = SimpleNamespace(
+        identifier="broadcast",
+        friendly_name="broadcast",
+        status="idle",
+        path="tcp://0.0.0.0:4978",
+        _stream={"uri": {"host": "0.0.0.0:4978"}},
+        set_callback=MagicMock(),
+    )
+    snapserver = SimpleNamespace(
+        streams=[],
+        stream_add_stream=AsyncMock(return_value={"id": "broadcast"}),
+        stream=MagicMock(return_value=created_stream),
+    )
+    stream = SnapcastMAStream(
+        provider=_create_provider(snapserver),  # type: ignore[arg-type]
+        media=PlayerMedia(uri="queue:broadcast"),
+        stream_name="mass_stream_broadcast",
+        stream_display_name="broadcast",
+        queue_id="broadcast",
+    )
+
+    await stream.setup()
+
+    snapserver.stream_add_stream.assert_awaited_once()
+    add_stream_uri = snapserver.stream_add_stream.await_args.args[0]
+    assert "&controlscript=mass_bridge.py" in add_stream_uri
+    assert "&controlscriptparams=--stream=broadcast" in add_stream_uri
+    assert add_stream_uri.endswith("&name=broadcast")
+
+
+@pytest.mark.asyncio
+async def test_setup_external_queue_backed_stream_replaces_idle_stream_without_mass_bridge() -> (
+    None
+):
+    """Queue-backed playback should replace an older idle stream that lacks mass_bridge."""
+    old_idle_stream = SimpleNamespace(
+        identifier="broadcast-old",
+        friendly_name="broadcast",
+        status="idle",
+        path="tcp://0.0.0.0:4978",
+        _stream={"uri": {"host": "0.0.0.0:4978", "raw": "tcp://0.0.0.0:4978?name=broadcast"}},
+        set_callback=MagicMock(),
+    )
+    created_stream = SimpleNamespace(
+        identifier="broadcast",
+        friendly_name="broadcast",
+        status="idle",
+        path="tcp://0.0.0.0:4988",
+        _stream={
+            "uri": {
+                "host": "0.0.0.0:4988",
+                "raw": "tcp://0.0.0.0:4988?controlscript=mass_bridge.py&name=broadcast",
+            }
+        },
+        set_callback=MagicMock(),
+    )
+    snapserver = SimpleNamespace(
+        groups=[
+            SimpleNamespace(
+                stream="broadcast-old",
+                set_stream=AsyncMock(),
+            )
+        ],
+        streams=[old_idle_stream],
+        stream_add_stream=AsyncMock(return_value={"id": "broadcast"}),
+        stream=MagicMock(return_value=created_stream),
+        stream_remove_stream=AsyncMock(),
+    )
+    stream = SnapcastMAStream(
+        provider=_create_provider(snapserver),  # type: ignore[arg-type]
+        media=PlayerMedia(uri="queue:broadcast"),
+        stream_name="mass_stream_broadcast",
+        stream_display_name="broadcast",
+        queue_id="broadcast",
+    )
+
+    await stream.setup()
+
+    snapserver.groups[0].set_stream.assert_not_awaited()
+    snapserver.stream_remove_stream.assert_awaited_once_with("broadcast-old")
+    add_stream_uri = snapserver.stream_add_stream.await_args.args[0]
+    assert "&controlscript=mass_bridge.py" in add_stream_uri
+    assert stream.snap_stream is created_stream
+
+
+@pytest.mark.asyncio
+async def test_destroy_external_idle_stream_does_not_force_default_stream() -> None:
+    """External Snapserver cleanup should not hardcode a default stream during removal."""
+    snap_stream = SimpleNamespace(
+        identifier="broadcast",
+        friendly_name="broadcast",
+        status="idle",
+        path="tcp://0.0.0.0:4978",
+        _stream={"uri": {"host": "0.0.0.0:4978"}},
+        set_callback=MagicMock(),
+    )
+    group = SimpleNamespace(
+        name="PC_VAIO_2",
+        stream="broadcast",
+        set_stream=AsyncMock(),
+    )
+    snapserver = SimpleNamespace(
+        groups=[group],
+        stream_remove_stream=AsyncMock(),
+    )
+    stream = SnapcastMAStream(
+        provider=_create_provider(snapserver),  # type: ignore[arg-type]
+        media=PlayerMedia(uri="queue:broadcast"),
+        stream_name="mass_stream_broadcast",
+        stream_display_name="broadcast",
+    )
+    stream.snap_stream = snap_stream
+
+    await stream.destroy()
+
+    group.set_stream.assert_not_awaited()
+    snapserver.stream_remove_stream.assert_awaited_once_with("broadcast")
+
+
+@pytest.mark.asyncio
+async def test_destroy_marks_stream_as_destroyed() -> None:
+    """Destroy should end with an explicit destroyed lifecycle state."""
+    snap_stream = SimpleNamespace(
+        identifier="snap-stream-123",
+        friendly_name="broadcast",
+        status="idle",
+        path="tcp://0.0.0.0:4978",
+        _stream={"uri": {"host": "0.0.0.0:4978"}},
+        set_callback=MagicMock(),
+    )
+    snapserver = SimpleNamespace(
+        groups=[],
+        stream_remove_stream=AsyncMock(),
+    )
+    stream = SnapcastMAStream(
+        provider=_create_provider(snapserver),  # type: ignore[arg-type]
+        media=PlayerMedia(uri="queue:broadcast"),
+        stream_name="mass_stream_broadcast",
+        stream_display_name="broadcast",
+    )
+    stream.snap_stream = snap_stream
+
+    await stream.destroy()
+
+    assert stream.lifecycle_state == "destroyed"
+    snapserver.stream_remove_stream.assert_awaited_once_with("snap-stream-123")

--- a/tests/providers/snapcast/test_mass_bridge.py
+++ b/tests/providers/snapcast/test_mass_bridge.py
@@ -1,0 +1,331 @@
+"""Tests for the external Snapcast mass_bridge control script."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from music_assistant.providers.snapcast.snapserver import mass_bridge
+from music_assistant.providers.snapcast.snapserver.mass_bridge import MusicAssistantControl
+
+
+def _create_control() -> Any:
+    """Create a lightweight controller instance without starting background threads."""
+    ctrl: Any = MusicAssistantControl.__new__(MusicAssistantControl)
+    ctrl.stream = "Kitchen Group"
+    ctrl.snapcast_host = "localhost"
+    ctrl.snapcast_port = 1780
+    ctrl.ma_websocket_ip = "localhost"
+    ctrl.ma_websocket_port = 8095
+    ctrl.ma_access_token = "token"
+    ctrl._metadata = {}
+    ctrl._properties = ctrl._default_properties()
+    ctrl._request_callbacks = {}
+    ctrl._ws = None
+    ctrl._authenticated = True
+    ctrl._stopped = False
+    ctrl._shutdown_event = threading.Event()
+    ctrl._send_lock = threading.Lock()
+    ctrl._callback_lock = threading.Lock()
+    ctrl._resolve_retry_lock = threading.Lock()
+    ctrl._current_queue_id = None
+    ctrl._current_player_id = None
+    ctrl._resolve_retry_timer = None
+    ctrl._ws_thread = None
+    return ctrl
+
+
+def test_has_existing_inactive_snapcast_stream_matches_uri_name() -> None:
+    """An idle Snapcast stream should be found by its configured URI name."""
+    ctrl = _create_control()
+    ctrl._fetch_snapcast_server_status = MagicMock(
+        return_value={
+            "streams": [
+                {
+                    "id": "snap-stream-123",
+                    "status": "idle",
+                    "uri": {
+                        "raw": ("tcp://0.0.0.0:4953?name=Kitchen+Group&sampleformat=48000:16:2"),
+                    },
+                }
+            ]
+        }
+    )
+
+    assert ctrl._has_existing_inactive_snapcast_stream() is True
+
+
+def test_resolve_runtime_params_uses_user_config_defaults_and_env_token() -> None:
+    """User-config defaults should be honored, with env token fallback when left empty."""
+    original_params = dict(mass_bridge.params)
+    try:
+        mass_bridge.params.update(
+            {
+                "progname": "mass_bridge.py",
+                "snapcast-host": "192.168.10.3",
+                "snapcast-port": 1780,
+                "ma-websocket-ip": "192.168.10.4",
+                "ma-websocket-port": 8095,
+                "ma-access-token": None,
+                "stream": "broadcast",
+            }
+        )
+
+        runtime_params = mass_bridge._resolve_runtime_params(
+            ["mass_bridge.py"], {"MASS_ACCESS_TOKEN": "env-token"}
+        )
+
+        assert runtime_params["snapcast-host"] == "192.168.10.3"
+        assert runtime_params["snapcast-port"] == 1780
+        assert runtime_params["ma-websocket-ip"] == "192.168.10.4"
+        assert runtime_params["ma-websocket-port"] == 8095
+        assert runtime_params["ma-access-token"] == "env-token"
+        assert runtime_params["stream"] == "broadcast"
+    finally:
+        mass_bridge.params.clear()
+        mass_bridge.params.update(original_params)
+
+
+def test_resolve_runtime_params_cli_overrides_user_config() -> None:
+    """CLI args should override the editable user-config block at the top of the script."""
+    original_params = dict(mass_bridge.params)
+    try:
+        mass_bridge.params.update(
+            {
+                "progname": "mass_bridge.py",
+                "snapcast-host": "192.168.10.3",
+                "snapcast-port": 1780,
+                "ma-websocket-ip": "192.168.10.4",
+                "ma-websocket-port": 8095,
+                "ma-access-token": "config-token",
+                "stream": "broadcast",
+            }
+        )
+
+        runtime_params = mass_bridge._resolve_runtime_params(
+            [
+                "mass_bridge.py",
+                "--snapcast-host=127.0.0.1",
+                "--ma-websocket-port=9000",
+                "--stream=living_room",
+            ],
+            {},
+        )
+
+        assert runtime_params["snapcast-host"] == "127.0.0.1"
+        assert runtime_params["ma-websocket-port"] == 9000
+        assert runtime_params["ma-access-token"] == "config-token"
+        assert runtime_params["stream"] == "living_room"
+    finally:
+        mass_bridge.params.clear()
+        mass_bridge.params.update(original_params)
+
+
+def test_resolve_runtime_params_reads_token_from_configured_file(tmp_path: Path) -> None:
+    """A configured token file should be read when no direct token value is set."""
+    token_file = tmp_path / "mass_token.txt"
+    token_file.write_text("file-token\n", encoding="utf-8")
+    original_params = dict(mass_bridge.params)
+    try:
+        mass_bridge.params.update(
+            {
+                "progname": "mass_bridge.py",
+                "ma-access-token": "",
+                "ma-access-token-file": str(token_file),
+            }
+        )
+
+        runtime_params = mass_bridge._resolve_runtime_params(["mass_bridge.py"], {})
+
+        assert runtime_params["ma-access-token-file"] == str(token_file)
+        assert runtime_params["ma-access-token"] == "file-token"
+    finally:
+        mass_bridge.params.clear()
+        mass_bridge.params.update(original_params)
+
+
+def test_resolve_runtime_params_prefers_direct_token_over_token_file(tmp_path: Path) -> None:
+    """A direct token value should win over a configured token file."""
+    token_file = tmp_path / "mass_token.txt"
+    token_file.write_text("file-token\n", encoding="utf-8")
+    original_params = dict(mass_bridge.params)
+    try:
+        mass_bridge.params.update(
+            {
+                "progname": "mass_bridge.py",
+                "ma-access-token": "direct-token",
+                "ma-access-token-file": str(token_file),
+            }
+        )
+
+        runtime_params = mass_bridge._resolve_runtime_params(["mass_bridge.py"], {})
+
+        assert runtime_params["ma-access-token"] == "direct-token"
+    finally:
+        mass_bridge.params.clear()
+        mass_bridge.params.update(original_params)
+
+
+def test_resolve_stream_state_schedules_retry_for_inactive_snapcast_stream() -> None:
+    """A reconnect should retry resolution when only a stale idle stream is still visible."""
+    ctrl = _create_control()
+    ctrl._has_existing_inactive_snapcast_stream = MagicMock(return_value=True)
+    ctrl._schedule_stream_state_retry = MagicMock()
+    ctrl._cancel_stream_state_retry = MagicMock()
+    ctrl.send_snapcast_properties_notification = MagicMock()
+
+    def fake_send_request(command: str, callback: Any = None, **args: Any) -> bool:
+        assert command == "snapcast/resolve_control_stream"
+        assert args["stream"] == "Kitchen Group"
+        assert callback is not None
+        callback(None)
+        return True
+
+    ctrl.send_request = fake_send_request
+
+    ctrl._resolve_stream_state(notify=True)
+
+    ctrl._schedule_stream_state_retry.assert_called_once_with()
+    ctrl._cancel_stream_state_retry.assert_not_called()
+    ctrl.send_snapcast_properties_notification.assert_called_once_with(ctrl._default_properties())
+
+
+def test_resolve_stream_state_without_queue_stays_read_only() -> None:
+    """A matched stream without queue data must remain unresolved and read-only."""
+    ctrl = _create_control()
+    ctrl._has_existing_inactive_snapcast_stream = MagicMock(return_value=False)
+    ctrl._schedule_stream_state_retry = MagicMock()
+    ctrl._cancel_stream_state_retry = MagicMock()
+    ctrl.send_snapcast_properties_notification = MagicMock()
+
+    def fake_send_request(command: str, callback: Any = None, **args: Any) -> bool:
+        assert command == "snapcast/resolve_control_stream"
+        assert args["stream"] == "Kitchen Group"
+        assert callback is not None
+        callback({"queue_id": "plugin-source", "player_id": "plugin-source"})
+        return True
+
+    ctrl.send_request = fake_send_request
+
+    ctrl._resolve_stream_state(notify=True)
+
+    assert ctrl._current_queue_id is None
+    assert ctrl._current_player_id is None
+    ctrl._schedule_stream_state_retry.assert_not_called()
+    ctrl._cancel_stream_state_retry.assert_called_once_with()
+    ctrl.send_snapcast_properties_notification.assert_called_once_with(ctrl._default_properties())
+
+
+def test_queue_time_updated_refreshes_position() -> None:
+    """Queue time updates should only refresh the published position."""
+    ctrl = _create_control()
+    ctrl._current_queue_id = "queue-1"
+    ctrl._properties = {
+        **ctrl._default_properties(),
+        "canControl": True,
+        "playbackStatus": "playing",
+        "position": 10.0,
+    }
+    ctrl.send_snapcast_properties_notification = MagicMock()
+
+    ctrl._handle_ws_message(
+        json.dumps({"event": "queue_time_updated", "object_id": "queue-1", "data": 42.5})
+    )
+
+    ctrl.send_snapcast_properties_notification.assert_called_once_with(
+        {
+            **ctrl._properties,
+            "position": 42.5,
+        }
+    )
+
+
+def test_create_properties_keeps_can_seek_boolean_without_current_item() -> None:
+    """Published Snapcast properties must keep canSeek as a strict boolean."""
+    ctrl = _create_control()
+
+    properties = ctrl._create_properties(
+        {
+            "state": "stopped",
+            "current_item": None,
+            "next_item": None,
+            "current_index": 0,
+            "elapsed_time": 0.0,
+            "shuffle_enabled": False,
+            "repeat_mode": "off",
+        }
+    )
+
+    assert properties["canSeek"] is False
+
+
+def test_unresolved_control_request_returns_error(monkeypatch: Any) -> None:
+    """Transport commands must be rejected while no queue is resolved."""
+    ctrl = _create_control()
+    ctrl._resolve_stream_state = MagicMock()
+    ctrl.send_request = MagicMock()
+    send_error_mock = MagicMock()
+    monkeypatch.setattr(mass_bridge, "send_error", send_error_mock)
+
+    ctrl.handle_snapcast_request(
+        {
+            "id": "req-1",
+            "jsonrpc": "2.0",
+            "method": "Plugin.Stream.Player.Control",
+            "params": {"command": "next", "params": {}},
+        }
+    )
+
+    ctrl._resolve_stream_state.assert_called_once_with(notify=False)
+    ctrl.send_request.assert_not_called()
+    send_error_mock.assert_called_once_with(
+        "req-1",
+        -32000,
+        "No active Music Assistant queue resolved for stream 'Kitchen Group'",
+    )
+
+
+def test_send_request_requires_auth_for_non_auth_commands() -> None:
+    """Normal MA commands must wait until the websocket has authenticated."""
+    ctrl = _create_control()
+    ctrl._authenticated = False
+    ctrl._ws = MagicMock()
+
+    sent = ctrl.send_request("players/all")
+
+    assert sent is False
+    ctrl._ws.send.assert_not_called()
+
+
+def test_handle_auth_result_marks_bridge_authenticated_and_resolves() -> None:
+    """Successful auth should mark the bridge authenticated and resolve stream state."""
+    ctrl = _create_control()
+    ctrl._ws = MagicMock()
+    ctrl._resolve_stream_state = MagicMock()
+
+    ctrl._handle_auth_result({"authenticated": True})
+
+    assert ctrl._authenticated is True
+    ctrl._ws.settimeout.assert_called_once_with(None)
+    ctrl._resolve_stream_state.assert_called_once_with(notify=True)
+
+
+def test_handle_auth_result_failed_keeps_bridge_read_only() -> None:
+    """Failed auth should keep the bridge unresolved and close the websocket."""
+    ctrl = _create_control()
+    ctrl._current_queue_id = "queue-1"
+    ctrl._current_player_id = "queue-1"
+    ctrl._properties = {**ctrl._default_properties(), "canControl": True}
+    ctrl._ws = MagicMock()
+    ctrl.send_snapcast_properties_notification = MagicMock()
+
+    ctrl._handle_auth_result({"authenticated": False})
+
+    assert ctrl._authenticated is False
+    assert ctrl._current_queue_id is None
+    assert ctrl._current_player_id is None
+    ctrl.send_snapcast_properties_notification.assert_called_once_with(ctrl._default_properties())
+    ctrl._ws.close.assert_called_once_with()

--- a/tests/providers/snapcast/test_provider.py
+++ b/tests/providers/snapcast/test_provider.py
@@ -1,0 +1,558 @@
+"""Tests for Snapcast provider stream naming."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bidict import bidict
+from music_assistant_models.enums import MediaType
+from music_assistant_models.player import PlayerMedia
+
+from music_assistant.providers.snapcast.player import SnapCastPlayer
+from music_assistant.providers.snapcast.provider import SnapCastProvider
+from music_assistant.providers.snapcast.stream_registry import SnapcastStreamRegistry
+from music_assistant.providers.sync_group.constants import SGP_PREFIX
+
+
+def _create_provider() -> Any:
+    """Create a lightweight SnapCastProvider instance for unit tests."""
+    provider = SnapCastProvider.__new__(SnapCastProvider)
+    provider.mass = MagicMock()
+    provider.logger = MagicMock()
+    provider._stream_registry = SnapcastStreamRegistry()
+    provider._snapcast_ma_streams = provider._stream_registry.streams_by_name
+    provider._snapcast_ma_streams_lock = asyncio.Lock()
+    provider._use_builtin_server = False
+    provider._controlscript_available = False
+    provider._snapserver_started = None
+    provider._external_dedicated_fallback_group = None
+    return provider
+
+
+def test_resolve_sync_group_player_supports_player_id_and_custom_name_ref() -> None:
+    """Resolve sync-group players by player id and configured group name."""
+    provider = _create_provider()
+    sync_group_player: Any = SimpleNamespace(
+        player_id=f"{SGP_PREFIX}abc12345",
+        config=SimpleNamespace(name="Kitchen Group"),
+    )
+    provider.mass.players.get_player.side_effect = lambda ref, raise_unavailable=False: (  # noqa: ARG005
+        sync_group_player if ref == sync_group_player.player_id else None
+    )
+    provider.mass.players.__iter__.return_value = iter([sync_group_player])
+    provider.mass.players.all_players.return_value = [sync_group_player]
+
+    assert provider.resolve_sync_group_player(sync_group_player.player_id) is sync_group_player
+    assert provider.resolve_sync_group_player("Kitchen Group") is sync_group_player
+    assert provider.resolve_sync_group_player(f"{SGP_PREFIX}Kitchen Group") is sync_group_player
+    assert provider.resolve_sync_group_player("normal_player") is None
+
+
+def test_get_sync_group_stream_display_name_uses_custom_player_name() -> None:
+    """Return the exact custom sync group name for queue and plugin source playback."""
+    provider = _create_provider()
+    sync_group_player = SimpleNamespace(config=SimpleNamespace(name="Woonkamer + Keuken"))
+    provider.resolve_sync_group_player = MagicMock(return_value=sync_group_player)
+
+    queue_media = PlayerMedia(uri="queue:test", source_id=f"{SGP_PREFIX}abc12345")
+    plugin_media = PlayerMedia(
+        uri="plugin:test",
+        media_type=MediaType.PLUGIN_SOURCE,
+        custom_data={"player_id": f"{SGP_PREFIX}abc12345"},
+    )
+
+    assert provider._get_sync_group_stream_display_name(queue_media) == "Woonkamer + Keuken"
+    assert provider._get_sync_group_stream_display_name(plugin_media) == "Woonkamer + Keuken"
+
+
+def test_get_snap_ma_stream_matches_internal_name_id_and_display_name() -> None:
+    """Lookup should work for all central registry references."""
+    provider = _create_provider()
+    fake_stream: Any = SimpleNamespace(
+        stream_id="snap-id-123",
+        stream_display_name="Living Room",
+        source_id="source-123",
+        queue_id="queue-123",
+    )
+    provider._snapcast_ma_streams["mass_stream_internal"] = fake_stream
+
+    assert provider.get_snap_ma_stream("mass_stream_internal") is fake_stream
+    assert provider.get_snap_ma_stream("snap-id-123") is fake_stream
+    assert provider.get_snap_ma_stream("Living Room") is fake_stream
+    assert provider.get_snap_ma_stream("source-123") is fake_stream
+    assert provider.get_snap_ma_stream("queue-123") is fake_stream
+    assert provider.get_snap_ma_stream("missing") is None
+
+
+def test_resolve_control_stream_requires_active_queue() -> None:
+    """External control resolution should ignore streams without an active queue."""
+    provider = _create_provider()
+    fake_stream: Any = SimpleNamespace(
+        queue_id=None,
+        source_id="plugin-source",
+        stream_id="snap-id-123",
+        stream_name="mass_stream_internal",
+        stream_display_name="Living Room",
+    )
+    provider._snapcast_ma_streams["mass_stream_internal"] = fake_stream
+    provider.mass.player_queues.get.return_value = None
+
+    assert provider.resolve_control_stream("Living Room") is None
+
+
+def test_resolve_control_stream_returns_active_queue_payload() -> None:
+    """External control resolution should expose the active queue metadata."""
+    provider = _create_provider()
+    fake_stream: Any = SimpleNamespace(
+        queue_id="living-room-player",
+        source_id="queue-source",
+        stream_id="snap-id-123",
+        stream_name="mass_stream_internal",
+        stream_display_name="Living Room",
+    )
+    queue = SimpleNamespace(
+        queue_id="living-room-player",
+        to_dict=MagicMock(return_value={"queue_id": "living-room-player"}),
+    )
+    provider._snapcast_ma_streams["mass_stream_internal"] = fake_stream
+    provider.mass.player_queues.get.return_value = queue
+
+    assert provider.resolve_control_stream("Living Room") == {
+        "player_id": "living-room-player",
+        "queue_id": "living-room-player",
+        "queue": {"queue_id": "living-room-player"},
+        "stream_id": "snap-id-123",
+        "stream_name": "mass_stream_internal",
+        "stream_display_name": "Living Room",
+    }
+
+
+def test_resolve_control_stream_prefers_queue_backed_match_for_shared_display_name() -> None:
+    """Visible stream-name resolution should skip stale idle matches and pick the active queue."""
+    provider = _create_provider()
+    idle_stream: Any = SimpleNamespace(
+        queue_id=None,
+        source_id=f"{SGP_PREFIX}abc12345",
+        stream_id="broadcast",
+        stream_name="mass_stream_idle",
+        stream_display_name="broadcast",
+    )
+    active_stream: Any = SimpleNamespace(
+        queue_id="syncgroup_active",
+        source_id=f"{SGP_PREFIX}abc12345",
+        stream_id="broadcast",
+        stream_name="mass_stream_active",
+        stream_display_name="broadcast",
+    )
+    queue = SimpleNamespace(
+        queue_id="syncgroup_active",
+        to_dict=MagicMock(return_value={"queue_id": "syncgroup_active"}),
+    )
+    provider._snapcast_ma_streams["mass_stream_idle"] = idle_stream
+    provider._snapcast_ma_streams["mass_stream_active"] = active_stream
+    provider.mass.player_queues.get.side_effect = lambda queue_id: (
+        queue if queue_id == "syncgroup_active" else None
+    )
+
+    assert provider.resolve_control_stream("broadcast") == {
+        "player_id": "syncgroup_active",
+        "queue_id": "syncgroup_active",
+        "queue": {"queue_id": "syncgroup_active"},
+        "stream_id": "broadcast",
+        "stream_name": "mass_stream_active",
+        "stream_display_name": "broadcast",
+    }
+
+
+def test_get_snap_ma_stream_prefers_active_queue_backed_match_for_shared_ref() -> None:
+    """Shared refs like a visible stream name should prefer the active queue-backed stream."""
+    provider = _create_provider()
+    idle_stream: Any = SimpleNamespace(
+        stream_name="mass_stream_idle",
+        stream_id="broadcast",
+        stream_display_name="broadcast",
+        source_id=f"{SGP_PREFIX}abc12345",
+        queue_id=None,
+        is_streaming=False,
+    )
+    active_stream: Any = SimpleNamespace(
+        stream_name="mass_stream_active",
+        stream_id="broadcast",
+        stream_display_name="broadcast",
+        source_id="broadcast",
+        queue_id="broadcast",
+        is_streaming=True,
+    )
+    provider._snapcast_ma_streams["mass_stream_idle"] = idle_stream
+    provider._snapcast_ma_streams["mass_stream_active"] = active_stream
+
+    assert provider.get_snap_ma_stream("broadcast") is active_stream
+    assert provider.get_snap_ma_stream("mass_stream_idle") is idle_stream
+
+
+def test_update_stream_usage_marks_all_matching_stream_variants_in_use() -> None:
+    """Shared visible refs should not idle-stop the active queue-backed stream."""
+    provider = _create_provider()
+    idle_stream = SimpleNamespace(
+        stream_name="mass_stream_idle",
+        stream_id="broadcast",
+        stream_display_name="broadcast",
+        set_in_use=MagicMock(),
+    )
+    active_stream = SimpleNamespace(
+        stream_name="mass_stream_active",
+        stream_id="broadcast",
+        stream_display_name="broadcast",
+        set_in_use=MagicMock(),
+    )
+    other_stream = SimpleNamespace(
+        stream_name="mass_stream_other",
+        stream_id="elsewhere",
+        stream_display_name="Elsewhere",
+        set_in_use=MagicMock(),
+    )
+    provider._snapcast_ma_streams["mass_stream_idle"] = idle_stream
+    provider._snapcast_ma_streams["mass_stream_active"] = active_stream
+    provider._snapcast_ma_streams["mass_stream_other"] = other_stream
+    provider._snapserver = SimpleNamespace(groups=[SimpleNamespace(stream="broadcast")])
+
+    provider.update_stream_usage()
+
+    idle_stream.set_in_use.assert_called_once_with(True)
+    active_stream.set_in_use.assert_called_once_with(True)
+    other_stream.set_in_use.assert_called_once_with(False)
+
+
+def test_handle_update_primes_group_member_ids_before_player_setup() -> None:
+    """Grouped clients should be resolvable before player setup computes members."""
+    provider = _create_provider()
+    provider._ids_map = bidict()
+
+    snap_client_1 = SimpleNamespace(
+        identifier="PC_VAIO_2",
+        friendly_name="PC_VAIO_2",
+        set_callback=MagicMock(),
+    )
+    snap_client_2 = SimpleNamespace(
+        identifier="thor-speakers",
+        friendly_name="Thor",
+        set_callback=MagicMock(),
+    )
+    provider._snapserver = SimpleNamespace(clients=[snap_client_1, snap_client_2])
+    provider.get_snap_player = MagicMock(return_value=None)
+    provider._update_group_callbacks = MagicMock()
+
+    seen_clients: list[str] = []
+
+    def fake_handle_player_init(snap_client: Any) -> None:
+        assert provider._get_ma_id("PC_VAIO_2") == "PC_VAIO_2"
+        assert provider._get_ma_id("thor-speakers") == "thor-speakers"
+        seen_clients.append(snap_client.identifier)
+
+    provider._handle_player_init = fake_handle_player_init
+
+    provider._handle_update()
+
+    assert seen_clients == ["PC_VAIO_2", "thor-speakers"]
+
+
+@pytest.mark.asyncio
+async def test_isolate_player_to_dedicated_group_reuses_stream_display_name_for_others() -> None:
+    """Removed players should inherit the current stream display name, not a hardcoded default."""
+    provider = _create_provider()
+    provider._get_snapclient_id = MagicMock(return_value="snap-target")
+    provider._get_ma_id = MagicMock(return_value="ma-other")
+    provider.ensure_player_owned_group = AsyncMock()
+    provider._snapcast_ma_streams["mass_stream_internal"] = SimpleNamespace(
+        stream_id="snap-stream-123",
+        stream_display_name="Kitchen Group",
+    )
+
+    target_group = SimpleNamespace(
+        identifier="group-target",
+        clients=["snap-target", "snap-other"],
+        stream="snap-stream-123",
+        set_callback=MagicMock(),
+        set_stream=AsyncMock(),
+    )
+    other_group = SimpleNamespace(
+        set_name=AsyncMock(),
+        set_stream=AsyncMock(),
+    )
+    other_client = SimpleNamespace(
+        group=other_group,
+        set_callback=MagicMock(),
+    )
+    provider.ensure_player_owned_group.return_value = target_group
+    provider._snapserver = SimpleNamespace(
+        client=MagicMock(
+            side_effect=lambda client_id: other_client if client_id == "snap-other" else None
+        ),
+        group_clients=AsyncMock(return_value={"server": {}}),
+        synchronize=MagicMock(),
+    )  # pyright: ignore[reportAttributeAccessIssue]
+    provider.mass.players.get_player.return_value = SimpleNamespace(
+        _handle_player_update=MagicMock()
+    )
+
+    await provider.isolate_player_to_dedicated_group("ma-target")
+
+    other_group.set_name.assert_awaited_once_with("ma-other")
+    other_group.set_stream.assert_awaited_once_with("Kitchen Group")
+    target_group.set_stream.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_move_player_to_fallback_group_uses_existing_named_group() -> None:
+    """Removed players should join the configured fallback group when it exists."""
+    provider = _create_provider()
+    provider._external_dedicated_fallback_group = "Media"
+
+    fallback_group = SimpleNamespace(
+        identifier="group-media",
+        name="Media",
+        add_client=AsyncMock(),
+    )
+    target_client = SimpleNamespace(
+        identifier="snap-thor",
+        group=SimpleNamespace(identifier="group-broadcast"),
+    )
+    provider._snapserver = SimpleNamespace(groups=[fallback_group])
+    provider.get_snap_client = MagicMock(return_value=target_client)
+
+    moved = await provider.move_player_to_fallback_group("thor-speakers")
+
+    assert moved is True
+    fallback_group.add_client.assert_awaited_once_with("snap-thor")
+
+
+@pytest.mark.asyncio
+async def test_set_members_reuses_current_stream_for_detached_player() -> None:
+    """Detached players should inherit the current stable stream reference."""
+    player_group = SimpleNamespace(
+        clients=["snap-target", "snap-other"],
+        stream="snap-stream-123",
+        set_callback=MagicMock(),
+        add_client=AsyncMock(),
+    )
+    provider: Any = SimpleNamespace(
+        instance_id="snapcast-test",
+        ensure_player_owned_group=AsyncMock(return_value=player_group),
+        get_snap_ma_stream=MagicMock(return_value=None),
+        move_player_to_fallback_group=AsyncMock(return_value=False),
+        isolate_player_to_dedicated_group=AsyncMock(),
+        _get_ma_id=MagicMock(
+            side_effect=lambda client_id: {
+                "snap-target": "ma-target",
+                "snap-other": "ma-other",
+            }.get(client_id)
+        ),
+        _get_stable_stream_reference=MagicMock(return_value="Kitchen Group"),
+        _update_group_callbacks=MagicMock(),
+    )
+
+    player: Any = SnapCastPlayer.__new__(SnapCastPlayer)
+    player.snap_client = SimpleNamespace(group=player_group)
+    player.mass = MagicMock()
+    player.logger = MagicMock()
+    player._provider = provider
+    player._player_id = "ma-target"
+    player._state_update_lock = asyncio.Lock()
+    player._process_snapcast_client_state = AsyncMock(return_value=False)
+    await player.set_members(player_ids_to_remove=["ma-other"])
+
+    provider._get_stable_stream_reference.assert_called_once_with("snap-stream-123")
+    provider.isolate_player_to_dedicated_group.assert_awaited_once_with(
+        "ma-other", target_stream_id="Kitchen Group"
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_members_prefers_configured_fallback_group_for_removed_player() -> None:
+    """Detached players should use the configured fallback group before isolate fallback."""
+    player_group = SimpleNamespace(
+        clients=["snap-target", "snap-other"],
+        stream="snap-stream-123",
+        set_callback=MagicMock(),
+        add_client=AsyncMock(),
+    )
+    provider: Any = SimpleNamespace(
+        instance_id="snapcast-test",
+        ensure_player_owned_group=AsyncMock(return_value=player_group),
+        get_snap_ma_stream=MagicMock(return_value=None),
+        move_player_to_fallback_group=AsyncMock(return_value=True),
+        isolate_player_to_dedicated_group=AsyncMock(),
+        _get_ma_id=MagicMock(
+            side_effect=lambda client_id: {
+                "snap-target": "ma-target",
+                "snap-other": "ma-other",
+            }.get(client_id)
+        ),
+        _get_stable_stream_reference=MagicMock(return_value="Kitchen Group"),
+        _update_group_callbacks=MagicMock(),
+    )
+
+    player: Any = SnapCastPlayer.__new__(SnapCastPlayer)
+    player.snap_client = SimpleNamespace(group=player_group)
+    player.mass = MagicMock()
+    player.logger = MagicMock()
+    player._provider = provider
+    player._player_id = "ma-target"
+    player._state_update_lock = asyncio.Lock()
+    player._process_snapcast_client_state = AsyncMock(return_value=False)
+    await player.set_members(player_ids_to_remove=["ma-other"])
+
+    provider.move_player_to_fallback_group.assert_awaited_once_with("ma-other")
+    provider.isolate_player_to_dedicated_group.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_members_keeps_remaining_syncgroup_member_on_current_stream_during_handoff() -> (
+    None
+):
+    """Leader handoff should keep the remaining member on the active Snapcast stream."""
+    player_group = SimpleNamespace(
+        clients=["snap-target", "snap-other"],
+        stream="snap-stream-123",
+        set_callback=MagicMock(),
+        add_client=AsyncMock(),
+    )
+    sync_group_player = SimpleNamespace(group_members=["ma-other"])
+    provider: Any = SimpleNamespace(
+        instance_id="snapcast-test",
+        ensure_player_owned_group=AsyncMock(return_value=player_group),
+        get_snap_ma_stream=MagicMock(
+            return_value=SimpleNamespace(
+                media=PlayerMedia(
+                    uri="snapcast-syncgroup://test",
+                    media_type=MediaType.PLUGIN_SOURCE,
+                    custom_data={"player_id": f"{SGP_PREFIX}abc12345"},
+                )
+            )
+        ),
+        move_player_to_fallback_group=AsyncMock(return_value=True),
+        isolate_player_to_dedicated_group=AsyncMock(),
+        _get_ma_id=MagicMock(
+            side_effect=lambda client_id: {
+                "snap-target": "ma-target",
+                "snap-other": "ma-other",
+            }.get(client_id)
+        ),
+        _get_stable_stream_reference=MagicMock(return_value="Kitchen Group"),
+        _update_group_callbacks=MagicMock(),
+    )
+
+    player: Any = SnapCastPlayer.__new__(SnapCastPlayer)
+    player.snap_client = SimpleNamespace(group=player_group)
+    player.mass = MagicMock()
+    player.mass.players.get_player.return_value = sync_group_player
+    player.logger = MagicMock()
+    player._provider = provider
+    player._player_id = "ma-target"
+    player._state_update_lock = asyncio.Lock()
+    player._process_snapcast_client_state = AsyncMock(return_value=False)
+    await player.set_members(player_ids_to_remove=["ma-other"])
+
+    provider.move_player_to_fallback_group.assert_awaited_once_with("ma-target")
+    provider.isolate_player_to_dedicated_group.assert_awaited_once_with(
+        "ma-other", target_stream_id="Kitchen Group"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_reuses_current_stream_reference_instead_of_default() -> None:
+    """Stop should keep using the stable current stream reference, not a hardcoded default."""
+    player_group = SimpleNamespace(
+        stream="snap-stream-123",
+        set_stream=AsyncMock(),
+    )
+    provider: Any = SimpleNamespace(
+        instance_id="snapcast-test",
+        ensure_player_owned_group=AsyncMock(return_value=player_group),
+        get_snap_ma_stream=MagicMock(return_value=None),
+        _get_stable_stream_reference=MagicMock(return_value="Kitchen Group"),
+    )
+
+    player: Any = SnapCastPlayer.__new__(SnapCastPlayer)
+    player.snap_client = SimpleNamespace(group=player_group)
+    player.mass = MagicMock()
+    player.logger = MagicMock()
+    player._provider = provider
+    player._player_id = "ma-target"
+    player._poke_evt = asyncio.Event()
+
+    await player.stop()
+
+    provider._get_stable_stream_reference.assert_called_once_with("snap-stream-123")
+    player_group.set_stream.assert_awaited_once_with("Kitchen Group")
+    assert player._poke_evt.is_set()
+
+
+@pytest.mark.asyncio
+async def test_get_snapcast_media_stream_recreates_idle_stream_on_display_name_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An idle stream should be recreated when the desired visible Snapcast name changes."""
+    provider = _create_provider()
+
+    class FakeStream:
+        """Minimal stand-in for SnapcastMAStream."""
+
+        def __init__(
+            self,
+            provider: SnapCastProvider,
+            media: PlayerMedia,
+            stream_name: str,
+            stream_display_name: str | None = None,
+            source_id: str | None = None,
+            queue_id: str | None = None,
+            filter_settings_owner: str | None = None,
+            use_cntrl_script: bool = False,
+            destroy_on_stop: bool = False,
+        ) -> None:
+            self.provider = provider
+            self.media = media
+            self.stream_name = stream_name
+            self.stream_display_name = stream_display_name or stream_name
+            self.source_id = source_id
+            self.queue_id = queue_id
+            self.filter_settings_owner = filter_settings_owner
+            self.use_cntrl_script = use_cntrl_script
+            self.destroy_on_stop = destroy_on_stop
+            self.is_streaming = False
+            self.stream_id = None
+            self.destroy_called = False
+            self.setup_called = False
+
+        async def setup(self) -> None:
+            self.setup_called = True
+
+        async def destroy(self) -> None:
+            self.destroy_called = True
+
+        def update_media(self, media: PlayerMedia) -> None:
+            self.media = media
+
+    monkeypatch.setattr(
+        "music_assistant.providers.snapcast.provider.SnapcastMAStream",
+        FakeStream,
+    )
+    provider._get_sync_group_stream_display_name = MagicMock(
+        side_effect=["Kitchen Group", "Living Room"]
+    )
+
+    media = PlayerMedia(uri="https://example.test/stream.mp3")
+    first_stream = await provider.get_snapcast_media_stream(media)
+    second_stream = await provider.get_snapcast_media_stream(media)
+
+    assert first_stream is not None
+    assert second_stream is not None
+    assert first_stream.stream_display_name == "Kitchen Group"
+    assert first_stream.destroy_called is True
+    assert second_stream is not first_stream
+    assert second_stream.stream_display_name == "Living Room"
+    assert second_stream.setup_called is True

--- a/tests/providers/snapcast/test_stream_registry.py
+++ b/tests/providers/snapcast/test_stream_registry.py
@@ -1,0 +1,53 @@
+"""Tests for the Snapcast stream registry."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from music_assistant.providers.snapcast.stream_registry import SnapcastStreamRegistry
+
+
+def test_stream_registry_resolves_all_supported_references() -> None:
+    """The registry should resolve a stream by all supported references."""
+    registry = SnapcastStreamRegistry()
+    stream: Any = SimpleNamespace(
+        stream_name="mass_stream_broadcast",
+        stream_id="snap-stream-123",
+        stream_display_name="broadcast",
+        source_id="source-broadcast",
+        queue_id="queue-broadcast",
+    )
+
+    registry.register(stream)
+
+    assert registry.resolve("mass_stream_broadcast") is stream
+    assert registry.resolve("snap-stream-123") is stream
+    assert registry.resolve("broadcast") is stream
+    assert registry.resolve("source-broadcast") is stream
+    assert registry.resolve("queue-broadcast") is stream
+    assert registry.resolve("missing") is None
+
+
+def test_stream_registry_resolve_all_returns_all_matching_streams() -> None:
+    """The registry should return every match when multiple streams share one ref."""
+    registry = SnapcastStreamRegistry()
+    idle_stream: Any = SimpleNamespace(
+        stream_name="mass_idle_broadcast",
+        stream_id="broadcast",
+        stream_display_name="broadcast",
+        source_id="syncgroup-broadcast",
+        queue_id=None,
+    )
+    active_stream: Any = SimpleNamespace(
+        stream_name="mass_active_broadcast",
+        stream_id="broadcast",
+        stream_display_name="broadcast",
+        source_id="syncgroup-broadcast",
+        queue_id="queue-broadcast",
+    )
+
+    registry.register(idle_stream)
+    registry.register(active_stream)
+
+    assert registry.resolve_all("broadcast") == (idle_stream, active_stream)


### PR DESCRIPTION
## Summary

This draft PR rebuilds the Snapcast external Snapserver integration around a standalone `mass_bridge.py` bridge and a provider-driven stream/group lifecycle.

It makes the external path restart-safe and idempotent, adds stream registry + group materialize/restore helpers, fixes duplicate `broadcast` stream creation, improves cleanup/fallback handling, and bumps Snapcast in `Dockerfile.base` to `0.35.0`.

## Validated

Tested live against an external Snapserver setup for group creation, member add/remove, idle stream materialization, playback start, bridge auth/resolve, restart recovery, fallback-group behavior, and empty-group cleanup.

Targeted tests were added for provider, stream registry, group materialization, group restore, stream lifecycle, `mass_bridge.py`, and the sync-group last-leader edge case.

## What to Review

Please focus review on:

- the external `mass_bridge.py` flow and provider-side resolve contract
- stream lifecycle/reuse behavior around `broadcast`
- plugin-side group materialization and restore logic
- the small remaining assist in `providers/sync_group/player.py`

## Still Draft

- one small targeted assist remains in `providers/sync_group/player.py`
- leader handoff can still show a brief ~300 ms double-`broadcast` transition
- final state is correct and Snap.Net no longer gets stuck during handoff
