### PR TITLE
Subsonic: Include bookmark creation date if available

### DIFF
--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -750,7 +750,11 @@ class OpenSonicProvider(MusicProvider):
 
         for mark in bookmarks:
             if mark.entry.id == ep_id:
-                return (False, mark.position, None)
+                return (
+                    False,
+                    mark.position,
+                    datetime.fromisoformat(mark.created) if mark.created else None,
+                )
         # If we get here, there is no bookmark
         return (False, 0, None)
 


### PR DESCRIPTION
Make get_resume_position return type match the base class and return the bookmark creation date if that is availalble from the provider.