### PR TITLE
Enable Sendspin bridge for Cast stereo pairs

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -110,10 +110,10 @@ class ProtocolLinkingMixin:
         if player.state.type == PlayerType.PROTOCOL:
             # Protocol player: try to find a native parent
             self._try_link_protocol_to_native(player)
-        elif player.state.type in (PlayerType.GROUP, PlayerType.STEREO_PAIR):
+        elif player.state.type == PlayerType.GROUP:
             return
         else:
-            # Native player: try to find protocol players to link
+            # Native player (including STEREO_PAIR): try to find protocol players to link
             self._try_link_protocols_to_native(player)
 
     def _try_link_protocol_to_native(self, protocol_player: Player) -> None:
@@ -150,7 +150,7 @@ class ProtocolLinkingMixin:
         :return: True if handled (linked or waiting), False if should fall through.
         """
         if parent_player := self.get_player(cached_parent_id):
-            if parent_player.state.type in (PlayerType.GROUP, PlayerType.STEREO_PAIR):
+            if parent_player.state.type == PlayerType.GROUP:
                 self._clear_protocol_parent_id(protocol_player.player_id)
                 return False
             already_linked = any(
@@ -202,11 +202,7 @@ class ProtocolLinkingMixin:
         for native_player in self.all_players(return_protocol_players=False):
             if native_player.player_id == protocol_player.player_id:
                 continue
-            if native_player.state.type in (
-                PlayerType.PROTOCOL,
-                PlayerType.GROUP,
-                PlayerType.STEREO_PAIR,
-            ):
+            if native_player.state.type in (PlayerType.PROTOCOL, PlayerType.GROUP):
                 continue
 
             # For universal players, check if this protocol player is in its stored list

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -409,10 +409,11 @@ class SendspinBridgeManager:
                 self.logger.debug("Bridge already exists for %s", cast_player.display_name)
                 return
 
-            # Skip bridging for audio groups and multichannel children
-            if cast_player.cast_info.is_audio_group:
-                return
-            if cast_player.cast_info.is_multichannel_child:
+            # Skip audio groups (non-stereo-pair) — they have their own playback mechanism
+            if (
+                cast_player.cast_info.is_audio_group
+                and not cast_player.cast_info.is_multichannel_group
+            ):
                 return
 
             # skip if the cast player's parent also has airplay linked


### PR DESCRIPTION
## Problem

Cast stereo pairs were excluded from the Sendspin Cast bridge, meaning they couldn't benefit from Sendspin-based playback. Users with stereo pair setups had no way to use the Sendspin protocol on these devices.

## Changes

- Remove the blanket exclusion of all audio groups from the Sendspin bridge, and instead only skip non-stereo-pair groups (regular Cast groups still use their own playback mechanism)
- Allow `STEREO_PAIR` player type in protocol linking so the Sendspin bridge player gets linked to the Cast stereo pair player via `CAST_UUID` matching (previously both `GROUP` and `STEREO_PAIR` were excluded)

> [!NOTE]
> This should be tested in nightly/beta first — I don't have access to a Cast stereo pair to verify this works in practice.