### PR TITLE
Fix AirPlay mDNS discovery race between RAOP and AirPlay services

### DIFF
--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -162,6 +162,8 @@ class DiscoveryController(CoreController):
         self._mdns_waiters.append(event)
         try:
             while True:
+                # Clear before scanning so events arriving during the scan are not lost
+                event.clear()
                 # Check cache for a matching entry
                 for mdns_name in set(self.aiozc.zeroconf.cache.cache):
                     if (
@@ -176,7 +178,6 @@ class DiscoveryController(CoreController):
                 if remaining <= 0:
                     return None
                 # Wait for the next mDNS state change event, then re-check the cache
-                event.clear()
                 try:
                     await asyncio.wait_for(event.wait(), timeout=remaining)
                 except TimeoutError:

--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -69,6 +69,7 @@ class DiscoveryController(CoreController):
         self._mdns_locks: dict[str, asyncio.Lock] = {}
         self._upnp_locks: dict[str, asyncio.Lock] = {}
         self._upnp_run_lock = asyncio.Lock()
+        self._mdns_waiters: list[asyncio.Event] = []
 
     @property
     def aiozc(self) -> AsyncZeroconf:
@@ -143,6 +144,45 @@ class DiscoveryController(CoreController):
         self._mdns_locks.pop(instance_id, None)
         self._upnp_locks.pop(instance_id, None)
         self._schedule_periodic_upnp_discovery()
+
+    async def async_find_mdns_service(
+        self, service_type: str, name_filter: str, timeout: float = 3.0
+    ) -> AsyncServiceInfo | None:
+        """Find an mDNS service by partial name match, checking cache first then waiting.
+
+        :param service_type: The mDNS service type (e.g., "_raop._tcp.local.").
+        :param name_filter: Substring that must appear in the service name.
+        :param timeout: Maximum time to wait in seconds.
+        """
+        deadline = asyncio.get_event_loop().time() + timeout
+        # Cache keys are lowercased DNS names, so we must match case-insensitively
+        name_filter_lower = name_filter.lower()
+        service_type_lower = service_type.lower()
+        event = asyncio.Event()
+        self._mdns_waiters.append(event)
+        try:
+            while True:
+                # Check cache for a matching entry
+                for mdns_name in set(self.aiozc.zeroconf.cache.cache):
+                    if (
+                        service_type_lower in mdns_name
+                        and name_filter_lower in mdns_name
+                        and mdns_name != service_type_lower
+                    ):
+                        info = AsyncServiceInfo(service_type, mdns_name)
+                        if await info.async_request(self.aiozc.zeroconf, 3000):
+                            return info
+                remaining = deadline - asyncio.get_event_loop().time()
+                if remaining <= 0:
+                    return None
+                # Wait for the next mDNS state change event, then re-check the cache
+                event.clear()
+                try:
+                    await asyncio.wait_for(event.wait(), timeout=remaining)
+                except TimeoutError:
+                    return None
+        finally:
+            self._mdns_waiters.remove(event)
 
     def _configure_library_loggers(self) -> None:
         """Align third-party discovery logging with the discovery controller log level."""
@@ -247,6 +287,9 @@ class DiscoveryController(CoreController):
             service_type,
             state_change,
         )
+        # Notify any waiters that a new mDNS event arrived
+        for waiter in self._mdns_waiters:
+            waiter.set()
         for provider in list(self.mass.providers):
             if not provider.available or not provider.manifest.mdns_discovery:
                 continue

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -141,33 +141,19 @@ class AirPlayProvider(PlayerProvider):
         raop_discovery_info: AsyncServiceInfo | None = None
         airplay_discovery_info: AsyncServiceInfo | None = None
         if discovery_info.type == RAOP_DISCOVERY_TYPE:
-            # RAOP service discovered
+            # RAOP service discovered - try to also find the AirPlay service
             raop_discovery_info = discovery_info
             self.logger.debug("Discovered RAOP service for %s", display_name)
-            # always prefer airplay mdns info as it has more details
-            # fallback to raop info if airplay info is not available,
-            # (old device only announcing raop)
-            airplay_discovery_info = AsyncServiceInfo(
-                AIRPLAY_DISCOVERY_TYPE,
-                discovery_info.name.split("@")[-1].replace("_raop", "_airplay"),
+            airplay_discovery_info = await self.mass.discovery.async_find_mdns_service(
+                AIRPLAY_DISCOVERY_TYPE, display_name, timeout=10.0
             )
-            if not await airplay_discovery_info.async_request(
-                self.mass.discovery.aiozc.zeroconf, 3000
-            ):
-                airplay_discovery_info = None
         else:
-            # AirPlay service discovered
+            # AirPlay service discovered - try to also find the RAOP service
             self.logger.debug("Discovered AirPlay service for %s", display_name)
             airplay_discovery_info = discovery_info
-            # also try to get the raop info if available
-            raop_discovery_info = AsyncServiceInfo(
-                RAOP_DISCOVERY_TYPE,
-                discovery_info.name.split("@")[-1].replace("_airplay", "_raop"),
+            raop_discovery_info = await self.mass.discovery.async_find_mdns_service(
+                RAOP_DISCOVERY_TYPE, display_name, timeout=10.0
             )
-            if not await raop_discovery_info.async_request(
-                self.mass.discovery.aiozc.zeroconf, 3000
-            ):
-                raop_discovery_info = None
 
         if airplay_discovery_info:
             manufacturer, model = get_model_info(airplay_discovery_info)


### PR DESCRIPTION
AirPlay devices can announce both RAOP and AirPlay mDNS services, often with a small delay between them. During player setup, we need both service types to make correct protocol decisions. The previous approach manually constructed the companion service name and queried it directly via `async_request`, which had two problems:

- **Wrong RAOP service name**: RAOP services use a `<device_id>@<name>._raop._tcp.local.` format, but the code constructed `<name>._raop._tcp.local.` (missing the device ID prefix), so the lookup always failed for AirPlay→RAOP
- **Race condition**: Even with correct names, the companion service may not have been announced yet

Changes:
- Add `async_find_mdns_service()` helper to the discovery controller that checks the zeroconf cache for a partial name match, then waits for browser events and re-checks until found or timeout
- Replace manual `AsyncServiceInfo` construction in the AirPlay provider with calls to the new helper using display name as a case-insensitive filter