### PR TITLE
Handle Ogg FLAC in-band metadata in chained radio streams

### DIFF
--- a/music_assistant/controllers/streams/ogg_handler.py
+++ b/music_assistant/controllers/streams/ogg_handler.py
@@ -32,6 +32,12 @@ OGG_FLAG_CONTINUATION: int = 0x01  # Continuation of previous page
 OGG_FLAG_BOS: int = 0x02  # Beginning of stream
 OGG_FLAG_EOS: int = 0x04  # End of stream
 
+# Ogg FLAC constants
+FLAC_METADATA_HEADER_SIZE: int = (
+    4  # Size of FLAC metadata block header (1 byte type + 3 bytes length)
+)
+FLAC_METADATA_BLOCK_VORBIS_COMMENT: int = 4  # FLAC metadata block type for Vorbis comments
+
 
 class OggPage:
     """Parsed OGG page with header fields and payload."""
@@ -89,9 +95,21 @@ class OggPage:
         return len(self.segment_data) > 7 and self.segment_data[0:7] == b"\x03vorbis"
 
     @property
-    def is_header_page(self) -> bool:
+    def is_ogg_flac_mapping_page(self) -> bool:
+        """Return True if page starts with the Ogg FLAC mapping header packet."""
+        return len(self.segment_data) > 5 and self.segment_data[0:5] == b"\x7fFLAC"
+
+    def is_header_page(self, is_ogg_flac_stream: bool = False) -> bool:
         """Return True if page is a header (not audio data)."""
-        return self.is_opus_head or self.is_opus_tags or self.is_vorbis_id or self.is_vorbis_comment
+        return (
+            self.is_opus_head
+            or self.is_opus_tags
+            or self.is_vorbis_id
+            or self.is_vorbis_comment
+            or self.is_ogg_flac_mapping_page
+            # In Ogg FLAC streams pages with granule position 0 contain header packets and not audio data
+            or (is_ogg_flac_stream and self.granule_position == 0)
+        )
 
 
 def parse_ogg_page(data: bytes | bytearray, offset: int = 0) -> tuple[OggPage, int] | None:
@@ -222,12 +240,41 @@ def parse_vorbis_comments(data: bytes) -> dict[str, str]:
     return comments
 
 
-def extract_metadata_from_page(page: OggPage) -> dict[str, str] | None:
-    """Extract metadata from page if it contains OpusTags or Vorbis comments."""
+def parse_flac_vorbis_comment_block(data: bytes) -> dict[str, str]:
+    """Parse Vorbis comments from a native FLAC metadata block."""
+    if len(data) < FLAC_METADATA_HEADER_SIZE:
+        return {}
+    block_length = int.from_bytes(data[1:4], byteorder="big")
+    if len(data) < FLAC_METADATA_HEADER_SIZE + block_length:
+        LOGGER.debug(
+            "Skipping FLAC Vorbis comment block spanning multiple OGG pages: "
+            "need %d bytes, have %d",
+            FLAC_METADATA_HEADER_SIZE + block_length,
+            len(data),
+        )
+        return {}
+    comment_data = data[FLAC_METADATA_HEADER_SIZE : FLAC_METADATA_HEADER_SIZE + block_length]
+    return parse_vorbis_comments(comment_data)
+
+
+def _is_flac_vorbis_comment_block(data: bytes) -> bool:
+    """Return True if Ogg FLAC packet data contains a FLAC Vorbis comment block."""
+    if len(data) < FLAC_METADATA_HEADER_SIZE:
+        return False
+    block_type = data[0] & 0x7F
+    return block_type == FLAC_METADATA_BLOCK_VORBIS_COMMENT
+
+
+def extract_metadata_from_page(
+    page: OggPage, is_ogg_flac_stream: bool = False
+) -> dict[str, str] | None:
+    """Extract metadata from page if it contains supported comment metadata."""
     if page.is_opus_tags:
         return parse_vorbis_comments(page.segment_data[8:])
     if page.is_vorbis_comment:
         return parse_vorbis_comments(page.segment_data[7:])
+    if is_ogg_flac_stream and _is_flac_vorbis_comment_block(page.segment_data):
+        return parse_flac_vorbis_comment_block(page.segment_data)
     return None
 
 
@@ -240,14 +287,15 @@ class _ChainedOggState:
         self.output_sequence: int = 0
         self.first_chain: bool = True
         self.seen_eos: bool = False
+        self.is_ogg_flac_chain: bool = False
         self.header_pages_sent: int = 0
         self.last_granule: int = 0
         self.granule_offset: int = 0
 
     def _handle_metadata(self, page: OggPage) -> None:
-        """Extract and invoke callback for OpusTags metadata."""
-        if self.metadata_callback and page.is_opus_tags:
-            metadata = extract_metadata_from_page(page)
+        """Extract and invoke callback for supported in-band metadata pages."""
+        if self.metadata_callback:
+            metadata = extract_metadata_from_page(page, is_ogg_flac_stream=self.is_ogg_flac_chain)
             if metadata:
                 LOGGER.debug("Extracted metadata: %s", metadata)
                 self.metadata_callback(metadata)
@@ -257,11 +305,17 @@ class _ChainedOggState:
         if page.is_bos:
             self.output_serial = page.serial_number
             LOGGER.debug("First chain BOS, serial=%d", self.output_serial)
+            if page.is_ogg_flac_mapping_page:
+                self.is_ogg_flac_chain = True
             self.output_sequence = page.page_sequence
             self.header_pages_sent = 1
             return page.raw_data
 
-        if page.is_header_page and self.header_pages_sent < 2:
+        # Ogg FLAC chains can carry additional header pages after the mapping header,
+        # so do not stop at the two-page limit used for Opus/Vorbis setup headers.
+        if page.is_header_page(self.is_ogg_flac_chain) and (
+            self.header_pages_sent < 2 or self.is_ogg_flac_chain
+        ):
             LOGGER.debug("First chain header page %d", self.header_pages_sent)
             self._handle_metadata(page)
             self.output_sequence = page.page_sequence
@@ -281,6 +335,7 @@ class _ChainedOggState:
             self.granule_offset = self.last_granule
             self.first_chain = False
             self.seen_eos = True
+            self.is_ogg_flac_chain = False
             return None
 
         self.output_sequence += 1
@@ -293,9 +348,12 @@ class _ChainedOggState:
         if self.seen_eos and page.is_bos:
             LOGGER.debug("New chain BOS, serial=%d (skipping)", page.serial_number)
             self.seen_eos = False
+            self.is_ogg_flac_chain = False
+            if page.is_ogg_flac_mapping_page:
+                self.is_ogg_flac_chain = True
             return None
 
-        if page.is_header_page:
+        if page.is_header_page(self.is_ogg_flac_chain):
             LOGGER.debug("Chain header page (skipping)")
             self._handle_metadata(page)
             return None

--- a/tests/core/test_ogg_handler.py
+++ b/tests/core/test_ogg_handler.py
@@ -1,0 +1,302 @@
+"""Tests for chained Ogg metadata handling."""
+
+from __future__ import annotations
+
+import struct
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from music_assistant.mass import MusicAssistant
+
+from music_assistant.controllers.streams.ogg_handler import (
+    OGG_FLAG_BOS,
+    OGG_FLAG_EOS,
+    get_chained_ogg_stream,
+)
+
+DEFAULT_VENDOR = "Music Assistant"
+DEFAULT_SERIAL = 1
+OGG_FLAC_MAPPING_PACKET = b"\x7fFLAC\x01\x00\x00\x01fLaC"
+FLAC_METADATA_BLOCK_STREAMINFO = 0
+FLAC_METADATA_BLOCK_VORBIS_COMMENT = 4
+FLAC_METADATA_BLOCK_IS_LAST_FLAG = 0x80
+
+
+class _FakeAudioStreamController:
+    """Minimal audio controller stub for get_chained_ogg_stream tests."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def get_reconnecting_radio_stream(self, url: str) -> AsyncGenerator[bytes, None]:
+        """Yield the provided Ogg chunks."""
+        del url
+        for chunk in self._chunks:
+            yield chunk
+
+
+def _pack_vorbis_comments(comments: dict[str, str], vendor: str = DEFAULT_VENDOR) -> bytes:
+    """Build a Vorbis comments payload."""
+    result = len(vendor).to_bytes(4, "little")
+    result += vendor.encode("utf-8")
+    result += len(comments).to_bytes(4, "little")
+    for key, value in comments.items():
+        comment = f"{key}={value}".encode()
+        result += len(comment).to_bytes(4, "little")
+        result += comment
+    return result
+
+
+def _pack_flac_metadata_block(block_type: int, payload: bytes, last: bool = False) -> bytes:
+    """Build a FLAC metadata block."""
+    block_header = (FLAC_METADATA_BLOCK_IS_LAST_FLAG if last else 0) | block_type
+    block_length = len(payload).to_bytes(3, "big")
+    return bytes([block_header]) + block_length + payload
+
+
+def _build_ogg_page(
+    segment_data: bytes,
+    *,
+    header_type: int = 0,
+    granule_position: int = 0,
+    serial_number: int = DEFAULT_SERIAL,
+    page_sequence: int = 0,
+) -> bytes:
+    """Build a minimal raw Ogg page."""
+    if len(segment_data) > 255:
+        msg = "Test helper only supports single-segment pages"
+        raise ValueError(msg)
+
+    num_segments = 1 if segment_data else 0
+    page = bytearray(27 + num_segments + len(segment_data))
+    page[0:4] = b"OggS"
+    page[4] = 0
+    page[5] = header_type
+    struct.pack_into("<Q", page, 6, granule_position)
+    struct.pack_into("<I", page, 14, serial_number)
+    struct.pack_into("<I", page, 18, page_sequence)
+    page[22:26] = b"\x00\x00\x00\x00"
+    page[26] = num_segments
+    if segment_data:
+        page[27] = len(segment_data)
+        page[28:] = segment_data
+    return bytes(page)
+
+
+def _build_bos_page(segment_data: bytes = b"", page_sequence: int = 0) -> bytes:
+    """Build a beginning-of-stream page."""
+    return _build_ogg_page(segment_data, header_type=OGG_FLAG_BOS, page_sequence=page_sequence)
+
+
+def _build_eos_page(
+    page_sequence: int,
+    *,
+    granule_position: int = 0,
+    serial_number: int = DEFAULT_SERIAL,
+) -> bytes:
+    """Build an end-of-stream page."""
+    return _build_ogg_page(
+        b"",
+        header_type=OGG_FLAG_EOS,
+        granule_position=granule_position,
+        serial_number=serial_number,
+        page_sequence=page_sequence,
+    )
+
+
+def _build_vorbis_comment_page(comments: dict[str, str], page_sequence: int = 1) -> bytes:
+    """Build a Vorbis comment header page."""
+    return _build_ogg_page(
+        b"\x03vorbis" + _pack_vorbis_comments(comments),
+        page_sequence=page_sequence,
+    )
+
+
+def _build_flac_streaminfo_page(page_sequence: int = 2) -> bytes:
+    """Build a FLAC STREAMINFO metadata page."""
+    streaminfo_payload = b"\x00" * 34
+    streaminfo_block = _pack_flac_metadata_block(
+        FLAC_METADATA_BLOCK_STREAMINFO, streaminfo_payload, last=True
+    )
+    return _build_ogg_page(streaminfo_block, page_sequence=page_sequence)
+
+
+def _build_flac_vorbis_comment_page(comments: dict[str, str], page_sequence: int = 2) -> bytes:
+    """Build a FLAC Vorbis comment metadata page."""
+    payload = _pack_vorbis_comments(comments)
+    block = _pack_flac_metadata_block(FLAC_METADATA_BLOCK_VORBIS_COMMENT, payload, last=True)
+    return _build_ogg_page(block, page_sequence=page_sequence)
+
+
+def _build_incomplete_flac_vorbis_comment_page(page_sequence: int = 2) -> bytes:
+    """Build a truncated FLAC Vorbis comment metadata page."""
+    payload = _pack_vorbis_comments({"TITLE": "Lossless Song"})
+    block = _pack_flac_metadata_block(FLAC_METADATA_BLOCK_VORBIS_COMMENT, payload, last=True)
+    truncated_length = len(block) - 1
+    truncated_block = block[:truncated_length]
+    return _build_ogg_page(truncated_block, page_sequence=page_sequence)
+
+
+async def _collect_metadata(chunks: list[bytes]) -> list[dict[str, str]]:
+    """Run a raw Ogg stream through the handler and collect metadata updates."""
+    metadata_updates: list[dict[str, str]] = []
+    mass = cast(
+        "MusicAssistant",
+        SimpleNamespace(
+            streams=SimpleNamespace(audio=_FakeAudioStreamController(chunks)),
+        ),
+    )
+
+    async for _ in get_chained_ogg_stream(
+        mass,
+        "https://example.invalid/test.ogg",
+        metadata_updates.append,
+    ):
+        pass
+
+    return metadata_updates
+
+
+async def test_vorbis_comment_page_emits_metadata() -> None:
+    """Vorbis comment header pages should emit metadata."""
+    # Setup
+    comments = {"TITLE": "Song Title", "ARTIST": "Test Artist", "ALBUM": "Live Set"}
+    chunks = [
+        _build_bos_page(),
+        _build_vorbis_comment_page(comments),
+    ]
+
+    # Act
+    metadata_updates = await _collect_metadata(chunks)
+
+    # Assert
+    assert metadata_updates == [
+        {
+            "title": "Song Title",
+            "artist": "Test Artist",
+            "album": "Live Set",
+        }
+    ]
+
+
+async def test_flac_vorbis_comment_page_emits_metadata_after_mapping_bos_page() -> None:
+    """FLAC Vorbis comment pages should emit metadata after the mapping BOS page."""
+    # Setup
+    comments = {"TITLE": "Lossless Song", "ARTIST": "Studio Band", "ALBUM": "Broadcast"}
+    chunks = [
+        _build_bos_page(OGG_FLAC_MAPPING_PACKET),
+        _build_flac_vorbis_comment_page(comments),
+    ]
+
+    # Act
+    metadata_updates = await _collect_metadata(chunks)
+
+    # Assert
+    assert metadata_updates == [
+        {
+            "title": "Lossless Song",
+            "artist": "Studio Band",
+            "album": "Broadcast",
+        }
+    ]
+
+
+async def test_flac_vorbis_comment_page_without_mapping_header_does_not_emit_metadata() -> None:
+    """FLAC metadata pages without Ogg FLAC context should not emit metadata."""
+    # Setup
+    comments = {"TITLE": "Lossless Song", "ARTIST": "Studio Band", "ALBUM": "Broadcast"}
+    chunks = [
+        _build_bos_page(),
+        _build_flac_vorbis_comment_page(comments),
+    ]
+
+    # Act
+    metadata_updates = await _collect_metadata(chunks)
+
+    # Assert
+    assert metadata_updates == []
+
+
+async def test_flac_vorbis_comment_page_emits_metadata_after_streaminfo_page() -> None:
+    """FLAC Vorbis comment pages should still emit metadata after other header pages."""
+    # Setup
+    comments = {"TITLE": "Lossless Song", "ARTIST": "Studio Band", "ALBUM": "Broadcast"}
+    chunks = [
+        _build_bos_page(OGG_FLAC_MAPPING_PACKET),
+        _build_flac_streaminfo_page(page_sequence=1),
+        _build_flac_vorbis_comment_page(comments, page_sequence=2),
+    ]
+
+    # Act
+    metadata_updates = await _collect_metadata(chunks)
+
+    # Assert
+    assert metadata_updates == [
+        {
+            "title": "Lossless Song",
+            "artist": "Studio Band",
+            "album": "Broadcast",
+        }
+    ]
+
+
+async def test_flac_identification_pages_without_comments_do_not_emit_metadata() -> None:
+    """Ogg FLAC mapping BOS pages and STREAMINFO pages should not emit metadata."""
+    # Setup
+    chunks = [
+        _build_bos_page(OGG_FLAC_MAPPING_PACKET),
+        _build_flac_streaminfo_page(),
+    ]
+
+    # Act
+    metadata_updates = await _collect_metadata(chunks)
+
+    # Assert
+    assert metadata_updates == []
+
+
+async def test_incomplete_flac_vorbis_comment_page_does_not_emit_metadata() -> None:
+    """Incomplete FLAC Vorbis comment blocks should be skipped."""
+    # Setup
+    chunks = [
+        _build_bos_page(OGG_FLAC_MAPPING_PACKET),
+        _build_incomplete_flac_vorbis_comment_page(),
+    ]
+
+    # Act
+    metadata_updates = await _collect_metadata(chunks)
+
+    # Assert
+    assert metadata_updates == []
+
+
+async def test_flac_metadata_is_emitted_across_chained_streams() -> None:
+    """FLAC metadata should be emitted again after an EOS/BOS chain boundary."""
+    # Setup
+    first_chain_comments = {"TITLE": "First Song", "ARTIST": "First Artist"}
+    second_chain_comments = {"TITLE": "Second Song", "ARTIST": "Second Artist"}
+    chunks = [
+        _build_bos_page(OGG_FLAC_MAPPING_PACKET, page_sequence=0),
+        _build_flac_vorbis_comment_page(first_chain_comments, page_sequence=1),
+        _build_eos_page(page_sequence=2, granule_position=100),
+        _build_bos_page(OGG_FLAC_MAPPING_PACKET, page_sequence=0),
+        _build_flac_vorbis_comment_page(second_chain_comments, page_sequence=1),
+    ]
+
+    # Act
+    metadata_updates = await _collect_metadata(chunks)
+
+    # Assert
+    assert metadata_updates == [
+        {
+            "title": "First Song",
+            "artist": "First Artist",
+        },
+        {
+            "title": "Second Song",
+            "artist": "Second Artist",
+        },
+    ]


### PR DESCRIPTION
## Summary
This adds Ogg-FLAC in-band metadata support to the chained Ogg stream handler used for internet radio streams.  Before this change the handler could extract metadata from Opus/Vorbis comment packets but would not surface metadata carried in Ogg-FLAC streams.

## Notes
This implementation only detects FLAC metadata blocks containing Vorbis comments when they begin at the start of an Ogg page, which is consistent with how the FLAC spec says streams "should" be implemented (see [RFC 9639 Section 10.1](https://www.rfc-editor.org/rfc/rfc9639.html#name-ogg-mapping)). Supporting non-typical streams that pack multiple FLAC metadata packets into a page and place the Vorbis comment block later in the same page payload would require packet-level parsing and reassembly which is outside the scope of this change.

## Testing
This implementation was tested with a local icecast stream. Additionally I've added unit tests that cover most of the original Opus/Vorbis path and all of the Ogg Flac path.

