### PR TITLE
Fix cache controller to enforce consistent JSON serialization

### DIFF
--- a/music_assistant/controllers/cache.py
+++ b/music_assistant/controllers/cache.py
@@ -7,8 +7,7 @@ import functools
 import logging
 import os
 import time
-from collections import OrderedDict
-from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Iterator, MutableMapping
+from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from pathlib import Path
@@ -44,9 +43,15 @@ CACHE_DATABASE_CLEANUP_TASK_ID = "cache_database_cleanup"
 
 BYPASS_CACHE: ContextVar[bool] = ContextVar("BYPASS_CACHE", default=False)
 
+# Type alias for data that can be stored in the cache.
+# Only JSON-serializable types are accepted - storing model objects directly
+# is not allowed as the cache always serializes/deserializes through JSON.
+# Note: tuples are not valid because JSON round-trips convert them to lists.
+SerializableType = str | int | float | bool | None | list[Any] | dict[str, Any]
+
 
 class CacheController(CoreController):
-    """Basic cache controller using both memory and database."""
+    """Basic cache controller using a database."""
 
     domain: str = "cache"
 
@@ -54,7 +59,6 @@ class CacheController(CoreController):
         """Initialize core controller."""
         super().__init__(mass)
         self.database: DatabaseConnection | None = None
-        self._mem_cache = MemoryCache(500)
         self.manifest.name = "Cache controller"
         self.manifest.description = (
             "Music Assistant's core controller for caching data throughout the application."
@@ -124,12 +128,6 @@ class CacheController(CoreController):
         cur_time = int(time.time())
         if checksum is not None and not isinstance(checksum, str):
             checksum = str(checksum)
-        # try memory cache first
-        memory_key = f"{provider}/{category}/{key}"
-        cache_data = self._mem_cache.get(memory_key)
-        if cache_data and (not checksum or cache_data[1] == checksum) and cache_data[2] >= cur_time:
-            return cache_data[0]
-        # fall back to db cache
         if (
             (
                 db_row := await self.database.get_row(
@@ -140,28 +138,22 @@ class CacheController(CoreController):
             and (not checksum or db_row["checksum"] == checksum)
         ):
             try:
-                data = await async_json_loads(db_row["data"])
+                return await async_json_loads(db_row["data"])
             except Exception as exc:
                 LOGGER.error(
-                    "Error parsing cache data for %s: %s",
-                    memory_key,
+                    "Error parsing cache data for %s/%s/%s: %s",
+                    provider,
+                    category,
+                    key,
                     str(exc),
                     exc_info=exc if self.logger.isEnabledFor(10) else None,
                 )
-            else:
-                # also store in memory cache for faster access
-                self._mem_cache[memory_key] = (
-                    data,
-                    db_row["checksum"],
-                    db_row["expires"],
-                )
-                return data
         return default
 
     async def set(
         self,
         key: str,
-        data: Any,
+        data: SerializableType,
         expiration: int = DEFAULT_CACHE_EXPIRATION,
         provider: str = "default",
         category: int = 0,
@@ -185,11 +177,8 @@ class CacheController(CoreController):
         if checksum is not None:
             checksum = str(checksum)
         expires = int(time.time() + expiration)
-        memory_key = f"{provider}/{category}/{key}"
-        self._mem_cache[memory_key] = (data, checksum, expires)
-        if (expires - time.time()) < 1800:
-            # do not cache items in db with short expiration
-            return
+        # always serialize to JSON to ensure data is serializable
+        # this raises if the data contains non-serializable objects
         data = await asyncio.to_thread(json_dumps, data)
         await self.database.insert_or_replace(
             DB_TABLE_CACHE,
@@ -216,10 +205,6 @@ class CacheController(CoreController):
             match["category"] = category
         if provider is not None:
             match["provider"] = provider
-        if key is not None and category is not None and provider is not None:
-            self._mem_cache.pop(f"{provider}/{category}/{key}", None)
-        else:
-            self._mem_cache.clear()
         await self.database.delete(DB_TABLE_CACHE, match)
 
     async def clear(
@@ -231,7 +216,6 @@ class CacheController(CoreController):
     ) -> None:
         """Clear all/partial items from cache."""
         assert self.database is not None
-        self._mem_cache.clear()
         self.logger.info("Clearing database...")
         query_parts: list[str] = []
         if category_filter is not None:
@@ -251,8 +235,6 @@ class CacheController(CoreController):
         assert self.database is not None
         self.logger.debug("Running automatic cleanup...")
         update_current_task_progress_text("Loading cache records")
-        # simply reset the memory cache
-        self._mem_cache.clear()
         cur_timestamp = int(time.time())
         cleaned_records = 0
         db_rows = await self.database.get_rows(DB_TABLE_CACHE)
@@ -489,7 +471,7 @@ def use_cache(
             self.mass.create_task(
                 cache.set(
                     key=cache_key,
-                    data=result,
+                    data=cast("SerializableType", result),
                     expiration=expiration,
                     provider=provider_id,
                     category=category,
@@ -502,54 +484,3 @@ def use_cache(
         return wrapper
 
     return _decorator
-
-
-class MemoryCache(MutableMapping[str, Any]):
-    """Simple limited in-memory cache implementation."""
-
-    def __init__(self, maxlen: int) -> None:
-        """Initialize."""
-        self._maxlen = maxlen
-        self.d: OrderedDict[str, Any] = OrderedDict()
-
-    @property
-    def maxlen(self) -> int:
-        """Return max length."""
-        return self._maxlen
-
-    def get(self, key: str, default: Any = None) -> Any:
-        """Return item or default."""
-        return self.d.get(key, default)
-
-    def pop(self, key: str, default: Any = None) -> Any:
-        """Pop item from collection."""
-        return self.d.pop(key, default)
-
-    def __getitem__(self, key: str) -> Any:
-        """Get item."""
-        self.d.move_to_end(key)
-        return self.d[key]
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        """Set item."""
-        if key in self.d:
-            self.d.move_to_end(key)
-        elif len(self.d) == self.maxlen:
-            self.d.popitem(last=False)
-        self.d[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        """Delete item."""
-        del self.d[key]
-
-    def __iter__(self) -> Iterator[str]:
-        """Iterate items."""
-        return self.d.__iter__()
-
-    def __len__(self) -> int:
-        """Return length."""
-        return len(self.d)
-
-    def clear(self) -> None:
-        """Clear cache."""
-        self.d.clear()

--- a/music_assistant/controllers/cache.py
+++ b/music_assistant/controllers/cache.py
@@ -51,7 +51,7 @@ SerializableType = str | int | float | bool | None | list[Any] | dict[str, Any]
 
 
 class CacheController(CoreController):
-    """Basic cache controller using a database."""
+    """Controller handling caching of data throughout the application."""
 
     domain: str = "cache"
 
@@ -111,11 +111,16 @@ class CacheController(CoreController):
         checksum: str | int | None = None,
         default: Any = None,
         allow_bypass: bool = True,
+        base_class: Any = None,
     ) -> Any:
-        """Get data from cache.
+        """
+        Get data from cache.
 
         Returns JSON-deserialized data (dicts, lists, strings, numbers, booleans, None).
-        Model objects must be reconstructed by the caller using e.g. Model.from_dict().
+
+        If base_class is provided, the raw data is automatically reconstructed using
+        its from_dict() method. If the cached data is a list of dicts, each item is
+        reconstructed individually.
 
         :param key: The (unique) lookup key of the cache object.
         :param provider: Provider id to group cache objects.
@@ -123,6 +128,7 @@ class CacheController(CoreController):
         :param checksum: If provided, only return data if the stored checksum matches.
         :param default: Value to return if no cache object is found.
         :param allow_bypass: Whether to respect the BYPASS_CACHE context variable.
+        :param base_class: If provided, reconstruct data using base_class.from_dict().
         """
         assert self.database is not None
         assert key, "No key provided"
@@ -141,7 +147,7 @@ class CacheController(CoreController):
             and (not checksum or db_row["checksum"] == checksum)
         ):
             try:
-                return await async_json_loads(db_row["data"])
+                data = await async_json_loads(db_row["data"])
             except Exception as exc:
                 LOGGER.error(
                     "Error parsing cache data for %s/%s/%s: %s",
@@ -151,6 +157,12 @@ class CacheController(CoreController):
                     str(exc),
                     exc_info=exc if self.logger.isEnabledFor(10) else None,
                 )
+            else:
+                if base_class is not None and data is not None:
+                    if isinstance(data, list):
+                        return [base_class.from_dict(item) for item in data]
+                    return base_class.from_dict(data)
+                return data
         return default
 
     async def set(

--- a/music_assistant/controllers/cache.py
+++ b/music_assistant/controllers/cache.py
@@ -112,14 +112,17 @@ class CacheController(CoreController):
         default: Any = None,
         allow_bypass: bool = True,
     ) -> Any:
-        """Get object from cache and return the results.
+        """Get data from cache.
 
-        - key: the (unique) lookup key of the cache object as reference
-        - provider: optional provider id to group cache objects
-        - category: optional category to group cache objects
-        - checksum: optional argument to check if the checksum in the
-                    cache object matches the checksum provided
-        - default: value to return if no cache object is found
+        Returns JSON-deserialized data (dicts, lists, strings, numbers, booleans, None).
+        Model objects must be reconstructed by the caller using e.g. Model.from_dict().
+
+        :param key: The (unique) lookup key of the cache object.
+        :param provider: Provider id to group cache objects.
+        :param category: Category to group cache objects.
+        :param checksum: If provided, only return data if the stored checksum matches.
+        :param default: Value to return if no cache object is found.
+        :param allow_bypass: Whether to respect the BYPASS_CACHE context variable.
         """
         assert self.database is not None
         assert key, "No key provided"
@@ -161,15 +164,19 @@ class CacheController(CoreController):
         persistent: bool = False,
     ) -> None:
         """
-        Set data in cache.
+        Store data in cache.
 
-        - key: the (unique) lookup key of the cache object as reference
-        - data: the actual data to store in the cache
-        - expiration: time in seconds the cache object should be valid
-        - provider: optional provider id to group cache objects
-        - category: optional category to group cache objects
-        - checksum: optional argument to store with the cache object
-        - persistent: if True the cache object will not be deleted when clearing the cache
+        Data must be JSON-serializable (str, int, float, bool, None, list, dict).
+        Do not pass model objects directly — use .to_dict() first.
+        Non-serializable data will raise TypeError.
+
+        :param key: The (unique) lookup key of the cache object.
+        :param data: JSON-serializable data to store.
+        :param expiration: Time in seconds the cache object should be valid.
+        :param provider: Provider id to group cache objects.
+        :param category: Category to group cache objects.
+        :param checksum: Optional checksum to store with the cache object.
+        :param persistent: If True, the entry survives cache clears.
         """
         assert self.database is not None
         if not key:

--- a/music_assistant/controllers/cache/README.md
+++ b/music_assistant/controllers/cache/README.md
@@ -1,0 +1,28 @@
+# Cache Controller
+
+This package provides a centralized caching layer backed by SQLite. All data stored in the cache goes through JSON serialization, ensuring consistent behavior regardless of when or how the data is retrieved.
+
+## Responsibilities
+
+- Store and retrieve JSON-serializable data with key/provider/category namespacing.
+- Enforce data integrity: only `SerializableType` values (str, int, float, bool, None, list, dict) are accepted. Non-serializable objects raise `TypeError` immediately on write.
+- Support expiration, checksums, and persistent entries that survive cache clears.
+- Provide a `base_class` parameter on `get()` to automatically reconstruct model objects from cached dicts using `from_dict()`.
+- Provide a `use_cache` decorator for transparently caching provider/controller method results with automatic serialization and deserialization based on type annotations.
+- Run scheduled cleanup of expired entries.
+- Detect and reset oversized cache databases on startup.
+
+## Package Layout
+
+- `controller.py`: main `CacheController` with get/set/delete/clear operations and database lifecycle.
+- `constants.py`: shared constants (`DEFAULT_CACHE_EXPIRATION`, `MAX_CACHE_DB_SIZE_MB`, `DB_SCHEMA_VERSION`), the `BYPASS_CACHE` context variable, and the `SerializableType` alias.
+- `helpers.py`: the `use_cache` decorator for provider/controller methods.
+
+## Design Notes
+
+- There is no in-memory cache layer. SQLite with WAL mode, mmap (30GB), a 64MB page cache, and `synchronous=normal` provides fast enough reads for all hot paths. This eliminates the inconsistency where an in-memory cache would return Python objects while the database returned deserialized dicts.
+- All data passes through `json_dumps` on write and `json_loads` on read. This means callers must use `.to_dict()` before storing model objects and `.from_dict()` (or the `base_class` parameter) after retrieval. The `use_cache` decorator handles this automatically using type annotations and the `parse_value` helper.
+- Cache entries are namespaced by `(category, provider, key)`. The `category` is an integer, `provider` and `key` are strings.
+- Entries with `persistent=True` survive calls to `clear()` unless `include_persistent=True` is passed.
+- The `BYPASS_CACHE` context variable, managed through `handle_refresh()`, forces cache misses for the duration of a context — useful for refresh operations.
+- A daily cleanup task removes expired entries. Oversized databases (>2GB) are removed entirely on startup.

--- a/music_assistant/controllers/cache/README.md
+++ b/music_assistant/controllers/cache/README.md
@@ -21,7 +21,7 @@ This package provides a centralized caching layer backed by SQLite. All data sto
 ## Design Notes
 
 - There is no in-memory cache layer. SQLite with WAL mode, mmap (30GB), a 64MB page cache, and `synchronous=normal` provides fast enough reads for all hot paths. This eliminates the inconsistency where an in-memory cache would return Python objects while the database returned deserialized dicts.
-- All data passes through `json_dumps` on write and `json_loads` on read. This means callers must use `.to_dict()` before storing model objects and `.from_dict()` (or the `base_class` parameter) after retrieval. The `use_cache` decorator handles this automatically using type annotations and the `parse_value` helper.
+- All data passes through `json_dumps` on write and `json_loads` on read. This means callers must use `.to_dict()` before storing model objects and `.from_dict()` (or the `base_class` parameter) after retrieval. Both `cache.get()` and the `use_cache` decorator accept a `base_class` parameter for automatic reconstruction.
 - Cache entries are namespaced by `(category, provider, key)`. The `category` is an integer, `provider` and `key` are strings.
 - Entries with `persistent=True` survive calls to `clear()` unless `include_persistent=True` is passed.
 - The `BYPASS_CACHE` context variable, managed through `handle_refresh()`, forces cache misses for the duration of a context — useful for refresh operations.

--- a/music_assistant/controllers/cache/__init__.py
+++ b/music_assistant/controllers/cache/__init__.py
@@ -1,0 +1,21 @@
+"""Cache controller package."""
+
+from __future__ import annotations
+
+from .constants import (
+    BYPASS_CACHE,
+    DEFAULT_CACHE_EXPIRATION,
+    MAX_CACHE_DB_SIZE_MB,
+    SerializableType,
+)
+from .controller import CacheController
+from .helpers import use_cache
+
+__all__ = [
+    "BYPASS_CACHE",
+    "DEFAULT_CACHE_EXPIRATION",
+    "MAX_CACHE_DB_SIZE_MB",
+    "CacheController",
+    "SerializableType",
+    "use_cache",
+]

--- a/music_assistant/controllers/cache/constants.py
+++ b/music_assistant/controllers/cache/constants.py
@@ -20,5 +20,5 @@ BYPASS_CACHE: ContextVar[bool] = ContextVar("BYPASS_CACHE", default=False)
 # Type alias for data that can be stored in the cache.
 # Only JSON-serializable types are accepted - storing model objects directly
 # is not allowed as the cache always serializes/deserializes through JSON.
-# Note: tuples are not valid because JSON round-trips convert them to lists.
-SerializableType = str | int | float | bool | None | list[Any] | dict[str, Any]
+# Note: tuples are accepted but will be returned as lists after JSON round-trip.
+SerializableType = str | int | float | bool | None | list[Any] | tuple[Any, ...] | dict[str, Any]

--- a/music_assistant/controllers/cache/constants.py
+++ b/music_assistant/controllers/cache/constants.py
@@ -1,0 +1,24 @@
+"""Constants for the cache controller."""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+from typing import Any
+
+from music_assistant.constants import MASS_LOGGER_NAME
+
+LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.cache")
+CONF_CLEAR_CACHE = "clear_cache"
+DEFAULT_CACHE_EXPIRATION = 86400 * 30  # 30 days
+DB_SCHEMA_VERSION = 7
+MAX_CACHE_DB_SIZE_MB = 2048
+CACHE_DATABASE_CLEANUP_TASK_ID = "cache_database_cleanup"
+
+BYPASS_CACHE: ContextVar[bool] = ContextVar("BYPASS_CACHE", default=False)
+
+# Type alias for data that can be stored in the cache.
+# Only JSON-serializable types are accepted - storing model objects directly
+# is not allowed as the cache always serializes/deserializes through JSON.
+# Note: tuples are not valid because JSON round-trips convert them to lists.
+SerializableType = str | int | float | bool | None | list[Any] | dict[str, Any]

--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -1,28 +1,34 @@
-"""Provides a simple stateless caching system."""
+"""Cache controller implementation."""
 
 from __future__ import annotations
 
 import asyncio
-import functools
-import logging
 import os
 import time
-from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from contextvars import ContextVar
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar, cast, get_type_hints
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType
 
-from music_assistant.constants import DB_TABLE_CACHE, DB_TABLE_SETTINGS, MASS_LOGGER_NAME
+from music_assistant.constants import DB_TABLE_CACHE, DB_TABLE_SETTINGS
+from music_assistant.controllers.cache.constants import (
+    BYPASS_CACHE,
+    CACHE_DATABASE_CLEANUP_TASK_ID,
+    CONF_CLEAR_CACHE,
+    DB_SCHEMA_VERSION,
+    DEFAULT_CACHE_EXPIRATION,
+    LOGGER,
+    MAX_CACHE_DB_SIZE_MB,
+    SerializableType,
+)
 from music_assistant.controllers.tasks.context import (
     update_current_task_progress_from_index,
     update_current_task_progress_text,
 )
-from music_assistant.helpers.api import parse_value
 from music_assistant.helpers.database import DatabaseConnection
 from music_assistant.helpers.datetime import local_clock_time_to_utc
 from music_assistant.helpers.json import async_json_loads, json_dumps
@@ -32,22 +38,6 @@ if TYPE_CHECKING:
     from music_assistant_models.config_entries import CoreConfig
 
     from music_assistant import MusicAssistant
-    from music_assistant.models.provider import Provider
-
-LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.cache")
-CONF_CLEAR_CACHE = "clear_cache"
-DEFAULT_CACHE_EXPIRATION = 86400 * 30  # 30 days
-DB_SCHEMA_VERSION = 7
-MAX_CACHE_DB_SIZE_MB = 2048
-CACHE_DATABASE_CLEANUP_TASK_ID = "cache_database_cleanup"
-
-BYPASS_CACHE: ContextVar[bool] = ContextVar("BYPASS_CACHE", default=False)
-
-# Type alias for data that can be stored in the cache.
-# Only JSON-serializable types are accepted - storing model objects directly
-# is not allowed as the cache always serializes/deserializes through JSON.
-# Note: tuples are not valid because JSON round-trips convert them to lists.
-SerializableType = str | int | float | bool | None | list[Any] | dict[str, Any]
 
 
 class CacheController(CoreController):
@@ -437,69 +427,3 @@ class CacheController(CoreController):
             metadata={"task_domain": "cache_database_cleanup"},
             allow_retry=True,
         )
-
-
-Param = ParamSpec("Param")
-RetType = TypeVar("RetType")
-
-
-ProviderT = TypeVar("ProviderT", bound="Provider | CoreController")
-P = ParamSpec("P")
-R = TypeVar("R")
-
-
-def use_cache(
-    expiration: int = DEFAULT_CACHE_EXPIRATION,
-    category: int = 0,
-    persistent: bool = False,
-    cache_checksum: str | None = None,
-    allow_bypass: bool = True,
-) -> Callable[
-    [Callable[Concatenate[ProviderT, P], Awaitable[R]]],
-    Callable[Concatenate[ProviderT, P], Coroutine[Any, Any, R]],
-]:
-    """Return decorator that can be used to cache a method's result."""
-
-    def _decorator(
-        func: Callable[Concatenate[ProviderT, P], Awaitable[R]],
-    ) -> Callable[Concatenate[ProviderT, P], Coroutine[Any, Any, R]]:
-        @functools.wraps(func)
-        async def wrapper(self: ProviderT, *args: P.args, **kwargs: P.kwargs) -> R:
-            cache = self.mass.cache
-            provider_id = getattr(self, "instance_id", self.domain)
-
-            # create a cache key dynamically based on the (remaining) args/kwargs
-            cache_key_parts = [func.__name__, *args]
-            for key in sorted(kwargs.keys()):
-                cache_key_parts.append(f"{key}{kwargs[key]}")
-            cache_key = ".".join(map(str, cache_key_parts))
-            # try to retrieve data from the cache
-            cachedata = await cache.get(
-                cache_key,
-                provider=provider_id,
-                checksum=cache_checksum,
-                category=category,
-                allow_bypass=allow_bypass,
-            )
-            if cachedata is not None:
-                type_hints = get_type_hints(func)
-                return cast("R", parse_value(func.__name__, cachedata, type_hints["return"]))
-            # get data from method/provider
-            result = await func(self, *args, **kwargs)
-            # store result in cache (but don't await)
-            self.mass.create_task(
-                cache.set(
-                    key=cache_key,
-                    data=cast("SerializableType", result),
-                    expiration=expiration,
-                    provider=provider_id,
-                    category=category,
-                    checksum=cache_checksum,
-                    persistent=persistent,
-                )
-            )
-            return result
-
-        return wrapper
-
-    return _decorator

--- a/music_assistant/controllers/cache/helpers.py
+++ b/music_assistant/controllers/cache/helpers.py
@@ -25,11 +25,23 @@ def use_cache(
     persistent: bool = False,
     cache_checksum: str | None = None,
     allow_bypass: bool = True,
+    base_class: Any = None,
 ) -> Callable[
     [Callable[Concatenate[ProviderT, P], Awaitable[R]]],
     Callable[Concatenate[ProviderT, P], Coroutine[Any, Any, R]],
 ]:
-    """Return decorator that can be used to cache a method's result."""
+    """
+    Return decorator that can be used to cache a method's result.
+
+    :param expiration: Time in seconds the cache entry should be valid.
+    :param category: Category to group cache objects.
+    :param persistent: If True, the entry survives cache clears.
+    :param cache_checksum: Optional checksum to store with the cache object.
+    :param allow_bypass: Whether to respect the BYPASS_CACHE context variable.
+    :param base_class: If provided, reconstruct cached data using base_class.from_dict().
+        Handles both single dicts and lists of dicts automatically.
+        If not provided, falls back to type-annotation based reconstruction.
+    """
 
     def _decorator(
         func: Callable[Concatenate[ProviderT, P], Awaitable[R]],
@@ -51,8 +63,12 @@ def use_cache(
                 checksum=cache_checksum,
                 category=category,
                 allow_bypass=allow_bypass,
+                base_class=base_class,
             )
             if cachedata is not None:
+                if base_class is not None:
+                    return cast("R", cachedata)
+                # fallback: reconstruct using type annotations
                 type_hints = get_type_hints(func)
                 return cast("R", parse_value(func.__name__, cachedata, type_hints["return"]))
             # get data from method/provider

--- a/music_assistant/controllers/cache/helpers.py
+++ b/music_assistant/controllers/cache/helpers.py
@@ -1,0 +1,76 @@
+"""Helper utilities for the cache controller."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar, cast, get_type_hints
+
+from music_assistant.controllers.cache.constants import DEFAULT_CACHE_EXPIRATION, SerializableType
+from music_assistant.helpers.api import parse_value
+
+if TYPE_CHECKING:
+    from music_assistant.models.core_controller import CoreController
+    from music_assistant.models.provider import Provider
+
+
+ProviderT = TypeVar("ProviderT", bound="Provider | CoreController")
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def use_cache(
+    expiration: int = DEFAULT_CACHE_EXPIRATION,
+    category: int = 0,
+    persistent: bool = False,
+    cache_checksum: str | None = None,
+    allow_bypass: bool = True,
+) -> Callable[
+    [Callable[Concatenate[ProviderT, P], Awaitable[R]]],
+    Callable[Concatenate[ProviderT, P], Coroutine[Any, Any, R]],
+]:
+    """Return decorator that can be used to cache a method's result."""
+
+    def _decorator(
+        func: Callable[Concatenate[ProviderT, P], Awaitable[R]],
+    ) -> Callable[Concatenate[ProviderT, P], Coroutine[Any, Any, R]]:
+        @functools.wraps(func)
+        async def wrapper(self: ProviderT, *args: P.args, **kwargs: P.kwargs) -> R:
+            cache = self.mass.cache
+            provider_id = getattr(self, "instance_id", self.domain)
+
+            # create a cache key dynamically based on the (remaining) args/kwargs
+            cache_key_parts = [func.__name__, *args]
+            for key in sorted(kwargs.keys()):
+                cache_key_parts.append(f"{key}{kwargs[key]}")
+            cache_key = ".".join(map(str, cache_key_parts))
+            # try to retrieve data from the cache
+            cachedata = await cache.get(
+                cache_key,
+                provider=provider_id,
+                checksum=cache_checksum,
+                category=category,
+                allow_bypass=allow_bypass,
+            )
+            if cachedata is not None:
+                type_hints = get_type_hints(func)
+                return cast("R", parse_value(func.__name__, cachedata, type_hints["return"]))
+            # get data from method/provider
+            result = await func(self, *args, **kwargs)
+            # store result in cache (but don't await)
+            self.mass.create_task(
+                cache.set(
+                    key=cache_key,
+                    data=cast("SerializableType", result),
+                    expiration=expiration,
+                    provider=provider_id,
+                    category=category,
+                    checksum=cache_checksum,
+                    persistent=persistent,
+                )
+            )
+            return result
+
+        return wrapper
+
+    return _decorator

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -312,7 +312,7 @@ class MusicController(CoreController):
         if cache := await self.mass.cache.get(
             key=cache_key, provider=self.domain, category=CACHE_CATEGORY_SEARCH_RESULTS
         ):
-            return cache
+            return SearchResults.from_dict(cache)
         if not media_types:
             media_types = MediaType.ALL
         # Check if the search query is a streaming provider public shareable URL
@@ -444,7 +444,7 @@ class MusicController(CoreController):
         result.podcasts = self._sort_search_result(search_query, result.podcasts)
         await self.mass.cache.set(
             key=cache_key,
-            data=result,
+            data=result.to_dict(),
             expiration=600,
             provider=self.domain,
             category=CACHE_CATEGORY_SEARCH_RESULTS,

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -310,9 +310,12 @@ class MusicController(CoreController):
         cache_provider_key = "library" if library_only else ",".join(search_providers)
         cache_key = f"{search_query}{'-'.join(sorted([mt.value for mt in media_types]))}-{limit}-{library_only}-{cache_provider_key}"
         if cache := await self.mass.cache.get(
-            key=cache_key, provider=self.domain, category=CACHE_CATEGORY_SEARCH_RESULTS
+            key=cache_key,
+            provider=self.domain,
+            category=CACHE_CATEGORY_SEARCH_RESULTS,
+            base_class=SearchResults,
         ):
-            return SearchResults.from_dict(cache)
+            return cache
         if not media_types:
             media_types = MediaType.ALL
         # Check if the search query is a streaming provider public shareable URL

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1287,34 +1287,13 @@ class PlayerQueuesController(CoreController):
                     category=CACHE_CATEGORY_PLAYER_QUEUE_ITEMS,
                     default=[],
                 )
-                queue_items = []
-                for idx, item_data in enumerate(prev_items):
-                    qi = QueueItem.from_cache(item_data)
-                    if not qi.media_item:
-                        # Skip items with missing media_item - this can happen if
-                        # MA was killed during shutdown while cache was being written
-                        self.logger.debug(
-                            "Skipping queue item %s (index %d) restored from cache "
-                            "without media_item",
-                            qi.name,
-                            idx,
-                        )
-                        continue
-                    queue_items.append(qi)
+                queue_items = [QueueItem.from_cache(item_data) for item_data in prev_items]
                 if queue.enqueued_media_items:
-                    # we need to restore the MediaItem objects for the enqueued media items
-                    # Items from cache may be dicts that need deserialization
-                    restored_enqueued_items: list[MediaItemType] = []
-                    cached_items: list[dict[str, Any] | MediaItemType] = cast(
-                        "list[dict[str, Any] | MediaItemType]", queue.enqueued_media_items
-                    )
-                    for item in cached_items:
-                        if isinstance(item, dict):
-                            restored_item = media_from_dict(item)
-                            restored_enqueued_items.append(cast("MediaItemType", restored_item))
-                        else:
-                            restored_enqueued_items.append(item)
-                    queue.enqueued_media_items = restored_enqueued_items
+                    # after deserialization from cache, enqueued_media_items are dicts
+                    queue.enqueued_media_items = [
+                        cast("MediaItemType", media_from_dict(cast("dict[str, Any]", item)))
+                        for item in queue.enqueued_media_items
+                    ]
             except Exception as err:
                 self.logger.warning(
                     "Failed to restore the queue(items) for %s - %s",

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -557,7 +557,7 @@ class StreamsAudio:
         cache_expiration = 3600 * 3
         await mass.cache.set(
             url,
-            result,
+            [resolved_url, stream_type],
             expiration=cache_expiration,
             provider=CACHE_PROVIDER,
             category=CACHE_CATEGORY_RESOLVED_RADIO_URL,

--- a/music_assistant/providers/bandcamp/__init__.py
+++ b/music_assistant/providers/bandcamp/__init__.py
@@ -728,12 +728,9 @@ class BandcampProvider(MusicProvider):
         :param person_id: Person to query. None = authenticated user.
         """
         cache_key = f"_browse_person_following_{person_id}"
-        cached = await self.mass.cache.get(cache_key, provider=self.instance_id)
+        cached = await self.mass.cache.get(cache_key, provider=self.instance_id, base_class=Artist)
         if cached is not None:
-            try:
-                return [Artist.from_dict(a) for a in cached]
-            except (LookupError, ValueError, UnserializableDataError, InvalidDataError):
-                self.logger.warning("Stale cache for %s, fetching fresh", cache_key)
+            return cached  # type: ignore[no-any-return]
         artists: list[Artist] = []
         async with self._map_api_errors(f"Failed to get following for person {person_id}"):
             collection = await self._get_all_collection_items(
@@ -769,19 +766,16 @@ class BandcampProvider(MusicProvider):
         """
         # base_path included intentionally: folder links differ per navigation path.
         cache_key = f"_browse_person_people_{person_id}_{collection_type.value}_{base_path}"
-        cached = await self.mass.cache.get(cache_key, provider=self.instance_id)
+        cached = await self.mass.cache.get(
+            cache_key, provider=self.instance_id, base_class=BrowseFolder
+        )
         if cached is not None:
-            try:
-                folders = [BrowseFolder.from_dict(f) for f in cached]
-            except (LookupError, ValueError, UnserializableDataError, InvalidDataError):
-                self.logger.warning("Stale cache for %s, fetching fresh", cache_key)
-            else:
-                for folder in folders:
-                    segment = folder.path.rstrip("/").rsplit("/", 1)[-1]
-                    fan_id_str = folder.item_id.removeprefix("person_")
-                    with suppress(ValueError):
-                        self._slug_to_fan_id[segment] = int(fan_id_str)
-                return folders
+            for folder in cached:
+                segment = folder.path.rstrip("/").rsplit("/", 1)[-1]
+                fan_id_str = folder.item_id.removeprefix("person_")
+                with suppress(ValueError):
+                    self._slug_to_fan_id[segment] = int(fan_id_str)
+            return cached  # type: ignore[no-any-return]
         context = f"Failed to get {collection_type.value} for person {person_id}"
         async with self._map_api_errors(context):
             collection = await self._get_all_collection_items(collection_type, fan_id=person_id)

--- a/music_assistant/providers/bandcamp/__init__.py
+++ b/music_assistant/providers/bandcamp/__init__.py
@@ -678,10 +678,8 @@ class BandcampProvider(MusicProvider):
             raise MediaNotFoundError(context) from error
 
     @staticmethod
-    def _deserialize_content_item(item: dict[str, object] | Album | Track) -> Album | Track:
+    def _deserialize_content_item(item: dict[str, object]) -> Album | Track:
         """Deserialize a cached content item back to its model type."""
-        if not isinstance(item, dict):
-            return item
         media_type = item.get("media_type")
         if media_type == MediaType.ALBUM:
             return Album.from_dict(item)
@@ -717,7 +715,7 @@ class BandcampProvider(MusicProvider):
                         results.append(await self.get_track(f"{item.band_id}-0-{item.item_id}"))
         await self.mass.cache.set(
             cache_key,
-            results,
+            [item.to_dict() for item in results],
             expiration=CACHE_USER_LISTS if results else CACHE_EMPTY_RESULTS,
             provider=self.instance_id,
         )
@@ -733,7 +731,7 @@ class BandcampProvider(MusicProvider):
         cached = await self.mass.cache.get(cache_key, provider=self.instance_id)
         if cached is not None:
             try:
-                return [Artist.from_dict(a) if isinstance(a, dict) else a for a in cached]
+                return [Artist.from_dict(a) for a in cached]
             except (LookupError, ValueError, UnserializableDataError, InvalidDataError):
                 self.logger.warning("Stale cache for %s, fetching fresh", cache_key)
         artists: list[Artist] = []
@@ -750,7 +748,7 @@ class BandcampProvider(MusicProvider):
                     )
         await self.mass.cache.set(
             cache_key,
-            artists,
+            [a.to_dict() for a in artists],
             expiration=CACHE_USER_LISTS if artists else CACHE_EMPTY_RESULTS,
             provider=self.instance_id,
         )
@@ -774,7 +772,7 @@ class BandcampProvider(MusicProvider):
         cached = await self.mass.cache.get(cache_key, provider=self.instance_id)
         if cached is not None:
             try:
-                folders = [BrowseFolder.from_dict(f) if isinstance(f, dict) else f for f in cached]
+                folders = [BrowseFolder.from_dict(f) for f in cached]
             except (LookupError, ValueError, UnserializableDataError, InvalidDataError):
                 self.logger.warning("Stale cache for %s, fetching fresh", cache_key)
             else:
@@ -790,7 +788,7 @@ class BandcampProvider(MusicProvider):
             folders = self._people_to_folders(collection, base_path)
         await self.mass.cache.set(
             cache_key,
-            folders,
+            [f.to_dict() for f in folders],
             expiration=CACHE_USER_LISTS if folders else CACHE_EMPTY_RESULTS,
             provider=self.instance_id,
         )

--- a/music_assistant/providers/bbc_sounds/__init__.py
+++ b/music_assistant/providers/bbc_sounds/__init__.py
@@ -10,6 +10,7 @@ FIXME skipping in non-live radio shows restarts the stream but keeps the seek ti
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from collections.abc import AsyncGenerator
 from datetime import timedelta
 from typing import TYPE_CHECKING, Literal
@@ -312,18 +313,21 @@ class BBCSoundsProvider(MusicProvider):
 
     async def _get_programme_segments(self, vpid: str) -> list[Segment] | None:
         """Get on demand segments from cache or API."""
-        segments = await self.mass.cache.get(
+        cached = await self.mass.cache.get(
             provider=self.domain, key=f"programme_segments_{vpid}", default=False
         )
-        if segments is False:
+        if cached is False:
             segments = await self.client.streaming.get_show_segments(vpid)
-            await self.mass.cache.set(
-                provider=self.domain,
-                key=f"programme_segments_{vpid}",
-                data=segments,
-            )
-        if isinstance(segments, list):
-            return segments
+            if isinstance(segments, list):
+                await self.mass.cache.set(
+                    provider=self.domain,
+                    key=f"programme_segments_{vpid}",
+                    data=[dataclasses.asdict(s) for s in segments],
+                )
+                return segments
+            return None
+        if isinstance(cached, list):
+            return [Segment(**item) for item in cached]
         return None
 
     async def _update_on_demand_stream_metadata(

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -722,9 +722,10 @@ class LocalFileSystemProvider(MusicProvider):
             provider=self.instance_id,
             checksum=cache_checksum,
             category=0,
+            base_class=Track,
         )
         if cached_data is not None:
-            return [Track.from_dict(track_dict) for track_dict in cached_data]
+            return cached_data  # type: ignore[no-any-return]
 
         _, ext = prov_playlist_id.rsplit(".", 1)
         try:
@@ -1092,10 +1093,13 @@ class LocalFileSystemProvider(MusicProvider):
         # prefer (short lived) cache for a bit more speed
         if artist_path and (
             cache := await self.cache.get(
-                key=artist_path, provider=self.instance_id, category=CACHE_CATEGORY_ARTIST_INFO
+                key=artist_path,
+                provider=self.instance_id,
+                category=CACHE_CATEGORY_ARTIST_INFO,
+                base_class=Artist,
             )
         ):
-            return Artist.from_dict(cache)
+            return cache  # type: ignore[no-any-return]
 
         prov_artist_id = artist_path or name
         artist = Artist(
@@ -1436,9 +1440,10 @@ class LocalFileSystemProvider(MusicProvider):
                 key=album_dir,
                 provider=self.instance_id,
                 category=CACHE_CATEGORY_ALBUM_INFO,
+                base_class=Album,
             )
         ):
-            return Album.from_dict(cache)
+            return cache  # type: ignore[no-any-return]
 
         # album artist(s)
         album_artists: UniqueList[Artist | ItemMapping] = UniqueList()
@@ -1597,10 +1602,13 @@ class LocalFileSystemProvider(MusicProvider):
         """Return local images found in a given folderpath."""
         if (
             cache := await self.cache.get(
-                key=folder, provider=self.instance_id, category=CACHE_CATEGORY_FOLDER_IMAGES
+                key=folder,
+                provider=self.instance_id,
+                category=CACHE_CATEGORY_FOLDER_IMAGES,
+                base_class=MediaItemImage,
             )
         ) is not None:
-            return UniqueList(MediaItemImage.from_dict(img) for img in cache)
+            return UniqueList(cache)
         if extra_thumb_names is None:
             extra_thumb_names = ()
         images: UniqueList[MediaItemImage] = UniqueList()

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -724,9 +724,7 @@ class LocalFileSystemProvider(MusicProvider):
             category=0,
         )
         if cached_data is not None:
-            if cached_data and isinstance(cached_data[0], dict):
-                return [Track.from_dict(track_dict) for track_dict in cached_data]
-            return cast("list[Track]", cached_data)
+            return [Track.from_dict(track_dict) for track_dict in cached_data]
 
         _, ext = prov_playlist_id.rsplit(".", 1)
         try:
@@ -761,7 +759,7 @@ class LocalFileSystemProvider(MusicProvider):
 
         await self.mass.cache.set(
             key=cache_key,
-            data=result,
+            data=[track.to_dict() for track in result],
             expiration=3600 * 24,  # Cache for 24 hours
             provider=self.instance_id,
             checksum=cache_checksum,
@@ -1097,7 +1095,7 @@ class LocalFileSystemProvider(MusicProvider):
                 key=artist_path, provider=self.instance_id, category=CACHE_CATEGORY_ARTIST_INFO
             )
         ):
-            return cast("Artist", cache)
+            return Artist.from_dict(cache)
 
         prov_artist_id = artist_path or name
         artist = Artist(
@@ -1152,7 +1150,7 @@ class LocalFileSystemProvider(MusicProvider):
 
         await self.cache.set(
             key=artist_path,
-            data=artist,
+            data=artist.to_dict(),
             provider=self.instance_id,
             category=CACHE_CATEGORY_ARTIST_INFO,
             expiration=120,
@@ -1440,7 +1438,7 @@ class LocalFileSystemProvider(MusicProvider):
                 category=CACHE_CATEGORY_ALBUM_INFO,
             )
         ):
-            return cast("Album", cache)
+            return Album.from_dict(cache)
 
         # album artist(s)
         album_artists: UniqueList[Artist | ItemMapping] = UniqueList()
@@ -1586,7 +1584,7 @@ class LocalFileSystemProvider(MusicProvider):
                     album.metadata.images += images
         await self.cache.set(
             key=album_dir,
-            data=album,
+            data=album.to_dict(),
             provider=self.instance_id,
             category=CACHE_CATEGORY_ALBUM_INFO,
             expiration=120,
@@ -1602,7 +1600,7 @@ class LocalFileSystemProvider(MusicProvider):
                 key=folder, provider=self.instance_id, category=CACHE_CATEGORY_FOLDER_IMAGES
             )
         ) is not None:
-            return cast("UniqueList[MediaItemImage]", cache)
+            return UniqueList(MediaItemImage.from_dict(img) for img in cache)
         if extra_thumb_names is None:
             extra_thumb_names = ()
         images: UniqueList[MediaItemImage] = UniqueList()
@@ -1644,7 +1642,7 @@ class LocalFileSystemProvider(MusicProvider):
 
         await self.cache.set(
             key=folder,
-            data=images,
+            data=[img.to_dict() for img in images],
             provider=self.instance_id,
             category=CACHE_CATEGORY_FOLDER_IMAGES,
             expiration=120,

--- a/music_assistant/providers/gpodder/__init__.py
+++ b/music_assistant/providers/gpodder/__init__.py
@@ -660,5 +660,5 @@ class GPodder(MusicProvider):
             key=CACHE_KEY_FEEDS,
             provider=self.instance_id,
             category=CACHE_CATEGORY_OTHER,
-            data=self.feeds,
+            data=list(self.feeds),
         )

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -14,6 +14,7 @@ from libopensonic.errors import (
     ParameterError,
     SonicError,
 )
+from libopensonic.media import PodcastChannel
 from music_assistant_models.enums import ContentType, MediaType, StreamType
 from music_assistant_models.errors import (
     ActionUnavailable,
@@ -67,7 +68,7 @@ if TYPE_CHECKING:
     from libopensonic.media import Bookmark as SonicBookmark
     from libopensonic.media import Child as SonicItem
     from libopensonic.media import Lyrics as SonicLyrics
-    from libopensonic.media import OpenSubsonicExtension, PodcastChannel, StructuredLyrics
+    from libopensonic.media import OpenSubsonicExtension, StructuredLyrics
     from libopensonic.media import Playlist as SonicPlaylist
     from libopensonic.media import PodcastEpisode as SonicEpisode
 
@@ -787,13 +788,14 @@ class OpenSonicProvider(MusicProvider):
             key=chan_id,
             provider=self.instance_id,
             category=CACHE_CATEGORY_PODCAST_CHANNEL,
+            base_class=PodcastChannel,
         ):
             return cache
         if channels := await self.conn.get_podcasts(inc_episodes=True, pid=chan_id):
             channel = channels[0]
             await self.mass.cache.set(
                 key=chan_id,
-                data=channel,
+                data=channel.to_dict(),
                 provider=self.instance_id,
                 expiration=600,
                 category=CACHE_CATEGORY_PODCAST_CHANNEL,

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -180,7 +180,7 @@ class SqueezelitePlayer(Player):
         # store last state in cache
         await self.mass.cache.set(
             key=self.player_id,
-            data=(powered, self.client.volume_level),
+            data=[powered, self.client.volume_level],
             provider=self.provider.instance_id,
             category=CACHE_CATEGORY_PREV_STATE,
         )
@@ -191,7 +191,7 @@ class SqueezelitePlayer(Player):
         # store last state in cache
         await self.mass.cache.set(
             key=self.player_id,
-            data=(self.client.powered, volume_level),
+            data=[self.client.powered, volume_level],
             provider=self.provider.instance_id,
             category=CACHE_CATEGORY_PREV_STATE,
         )

--- a/tests/core/test_cache_controller.py
+++ b/tests/core/test_cache_controller.py
@@ -1,4 +1,4 @@
-"""Tests for cache controller oversized cache detection and reset."""
+"""Tests for cache controller."""
 
 import os
 from collections.abc import Callable
@@ -8,8 +8,15 @@ from unittest.mock import AsyncMock, patch
 import aiofiles
 import pytest
 
-from music_assistant.controllers.cache import MAX_CACHE_DB_SIZE_MB
+from music_assistant.controllers.cache import MAX_CACHE_DB_SIZE_MB, CacheController
 from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture
+async def cache(mass_minimal: MusicAssistant) -> CacheController:
+    """Return an initialized cache controller."""
+    await mass_minimal.cache._setup_database()
+    return mass_minimal.cache
 
 
 async def _create_db_files(cache_path: str) -> list[str]:
@@ -25,11 +32,220 @@ async def _create_db_files(cache_path: str) -> list[str]:
     return paths
 
 
-async def test_cache_reset_when_exceeding_limit(mass_minimal: MusicAssistant) -> None:
-    """Test that the cache database is removed when it exceeds MAX_CACHE_DB_SIZE_MB.
+# --- Core get/set behavior ---
 
-    :param mass_minimal: Minimal MusicAssistant instance.
-    """
+
+async def test_set_and_get_string(cache: CacheController) -> None:
+    """Test storing and retrieving a string value."""
+    await cache.set("test_key", "hello", provider="test")
+    result = await cache.get("test_key", provider="test")
+    assert result == "hello"
+
+
+async def test_set_and_get_int(cache: CacheController) -> None:
+    """Test storing and retrieving an integer value."""
+    await cache.set("num", 42, provider="test")
+    result = await cache.get("num", provider="test")
+    assert result == 42
+
+
+async def test_set_and_get_float(cache: CacheController) -> None:
+    """Test storing and retrieving a float value."""
+    await cache.set("pi", 3.14, provider="test")
+    result = await cache.get("pi", provider="test")
+    assert result == pytest.approx(3.14)
+
+
+async def test_set_and_get_bool(cache: CacheController) -> None:
+    """Test storing and retrieving a boolean value."""
+    await cache.set("flag", True, provider="test")
+    result = await cache.get("flag", provider="test")
+    assert result is True
+
+
+async def test_set_and_get_none(cache: CacheController) -> None:
+    """Test storing and retrieving None."""
+    await cache.set("empty", None, provider="test")
+    result = await cache.get("empty", provider="test", default="MISSING")
+    assert result is None
+
+
+async def test_set_and_get_dict(cache: CacheController) -> None:
+    """Test storing and retrieving a dict value."""
+    data = {"name": "test", "count": 5, "nested": {"a": 1}}
+    await cache.set("dict_key", data, provider="test")
+    result = await cache.get("dict_key", provider="test")
+    assert result == data
+
+
+async def test_set_and_get_list(cache: CacheController) -> None:
+    """Test storing and retrieving a list value."""
+    data = [1, "two", 3.0, None, True]
+    await cache.set("list_key", data, provider="test")
+    result = await cache.get("list_key", provider="test")
+    assert result == data
+
+
+async def test_set_and_get_nested_structure(cache: CacheController) -> None:
+    """Test storing and retrieving a deeply nested structure."""
+    data = {"items": [{"id": 1, "tags": ["a", "b"]}, {"id": 2, "tags": []}]}
+    await cache.set("nested", data, provider="test")
+    result = await cache.get("nested", provider="test")
+    assert result == data
+
+
+# --- JSON serialization guarantees ---
+
+
+async def test_data_always_deserialized_from_json(cache: CacheController) -> None:
+    """Test that data is always returned as JSON-deserialized (no Python objects)."""
+    await cache.set("list_data", [1, 2, 3], provider="test")
+    result = await cache.get("list_data", provider="test")
+    assert isinstance(result, list)
+    assert result == [1, 2, 3]
+
+
+async def test_non_serializable_raises(cache: CacheController) -> None:
+    """Test that non-serializable data raises on set."""
+    with pytest.raises(TypeError):
+        await cache.set("bad", object(), provider="test")  # type: ignore[arg-type]
+
+
+# --- Expiration ---
+
+
+async def test_expired_cache_returns_default(cache: CacheController) -> None:
+    """Test that expired cache entries return the default value."""
+    await cache.set("expiring", "data", provider="test", expiration=-1)
+    result = await cache.get("expiring", provider="test", default="gone")
+    assert result == "gone"
+
+
+# --- Checksum validation ---
+
+
+async def test_checksum_match(cache: CacheController) -> None:
+    """Test that data is returned when checksum matches."""
+    await cache.set("ck", "val", provider="test", checksum="abc")
+    result = await cache.get("ck", provider="test", checksum="abc")
+    assert result == "val"
+
+
+async def test_checksum_mismatch(cache: CacheController) -> None:
+    """Test that default is returned when checksum doesn't match."""
+    await cache.set("ck2", "val", provider="test", checksum="abc")
+    result = await cache.get("ck2", provider="test", checksum="xyz", default="nope")
+    assert result == "nope"
+
+
+async def test_checksum_as_int(cache: CacheController) -> None:
+    """Test that integer checksums are converted to strings."""
+    await cache.set("ck3", "val", provider="test", checksum="123")
+    result = await cache.get("ck3", provider="test", checksum=123)
+    assert result == "val"
+
+
+# --- Category and provider isolation ---
+
+
+async def test_different_providers_isolated(cache: CacheController) -> None:
+    """Test that the same key in different providers returns different data."""
+    await cache.set("key", "from_a", provider="prov_a")
+    await cache.set("key", "from_b", provider="prov_b")
+    assert await cache.get("key", provider="prov_a") == "from_a"
+    assert await cache.get("key", provider="prov_b") == "from_b"
+
+
+async def test_different_categories_isolated(cache: CacheController) -> None:
+    """Test that the same key in different categories returns different data."""
+    await cache.set("key", "cat_1", provider="test", category=1)
+    await cache.set("key", "cat_2", provider="test", category=2)
+    assert await cache.get("key", provider="test", category=1) == "cat_1"
+    assert await cache.get("key", provider="test", category=2) == "cat_2"
+
+
+# --- Delete and clear ---
+
+
+async def test_delete_specific_key(cache: CacheController) -> None:
+    """Test deleting a specific cache entry."""
+    await cache.set("del_me", "data", provider="test")
+    await cache.delete("del_me", provider="test")
+    result = await cache.get("del_me", provider="test", default="gone")
+    assert result == "gone"
+
+
+async def test_clear_removes_entries(cache: CacheController) -> None:
+    """Test that clear removes all non-persistent entries."""
+    await cache.set("a", "1", provider="test")
+    await cache.set("b", "2", provider="test")
+    await cache.clear()
+    assert await cache.get("a", provider="test") is None
+    assert await cache.get("b", provider="test") is None
+
+
+async def test_clear_preserves_persistent(cache: CacheController) -> None:
+    """Test that clear preserves persistent entries."""
+    await cache.set("persist", "keep", provider="test", persistent=True)
+    await cache.set("temp", "drop", provider="test")
+    await cache.clear()
+    assert await cache.get("persist", provider="test") == "keep"
+    assert await cache.get("temp", provider="test") is None
+
+
+async def test_clear_with_provider_filter(cache: CacheController) -> None:
+    """Test that clear with provider filter only removes matching entries."""
+    await cache.set("k", "v1", provider="spotify")
+    await cache.set("k", "v2", provider="tidal")
+    await cache.clear(provider_filter="spotify")
+    assert await cache.get("k", provider="spotify") is None
+    assert await cache.get("k", provider="tidal") == "v2"
+
+
+# --- Bypass ---
+
+
+async def test_bypass_cache(cache: CacheController) -> None:
+    """Test that the bypass context manager skips cache reads."""
+    await cache.set("bypass_key", "data", provider="test")
+    async with cache.handle_refresh(bypass=True):
+        result = await cache.get("bypass_key", provider="test", default="bypassed")
+    assert result == "bypassed"
+    # outside bypass, cache should still work
+    result = await cache.get("bypass_key", provider="test")
+    assert result == "data"
+
+
+# --- Overwrite ---
+
+
+async def test_overwrite_existing_key(cache: CacheController) -> None:
+    """Test that setting the same key overwrites the previous value."""
+    await cache.set("ow", "old", provider="test")
+    await cache.set("ow", "new", provider="test")
+    assert await cache.get("ow", provider="test") == "new"
+
+
+# --- Empty key handling ---
+
+
+async def test_get_with_empty_key_raises(cache: CacheController) -> None:
+    """Test that getting with empty key raises."""
+    with pytest.raises(AssertionError):
+        await cache.get("", provider="test")
+
+
+async def test_set_with_empty_key_is_noop(cache: CacheController) -> None:
+    """Test that setting with empty key is silently ignored."""
+    await cache.set("", "data", provider="test")
+    # should not raise, just be a no-op
+
+
+# --- Oversized cache detection ---
+
+
+async def test_cache_reset_when_exceeding_limit(mass_minimal: MusicAssistant) -> None:
+    """Test that the cache database is removed when it exceeds MAX_CACHE_DB_SIZE_MB."""
     cache = mass_minimal.cache
     db_files = await _create_db_files(mass_minimal.cache_path)
 
@@ -49,10 +265,7 @@ async def test_cache_reset_when_exceeding_limit(mass_minimal: MusicAssistant) ->
 
 
 async def test_cache_not_reset_when_under_limit(mass_minimal: MusicAssistant) -> None:
-    """Test that the cache database is kept when it is under MAX_CACHE_DB_SIZE_MB.
-
-    :param mass_minimal: Minimal MusicAssistant instance.
-    """
+    """Test that the cache database is kept when it is under MAX_CACHE_DB_SIZE_MB."""
     cache = mass_minimal.cache
     db_files = await _create_db_files(mass_minimal.cache_path)
 
@@ -72,24 +285,18 @@ async def test_cache_not_reset_when_under_limit(mass_minimal: MusicAssistant) ->
 
 
 async def test_all_three_db_files_included_in_size(mass_minimal: MusicAssistant) -> None:
-    """Test that cache.db, cache.db-wal, and cache.db-shm are all summed for size check.
-
-    :param mass_minimal: Minimal MusicAssistant instance.
-    """
+    """Test that cache.db, cache.db-wal, and cache.db-shm are all summed for size check."""
     cache = mass_minimal.cache
     db_path = os.path.join(mass_minimal.cache_path, "cache.db")
 
-    # Create 3 files of 100 bytes each (300 bytes total)
     for suffix in ("", "-wal", "-shm"):
         async with aiofiles.open(db_path + suffix, "wb") as f:
             await f.write(b"\0" * 100)
 
-    # Set threshold to ~200 bytes so 2 files pass but 3 files exceed it
     size_threshold_mb = 0.0002
     with patch("music_assistant.controllers.cache.MAX_CACHE_DB_SIZE_MB", size_threshold_mb):
         result = await cache._check_and_reset_oversized_cache()
 
-    # 300 bytes exceeds the ~200 byte threshold, proving all 3 files are summed
     assert result is True
     assert not os.path.exists(db_path)
     assert not os.path.exists(db_path + "-wal")
@@ -100,11 +307,7 @@ async def test_skip_migration_when_cache_reset(
     mass_minimal: MusicAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that database migration is skipped when the cache was reset.
-
-    :param mass_minimal: Minimal MusicAssistant instance.
-    :param caplog: Log capture fixture.
-    """
+    """Test that database migration is skipped when the cache was reset."""
     cache = mass_minimal.cache
 
     with patch.object(cache, "_check_and_reset_oversized_cache", return_value=True):
@@ -117,11 +320,7 @@ async def test_skip_vacuum_when_cache_reset(
     mass_minimal: MusicAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that database vacuum is skipped when the cache was reset.
-
-    :param mass_minimal: Minimal MusicAssistant instance.
-    :param caplog: Log capture fixture.
-    """
+    """Test that database vacuum is skipped when the cache was reset."""
     cache = mass_minimal.cache
 
     with patch.object(cache, "_check_and_reset_oversized_cache", return_value=True):

--- a/tests/core/test_cache_controller.py
+++ b/tests/core/test_cache_controller.py
@@ -2,6 +2,7 @@
 
 import os
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -10,6 +11,19 @@ import pytest
 
 from music_assistant.controllers.cache import MAX_CACHE_DB_SIZE_MB, CacheController
 from music_assistant.mass import MusicAssistant
+
+
+@dataclass
+class _FakeModel:
+    """Simple model for testing base_class reconstruction."""
+
+    name: str = ""
+    value: int = 0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "_FakeModel":
+        """Reconstruct from dict."""
+        return cls(name=data.get("name", ""), value=data.get("value", 0))
 
 
 @pytest.fixture
@@ -103,6 +117,32 @@ async def test_data_always_deserialized_from_json(cache: CacheController) -> Non
     result = await cache.get("list_data", provider="test")
     assert isinstance(result, list)
     assert result == [1, 2, 3]
+
+
+async def test_base_class_single_dict(cache: CacheController) -> None:
+    """Test that base_class reconstructs a single dict into a model."""
+    await cache.set("model", {"name": "test", "value": 42}, provider="test")
+    result = await cache.get("model", provider="test", base_class=_FakeModel)
+    assert isinstance(result, _FakeModel)
+    assert result.name == "test"
+    assert result.value == 42
+
+
+async def test_base_class_list_of_dicts(cache: CacheController) -> None:
+    """Test that base_class reconstructs each item in a list of dicts."""
+    await cache.set("models", [{"name": "a"}, {"name": "b"}], provider="test")
+    result = await cache.get("models", provider="test", base_class=_FakeModel)
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(item, _FakeModel) for item in result)
+    assert result[0].name == "a"
+    assert result[1].name == "b"
+
+
+async def test_base_class_not_applied_to_none(cache: CacheController) -> None:
+    """Test that base_class is not applied when cache returns default."""
+    result = await cache.get("nonexistent", provider="test", base_class=_FakeModel)
+    assert result is None
 
 
 async def test_non_serializable_raises(cache: CacheController) -> None:

--- a/tests/core/test_cache_controller.py
+++ b/tests/core/test_cache_controller.py
@@ -334,7 +334,9 @@ async def test_all_three_db_files_included_in_size(mass_minimal: MusicAssistant)
             await f.write(b"\0" * 100)
 
     size_threshold_mb = 0.0002
-    with patch("music_assistant.controllers.cache.MAX_CACHE_DB_SIZE_MB", size_threshold_mb):
+    with patch(
+        "music_assistant.controllers.cache.controller.MAX_CACHE_DB_SIZE_MB", size_threshold_mb
+    ):
         result = await cache._check_and_reset_oversized_cache()
 
     assert result is True

--- a/tests/providers/bandcamp/test_provider.py
+++ b/tests/providers/bandcamp/test_provider.py
@@ -1600,18 +1600,20 @@ async def test_browse_person_following_with_person_id(provider: BandcampProvider
 
 
 async def test_browse_person_following_cache_hit(provider: BandcampProvider) -> None:
-    """Test _browse_person_following deserializes cached dicts back to Artist objects."""
-    cached_items = [
+    """Test _browse_person_following returns cached Artist objects without calling API."""
+    cached_artists = [
         Artist(
             item_id="100",
             provider="bandcamp",
             name="Cached Artist",
             provider_mappings=set(),
-        ).to_dict(),
+        ),
     ]
 
     with (
-        patch.object(provider.mass.cache, "get", new_callable=AsyncMock, return_value=cached_items),
+        patch.object(
+            provider.mass.cache, "get", new_callable=AsyncMock, return_value=cached_artists
+        ),
         patch.object(
             provider, "_get_all_collection_items", new_callable=AsyncMock
         ) as mock_get_collection,
@@ -1644,26 +1646,6 @@ async def test_browse_person_following_skips_not_found(provider: BandcampProvide
         result = await provider._browse_person_following(42)
 
         assert len(result) == 1
-
-
-async def test_browse_person_following_cache_hit_stale_data(
-    provider: BandcampProvider, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test _browse_person_following falls through to API on stale/corrupt cache."""
-    stale_cache = [{"garbage": True}]
-
-    with (
-        patch.object(provider.mass.cache, "get", new_callable=AsyncMock, return_value=stale_cache),
-        patch.object(
-            provider, "_get_all_collection_items", new_callable=AsyncMock
-        ) as mock_get_collection,
-    ):
-        mock_get_collection.return_value = []
-        result = await provider._browse_person_following(42)
-
-        mock_get_collection.assert_called_once()
-        assert result == []
-        assert "Stale cache" in caplog.text
 
 
 # --- _browse_person_people tests ---
@@ -1713,16 +1695,16 @@ async def test_browse_person_people_cache_hit_rebuilds_slugs(
             provider="bandcamp_test",
             path="bandcamp_test://fans/coolslug",
             name="Cool User",
-        ).to_dict(),
+        ),
         BrowseFolder(
             item_id="person_222",
             provider="bandcamp_test",
             path="bandcamp_test://fans/anotherslug",
             name="Another User",
-        ).to_dict(),
+        ),
     ]
 
-    async def fake_cache_get(key: str, **kwargs: object) -> list[dict[str, object]] | None:  # noqa: ARG001
+    async def fake_cache_get(key: str, **kwargs: object) -> list[BrowseFolder] | None:  # noqa: ARG001
         if "_browse_person_people_" in key:
             return cached_folders
         return None
@@ -1742,34 +1724,6 @@ async def test_browse_person_people_cache_hit_rebuilds_slugs(
     assert result[1].name == "Another User"
     assert provider._slug_to_fan_id["coolslug"] == 111
     assert provider._slug_to_fan_id["anotherslug"] == 222
-
-
-async def test_browse_person_people_cache_hit_stale_data(
-    provider: BandcampProvider, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test _browse_person_people falls through to API on stale/corrupt cache."""
-    stale_cache = [{"garbage": True}]
-
-    async def fake_cache_get(key: str, **kwargs: object) -> object:  # noqa: ARG001
-        if "_browse_person_people_" in key:
-            return stale_cache
-        return None
-
-    with (
-        patch.object(provider.mass.cache, "get", new_callable=AsyncMock) as mock_cache_get,
-        patch.object(
-            provider, "_get_all_collection_items", new_callable=AsyncMock
-        ) as mock_get_collection,
-    ):
-        mock_cache_get.side_effect = fake_cache_get
-        mock_get_collection.return_value = []
-        result = await provider._browse_person_people(
-            CollectionType.FOLLOWING_FANS, "bandcamp_test://fans"
-        )
-
-        mock_get_collection.assert_called_once()
-        assert result == []
-        assert "Stale cache" in caplog.text
 
 
 async def test_rebuild_slug_cache_calls_browse_person_people(


### PR DESCRIPTION
Queue items were losing their `media_item` after restarts because the in-memory cache stored full Python objects, but the database serialized them to JSON — and nested model fields didn't survive the round-trip. This caused hundreds of "Skipping queue item ... restored from cache without media_item" warnings on every startup.

- **Removed the in-memory cache layer** — the SQLite database (WAL mode, mmap, 64MB page cache) is fast enough for all paths. This eliminates the inconsistency where memory cache returned Python objects while the DB cache returned deserialized dicts.
- **Cache now always serializes through JSON on write** — non-serializable data (model objects, custom classes) raises immediately instead of silently losing data on restart.
- **Fixed all callers** to explicitly use `.to_dict()` on set and `.from_dict()` on get, removing `isinstance(dict)` workarounds in bandcamp, filesystem_local, and player_queues.
- **Removed the "restored from cache without media_item" workaround** in player_queues — this was a symptom of the serialization inconsistency, not a valid edge case.
- Added `SerializableType` alias to document the cache contract.
- Added 29 tests for the cache controller.

