### PR TITLE
Add duplicate track prevention and empty default for party name/QR text

### DIFF
--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -63,6 +63,7 @@ CONF_PARTY_NAME = "party_name"
 CONF_PARTY_QR_TEXT = "qr_text"
 CONF_HIDE_BACK_BUTTON = "hide_back_button"
 CONF_SHOW_PROGRESS_BAR = "show_progress_bar"
+CONF_PREVENT_DUPLICATE_TRACKS = "prevent_duplicate_tracks"
 # Actions
 CONF_ACTION_ENABLE_GUEST_ACCESS = "action_enable_guest_access"
 CONF_ACTION_DISABLE_GUEST_ACCESS = "action_disable_guest_access"
@@ -128,6 +129,7 @@ class PartyConfig(DataClassDictMixin):
     qr_text: str | None
     hide_back_button: bool
     show_progress_bar: bool
+    prevent_duplicate_tracks: bool
 
 
 async def setup(
@@ -184,7 +186,7 @@ async def get_config_entries(
         ConfigEntry(
             key=CONF_PARTY_NAME,
             type=ConfigEntryType.STRING,
-            default_value="Party time!",
+            default_value="",
             required=False,
             label="Party Name",
             description=(
@@ -241,7 +243,7 @@ async def get_config_entries(
         ConfigEntry(
             key=CONF_PARTY_QR_TEXT,
             type=ConfigEntryType.STRING,
-            default_value="Scan the QR code to join the party!",
+            default_value="",
             required=False,
             label="QR Code Text",
             description=(
@@ -335,6 +337,19 @@ async def get_config_entries(
                 "When disabled, guests cannot add songs to the queue at all."
             ),
             depends_on=CONF_ENABLE_GUEST_ACCESS,
+            advanced=True,
+            category="Guest Features",
+        ),
+        ConfigEntry(
+            key=CONF_PREVENT_DUPLICATE_TRACKS,
+            type=ConfigEntryType.BOOLEAN,
+            default_value=True,
+            label="Prevent Duplicate Tracks",
+            description=(
+                "Prevent guests from adding a track that is already in the queue. "
+                "When enabled, duplicate track requests will be rejected."
+            ),
+            depends_on=CONF_ENABLE_ADD_QUEUE,
             advanced=True,
             category="Guest Features",
         ),
@@ -669,6 +684,9 @@ class PartyPlugin(PluginProvider):
             qr_text=cast("str | None", self.config.get_value(CONF_PARTY_QR_TEXT)),
             hide_back_button=cast("bool", self.config.get_value(CONF_HIDE_BACK_BUTTON)),
             show_progress_bar=cast("bool", self.config.get_value(CONF_SHOW_PROGRESS_BAR)),
+            prevent_duplicate_tracks=cast(
+                "bool", self.config.get_value(CONF_PREVENT_DUPLICATE_TRACKS)
+            ),
         )
 
     # ==================== Guest Action API Commands ====================
@@ -707,6 +725,13 @@ class PartyPlugin(PluginProvider):
         queue = self.mass.player_queues.get(queue_id)
         if not queue:
             raise InvalidDataError(f"Queue not found: {queue_id}")
+
+        # Check for duplicate tracks if configured
+        if self.config.get_value(CONF_PREVENT_DUPLICATE_TRACKS):
+            queue_items = self.mass.player_queues.items(queue_id)
+            for queue_item in queue_items:
+                if queue_item.uri == uri:
+                    raise InvalidDataError("This track is already in the queue")
 
         # Handle different scenarios based on queue state and boost mode
         started_playback = False


### PR DESCRIPTION
- Add "Prevent Duplicate Tracks" config option (enabled by default) that rejects guest requests for tracks already in the queue
- Change party name and QR text defaults to empty string so the fields are blank by default