### PR TITLE
Fix plugin source volume feedback loop with group players

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1805,6 +1805,12 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             coros.append(self._handle_cmd_volume_set(child_player.player_id, new_child_volume))
         await asyncio.gather(*coros)
 
+        # notify active plugin source once at the group level to prevent
+        # feedback loops from per-child callbacks with different volume values
+        if plugin_source := self._get_active_plugin_source(group_player):
+            if plugin_source.on_volume:
+                await plugin_source.on_volume(volume_level)
+
     def _invalidate_group_volume_snapshot(self, player_id: str) -> None:
         """Clear the cached group volume snapshot for all groups this player belongs to."""
         player = self.get_player(player_id)
@@ -3028,9 +3034,12 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # always reset fake mute when controlling volume
         player.extra_data.pop(ATTR_FAKE_MUTE, None)
 
-        # Check if a plugin source is active with a volume callback
+        # Check if a plugin source is active with a volume callback.
+        # Only fire if this player is the direct owner of the plugin source,
+        # not when it merely inherits active_source from a parent group —
+        # group volume changes handle the callback once at the group level.
         if plugin_source := self._get_active_plugin_source(player):
-            if plugin_source.on_volume:
+            if plugin_source.on_volume and plugin_source.in_use_by == player.player_id:
                 await plugin_source.on_volume(volume_level)
         # Handle native volume control support
         if player.volume_control == PLAYER_CONTROL_NATIVE:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1808,7 +1808,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # notify active plugin source once at the group level to prevent
         # feedback loops from per-child callbacks with different volume values
         if plugin_source := self._get_active_plugin_source(group_player):
-            if plugin_source.on_volume:
+            if plugin_source.on_volume and plugin_source.in_use_by == group_player.player_id:
                 await plugin_source.on_volume(volume_level)
 
     def _invalidate_group_volume_snapshot(self, player_id: str) -> None:


### PR DESCRIPTION
## Problem

When a plugin source like Spotify Connect is active on a group/syncgroup, changing the group volume triggers `on_volume` callbacks on every child player (because children inherit `active_source` from the group). Each child sends a different volume value to Spotify, Spotify picks one and echoes it back as a `volume_changed` event, which triggers another group volume change — creating an oscillating feedback loop.

Reported in https://github.com/music-assistant/support/issues/5163

## Changes

- **Skip per-child plugin callbacks during group volume changes**: `_handle_cmd_volume_set` now only fires `on_volume` when the player is the direct owner of the plugin source (`in_use_by == player_id`), not when it merely inherits `active_source` from a parent group.
- **Fire plugin callback once at the group level**: `set_group_volume` notifies the active plugin source once after all child volumes have been adjusted, with the group volume value.