### PR TITLE
Fix AirPlay late-join sync: start_at must match first byte stream position

### DIFF
--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -133,67 +133,56 @@ class AirPlayStreamSession:
             now = time.time()
             all_buffered = list(self._chunk_buffer)
 
-            # The preferred start time is now + wait_start (in the future),
-            # just like for the original players. We then find which stream
-            # position aligns with that timestamp and send ring buffer chunks
-            # to fill the pipeline with audio that other players already have
-            # in their device buffers.
+            # Two constraints:
+            # 1. start_at must be >= now + wait_start (device can't handle past NTP)
+            # 2. byte 0 of CLI stdin must match start_at (for sync with other players)
+            #
+            # We compute the minimum stream position whose wall-clock time satisfies
+            # constraint 1, then only send ring buffer data from that position onward.
             wait_start_seconds = airplay_player.wait_start / 1000
-            preferred_start_at = now + wait_start_seconds
-            # The stream position that corresponds to the preferred start time
-            target_position = preferred_start_at - self.start_time
+            min_start_at = now + wait_start_seconds
+            min_position = min_start_at - self.start_time
 
-            # Find the ring buffer chunk that contains target_position and
-            # trim it so byte 0 of the CLI stdin aligns exactly with
-            # preferred_start_at. This is the same approach as the sendspin
-            # bridge alignment logic.
-            pcm_sample_size = self.pcm_format.pcm_sample_size
-            bytes_per_frame = pcm_sample_size // self.pcm_format.sample_rate
-            buffered_chunks: list[tuple[bytes, float]] = []
-            start_at = preferred_start_at
+            # Filter ring buffer to chunks at or after min_position
+            buffered_chunks = [(chunk, pos) for chunk, pos in all_buffered if pos >= min_position]
 
-            for i, (chunk, pos) in enumerate(all_buffered):
-                chunk_duration = len(chunk) / pcm_sample_size
-                if pos <= target_position < pos + chunk_duration:
-                    # This chunk contains target_position - trim the beginning
-                    trim_seconds = target_position - pos
-                    trim_bytes = int(trim_seconds * pcm_sample_size)
-                    trim_bytes = (trim_bytes // bytes_per_frame) * bytes_per_frame
-                    trimmed = chunk[trim_bytes:]
-                    if trimmed:
-                        buffered_chunks.append((trimmed, target_position))
-                    # Include all subsequent chunks
-                    buffered_chunks.extend(all_buffered[i + 1 :])
-                    break
-
+            # Trim the first chunk so byte 0 aligns exactly with min_position.
+            # Without trimming, if a chunk starts before min_position but extends
+            # past it, we'd either skip it entirely (losing useful data) or send
+            # it from the start (violating constraint 1).
             if not buffered_chunks and all_buffered:
-                # target_position is at or beyond the latest ring buffer chunk.
-                # This is the normal case when wait_start values match: real-time
-                # data arriving during the wait_start window fills the device buffer.
-                # Use preferred_start_at and send any future-mapped chunks to
-                # give the device a head start.
-                usable = [
-                    (chunk, pos) for chunk, pos in all_buffered if self.start_time + pos > now
-                ]
-                if usable:
-                    buffered_chunks = usable
+                pcm_sample_size = self.pcm_format.pcm_sample_size
+                bytes_per_sample = pcm_sample_size // self.pcm_format.sample_rate
+                for i, (chunk, pos) in enumerate(all_buffered):
+                    chunk_duration = len(chunk) / pcm_sample_size
+                    if pos < min_position < pos + chunk_duration:
+                        trim_seconds = min_position - pos
+                        trim_bytes = int(trim_seconds * pcm_sample_size)
+                        trim_bytes = (trim_bytes // bytes_per_sample) * bytes_per_sample
+                        trimmed = chunk[trim_bytes:]
+                        if trimmed:
+                            buffered_chunks.append((trimmed, min_position))
+                        buffered_chunks.extend(all_buffered[i + 1 :])
+                        break
 
             if buffered_chunks:
+                first_chunk_position = buffered_chunks[0][1]
+                start_at = self.start_time + first_chunk_position
+                buffer_duration = self.seconds_streamed - first_chunk_position
                 buffered_bytes = sum(len(chunk) for chunk, _ in buffered_chunks)
+
                 self.prov.logger.debug(
                     "Late joiner %s: sending %.2fs of buffered audio (%d bytes, %d chunks), "
-                    "stream position=%.2fs, start_at is %.2fs from now, "
-                    "wait_start=%.1fms, target_position=%.2f",
+                    "stream position=%.2fs, start_at is %.2fs from now",
                     airplay_player.player_id,
-                    self.seconds_streamed - target_position,
+                    buffer_duration,
                     buffered_bytes,
                     len(buffered_chunks),
                     self.seconds_streamed,
                     start_at - now,
-                    wait_start_seconds * 1000,
-                    target_position,
                 )
             else:
+                start_at = max(min_start_at, self.start_time + self.seconds_streamed)
                 self.prov.logger.debug(
                     "Late joiner %s: no buffered chunks available, "
                     "stream position=%.2fs, start_at is %.2fs from now",

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -9,9 +9,8 @@ import pytest
 
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 
-# 44.1kHz / 16-bit / 2ch
-PCM_SAMPLE_SIZE = 176400
-BYTES_PER_FRAME = 4  # 16-bit * 2ch
+PCM_SAMPLE_SIZE = 176400  # 44.1kHz / 16-bit / 2ch
+BYTES_PER_SAMPLE = 4  # 16-bit * 2ch
 
 
 def _make_session(
@@ -41,7 +40,6 @@ def _make_session(
     session.start_ntp = 1  # dummy
     session.wait_start = 2.0
 
-    # Fill ring buffer with dummy chunks at specified positions
     session._chunk_buffer = deque(maxlen=12)
     for pos in chunk_positions:
         session._chunk_buffer.append((b"\x00" * PCM_SAMPLE_SIZE, pos))
@@ -109,119 +107,90 @@ async def _run_add_client(
 
 
 @pytest.mark.asyncio
-async def test_late_join_start_at_equals_preferred() -> None:
-    """Test that start_at equals now + wait_start when buffer is available."""
-    now = time.time()
-    wait_start_s = 2.0
-    start_time = now - 50 + wait_start_s
-    seconds_streamed = 50.0
-    chunk_positions = [float(i) for i in range(40, 50)]
+async def test_late_join_start_at_never_in_the_past() -> None:
+    """Test that start_at is always >= now + wait_start.
 
-    session = _make_session(start_time, seconds_streamed, chunk_positions)
-    player = _make_late_joiner(wait_start_ms=2000)
+    AirPlay 2 cannot handle receiving an NTP start time in the past.
+    """
+    now = time.time()
+    wait_start_ms = 2000
+    # Stream running for 20s, ring buffer has chunks at positions 10-19.
+    # With wait_start=2s, min_position = (now+2) - (now-10) = 12.
+    # Chunks at 12-19 pass the filter.
+    start_time = now - 10
+    session = _make_session(start_time, 20.0, [float(i) for i in range(10, 20)])
+    player = _make_late_joiner(wait_start_ms=wait_start_ms)
 
     start_at, _ = await _run_add_client(session, player)
 
-    # start_at should be exactly preferred (now + wait_start), not just "in the future"
-    preferred = now + wait_start_s
-    assert abs(start_at - preferred) < 0.1, (
-        f"start_at should be ~preferred ({preferred:.2f}), got {start_at:.2f}"
+    min_start_at = now + wait_start_ms / 1000
+    assert start_at >= min_start_at - 0.1, (
+        f"start_at must be >= now + wait_start, got {start_at - now:.2f}s from now"
     )
 
 
 @pytest.mark.asyncio
-async def test_late_join_trims_first_chunk_to_align() -> None:
-    """Test that the first chunk is trimmed so byte 0 aligns with start_at."""
+async def test_late_join_start_at_matches_first_byte() -> None:
+    """Test that start_at corresponds to the stream position of the first byte fed.
+
+    The CLI maps byte 0 to start_ntp, so they must match for sync.
+    """
     now = time.time()
-    # Use a larger wait_start so target_position lands inside a chunk
-    # (not at the very end of the ring buffer).
-    # start_time + target_position = now + wait_start
-    # target_position = now + wait_start - start_time
-    # With wait_start=5s, start_time = now - 50 + 2, target_position = 53
-    # but seconds_streamed=55, so chunk at pos 53 exists and is mid-buffer.
-    wait_start_s = 5.0
-    start_time = now - 55 + 2.0
-    seconds_streamed = 55.0
-    # Ring buffer: positions 45-54 (10 chunks)
-    chunk_positions = [float(i) for i in range(45, 55)]
-
-    session = _make_session(start_time, seconds_streamed, chunk_positions)
-    # target_position = now + 5 - (now - 53) = 58 ... hmm let me recalculate
-    # start_time = now - 53, target = (now + 5) - (now - 53) = 58? No.
-    # Let me be more precise:
-    # start_time = now - 55 + 2 = now - 53
-    # target_position = (now + 5) - (now - 53) = 58
-    # That's way beyond seconds_streamed (55). Need to adjust.
-    #
-    # For target to be ~52.5 (mid-chunk at pos 52):
-    # target = now + wait_start - start_time
-    # We want target = 52.5
-    # 52.5 = now + wait_start - start_time
-    # start_time = now + wait_start - 52.5
-    start_time_fixed = now + wait_start_s - 52.5
-    session.start_time = start_time_fixed
-
-    player = _make_late_joiner(wait_start_ms=int(wait_start_s * 1000))
-
-    start_at, fed_chunks = await _run_add_client(session, player)
-
-    # start_at should match preferred (now + wait_start)
-    assert abs(start_at - (now + wait_start_s)) < 0.1
-
-    assert fed_chunks, "Expected buffered chunks to be fed"
-
-    first_chunk_data, first_chunk_pos = fed_chunks[0]
-
-    # First chunk position should be target_position (52.5)
-    assert abs(first_chunk_pos - 52.5) < 0.01
-
-    # The first chunk should be trimmed to roughly half (target is mid-chunk)
-    assert len(first_chunk_data) < PCM_SAMPLE_SIZE
-    half = PCM_SAMPLE_SIZE // 2
-    assert abs(len(first_chunk_data) - half) < PCM_SAMPLE_SIZE * 0.05
-
-    # Trimmed size should be frame-aligned
-    assert len(first_chunk_data) % BYTES_PER_FRAME == 0
-
-    # Subsequent chunks should be full-size
-    if len(fed_chunks) > 1:
-        assert len(fed_chunks[1][0]) == PCM_SAMPLE_SIZE
-
-
-@pytest.mark.asyncio
-async def test_late_join_fallback_when_buffer_too_old() -> None:
-    """Test fallback when ring buffer doesn't contain target_position."""
-    now = time.time()
-    wait_start_s = 2.0
-    start_time = now - 50 + wait_start_s
-    seconds_streamed = 50.0
-    # Only old chunks that are still in the future
-    chunk_positions = [49.0, 50.0]
-
-    session = _make_session(start_time, seconds_streamed, chunk_positions)
+    # With wait_start=2s, min_position = (now+2) - start_time.
+    # Place chunks so some are at or after min_position.
+    # start_time = now - 10, min_position = 12, chunks at 10-19.
+    start_time = now - 10
+    session = _make_session(start_time, 20.0, [float(i) for i in range(10, 20)])
     player = _make_late_joiner(wait_start_ms=2000)
 
     start_at, fed_chunks = await _run_add_client(session, player)
 
-    # Should still use chunks and start_at should be in the future
     assert fed_chunks, "Expected buffered chunks to be fed"
-    assert start_at > now, "start_at should be in the future"
-
-
-@pytest.mark.asyncio
-async def test_late_join_no_buffer_uses_preferred_start() -> None:
-    """Test that with no ring buffer, preferred start_at is used."""
-    now = time.time()
-    wait_start_s = 2.0
-    start_time = now - 50 + wait_start_s
-    seconds_streamed = 50.0
-
-    session = _make_session(start_time, seconds_streamed, chunk_positions=[])
-    player = _make_late_joiner(wait_start_ms=2000)
-
-    start_at, fed_chunks = await _run_add_client(session, player)
-
-    assert not fed_chunks, "No chunks should be fed when buffer is empty"
-    assert 1.5 < (start_at - now) < 2.5, (
-        f"Expected start_at ~2s from now, got {start_at - now:.2f}s"
+    first_chunk_pos = fed_chunks[0][1]
+    expected = start_time + first_chunk_pos
+    assert abs(start_at - expected) < 0.01, (
+        f"start_at must equal start_time + first_chunk_pos, got diff={start_at - expected:.4f}s"
     )
+
+
+@pytest.mark.asyncio
+async def test_late_join_trims_first_chunk() -> None:
+    """Test that the first chunk is trimmed when it straddles min_position."""
+    now = time.time()
+    # With wait_start=2s, min_position = (now+2) - start_time = 52.
+    # Place a chunk at position 51 that extends to 52 (straddles min_position).
+    start_time = now - 50
+    session = _make_session(start_time, 53.0, [51.0, 52.0, 53.0])
+    player = _make_late_joiner(wait_start_ms=2000)
+
+    start_at, fed_chunks = await _run_add_client(session, player)
+
+    assert fed_chunks, "Expected buffered chunks to be fed"
+    first_data, first_pos = fed_chunks[0]
+
+    # start_at must match the first byte and be >= now + wait_start
+    assert start_at >= now + 2.0 - 0.1
+    assert abs(start_at - (session.start_time + first_pos)) < 0.01
+
+    # First chunk should be at min_position (52.0), not 51.0
+    assert first_pos >= 52.0 - 0.1
+
+    # If trimmed from position 51, it should be smaller than a full chunk
+    # (the chunk at 52.0 passes the filter directly, so trimming only happens
+    # if no full chunks are >= min_position)
+    assert len(first_data) <= PCM_SAMPLE_SIZE
+    assert len(first_data) % BYTES_PER_SAMPLE == 0
+
+
+@pytest.mark.asyncio
+async def test_late_join_no_buffer() -> None:
+    """Test that with no ring buffer, start_at is still >= now + wait_start."""
+    now = time.time()
+    start_time = now - 50
+    session = _make_session(start_time, 50.0, chunk_positions=[])
+    player = _make_late_joiner(wait_start_ms=2000)
+
+    start_at, fed_chunks = await _run_add_client(session, player)
+
+    assert not fed_chunks
+    assert start_at >= now + 2.0 - 0.1


### PR DESCRIPTION
## Problem

Follow-up fix to #3581. Late joiners are completely out of sync with other players.

The previous change set `start_at = now + wait_start` (future) but fed ring buffer data from earlier stream positions. Since the CLI maps byte 0 to the NTP start time, the device played old audio at the wrong wall-clock time.

## Fix

- `start_at = self.start_time + first_chunk_position` — NTP timestamp must match the stream position of the first byte fed to the CLI
- Ring buffer data primes the pipeline so the device has audio ready when it connects, same as the initial session start
- The 10s delay was caused by the 1MB pipe buffers (removed in #3581), not the start_at calculation