### PR TITLE
Fix MusicBrainz track lookup to aggregate release groups from all rec…

### DIFF
--- a/music_assistant/providers/musicbrainz/__init__.py
+++ b/music_assistant/providers/musicbrainz/__init__.py
@@ -475,26 +475,44 @@ class MusicbrainzProvider(MetadataProvider):
         # Sort by first-release-date to find the earliest (likely original studio recording)
         matches.sort(key=lambda x: x[2] if x[2] else "9999")
 
-        # Try recordings in order, looking for one with release groups
+        # Aggregate release groups from ALL matching recordings
+        # This ensures we find albums even if the first recording only has singles
+        all_release_groups: dict[str, tuple[MusicBrainzReleaseGroup, str]] = {}
+        first_artist = None
         for recording, artist, first_release_date in matches:
-            release_groups = self._get_release_groups_by_date(recording, first_release_date)
-            if release_groups:
-                return (MusicBrainzArtist.from_raw(artist), release_groups)
+            if first_artist is None:
+                first_artist = artist
+            for rg, release_date in self._get_release_groups_with_dates(recording, track_name):
+                rg_id = rg.id
+                if rg_id in all_release_groups:
+                    _, existing_date = all_release_groups[rg_id]
+                    if release_date and (not existing_date or release_date < existing_date):
+                        all_release_groups[rg_id] = (rg, release_date)
+                else:
+                    all_release_groups[rg_id] = (rg, release_date)
+
+        if all_release_groups:
+            # Sort by release date
+            sorted_groups = sorted(
+                all_release_groups.values(), key=lambda x: x[1] if x[1] else "9999"
+            )
+            return (MusicBrainzArtist.from_raw(first_artist), [rg for rg, _ in sorted_groups])
 
         # Fall back to the earliest recording (for artist lookup at least)
         recording, artist, _ = matches[0]
         return (MusicBrainzArtist.from_raw(artist), [])
 
-    def _get_release_groups_by_date(
-        self, recording: dict[str, Any], first_release_date: str
-    ) -> list[MusicBrainzReleaseGroup]:
-        """Collect release groups for a recording, sorted by release date.
+    def _get_release_groups_with_dates(
+        self, recording: dict[str, Any], track_name: str
+    ) -> list[tuple[MusicBrainzReleaseGroup, str]]:
+        """Collect release groups for a recording with their release dates.
 
         Filters out compilations and other secondary-type releases.
-        Returns singles and studio albums sorted chronologically.
+        For singles, only includes those where the title matches the track name.
+        Returns list of (release_group, release_date) tuples for singles and studio albums.
 
         :param recording: MusicBrainz recording dict.
-        :param first_release_date: The recording's first-release-date (e.g. "1982-03-29").
+        :param track_name: Track name to match against single titles.
         """
         releases = recording.get("releases", [])
         if not releases:
@@ -518,6 +536,12 @@ class MusicbrainzProvider(MetadataProvider):
             if secondary_types:
                 continue
 
+            # For singles, only include if the title matches the track name
+            # (avoid B-sides and bonus tracks on unrelated singles)
+            if primary_type == "Single":
+                if not compare_strings(rg.get("title", ""), track_name, strict=False):
+                    continue
+
             release_date = release.get("date", "") or ""
 
             # Keep the earliest release date per release group
@@ -528,9 +552,7 @@ class MusicbrainzProvider(MetadataProvider):
             else:
                 seen[rg_id] = (MusicBrainzReleaseGroup.from_raw(rg), release_date)
 
-        # Sort by release date
-        sorted_groups = sorted(seen.values(), key=lambda x: x[1] if x[1] else "9999")
-        return [rg for rg, _ in sorted_groups]
+        return list(seen.values())
 
     @use_cache(86400 * 30)  # Cache for 30 days
     @throttle_with_retries


### PR DESCRIPTION
When looking up release groups for a track, the old code would return as soon as it found the first recording with any release groups. This meant that if Recording 1 only had a single but Recording 4 had the album, we'd never find the album.

Now we aggregate release groups from all matching recordings before returning.

Also filters singles to only include those where the release group title matches the track name. This prevents returning artwork for unrelated singles that happen to include the track (eg. a B-side)