### PR TITLE
Fix scheduled sync task settings not persisting across restarts

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1725,17 +1725,24 @@ class MusicController(CoreController):
         """Schedule Library sync for given provider."""
         if not (provider := self.mass.get_provider(provider_instance_id)):
             return
-        self.unschedule_provider_sync(provider.instance_id)
+        self.unschedule_provider_sync(provider.instance_id, clear_persisted_state=False)
         for media_type in MediaType:
             if not provider.library_supported(media_type):
                 continue
             await self._schedule_provider_mediatype_sync(provider, media_type, True)
 
-    def unschedule_provider_sync(self, provider_instance_id: str) -> None:
-        """Unschedule Library sync for given provider."""
+    def unschedule_provider_sync(
+        self, provider_instance_id: str, clear_persisted_state: bool = True
+    ) -> None:
+        """Unschedule Library sync for given provider.
+
+        :param provider_instance_id: The provider instance id to unschedule.
+        :param clear_persisted_state: Whether to remove persisted schedule state from config.
+        """
         for media_type in MediaType:
             self.mass.tasks.unregister_scheduled_task(
-                self._get_sync_task_id(provider_instance_id, media_type)
+                self._get_sync_task_id(provider_instance_id, media_type),
+                clear_persisted_state=clear_persisted_state,
             )
 
     def get_provider_sync_schedule(

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -721,7 +721,7 @@ class MusicAssistant:
 
     async def unload_provider(self, instance_id: str, is_removed: bool = False) -> None:
         """Unload a provider."""
-        self.music.unschedule_provider_sync(instance_id)
+        self.music.unschedule_provider_sync(instance_id, clear_persisted_state=is_removed)
         if provider := self._providers.get(instance_id):
             if isinstance(provider, PlayerProvider):
                 await self.players.on_provider_unload(provider)


### PR DESCRIPTION
## Problem

User-customized background task schedules (e.g. disabling Plex library sync or changing the interval) were reset to defaults on every container restart. This caused unnecessary full library syncs on startup even when the user had explicitly disabled them.

Reported in music-assistant/support#5183.

## Cause

`schedule_provider_sync()` calls `unschedule_provider_sync()` on every provider load, which calls `unregister_scheduled_task()` with `clear_persisted_state=True` (the default). This wipes the saved schedule settings from config **before** the tasks are re-registered, so `_restore_scheduled_task_state()` finds nothing to restore.

## Changes

- Pass `clear_persisted_state=False` in `schedule_provider_sync()` when calling `unschedule_provider_sync()`, since the intent is to re-register tasks (not permanently remove them)
- Add `clear_persisted_state` parameter to `unschedule_provider_sync()` (defaults to `True` for actual provider unloads)