### PR TITLE
Fix external source reporting on Universal Players

### DIFF
--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -348,7 +348,17 @@ class DLNAPlayer(Player):
         self._attr_playback_state = _playback_state
 
         _device_uri = self.device.current_track_uri or ""
-        self.set_current_media(uri=_device_uri, clear_all=True)
+        self.set_current_media(
+            uri=_device_uri,
+            clear_all=True,
+            title=self.device.media_title,
+            artist=self.device.media_artist,
+            album=self.device.media_album_name,
+            image_url=self.device.media_image_url,
+            duration=int(self.device.media_duration)
+            if self.device.media_duration is not None
+            else None,
+        )
 
         # Let player controller determine active source, only override for known external sources
         if _device_uri and _device_uri.startswith(self.mass.streams.base_url):

--- a/music_assistant/providers/universal_player/constants.py
+++ b/music_assistant/providers/universal_player/constants.py
@@ -11,3 +11,7 @@ CONF_DEVICE_IDENTIFIERS: Final[str] = "device_identifiers"
 
 # Config key for storing device info (model, manufacturer)
 CONF_DEVICE_INFO: Final[str] = "device_info"
+
+# Protocols where external sources (e.g. Spotify Connect) can play
+# independently of Music Assistant.
+EXTERNAL_SOURCE_PROTOCOLS = {"chromecast", "dlna"}

--- a/music_assistant/providers/universal_player/player.py
+++ b/music_assistant/providers/universal_player/player.py
@@ -14,9 +14,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from music_assistant_models.enums import PlaybackState, PlayerFeature
+
+from music_assistant.constants import EXTERNAL_SOURCES
 from music_assistant.models.player import DeviceInfo, Player
 
+from .constants import EXTERNAL_SOURCE_PROTOCOLS
+
 if TYPE_CHECKING:
+    from music_assistant_models.player import PlayerMedia, PlayerSource
+
     from .provider import UniversalPlayerProvider
 
 
@@ -59,11 +66,95 @@ class UniversalPlayer(Player):
     @property
     def available(self) -> bool:
         """Return if the player is currently available."""
-        # A universal player is available if any of its linked protocol players are available
         return any(
             (p := self.mass.players.get_player(pid)) and p.available
             for pid in self._protocol_player_ids
         )
+
+    @property
+    def supported_features(self) -> set[PlayerFeature]:
+        """Return the supported features of the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            return ext_player.supported_features
+        return self._attr_supported_features
+
+    @property
+    def active_source(self) -> str | None:
+        """Return the active source of the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            return ext_player.active_source
+        return None
+
+    @property
+    def playback_state(self) -> PlaybackState:
+        """Return the current playback state of the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            return ext_player.playback_state
+        return self._attr_playback_state
+
+    @property
+    def elapsed_time(self) -> float | None:
+        """Return the elapsed time in (fractional) seconds of the current track."""
+        if ext_player := self._get_external_source_protocol_player():
+            return ext_player.elapsed_time
+        return None
+
+    @property
+    def elapsed_time_last_updated(self) -> float | None:
+        """Return when the elapsed time was last updated."""
+        if ext_player := self._get_external_source_protocol_player():
+            return ext_player.elapsed_time_last_updated
+        return None
+
+    @property
+    def current_media(self) -> PlayerMedia | None:
+        """Return the current media being played by the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            return ext_player.current_media
+        return None
+
+    @property
+    def source_list(self) -> list[PlayerSource]:
+        """Return list of available sources for this player."""
+        if ext_player := self._get_external_source_protocol_player():
+            # if an external source is active, show sources from that protocol player
+            return ext_player.source_list
+        return super().source_list
+
+    async def stop(self) -> None:
+        """Handle STOP command on the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            # power off the protocol player to fully stop external apps (e.g. quit cast app)
+            if PlayerFeature.POWER in ext_player.supported_features:
+                await ext_player.power(False)
+            else:
+                await ext_player.stop()
+
+    async def play(self) -> None:
+        """Handle PLAY command on the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            await ext_player.play()
+
+    async def pause(self) -> None:
+        """Handle PAUSE command on the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            await ext_player.pause()
+
+    async def next_track(self) -> None:
+        """Handle NEXT_TRACK command on the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            await ext_player.next_track()
+
+    async def previous_track(self) -> None:
+        """Handle PREVIOUS_TRACK command on the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            await ext_player.previous_track()
+
+    async def seek(self, position: int) -> None:
+        """Handle SEEK command on the player."""
+        if ext_player := self._get_external_source_protocol_player():
+            await ext_player.seek(position)
+            self.mass.players.trigger_player_update(ext_player.player_id, debounce_delay=2)
 
     def add_protocol_player(self, protocol_player_id: str) -> None:
         """Add a protocol player to this universal player."""
@@ -74,3 +165,30 @@ class UniversalPlayer(Player):
         """Remove a protocol player from this universal player."""
         if protocol_player_id in self._protocol_player_ids:
             self._protocol_player_ids.remove(protocol_player_id)
+
+    def _get_external_source_protocol_player(self) -> Player | None:
+        """
+        Return a chromecast or dlna protocol player that has an external source active.
+
+        Prefers chromecast over dlna because dlna metadata tends to be less reliable.
+        """
+        if self.active_output_protocol:
+            # if an output protocol is active, don't consider external sources
+            return None
+        result: Player | None = None
+        for pid in self._protocol_player_ids:
+            protocol_player = self.mass.players.get_player(pid)
+            if not protocol_player or not protocol_player.available:
+                continue
+            if protocol_player.provider.domain not in EXTERNAL_SOURCE_PROTOCOLS:
+                continue
+            if (
+                protocol_player.active_source
+                and protocol_player.active_source.lower() in EXTERNAL_SOURCES
+                and protocol_player.playback_state != PlaybackState.IDLE
+            ):
+                # chromecast is preferred, return immediately
+                if protocol_player.provider.domain == "chromecast":
+                    return protocol_player
+                result = result or protocol_player
+        return result


### PR DESCRIPTION
## Problem

When an external source (e.g. Spotify Connect, YouTube Music) is playing on a Chromecast or DLNA protocol player that is part of a Universal Player, the Universal Player does not reflect this. It stays idle with no active source, no playback controls, and no media info shown in the UI.

Fixes https://github.com/music-assistant/support/issues/5160

## Changes

- **Universal Player**: Override state properties (`active_source`, `playback_state`, `elapsed_time`, `current_media`, `supported_features`, `source_list`) to propagate external source state from linked Chromecast/DLNA protocol players. AirPlay and Squeezelite are excluded as MA is the sole controller for those.
- **Universal Player**: Add playback command delegation (`stop`, `play`, `pause`, `next_track`, `previous_track`, `seek`) to the protocol player when an external source is active. Stop uses power-off for Chromecast to properly quit external apps.
- **Universal Player**: Prefer Chromecast over DLNA when both report an external source, as DLNA metadata tends to be less reliable.
- **DLNA Player**: Extract available metadata (`media_title`, `media_artist`, `media_album_name`, `media_image_url`, `media_duration`) from the DLNA device when setting `current_media`.