### PR TITLE
Add Infinite Mix dynamic builtin playlists

### DIFF
--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -84,6 +84,9 @@ from .constants import (
     CONF_KEY_TRACKS,
     DEFAULT_FANART,
     DEFAULT_THUMB,
+    DYNAMIC_BUILTIN_PLAYLISTS,
+    INFINITE_MIX,
+    INFINITE_MIX_FAVORITES,
     RANDOM_ALBUM,
     RANDOM_ARTIST,
     RANDOM_TRACKS,
@@ -255,6 +258,7 @@ class BuiltinProvider(MusicProvider):
                 },
                 owner="Music Assistant",
                 is_editable=False,
+                is_dynamic=prov_playlist_id in DYNAMIC_BUILTIN_PLAYLISTS,
                 metadata=MediaItemMetadata(
                     images=UniqueList([DEFAULT_THUMB])
                     if prov_playlist_id in COLLAGE_IMAGE_PLAYLISTS
@@ -1010,6 +1014,27 @@ class BuiltinProvider(MusicProvider):
             result.append(track)
         return result
 
+    async def _get_builtin_playlist_infinite_mix(self) -> list[Track]:
+        """Return 25 random library tracks for the Infinite Mix dynamic playlist."""
+        result: list[Track] = []
+        for idx, track in enumerate(
+            await self.mass.music.tracks.library_items(limit=25, order_by="random"), 1
+        ):
+            track.position = idx
+            result.append(track)
+        return result
+
+    async def _get_builtin_playlist_infinite_mix_favorites(self) -> list[Track]:
+        """Return 25 random favorited tracks for the Infinite Mix (favorites) dynamic playlist."""
+        result: list[Track] = []
+        for idx, track in enumerate(
+            await self.mass.music.tracks.library_items(favorite=True, limit=25, order_by="random"),
+            1,
+        ):
+            track.position = idx
+            result.append(track)
+        return result
+
     async def _get_builtin_playlist_tracks(
         self, builtin_playlist_id: str
     ) -> list[Track] | UniqueList[Track]:
@@ -1022,6 +1047,8 @@ class BuiltinProvider(MusicProvider):
                 RANDOM_ARTIST: self._get_builtin_playlist_random_artist,
                 RECENTLY_PLAYED: self._get_builtin_playlist_recently_played,
                 RECENTLY_ADDED_TRACKS: self._get_builtin_playlist_recently_added_tracks,
+                INFINITE_MIX: self._get_builtin_playlist_infinite_mix,
+                INFINITE_MIX_FAVORITES: self._get_builtin_playlist_infinite_mix_favorites,
             }[builtin_playlist_id]()
         except KeyError:
             raise MediaNotFoundError(f"No built in playlist: {builtin_playlist_id}")

--- a/music_assistant/providers/builtin/constants.py
+++ b/music_assistant/providers/builtin/constants.py
@@ -53,12 +53,26 @@ BUILTIN_PLAYLISTS = {
 # Playlists that are dynamic: tracks are fetched on demand, never pre-loaded.
 DYNAMIC_BUILTIN_PLAYLISTS = frozenset({INFINITE_MIX, INFINITE_MIX_FAVORITES})
 
+# Optional descriptions shown in the UI for built-in playlists.
+BUILTIN_PLAYLIST_DESCRIPTIONS: dict[str, str] = {
+    INFINITE_MIX: (
+        "An endless, ever-changing playlist that draws 25 random tracks from your full library "
+        "each time the queue is about to run out. No pre-loading — memory usage stays constant "
+        "regardless of library size."
+    ),
+    INFINITE_MIX_FAVORITES: (
+        "Like Infinite Mix, but limited to your favorited tracks. "
+        "25 fresh random favorites are added whenever the queue is nearly empty."
+    ),
+}
+
 BUILTIN_PLAYLISTS_ENTRIES = [
     ConfigEntry(
         key=key,
         type=ConfigEntryType.BOOLEAN,
         label=name,
         default_value=True,
+        description=BUILTIN_PLAYLIST_DESCRIPTIONS.get(key),
         category="generic",
     )
     for key, name in BUILTIN_PLAYLISTS.items()

--- a/music_assistant/providers/builtin/constants.py
+++ b/music_assistant/providers/builtin/constants.py
@@ -36,6 +36,8 @@ RANDOM_ALBUM = "random_album"
 RANDOM_TRACKS = "random_tracks"
 RECENTLY_PLAYED = "recently_played"
 RECENTLY_ADDED_TRACKS = "recently_added_tracks"
+INFINITE_MIX = "infinite_mix"
+INFINITE_MIX_FAVORITES = "infinite_mix_favorites"
 
 BUILTIN_PLAYLISTS = {
     ALL_FAVORITE_TRACKS: "All favorited tracks",
@@ -44,7 +46,13 @@ BUILTIN_PLAYLISTS = {
     RANDOM_TRACKS: "500 Random tracks (from library)",
     RECENTLY_PLAYED: "Recently played tracks",
     RECENTLY_ADDED_TRACKS: "Recently added tracks",
+    INFINITE_MIX: "Infinite Mix (library)",
+    INFINITE_MIX_FAVORITES: "Infinite Mix (favorites)",
 }
+
+# Playlists that are dynamic: tracks are fetched on demand, never pre-loaded.
+DYNAMIC_BUILTIN_PLAYLISTS = frozenset({INFINITE_MIX, INFINITE_MIX_FAVORITES})
+
 BUILTIN_PLAYLISTS_ENTRIES = [
     ConfigEntry(
         key=key,

--- a/tests/providers/builtin/__init__.py
+++ b/tests/providers/builtin/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the built-in provider."""

--- a/tests/providers/builtin/test_infinite_mix.py
+++ b/tests/providers/builtin/test_infinite_mix.py
@@ -1,0 +1,124 @@
+"""Tests for Infinite Mix dynamic built-in playlists."""
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.media_items import Track
+
+from music_assistant.providers.builtin import BuiltinProvider
+from music_assistant.providers.builtin.constants import (
+    ALL_FAVORITE_TRACKS,
+    BUILTIN_PLAYLISTS,
+    DYNAMIC_BUILTIN_PLAYLISTS,
+    INFINITE_MIX,
+    INFINITE_MIX_FAVORITES,
+    RANDOM_TRACKS,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_infinite_mix_ids_in_builtin_playlists() -> None:
+    """Both Infinite Mix IDs must be registered in BUILTIN_PLAYLISTS."""
+    assert INFINITE_MIX in BUILTIN_PLAYLISTS
+    assert INFINITE_MIX_FAVORITES in BUILTIN_PLAYLISTS
+
+
+def test_dynamic_builtin_playlists_membership() -> None:
+    """DYNAMIC_BUILTIN_PLAYLISTS contains exactly the two Infinite Mix variants."""
+    assert INFINITE_MIX in DYNAMIC_BUILTIN_PLAYLISTS
+    assert INFINITE_MIX_FAVORITES in DYNAMIC_BUILTIN_PLAYLISTS
+    # Static playlists must NOT be in the dynamic set.
+    assert RANDOM_TRACKS not in DYNAMIC_BUILTIN_PLAYLISTS
+    assert ALL_FAVORITE_TRACKS not in DYNAMIC_BUILTIN_PLAYLISTS
+
+
+# ---------------------------------------------------------------------------
+# get_playlist() — is_dynamic flag
+# ---------------------------------------------------------------------------
+
+
+def _make_provider() -> BuiltinProvider:
+    """Return a BuiltinProvider instance with a minimal mock mass."""
+    provider = BuiltinProvider.__new__(BuiltinProvider)
+    provider.mass = MagicMock()
+    # instance_id and domain are read-only properties backed by config/manifest
+    provider.config = MagicMock()
+    provider.config.instance_id = "builtin"
+    provider.manifest = MagicMock()
+    provider.manifest.domain = "builtin"
+    return provider
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("playlist_id", [INFINITE_MIX, INFINITE_MIX_FAVORITES])
+async def test_get_playlist_is_dynamic_true_for_infinite_mix(playlist_id: str) -> None:
+    """get_playlist() must set is_dynamic=True for Infinite Mix playlists."""
+    provider = _make_provider()
+    playlist = await provider.get_playlist(playlist_id)
+    assert playlist.is_dynamic is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("playlist_id", [ALL_FAVORITE_TRACKS, RANDOM_TRACKS])
+async def test_get_playlist_is_dynamic_false_for_static_playlists(playlist_id: str) -> None:
+    """get_playlist() must set is_dynamic=False for non-dynamic built-in playlists."""
+    provider = _make_provider()
+    playlist = await provider.get_playlist(playlist_id)
+    assert playlist.is_dynamic is False
+
+
+# ---------------------------------------------------------------------------
+# _get_builtin_playlist_infinite_mix — track fetching
+# ---------------------------------------------------------------------------
+
+
+def _make_tracks(n: int) -> list[Track]:
+    """Return n minimal Track objects."""
+    return cast("list[Track]", [MagicMock(spec=Track) for _ in range(n)])
+
+
+@pytest.mark.asyncio
+async def test_infinite_mix_returns_25_tracks_with_positions() -> None:
+    """_get_builtin_playlist_infinite_mix returns 25 tracks with 1-based positions."""
+    provider = _make_provider()
+    fake_tracks = _make_tracks(25)
+    provider.mass.music.tracks.library_items = AsyncMock(return_value=fake_tracks)  # type: ignore[method-assign]
+
+    result = await provider._get_builtin_playlist_infinite_mix()
+
+    provider.mass.music.tracks.library_items.assert_called_once_with(limit=25, order_by="random")
+    assert len(result) == 25
+    for expected_pos, track in enumerate(result, 1):
+        assert track.position == expected_pos
+
+
+@pytest.mark.asyncio
+async def test_infinite_mix_favorites_passes_favorite_filter() -> None:
+    """_get_builtin_playlist_infinite_mix_favorites passes favorite=True to library_items."""
+    provider = _make_provider()
+    fake_tracks = _make_tracks(25)
+    provider.mass.music.tracks.library_items = AsyncMock(return_value=fake_tracks)  # type: ignore[method-assign]
+
+    result = await provider._get_builtin_playlist_infinite_mix_favorites()
+
+    provider.mass.music.tracks.library_items.assert_called_once_with(
+        favorite=True, limit=25, order_by="random"
+    )
+    assert len(result) == 25
+    for expected_pos, track in enumerate(result, 1):
+        assert track.position == expected_pos
+
+
+@pytest.mark.asyncio
+async def test_infinite_mix_empty_library_returns_empty_list() -> None:
+    """_get_builtin_playlist_infinite_mix handles an empty library gracefully."""
+    provider = _make_provider()
+    provider.mass.music.tracks.library_items = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    result = await provider._get_builtin_playlist_infinite_mix()
+
+    assert result == []


### PR DESCRIPTION
## Summary

Adds two new built-in playlists that use \`Playlist.is_dynamic=True\` to deliver an endless, randomly-ordered playback experience from the local library — without pre-loading the full track list upfront.

### New playlists

| ID | Name | Source |
|---|---|---|
| \`infinite_mix\` | Infinite Mix (library) | 25 random tracks from the full library |
| \`infinite_mix_favorites\` | Infinite Mix (favorites) | 25 random tracks from favorited tracks only |

### How it works

- Both playlists set \`is_dynamic=True\` on the returned \`Playlist\` object.
- \`get_playlist_tracks()\` returns 25 tracks per call with \`order_by="random"\` — **no cache**, so every refill yields a fresh random batch.
- The queue controller (#3527, already merged) detects \`is_dynamic=True\` at end-of-queue and automatically calls \`get_playlist_tracks(force_refresh=True)\` to append the next 25 tracks.
- Memory usage stays constant regardless of library size — no 50k-track pre-expansion.
- UI descriptions are included as \`ConfigEntry.description\` (English fallback; translatable via the frontend repo using keys \`settings.infinite_mix\` / \`settings.infinite_mix_favorites\`).

### What this replaces / complements

The existing \`RANDOM_TRACKS\` playlist loads up to 500 tracks upfront and caches them for 2 minutes. The Infinite Mix playlists load 25 tracks on demand with no cap and no cache — more suitable for long listening sessions.

Closes / implements the "Infinite Mix" use case from [discussion #5129](https://github.com/orgs/music-assistant/discussions/5129).