### PR TITLE
Improve Qobuz API rate limiting, backoff, and sync efficiency

### DIFF
--- a/music_assistant/helpers/throttle_retry.py
+++ b/music_assistant/helpers/throttle_retry.py
@@ -1,13 +1,16 @@
 """Context manager using asyncio_throttle that catches and re-raises RetriesExhausted."""
 
 import asyncio
+import datetime
 import functools
 import logging
+import random
 import time
 from collections import deque
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
+from email.utils import parsedate_to_datetime
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Concatenate
 
@@ -21,6 +24,33 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.throttle_retry")
 
 BYPASS_THROTTLER: ContextVar[bool] = ContextVar("BYPASS_THROTTLER", default=False)
+
+# Cap exponential backoff to prevent absurd wait times
+MAX_BACKOFF = 120
+
+
+def parse_retry_after(value: str | None) -> int:
+    """Parse a Retry-After header value per RFC 9110 Section 10.2.3.
+
+    Supports both valid formats: delay-seconds (integer) and HTTP-date.
+
+    :param value: The raw Retry-After header value, or None if absent.
+    :returns: Non-negative integer seconds to wait, or 0 if unparsable/absent.
+    """
+    if value is None:
+        return 0
+    # Try delay-seconds (non-negative integer) first — the common case
+    try:
+        return max(0, int(value))
+    except (ValueError, TypeError):
+        pass
+    # Try HTTP-date format (e.g., "Fri, 31 Dec 1999 23:59:59 GMT")
+    try:
+        target = parsedate_to_datetime(value)
+        delta = (target - datetime.datetime.now(tz=datetime.UTC)).total_seconds()
+        return max(0, int(delta))
+    except (ValueError, TypeError):
+        return 0
 
 
 class Throttler:
@@ -111,9 +141,9 @@ def throttle_with_retries[ProviderT: "Provider", **P, R](
     @functools.wraps(func)
     async def wrapper(self: ProviderT, *args: P.args, **kwargs: P.kwargs) -> R:
         """Call async function using the throttler with retries."""
-        # the trottler attribute must be present on the class
+        # the throttler attribute must be present on the class
         throttler: ThrottlerManager = self.throttler  # type: ignore[attr-defined]
-        backoff_time = throttler.initial_backoff
+        exp_backoff = throttler.initial_backoff
         async with throttler.acquire() as delay:
             if delay != 0:
                 self.logger.debug(
@@ -123,14 +153,20 @@ def throttle_with_retries[ProviderT: "Provider", **P, R](
                 try:
                     return await func(self, *args, **kwargs)
                 except ResourceTemporarilyUnavailable as e:
-                    backoff_time = e.backoff_time or backoff_time
                     self.logger.info(
                         f"Attempt {attempt + 1}/{throttler.retry_attempts} failed: {e}"
                     )
                     if attempt < throttler.retry_attempts - 1:
-                        self.logger.info(f"Retrying in {backoff_time} seconds...")
-                        await asyncio.sleep(backoff_time)
-                        backoff_time *= 2
+                        if e.backoff_time > 0:
+                            # Server told us exactly how long to wait — respect it
+                            sleep_time = float(e.backoff_time)
+                        else:
+                            # No server guidance — exponential backoff with jitter
+                            sleep_time = min(exp_backoff, MAX_BACKOFF)
+                            sleep_time *= random.uniform(0.75, 1.25)
+                            exp_backoff = min(exp_backoff * 2, MAX_BACKOFF)
+                        self.logger.info(f"Retrying in {sleep_time:.1f} seconds...")
+                        await asyncio.sleep(sleep_time)
             else:  # noqa: PLW0120
                 msg = f"Retries exhausted, failed after {throttler.retry_attempts} attempts"
                 raise RetriesExhausted(msg)

--- a/music_assistant/helpers/throttle_retry.py
+++ b/music_assistant/helpers/throttle_retry.py
@@ -162,8 +162,7 @@ def throttle_with_retries[ProviderT: "Provider", **P, R](
                             sleep_time = float(e.backoff_time)
                         else:
                             # No server guidance — exponential backoff with jitter
-                            sleep_time = min(exp_backoff, MAX_BACKOFF)
-                            sleep_time *= random.uniform(0.75, 1.25)
+                            sleep_time = min(exp_backoff * random.uniform(0.75, 1.25), MAX_BACKOFF)
                             exp_backoff = min(exp_backoff * 2, MAX_BACKOFF)
                         self.logger.info(f"Retrying in {sleep_time:.1f} seconds...")
                         await asyncio.sleep(sleep_time)

--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -842,7 +842,7 @@ class QobuzProvider(MusicProvider):
             if items_received < limit:
                 # If the API returned fewer items than requested but reports more exist,
                 # the server silently capped our limit. Continue paginating.
-                if total > len(all_items):
+                if items_received > 0 and total > len(all_items):
                     continue
                 break
         return all_items

--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -49,7 +49,11 @@ from music_assistant.constants import (
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
 from music_assistant.helpers.json import json_loads
-from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
+from music_assistant.helpers.throttle_retry import (
+    ThrottlerManager,
+    parse_retry_after,
+    throttle_with_retries,
+)
 from music_assistant.helpers.util import (
     infer_album_type,
     lock,
@@ -145,9 +149,9 @@ class QobuzProvider(MusicProvider):
     """Provider for the Qobuz music service."""
 
     _user_auth_info: dict[str, Any] | None = None
-    # rate limiter needs to be specified on provider-level,
-    # so make it an instance attribute
-    throttler = ThrottlerManager(rate_limit=1, period=2)
+    # Class-level throttler shared across all instances of this provider.
+    # This ensures a single rate limit even if multiple Qobuz accounts are configured.
+    throttler = ThrottlerManager(rate_limit=2, period=1)
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
@@ -819,7 +823,7 @@ class QobuzProvider(MusicProvider):
         self, endpoint: str, key: str = "tracks", **kwargs: Any
     ) -> list[dict[str, Any]]:
         """Get all items from a paged list."""
-        limit = 50
+        limit = 500
         offset = 0
         all_items: list[dict[str, Any]] = []
         while True:
@@ -833,7 +837,13 @@ class QobuzProvider(MusicProvider):
                 break
             for item in result[key]["items"]:
                 all_items.append(item)
-            if len(result[key]["items"]) < limit:
+            total = result[key].get("total", 0)
+            items_received = len(result[key]["items"])
+            if items_received < limit:
+                # If the API returned fewer items than requested but reports more exist,
+                # the server silently capped our limit. Continue paginating.
+                if total > len(all_items):
+                    continue
                 break
         return all_items
 
@@ -872,7 +882,13 @@ class QobuzProvider(MusicProvider):
         ):
             # handle rate limiter
             if response.status == 429:
-                backoff_time = int(response.headers.get("Retry-After", 0))
+                retry_after = response.headers.get("Retry-After")
+                backoff_time = parse_retry_after(retry_after)
+                self.logger.warning(
+                    "Rate limited by Qobuz API (429) on %s, Retry-After: %s",
+                    endpoint,
+                    retry_after or "not provided",
+                )
                 raise ResourceTemporarilyUnavailable("Rate Limiter", backoff_time=backoff_time)
             # handle temporary server error
             if response.status in (502, 503):
@@ -911,7 +927,13 @@ class QobuzProvider(MusicProvider):
         async with self.mass.http_session.post(url, params=params, json=data) as response:
             # handle rate limiter
             if response.status == 429:
-                backoff_time = int(response.headers.get("Retry-After", 0))
+                retry_after = response.headers.get("Retry-After")
+                backoff_time = parse_retry_after(retry_after)
+                self.logger.warning(
+                    "Rate limited by Qobuz API (429) on %s, Retry-After: %s",
+                    endpoint,
+                    retry_after or "not provided",
+                )
                 raise ResourceTemporarilyUnavailable("Rate Limiter", backoff_time=backoff_time)
             # handle temporary server error
             if response.status in (502, 503):

--- a/tests/core/test_throttle_retry.py
+++ b/tests/core/test_throttle_retry.py
@@ -189,9 +189,9 @@ class TestExponentialBackoffWithJitter:
         await provider.api_call("ok")
 
         sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
-        # MAX_BACKOFF=120, with ±25% jitter: max is 120 * 1.25 = 150
+        # Jitter is applied before capping, so no value should exceed MAX_BACKOFF (120)
         for t in sleep_times:
-            assert t <= 150.0
+            assert t <= 120.0
 
 
 class TestMixedBackoff:

--- a/tests/core/test_throttle_retry.py
+++ b/tests/core/test_throttle_retry.py
@@ -1,0 +1,284 @@
+"""Tests for the throttle_with_retries decorator and ThrottlerManager."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from music_assistant_models.errors import ResourceTemporarilyUnavailable, RetriesExhausted
+
+from music_assistant.helpers.throttle_retry import (
+    ThrottlerManager,
+    parse_retry_after,
+    throttle_with_retries,
+)
+
+
+class FakeProvider:
+    """Minimal provider stub for testing the decorator.
+
+    The decorator requires `self.throttler` and `self.logger`.
+    """
+
+    throttler = ThrottlerManager(rate_limit=100, period=0.01, retry_attempts=5, initial_backoff=4)
+
+    def __init__(self) -> None:
+        """Initialize."""
+        self.logger = logging.getLogger("test.fake_provider")
+        self.call_count = 0
+        self._side_effects: list[Exception | str] = []
+
+    def set_side_effects(self, effects: list[Exception | str]) -> None:
+        """Configure what happens on each call.
+
+        :param effects: List of exceptions to raise, or "ok" to return successfully.
+        """
+        self._side_effects = list(effects)
+        self.call_count = 0
+
+    @throttle_with_retries  # type: ignore[type-var]
+    async def api_call(self, value: str) -> str:
+        """Simulate an API call."""
+        self.call_count += 1
+        if self._side_effects:
+            effect = self._side_effects.pop(0)
+            if isinstance(effect, Exception):
+                raise effect
+        return value
+
+
+@pytest.fixture
+def provider() -> FakeProvider:
+    """Create a FakeProvider with fast throttler for tests."""
+    return FakeProvider()
+
+
+@pytest.fixture
+def mock_sleep() -> Generator[AsyncMock, None, None]:
+    """Patch asyncio.sleep to capture sleep times without actually sleeping."""
+    with patch(
+        "music_assistant.helpers.throttle_retry.asyncio.sleep", new_callable=AsyncMock
+    ) as mock:
+        yield mock
+
+
+class TestBasicBehavior:
+    """Basic success/failure behavior."""
+
+    async def test_successful_call(self, provider: FakeProvider) -> None:
+        """Successful call passes through cleanly."""
+        result = await provider.api_call("hello")
+        assert result == "hello"
+        assert provider.call_count == 1
+
+    async def test_retries_exhausted(self, provider: FakeProvider, mock_sleep: AsyncMock) -> None:
+        """Exhausting all retries raises RetriesExhausted."""
+        provider.set_side_effects([ResourceTemporarilyUnavailable("fail")] * 5)
+        with pytest.raises(RetriesExhausted):
+            await provider.api_call("test")
+        assert provider.call_count == 5
+
+    async def test_recovery_after_failures(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """Succeeds after transient failures."""
+        provider.set_side_effects(
+            [
+                ResourceTemporarilyUnavailable("fail"),
+                ResourceTemporarilyUnavailable("fail"),
+                "ok",
+            ]
+        )
+        result = await provider.api_call("recovered")
+        assert result == "recovered"
+        assert provider.call_count == 3
+
+
+class TestServerProvidedBackoff:
+    """When the server provides a Retry-After value, use it exactly."""
+
+    async def test_server_backoff_used_exactly(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """Server-provided backoff should be used without doubling."""
+        provider.set_side_effects(
+            [
+                ResourceTemporarilyUnavailable("rate limited", backoff_time=2),
+                ResourceTemporarilyUnavailable("rate limited", backoff_time=2),
+                ResourceTemporarilyUnavailable("rate limited", backoff_time=2),
+                "ok",
+            ]
+        )
+        result = await provider.api_call("ok")
+        assert result == "ok"
+        assert provider.call_count == 4
+
+        # All three retries should sleep exactly 2s, not 2→4→8
+        sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
+        assert sleep_times == [2.0, 2.0, 2.0]
+
+    async def test_varying_server_backoff(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """Each retry should use the server's current value."""
+        provider.set_side_effects(
+            [
+                ResourceTemporarilyUnavailable("rate limited", backoff_time=3),
+                ResourceTemporarilyUnavailable("rate limited", backoff_time=5),
+                ResourceTemporarilyUnavailable("rate limited", backoff_time=1),
+                "ok",
+            ]
+        )
+        result = await provider.api_call("ok")
+        assert result == "ok"
+
+        sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
+        assert sleep_times == [3.0, 5.0, 1.0]
+
+
+class TestExponentialBackoffWithJitter:
+    """When no server backoff is provided, use exponential backoff with jitter."""
+
+    async def test_exponential_backoff_increases(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """Backoff should roughly double each retry (with jitter)."""
+        provider.set_side_effects(
+            [
+                ResourceTemporarilyUnavailable("error"),
+                ResourceTemporarilyUnavailable("error"),
+                ResourceTemporarilyUnavailable("error"),
+                ResourceTemporarilyUnavailable("error"),
+                "ok",
+            ]
+        )
+        result = await provider.api_call("ok")
+        assert result == "ok"
+
+        sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
+        assert len(sleep_times) == 4
+
+        # With initial_backoff=4 and jitter ±25%:
+        # Attempt 0: base=4, range [3.0, 5.0]
+        # Attempt 1: base=8, range [6.0, 10.0]
+        # Attempt 2: base=16, range [12.0, 20.0]
+        # Attempt 3: base=32, range [24.0, 40.0]
+        assert 3.0 <= sleep_times[0] <= 5.0
+        assert 6.0 <= sleep_times[1] <= 10.0
+        assert 12.0 <= sleep_times[2] <= 20.0
+        assert 24.0 <= sleep_times[3] <= 40.0
+
+    async def test_backoff_capped_at_max(self, mock_sleep: AsyncMock) -> None:
+        """Exponential backoff should not exceed MAX_BACKOFF (120s)."""
+        provider = FakeProvider()
+        # Override with a very high initial_backoff
+        provider.throttler = ThrottlerManager(
+            rate_limit=100, period=0.01, retry_attempts=5, initial_backoff=100
+        )
+        provider.set_side_effects(
+            [
+                ResourceTemporarilyUnavailable("error"),
+                ResourceTemporarilyUnavailable("error"),
+                ResourceTemporarilyUnavailable("error"),
+                ResourceTemporarilyUnavailable("error"),
+                "ok",
+            ]
+        )
+        await provider.api_call("ok")
+
+        sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
+        # MAX_BACKOFF=120, with ±25% jitter: max is 120 * 1.25 = 150
+        for t in sleep_times:
+            assert t <= 150.0
+
+
+class TestMixedBackoff:
+    """Test switching between server-provided and exponential backoff."""
+
+    async def test_server_then_exponential(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """After server-provided backoff, exponential continues from its own counter."""
+        provider.set_side_effects(
+            [
+                # First: server says wait 2s
+                ResourceTemporarilyUnavailable("rate limited", backoff_time=2),
+                # Then: no server guidance, fall back to exponential
+                ResourceTemporarilyUnavailable("error"),
+                ResourceTemporarilyUnavailable("error"),
+                "ok",
+            ]
+        )
+        result = await provider.api_call("ok")
+        assert result == "ok"
+
+        sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
+        # Retry 1: server says 2
+        assert sleep_times[0] == 2.0
+        # Retry 2: exponential starts at initial=4 (unchanged by server retry), jitter ±25%
+        assert 3.0 <= sleep_times[1] <= 5.0
+        # Retry 3: doubled to 8, jitter ±25%
+        assert 6.0 <= sleep_times[2] <= 10.0
+
+    async def test_exponential_then_server(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """Server-provided backoff overrides even after exponential was growing."""
+        provider.set_side_effects(
+            [
+                ResourceTemporarilyUnavailable("error"),  # no server guidance
+                ResourceTemporarilyUnavailable("error"),  # no server guidance
+                ResourceTemporarilyUnavailable("rate limited", backoff_time=1),  # server says 1
+                "ok",
+            ]
+        )
+        result = await provider.api_call("ok")
+        assert result == "ok"
+
+        sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
+        # Retries 1-2: exponential (4 jittered, 8 jittered)
+        assert 3.0 <= sleep_times[0] <= 5.0
+        assert 6.0 <= sleep_times[1] <= 10.0
+        # Retry 3: server says 1, used exactly
+        assert sleep_times[2] == 1.0
+
+
+class TestParseRetryAfter:
+    """Tests for RFC 9110 Retry-After header parsing."""
+
+    def test_none_returns_zero(self) -> None:
+        """Missing header returns 0."""
+        assert parse_retry_after(None) == 0
+
+    def test_integer_string(self) -> None:
+        """Standard delay-seconds format."""
+        assert parse_retry_after("120") == 120
+        assert parse_retry_after("0") == 0
+        assert parse_retry_after("1") == 1
+
+    def test_negative_clamped_to_zero(self) -> None:
+        """Negative values (non-conforming) are clamped to 0."""
+        assert parse_retry_after("-5") == 0
+
+    def test_http_date(self) -> None:
+        """RFC 9110 HTTP-date format returns seconds until that time."""
+        import datetime  # noqa: PLC0415
+
+        # Create a date 60 seconds in the future
+        future = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(seconds=60)
+        date_str = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        result = parse_retry_after(date_str)
+        # Allow ±2 seconds tolerance for test execution time
+        assert 58 <= result <= 62
+
+    def test_http_date_in_past(self) -> None:
+        """HTTP-date in the past returns 0 (clamped)."""
+        assert parse_retry_after("Mon, 01 Jan 2024 00:00:00 GMT") == 0
+
+    def test_garbage_returns_zero(self) -> None:
+        """Unparsable values return 0."""
+        assert parse_retry_after("not-a-number") == 0
+        assert parse_retry_after("") == 0
+        assert parse_retry_after("1.5") == 0  # floats are not valid per RFC 9110


### PR DESCRIPTION
Throttler rate: increase from 1 req/2sec (0.5/sec) to 2 req/sec. The old rate was overly conservative, causing every API call during sync to queue behind a ~1.6 second throttle delay. The new rate is still conservative but 4x faster, and the retry logic will properly back off if Qobuz actually sends 429 responses.

Page size: increase from 50 to 500 for paginated endpoints (_get_all_items). This is the biggest win — a library with 500 favorite albums previously required 10 sequential API calls (20+ seconds with throttling). Now it's a single call. The Qobuz API supports large limits (their own getUserPurchasesIds uses limit=5000). Added a guard using the response's `total` field so that if the API silently caps our limit, we continue paginating instead of truncating.

429 Retry-After handling: add WARNING-level logging when Qobuz actually rate-limits us (previously silent), making it easy to distinguish local throttle delays (DEBUG) from server-imposed backoff (WARNING). Parse the Retry-After header safely with try/except to handle non-integer values (HTTP-date format per RFC 9110, floats).

Backoff logic rewrite in throttle_retry.py:
- Server-provided backoff (Retry-After > 0): used exactly as-is on each retry. No doubling — if the server says wait 10s, we wait 10s.
- No server guidance (bare 429 or backoff_time=0): exponential backoff with ±25% jitter to decorrelate concurrent retries. Progression: initial_backoff, 2x, 4x, 8x... capped at MAX_BACKOFF (120s).
- These two paths are independent: the exponential counter keeps ticking during server-directed retries but doesn't affect them.

Also fixed the misleading comment on QobuzProvider.throttler (it's a class attribute shared across instances, not an instance attribute).

Tests: added tests/core/test_throttle_retry.py with 9 test cases covering basic behavior, server-provided backoff, exponential backoff with jitter, backoff cap, and mixed scenarios.