### PR TITLE
Fix high CPU usage during audio streaming on low-power devices

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1544,6 +1544,7 @@ class StreamsAudio:
                 yield buffer[: pcm_format.pcm_sample_size]
                 bytes_written += pcm_format.pcm_sample_size
                 buffer = buffer[pcm_format.pcm_sample_size :]
+                await asyncio.sleep(0)
 
         #### HANDLE END OF TRACK
 
@@ -1867,6 +1868,7 @@ class StreamsAudio:
                     yield crossfade_buffer[:pcm_sample_size]
                     bytes_written += pcm_sample_size
                     crossfade_buffer = crossfade_buffer[pcm_sample_size:]
+                    await asyncio.sleep(0)
 
             #### HANDLE END OF TRACK
             if not first_chunk_received:

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -434,8 +434,11 @@ class AudioBuffer:
             # audio analysis providers
             # loudness analysis for all streams (tracks and radio)
             mass.streams.audio.attach_loudness_analyzer(audio_buffer, streamdetails)
-            # smart fades analysis only for music tracks (not podcasts/audiobooks)
-            if streamdetails.media_type == MediaType.TRACK:
+            # smart fades analysis only when enabled and only for music tracks
+            if (
+                streamdetails.media_type == MediaType.TRACK
+                and smart_fades_mode != SmartFadesMode.DISABLED
+            ):
                 mass.streams.smart_fades_analyzer.attach_to_buffer(audio_buffer, streamdetails)
             # audio analysis providers (beat tracking, key detection, etc.)
             await mass.streams.audio_analysis.start_analysis(audio_buffer, streamdetails)

--- a/music_assistant/controllers/streams/smart_fades/analyzer.py
+++ b/music_assistant/controllers/streams/smart_fades/analyzer.py
@@ -31,6 +31,10 @@ if TYPE_CHECKING:
     from music_assistant.controllers.streams.controller import StreamsController
 
 ANALYSIS_FPS = 100
+# Sample rate used for librosa beat analysis.
+# librosa defaults to 22050 Hz; using a higher rate than necessary
+# wastes CPU (e.g. 192 kHz is ~8.7x more work for no benefit).
+ANALYSIS_SAMPLE_RATE = 22050
 
 
 class SmartFadesAnalyzer:
@@ -170,7 +174,22 @@ class SmartFadesAnalyzer:
                 )
                 return None
 
-            analysis = await self._analyze_track_beats(mono_audio, fragment, pcm_format.sample_rate)
+            # downsample to ANALYSIS_SAMPLE_RATE before beat analysis to avoid
+            # wasting CPU on high sample rates (e.g. 192 kHz)
+            analysis_sr = pcm_format.sample_rate
+            if analysis_sr > ANALYSIS_SAMPLE_RATE:
+                mono_audio = np.asarray(
+                    await asyncio.to_thread(
+                        librosa.resample,
+                        mono_audio,
+                        orig_sr=analysis_sr,
+                        target_sr=ANALYSIS_SAMPLE_RATE,
+                    ),
+                    dtype=np.float32,
+                )
+                analysis_sr = ANALYSIS_SAMPLE_RATE
+
+            analysis = await self._analyze_track_beats(mono_audio, fragment, analysis_sr)
 
             total_time = time.perf_counter() - start_time
             if not analysis:


### PR DESCRIPTION
## Problem

Playing high sample rate audio (e.g. 192kHz/24-bit from Qobuz) on low-power hardware like HA Green causes CPU to spike to 95%+ and eventually crashes the server. This is especially problematic with short tracks (e.g. 30-second previews), where analyses pile up faster than they complete.

## Changes

- **Only run smart fades analysis when enabled**: The beat analyzer was attaching to every track buffer unconditionally, even when smart fades mode was disabled. Now it only attaches when the feature is actually enabled.
- **Downsample before librosa beat analysis**: librosa was processing audio at the native sample rate (e.g. 192kHz), which is ~8.7x more work than needed. Audio is now downsampled to 22050 Hz before analysis.
- **Yield to event loop in crossfade buffer loops**: Added `await asyncio.sleep(0)` in the tight crossfade buffer trim loops to prevent event loop starvation during large buffer processing.