### PR TITLE
Fix Universal Group Player playback issues

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -92,6 +92,7 @@ from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
 from music_assistant.helpers.util import clean_stream_title, detect_charset, remove_file
 from music_assistant.models.smart_fades import SmartFadesMode
 from music_assistant.providers.sync_group.constants import SGP_PREFIX
+from music_assistant.providers.universal_group.constants import UGP_PREFIX
 
 if TYPE_CHECKING:
     from music_assistant_models.player_queue import PlayerQueue
@@ -1012,12 +1013,23 @@ class StreamsAudio:
                 sgp_player = cast("SyncGroupPlayer", player)
                 if sync_leader := sgp_player.sync_leader:
                     output_format = sync_leader.extra_data.get("output_format", None)
+        elif player.player_id.startswith(UGP_PREFIX):
+            # UGP is a virtual group player - don't add it to DSP details,
+            # only its children (handled below)
+            pass
         else:
             details = self.get_player_dsp_details(player)
             dsp[player.player_id] = details
             if group_preventing_dsp:
                 output_format = player.extra_data.get("output_format", None)
-            is_external_group = player.state.type in (PlayerType.GROUP, PlayerType.STEREO_PAIR)
+            is_external_group = (
+                player.state.type
+                in (
+                    PlayerType.GROUP,
+                    PlayerType.STEREO_PAIR,
+                )
+                and PlayerFeature.MULTI_DEVICE_DSP not in player.state.supported_features
+            )
 
         if player and player.state.group_members and not is_external_group:
             for child_id in player.state.group_members:

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -328,7 +328,7 @@ class StreamsController(CoreController):
         :param media: The PlayerMedia object for which to resolve the stream URL.
         :return: The resolved stream URL as a string.
         """
-        if media.media_type == MediaType.ANNOUNCEMENT:
+        if media.media_type in (MediaType.ANNOUNCEMENT, MediaType.FLOW_STREAM):
             return media.uri
         if media.media_type == MediaType.PLUGIN_SOURCE:
             if media.custom_data and (source_id := media.custom_data.get("source_id")):

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -282,9 +282,7 @@ class UniversalGroupPlayer(Player):
 
         # forward to downstream play_media commands
         async with TaskManager(self.mass) as tg:
-            for member in self.mass.players.iter_group_members(
-                self, only_powered=True, active_only=True
-            ):
+            for member in self.mass.players.iter_group_members(self, only_powered=True):
                 # Use internal handler to get protocol selection and avoid redirect
                 tg.create_task(
                     self.mass.players._handle_play_media(
@@ -376,11 +374,12 @@ class UniversalGroupPlayer(Player):
             # static group players should not support SET_MEMBERS feature
             self._attr_supported_features.discard(PlayerFeature.SET_MEMBERS)
         # grab current media and state from one of the active players
+        # use state properties (not raw attributes) to account for protocol player propagation
         for child_player in self.mass.players.iter_group_members(self, active_only=True):
-            self._attr_playback_state = child_player.playback_state
-            if child_player.elapsed_time:
-                self._attr_elapsed_time = child_player.elapsed_time
-                self._attr_elapsed_time_last_updated = child_player.elapsed_time_last_updated
+            self._attr_playback_state = child_player.state.playback_state
+            if child_player.state.elapsed_time:
+                self._attr_elapsed_time = child_player.state.elapsed_time
+                self._attr_elapsed_time_last_updated = child_player.state.elapsed_time_last_updated
             break
         else:
             self._attr_playback_state = PlaybackState.IDLE


### PR DESCRIPTION
The Universal Group Player (UGP) was completely broken - playback would fail after ~2 seconds and revert to idle, with no audio heard on any child player.

**Root cause:** Several issues compounding:

- **No play commands sent to children:** `play_media()` used `active_only=True` when iterating group members, but children's cached `active_group` property hadn't been recomputed yet (debounced 0.25s), so all children were filtered out
- **Stream URL resolution failed for protocol players:** `resolve_stream_url` didn't handle `FLOW_STREAM` media type, causing providers like Sonos (that call resolve) to error with "Invalid PlayerMedia data"
- **No elapsed time propagation:** `_set_attributes` read raw `child_player.elapsed_time` instead of `child_player.state.elapsed_time`, missing the protocol player chain (UGP → child → protocol player)
- **DSP/output format not populated for children:** `get_stream_dsp_details` treated UGP as an "external group" (skipping child iteration), and also incorrectly included the virtual UGP player itself in the DSP dict

**Changes:**

- Remove `active_only=True` from `play_media()` member iteration - use `only_powered=True` only
- Handle `FLOW_STREAM` in `resolve_stream_url` by returning the URI directly (like announcements)
- Read from `child_player.state.*` in `_set_attributes` to get protocol-propagated values
- Skip UGP virtual player in `get_stream_dsp_details` (matching sync group behavior)
- Don't treat groups with `MULTI_DEVICE_DSP` as external groups when iterating children for DSP details