### PR TITLE
Stream smart fades FFmpeg output instead of buffering

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1586,7 +1586,8 @@ class StreamsAudio:
                     if len(buffer) >= crossfade_buffer_size:
                         break
                 # both fade_out_data and buffer are in pcm_format — mix directly
-                crossfade_bytes = await self.smart_fades_mixer.mix(
+                crossfade_buf = bytearray()
+                async for mix_chunk in self.smart_fades_mixer.mix(
                     fade_in_part=buffer,
                     fade_out_part=fade_out_data,
                     fade_in_streamdetails=cast("StreamDetails", next_queue_item.streamdetails),
@@ -1594,7 +1595,10 @@ class StreamsAudio:
                     pcm_format=pcm_format,
                     standard_crossfade_duration=standard_crossfade_duration,
                     mode=smart_fades_mode,
-                )
+                ):
+                    crossfade_buf.extend(mix_chunk)
+                crossfade_bytes = bytes(crossfade_buf)
+                del crossfade_buf
                 # first half yielded now, second half stored for next track
                 split_point = (len(crossfade_bytes) + 1) // 2
                 crossfade_first = crossfade_bytes[:split_point]
@@ -1788,7 +1792,8 @@ class StreamsAudio:
                     fadein_part = crossfade_buffer[:crossfade_buffer_size]
                     remaining_bytes = crossfade_buffer[crossfade_buffer_size:]
                     try:
-                        crossfade_part = await self.smart_fades_mixer.mix(
+                        crossfade_buf = bytearray()
+                        async for mix_chunk in self.smart_fades_mixer.mix(
                             fade_in_part=fadein_part,
                             fade_out_part=last_fadeout_part,
                             fade_in_streamdetails=queue_track.streamdetails,
@@ -1796,7 +1801,9 @@ class StreamsAudio:
                             pcm_format=pcm_format,
                             standard_crossfade_duration=standard_crossfade_duration,
                             mode=smart_fades_mode,
-                        )
+                        ):
+                            crossfade_buf.extend(mix_chunk)
+                        crossfade_part = bytes(crossfade_buf)
                     except Exception as mix_err:
                         self.logger.warning(
                             "Crossfade mixer failed for %s, falling back to simple concat: %s",

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1573,15 +1573,31 @@ class StreamsAudio:
             fade_out_data = buffer
             buffer = b""
             try:
-                # pass next track's audio stream directly to the mixer so FFmpeg can
-                # start processing as chunks arrive (no pre-collection needed)
-                fade_in_source = self.get_queue_item_stream(
-                    next_queue_item,
-                    pcm_format,
-                    playback_speed=cast(
-                        "float", queue_item.extra_attributes.get("playback_speed", 1.0)
-                    ),
-                )
+                # wrap the next track's stream in a counting generator that caps
+                # at crossfade_buffer_size and tracks how many bytes were consumed
+                fade_in_bytes_consumed = 0
+
+                _next_item = next_queue_item
+
+                async def _limited_fade_in() -> AsyncGenerator[bytes, None]:
+                    nonlocal fade_in_bytes_consumed
+                    async for chunk in self.get_queue_item_stream(
+                        _next_item,
+                        pcm_format,
+                        playback_speed=cast(
+                            "float", queue_item.extra_attributes.get("playback_speed", 1.0)
+                        ),
+                    ):
+                        remaining = crossfade_buffer_size - fade_in_bytes_consumed
+                        if remaining <= 0:
+                            break
+                        if len(chunk) > remaining:
+                            fade_in_bytes_consumed += remaining
+                            yield chunk[:remaining]
+                            break
+                        fade_in_bytes_consumed += len(chunk)
+                        yield chunk
+
                 # yield first half of crossfade output directly to the player as chunks
                 # arrive from FFmpeg, keeping the stream alive during crossfade mixing.
                 # the second half is buffered for the next track's intro.
@@ -1590,12 +1606,11 @@ class StreamsAudio:
                 first_half_written = 0
                 second_half_buf = bytearray()
                 async for mix_chunk in self.smart_fades_mixer.mix(
-                    fade_in_part=fade_in_source,
+                    fade_in_part=_limited_fade_in(),
                     fade_out_part=fade_out_data,
                     fade_in_streamdetails=cast("StreamDetails", next_queue_item.streamdetails),
                     fade_out_streamdetails=streamdetails,
                     pcm_format=pcm_format,
-                    fade_in_buffer_size=crossfade_buffer_size,
                     standard_crossfade_duration=standard_crossfade_duration,
                     mode=smart_fades_mode,
                 ):
@@ -1607,7 +1622,7 @@ class StreamsAudio:
                         second_half_buf.extend(mix_chunk)
                 self._crossfade_data[queue_item.queue_id] = CrossfadeData(
                     data=second_half_buf,
-                    fade_in_size=self.smart_fades_mixer.fade_in_bytes_consumed,
+                    fade_in_size=fade_in_bytes_consumed,
                     pcm_format=pcm_format,
                     fade_in_pcm_format=pcm_format,
                     queue_item_id=next_queue_item.queue_item_id,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1573,26 +1573,23 @@ class StreamsAudio:
             fade_out_data = buffer
             buffer = b""
             try:
-                # request next track's intro-part (in current track's pcm_format)
-                async for chunk in self.get_queue_item_stream(
+                # pass next track's audio stream directly to the mixer so FFmpeg can
+                # start processing as chunks arrive (no pre-collection needed)
+                fade_in_source = self.get_queue_item_stream(
                     next_queue_item,
                     pcm_format,
                     playback_speed=cast(
                         "float", queue_item.extra_attributes.get("playback_speed", 1.0)
                     ),
-                ):
-                    buffer += chunk
-                    del chunk
-                    if len(buffer) >= crossfade_buffer_size:
-                        break
-                # both fade_out_data and buffer are in pcm_format — mix directly
+                )
                 crossfade_buf = bytearray()
                 async for mix_chunk in self.smart_fades_mixer.mix(
-                    fade_in_part=buffer,
+                    fade_in_part=fade_in_source,
                     fade_out_part=fade_out_data,
                     fade_in_streamdetails=cast("StreamDetails", next_queue_item.streamdetails),
                     fade_out_streamdetails=streamdetails,
                     pcm_format=pcm_format,
+                    fade_in_buffer_size=crossfade_buffer_size,
                     standard_crossfade_duration=standard_crossfade_duration,
                     mode=smart_fades_mode,
                 ):
@@ -1610,7 +1607,7 @@ class StreamsAudio:
                 # causing the FFMpeg stdin feeder to be cancelled)
                 self._crossfade_data[queue_item.queue_id] = CrossfadeData(
                     data=crossfade_second,
-                    fade_in_size=len(buffer),
+                    fade_in_size=self.smart_fades_mixer.fade_in_bytes_consumed,
                     pcm_format=pcm_format,
                     fade_in_pcm_format=pcm_format,
                     queue_item_id=next_queue_item.queue_item_id,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1524,8 +1524,6 @@ class StreamsAudio:
         #### HANDLE END OF TRACK
 
         # get next track for crossfade
-        # NOTE: during this phase (loading next track + mixing crossfade),
-        # no audio is yielded to the player. The player must survive on its buffer.
         crossfade_start_time = asyncio.get_event_loop().time()
         next_queue_item: QueueItem | None
         try:
@@ -1569,7 +1567,7 @@ class StreamsAudio:
             yield buffer
         else:
             assert next_queue_item is not None
-            # if crossfade is enabled, save fadeout part in buffer to pickup for next track
+            # the remaining buffer is the fade-out tail of the current track
             fade_out_data = buffer
             buffer = b""
             try:
@@ -1803,7 +1801,7 @@ class StreamsAudio:
                     fadein_part = crossfade_buffer[:crossfade_buffer_size]
                     remaining_bytes = crossfade_buffer[crossfade_buffer_size:]
                     try:
-                        crossfade_buf = bytearray()
+                        crossfade_bytes_written = 0
                         async for mix_chunk in self.smart_fades_mixer.mix(
                             fade_in_part=fadein_part,
                             fade_out_part=last_fadeout_part,
@@ -1813,8 +1811,8 @@ class StreamsAudio:
                             standard_crossfade_duration=standard_crossfade_duration,
                             mode=smart_fades_mode,
                         ):
-                            crossfade_buf.extend(mix_chunk)
-                        crossfade_part = bytes(crossfade_buf)
+                            yield mix_chunk
+                            crossfade_bytes_written += len(mix_chunk)
                     except Exception as mix_err:
                         self.logger.warning(
                             "Crossfade mixer failed for %s, falling back to simple concat: %s",
@@ -1823,18 +1821,15 @@ class StreamsAudio:
                         )
                         yield last_fadeout_part
                         bytes_written += len(last_fadeout_part)
-                        crossfade_part = b""
+                        crossfade_bytes_written = 0
                         remaining_bytes = crossfade_buffer
-                    if crossfade_part:
-                        crossfade_part_len = len(crossfade_part)
-                        bytes_written += int(crossfade_part_len / 2)
+                    if crossfade_bytes_written:
+                        bytes_written += int(crossfade_bytes_written / 2)
                         if last_play_log_entry:
                             assert last_play_log_entry.seconds_streamed is not None
                             last_play_log_entry.seconds_streamed += (
-                                crossfade_part_len / 2 / pcm_sample_size
+                                crossfade_bytes_written / 2 / pcm_sample_size
                             )
-                        yield crossfade_part
-                        del crossfade_part
                     if remaining_bytes:
                         yield remaining_bytes
                         bytes_written += len(remaining_bytes)

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1582,7 +1582,13 @@ class StreamsAudio:
                         "float", queue_item.extra_attributes.get("playback_speed", 1.0)
                     ),
                 )
-                crossfade_buf = bytearray()
+                # yield first half of crossfade output directly to the player as chunks
+                # arrive from FFmpeg, keeping the stream alive during crossfade mixing.
+                # the second half is buffered for the next track's intro.
+                # the midpoint estimate is one buffer's worth (the fade-out contribution).
+                estimated_first_half = len(fade_out_data)
+                first_half_written = 0
+                second_half_buf = bytearray()
                 async for mix_chunk in self.smart_fades_mixer.mix(
                     fade_in_part=fade_in_source,
                     fade_out_part=fade_out_data,
@@ -1593,20 +1599,14 @@ class StreamsAudio:
                     standard_crossfade_duration=standard_crossfade_duration,
                     mode=smart_fades_mode,
                 ):
-                    crossfade_buf.extend(mix_chunk)
-                crossfade_bytes = bytes(crossfade_buf)
-                del crossfade_buf
-                # first half yielded now, second half stored for next track
-                split_point = (len(crossfade_bytes) + 1) // 2
-                crossfade_first = crossfade_bytes[:split_point]
-                crossfade_second = crossfade_bytes[split_point:]
-                del crossfade_bytes
-                bytes_written += len(crossfade_first)
-                # store second half BEFORE yielding first half to prevent data loss
-                # if the generator is interrupted after the yield (e.g., player disconnect
-                # causing the FFMpeg stdin feeder to be cancelled)
+                    if first_half_written < estimated_first_half:
+                        yield mix_chunk
+                        first_half_written += len(mix_chunk)
+                        bytes_written += len(mix_chunk)
+                    else:
+                        second_half_buf.extend(mix_chunk)
                 self._crossfade_data[queue_item.queue_id] = CrossfadeData(
-                    data=crossfade_second,
+                    data=bytes(second_half_buf),
                     fade_in_size=self.smart_fades_mixer.fade_in_bytes_consumed,
                     pcm_format=pcm_format,
                     fade_in_pcm_format=pcm_format,
@@ -1620,7 +1620,6 @@ class StreamsAudio:
                     next_queue_item.queue_item_id,
                     crossfade_elapsed,
                 )
-                yield crossfade_first
             except Exception as err:
                 # crossfade failed, fall back to just yielding the fade_out_data
                 self.logger.warning(

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -110,7 +110,7 @@ if TYPE_CHECKING:
 class CrossfadeData:
     """Data class to hold crossfade data."""
 
-    data: bytes
+    data: bytes | bytearray
     fade_in_size: int
     pcm_format: AudioFormat  # Format of the 'data' bytes (current/previous track's format)
     fade_in_pcm_format: AudioFormat  # Format for 'fade_in_size' (next track's format)
@@ -1606,7 +1606,7 @@ class StreamsAudio:
                     else:
                         second_half_buf.extend(mix_chunk)
                 self._crossfade_data[queue_item.queue_id] = CrossfadeData(
-                    data=bytes(second_half_buf),
+                    data=second_half_buf,
                     fade_in_size=self.smart_fades_mixer.fade_in_bytes_consumed,
                     pcm_format=pcm_format,
                     fade_in_pcm_format=pcm_format,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -110,7 +110,7 @@ if TYPE_CHECKING:
 class CrossfadeData:
     """Data class to hold crossfade data."""
 
-    data: bytes | bytearray
+    data: bytes
     fade_in_size: int
     pcm_format: AudioFormat  # Format of the 'data' bytes (current/previous track's format)
     fade_in_pcm_format: AudioFormat  # Format for 'fade_in_size' (next track's format)
@@ -1619,7 +1619,7 @@ class StreamsAudio:
                     else:
                         second_half_buf.extend(mix_chunk)
                 self._crossfade_data[queue_item.queue_id] = CrossfadeData(
-                    data=second_half_buf,
+                    data=bytes(second_half_buf),
                     fade_in_size=fade_in_bytes_consumed,
                     pcm_format=pcm_format,
                     fade_in_pcm_format=pcm_format,

--- a/music_assistant/controllers/streams/smart_fades/analyzer.py
+++ b/music_assistant/controllers/streams/smart_fades/analyzer.py
@@ -156,31 +156,8 @@ class SmartFadesAnalyzer:
                 fragment_duration,
                 len(audio_data),
             )
-            # Convert PCM bytes to numpy array and then to mono for analysis
-            audio_array = self._pcm_bytes_to_float32(audio_data, pcm_format)
-            if pcm_format.channels > 1:
-                # Ensure array size is divisible by channel count
-                samples_per_channel = len(audio_array) // pcm_format.channels
-                valid_samples = samples_per_channel * pcm_format.channels
-                if valid_samples != len(audio_array):
-                    self.logger.warning(
-                        "Audio buffer size (%d) not divisible by channels (%d), "
-                        "truncating %d samples",
-                        len(audio_array),
-                        pcm_format.channels,
-                        len(audio_array) - valid_samples,
-                    )
-                    audio_array = audio_array[:valid_samples]
-
-                # Reshape to separate channels and take average for mono conversion
-                audio_array = audio_array.reshape(-1, pcm_format.channels)
-                mono_audio = np.asarray(np.mean(audio_array, axis=1, dtype=np.float32))
-            else:
-                # Single channel - ensure consistent array type
-                mono_audio = np.asarray(audio_array, dtype=np.float32)
-
-            # Validate that the audio is finite (no NaN or Inf values)
-            if not np.all(np.isfinite(mono_audio)):
+            mono_audio = await asyncio.to_thread(self._pcm_to_mono_float32, audio_data, pcm_format)
+            if mono_audio is None:
                 self.logger.error(
                     "Audio buffer contains non-finite values (NaN/Inf) for %s, cannot analyze",
                     stream_details_name,
@@ -346,6 +323,37 @@ class SmartFadesAnalyzer:
         except Exception as e:
             self.logger.exception("Beat tracking analysis failed: %s", e)
             return None
+
+    def _pcm_to_mono_float32(
+        self,
+        audio_data: bytes,
+        pcm_format: AudioFormat,
+    ) -> npt.NDArray[np.float32] | None:
+        """
+        Convert raw PCM bytes to a mono float32 numpy array.
+
+        :param audio_data: Raw PCM audio data.
+        :param pcm_format: Audio format of the PCM data.
+        """
+        audio_array = self._pcm_bytes_to_float32(audio_data, pcm_format)
+        if pcm_format.channels > 1:
+            # Ensure array size is divisible by channel count
+            samples_per_channel = len(audio_array) // pcm_format.channels
+            valid_samples = samples_per_channel * pcm_format.channels
+            if valid_samples != len(audio_array):
+                audio_array = audio_array[:valid_samples]
+
+            # Reshape to separate channels and take average for mono conversion
+            audio_array = audio_array.reshape(-1, pcm_format.channels)
+            mono_audio = np.asarray(np.mean(audio_array, axis=1, dtype=np.float32))
+        else:
+            # Single channel - ensure consistent array type
+            mono_audio = np.asarray(audio_array, dtype=np.float32)
+
+        # Validate that the audio is finite (no NaN or Inf values)
+        if not np.all(np.isfinite(mono_audio)):
+            return None
+        return mono_audio
 
     def _pcm_bytes_to_float32(
         self,

--- a/music_assistant/controllers/streams/smart_fades/analyzer.py
+++ b/music_assistant/controllers/streams/smart_fades/analyzer.py
@@ -156,7 +156,7 @@ class SmartFadesAnalyzer:
                 fragment_duration,
                 len(audio_data),
             )
-            mono_audio = await asyncio.to_thread(self._pcm_to_mono_float32, audio_data, pcm_format)
+            mono_audio = await self._pcm_to_mono_float32(audio_data, pcm_format)
             if mono_audio is None:
                 self.logger.error(
                     "Audio buffer contains non-finite values (NaN/Inf) for %s, cannot analyze",
@@ -324,7 +324,7 @@ class SmartFadesAnalyzer:
             self.logger.exception("Beat tracking analysis failed: %s", e)
             return None
 
-    def _pcm_to_mono_float32(
+    async def _pcm_to_mono_float32(
         self,
         audio_data: bytes,
         pcm_format: AudioFormat,
@@ -335,25 +335,30 @@ class SmartFadesAnalyzer:
         :param audio_data: Raw PCM audio data.
         :param pcm_format: Audio format of the PCM data.
         """
-        audio_array = self._pcm_bytes_to_float32(audio_data, pcm_format)
-        if pcm_format.channels > 1:
-            # Ensure array size is divisible by channel count
-            samples_per_channel = len(audio_array) // pcm_format.channels
-            valid_samples = samples_per_channel * pcm_format.channels
-            if valid_samples != len(audio_array):
-                audio_array = audio_array[:valid_samples]
 
-            # Reshape to separate channels and take average for mono conversion
-            audio_array = audio_array.reshape(-1, pcm_format.channels)
-            mono_audio = np.asarray(np.mean(audio_array, axis=1, dtype=np.float32))
-        else:
-            # Single channel - ensure consistent array type
-            mono_audio = np.asarray(audio_array, dtype=np.float32)
+        def _convert() -> npt.NDArray[np.float32] | None:
+            # CPU-intensive numpy operations, must run in executor
+            audio_array = self._pcm_bytes_to_float32(audio_data, pcm_format)
+            if pcm_format.channels > 1:
+                # Ensure array size is divisible by channel count
+                samples_per_channel = len(audio_array) // pcm_format.channels
+                valid_samples = samples_per_channel * pcm_format.channels
+                if valid_samples != len(audio_array):
+                    audio_array = audio_array[:valid_samples]
 
-        # Validate that the audio is finite (no NaN or Inf values)
-        if not np.all(np.isfinite(mono_audio)):
-            return None
-        return mono_audio
+                # Reshape to separate channels and take average for mono conversion
+                audio_array_reshaped = audio_array.reshape(-1, pcm_format.channels)
+                mono_audio = np.asarray(np.mean(audio_array_reshaped, axis=1, dtype=np.float32))
+            else:
+                # Single channel - ensure consistent array type
+                mono_audio = np.asarray(audio_array, dtype=np.float32)
+
+            # Validate that the audio is finite (no NaN or Inf values)
+            if not np.all(np.isfinite(mono_audio)):
+                return None
+            return mono_audio
+
+        return await asyncio.to_thread(_convert)
 
     def _pcm_bytes_to_float32(
         self,

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -528,16 +528,34 @@ class StandardCrossFade(SmartFade):
 
         Only the overlapping portions are crossfaded, not the full buffers.
         """
-        # StandardCrossFade needs full bytes for slicing - caller must ensure this
-        assert isinstance(fade_in_part, bytes)
         crossfade_size = int(pcm_format.pcm_sample_size * self.crossfade_duration)
         # Pre-crossfade: outgoing track minus the crossfaded portion
         pre_crossfade = fade_out_part[:-crossfade_size]
-        # Post-crossfade: incoming track minus the crossfaded portion
-        post_crossfade = fade_in_part[crossfade_size:]
-        # Adjust portions to exact crossfade size
-        adjusted_fade_in_part = fade_in_part[:crossfade_size]
         adjusted_fade_out_part = fade_out_part[-crossfade_size:]
+
+        # Collect only the crossfade portion from fade_in, keep the rest as a generator
+        if isinstance(fade_in_part, bytes):
+            adjusted_fade_in_part = fade_in_part[:crossfade_size]
+            post_crossfade: bytes | AsyncGenerator[bytes, None] = fade_in_part[crossfade_size:]
+        else:
+            # read exactly crossfade_size bytes from the generator
+            buf = bytearray()
+            async for chunk in fade_in_part:
+                buf.extend(chunk)
+                if len(buf) >= crossfade_size:
+                    break
+            adjusted_fade_in_part = bytes(buf[:crossfade_size])
+            # anything beyond crossfade_size plus the remaining generator is post_crossfade
+            leftover = bytes(buf[crossfade_size:])
+
+            async def _post_crossfade() -> AsyncGenerator[bytes, None]:
+                if leftover:
+                    yield leftover
+                async for remaining_chunk in fade_in_part:
+                    yield remaining_chunk
+
+            post_crossfade = _post_crossfade()
+
         # Adjust the duration to match actual sizes
         self.crossfade_duration = min(
             len(adjusted_fade_in_part) / pcm_format.pcm_sample_size,
@@ -547,7 +565,11 @@ class StandardCrossFade(SmartFade):
         yield pre_crossfade
         async for chunk in super().apply(adjusted_fade_out_part, adjusted_fade_in_part, pcm_format):
             yield chunk
-        yield post_crossfade
+        if isinstance(post_crossfade, bytes):
+            yield post_crossfade
+        else:
+            async for chunk in post_crossfade:
+                yield chunk
 
 
 # HELPER METHODS

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
 import aiofiles
@@ -19,7 +22,7 @@ from music_assistant.controllers.streams.smart_fades.filters import (
     TimeStretchFilter,
     TrimFilter,
 )
-from music_assistant.helpers.process import communicate
+from music_assistant.helpers.process import AsyncProcess
 from music_assistant.helpers.util import remove_file
 from music_assistant.models.smart_fades import (
     SmartFadesAnalysis,
@@ -69,8 +72,14 @@ class SmartFade(ABC):
         fade_out_part: bytes,
         fade_in_part: bytes,
         pcm_format: AudioFormat,
-    ) -> bytes:
-        """Apply the smart fade to the given PCM audio parts."""
+    ) -> AsyncGenerator[bytes, None]:
+        """
+        Apply the smart fade, yielding PCM audio chunks as they become available.
+
+        :param fade_out_part: Raw PCM bytes for the outgoing track's tail.
+        :param fade_in_part: Raw PCM bytes for the incoming track's head.
+        :param pcm_format: Audio format of both input parts and the output.
+        """
         # Write the fade_out_part to a temporary file
         fadeout_filename = f"/tmp/{shortuuid.random(20)}.pcm"  # noqa: S108
         async with aiofiles.open(fadeout_filename, "wb") as outfile:
@@ -133,14 +142,28 @@ class SmartFade(ABC):
         )
         self.logger.log(VERBOSE_LOG_LEVEL, "FFmpeg command args: %s", " ".join(args))
 
+        got_output = False
         try:
-            # Execute the enhanced smart fade with full buffer
-            _, raw_crossfade_output, stderr = await communicate(args, fade_in_part)
+            proc = AsyncProcess(args, stdin=True, stdout=True, stderr=True, name="smartfade")
+            async with proc:
 
-            if raw_crossfade_output:
-                return raw_crossfade_output
-            stderr_msg = stderr.decode() if stderr else "(no stderr output)"
-            raise RuntimeError(f"Smart crossfade failed. FFmpeg stderr: {stderr_msg}")
+                async def _feed_stdin() -> None:
+                    await proc.write(fade_in_part)
+                    await proc.write_eof()
+
+                feed_task = asyncio.create_task(_feed_stdin())
+                try:
+                    async for chunk in proc.iter_any():
+                        got_output = True
+                        yield chunk
+                finally:
+                    if not feed_task.done():
+                        feed_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await feed_task
+
+            if not got_output:
+                raise RuntimeError("Smart crossfade failed: FFmpeg produced no output")
         finally:
             # Always cleanup temp file, even if ffmpeg fails
             await remove_file(fadeout_filename)
@@ -480,10 +503,12 @@ class StandardCrossFade(SmartFade):
 
     async def apply(
         self, fade_out_part: bytes, fade_in_part: bytes, pcm_format: AudioFormat
-    ) -> bytes:
-        """Apply the standard crossfade to the given PCM audio parts."""
-        # We need to override the default apply here, since standard crossfade only needs to be
-        # applied to the overlapping parts, not the full buffers.
+    ) -> AsyncGenerator[bytes, None]:
+        """
+        Apply standard crossfade, yielding PCM audio chunks.
+
+        Only the overlapping portions are crossfaded, not the full buffers.
+        """
         crossfade_size = int(pcm_format.pcm_sample_size * self.crossfade_duration)
         # Pre-crossfade: outgoing track minus the crossfaded portion
         pre_crossfade = fade_out_part[:-crossfade_size]
@@ -497,12 +522,11 @@ class StandardCrossFade(SmartFade):
             len(adjusted_fade_in_part) / pcm_format.pcm_sample_size,
             len(adjusted_fade_out_part) / pcm_format.pcm_sample_size,
         )
-        # Crossfaded portion: user's configured duration
-        crossfaded_section = await super().apply(
-            adjusted_fade_out_part, adjusted_fade_in_part, pcm_format
-        )
-        # Full result: everything concatenated
-        return pre_crossfade + crossfaded_section + post_crossfade
+        # Yield pre-crossfade, crossfaded section, and post-crossfade
+        yield pre_crossfade
+        async for chunk in super().apply(adjusted_fade_out_part, adjusted_fade_in_part, pcm_format):
+            yield chunk
+        yield post_crossfade
 
 
 # HELPER METHODS

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -144,7 +144,8 @@ class SmartFade(ABC):
 
         got_output = False
         try:
-            proc = AsyncProcess(args, stdin=True, stdout=True, stderr=True, name="smartfade")
+            # stderr=False sends it to DEVNULL; a pipe would deadlock if unread
+            proc = AsyncProcess(args, stdin=True, stdout=True, stderr=False, name="smartfade")
             async with proc:
 
                 async def _feed_stdin() -> None:

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -70,14 +70,14 @@ class SmartFade(ABC):
     async def apply(
         self,
         fade_out_part: bytes,
-        fade_in_part: bytes,
+        fade_in_part: bytes | AsyncGenerator[bytes, None],
         pcm_format: AudioFormat,
     ) -> AsyncGenerator[bytes, None]:
         """
         Apply the smart fade, yielding PCM audio chunks as they become available.
 
         :param fade_out_part: Raw PCM bytes for the outgoing track's tail.
-        :param fade_in_part: Raw PCM bytes for the incoming track's head.
+        :param fade_in_part: Raw PCM bytes or async generator for the incoming track's head.
         :param pcm_format: Audio format of both input parts and the output.
         """
         # Write the fade_out_part to a temporary file
@@ -149,7 +149,11 @@ class SmartFade(ABC):
             async with proc:
 
                 async def _feed_stdin() -> None:
-                    await proc.write(fade_in_part)
+                    if isinstance(fade_in_part, bytes):
+                        await proc.write(fade_in_part)
+                    else:
+                        async for fade_chunk in fade_in_part:
+                            await proc.write(fade_chunk)
                     await proc.write_eof()
 
                 async def _drain_stderr() -> None:
@@ -514,13 +518,18 @@ class StandardCrossFade(SmartFade):
         ]
 
     async def apply(
-        self, fade_out_part: bytes, fade_in_part: bytes, pcm_format: AudioFormat
+        self,
+        fade_out_part: bytes,
+        fade_in_part: bytes | AsyncGenerator[bytes, None],
+        pcm_format: AudioFormat,
     ) -> AsyncGenerator[bytes, None]:
         """
         Apply standard crossfade, yielding PCM audio chunks.
 
         Only the overlapping portions are crossfaded, not the full buffers.
         """
+        # StandardCrossFade needs full bytes for slicing - caller must ensure this
+        assert isinstance(fade_in_part, bytes)
         crossfade_size = int(pcm_format.pcm_sample_size * self.crossfade_duration)
         # Pre-crossfade: outgoing track minus the crossfaded portion
         pre_crossfade = fade_out_part[:-crossfade_size]

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -143,16 +143,22 @@ class SmartFade(ABC):
         self.logger.log(VERBOSE_LOG_LEVEL, "FFmpeg command args: %s", " ".join(args))
 
         got_output = False
+        stderr_lines: list[str] = []
         try:
-            # stderr=False sends it to DEVNULL; a pipe would deadlock if unread
-            proc = AsyncProcess(args, stdin=True, stdout=True, stderr=False, name="smartfade")
+            proc = AsyncProcess(args, stdin=True, stdout=True, stderr=True, name="smartfade")
             async with proc:
 
                 async def _feed_stdin() -> None:
                     await proc.write(fade_in_part)
                     await proc.write_eof()
 
+                async def _drain_stderr() -> None:
+                    """Read stderr to prevent pipe deadlock."""
+                    async for line in proc.iter_stderr():
+                        stderr_lines.append(line)
+
                 feed_task = asyncio.create_task(_feed_stdin())
+                stderr_task = asyncio.create_task(_drain_stderr())
                 try:
                     async for chunk in proc.iter_any():
                         got_output = True
@@ -162,10 +168,13 @@ class SmartFade(ABC):
                         feed_task.cancel()
                     with suppress(asyncio.CancelledError):
                         await feed_task
+                    with suppress(asyncio.CancelledError):
+                        await stderr_task
 
             if proc.returncode not in (None, 0) or not got_output:
+                stderr_msg = "; ".join(stderr_lines) if stderr_lines else "(no stderr)"
                 raise RuntimeError(
-                    f"Smart crossfade FFmpeg failed (rc={proc.returncode}, output={got_output})"
+                    f"Smart crossfade FFmpeg failed (rc={proc.returncode}): {stderr_msg}"
                 )
         finally:
             # Always cleanup temp file, even if ffmpeg fails

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -162,8 +162,10 @@ class SmartFade(ABC):
                     with suppress(asyncio.CancelledError):
                         await feed_task
 
-            if not got_output:
-                raise RuntimeError("Smart crossfade failed: FFmpeg produced no output")
+            if proc.returncode not in (None, 0) or not got_output:
+                raise RuntimeError(
+                    f"Smart crossfade FFmpeg failed (rc={proc.returncode}, output={got_output})"
+                )
         finally:
             # Always cleanup temp file, even if ffmpeg fails
             await remove_file(fadeout_filename)

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -124,14 +124,19 @@ class SmartFadesMixer:
                     fade_out_analysis=fade_out_analysis,
                     fade_in_analysis=fade_in_analysis,
                 )
+                got_chunks = False
                 async for chunk in smart_fade.apply(
                     fade_out_part,
                     fade_in_part,
                     pcm_format,
                 ):
+                    got_chunks = True
                     yield chunk
                 return
             except Exception as e:
+                if got_chunks:
+                    # partial output already yielded, can't fall back safely
+                    raise
                 self.logger.warning(
                     "Smart crossfade failed: %s, falling back to standard crossfade", e
                 )

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -67,7 +67,6 @@ class SmartFadesMixer:
             return
 
         if mode == SmartFadesMode.STANDARD_CROSSFADE:
-            fade_in_bytes = await self._ensure_bytes(fade_in_part, fade_in_buffer_size)
             # strip silence from end of outgoing track (common in song outros)
             fade_out_part = await strip_silence(
                 fade_out_part,
@@ -80,9 +79,12 @@ class SmartFadesMixer:
                 logger=self.logger,
                 crossfade_duration=standard_crossfade_duration,
             )
+            # pass fade_in through directly - StandardCrossFade handles both bytes and generators
             async for chunk in smart_fade.apply(
                 fade_out_part,
-                fade_in_bytes,
+                self._limit_generator(fade_in_part, fade_in_buffer_size)
+                if not isinstance(fade_in_part, bytes)
+                else fade_in_part,
                 pcm_format,
             ):
                 yield chunk

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -31,7 +31,6 @@ class SmartFadesMixer:
         """Initialize smart fades mixer."""
         self.streams = streams
         self.logger = streams.logger.getChild("smart_fades_mixer")
-        self.fade_in_bytes_consumed: int = 0
 
     async def mix(
         self,
@@ -40,7 +39,6 @@ class SmartFadesMixer:
         fade_in_streamdetails: StreamDetails,
         fade_out_streamdetails: StreamDetails,
         pcm_format: AudioFormat,
-        fade_in_buffer_size: int = 0,
         standard_crossfade_duration: int = 10,
         mode: SmartFadesMode = SmartFadesMode.SMART_CROSSFADE,
     ) -> AsyncGenerator[bytes, None]:
@@ -52,17 +50,14 @@ class SmartFadesMixer:
         :param fade_in_streamdetails: Stream details for the incoming track.
         :param fade_out_streamdetails: Stream details for the outgoing track.
         :param pcm_format: Audio format of both input parts and the output.
-        :param fade_in_buffer_size: Max bytes to read from fade_in_part generator (0 = unlimited).
         :param standard_crossfade_duration: Duration in seconds for standard crossfade fallback.
         :param mode: Smart fades mode to use.
         """
-        self.fade_in_bytes_consumed = 0
-
         if mode == SmartFadesMode.DISABLED:
             # No crossfade, just concatenate
             # Note that this should not happen since we check this before calling mix()
             # but just to be sure...
-            fade_in_bytes = await self._ensure_bytes(fade_in_part, fade_in_buffer_size)
+            fade_in_bytes = await self._ensure_bytes(fade_in_part)
             yield fade_out_part + fade_in_bytes
             return
 
@@ -79,12 +74,9 @@ class SmartFadesMixer:
                 logger=self.logger,
                 crossfade_duration=standard_crossfade_duration,
             )
-            # pass fade_in through directly - StandardCrossFade handles both bytes and generators
             async for chunk in smart_fade.apply(
                 fade_out_part,
-                self._limit_generator(fade_in_part, fade_in_buffer_size)
-                if not isinstance(fade_in_part, bytes)
-                else fade_in_part,
+                fade_in_part,
                 pcm_format,
             ):
                 yield chunk
@@ -116,7 +108,7 @@ class SmartFadesMixer:
             fade_in_analysis = stored_analysis
         else:
             # analysis not cached, need full bytes for beat analysis
-            fade_in_part = await self._ensure_bytes(fade_in_part, fade_in_buffer_size)
+            fade_in_part = await self._ensure_bytes(fade_in_part)
             fade_in_analysis = await self.streams.mass.streams.smart_fades_analyzer.analyze(
                 fade_in_streamdetails.item_id,
                 fade_in_streamdetails.provider,
@@ -137,13 +129,10 @@ class SmartFadesMixer:
                     fade_out_analysis=fade_out_analysis,
                     fade_in_analysis=fade_in_analysis,
                 )
-                # stream fade_in directly to FFmpeg when possible (generator not yet consumed)
                 got_chunks = False
                 async for chunk in smart_fade.apply(
                     fade_out_part,
-                    self._limit_generator(fade_in_part, fade_in_buffer_size)
-                    if not isinstance(fade_in_part, bytes)
-                    else fade_in_part,
+                    fade_in_part,
                     pcm_format,
                 ):
                     got_chunks = True
@@ -159,7 +148,7 @@ class SmartFadesMixer:
 
         # Always fallback to Standard Crossfade in case something goes wrong
         # StandardCrossFade needs full bytes for slicing
-        fade_in_bytes = await self._ensure_bytes(fade_in_part, fade_in_buffer_size)
+        fade_in_bytes = await self._ensure_bytes(fade_in_part)
         smart_fade = StandardCrossFade(
             logger=self.logger,
             crossfade_duration=standard_crossfade_duration,
@@ -171,38 +160,14 @@ class SmartFadesMixer:
         ):
             yield chunk
 
+    @staticmethod
     async def _ensure_bytes(
-        self,
         data: bytes | AsyncGenerator[bytes, None],
-        max_bytes: int = 0,
     ) -> bytes:
         """Consume an async generator into bytes, or return bytes as-is."""
         if isinstance(data, bytes):
-            self.fade_in_bytes_consumed = len(data)
             return data
         buf = bytearray()
         async for chunk in data:
             buf.extend(chunk)
-            self.fade_in_bytes_consumed += len(chunk)
-            if max_bytes and len(buf) >= max_bytes:
-                break
         return bytes(buf)
-
-    async def _limit_generator(
-        self,
-        source: AsyncGenerator[bytes, None],
-        max_bytes: int,
-    ) -> AsyncGenerator[bytes, None]:
-        """Yield chunks from source up to max_bytes total."""
-        total = 0
-        async for chunk in source:
-            remaining = max_bytes - total if max_bytes else len(chunk)
-            if remaining <= 0:
-                break
-            if len(chunk) > remaining:
-                self.fade_in_bytes_consumed += remaining
-                yield chunk[:remaining]
-                break
-            self.fade_in_bytes_consumed += len(chunk)
-            yield chunk
-            total += len(chunk)

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -67,9 +67,8 @@ class SmartFadesMixer:
             return
 
         if mode == SmartFadesMode.STANDARD_CROSSFADE:
-            # standard crossfade needs full bytes for strip_silence
             fade_in_bytes = await self._ensure_bytes(fade_in_part, fade_in_buffer_size)
-            # strip silence from end of audio of fade_out_part
+            # strip silence from end of outgoing track (common in song outros)
             fade_out_part = await strip_silence(
                 fade_out_part,
                 pcm_format=pcm_format,
@@ -77,14 +76,6 @@ class SmartFadesMixer:
             )
             # Ensure frame alignment after silence stripping
             fade_out_part = align_audio_to_frame_boundary(fade_out_part, pcm_format)
-            # strip silence from begin of audio of fade_in_part
-            fade_in_bytes = await strip_silence(
-                fade_in_bytes,
-                pcm_format=pcm_format,
-                reverse=False,
-            )
-            # Ensure frame alignment after silence stripping
-            fade_in_bytes = align_audio_to_frame_boundary(fade_in_bytes, pcm_format)
             smart_fade: SmartFade = StandardCrossFade(
                 logger=self.logger,
                 crossfade_duration=standard_crossfade_duration,

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -31,26 +31,44 @@ class SmartFadesMixer:
         """Initialize smart fades mixer."""
         self.streams = streams
         self.logger = streams.logger.getChild("smart_fades_mixer")
+        self.fade_in_bytes_consumed: int = 0
 
     async def mix(
         self,
-        fade_in_part: bytes,
+        fade_in_part: bytes | AsyncGenerator[bytes, None],
         fade_out_part: bytes,
         fade_in_streamdetails: StreamDetails,
         fade_out_streamdetails: StreamDetails,
         pcm_format: AudioFormat,
+        fade_in_buffer_size: int = 0,
         standard_crossfade_duration: int = 10,
         mode: SmartFadesMode = SmartFadesMode.SMART_CROSSFADE,
     ) -> AsyncGenerator[bytes, None]:
-        """Apply crossfade, yielding mixed PCM audio chunks as they become available."""
+        """
+        Apply crossfade, yielding mixed PCM audio chunks as they become available.
+
+        :param fade_in_part: Raw PCM bytes or async generator for the incoming track's head.
+        :param fade_out_part: Raw PCM bytes for the outgoing track's tail.
+        :param fade_in_streamdetails: Stream details for the incoming track.
+        :param fade_out_streamdetails: Stream details for the outgoing track.
+        :param pcm_format: Audio format of both input parts and the output.
+        :param fade_in_buffer_size: Max bytes to read from fade_in_part generator (0 = unlimited).
+        :param standard_crossfade_duration: Duration in seconds for standard crossfade fallback.
+        :param mode: Smart fades mode to use.
+        """
+        self.fade_in_bytes_consumed = 0
+
         if mode == SmartFadesMode.DISABLED:
             # No crossfade, just concatenate
             # Note that this should not happen since we check this before calling mix()
             # but just to be sure...
-            yield fade_out_part + fade_in_part
+            fade_in_bytes = await self._ensure_bytes(fade_in_part, fade_in_buffer_size)
+            yield fade_out_part + fade_in_bytes
             return
 
         if mode == SmartFadesMode.STANDARD_CROSSFADE:
+            # standard crossfade needs full bytes for strip_silence
+            fade_in_bytes = await self._ensure_bytes(fade_in_part, fade_in_buffer_size)
             # strip silence from end of audio of fade_out_part
             fade_out_part = await strip_silence(
                 fade_out_part,
@@ -60,20 +78,20 @@ class SmartFadesMixer:
             # Ensure frame alignment after silence stripping
             fade_out_part = align_audio_to_frame_boundary(fade_out_part, pcm_format)
             # strip silence from begin of audio of fade_in_part
-            fade_in_part = await strip_silence(
-                fade_in_part,
+            fade_in_bytes = await strip_silence(
+                fade_in_bytes,
                 pcm_format=pcm_format,
                 reverse=False,
             )
             # Ensure frame alignment after silence stripping
-            fade_in_part = align_audio_to_frame_boundary(fade_in_part, pcm_format)
+            fade_in_bytes = align_audio_to_frame_boundary(fade_in_bytes, pcm_format)
             smart_fade: SmartFade = StandardCrossFade(
                 logger=self.logger,
                 crossfade_duration=standard_crossfade_duration,
             )
             async for chunk in smart_fade.apply(
                 fade_out_part,
-                fade_in_part,
+                fade_in_bytes,
                 pcm_format,
             ):
                 yield chunk
@@ -104,6 +122,8 @@ class SmartFadesMixer:
         ):
             fade_in_analysis = stored_analysis
         else:
+            # analysis not cached, need full bytes for beat analysis
+            fade_in_part = await self._ensure_bytes(fade_in_part, fade_in_buffer_size)
             fade_in_analysis = await self.streams.mass.streams.smart_fades_analyzer.analyze(
                 fade_in_streamdetails.item_id,
                 fade_in_streamdetails.provider,
@@ -124,10 +144,13 @@ class SmartFadesMixer:
                     fade_out_analysis=fade_out_analysis,
                     fade_in_analysis=fade_in_analysis,
                 )
+                # stream fade_in directly to FFmpeg when possible (generator not yet consumed)
                 got_chunks = False
                 async for chunk in smart_fade.apply(
                     fade_out_part,
-                    fade_in_part,
+                    self._limit_generator(fade_in_part, fade_in_buffer_size)
+                    if not isinstance(fade_in_part, bytes)
+                    else fade_in_part,
                     pcm_format,
                 ):
                     got_chunks = True
@@ -142,13 +165,51 @@ class SmartFadesMixer:
                 )
 
         # Always fallback to Standard Crossfade in case something goes wrong
+        # StandardCrossFade needs full bytes for slicing
+        fade_in_bytes = await self._ensure_bytes(fade_in_part, fade_in_buffer_size)
         smart_fade = StandardCrossFade(
             logger=self.logger,
             crossfade_duration=standard_crossfade_duration,
         )
         async for chunk in smart_fade.apply(
             fade_out_part,
-            fade_in_part,
+            fade_in_bytes,
             pcm_format,
         ):
             yield chunk
+
+    async def _ensure_bytes(
+        self,
+        data: bytes | AsyncGenerator[bytes, None],
+        max_bytes: int = 0,
+    ) -> bytes:
+        """Consume an async generator into bytes, or return bytes as-is."""
+        if isinstance(data, bytes):
+            self.fade_in_bytes_consumed = len(data)
+            return data
+        buf = bytearray()
+        async for chunk in data:
+            buf.extend(chunk)
+            self.fade_in_bytes_consumed += len(chunk)
+            if max_bytes and len(buf) >= max_bytes:
+                break
+        return bytes(buf)
+
+    async def _limit_generator(
+        self,
+        source: AsyncGenerator[bytes, None],
+        max_bytes: int,
+    ) -> AsyncGenerator[bytes, None]:
+        """Yield chunks from source up to max_bytes total."""
+        total = 0
+        async for chunk in source:
+            remaining = max_bytes - total if max_bytes else len(chunk)
+            if remaining <= 0:
+                break
+            if len(chunk) > remaining:
+                self.fade_in_bytes_consumed += remaining
+                yield chunk[:remaining]
+                break
+            self.fade_in_bytes_consumed += len(chunk)
+            yield chunk
+            total += len(chunk)

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
 from music_assistant.controllers.streams.smart_fades.fades import (
@@ -40,13 +41,14 @@ class SmartFadesMixer:
         pcm_format: AudioFormat,
         standard_crossfade_duration: int = 10,
         mode: SmartFadesMode = SmartFadesMode.SMART_CROSSFADE,
-    ) -> bytes:
-        """Apply crossfade with internal state management and smart/standard fallback logic."""
+    ) -> AsyncGenerator[bytes, None]:
+        """Apply crossfade, yielding mixed PCM audio chunks as they become available."""
         if mode == SmartFadesMode.DISABLED:
             # No crossfade, just concatenate
             # Note that this should not happen since we check this before calling mix()
             # but just to be sure...
-            return fade_out_part + fade_in_part
+            yield fade_out_part + fade_in_part
+            return
 
         if mode == SmartFadesMode.STANDARD_CROSSFADE:
             # strip silence from end of audio of fade_out_part
@@ -69,11 +71,14 @@ class SmartFadesMixer:
                 logger=self.logger,
                 crossfade_duration=standard_crossfade_duration,
             )
-            return await smart_fade.apply(
+            async for chunk in smart_fade.apply(
                 fade_out_part,
                 fade_in_part,
                 pcm_format,
-            )
+            ):
+                yield chunk
+            return
+
         # Attempt smart crossfade with analysis data
         fade_out_analysis: SmartFadesAnalysis | None
         if stored_analysis := await self.streams.mass.music.get_smart_fades_analysis(
@@ -119,11 +124,13 @@ class SmartFadesMixer:
                     fade_out_analysis=fade_out_analysis,
                     fade_in_analysis=fade_in_analysis,
                 )
-                return await smart_fade.apply(
+                async for chunk in smart_fade.apply(
                     fade_out_part,
                     fade_in_part,
                     pcm_format,
-                )
+                ):
+                    yield chunk
+                return
             except Exception as e:
                 self.logger.warning(
                     "Smart crossfade failed: %s, falling back to standard crossfade", e
@@ -134,8 +141,9 @@ class SmartFadesMixer:
             logger=self.logger,
             crossfade_duration=standard_crossfade_duration,
         )
-        return await smart_fade.apply(
+        async for chunk in smart_fade.apply(
             fade_out_part,
             fade_in_part,
             pcm_format,
-        )
+        ):
+            yield chunk


### PR DESCRIPTION
## Problem

When smart fades is enabled, the crossfade mixing blocks the audio stream generator for extended periods (up to 17+ seconds observed). During this time no audio is yielded to the player, causing Sonos (and likely other gapless players) to run out of buffer and disconnect prematurely, skipping tracks.

The root cause is twofold:
1. `SmartFade.apply()` uses `communicate()` which buffers the entire FFmpeg input+output in memory before returning
2. CPU-intensive numpy operations in the analyzer run on the main thread, blocking the event loop

## Changes

- Refactor `SmartFade.apply()` to stream FFmpeg output chunk-by-chunk using `AsyncProcess` with concurrent stdin feeding, instead of buffering via `communicate()`
- Convert `SmartFadesMixer.mix()` and `StandardCrossFade.apply()` to async generators that yield chunks as they become available
- Update both `get_queue_item_stream_with_smartfade` (single mode) and `get_queue_flow_stream` (flow mode) to consume the streaming mixer
- Move numpy PCM-to-mono conversion and validation into `asyncio.to_thread()` to stop blocking the event loop during beat analysis