### PR TITLE
Bandcamp: fix Liskov substitution violation in get_artist signature

### DIFF
--- a/music_assistant/providers/bandcamp/__init__.py
+++ b/music_assistant/providers/bandcamp/__init__.py
@@ -286,7 +286,7 @@ class BandcampProvider(MusicProvider):
                     band_ids.add(item.band_id)
 
             for band_id in band_ids:
-                yield await self.get_artist(band_id)
+                yield await self.get_artist(str(band_id))
                 await asyncio.sleep(0)  # Yield control to avoid blocking
 
         except BandcampMustBeLoggedInError as error:
@@ -337,7 +337,7 @@ class BandcampProvider(MusicProvider):
 
     @use_cache(CACHE_METADATA)
     @throttle_with_retries
-    async def get_artist(self, prov_artist_id: str | int) -> Artist:
+    async def get_artist(self, prov_artist_id: str) -> Artist:
         """Get full artist details by id."""
         try:
             api_artist = await self._client.get_artist(prov_artist_id)

--- a/tests/providers/bandcamp/test_provider.py
+++ b/tests/providers/bandcamp/test_provider.py
@@ -1880,9 +1880,9 @@ async def test_get_library_artists_paginates(provider: BandcampProvider) -> None
 
         assert len(artists) == 2
         assert mock_get.call_count == 2
-        # Band IDs 100 and 200 from pages 1 and 2
+        # Band IDs 100 and 200 from pages 1 and 2, converted to str per base class contract
         called_ids = {call.args[0] for call in mock_get_artist.call_args_list}
-        assert called_ids == {100, 200}
+        assert called_ids == {"100", "200"}
 
 
 async def test_get_all_collection_items_error_mid_pagination(


### PR DESCRIPTION
The override accepted `str | int` while the base class declares `str`. Convert band_id to str at the call site instead of widening the parameter type.