### PR TITLE
Fix infinite loop in plex_connect when handling refreshPlayQueue

### DIFF
--- a/music_assistant/providers/plex_connect/player_remote.py
+++ b/music_assistant/providers/plex_connect/player_remote.py
@@ -857,6 +857,8 @@ class PlexRemoteControlServer:
         This is called when the play queue is modified (items added, removed, reordered).
         We need to sync the entire updated queue state to MA while preserving playback.
         """
+        # Set flag to prevent circular updates
+        self._updating_from_plex = True
         try:
             play_queue_id = request.query.get("playQueueID")
 
@@ -955,6 +957,8 @@ class PlexRemoteControlServer:
         except Exception as e:
             LOGGER.exception(f"Error handling refreshPlayQueue: {e}")
             return web.Response(status=500, text=str(e))
+        finally:
+            self._updating_from_plex = False
 
     async def handle_create_play_queue(self, request: web.Request) -> web.Response:
         """


### PR DESCRIPTION
handle_refresh_play_queue was missing the _updating_from_plex guard that all other command handlers use. Without it, any queue refresh from Plex would modify the MA queue, triggering _handle_queue_items_updated, which would recreate the Plex PlayQueue, causing another refreshPlayQueue — an infinite loop. The stale PlayQueue 404 errors were also a symptom of this.

It should fix [this issue](https://github.com/music-assistant/support/issues/5074#issuecomment-4039698066).