### PR TITLE
Replace blind asyncio.sleep calls with event-based state waiting

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -105,7 +105,7 @@ from .helpers import AnnounceData, handle_player_command, wait_for_power_on
 from .protocol_linking import ProtocolLinkingMixin
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Coroutine, Iterator
 
     from music_assistant_models.config_entries import (
         ConfigEntry,
@@ -113,6 +113,7 @@ if TYPE_CHECKING:
         CoreConfig,
         PlayerConfig,
     )
+    from music_assistant_models.event import MassEvent
     from music_assistant_models.player_queue import PlayerQueue
 
     from music_assistant import MusicAssistant
@@ -1875,6 +1876,48 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 elapsed_time,
             )
 
+    async def wait_for_player_update(
+        self,
+        player_id: str,
+        timeout: float = 5.0,
+        action: Coroutine[Any, Any, Any] | None = None,
+    ) -> bool:
+        """
+        Wait for a state update event on the given player.
+
+        Subscribes to PLAYER_UPDATED events *before* executing the optional action,
+        so that state updates emitted synchronously during the action are not missed.
+
+        :param player_id: The player ID to wait for.
+        :param timeout: Maximum time to wait in seconds.
+        :param action: Optional coroutine to execute while subscribed.
+        :return: True if a state update was received, False if timed out.
+        """
+        update_event = asyncio.Event()
+
+        def _on_event(_event: MassEvent) -> None:
+            update_event.set()
+
+        unsub = self.mass.subscribe(
+            _on_event,
+            event_filter=EventType.PLAYER_UPDATED,
+            id_filter=player_id,
+        )
+        try:
+            if action is not None:
+                await action
+            async with asyncio.timeout(timeout):
+                await update_event.wait()
+                return True
+        except TimeoutError:
+            self.logger.debug(
+                "Timed out waiting for state update on player %s, proceeding optimistically",
+                player_id,
+            )
+            return False
+        finally:
+            unsub()
+
     async def on_player_config_change(self, config: PlayerConfig, changed_keys: set[str]) -> None:
         """Call (by config manager) when the configuration of a player changes."""
         player = self.get_player(config.player_id)
@@ -2518,8 +2561,13 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             player.state.synced_to,
             log_context,
         )
-        await self.cmd_set_members(player.state.synced_to, player_ids_to_remove=[player.player_id])
-        await asyncio.sleep(2)
+        await self.wait_for_player_update(
+            player.player_id,
+            timeout=5,
+            action=self.cmd_set_members(
+                player.state.synced_to, player_ids_to_remove=[player.player_id]
+            ),
+        )
 
     async def _handle_set_members(
         self,
@@ -2812,9 +2860,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             and not player_was_sync_child
             and player_state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
         ):
-            await self._handle_cmd_stop(player_id)
-            # short sleep: allow the stop command to process and prevent race conditions
-            await asyncio.sleep(0.2)
+            # wait for the stop command to process and prevent race conditions
+            await self.wait_for_player_update(
+                player_id, timeout=5, action=self._handle_cmd_stop(player_id)
+            )
 
         # power off all synced childs when player is a sync leader
         elif not powered and player_state.type == PlayerType.PLAYER and player_state.group_members:
@@ -3074,8 +3123,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if prev_source and source != prev_source:
             with suppress(PlayerCommandFailed, RuntimeError):
                 # just try to stop (regardless of state)
-                await self._handle_cmd_stop(player_id)
-                await asyncio.sleep(2)  # small delay to allow stop to process
+                await self.wait_for_player_update(
+                    player_id, timeout=5, action=self._handle_cmd_stop(player_id)
+                )
         # check if source is a pluginsource
         # in that case the source id is the instance_id of the plugin provider
         if plugin_prov := self.mass.get_provider(source):

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
@@ -442,20 +441,25 @@ class SyncGroupPlayer(Player):
                 self.sync_leader.display_name,
                 self.display_name,
             )
-            await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
-            await asyncio.sleep(1)
+            await self.mass.players.wait_for_player_update(
+                self.sync_leader.player_id,
+                timeout=5,
+                action=self.mass.players._handle_cmd_stop(self.sync_leader.player_id),
+            )
             await self._dissolve_syncgroup()
             # remove the old leader from the group members list so it won't be re-selected
             if old_leader_id in self._attr_group_members:
                 self._attr_group_members.remove(old_leader_id)
             if was_playing and self._attr_group_members:
-                await asyncio.sleep(2)
                 await self.play()
         elif self.sync_leader and (leader_removed or not self._attr_group_members):
             # we removed the current sync leader, and we have no members left in the group
             # or we just removed the last member from the group, so we dissolve the syncgroup
-            await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
-            await asyncio.sleep(1)
+            await self.mass.players.wait_for_player_update(
+                self.sync_leader.player_id,
+                timeout=5,
+                action=self.mass.players._handle_cmd_stop(self.sync_leader.player_id),
+            )
             await self._dissolve_syncgroup()
 
         elif self.sync_leader:
@@ -516,7 +520,14 @@ class SyncGroupPlayer(Player):
                 x for x in sync_leader.state.group_members if x != sync_leader.player_id
             ]
             if sync_children:
-                await self.mass.players.cmd_set_members(sync_leader.player_id, [], sync_children)
+                # wait for the leader's state to reflect the ungroup
+                await self.mass.players.wait_for_player_update(
+                    sync_leader.player_id,
+                    timeout=5,
+                    action=self.mass.players.cmd_set_members(
+                        sync_leader.player_id, [], sync_children
+                    ),
+                )
         self.sync_leader = None
         self.update_state()
 

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from copy import deepcopy
 from time import time
 from typing import TYPE_CHECKING, cast
@@ -218,13 +217,21 @@ class UniversalGroupPlayer(Player):
                             other_group.supports_feature(PlayerFeature.SET_MEMBERS)
                             and member.player_id not in other_group.static_group_members
                         ):
-                            await other_group.set_members(player_ids_to_remove=[member.player_id])
+                            await self.mass.players.wait_for_player_update(
+                                member.player_id,
+                                timeout=5,
+                                action=other_group.set_members(
+                                    player_ids_to_remove=[member.player_id]
+                                ),
+                            )
                         else:
                             # if the other group does not support SET_MEMBERS or it is a static
                             # member, we need to power it off to leave the group
-                            await other_group.power(False)
-                            await asyncio.sleep(1)
-                    await asyncio.sleep(1)
+                            await self.mass.players.wait_for_player_update(
+                                member.player_id,
+                                timeout=5,
+                                action=other_group.power(False),
+                            )
                 if member.synced_to:
                     # edge case: the member is part of a syncgroup - ungroup it first
                     await member.ungroup()


### PR DESCRIPTION
Add `wait_for_player_update` helper that subscribes to `PLAYER_UPDATED` events for a specific player and awaits the first one (with timeout). On timeout it logs a warning and proceeds optimistically — playback commands always get priority.

Replaces fixed `asyncio.sleep()` calls after player commands (stop, ungroup, power off, dissolve) with proper event-based waiting in the player controller, syncgroup player, and universal group player.