### PR TITLE
Fix filesystem provider sync config checkboxes not being respected

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -190,6 +190,8 @@ class LocalFileSystemProvider(MusicProvider):
         self.base_path: str = base_path
         self.write_access: bool = False
         self.sync_running: bool = False
+        self._sync_tracks: bool = True
+        self._sync_playlists: bool = True
         self.media_content_type = cast("str", config.get_value(CONF_ENTRY_CONTENT_TYPE.key))
 
     @property
@@ -333,6 +335,22 @@ class LocalFileSystemProvider(MusicProvider):
         if media_type in (MediaType.ARTIST, MediaType.ALBUM):
             # artists and albums are synced as part of track sync
             return
+        # check if any sync options are enabled for this content type
+        # the filesystem provider processes all file types in one scan,
+        # so we can return early if nothing needs syncing
+        if self.media_content_type == "music":
+            self._sync_tracks = bool(self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_TRACKS.key))
+            self._sync_playlists = bool(
+                self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS.key)
+            )
+            if not self._sync_tracks and not self._sync_playlists:
+                return
+        elif self.media_content_type == "audiobooks":
+            if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS.key):
+                return
+        elif self.media_content_type == "podcasts":
+            if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PODCASTS.key):
+                return
         assert self.mass.music.database
         start_time = time.time()
         if self.sync_running:
@@ -444,7 +462,7 @@ class LocalFileSystemProvider(MusicProvider):
             self.logger.log(VERBOSE_LOG_LEVEL, "Processing: %s", item.relative_path)
 
             if item.ext in TRACK_EXTENSIONS and self.media_content_type == "music":
-                if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_TRACKS.key):
+                if not self._sync_tracks:
                     return False
                 tags = await async_parse_tags(item.absolute_path, item.file_size)
                 track = await self._parse_track(item, tags)
@@ -455,8 +473,6 @@ class LocalFileSystemProvider(MusicProvider):
                 return True
 
             if item.ext in AUDIOBOOK_EXTENSIONS and self.media_content_type == "audiobooks":
-                if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS.key):
-                    return False
                 tags = await async_parse_tags(item.absolute_path, item.file_size)
                 try:
                     audiobook = await self._parse_audiobook(item, tags)
@@ -468,8 +484,6 @@ class LocalFileSystemProvider(MusicProvider):
                 return True
 
             if item.ext in PODCAST_EPISODE_EXTENSIONS and self.media_content_type == "podcasts":
-                if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PODCASTS.key):
-                    return False
                 tags = await async_parse_tags(item.absolute_path, item.file_size)
                 episode = await self._parse_podcast_episode(item, tags)
                 assert isinstance(episode.podcast, Podcast)
@@ -479,7 +493,7 @@ class LocalFileSystemProvider(MusicProvider):
                 return True
 
             if item.ext in PLAYLIST_EXTENSIONS and self.media_content_type == "music":
-                if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS.key):
+                if not self._sync_playlists:
                     return False
                 playlist = await self.get_playlist(item.relative_path)
                 await self.mass.music.playlists.add_item_to_library(

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -197,20 +197,16 @@ class LocalFileSystemProvider(MusicProvider):
         """Return the features supported by this Provider."""
         base_features = {*SUPPORTED_FEATURES}
         if self.media_content_type == "audiobooks":
-            if self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS.key):
-                base_features.add(ProviderFeature.LIBRARY_AUDIOBOOKS)
-            return base_features
+            return {ProviderFeature.LIBRARY_AUDIOBOOKS, *base_features}
         if self.media_content_type == "podcasts":
-            if self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PODCASTS.key):
-                base_features.add(ProviderFeature.LIBRARY_PODCASTS)
-            return base_features
-        # Albums and artists are derived from track imports; not advertised as
-        # independent features to prevent phantom sync checkboxes in the UI.
-        music_features = {*base_features}
-        if self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_TRACKS.key):
-            music_features.add(ProviderFeature.LIBRARY_TRACKS)
-        if self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS.key):
-            music_features.add(ProviderFeature.LIBRARY_PLAYLISTS)
+            return {ProviderFeature.LIBRARY_PODCASTS, *base_features}
+        music_features = {
+            ProviderFeature.LIBRARY_ALBUMS,
+            ProviderFeature.LIBRARY_ARTISTS,
+            ProviderFeature.LIBRARY_TRACKS,
+            ProviderFeature.LIBRARY_PLAYLISTS,
+            *base_features,
+        }
         if self.write_access:
             music_features.add(ProviderFeature.PLAYLIST_TRACKS_EDIT)
             music_features.add(ProviderFeature.PLAYLIST_CREATE)

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -197,16 +197,20 @@ class LocalFileSystemProvider(MusicProvider):
         """Return the features supported by this Provider."""
         base_features = {*SUPPORTED_FEATURES}
         if self.media_content_type == "audiobooks":
-            return {ProviderFeature.LIBRARY_AUDIOBOOKS, *base_features}
+            if self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS.key):
+                base_features.add(ProviderFeature.LIBRARY_AUDIOBOOKS)
+            return base_features
         if self.media_content_type == "podcasts":
-            return {ProviderFeature.LIBRARY_PODCASTS, *base_features}
-        music_features = {
-            ProviderFeature.LIBRARY_ALBUMS,
-            ProviderFeature.LIBRARY_ARTISTS,
-            ProviderFeature.LIBRARY_TRACKS,
-            ProviderFeature.LIBRARY_PLAYLISTS,
-            *base_features,
-        }
+            if self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PODCASTS.key):
+                base_features.add(ProviderFeature.LIBRARY_PODCASTS)
+            return base_features
+        # Albums and artists are derived from track imports; not advertised as
+        # independent features to prevent phantom sync checkboxes in the UI.
+        music_features = {*base_features}
+        if self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_TRACKS.key):
+            music_features.add(ProviderFeature.LIBRARY_TRACKS)
+        if self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS.key):
+            music_features.add(ProviderFeature.LIBRARY_PLAYLISTS)
         if self.write_access:
             music_features.add(ProviderFeature.PLAYLIST_TRACKS_EDIT)
             music_features.add(ProviderFeature.PLAYLIST_CREATE)
@@ -444,6 +448,8 @@ class LocalFileSystemProvider(MusicProvider):
             self.logger.log(VERBOSE_LOG_LEVEL, "Processing: %s", item.relative_path)
 
             if item.ext in TRACK_EXTENSIONS and self.media_content_type == "music":
+                if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_TRACKS.key):
+                    return False
                 tags = await async_parse_tags(item.absolute_path, item.file_size)
                 track = await self._parse_track(item, tags)
                 track.favorite = False  # TODO: implement favorite status based on rating ?
@@ -453,6 +459,8 @@ class LocalFileSystemProvider(MusicProvider):
                 return True
 
             if item.ext in AUDIOBOOK_EXTENSIONS and self.media_content_type == "audiobooks":
+                if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS.key):
+                    return False
                 tags = await async_parse_tags(item.absolute_path, item.file_size)
                 try:
                     audiobook = await self._parse_audiobook(item, tags)
@@ -464,6 +472,8 @@ class LocalFileSystemProvider(MusicProvider):
                 return True
 
             if item.ext in PODCAST_EPISODE_EXTENSIONS and self.media_content_type == "podcasts":
+                if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PODCASTS.key):
+                    return False
                 tags = await async_parse_tags(item.absolute_path, item.file_size)
                 episode = await self._parse_podcast_episode(item, tags)
                 assert isinstance(episode.podcast, Podcast)
@@ -473,6 +483,8 @@ class LocalFileSystemProvider(MusicProvider):
                 return True
 
             if item.ext in PLAYLIST_EXTENSIONS and self.media_content_type == "music":
+                if not self.config.get_value(CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS.key):
+                    return False
                 playlist = await self.get_playlist(item.relative_path)
                 await self.mass.music.playlists.add_item_to_library(
                     playlist, overwrite_existing=prev_checksum is not None

--- a/music_assistant/providers/filesystem_local/constants.py
+++ b/music_assistant/providers/filesystem_local/constants.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Final
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
-from music_assistant_models.enums import ConfigEntryType, ProviderFeature
+from music_assistant_models.enums import ConfigEntryType
 
 CONF_MISSING_ALBUM_ARTIST_ACTION = "missing_album_artist_action"
 CONF_CONTENT_TYPE = "content_type"
@@ -175,16 +175,6 @@ SUPPORTED_EXTENSIONS = {
     *AUDIOBOOK_EXTENSIONS,
     *PODCAST_EPISODE_EXTENSIONS,
     *PLAYLIST_EXTENSIONS,
-}
-
-
-SUPPORTED_FEATURES = {
-    ProviderFeature.LIBRARY_ARTISTS,
-    ProviderFeature.LIBRARY_ALBUMS,
-    ProviderFeature.LIBRARY_TRACKS,
-    ProviderFeature.LIBRARY_PLAYLISTS,
-    ProviderFeature.BROWSE,
-    ProviderFeature.SEARCH,
 }
 
 

--- a/tests/providers/filesystem/test_sync_config.py
+++ b/tests/providers/filesystem/test_sync_config.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import ProviderFeature
+from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.media_items import Podcast
 
 from music_assistant.providers.filesystem_local import LocalFileSystemProvider
@@ -51,6 +51,9 @@ def _create_provider(
     provider.config = mock_config
     provider.media_content_type = content_type
     provider.write_access = False
+    provider._sync_tracks = sync_tracks
+    provider._sync_playlists = sync_playlists
+    provider.sync_running = False
     provider.mass = MagicMock()
     provider.logger = MagicMock()
 
@@ -78,6 +81,31 @@ class TestSupportedFeatures:
         """Podcasts content type advertises podcast library feature."""
         provider = _create_provider(content_type="podcasts")
         assert ProviderFeature.LIBRARY_PODCASTS in provider.supported_features
+
+
+class TestSyncLibraryEarlyReturn:
+    """Test that sync_library returns early when all sync options are disabled."""
+
+    @pytest.mark.asyncio
+    async def test_music_returns_early_when_all_disabled(self) -> None:
+        """Music provider returns early when both tracks and playlists sync are disabled."""
+        provider = _create_provider(sync_tracks=False, sync_playlists=False)
+        await provider.sync_library(MediaType.TRACK)
+        provider.mass.music.database.get_rows_from_query.assert_not_called()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_audiobooks_returns_early_when_disabled(self) -> None:
+        """Audiobooks provider returns early when audiobook sync is disabled."""
+        provider = _create_provider(content_type="audiobooks", sync_audiobooks=False)
+        await provider.sync_library(MediaType.AUDIOBOOK)
+        provider.mass.music.database.get_rows_from_query.assert_not_called()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_podcasts_returns_early_when_disabled(self) -> None:
+        """Podcasts provider returns early when podcast sync is disabled."""
+        provider = _create_provider(content_type="podcasts", sync_podcasts=False)
+        await provider.sync_library(MediaType.PODCAST)
+        provider.mass.music.database.get_rows_from_query.assert_not_called()  # type: ignore[attr-defined]
 
 
 class TestProcessItemRespectsConfig:
@@ -151,19 +179,6 @@ class TestProcessItemRespectsConfig:
         provider.mass.music.playlists.add_item_to_library.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_audiobooks_skipped_when_sync_disabled(self) -> None:
-        """Audiobook files are not imported when audiobook sync is disabled."""
-        provider = _create_provider(content_type="audiobooks", sync_audiobooks=False)
-        item = MagicMock()
-        item.ext = next(iter(AUDIOBOOK_EXTENSIONS))
-        item.relative_path = "Author/Book/chapter01.m4b"
-
-        result = await provider._process_item_async(item, None)
-
-        assert result is False
-        provider.mass.music.audiobooks.add_item_to_library.assert_not_called()  # type: ignore[attr-defined]
-
-    @pytest.mark.asyncio
     async def test_audiobooks_imported_when_sync_enabled(self) -> None:
         """Audiobook files are imported when audiobook sync is enabled."""
         provider = _create_provider(content_type="audiobooks", sync_audiobooks=True)
@@ -185,19 +200,6 @@ class TestProcessItemRespectsConfig:
 
         assert result is True
         provider.mass.music.audiobooks.add_item_to_library.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_podcasts_skipped_when_sync_disabled(self) -> None:
-        """Podcast files are not imported when podcast sync is disabled."""
-        provider = _create_provider(content_type="podcasts", sync_podcasts=False)
-        item = MagicMock()
-        item.ext = next(iter(PODCAST_EPISODE_EXTENSIONS))
-        item.relative_path = "Podcast/episode01.mp3"
-
-        result = await provider._process_item_async(item, None)
-
-        assert result is False
-        provider.mass.music.podcasts.add_item_to_library.assert_not_called()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_podcasts_imported_when_sync_enabled(self) -> None:

--- a/tests/providers/filesystem/test_sync_config.py
+++ b/tests/providers/filesystem/test_sync_config.py
@@ -1,19 +1,22 @@
 """Tests for filesystem provider sync configuration behavior."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from music_assistant_models.enums import ProviderFeature
+from music_assistant_models.media_items import Podcast
 
 from music_assistant.providers.filesystem_local import LocalFileSystemProvider
 from music_assistant.providers.filesystem_local.constants import (
+    AUDIOBOOK_EXTENSIONS,
     CONF_ENTRY_CONTENT_TYPE,
     CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
     CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
     CONF_ENTRY_LIBRARY_SYNC_PODCASTS,
     CONF_ENTRY_LIBRARY_SYNC_TRACKS,
+    PODCAST_EPISODE_EXTENSIONS,
+    TRACK_EXTENSIONS,
 )
-
-BASE_FEATURES = {ProviderFeature.BROWSE, ProviderFeature.SEARCH}
 
 
 def _create_provider(
@@ -22,7 +25,6 @@ def _create_provider(
     sync_playlists: bool = True,
     sync_audiobooks: bool = True,
     sync_podcasts: bool = True,
-    write_access: bool = False,
 ) -> LocalFileSystemProvider:
     """Create a LocalFileSystemProvider with mocked dependencies.
 
@@ -31,7 +33,6 @@ def _create_provider(
     :param sync_playlists: Whether the playlists sync checkbox is enabled.
     :param sync_audiobooks: Whether the audiobooks sync checkbox is enabled.
     :param sync_podcasts: Whether the podcasts sync checkbox is enabled.
-    :param write_access: Whether the provider has write access.
     """
     config_values = {
         CONF_ENTRY_CONTENT_TYPE.key: content_type,
@@ -49,88 +50,175 @@ def _create_provider(
 
     provider.config = mock_config
     provider.media_content_type = content_type
-    provider.write_access = write_access
+    provider.write_access = False
+    provider.mass = MagicMock()
+    provider.logger = MagicMock()
 
     return provider
 
 
-class TestSupportedFeaturesMusic:
-    """Test supported_features for music content type."""
+class TestSupportedFeatures:
+    """Test that supported_features reflects content type, not sync preferences."""
 
-    def test_all_sync_enabled(self) -> None:
-        """All music sync features are present when both checkboxes are enabled."""
-        provider = _create_provider(sync_tracks=True, sync_playlists=True)
-        features = provider.supported_features
-        assert features == {
-            *BASE_FEATURES,
-            ProviderFeature.LIBRARY_TRACKS,
-            ProviderFeature.LIBRARY_PLAYLISTS,
-        }
-        assert ProviderFeature.PLAYLIST_TRACKS_EDIT not in features
-        assert ProviderFeature.PLAYLIST_CREATE not in features
-
-    def test_tracks_disabled_removes_track_feature(self) -> None:
-        """Disabling tracks removes LIBRARY_TRACKS from features."""
-        provider = _create_provider(sync_tracks=False, sync_playlists=True)
-        features = provider.supported_features
-        assert ProviderFeature.LIBRARY_TRACKS not in features
-        assert ProviderFeature.LIBRARY_PLAYLISTS in features
-
-    def test_playlists_disabled_removes_playlist_feature(self) -> None:
-        """Disabling playlists removes LIBRARY_PLAYLISTS from features."""
-        provider = _create_provider(sync_tracks=True, sync_playlists=False)
+    def test_music_content_type(self) -> None:
+        """Music content type advertises all music library features."""
+        provider = _create_provider(content_type="music")
         features = provider.supported_features
         assert ProviderFeature.LIBRARY_TRACKS in features
-        assert ProviderFeature.LIBRARY_PLAYLISTS not in features
+        assert ProviderFeature.LIBRARY_PLAYLISTS in features
+        assert ProviderFeature.LIBRARY_ALBUMS in features
+        assert ProviderFeature.LIBRARY_ARTISTS in features
 
-    def test_all_sync_disabled_leaves_only_base_features(self) -> None:
-        """Disabling all sync options leaves only browse and search."""
-        provider = _create_provider(sync_tracks=False, sync_playlists=False)
-        assert provider.supported_features == BASE_FEATURES
-
-    def test_albums_and_artists_never_in_features(self) -> None:
-        """LIBRARY_ALBUMS and LIBRARY_ARTISTS are never advertised.
-
-        Albums and artists are always derived from track imports, not synced
-        independently. Advertising these features would cause the config
-        controller to inject meaningless sync checkboxes.
-        """
-        provider = _create_provider(sync_tracks=True, sync_playlists=True)
-        features = provider.supported_features
-        assert ProviderFeature.LIBRARY_ALBUMS not in features
-        assert ProviderFeature.LIBRARY_ARTISTS not in features
-
-    def test_write_access_adds_playlist_edit_features(self) -> None:
-        """Write access adds playlist editing features regardless of sync config."""
-        provider = _create_provider(sync_tracks=False, sync_playlists=False, write_access=True)
-        features = provider.supported_features
-        assert ProviderFeature.PLAYLIST_TRACKS_EDIT in features
-        assert ProviderFeature.PLAYLIST_CREATE in features
-
-
-class TestSupportedFeaturesAudiobooks:
-    """Test supported_features for audiobooks content type."""
-
-    def test_sync_enabled(self) -> None:
-        """Audiobook feature present when sync is enabled."""
-        provider = _create_provider(content_type="audiobooks", sync_audiobooks=True)
+    def test_audiobooks_content_type(self) -> None:
+        """Audiobooks content type advertises audiobook library feature."""
+        provider = _create_provider(content_type="audiobooks")
         assert ProviderFeature.LIBRARY_AUDIOBOOKS in provider.supported_features
 
-    def test_sync_disabled(self) -> None:
-        """Audiobook feature absent when sync is disabled."""
-        provider = _create_provider(content_type="audiobooks", sync_audiobooks=False)
-        assert provider.supported_features == BASE_FEATURES
-
-
-class TestSupportedFeaturesPodcasts:
-    """Test supported_features for podcasts content type."""
-
-    def test_sync_enabled(self) -> None:
-        """Podcast feature present when sync is enabled."""
-        provider = _create_provider(content_type="podcasts", sync_podcasts=True)
+    def test_podcasts_content_type(self) -> None:
+        """Podcasts content type advertises podcast library feature."""
+        provider = _create_provider(content_type="podcasts")
         assert ProviderFeature.LIBRARY_PODCASTS in provider.supported_features
 
-    def test_sync_disabled(self) -> None:
-        """Podcast feature absent when sync is disabled."""
+
+class TestProcessItemRespectsConfig:
+    """Test that _process_item_async skips items when sync is disabled."""
+
+    @pytest.mark.asyncio
+    async def test_tracks_skipped_when_sync_disabled(self) -> None:
+        """Track files are not imported when track sync is disabled."""
+        provider = _create_provider(sync_tracks=False)
+        item = MagicMock()
+        item.ext = next(iter(TRACK_EXTENSIONS))
+        item.relative_path = "Artist/Album/track.mp3"
+
+        result = await provider._process_item_async(item, None)
+
+        assert result is False
+        provider.mass.music.tracks.add_item_to_library.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tracks_imported_when_sync_enabled(self) -> None:
+        """Track files are imported when track sync is enabled."""
+        provider = _create_provider(sync_tracks=True)
+        item = MagicMock()
+        item.ext = next(iter(TRACK_EXTENSIONS))
+        item.absolute_path = "/media/Artist/Album/track.mp3"
+        item.relative_path = "Artist/Album/track.mp3"
+        item.file_size = 1000
+
+        mock_track = MagicMock()
+        provider._parse_track = AsyncMock(return_value=mock_track)
+        provider.mass.music.tracks.add_item_to_library = AsyncMock()
+
+        with patch(
+            "music_assistant.providers.filesystem_local.async_parse_tags",
+            new_callable=AsyncMock,
+        ):
+            result = await provider._process_item_async(item, None)
+
+        assert result is True
+        provider.mass.music.tracks.add_item_to_library.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_playlists_skipped_when_sync_disabled(self) -> None:
+        """Playlist files are not imported when playlist sync is disabled."""
+        provider = _create_provider(sync_playlists=False)
+        item = MagicMock()
+        item.ext = "m3u"
+        item.relative_path = "playlists/favorites.m3u"
+
+        result = await provider._process_item_async(item, None)
+
+        assert result is False
+        provider.mass.music.playlists.add_item_to_library.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_playlists_imported_when_sync_enabled(self) -> None:
+        """Playlist files are imported when playlist sync is enabled."""
+        provider = _create_provider(sync_playlists=True)
+        item = MagicMock()
+        item.ext = "m3u"
+        item.absolute_path = "/media/playlists/favorites.m3u"
+        item.relative_path = "playlists/favorites.m3u"
+
+        mock_playlist = MagicMock()
+        provider.get_playlist = AsyncMock(return_value=mock_playlist)
+        provider.mass.music.playlists.add_item_to_library = AsyncMock()
+
+        result = await provider._process_item_async(item, None)
+
+        assert result is True
+        provider.mass.music.playlists.add_item_to_library.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_audiobooks_skipped_when_sync_disabled(self) -> None:
+        """Audiobook files are not imported when audiobook sync is disabled."""
+        provider = _create_provider(content_type="audiobooks", sync_audiobooks=False)
+        item = MagicMock()
+        item.ext = next(iter(AUDIOBOOK_EXTENSIONS))
+        item.relative_path = "Author/Book/chapter01.m4b"
+
+        result = await provider._process_item_async(item, None)
+
+        assert result is False
+        provider.mass.music.audiobooks.add_item_to_library.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_audiobooks_imported_when_sync_enabled(self) -> None:
+        """Audiobook files are imported when audiobook sync is enabled."""
+        provider = _create_provider(content_type="audiobooks", sync_audiobooks=True)
+        item = MagicMock()
+        item.ext = next(iter(AUDIOBOOK_EXTENSIONS))
+        item.absolute_path = "/media/Author/Book/chapter01.m4b"
+        item.relative_path = "Author/Book/chapter01.m4b"
+        item.file_size = 5000
+
+        mock_audiobook = MagicMock()
+        provider._parse_audiobook = AsyncMock(return_value=mock_audiobook)
+        provider.mass.music.audiobooks.add_item_to_library = AsyncMock()
+
+        with patch(
+            "music_assistant.providers.filesystem_local.async_parse_tags",
+            new_callable=AsyncMock,
+        ):
+            result = await provider._process_item_async(item, None)
+
+        assert result is True
+        provider.mass.music.audiobooks.add_item_to_library.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_podcasts_skipped_when_sync_disabled(self) -> None:
+        """Podcast files are not imported when podcast sync is disabled."""
         provider = _create_provider(content_type="podcasts", sync_podcasts=False)
-        assert provider.supported_features == BASE_FEATURES
+        item = MagicMock()
+        item.ext = next(iter(PODCAST_EPISODE_EXTENSIONS))
+        item.relative_path = "Podcast/episode01.mp3"
+
+        result = await provider._process_item_async(item, None)
+
+        assert result is False
+        provider.mass.music.podcasts.add_item_to_library.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_podcasts_imported_when_sync_enabled(self) -> None:
+        """Podcast files are imported when podcast sync is enabled."""
+        provider = _create_provider(content_type="podcasts", sync_podcasts=True)
+        item = MagicMock()
+        item.ext = next(iter(PODCAST_EPISODE_EXTENSIONS))
+        item.absolute_path = "/media/Podcast/episode01.mp3"
+        item.relative_path = "Podcast/episode01.mp3"
+        item.file_size = 3000
+
+        mock_episode = MagicMock()
+        mock_episode.podcast = MagicMock(spec=Podcast)
+        provider._parse_podcast_episode = AsyncMock(return_value=mock_episode)
+        provider.mass.music.podcasts.add_item_to_library = AsyncMock()
+
+        with patch(
+            "music_assistant.providers.filesystem_local.async_parse_tags",
+            new_callable=AsyncMock,
+        ):
+            result = await provider._process_item_async(item, None)
+
+        assert result is True
+        provider.mass.music.podcasts.add_item_to_library.assert_called_once()

--- a/tests/providers/filesystem/test_sync_config.py
+++ b/tests/providers/filesystem/test_sync_config.py
@@ -1,0 +1,136 @@
+"""Tests for filesystem provider sync configuration behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from music_assistant_models.enums import ProviderFeature
+
+from music_assistant.providers.filesystem_local import LocalFileSystemProvider
+from music_assistant.providers.filesystem_local.constants import (
+    CONF_ENTRY_CONTENT_TYPE,
+    CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS,
+    CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS,
+    CONF_ENTRY_LIBRARY_SYNC_PODCASTS,
+    CONF_ENTRY_LIBRARY_SYNC_TRACKS,
+)
+
+BASE_FEATURES = {ProviderFeature.BROWSE, ProviderFeature.SEARCH}
+
+
+def _create_provider(
+    content_type: str = "music",
+    sync_tracks: bool = True,
+    sync_playlists: bool = True,
+    sync_audiobooks: bool = True,
+    sync_podcasts: bool = True,
+    write_access: bool = False,
+) -> LocalFileSystemProvider:
+    """Create a LocalFileSystemProvider with mocked dependencies.
+
+    :param content_type: The media content type ("music", "audiobooks", "podcasts").
+    :param sync_tracks: Whether the tracks sync checkbox is enabled.
+    :param sync_playlists: Whether the playlists sync checkbox is enabled.
+    :param sync_audiobooks: Whether the audiobooks sync checkbox is enabled.
+    :param sync_podcasts: Whether the podcasts sync checkbox is enabled.
+    :param write_access: Whether the provider has write access.
+    """
+    config_values = {
+        CONF_ENTRY_CONTENT_TYPE.key: content_type,
+        CONF_ENTRY_LIBRARY_SYNC_TRACKS.key: sync_tracks,
+        CONF_ENTRY_LIBRARY_SYNC_PLAYLISTS.key: sync_playlists,
+        CONF_ENTRY_LIBRARY_SYNC_AUDIOBOOKS.key: sync_audiobooks,
+        CONF_ENTRY_LIBRARY_SYNC_PODCASTS.key: sync_podcasts,
+    }
+
+    mock_config = MagicMock()
+    mock_config.get_value = MagicMock(side_effect=lambda key: config_values.get(key))
+
+    with patch.object(LocalFileSystemProvider, "__init__", lambda *_a, **_kw: None):
+        provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
+
+    provider.config = mock_config
+    provider.media_content_type = content_type
+    provider.write_access = write_access
+
+    return provider
+
+
+class TestSupportedFeaturesMusic:
+    """Test supported_features for music content type."""
+
+    def test_all_sync_enabled(self) -> None:
+        """All music sync features are present when both checkboxes are enabled."""
+        provider = _create_provider(sync_tracks=True, sync_playlists=True)
+        features = provider.supported_features
+        assert features == {
+            *BASE_FEATURES,
+            ProviderFeature.LIBRARY_TRACKS,
+            ProviderFeature.LIBRARY_PLAYLISTS,
+        }
+        assert ProviderFeature.PLAYLIST_TRACKS_EDIT not in features
+        assert ProviderFeature.PLAYLIST_CREATE not in features
+
+    def test_tracks_disabled_removes_track_feature(self) -> None:
+        """Disabling tracks removes LIBRARY_TRACKS from features."""
+        provider = _create_provider(sync_tracks=False, sync_playlists=True)
+        features = provider.supported_features
+        assert ProviderFeature.LIBRARY_TRACKS not in features
+        assert ProviderFeature.LIBRARY_PLAYLISTS in features
+
+    def test_playlists_disabled_removes_playlist_feature(self) -> None:
+        """Disabling playlists removes LIBRARY_PLAYLISTS from features."""
+        provider = _create_provider(sync_tracks=True, sync_playlists=False)
+        features = provider.supported_features
+        assert ProviderFeature.LIBRARY_TRACKS in features
+        assert ProviderFeature.LIBRARY_PLAYLISTS not in features
+
+    def test_all_sync_disabled_leaves_only_base_features(self) -> None:
+        """Disabling all sync options leaves only browse and search."""
+        provider = _create_provider(sync_tracks=False, sync_playlists=False)
+        assert provider.supported_features == BASE_FEATURES
+
+    def test_albums_and_artists_never_in_features(self) -> None:
+        """LIBRARY_ALBUMS and LIBRARY_ARTISTS are never advertised.
+
+        Albums and artists are always derived from track imports, not synced
+        independently. Advertising these features would cause the config
+        controller to inject meaningless sync checkboxes.
+        """
+        provider = _create_provider(sync_tracks=True, sync_playlists=True)
+        features = provider.supported_features
+        assert ProviderFeature.LIBRARY_ALBUMS not in features
+        assert ProviderFeature.LIBRARY_ARTISTS not in features
+
+    def test_write_access_adds_playlist_edit_features(self) -> None:
+        """Write access adds playlist editing features regardless of sync config."""
+        provider = _create_provider(sync_tracks=False, sync_playlists=False, write_access=True)
+        features = provider.supported_features
+        assert ProviderFeature.PLAYLIST_TRACKS_EDIT in features
+        assert ProviderFeature.PLAYLIST_CREATE in features
+
+
+class TestSupportedFeaturesAudiobooks:
+    """Test supported_features for audiobooks content type."""
+
+    def test_sync_enabled(self) -> None:
+        """Audiobook feature present when sync is enabled."""
+        provider = _create_provider(content_type="audiobooks", sync_audiobooks=True)
+        assert ProviderFeature.LIBRARY_AUDIOBOOKS in provider.supported_features
+
+    def test_sync_disabled(self) -> None:
+        """Audiobook feature absent when sync is disabled."""
+        provider = _create_provider(content_type="audiobooks", sync_audiobooks=False)
+        assert provider.supported_features == BASE_FEATURES
+
+
+class TestSupportedFeaturesPodcasts:
+    """Test supported_features for podcasts content type."""
+
+    def test_sync_enabled(self) -> None:
+        """Podcast feature present when sync is enabled."""
+        provider = _create_provider(content_type="podcasts", sync_podcasts=True)
+        assert ProviderFeature.LIBRARY_PODCASTS in provider.supported_features
+
+    def test_sync_disabled(self) -> None:
+        """Podcast feature absent when sync is disabled."""
+        provider = _create_provider(content_type="podcasts", sync_podcasts=False)
+        assert provider.supported_features == BASE_FEATURES

--- a/tests/providers/filesystem/test_sync_config.py
+++ b/tests/providers/filesystem/test_sync_config.py
@@ -94,7 +94,7 @@ class TestProcessItemRespectsConfig:
         result = await provider._process_item_async(item, None)
 
         assert result is False
-        provider.mass.music.tracks.add_item_to_library.assert_not_called()
+        provider.mass.music.tracks.add_item_to_library.assert_not_called()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_tracks_imported_when_sync_enabled(self) -> None:
@@ -107,8 +107,8 @@ class TestProcessItemRespectsConfig:
         item.file_size = 1000
 
         mock_track = MagicMock()
-        provider._parse_track = AsyncMock(return_value=mock_track)
-        provider.mass.music.tracks.add_item_to_library = AsyncMock()
+        provider._parse_track = AsyncMock(return_value=mock_track)  # type: ignore[method-assign]
+        provider.mass.music.tracks.add_item_to_library = AsyncMock()  # type: ignore[method-assign,misc]
 
         with patch(
             "music_assistant.providers.filesystem_local.async_parse_tags",
@@ -130,7 +130,7 @@ class TestProcessItemRespectsConfig:
         result = await provider._process_item_async(item, None)
 
         assert result is False
-        provider.mass.music.playlists.add_item_to_library.assert_not_called()
+        provider.mass.music.playlists.add_item_to_library.assert_not_called()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_playlists_imported_when_sync_enabled(self) -> None:
@@ -142,8 +142,8 @@ class TestProcessItemRespectsConfig:
         item.relative_path = "playlists/favorites.m3u"
 
         mock_playlist = MagicMock()
-        provider.get_playlist = AsyncMock(return_value=mock_playlist)
-        provider.mass.music.playlists.add_item_to_library = AsyncMock()
+        provider.get_playlist = AsyncMock(return_value=mock_playlist)  # type: ignore[method-assign]
+        provider.mass.music.playlists.add_item_to_library = AsyncMock()  # type: ignore[method-assign,misc]
 
         result = await provider._process_item_async(item, None)
 
@@ -161,7 +161,7 @@ class TestProcessItemRespectsConfig:
         result = await provider._process_item_async(item, None)
 
         assert result is False
-        provider.mass.music.audiobooks.add_item_to_library.assert_not_called()
+        provider.mass.music.audiobooks.add_item_to_library.assert_not_called()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_audiobooks_imported_when_sync_enabled(self) -> None:
@@ -174,8 +174,8 @@ class TestProcessItemRespectsConfig:
         item.file_size = 5000
 
         mock_audiobook = MagicMock()
-        provider._parse_audiobook = AsyncMock(return_value=mock_audiobook)
-        provider.mass.music.audiobooks.add_item_to_library = AsyncMock()
+        provider._parse_audiobook = AsyncMock(return_value=mock_audiobook)  # type: ignore[method-assign]
+        provider.mass.music.audiobooks.add_item_to_library = AsyncMock()  # type: ignore[method-assign,misc]
 
         with patch(
             "music_assistant.providers.filesystem_local.async_parse_tags",
@@ -197,7 +197,7 @@ class TestProcessItemRespectsConfig:
         result = await provider._process_item_async(item, None)
 
         assert result is False
-        provider.mass.music.podcasts.add_item_to_library.assert_not_called()
+        provider.mass.music.podcasts.add_item_to_library.assert_not_called()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_podcasts_imported_when_sync_enabled(self) -> None:
@@ -211,8 +211,8 @@ class TestProcessItemRespectsConfig:
 
         mock_episode = MagicMock()
         mock_episode.podcast = MagicMock(spec=Podcast)
-        provider._parse_podcast_episode = AsyncMock(return_value=mock_episode)
-        provider.mass.music.podcasts.add_item_to_library = AsyncMock()
+        provider._parse_podcast_episode = AsyncMock(return_value=mock_episode)  # type: ignore[method-assign]
+        provider.mass.music.podcasts.add_item_to_library = AsyncMock()  # type: ignore[method-assign,misc]
 
         with patch(
             "music_assistant.providers.filesystem_local.async_parse_tags",


### PR DESCRIPTION
I saw Dawsnet in the discord mention these as issues, and @marcelveldt pointed me in the right direction. 

The sync config checkboxes (e.g. "Import tracks/files into the Music
Assistant library") allow users to control whether files are added to
the library database during sync, or only available via Browse. These
checkboxes were ignored — the provider imported everything on sync
regardless of settings.

Additionally, once a filesystem provider instance was saved and its
config page reopened, phantom "Sync Library Albums" and "Sync Library
Artists" checkboxes appeared. These were auto-injected by the config
controller because the provider advertised LIBRARY_ALBUMS and
LIBRARY_ARTISTS in supported_features. Those features are meaningless
for the filesystem provider — albums and artists are always derived
from track imports, never synced independently.

Changes:
- _process_item_async now checks the sync config value before
  importing each media type (tracks, playlists, audiobooks, podcasts).
- supported_features no longer advertises LIBRARY_ALBUMS or
  LIBRARY_ARTISTS, preventing the phantom checkboxes.
- Removed SUPPORTED_FEATURES constant from constants.py (dead since
  #2405 added a replacement in __init__.py).
- Added tests for supported_features across all content types.
