### PR TITLE
Fix group volume balance drift with interpolation-based scaling

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -898,6 +898,7 @@ ATTR_MUTE_CONTROL: Final[str] = "mute_control"
 ATTR_VOLUME_CONTROL: Final[str] = "volume_control"
 ATTR_POWER_CONTROL: Final[str] = "power_control"
 ATTR_PLAY_ACTION_IN_PROGRESS: Final[str] = "play_action_in_progress"
+ATTR_GROUP_VOLUME_SNAPSHOT: Final[str] = "group_volume_snapshot"
 
 # Album type detection patterns
 LIVE_INDICATORS = [

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -62,6 +62,7 @@ from music_assistant.constants import (
     ATTR_FAKE_POWER,
     ATTR_FAKE_VOLUME,
     ATTR_GROUP_MEMBERS,
+    ATTR_GROUP_VOLUME_SNAPSHOT,
     ATTR_LAST_POLL,
     ATTR_MUTE_CONTROL,
     ATTR_MUTE_LOCK,
@@ -624,6 +625,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         :param volume_level: volume level (0..100) to set on the player.
         """
         await self._handle_cmd_volume_set(player_id, volume_level)
+        # individual child volume change invalidates any cached group volume snapshot
+        self._invalidate_group_volume_snapshot(player_id)
 
     @api_command("players/cmd/volume_up")
     @handle_player_command
@@ -1738,26 +1741,74 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         return None
 
     async def set_group_volume(self, group_player: Player, volume_level: int) -> None:
-        """Handle adjusting the overall/group volume to a playergroup (or synced players)."""
+        """
+        Set the overall volume for a player group or synced players.
+
+        Uses interpolation to adjust all child volumes while preserving their
+        relative balance. A snapshot of child volumes is cached on first call and
+        used as the reference point for subsequent adjustments.
+
+        :param group_player: The group player or sync leader.
+        :param volume_level: Target volume level (0..100).
+        """
         cur_volume = group_player.state.group_volume
         if cur_volume is None:
             return
-        volume_dif = volume_level - cur_volume
-        coros = []
-        # handle group volume by only applying the volume to powered members
+
+        children: list[Player] = []
         for child_player in self.iter_group_members(
             group_player, only_powered=True, exclude_self=False
         ):
             if child_player.state.volume_control == PLAYER_CONTROL_NONE:
                 continue
-            cur_child_volume = child_player.state.volume_level or 0
-            new_child_volume = int(cur_child_volume + volume_dif)
-            new_child_volume = max(0, new_child_volume)
-            new_child_volume = min(100, new_child_volume)
-            # Use private method to skip permission check - already validated on group
-            # ATTR_MUTE_LOCK on muted players prevents auto-unmute during group volume changes
+            children.append(child_player)
+        if not children:
+            return
+
+        # cache a snapshot of child volumes on the group player as reference for interpolation.
+        # scaling up: each child interpolates from its snapshot value toward 100.
+        # scaling down: each child interpolates from its snapshot value toward 0.
+        # this ensures the relative balance is preserved and all children converge
+        # to 0 and 100 at the extremes. the snapshot is invalidated when a child's
+        # individual volume changes or group membership changes.
+        snapshot: dict[str, int] | None = group_player.extra_data.get(ATTR_GROUP_VOLUME_SNAPSHOT)
+        if snapshot is None or not all(c.player_id in snapshot for c in children):
+            snapshot = {c.player_id: c.state.volume_level or 0 for c in children}
+            group_player.extra_data[ATTR_GROUP_VOLUME_SNAPSHOT] = snapshot
+
+        base_group = max(snapshot.values())
+
+        coros = []
+        for child_player in children:
+            child_base = snapshot.get(child_player.player_id, 0)
+            if volume_level >= base_group:
+                # scaling up: interpolate each child from snapshot toward 100
+                if base_group >= 100:
+                    new_child_volume = child_base
+                else:
+                    progress = (volume_level - base_group) / (100 - base_group)
+                    new_child_volume = round(child_base + (100 - child_base) * progress)
+            elif base_group == 0:
+                new_child_volume = 0
+            else:
+                # scaling down: interpolate each child from snapshot toward 0
+                progress = volume_level / base_group
+                new_child_volume = round(child_base * progress)
+            new_child_volume = max(0, min(100, new_child_volume))
             coros.append(self._handle_cmd_volume_set(child_player.player_id, new_child_volume))
         await asyncio.gather(*coros)
+
+    def _invalidate_group_volume_snapshot(self, player_id: str) -> None:
+        """Clear the cached group volume snapshot for all groups this player belongs to."""
+        player = self.get_player(player_id)
+        if not player:
+            return
+        if player.state.group_members:
+            player.extra_data.pop(ATTR_GROUP_VOLUME_SNAPSHOT, None)
+        for group_player in self._get_player_groups(player, powered_only=False):
+            group_player.extra_data.pop(ATTR_GROUP_VOLUME_SNAPSHOT, None)
+        if player.state.synced_to and (leader := self.get_player(player.state.synced_to)):
+            leader.extra_data.pop(ATTR_GROUP_VOLUME_SNAPSHOT, None)
 
     def get_announcement_volume(self, player_id: str, volume_override: int | None) -> int | None:
         """Get the (player specific) volume for a announcement."""
@@ -2377,6 +2428,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         self, player: Player, prev_group_members: list[str], new_group_members: list[str]
     ) -> None:
         """Handle DSP reload when group membership changes."""
+        # reset cached group volume snapshot since membership changed
+        player.extra_data.pop(ATTR_GROUP_VOLUME_SNAPSHOT, None)
         prev_child_count = len(prev_group_members)
         new_child_count = len(new_group_members)
         is_player_group = player.state.type == PlayerType.GROUP

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -626,7 +626,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         await self._handle_cmd_volume_set(player_id, volume_level)
         # individual child volume change invalidates any cached group volume snapshot
-        self._invalidate_group_volume_snapshot(player_id)
+        # skip for group players since _handle_cmd_volume_set redirects those to
+        # set_group_volume which creates/uses the snapshot itself
+        if (player := self.get_player(player_id)) and player.type != PlayerType.GROUP:
+            self._invalidate_group_volume_snapshot(player_id)
 
     @api_command("players/cmd/volume_up")
     @handle_player_command

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -841,21 +841,18 @@ class Player(ABC):
         """
         Return the group volume level.
 
-        If this player is a group player or syncgroup, this will return the average volume
-        level of all (powered on) child players in the group or None if none of the players
-        within the group support volume control.
+        For group players or syncgroups, returns the maximum volume level of all
+        powered-on child players, or None if no children support volume control.
 
-        If the player is not a group player or syncgroup, this will return the volume level
-        of the player itself (if set), or None if not supported.
+        For non-group players, returns the player's own volume level.
         """
         if len(self.state.group_members) == 0:
             # player is not a group or syncgroup
             if self.state.volume_control == PLAYER_CONTROL_NONE:
                 return None
             return self.state.volume_level
-        # calculate group volume from all (turned on) players
-        group_volume = 0
-        active_players = 0
+        # return the maximum volume of all (turned on) child players
+        group_volume: int | None = None
         for child_player in self.mass.players.iter_group_members(
             self, only_powered=True, exclude_self=self.type != PlayerType.PLAYER
         ):
@@ -863,11 +860,9 @@ class Player(ABC):
                 continue
             if (child_volume := child_player.state.volume_level) is None:
                 continue
-            group_volume += child_volume
-            active_players += 1
-        if active_players:
-            group_volume = int(group_volume / active_players)
-        return group_volume if active_players else None
+            if group_volume is None or child_volume > group_volume:
+                group_volume = child_volume
+        return group_volume
 
     @cached_property
     @final


### PR DESCRIPTION
## Problem

When adjusting group volume, the old algorithm added the same flat delta to every child player and clamped to 0-100. Once a child hit the ceiling or floor, the relative balance between speakers was permanently lost — moving the slider back wouldn't restore it. It also meant setting group volume to 0 couldn't always silence all speakers, and a child sitting at volume 0 would stay stuck there when raising the group slider.

## Solution

Replace the additive delta with interpolation-based scaling, similar to how the Sonos app handles group volume. This is widely regarded as an intuitive, user-friendly interaction model for multi-speaker volume control.

A snapshot of each child's volume is taken on the first group volume adjustment and used as reference. Moving the group slider up interpolates each child from its snapshot toward 100, moving it down interpolates toward 0. This means:

- All speakers reach 0 when the slider hits 0 and 100 when it hits 100
- The relative balance between speakers is always preserved
- Returning the slider to its original position restores the exact original child volumes
- A child at volume 0 will still increase when raising the group slider

The snapshot is automatically cleared when a child's individual volume changes or when group membership changes, so the next group adjustment always starts fresh from current state.

Additionally, group volume is now derived from the maximum child volume instead of the average. This makes the slider act as a master fader representing the loudest speaker, ensuring it always has the full 0-100 range available.