### PR TITLE
Copy queue items list before mutation in delete_item for consistency

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -828,7 +828,7 @@ class PlayerQueuesController(CoreController):
             # the frontend should guard so this is just in case
             self.logger.warning("delete requested for item already loaded in buffer")
             return
-        queue_items = self._queue_items[queue_id]
+        queue_items = self._queue_items[queue_id].copy()
         queue_items.pop(item_index)
         self.update_items(queue_id, queue_items)
 


### PR DESCRIPTION
delete_item() mutated the live list in _queue_items[queue_id] via .pop() before passing it to update_items(). While not a high-risk bug in practice (no await between pop and update_items), this is inconsistent with move_item() and move_item_end() which already works on a copy. Use the same copy-then-mutate pattern for consistency across all queue item modification methods.