### PR TITLE
Fix plugin source players stuck in PLAYING state after disconnect

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1047,6 +1047,21 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # Delegate to internal handler for actual implementation
         await self._handle_select_source(player_id, source)
 
+    async def deselect_source(self, player_id: str) -> None:
+        """
+        Deselect the current source and stop the player.
+
+        Use this when an external source (plugin/receiver) disconnects and the player
+        should stop playback rather than switch to another source.
+
+        :param player_id: player_id of the player to stop and deselect.
+        """
+        player = self.get_player(player_id, raise_unavailable=False)
+        if not player:
+            return
+        with suppress(PlayerCommandFailed, RuntimeError):
+            await self._handle_cmd_stop(player_id)
+
     @handle_player_command(lock=True)
     async def enqueue_next_media(self, player_id: str, media: PlayerMedia) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1059,7 +1059,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         player = self.get_player(player_id, raise_unavailable=False)
         if not player:
             return
-        with suppress(PlayerCommandFailed, RuntimeError):
+        with suppress(PlayerCommandFailed, PlayerUnavailableError, RuntimeError):
             await self._handle_cmd_stop(player_id)
 
     @handle_player_command(lock=True)

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -571,9 +571,9 @@ class AirPlayReceiverProvider(PluginProvider):
             # This will cause ffmpeg to output a chunk, which will then check in_use_by
             # and break out of the loop when it sees it's None
             self.mass.create_task(self._write_silence_to_unblock_stream())
-            # Deselect source from player if there was one
+            # Stop the player that was using this source
             if current_player_id:
-                self.mass.create_task(self.mass.players.select_source(current_player_id, None))
+                self.mass.create_task(self.mass.players.deselect_source(current_player_id))
 
     def _handle_volume_change(self, volume: int) -> None:
         """Handle volume changes from AirPlay client (iOS/macOS device).

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -739,8 +739,11 @@ class SpotifyConnectProvider(PluginProvider):
             if self._spotify_provider is not None:
                 self._spotify_provider = None
                 self._update_source_capabilities()
-            # Clear active player and potentially stop daemon on session disconnect
+            # Clear active player and stop the player on session disconnect
+            prev_player_id = self._active_player_id
             self._clear_active_player()
+            if prev_player_id:
+                self.mass.create_task(self.mass.players.deselect_source(prev_player_id))
 
         # handle paused event - clear in_use_by so UI shows correct active source
         # this happens when MA starts playing while Spotify Connect was active

--- a/tests/core/test_plugin_source.py
+++ b/tests/core/test_plugin_source.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature
-from music_assistant_models.errors import PlayerCommandFailed
+from music_assistant_models.errors import PlayerCommandFailed, PlayerUnavailableError
 
 from music_assistant.controllers.players import PlayerController
 from music_assistant.helpers.throttle_retry import Throttler
@@ -119,6 +119,17 @@ class TestDeselectSource:
         """Deselect should not raise RuntimeError."""
         controller._handle_cmd_stop = AsyncMock(  # type: ignore[method-assign]
             side_effect=RuntimeError("test error")
+        )
+
+        await controller.deselect_source("player_1")
+
+    @pytest.mark.asyncio
+    async def test_deselect_source_suppresses_player_unavailable(
+        self, controller: PlayerController, player: MockPlayer
+    ) -> None:
+        """Deselect should not raise PlayerUnavailableError."""
+        controller._handle_cmd_stop = AsyncMock(  # type: ignore[method-assign]
+            side_effect=PlayerUnavailableError("player unavailable")
         )
 
         await controller.deselect_source("player_1")

--- a/tests/core/test_plugin_source.py
+++ b/tests/core/test_plugin_source.py
@@ -1,0 +1,239 @@
+"""Tests for plugin source selection and deselection on the PlayerController.
+
+This module tests:
+- deselect_source stops the player via _handle_cmd_stop
+- deselect_source is a no-op for unknown players
+- deselect_source suppresses errors from stop
+- in_use_by lifecycle on PluginSource
+- select_source(id, None) differs from deselect_source (selects queue vs stops)
+- Disconnect flow: clear in_use_by then deselect stops the player
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import PlaybackState, PlayerFeature
+from music_assistant_models.errors import PlayerCommandFailed
+
+from music_assistant.controllers.players import PlayerController
+from music_assistant.helpers.throttle_retry import Throttler
+from music_assistant.models.plugin import PluginProvider, PluginSource
+from tests.common import MockPlayer, MockProvider
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock MusicAssistant instance."""
+    mass = MagicMock()
+    mass.closing = False
+    mass.loop = None
+    mass.config = MagicMock()
+    mass.config.get = MagicMock(return_value=[])
+    mass.config.get_raw_player_config_value = MagicMock(return_value="auto")
+    mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")
+    mass.config.set = MagicMock()
+    mass.signal_event = MagicMock()
+    mass.get_providers = MagicMock(return_value=[])
+    mass.streams = MagicMock()
+    mass.streams.get_plugin_source_url = AsyncMock(return_value="http://localhost/plugin/test")
+    mass.player_queues = MagicMock()
+    mass.player_queues.get = MagicMock(return_value=None)
+    return mass
+
+
+@pytest.fixture
+def controller(mock_mass: MagicMock) -> PlayerController:
+    """Create a PlayerController instance."""
+    ctrl = PlayerController(mock_mass)
+    mock_mass.players = ctrl
+    return ctrl
+
+
+@pytest.fixture
+def provider(mock_mass: MagicMock) -> MockProvider:
+    """Create a mock provider."""
+    return MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
+
+
+@pytest.fixture
+def player(provider: MockProvider, controller: PlayerController) -> MockPlayer:
+    """Create and register a mock player."""
+    p = MockPlayer(provider, "player_1", "Test Player")
+    p._attr_supported_features = {PlayerFeature.VOLUME_SET}
+    controller._players = {"player_1": p}
+    controller._player_throttlers = {"player_1": Throttler(1, 0.05)}
+    return p
+
+
+@pytest.fixture
+def plugin_source() -> PluginSource:
+    """Create a PluginSource for testing."""
+    return PluginSource(
+        id="test_plugin",
+        name="Test Plugin Source",
+    )
+
+
+class TestDeselectSource:
+    """Test deselect_source stops the player when a plugin source disconnects."""
+
+    @pytest.mark.asyncio
+    async def test_deselect_source_calls_stop(
+        self, controller: PlayerController, player: MockPlayer
+    ) -> None:
+        """Deselecting a source should call _handle_cmd_stop."""
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        await controller.deselect_source("player_1")
+
+        controller._handle_cmd_stop.assert_awaited_once_with("player_1")
+
+    @pytest.mark.asyncio
+    async def test_deselect_source_noop_for_unknown_player(
+        self, controller: PlayerController
+    ) -> None:
+        """Deselecting on a non-existent player should not raise."""
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        await controller.deselect_source("nonexistent_player")
+
+        controller._handle_cmd_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_deselect_source_suppresses_player_command_failed(
+        self, controller: PlayerController, player: MockPlayer
+    ) -> None:
+        """Deselect should not raise PlayerCommandFailed."""
+        controller._handle_cmd_stop = AsyncMock(  # type: ignore[method-assign]
+            side_effect=PlayerCommandFailed("test error")
+        )
+
+        await controller.deselect_source("player_1")
+
+    @pytest.mark.asyncio
+    async def test_deselect_source_suppresses_runtime_error(
+        self, controller: PlayerController, player: MockPlayer
+    ) -> None:
+        """Deselect should not raise RuntimeError."""
+        controller._handle_cmd_stop = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("test error")
+        )
+
+        await controller.deselect_source("player_1")
+
+
+class TestPluginSourceInUseBy:
+    """Test that in_use_by is properly managed during plugin source lifecycle."""
+
+    def test_in_use_by_initially_none(self, plugin_source: PluginSource) -> None:
+        """New plugin source should have in_use_by as None."""
+        assert plugin_source.in_use_by is None
+
+    def test_set_and_clear_in_use_by(self, plugin_source: PluginSource) -> None:
+        """Setting in_use_by to None should clear the source."""
+        plugin_source.in_use_by = "player_1"
+        assert plugin_source.in_use_by == "player_1"
+
+        plugin_source.in_use_by = None
+        assert plugin_source.in_use_by is None
+
+    def test_as_player_source_strips_callbacks(self, plugin_source: PluginSource) -> None:
+        """as_player_source should return a basic PlayerSource without plugin-specific fields."""
+        plugin_source.on_select = AsyncMock()
+        plugin_source.in_use_by = "player_1"
+
+        ps = plugin_source.as_player_source()
+        assert ps.id == "test_plugin"
+        assert ps.name == "Test Plugin Source"
+        # PlayerSource doesn't have in_use_by or on_select
+        assert not hasattr(ps, "in_use_by")
+
+
+class TestSelectSourceVsDeselectSource:
+    """Test that select_source(id, None) and deselect_source have different semantics."""
+
+    @pytest.mark.asyncio
+    async def test_select_source_none_selects_queue(
+        self, controller: PlayerController, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """select_source with None should select the queue source (not stop)."""
+        mock_mass.player_queues.get = MagicMock(return_value=MagicMock())
+        mock_mass.get_provider = MagicMock(return_value=None)
+
+        with patch.object(player, "set_active_mass_source") as mock_set:
+            await controller.select_source("player_1", None)
+            # source defaults to player_id, which matches the queue
+            mock_set.assert_called_once_with("player_1")
+
+    @pytest.mark.asyncio
+    async def test_deselect_source_stops_instead_of_selecting(
+        self, controller: PlayerController, player: MockPlayer
+    ) -> None:
+        """deselect_source should stop, not select the queue."""
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        await controller.deselect_source("player_1")
+
+        controller._handle_cmd_stop.assert_awaited_once_with("player_1")
+
+    @pytest.mark.asyncio
+    async def test_select_source_with_plugin_sets_in_use_by(
+        self, controller: PlayerController, player: MockPlayer, mock_mass: MagicMock
+    ) -> None:
+        """Selecting a plugin source should set in_use_by to the player."""
+        plugin_source = PluginSource(id="my_plugin", name="My Plugin")
+        mock_plugin_prov = MagicMock(spec=PluginProvider)
+        mock_plugin_prov.instance_id = "my_plugin"
+        mock_plugin_prov.get_source.return_value = plugin_source
+
+        mock_mass.get_provider = MagicMock(return_value=mock_plugin_prov)
+
+        # Mock _handle_select_plugin_source to avoid needing full playback infrastructure
+        controller._handle_select_plugin_source = AsyncMock()  # type: ignore[method-assign]
+
+        await controller.select_source("player_1", "my_plugin")
+
+        controller._handle_select_plugin_source.assert_awaited_once()
+
+
+class TestAirplayReceiverDisconnectFlow:
+    """Integration-style test simulating the AirPlay receiver disconnect scenario."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_source_and_stops_player(
+        self, controller: PlayerController, player: MockPlayer
+    ) -> None:
+        """Simulating the disconnect flow: clear in_use_by, then deselect stops player.
+
+        This reproduces the scenario from music-assistant/support#5130.
+        """
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        plugin_source = PluginSource(id="airplay_recv", name="AirPlay")
+        plugin_source.in_use_by = "player_1"
+
+        # Step 1: Clear in_use_by (as _clear_active_player does)
+        plugin_source.in_use_by = None
+        assert plugin_source.in_use_by is None
+
+        # Step 2: Deselect source on the player (the fix)
+        await controller.deselect_source("player_1")
+
+        # Step 3: Verify the player was stopped
+        controller._handle_cmd_stop.assert_awaited_once_with("player_1")
+
+    @pytest.mark.asyncio
+    async def test_disconnect_with_no_active_player_is_noop(
+        self, controller: PlayerController
+    ) -> None:
+        """If no player was active, deselect should be a no-op."""
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        plugin_source = PluginSource(id="airplay_recv", name="AirPlay")
+        # in_use_by is already None (no active player)
+
+        await controller.deselect_source("nonexistent")
+
+        controller._handle_cmd_stop.assert_not_awaited()

--- a/tests/core/test_plugin_source.py
+++ b/tests/core/test_plugin_source.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import PlaybackState, PlayerFeature
+from music_assistant_models.enums import PlayerFeature
 from music_assistant_models.errors import PlayerCommandFailed, PlayerUnavailableError
 
 from music_assistant.controllers.players import PlayerController
@@ -241,9 +241,6 @@ class TestAirplayReceiverDisconnectFlow:
     ) -> None:
         """If no player was active, deselect should be a no-op."""
         controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
-
-        plugin_source = PluginSource(id="airplay_recv", name="AirPlay")
-        # in_use_by is already None (no active player)
 
         await controller.deselect_source("nonexistent")
 

--- a/tests/core/test_plugin_source.py
+++ b/tests/core/test_plugin_source.py
@@ -190,10 +190,10 @@ class TestSelectSourceVsDeselectSource:
         controller._handle_cmd_stop.assert_awaited_once_with("player_1")
 
     @pytest.mark.asyncio
-    async def test_select_source_with_plugin_sets_in_use_by(
+    async def test_select_source_with_plugin_delegates_to_handler(
         self, controller: PlayerController, player: MockPlayer, mock_mass: MagicMock
     ) -> None:
-        """Selecting a plugin source should set in_use_by to the player."""
+        """Selecting a plugin source should delegate to _handle_select_plugin_source."""
         plugin_source = PluginSource(id="my_plugin", name="My Plugin")
         mock_plugin_prov = MagicMock(spec=PluginProvider)
         mock_plugin_prov.instance_id = "my_plugin"
@@ -209,30 +209,31 @@ class TestSelectSourceVsDeselectSource:
         controller._handle_select_plugin_source.assert_awaited_once()
 
 
-class TestAirplayReceiverDisconnectFlow:
-    """Integration-style test simulating the AirPlay receiver disconnect scenario."""
+class TestPluginSourceDisconnectFlow:
+    """Test the disconnect flow for plugin sources (AirPlay, Spotify Connect, etc.)."""
 
     @pytest.mark.asyncio
-    async def test_disconnect_clears_source_and_stops_player(
+    async def test_deselect_after_clearing_in_use_by_stops_player(
         self, controller: PlayerController, player: MockPlayer
     ) -> None:
-        """Simulating the disconnect flow: clear in_use_by, then deselect stops player.
+        """Verify that the provider disconnect pattern (clear in_use_by + deselect) stops the player.
 
-        This reproduces the scenario from music-assistant/support#5130.
+        Providers call _clear_active_player() which sets in_use_by=None,
+        then deselect_source() to stop the player. This test verifies both
+        steps work correctly together.
         """
         controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
 
         plugin_source = PluginSource(id="airplay_recv", name="AirPlay")
         plugin_source.in_use_by = "player_1"
 
-        # Step 1: Clear in_use_by (as _clear_active_player does)
+        # Provider clears in_use_by (breaks the stream loop in the controller)
         plugin_source.in_use_by = None
         assert plugin_source.in_use_by is None
 
-        # Step 2: Deselect source on the player (the fix)
+        # Provider calls deselect_source to stop the player (the fix for #5130)
         await controller.deselect_source("player_1")
 
-        # Step 3: Verify the player was stopped
         controller._handle_cmd_stop.assert_awaited_once_with("player_1")
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes music-assistant/support#5130

## Problem

When an external source (AirPlay Receiver, Spotify Connect) disconnects, the target player gets stuck in PLAYING state indefinitely. This happens because `select_source(player_id, None)` internally converts `None` to the player's queue source instead of stopping playback. The stop attempt inside `_handle_select_source` is wrapped in `suppress()` and can fail silently, leaving the player playing forever.

## Changes

- Add `deselect_source(player_id)` method to `PlayerController` that explicitly stops the player via `_handle_cmd_stop` — the correct semantic for "source disconnected"
- Update AirPlay Receiver to call `deselect_source()` instead of `select_source(id, None)` on disconnect
- Update Spotify Connect to call `deselect_source()` on session disconnect (same latent bug)
- Add tests for plugin source selection/deselection lifecycle