### PR TITLE
Add optional timestamp to get_resume_position

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1547,9 +1547,9 @@ class MusicController(CoreController):
             ma_fully_played = parse_optional_bool(db_entry["fully_played"])
             ma_timestamp = from_utc_timestamp(db_entry["timestamp"])
 
-        # Return the higher position to ensure users never lose progress
-        if provider_timestamp and provider_timestamp > ma_timestamp:
+        if provider_timestamp is not None and provider_timestamp > ma_timestamp:
             return provider_fully_played, provider_position_ms
+        # Return the higher position to ensure users never lose progress
         if ma_position_ms >= provider_position_ms:
             return ma_fully_played, ma_position_ms
         return provider_fully_played, provider_position_ms

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -78,7 +78,11 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import get_cu
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.compare import compare_strings, compare_version, create_safe_string
 from music_assistant.helpers.database import UNSET, DatabaseConnection
-from music_assistant.helpers.datetime import local_clock_time_to_utc, utc_timestamp
+from music_assistant.helpers.datetime import (
+    from_utc_timestamp,
+    local_clock_time_to_utc,
+    utc_timestamp,
+)
 from music_assistant.helpers.json import json_dumps, json_loads, serialize_to_json
 from music_assistant.helpers.tags import split_artists
 from music_assistant.helpers.uri import parse_uri
@@ -1482,6 +1486,7 @@ class MusicController(CoreController):
         """
         provider_fully_played = False
         provider_position_ms = 0
+        provider_timestamp: datetime | None = None
 
         user: User | None = None
         if userid:
@@ -1520,12 +1525,14 @@ class MusicController(CoreController):
                 (
                     provider_fully_played,
                     provider_position_ms,
+                    provider_timestamp,
                 ) = await provider.get_resume_position(prov_mapping.item_id, media_item.media_type)
                 break  # Use first provider that returns data
 
         # Get MA's internal position from playlog
         ma_fully_played = False
         ma_position_ms = 0
+        ma_timestamp = from_utc_timestamp(0)
         params = {
             "media_type": media_item.media_type.value,
             "item_id": media_item.item_id,
@@ -1538,8 +1545,11 @@ class MusicController(CoreController):
         if db_entry := await self.database.get_row(DB_TABLE_PLAYLOG, params):
             ma_position_ms = db_entry["seconds_played"] * 1000 if db_entry["seconds_played"] else 0
             ma_fully_played = parse_optional_bool(db_entry["fully_played"])
+            ma_timestamp = from_utc_timestamp(db_entry["timestamp"])
 
         # Return the higher position to ensure users never lose progress
+        if provider_timestamp and provider_timestamp > ma_timestamp:
+            return provider_fully_played, provider_position_ms
         if ma_position_ms >= provider_position_ms:
             return ma_fully_played, ma_position_ms
         return provider_fully_played, provider_position_ms

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, Final, cast
 
 from music_assistant_models.background_task import TaskSchedule
@@ -397,7 +398,9 @@ class MusicProvider(Provider):
         """
         raise NotImplementedError
 
-    async def get_resume_position(self, item_id: str, media_type: MediaType) -> tuple[bool, int]:
+    async def get_resume_position(
+        self, item_id: str, media_type: MediaType
+    ) -> tuple[bool, int, datetime | None]:
         """
         Get progress (resume point) details for the given Audiobook or Podcast episode.
 
@@ -408,7 +411,8 @@ class MusicProvider(Provider):
         Will be called right before playback starts to ensure the resume position is correct.
 
         Returns a boolean with the fully_played status
-        and an integer with the resume position in ms.
+        an integer with the resume position in ms,
+        and an optional timestamp as datetime giving when this resume position was set
         """
         raise NotImplementedError
 

--- a/music_assistant/providers/_demo_music_provider/__init__.py
+++ b/music_assistant/providers/_demo_music_provider/__init__.py
@@ -43,6 +43,7 @@ See also our general DEVELOPMENT.md guide in the repository for more information
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import ContentType, MediaType, ProviderFeature, StreamType
@@ -449,7 +450,9 @@ class MyDemoMusicprovider(MusicProvider):
         # You can use the @use_cache decorator from music_assistant.controllers.cache
         # to easily apply caching to this method.
 
-    async def get_resume_position(self, item_id: str, media_type: MediaType) -> tuple[bool, int]:  # type: ignore[empty-body]
+    async def get_resume_position(  # type: ignore[empty-body]
+        self, item_id: str, media_type: MediaType
+    ) -> tuple[bool, int, datetime | None]:
         """
         Get progress (resume point) details for the given Audiobook or Podcast episode.
 
@@ -460,7 +463,8 @@ class MyDemoMusicprovider(MusicProvider):
         Will be called right before playback starts to ensure the resume position is correct.
 
         Returns a boolean with the fully_played status
-        and an integer with the resume position in ms.
+        and an integer with the resume position in ms,
+        and an optional timestamp as datetime when this resume position was set.
         """
         # optional function to get the resume position of a audiobook or podcast episode
         # only implement this if your provider supports providing this information!

--- a/music_assistant/providers/ard_audiothek/__init__.py
+++ b/music_assistant/providers/ard_audiothek/__init__.py
@@ -320,12 +320,14 @@ class ARDAudiothek(MusicProvider):
             )
         return False, 0
 
-    async def get_resume_position(self, item_id: str, media_type: MediaType) -> tuple[bool, int]:
+    async def get_resume_position(
+        self, item_id: str, media_type: MediaType
+    ) -> tuple[bool, int, datetime | None]:
         """Return: finished, position_ms."""
         assert media_type == MediaType.PODCAST_EPISODE
         await self._update_progress()
 
-        return self._get_progress(item_id)
+        return *self._get_progress(item_id), None
 
     async def on_played(
         self,

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -8,6 +8,7 @@ import itertools
 import time
 from collections.abc import AsyncGenerator, Callable, Coroutine, Sequence
 from contextlib import suppress
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
 import aioaudiobookshelf as aioabs
@@ -95,6 +96,7 @@ from music_assistant_models.media_items.media_item import RecommendationFolder
 from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 
 from music_assistant.constants import PLAYBACK_REPORT_INTERVAL_SECONDS, PlaylistPlayableItem
+from music_assistant.helpers.datetime import from_utc_timestamp
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.audiobookshelf.parsers import (
     parse_audiobook,
@@ -959,14 +961,31 @@ for more details.
         raise web.HTTPFound(location=stream_url)
 
     @handle_refresh_token
-    async def get_resume_position(self, item_id: str, media_type: MediaType) -> tuple[bool, int]:
+    async def get_resume_position(
+        self, item_id: str, media_type: MediaType
+    ) -> tuple[bool, int, datetime | None]:
         """Return finished:bool, position_ms: int."""
         # this method is called _before_ get_stream_details, so the playback session
         # is created here.
         session = await self._get_playback_session(mass_item_id=item_id)
         finished = session.current_time > session.duration - PLAYBACK_REPORT_INTERVAL_SECONDS
-        self.logger.debug("Resume position: obtained.")
-        return finished, int(session.current_time * 1000)
+
+        item_ids = item_id.split(" ")
+        abs_item_id = item_ids[0]
+        episode_id = item_ids[1] if len(item_ids) == 2 else None
+        timestamp = None
+        if progress := await self._client.get_my_media_progress(
+            item_id=abs_item_id, episode_id=episode_id
+        ):
+            # only the progress object has a timestamp of the progress (not the session)
+            # last_update is in ms epoch
+            timestamp = from_utc_timestamp(progress.last_update / 1000)
+        self.logger.debug("Resume position %s: obtained.", session.current_time)
+        return (
+            finished,
+            int(session.current_time * 1000),
+            timestamp,
+        )
 
     @handle_refresh_token
     async def recommendations(self) -> list[RecommendationFolder]:

--- a/music_assistant/providers/gpodder/__init__.py
+++ b/music_assistant/providers/gpodder/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
@@ -35,6 +36,7 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import AudioFormat, MediaItemType, Podcast, PodcastEpisode
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.helpers.datetime import from_utc_timestamp
 from music_assistant.helpers.podcast_parsers import (
     get_podcastparser_dict,
     get_stream_url_and_guid_from_episode,
@@ -508,7 +510,9 @@ class GPodder(MusicProvider):
                 return mass_episode
         raise MediaNotFoundError("Did not find episode.")
 
-    async def get_resume_position(self, item_id: str, media_type: MediaType) -> tuple[bool, int]:
+    async def get_resume_position(
+        self, item_id: str, media_type: MediaType
+    ) -> tuple[bool, int, datetime | None]:
         """Return: finished, position_ms."""
         assert media_type == MediaType.PODCAST_EPISODE
         podcast_id, guid_or_stream_url = item_id.split(" ")
@@ -526,16 +530,18 @@ class GPodder(MusicProvider):
             if action.podcast == podcast_id and (
                 guid_or_stream_url in _test or stream_url in _test
             ):
+                dt_timestamp: datetime | None = None
                 if timestamp is not None:
                     self.timestamp_actions = timestamp
                     await self._cache_set_timestamps()
+                    dt_timestamp = from_utc_timestamp(timestamp)
                 if isinstance(action, EpisodeActionNew | EpisodeActionDelete):
                     # no progress, it might have been actively reset
                     # in case of delete, we start from start.
-                    return False, 0
+                    return False, 0, None
                 _progress = (action.position >= action.total, max(action.position * 1000, 0))
                 self.logger.debug("Found an updated external resume position.")
-                return action.position >= action.total, max(action.position * 1000, 0)
+                return action.position >= action.total, max(action.position * 1000, 0), dt_timestamp
         self.logger.debug("Did not find an updated resume position, falling back to stored.")
         # If we did not find a resume position, nothing changed since our last timestamp
         # we raise NotImplementedError, such that MA falls back to the already stored

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from asyncio import TaskGroup
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
 from libopensonic import AsyncConnection as SonicConnection
@@ -725,7 +726,9 @@ class OpenSonicProvider(MusicProvider):
             comment="Music Assistant Bookmark",
         )
 
-    async def get_resume_position(self, item_id: str, media_type: MediaType) -> tuple[bool, int]:
+    async def get_resume_position(
+        self, item_id: str, media_type: MediaType
+    ) -> tuple[bool, int, datetime | None]:
         """
         Get progress (resume point) details for the given Audiobook or Podcast episode.
 
@@ -747,9 +750,9 @@ class OpenSonicProvider(MusicProvider):
 
         for mark in bookmarks:
             if mark.entry.id == ep_id:
-                return (False, mark.position)
+                return (False, mark.position, None)
         # If we get here, there is no bookmark
-        return (False, 0)
+        return (False, 0, None)
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import AsyncGenerator
+from datetime import datetime
 from typing import Any, cast
 
 import aiohttp
@@ -455,7 +456,9 @@ class SpotifyProvider(MusicProvider):
             raise MediaNotFoundError(f"Episode not found: {prov_episode_id}")
         return parse_podcast_episode(episode_obj, self)
 
-    async def get_resume_position(self, item_id: str, media_type: MediaType) -> tuple[bool, int]:
+    async def get_resume_position(
+        self, item_id: str, media_type: MediaType
+    ) -> tuple[bool, int, datetime | None]:
         """Get resume position for episode/audiobook from Spotify."""
         if media_type == MediaType.PODCAST_EPISODE:
             if not self.podcast_progress_sync_enabled:
@@ -479,7 +482,7 @@ class SpotifyProvider(MusicProvider):
             resume_point = episode_obj["resume_point"]
             fully_played = resume_point.get("fully_played", False)
             position_ms = resume_point.get("resume_position_ms", 0)
-            return fully_played, position_ms
+            return fully_played, position_ms, None
 
         if media_type == MediaType.AUDIOBOOK:
             if not self.audiobooks_supported:
@@ -510,7 +513,7 @@ class SpotifyProvider(MusicProvider):
                         fully_played = False
                         break
 
-                return fully_played, total_position_ms
+                return fully_played, total_position_ms, None
 
             except (MediaNotFoundError, ResourceTemporarilyUnavailable, aiohttp.ClientError) as e:
                 self.logger.debug(f"Failed to get audiobook resume position for {item_id}: {e}")


### PR DESCRIPTION
Still trying to debug https://github.com/music-assistant/support/issues/4698 

This adds an optional timestamp to the get_resume_position method.