### PR TITLE
Fix audio analysis version gating for non-track media

### DIFF
--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -74,6 +74,7 @@ class AudioAnalysisProvider(Provider):
             streamdetails.item_id,
             streamdetails.provider,
             self.domain,
+            media_type=streamdetails.media_type,
         )
         if stored_version is not None and stored_version >= self.analysis_version:
             return False

--- a/music_assistant/providers/_demo_audio_analysis_provider/__init__.py
+++ b/music_assistant/providers/_demo_audio_analysis_provider/__init__.py
@@ -180,6 +180,7 @@ class DemoAudioAnalysisProvider(AudioAnalysisProvider):
                 aa_provider_domain=self.domain,
                 analysis=analysis,
                 analysis_version=self.analysis_version,
+                media_type=session.streamdetails.media_type,
             )
 
         Note: The base class's finalize() method calls this, then cleans up

--- a/tests/core/test_audio_analysis_controller.py
+++ b/tests/core/test_audio_analysis_controller.py
@@ -7,8 +7,7 @@ import unittest.mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import MediaType
-from music_assistant_models.enums import ContentType
+from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.controllers.streams.audio_analysis import (

--- a/tests/core/test_audio_analysis_controller.py
+++ b/tests/core/test_audio_analysis_controller.py
@@ -7,6 +7,7 @@ import unittest.mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.enums import MediaType
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
 
@@ -432,6 +433,38 @@ async def test_finalize_cleans_up_provider_sessions() -> None:
 
     provider._finalize.assert_called_once_with("test_session")
     assert "test_session" not in provider._sessions
+
+
+@pytest.mark.asyncio
+async def test_provider_start_analysis_uses_media_type_for_version_gating() -> None:
+    """Version gating must include media_type so analyses do not collide across item types."""
+    provider = MagicMock(spec=AudioAnalysisProvider)
+    provider.mass = MagicMock()
+    provider.mass.streams.audio_analysis.get_audio_analysis_version = AsyncMock(return_value=None)
+    provider._sessions = {}
+    provider._start_analysis = AsyncMock(return_value=True)
+    provider.domain = "test_domain"
+    provider.analysis_version = 1
+
+    streamdetails = MagicMock()
+    streamdetails.item_id = "shared_id"
+    streamdetails.provider = "test_prov"
+    streamdetails.media_type = MediaType.RADIO
+
+    accepted = await AudioAnalysisProvider.start_analysis(
+        provider,
+        session_id="session_1",
+        streamdetails=streamdetails,
+        audio_format=TEST_PCM_FORMAT,
+    )
+
+    assert accepted is True
+    provider.mass.streams.audio_analysis.get_audio_analysis_version.assert_awaited_once_with(
+        "shared_id",
+        "test_prov",
+        "test_domain",
+        media_type=MediaType.RADIO,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
Audio analysis version gating looked up stored results without `media_type`, so an analysis for one media type could incorrectly suppress analysis for another item with the same provider/item ID.

## Changes
- include `media_type` in the audio analysis version lookup
- add regression coverage for media-type-aware version gating
- update the demo provider example to pass `media_type` when storing analysis