### PR TITLE
Apple Music: Add content rating check for explicit tracks

### DIFF
--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -935,6 +935,8 @@ class AppleMusicProvider(MusicProvider):
             track.metadata.genres = set(genres)
         if composers := attributes.get("composerName"):
             track.metadata.performers = set(composers.split(", "))
+        if content_rating := attributes.get("contentRating"):
+            track.metadata.explicit = content_rating == "explicit"
         if isrc := attributes.get("isrc"):
             track.external_ids.add((ExternalID.ISRC, isrc))
         track.favorite = is_favourite or False


### PR DESCRIPTION
The Apple Music provider parses contentRating on albums (line 841) but not on tracks, leaving track.metadata.explicit as None for all Apple Music tracks. The Apple Music API does return contentRating on song objects with values "explicit", "clean", or absent.

This prevents Music Assistant from distinguishing between explicit and clean versions of the same track, affecting compare_track() matching and any downstream integrations relying on the explicit flag.

Every other provider (Spotify, Tidal, Deezer, Qobuz, YouTube Music) already sets metadata.explicit on tracks.

Ref: https://developer.apple.com/documentation/applemusicapi/songs/attributes-data.dictionary