### PR TITLE
Guard against non-UTF-8 filenames in file system providers

### DIFF
--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -297,7 +297,20 @@ class WebsocketClientHandler:
 
         Serializes inline without executor overhead since events are typically small.
         """
-        _message = message.to_json()
+        try:
+            _message = message.to_json()
+        except (UnicodeEncodeError, TypeError):
+            if isinstance(message, MassEvent):
+                self._logger.warning(
+                    "Dropping websocket event '%s' for '%s': contains non-UTF-8 characters.",
+                    message.event,
+                    message.object_id,
+                )
+            else:
+                self._logger.warning(
+                    "Dropping websocket message: contains non-UTF-8 characters.",
+                )
+            return
 
         try:
             self._to_write.put_nowait(_message)

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -297,20 +297,7 @@ class WebsocketClientHandler:
 
         Serializes inline without executor overhead since events are typically small.
         """
-        try:
-            _message = message.to_json()
-        except (UnicodeEncodeError, TypeError):
-            if isinstance(message, MassEvent):
-                self._logger.warning(
-                    "Dropping websocket event '%s' for '%s': contains non-UTF-8 characters.",
-                    message.event,
-                    message.object_id,
-                )
-            else:
-                self._logger.warning(
-                    "Dropping websocket message: contains non-UTF-8 characters.",
-                )
-            return
+        _message = message.to_json()
 
         try:
             self._to_write.put_nowait(_message)

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -602,6 +602,13 @@ class AudioTags:
     @classmethod
     def parse(cls, raw: dict[str, Any]) -> AudioTags:
         """Parse instance from raw ffmpeg info output."""
+        filename = raw["format"]["filename"]
+        try:
+            filename.encode("utf-8")
+        except UnicodeEncodeError:
+            raise InvalidDataError(
+                f"File skipped, filename contains non-UTF-8 characters: {filename!r}"
+            )
         audio_stream = next((x for x in raw["streams"] if x["codec_type"] == "audio"), None)
         if audio_stream is None:
             msg = "No audio stream found"
@@ -623,7 +630,6 @@ class AudioTags:
                 if alt_key in tags:
                     continue
                 tags[alt_key] = value
-
         return AudioTags(
             raw=raw,
             sample_rate=int(audio_stream.get("sample_rate", 44100)),
@@ -636,7 +642,7 @@ class AudioTags:
             duration=float(raw["format"].get("duration", 0)) or None,
             tags=tags,
             has_cover_image=has_cover_image,
-            filename=raw["format"]["filename"],
+            filename=filename,
         )
 
     def get(self, key: str, default: Any | None = None) -> Any:
@@ -716,7 +722,11 @@ def parse_tags(
                 error_msg = f"{error_msg} ({err_details['error']['string']})"
         raise InvalidDataError(error_msg) from err
     except (KeyError, ValueError, JSONDecodeError, InvalidDataError) as err:
-        msg = f"Unable to retrieve info for {input_file}: {err!s}"
+        try:
+            msg = f"Unable to retrieve info for {input_file}: {err!s}"
+            msg.encode("utf-8")
+        except UnicodeEncodeError:
+            msg = f"Unable to retrieve info for a file with a non-UTF-8 filename: {input_file!r}"
         raise InvalidDataError(msg) from err
 
 


### PR DESCRIPTION
Hopefully fixes: https://github.com/orgs/music-assistant/discussions/5198

IN that discussion recurring errors were reported during library sync and websocket event handling caused by a file with a non-UTF-8 character in its filename. The surrogate character propagated through the system causing multiple failure points:

- Library sync failed to process the file and logged an error that itself crashed the logging handler
- Every websocket event carrying the filename caused an unhandled exception in `_send_message_sync`, spamming the log
- A config save also failed when the surrogate reached orjson

Changes:
`music_assistant/helpers/tags.py` — `AudioTags.parse()` now checks the filename for non-UTF-8 characters before doing anything else and raises `InvalidDataError` with the offending filename, skipping the file cleanly. The error message construction in `parse_tags()` is also guarded so that logging the skip does not itself crash.