### PR TITLE
Fix: select_source should ungroup a player if its grouped/synced

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1022,9 +1022,21 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             source = player_id  # default to MA queue source
         player = self.get_player(player_id, True)
         assert player is not None  # for type checking
-        # Check if player is currently grouped (reject for public API)
-        if player.state.synced_to or player.state.active_group:
-            raise PlayerCommandFailed(f"Player {player.state.name} is currently grouped")
+        # If player is currently grouped, handle it so the source switch can proceed.
+        # This allows external sources (e.g. Spotify Connect, AirPlay) to take over a grouped player.
+        if player.state.active_group and (
+            group_player := self.get_player(player.state.active_group)
+        ):
+            if player_id in group_player.state.static_group_members:
+                # player is a static member of a permanent group - stop the group
+                # and power it off if supported, rather than removing the member
+                await self._handle_cmd_stop(group_player.player_id)
+                if group_player.state.power_control != PLAYER_CONTROL_NONE:
+                    await self._handle_cmd_power(group_player.player_id, False)
+            else:
+                await self.cmd_ungroup(player_id)
+        elif player.state.synced_to:
+            await self.cmd_ungroup(player_id)
         # Delegate to internal handler for actual implementation
         await self._handle_select_source(player_id, source)
 


### PR DESCRIPTION
fixes https://github.com/orgs/music-assistant/discussions/5208