### PR TITLE
Fix jellyfin get_artist_albums always returning empty list

### DIFF
--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -58,8 +58,6 @@ CONF_URL = "url"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_VERIFY_SSL = "verify_ssl"
-FAKE_ARTIST_PREFIX = "_fake://"
-
 SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_ARTISTS,
     ProviderFeature.LIBRARY_ALBUMS,
@@ -429,8 +427,6 @@ class JellyfinProvider(MusicProvider):
     @use_cache(3600)  # Cache for 1 hour
     async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
         """Get a list of albums for the given artist."""
-        if not prov_artist_id.startswith(FAKE_ARTIST_PREFIX):
-            return []
         albums = (
             await self._client.albums.parent(prov_artist_id)
             .fields(*ALBUM_FIELDS)

--- a/tests/providers/jellyfin/__snapshots__/test_parsers.ambr
+++ b/tests/providers/jellyfin/__snapshots__/test_parsers.ambr
@@ -95,6 +95,102 @@
     'year': 2000,
   })
 # ---
+# name: test_parse_albums[nu_clear_sounds]
+  dict({
+    'album_type': 'unknown',
+    'artists': list([
+      dict({
+        'available': True,
+        'external_ids': list([
+        ]),
+        'image': None,
+        'is_playable': True,
+        'item_id': 'dd954bbf54398e247d803186d3585b79',
+        'media_type': 'artist',
+        'name': 'Ash',
+        'provider': 'xx-instance-id-xx',
+        'sort_name': 'ash',
+        'translation_key': None,
+        'uri': 'xx-instance-id-xx://artist/dd954bbf54398e247d803186d3585b79',
+        'version': '',
+        'year': None,
+      }),
+    ]),
+    'date_added': None,
+    'external_ids': list([
+      list([
+        'musicbrainz_albumid',
+        '4e8b3c7a-1234-5678-abcd-ef0123456789',
+      ]),
+      list([
+        'musicbrainz_releasegroupid',
+        '5f9c4d8b-2345-6789-bcde-f01234567890',
+      ]),
+    ]),
+    'favorite': False,
+    'is_playable': True,
+    'item_id': 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+    'media_type': 'album',
+    'metadata': dict({
+      'chapters': None,
+      'copyright': None,
+      'description': None,
+      'explicit': None,
+      'genres': None,
+      'grouping': None,
+      'images': list([
+        dict({
+          'path': 'http://localhost:1234/Items/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4/Images/Primary?api_key=ACCESS_TOKEN',
+          'provider': 'xx-instance-id-xx',
+          'remotely_accessible': False,
+          'type': 'thumb',
+        }),
+      ]),
+      'label': None,
+      'languages': None,
+      'last_refresh': None,
+      'links': None,
+      'lrc_lyrics': None,
+      'lyrics': None,
+      'mood': None,
+      'performers': None,
+      'popularity': None,
+      'preview': None,
+      'release_date': None,
+      'review': None,
+      'style': None,
+    }),
+    'name': 'Nu-Clear Sounds',
+    'position': None,
+    'provider': 'jellyfin',
+    'provider_mappings': list([
+      dict({
+        'audio_format': dict({
+          'bit_depth': 16,
+          'bit_rate': 0,
+          'channels': 2,
+          'codec_type': '?',
+          'content_type': '?',
+          'output_format_str': '?',
+          'sample_rate': 44100,
+        }),
+        'available': True,
+        'details': None,
+        'in_library': None,
+        'is_unique': None,
+        'item_id': 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+        'provider_domain': 'jellyfin',
+        'provider_instance': 'xx-instance-id-xx',
+        'url': None,
+      }),
+    ]),
+    'sort_name': 'nu-clear sounds',
+    'translation_key': None,
+    'uri': 'jellyfin://album/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+    'version': '',
+    'year': 1998,
+  })
+# ---
 # name: test_parse_albums[this_is_christmas]
   dict({
     'album_type': 'unknown',

--- a/tests/providers/jellyfin/fixtures/albums/nu_clear_sounds.json
+++ b/tests/providers/jellyfin/fixtures/albums/nu_clear_sounds.json
@@ -1,0 +1,43 @@
+{
+    "Name": "Nu-Clear Sounds",
+    "ServerId": "58f180d8d2b34927bcfd73eee400ffad",
+    "Id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    "SortName": "nu-clear sounds",
+    "ChannelId": null,
+    "ProductionYear": 1998,
+    "ProviderIds": {
+        "MusicBrainzAlbum": "4e8b3c7a-1234-5678-abcd-ef0123456789",
+        "MusicBrainzReleaseGroup": "5f9c4d8b-2345-6789-bcde-f01234567890"
+    },
+    "IsFolder": true,
+    "Type": "MusicAlbum",
+    "AlbumArtists": [
+        {
+            "Name": "Ash",
+            "Id": "dd954bbf54398e247d803186d3585b79"
+        }
+    ],
+    "ArtistItems": [
+        {
+            "Name": "Ash",
+            "Id": "dd954bbf54398e247d803186d3585b79"
+        }
+    ],
+    "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "Album-MusicBrainz-4e8b3c7a-1234-5678-abcd-ef0123456789"
+    },
+    "ImageTags": {
+        "Primary": "abc123def456abc123def456abc123de"
+    },
+    "ImageBlurHashes": {
+        "Primary": {
+            "abc123def456abc123def456abc123de": "LKO2?U%2Tw=w]~RBVZRi};RPxuwH"
+        }
+    },
+    "LocationType": "FileSystem",
+    "MediaType": "Unknown"
+}

--- a/tests/providers/jellyfin/test_init.py
+++ b/tests/providers/jellyfin/test_init.py
@@ -44,6 +44,18 @@ async def jellyfin_provider(mass: MusicAssistant) -> AsyncGenerator[ProviderConf
 
 
 @pytest.mark.usefixtures("jellyfin_provider")
+async def test_get_artist_albums(mass: MusicAssistant) -> None:
+    """Test that get_artist_albums returns albums for a real artist ID."""
+    artists = await mass.music.artists.library_items(search="Ash")
+    ash = artists[0]
+    prov_mapping = next(m for m in ash.provider_mappings if m.provider_domain == "jellyfin")
+    albums = await mass.music.artists.get_provider_artist_albums(
+        prov_mapping.item_id, prov_mapping.provider_instance
+    )
+    assert any(album.name == "Nu-Clear Sounds" for album in albums)
+
+
+@pytest.mark.usefixtures("jellyfin_provider")
 async def test_initial_sync(mass: MusicAssistant) -> None:
     """Test that initial sync worked."""
     artists = await mass.music.artists.library_items(search="Ash")


### PR DESCRIPTION
The guard condition was inverted, so `get_artist_albums` always returned an empty list.

The part I'm a bit less sure about and would like confirmation from a maintainer (this is my first PR here) is whether the `FAKE_ARTIST_PREFIX` check can be entirely removed. Claude claims IDs with such a prefix are never created by this provider and so it is not relevant here, and from what I can tell that is true, but it seems strange to me to include such a check if it was not relevant (unless it's a remnant from copy+pasting the Plex provider where it does appear to be a thing).