### PR TITLE
Add Local Audio Out player provider

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -186,6 +186,8 @@ RUN set -x \
         liblzma5 \
         # Snapcast dependencies
         libasound2 \
+        # PortAudio for local audio output (sounddevice)
+        libportaudio2 \
         libvorbisidec1 \
         libflac12 \
         libavahi-client3 \

--- a/music_assistant/providers/local_audio/README.md
+++ b/music_assistant/providers/local_audio/README.md
@@ -1,0 +1,78 @@
+# Local Audio Out Provider
+
+## Overview
+
+The Local Audio Out provider exposes locally attached soundcards (USB DACs, built-in speakers, HDMI audio, etc.) as players in Music Assistant. It leverages the Sendspin provider for synchronization and timing, registering each soundcard as an external Sendspin bridge client.
+
+### Key Features
+
+- **Automatic Device Discovery**: Enumerates all audio output devices via PortAudio/sounddevice
+- **Sendspin Integration**: Each device is registered as a Sendspin bridge client, enabling synchronized multi-room playback
+- **Software Volume Control**: Per-device volume and mute via PCM sample scaling
+- **Stable Player IDs**: Uses UUIDv5 from device name + host API index so players persist across restarts
+
+## Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    LocalAudioProvider                         │
+│  - Thin provider shell, delegates to bridge manager          │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                ┌─────────────▼──────────────┐
+                │  LocalAudioBridgeManager   │
+                │  - Enumerates soundcards   │
+                │  - Creates/stops bridges   │
+                └─────────────┬──────────────┘
+                              │
+          ┌───────────────────┼───────────────────┐
+          │                                       │
+┌─────────▼──────────┐              ┌─────────────▼──────────┐
+│ SendspinLocalAudio  │              │ SendspinLocalAudio     │
+│ Bridge (Device A)   │              │ Bridge (Device B)      │
+│                     │              │                        │
+│ Sendspin Client ──► │              │ Sendspin Client ──►    │
+│ BridgePlayerRole    │              │ BridgePlayerRole       │
+│ sounddevice Output  │              │ sounddevice Output     │
+└─────────────────────┘              └────────────────────────┘
+```
+
+### Audio Flow
+
+```
+Sendspin PushStream
+       │
+       ▼
+BridgePlayerRole.on_audio_chunk
+       │
+       ▼ (volume/mute applied)
+asyncio.Queue
+       │
+       ▼
+sounddevice.RawOutputStream (PortAudio)
+       │
+       ▼
+Physical Soundcard
+```
+
+### File Structure
+
+| File | Description |
+|------|-------------|
+| `__init__.py` | Provider entry point, setup, and config |
+| `provider.py` | `LocalAudioProvider` class |
+| `sendspin_bridge.py` | Bridge manager and per-device bridge implementation |
+| `constants.py` | Shared constants (UUID namespace, buffer size) |
+| `manifest.json` | Provider metadata and dependencies |
+
+## Dependencies
+
+- **Sendspin provider** (`depends_on: sendspin`): Required for audio synchronization and player management
+- **sounddevice**: Python bindings for PortAudio, used for audio output
+- **numpy**: Used for PCM volume scaling
+
+## Related Documentation
+
+- [Sendspin Provider](../sendspin/README.md)

--- a/music_assistant/providers/local_audio/__init__.py
+++ b/music_assistant/providers/local_audio/__init__.py
@@ -1,0 +1,47 @@
+"""Local Audio Out player provider for Music Assistant."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.enums import ProviderFeature
+from music_assistant_models.provider import ProviderManifest
+
+from music_assistant.mass import MusicAssistant
+
+from .provider import LocalAudioProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+    from music_assistant_models.provider import ProviderManifest
+
+    from music_assistant.models import ProviderInstanceType
+
+SUPPORTED_FEATURES = {
+    ProviderFeature.SYNC_PLAYERS,
+}
+
+
+async def get_config_entries(
+    mass: MusicAssistant,
+    instance_id: str | None = None,
+    action: str | None = None,
+    values: dict[str, ConfigValueType] | None = None,
+) -> tuple[ConfigEntry, ...]:
+    """
+    Return Config entries to setup this provider.
+
+    :param mass: The Music Assistant instance.
+    :param instance_id: id of an existing provider instance (None if new instance setup).
+    :param action: action key called from config entries UI.
+    :param values: the (intermediate) raw values for config entries sent with the action.
+    """
+    # ruff: noqa: ARG001
+    return ()
+
+
+async def setup(
+    mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
+) -> ProviderInstanceType:
+    """Initialize provider(instance) with given configuration."""
+    return LocalAudioProvider(mass, manifest, config, SUPPORTED_FEATURES)

--- a/music_assistant/providers/local_audio/__init__.py
+++ b/music_assistant/providers/local_audio/__init__.py
@@ -4,15 +4,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.enums import ProviderFeature
-from music_assistant_models.provider import ProviderManifest
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 
 from music_assistant.mass import MusicAssistant
 
+from .constants import (
+    CONF_VOLUME_CONTROL,
+    VOLUME_CONTROL_DISABLED,
+    VOLUME_CONTROL_HARDWARE,
+    VOLUME_CONTROL_SOFTWARE,
+)
 from .provider import LocalAudioProvider
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+    from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.models import ProviderInstanceType
@@ -28,16 +34,24 @@ async def get_config_entries(
     action: str | None = None,
     values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """
-    Return Config entries to setup this provider.
-
-    :param mass: The Music Assistant instance.
-    :param instance_id: id of an existing provider instance (None if new instance setup).
-    :param action: action key called from config entries UI.
-    :param values: the (intermediate) raw values for config entries sent with the action.
-    """
+    """Return Config entries to setup this provider."""
     # ruff: noqa: ARG001
-    return ()
+    return (
+        ConfigEntry(
+            key=CONF_VOLUME_CONTROL,
+            type=ConfigEntryType.STRING,
+            label="Volume control mode",
+            options=[
+                ConfigValueOption(title="Hardware (preferred)", value=VOLUME_CONTROL_HARDWARE),
+                ConfigValueOption(title="Software", value=VOLUME_CONTROL_SOFTWARE),
+                ConfigValueOption(title="Disabled", value=VOLUME_CONTROL_DISABLED),
+            ],
+            default_value=VOLUME_CONTROL_HARDWARE,
+            description="Hardware uses OS/ALSA-level volume control. "
+            "Software applies volume scaling to PCM audio data. "
+            "Disabled passes audio at full volume.",
+        ),
+    )
 
 
 async def setup(

--- a/music_assistant/providers/local_audio/constants.py
+++ b/music_assistant/providers/local_audio/constants.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import uuid
 
-# UUID namespace for generating stable player IDs from device name + host API.
-# This ensures the same device always gets the same player_id across restarts.
+# UUID namespace for generating stable player IDs from device name + host API
 DEVICE_UUID_NAMESPACE = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 
-# Default buffer size in frames for the sounddevice output stream.
+# Default buffer size in frames for the sounddevice output stream
 DEFAULT_BUFFER_FRAMES = 2048
+
+CONF_VOLUME_CONTROL = "volume_control"
+VOLUME_CONTROL_SOFTWARE = "software"
+VOLUME_CONTROL_HARDWARE = "hardware"
+VOLUME_CONTROL_DISABLED = "disabled"

--- a/music_assistant/providers/local_audio/constants.py
+++ b/music_assistant/providers/local_audio/constants.py
@@ -1,0 +1,12 @@
+"""Constants for Local Audio Out provider."""
+
+from __future__ import annotations
+
+import uuid
+
+# UUID namespace for generating stable player IDs from device name + host API.
+# This ensures the same device always gets the same player_id across restarts.
+DEVICE_UUID_NAMESPACE = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+# Default buffer size in frames for the sounddevice output stream.
+DEFAULT_BUFFER_FRAMES = 2048

--- a/music_assistant/providers/local_audio/coreaudio_volume.py
+++ b/music_assistant/providers/local_audio/coreaudio_volume.py
@@ -1,0 +1,157 @@
+"""CoreAudio hardware volume control for macOS.
+
+Uses ctypes to call CoreAudio's AudioObject API directly,
+controlling the actual device hardware volume rather than the system mixer.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+
+# CoreAudio property selectors (FourCC encoded as big-endian uint32)
+_PROP_DEVICES = int.from_bytes(b"dev#", "big")
+_PROP_NAME = int.from_bytes(b"lnam", "big")
+_SCOPE_GLOBAL = int.from_bytes(b"glob", "big")
+_SCOPE_OUTPUT = int.from_bytes(b"outp", "big")
+_PROP_VOLUME_SCALAR = int.from_bytes(b"volm", "big")
+_PROP_MUTE = int.from_bytes(b"mute", "big")
+_SYSTEM_OBJECT = 1
+
+# CoreFoundation UTF-8 encoding
+_CF_ENCODING_UTF8 = 0x08000100
+
+
+class _AudioObjectPropertyAddress(ctypes.Structure):
+    _fields_ = [
+        ("mSelector", ctypes.c_uint32),
+        ("mScope", ctypes.c_uint32),
+        ("mElement", ctypes.c_uint32),
+    ]
+
+
+def _load_frameworks() -> tuple[ctypes.CDLL, ctypes.CDLL]:
+    """Load CoreAudio and CoreFoundation frameworks."""
+    ca_path = ctypes.util.find_library("CoreAudio")
+    cf_path = ctypes.util.find_library("CoreFoundation")
+    if not ca_path or not cf_path:
+        msg = "CoreAudio or CoreFoundation not found"
+        raise OSError(msg)
+    ca = ctypes.cdll.LoadLibrary(ca_path)
+    cf = ctypes.cdll.LoadLibrary(cf_path)
+    # Set up CFString helper signatures
+    cf.CFStringGetCStringPtr.restype = ctypes.c_char_p
+    cf.CFStringGetCStringPtr.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+    cf.CFStringGetCString.restype = ctypes.c_bool
+    cf.CFStringGetCString.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_long,
+        ctypes.c_uint32,
+    ]
+    return ca, cf
+
+
+def _cfstring_to_str(cf: ctypes.CDLL, cfstr: ctypes.c_void_p) -> str:
+    """Convert a CFStringRef to a Python string."""
+    ptr = cf.CFStringGetCStringPtr(cfstr, _CF_ENCODING_UTF8)
+    if ptr:
+        return str(ptr.decode("utf-8"))
+    buf = ctypes.create_string_buffer(512)
+    if cf.CFStringGetCString(cfstr, buf, 512, _CF_ENCODING_UTF8):
+        return buf.value.decode("utf-8")
+    return ""
+
+
+def _find_device_id(ca: ctypes.CDLL, cf: ctypes.CDLL, device_name: str) -> int | None:
+    """Find a CoreAudio device ID by name."""
+    prop = _AudioObjectPropertyAddress(_PROP_DEVICES, _SCOPE_GLOBAL, 0)
+    size = ctypes.c_uint32(0)
+    if (
+        ca.AudioObjectGetPropertyDataSize(
+            _SYSTEM_OBJECT, ctypes.byref(prop), 0, None, ctypes.byref(size)
+        )
+        != 0
+    ):
+        return None
+
+    n_devices = size.value // 4
+    device_ids = (ctypes.c_uint32 * n_devices)()
+    if (
+        ca.AudioObjectGetPropertyData(
+            _SYSTEM_OBJECT, ctypes.byref(prop), 0, None, ctypes.byref(size), device_ids
+        )
+        != 0
+    ):
+        return None
+
+    for did in device_ids:
+        name_prop = _AudioObjectPropertyAddress(_PROP_NAME, _SCOPE_GLOBAL, 0)
+        cfstr = ctypes.c_void_p()
+        sz = ctypes.c_uint32(ctypes.sizeof(cfstr))
+        if (
+            ca.AudioObjectGetPropertyData(
+                did, ctypes.byref(name_prop), 0, None, ctypes.byref(sz), ctypes.byref(cfstr)
+            )
+            == 0
+        ):
+            name = _cfstring_to_str(cf, cfstr)
+            if name == device_name:
+                return int(did)
+    return None
+
+
+def set_device_volume(device_name: str, volume: int) -> bool:
+    """Set the hardware volume for a named CoreAudio device.
+
+    :param device_name: The device name (must match CoreAudio device name).
+    :param volume: Volume level 0-100.
+    :return: True if successful.
+    """
+    try:
+        ca, cf = _load_frameworks()
+    except OSError:
+        return False
+
+    device_id = _find_device_id(ca, cf, device_name)
+    if device_id is None:
+        return False
+
+    vol_prop = _AudioObjectPropertyAddress(_PROP_VOLUME_SCALAR, _SCOPE_OUTPUT, 0)
+    if not ca.AudioObjectHasProperty(device_id, ctypes.byref(vol_prop)):
+        return False
+
+    scalar = ctypes.c_float(volume / 100.0)
+    size = ctypes.c_uint32(4)
+    result: int = ca.AudioObjectSetPropertyData(
+        device_id, ctypes.byref(vol_prop), 0, None, size, ctypes.byref(scalar)
+    )
+    return result == 0
+
+
+def set_device_mute(device_name: str, muted: bool) -> bool:
+    """Set the hardware mute state for a named CoreAudio device.
+
+    :param device_name: The device name (must match CoreAudio device name).
+    :param muted: Whether to mute or unmute.
+    :return: True if successful.
+    """
+    try:
+        ca, cf = _load_frameworks()
+    except OSError:
+        return False
+
+    device_id = _find_device_id(ca, cf, device_name)
+    if device_id is None:
+        return False
+
+    mute_prop = _AudioObjectPropertyAddress(_PROP_MUTE, _SCOPE_OUTPUT, 0)
+    if not ca.AudioObjectHasProperty(device_id, ctypes.byref(mute_prop)):
+        return False
+
+    mute_val = ctypes.c_uint32(1 if muted else 0)
+    size = ctypes.c_uint32(4)
+    result: int = ca.AudioObjectSetPropertyData(
+        device_id, ctypes.byref(mute_prop), 0, None, size, ctypes.byref(mute_val)
+    )
+    return result == 0

--- a/music_assistant/providers/local_audio/icon.svg
+++ b/music_assistant/providers/local_audio/icon.svg
@@ -1,15 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-  <path fill="#4A90D9" d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0z"/>
-  <path fill="#FFFFFF" d="M12 4a2 2 0 0 0-2 2v5.17l-1.59-1.58A2 2 0 0 0 5 12v0a2 2 0 0 0 2 2h2.17l1.42 1.42A2 2 0 0 0 12 16h0a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z"/>
-  <path fill="#FFFFFF" d="M3.5 9.5a.75.75 0 0 0-.75.75v3.5a.75.75 0 0 0 1.5 0v-3.5A.75.75 0 0 0 3.5 9.5z"/>
-  <g fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round">
-    <path d="M8 7.5v9"/>
-    <path d="M5.5 9v6"/>
-    <path d="M10.5 5v14"/>
-    <path d="M13 6.5v11"/>
-    <path d="M15.5 8v8"/>
-    <path d="M18 9.5v5"/>
-    <path d="M20.5 10.5v3"/>
-  </g>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 9V15H7L12 20V4L7 9H3Z" fill="#4A90D9"/>
+<path d="M15.54 8.46C16.48 9.4 17.01 10.67 17.01 12C17.01 13.33 16.48 14.6 15.54 15.54" stroke="#4A90D9" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M18.07 5.93C19.79 7.65 20.74 9.94 20.74 12.34C20.74 14.74 19.79 17.03 18.07 18.75" stroke="#4A90D9" stroke-width="1.5" stroke-linecap="round"/>
 </svg>

--- a/music_assistant/providers/local_audio/icon.svg
+++ b/music_assistant/providers/local_audio/icon.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path fill="#4A90D9" d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0z"/>
+  <path fill="#FFFFFF" d="M12 4a2 2 0 0 0-2 2v5.17l-1.59-1.58A2 2 0 0 0 5 12v0a2 2 0 0 0 2 2h2.17l1.42 1.42A2 2 0 0 0 12 16h0a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z"/>
+  <path fill="#FFFFFF" d="M3.5 9.5a.75.75 0 0 0-.75.75v3.5a.75.75 0 0 0 1.5 0v-3.5A.75.75 0 0 0 3.5 9.5z"/>
+  <g fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round">
+    <path d="M8 7.5v9"/>
+    <path d="M5.5 9v6"/>
+    <path d="M10.5 5v14"/>
+    <path d="M13 6.5v11"/>
+    <path d="M15.5 8v8"/>
+    <path d="M18 9.5v5"/>
+    <path d="M20.5 10.5v3"/>
+  </g>
+</svg>

--- a/music_assistant/providers/local_audio/manifest.json
+++ b/music_assistant/providers/local_audio/manifest.json
@@ -1,0 +1,12 @@
+{
+  "type": "player",
+  "domain": "local_audio",
+  "name": "Local Audio Out",
+  "description": "Play audio through locally attached soundcards (USB DACs, built-in speakers, etc.).",
+  "codeowners": ["@music-assistant"],
+  "requirements": ["sounddevice==0.5.5"],
+  "documentation": "https://music-assistant.io/player-support/local-audio/",
+  "builtin": true,
+  "allow_disable": true,
+  "stage": "alpha"
+}

--- a/music_assistant/providers/local_audio/manifest.json
+++ b/music_assistant/providers/local_audio/manifest.json
@@ -4,6 +4,7 @@
   "name": "Local Audio Out",
   "description": "Play audio through locally attached soundcards (USB DACs, built-in speakers, etc.).",
   "codeowners": ["@music-assistant"],
+  "depends_on": "sendspin",
   "requirements": ["sounddevice==0.5.5"],
   "documentation": "https://music-assistant.io/player-support/local-audio/",
   "builtin": true,

--- a/music_assistant/providers/local_audio/player.py
+++ b/music_assistant/providers/local_audio/player.py
@@ -1,0 +1,140 @@
+"""Local Audio Player implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import uuid
+from typing import TYPE_CHECKING
+
+from music_assistant_models.enums import IdentifierType, PlayerFeature, PlayerType
+from music_assistant_models.player import DeviceInfo
+
+from music_assistant.helpers.process import check_output
+from music_assistant.models.player import Player
+
+from .constants import (
+    CONF_VOLUME_CONTROL,
+    DEVICE_UUID_NAMESPACE,
+    VOLUME_CONTROL_HARDWARE,
+    VOLUME_CONTROL_SOFTWARE,
+)
+
+if sys.platform == "darwin":
+    from .coreaudio_volume import set_device_mute, set_device_volume
+
+if TYPE_CHECKING:
+    from .provider import LocalAudioProvider
+
+
+def get_device_uuid(device_name: str, hostapi_index: int) -> str:
+    """Generate a stable UUID for a local audio device.
+
+    :param device_name: The device name reported by PortAudio.
+    :param hostapi_index: The host API index (e.g. CoreAudio=0, ALSA=0).
+    """
+    return str(uuid.uuid5(DEVICE_UUID_NAMESPACE, f"{device_name}:{hostapi_index}"))
+
+
+class LocalAudioPlayer(Player):
+    """Player for a locally attached soundcard."""
+
+    def __init__(
+        self,
+        provider: LocalAudioProvider,
+        player_id: str,
+        device_name: str,
+        hostapi_index: int,
+    ) -> None:
+        """
+        Initialize the Local Audio player.
+
+        :param provider: The Local Audio provider instance.
+        :param player_id: Stable player ID derived from device UUID.
+        :param device_name: The device name reported by PortAudio.
+        :param hostapi_index: The host API index.
+        """
+        super().__init__(provider, player_id)
+        self._attr_type = PlayerType.PLAYER
+        self._attr_name = device_name
+        self._attr_available = True
+        self._attr_supported_features = {
+            PlayerFeature.VOLUME_SET,
+            PlayerFeature.VOLUME_MUTE,
+        }
+        self._attr_device_info = DeviceInfo(
+            model=device_name,
+            manufacturer="Local Audio",
+        )
+        device_uuid = get_device_uuid(device_name, hostapi_index)
+        self._attr_device_info.add_identifier(IdentifierType.UUID, device_uuid)
+        self._attr_can_group_with = set()
+        self._attr_volume_level = 100
+        # Set when hardware volume fails, causes automatic fallback to software
+        self._hardware_volume_fallback = False
+
+    @property
+    def volume_control_mode(self) -> str:
+        """Return the effective volume control mode for this player."""
+        if self._hardware_volume_fallback:
+            return VOLUME_CONTROL_SOFTWARE
+        # Volume control mode is configured at provider level
+        return str(self._provider.config.get_value(CONF_VOLUME_CONTROL) or VOLUME_CONTROL_HARDWARE)
+
+    async def volume_set(self, volume_level: int) -> None:
+        """Handle VOLUME_SET command."""
+        self._attr_volume_level = volume_level
+        if self.volume_control_mode == VOLUME_CONTROL_HARDWARE:
+            await self._set_hardware_volume(volume_level)
+        self.update_state()
+
+    async def volume_mute(self, muted: bool) -> None:
+        """Handle VOLUME_MUTE command."""
+        self._attr_volume_muted = muted
+        mode = self.volume_control_mode
+        if mode == VOLUME_CONTROL_HARDWARE:
+            await self._set_hardware_mute(muted)
+        self.update_state()
+
+    async def _set_hardware_volume(self, volume: int) -> None:
+        """Set the OS-level volume for this device.
+
+        :param volume: Volume level 0-100.
+        """
+        try:
+            if sys.platform == "darwin":
+                loop = asyncio.get_running_loop()
+                ok = await loop.run_in_executor(None, set_device_volume, self.name, volume)
+                if not ok:
+                    self.logger.warning("CoreAudio volume control failed for %s", self.name)
+                    self._hardware_volume_fallback = True
+            elif sys.platform == "linux":
+                await check_output("amixer", "sset", "Master", f"{volume}%")
+            else:
+                self.logger.warning(
+                    "Hardware volume not supported on %s, falling back to software",
+                    sys.platform,
+                )
+                self._hardware_volume_fallback = True
+        except FileNotFoundError:
+            self.logger.warning("Volume control command not found, falling back to software")
+            self._hardware_volume_fallback = True
+
+    async def _set_hardware_mute(self, muted: bool) -> None:
+        """Set the OS-level mute state for this device.
+
+        :param muted: Whether to mute or unmute.
+        """
+        try:
+            if sys.platform == "darwin":
+                loop = asyncio.get_running_loop()
+                ok = await loop.run_in_executor(None, set_device_mute, self.name, muted)
+                if not ok:
+                    self.logger.warning("CoreAudio mute control failed for %s", self.name)
+                    self._hardware_volume_fallback = True
+            elif sys.platform == "linux":
+                toggle = "mute" if muted else "unmute"
+                await check_output("amixer", "sset", "Master", toggle)
+        except FileNotFoundError:
+            self.logger.warning("Mute control command not found, falling back to software")
+            self._hardware_volume_fallback = True

--- a/music_assistant/providers/local_audio/player.py
+++ b/music_assistant/providers/local_audio/player.py
@@ -149,6 +149,8 @@ class LocalAudioPlayer(Player):
                 if rc != 0:
                     self.logger.warning("amixer mute failed for card %d", self._device_index)
                     self._hardware_volume_fallback = True
+            else:
+                self._hardware_volume_fallback = True
         except FileNotFoundError:
             self.logger.warning("Mute control command not found, falling back to software")
             self._hardware_volume_fallback = True

--- a/music_assistant/providers/local_audio/player.py
+++ b/music_assistant/providers/local_audio/player.py
@@ -113,9 +113,12 @@ class LocalAudioPlayer(Player):
                     self._hardware_volume_fallback = True
             elif sys.platform == "linux":
                 # Use -c to target the specific ALSA card by index
-                await check_output(
+                rc, _ = await check_output(
                     "amixer", "-c", str(self._device_index), "sset", "Master", f"{volume}%"
                 )
+                if rc != 0:
+                    self.logger.warning("amixer volume failed for card %d", self._device_index)
+                    self._hardware_volume_fallback = True
             else:
                 self.logger.warning(
                     "Hardware volume not supported on %s, falling back to software",
@@ -140,9 +143,12 @@ class LocalAudioPlayer(Player):
                     self._hardware_volume_fallback = True
             elif sys.platform == "linux":
                 toggle = "mute" if muted else "unmute"
-                await check_output(
+                rc, _ = await check_output(
                     "amixer", "-c", str(self._device_index), "sset", "Master", toggle
                 )
+                if rc != 0:
+                    self.logger.warning("amixer mute failed for card %d", self._device_index)
+                    self._hardware_volume_fallback = True
         except FileNotFoundError:
             self.logger.warning("Mute control command not found, falling back to software")
             self._hardware_volume_fallback = True

--- a/music_assistant/providers/local_audio/player.py
+++ b/music_assistant/providers/local_audio/player.py
@@ -45,6 +45,7 @@ class LocalAudioPlayer(Player):
         player_id: str,
         device_name: str,
         hostapi_index: int,
+        device_index: int,
     ) -> None:
         """
         Initialize the Local Audio player.
@@ -53,6 +54,7 @@ class LocalAudioPlayer(Player):
         :param player_id: Stable player ID derived from device UUID.
         :param device_name: The device name reported by PortAudio.
         :param hostapi_index: The host API index.
+        :param device_index: The PortAudio device index (maps to ALSA card on Linux).
         """
         super().__init__(provider, player_id)
         self._attr_type = PlayerType.PLAYER
@@ -70,6 +72,7 @@ class LocalAudioPlayer(Player):
         self._attr_device_info.add_identifier(IdentifierType.UUID, device_uuid)
         self._attr_can_group_with = set()
         self._attr_volume_level = 100
+        self._device_index = device_index
         # Set when hardware volume fails, causes automatic fallback to software
         self._hardware_volume_fallback = False
 
@@ -109,7 +112,10 @@ class LocalAudioPlayer(Player):
                     self.logger.warning("CoreAudio volume control failed for %s", self.name)
                     self._hardware_volume_fallback = True
             elif sys.platform == "linux":
-                await check_output("amixer", "sset", "Master", f"{volume}%")
+                # Use -c to target the specific ALSA card by index
+                await check_output(
+                    "amixer", "-c", str(self._device_index), "sset", "Master", f"{volume}%"
+                )
             else:
                 self.logger.warning(
                     "Hardware volume not supported on %s, falling back to software",
@@ -134,7 +140,9 @@ class LocalAudioPlayer(Player):
                     self._hardware_volume_fallback = True
             elif sys.platform == "linux":
                 toggle = "mute" if muted else "unmute"
-                await check_output("amixer", "sset", "Master", toggle)
+                await check_output(
+                    "amixer", "-c", str(self._device_index), "sset", "Master", toggle
+                )
         except FileNotFoundError:
             self.logger.warning("Mute control command not found, falling back to software")
             self._hardware_volume_fallback = True

--- a/music_assistant/providers/local_audio/provider.py
+++ b/music_assistant/providers/local_audio/provider.py
@@ -1,0 +1,36 @@
+"""Local Audio Out player provider for Music Assistant."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant.models.player_provider import PlayerProvider
+
+if TYPE_CHECKING:
+    from .sendspin_bridge import LocalAudioBridgeManager
+
+
+class LocalAudioProvider(PlayerProvider):
+    """Player provider that exposes locally attached soundcards as Sendspin players."""
+
+    _bridge_manager: LocalAudioBridgeManager
+
+    async def handle_async_init(self) -> None:
+        """Handle async initialization of the provider."""
+        from .sendspin_bridge import LocalAudioBridgeManager
+
+        self._bridge_manager = LocalAudioBridgeManager(self)
+
+    async def loaded_in_mass(self) -> None:
+        """Handle provider fully loaded in Music Assistant."""
+        await self._bridge_manager.discover_and_register()
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Handle unload/removal of the provider."""
+        bridge_manager = getattr(self, "_bridge_manager", None)
+        if bridge_manager:
+            await bridge_manager.stop_all()
+
+    async def discover_players(self) -> None:
+        """Discover players (re-enumerate soundcards)."""
+        await self._bridge_manager.discover_and_register()

--- a/music_assistant/providers/local_audio/provider.py
+++ b/music_assistant/providers/local_audio/provider.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from music_assistant.models.player_provider import PlayerProvider
 
-if TYPE_CHECKING:
-    from .sendspin_bridge import LocalAudioBridgeManager
+from .sendspin_bridge import LocalAudioBridgeManager
 
 
 class LocalAudioProvider(PlayerProvider):
@@ -17,8 +14,6 @@ class LocalAudioProvider(PlayerProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        from .sendspin_bridge import LocalAudioBridgeManager
-
         self._bridge_manager = LocalAudioBridgeManager(self)
 
     async def loaded_in_mass(self) -> None:

--- a/music_assistant/providers/local_audio/sendspin_bridge.py
+++ b/music_assistant/providers/local_audio/sendspin_bridge.py
@@ -129,8 +129,8 @@ class SendspinLocalAudioBridge:
             self._bridge_role = cast("BridgePlayerRole", roles[0])
             self._bridge_role.set_callbacks(
                 on_audio_chunk=self._on_audio_chunk,
-                on_volume_change=lambda _vol: None,
-                on_mute_change=lambda _muted: None,
+                on_volume_change=self._on_volume_change,
+                on_mute_change=self._on_mute_change,
                 on_stream_start=self._on_bridge_stream_start,
                 on_stream_end=self._on_bridge_stream_end,
             )
@@ -187,6 +187,14 @@ class SendspinLocalAudioBridge:
         """Stop streaming when the stream ends."""
         self._is_streaming = False
         self.mass.create_task(self._stop_streaming_locked())
+
+    def _on_volume_change(self, volume: int) -> None:
+        """Sync volume from Sendspin side back to our player."""
+        self.mass.create_task(self.player.volume_set(volume))
+
+    def _on_mute_change(self, muted: bool) -> None:
+        """Sync mute from Sendspin side back to our player."""
+        self.mass.create_task(self.player.volume_mute(muted))
 
     def _on_audio_chunk(self, chunk: AudioChunk) -> None:
         """Handle an incoming audio chunk."""

--- a/music_assistant/providers/local_audio/sendspin_bridge.py
+++ b/music_assistant/providers/local_audio/sendspin_bridge.py
@@ -329,7 +329,9 @@ class LocalAudioBridgeManager:
                     continue
 
                 # Register our own player with MA first
-                player = LocalAudioPlayer(self.provider, device_uuid, device_name, hostapi_index)
+                player = LocalAudioPlayer(
+                    self.provider, device_uuid, device_name, hostapi_index, device_index
+                )
                 await self.mass.players.register(player)
 
                 # Then set up the Sendspin bridge with identifier for protocol linking

--- a/music_assistant/providers/local_audio/sendspin_bridge.py
+++ b/music_assistant/providers/local_audio/sendspin_bridge.py
@@ -1,0 +1,421 @@
+"""Sendspin Bridge for Local Audio Out - streams audio to local soundcards.
+
+This module enables locally attached soundcards to be used as Sendspin players.
+Sendspin handles all synchronization and timing - the soundcard is just the output.
+
+The bridge:
+1. Enumerates local audio output devices via sounddevice (PortAudio)
+2. Registers each device as an external Sendspin client
+3. The Sendspin provider creates a SendspinPlayer for each device
+4. When grouped, Sendspin handles timing/sync, sounddevice outputs audio
+
+Audio flow:
+Sendspin PushStream -> BridgePlayerRole.on_audio_chunk -> asyncio.Queue -> sounddevice.RawOutputStream
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+import sounddevice as sd
+from aiosendspin.models.core import ClientHelloPayload
+from aiosendspin.models.core import DeviceInfo as SendspinDeviceInfo
+from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
+from aiosendspin.models.types import AudioCodec, PlayerCommand
+
+from music_assistant.providers.sendspin.bridge_role import (
+    BRIDGE_BIT_DEPTH,
+    BRIDGE_CHANNELS,
+    BRIDGE_ROLE_ID,
+    BRIDGE_SAMPLE_RATE,
+    BridgePlayerRole,
+)
+from music_assistant.providers.sendspin.helpers import bridge_client_id_from_uuid
+
+from .constants import DEFAULT_BUFFER_FRAMES, DEVICE_UUID_NAMESPACE
+
+if TYPE_CHECKING:
+    from aiosendspin.server import ExternalStreamStartRequest, SendspinClient, SendspinServer
+    from aiosendspin.server.roles import AudioChunk
+
+    from music_assistant.providers.sendspin.provider import SendspinProvider
+
+    from .provider import LocalAudioProvider
+
+
+def _get_device_client_id(device_name: str, hostapi_index: int) -> str:
+    """Generate a stable Sendspin bridge client ID for a local audio device.
+
+    Uses UUIDv5 from device name + host API index to produce a deterministic ID
+    that persists across restarts as long as hardware doesn't change.
+
+    :param device_name: The device name reported by PortAudio.
+    :param hostapi_index: The host API index (e.g. CoreAudio=0, ALSA=0).
+    :return: A Sendspin bridge client ID (spb_ prefix).
+    """
+    device_uuid = uuid.uuid5(DEVICE_UUID_NAMESPACE, f"{device_name}:{hostapi_index}")
+    return bridge_client_id_from_uuid(str(device_uuid))
+
+
+class SendspinLocalAudioBridge:
+    """Manages the Sendspin to local soundcard bridge for a single device.
+
+    This class handles:
+    1. Registering the device as an external Sendspin client
+    2. Creating a BridgePlayerRole to receive audio from PushStream
+    3. Streaming audio to the soundcard via sounddevice RawOutputStream
+    """
+
+    def __init__(
+        self,
+        provider: LocalAudioProvider,
+        device_index: int,
+        device_info: dict[str, Any],
+        sendspin_server: SendspinServer,
+    ) -> None:
+        """Initialize the bridge.
+
+        :param provider: The Local Audio provider instance.
+        :param device_index: The PortAudio device index.
+        :param device_info: The device info dict from sounddevice.query_devices().
+        :param sendspin_server: The Sendspin server to register with.
+        """
+        self.provider = provider
+        self.mass = provider.mass
+        self.sendspin_server = sendspin_server
+        self.device_index = device_index
+        self.device_name: str = device_info["name"]
+        self.device_info = device_info
+        self.logger = provider.logger.getChild(f"bridge.{self.device_name}")
+
+        self._sendspin_client: SendspinClient | None = None
+        self._bridge_client_id: str | None = None
+        self._bridge_role: BridgePlayerRole | None = None
+        self._is_streaming = False
+        self._write_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        self._writer_task: asyncio.Task[None] | None = None
+        self._output_stream: sd.RawOutputStream | None = None
+        self._volume: int = 100
+        self._muted: bool = False
+        self._lock = asyncio.Lock()
+
+    @property
+    def is_registered(self) -> bool:
+        """Return whether the bridge is registered with Sendspin."""
+        return self._sendspin_client is not None
+
+    async def start(self) -> None:
+        """Register the local audio device as an external Sendspin client."""
+        hostapi_index: int = self.device_info.get("hostapi", 0)
+        self._bridge_client_id = _get_device_client_id(self.device_name, hostapi_index)
+
+        hello = ClientHelloPayload(
+            client_id=self._bridge_client_id,
+            name=self.device_name,
+            version=1,
+            supported_roles=[BRIDGE_ROLE_ID, "player@v1"],
+            device_info=SendspinDeviceInfo(
+                product_name=self.device_name,
+                manufacturer="Local Audio",
+            ),
+            player_support=ClientHelloPlayerSupport(
+                supported_formats=[
+                    SupportedAudioFormat(
+                        codec=AudioCodec.PCM,
+                        channels=BRIDGE_CHANNELS,
+                        sample_rate=BRIDGE_SAMPLE_RATE,
+                        bit_depth=BRIDGE_BIT_DEPTH,
+                    )
+                ],
+                buffer_capacity=1_000,
+                supported_commands=[PlayerCommand.VOLUME, PlayerCommand.MUTE],
+            ),
+        )
+
+        self.logger.debug(
+            "Registering Sendspin bridge for %s with client_id=%s",
+            self.device_name,
+            self._bridge_client_id,
+        )
+
+        self._sendspin_client = self.sendspin_server.register_external_player(
+            hello, on_stream_start=self._on_stream_start
+        )
+
+        # Retrieve the BridgePlayerRole and wire up callbacks.
+        roles = self._sendspin_client.roles_by_family("player")
+        if roles:
+            self._bridge_role = cast("BridgePlayerRole", roles[0])
+            self._bridge_role.set_callbacks(
+                on_audio_chunk=self._on_audio_chunk,
+                on_volume_change=self._on_volume_change,
+                on_mute_change=self._on_mute_change,
+                on_stream_start=self._on_bridge_stream_start,
+                on_stream_end=self._on_bridge_stream_end,
+            )
+            self._bridge_role.setup_audio_requirements()
+
+        self.logger.info(
+            "Sendspin bridge registered for %s (client_id=%s)",
+            self.device_name,
+            self._bridge_client_id,
+        )
+
+    async def stop(self) -> None:
+        """Stop and unregister the Sendspin bridge."""
+        async with self._lock:
+            await self._stop_streaming()
+            if self._sendspin_client and self._bridge_client_id:
+                await self.sendspin_server.remove_client(self._bridge_client_id)
+                self._sendspin_client = None
+                self._bridge_role = None
+
+        self.logger.debug("Sendspin bridge stopped for %s", self.device_name)
+
+    def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
+        """Handle stream start request from Sendspin server.
+
+        Called when Sendspin wants to play audio to this bridge player.
+        Resets state before starting a new stream.
+        """
+        self.logger.debug(
+            "Sendspin stream start request for %s (reason=%s)",
+            self.device_name,
+            request.connection_reason,
+        )
+        self._is_streaming = True
+
+    def _on_bridge_stream_start(self) -> None:
+        """Start the writer task when PushStream begins delivering audio chunks."""
+        if self._writer_task is not None and not self._writer_task.done():
+            self._writer_task.cancel()
+
+        self._is_streaming = True
+
+        # Drain stale audio data from the previous stream
+        while not self._write_queue.empty():
+            self._write_queue.get_nowait()
+
+        self._writer_task = self.mass.create_task(self._audio_writer())
+        self.logger.info("Bridge writer started for %s", self.device_name)
+
+    def _on_bridge_stream_end(self) -> None:
+        """Stop streaming when the stream ends."""
+        self._is_streaming = False
+        self.mass.create_task(self._stop_streaming_locked())
+
+    def _on_audio_chunk(self, chunk: AudioChunk) -> None:
+        """Handle audio chunk from Sendspin PushStream."""
+        if not self._is_streaming:
+            return
+
+        data = chunk.data
+        if self._muted:
+            data = b"\x00" * len(data)
+        elif self._volume < 100:
+            data = self._apply_volume(data)
+
+        self._write_queue.put_nowait(data)
+
+    def _apply_volume(self, pcm_data: bytes) -> bytes:
+        """Apply software volume scaling to PCM data.
+
+        :param pcm_data: Raw 16-bit signed integer PCM data.
+        :return: Volume-adjusted PCM data.
+        """
+        samples = np.frombuffer(pcm_data, dtype=np.int16).copy()
+        scale = self._volume / 100.0
+        samples = np.clip(samples * scale, -32768, 32767).astype(np.int16)
+        return samples.tobytes()
+
+    def _on_volume_change(self, volume: int) -> None:
+        """Handle volume change from Sendspin."""
+        self._volume = volume
+
+    def _on_mute_change(self, muted: bool) -> None:
+        """Handle mute change from Sendspin."""
+        self._muted = muted
+
+    async def _audio_writer(self) -> None:
+        """Write queued audio data to the soundcard via sounddevice.
+
+        Opens a RawOutputStream for the device, reads PCM data from the queue,
+        and writes it to the soundcard. A None sentinel signals end-of-stream.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            self._output_stream = sd.RawOutputStream(
+                device=self.device_index,
+                samplerate=BRIDGE_SAMPLE_RATE,
+                channels=BRIDGE_CHANNELS,
+                dtype="int16",
+                blocksize=DEFAULT_BUFFER_FRAMES,
+            )
+            self._output_stream.start()
+            self.logger.debug("Audio output stream opened for %s", self.device_name)
+
+            while True:
+                data = await self._write_queue.get()
+                if data is None:
+                    break
+                if not self._is_streaming:
+                    break
+                try:
+                    await loop.run_in_executor(None, self._output_stream.write, data)
+                except sd.PortAudioError as err:
+                    self.logger.error(
+                        "PortAudio error writing to %s: %s", self.device_name, err
+                    )
+                    break
+        except sd.PortAudioError as err:
+            self.logger.error(
+                "Failed to open audio output stream for %s: %s", self.device_name, err
+            )
+        finally:
+            if self._output_stream is not None:
+                with suppress(Exception):
+                    self._output_stream.stop()
+                with suppress(Exception):
+                    self._output_stream.close()
+                self._output_stream = None
+            if self._writer_task is asyncio.current_task():
+                self._writer_task = None
+
+    async def _stop_streaming_locked(self) -> None:
+        """Serialize streaming teardown."""
+        async with self._lock:
+            await self._stop_streaming()
+
+    async def _stop_streaming(self) -> None:
+        """Stop streaming (internal, called with lock held)."""
+        self._is_streaming = False
+        if self._writer_task:
+            self._writer_task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await self._writer_task
+            self._writer_task = None
+        while not self._write_queue.empty():
+            self._write_queue.get_nowait()
+        if self._output_stream is not None:
+            with suppress(Exception):
+                self._output_stream.stop()
+            with suppress(Exception):
+                self._output_stream.close()
+            self._output_stream = None
+
+
+class LocalAudioBridgeManager:
+    """Manages Sendspin bridges for all local audio output devices."""
+
+    def __init__(self, provider: LocalAudioProvider) -> None:
+        """Initialize the bridge manager.
+
+        :param provider: The Local Audio provider instance.
+        """
+        self.provider = provider
+        self.mass = provider.mass
+        self.logger = provider.logger.getChild("bridge_manager")
+        self._bridges: dict[str, SendspinLocalAudioBridge] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def sendspin_provider(self) -> SendspinProvider | None:
+        """Get the Sendspin provider if available."""
+        return cast(
+            "SendspinProvider | None",
+            self.mass.get_provider("sendspin"),
+        )
+
+    @property
+    def sendspin_server(self) -> SendspinServer | None:
+        """Get the Sendspin server if available."""
+        if provider := self.sendspin_provider:
+            return provider.server_api
+        return None
+
+    async def discover_and_register(self) -> None:
+        """Enumerate local audio devices and register bridges for each."""
+        sendspin_server = self.sendspin_server
+        if not sendspin_server:
+            self.logger.debug("Sendspin provider not available, skipping device enumeration")
+            return
+
+        loop = asyncio.get_running_loop()
+        try:
+            devices: list[dict[str, Any]] = await loop.run_in_executor(
+                None, self._enumerate_output_devices
+            )
+        except Exception as err:
+            self.logger.warning("Failed to enumerate audio devices: %s", err)
+            return
+
+        if not devices:
+            self.logger.info("No local audio output devices found")
+            return
+
+        self.logger.info("Found %d local audio output device(s)", len(devices))
+
+        async with self._lock:
+            for device in devices:
+                device_index: int = device["index"]
+                device_name: str = device["name"]
+                hostapi_index: int = device.get("hostapi", 0)
+                client_id = _get_device_client_id(device_name, hostapi_index)
+
+                if client_id in self._bridges:
+                    self.logger.debug("Bridge already exists for %s", device_name)
+                    continue
+
+                bridge = SendspinLocalAudioBridge(
+                    self.provider, device_index, device, sendspin_server
+                )
+                try:
+                    await bridge.start()
+                except Exception:
+                    self.logger.warning("Failed to start bridge for %s", device_name)
+                    with suppress(Exception):
+                        await bridge.stop()
+                    continue
+
+                if not bridge.is_registered:
+                    continue
+
+                self._bridges[client_id] = bridge
+                self.logger.info("Bridge created for %s", device_name)
+
+    @staticmethod
+    def _enumerate_output_devices() -> list[dict[str, Any]]:
+        """Enumerate available audio output devices via sounddevice.
+
+        Filters for devices with at least 2 output channels.
+        Runs in an executor since PortAudio device enumeration may block.
+
+        :return: List of device info dicts with an added 'index' key.
+        """
+        devices: list[dict[str, Any]] = []
+        all_devices = sd.query_devices()
+        if not isinstance(all_devices, list):
+            all_devices = [all_devices]
+        for idx, dev in enumerate(all_devices):
+            if not isinstance(dev, dict):
+                continue
+            max_output_channels: int = dev.get("max_output_channels", 0)
+            if max_output_channels >= 2:
+                dev_with_index = dict(dev)
+                dev_with_index["index"] = idx
+                devices.append(dev_with_index)
+        return devices
+
+    async def stop_all(self) -> None:
+        """Stop all Sendspin bridges."""
+        async with self._lock:
+            for bridge in list(self._bridges.values()):
+                with suppress(Exception):
+                    await bridge.stop()
+            self._bridges.clear()
+
+        self.logger.debug("All local audio bridges stopped")

--- a/music_assistant/providers/local_audio/sendspin_bridge.py
+++ b/music_assistant/providers/local_audio/sendspin_bridge.py
@@ -1,22 +1,8 @@
-"""Sendspin Bridge for Local Audio Out - streams audio to local soundcards.
-
-This module enables locally attached soundcards to be used as Sendspin players.
-Sendspin handles all synchronization and timing - the soundcard is just the output.
-
-The bridge:
-1. Enumerates local audio output devices via sounddevice (PortAudio)
-2. Registers each device as an external Sendspin client
-3. The Sendspin provider creates a SendspinPlayer for each device
-4. When grouped, Sendspin handles timing/sync, sounddevice outputs audio
-
-Audio flow:
-Sendspin PushStream -> BridgePlayerRole.on_audio_chunk -> asyncio.Queue -> sounddevice.RawOutputStream
-"""
+"""Sendspin Bridge for Local Audio Out - streams audio to local soundcards."""
 
 from __future__ import annotations
 
 import asyncio
-import uuid
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
@@ -26,6 +12,7 @@ from aiosendspin.models.core import ClientHelloPayload
 from aiosendspin.models.core import DeviceInfo as SendspinDeviceInfo
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
 from aiosendspin.models.types import AudioCodec, PlayerCommand
+from music_assistant_models.enums import IdentifierType
 
 from music_assistant.providers.sendspin.bridge_role import (
     BRIDGE_BIT_DEPTH,
@@ -36,7 +23,8 @@ from music_assistant.providers.sendspin.bridge_role import (
 )
 from music_assistant.providers.sendspin.helpers import bridge_client_id_from_uuid
 
-from .constants import DEFAULT_BUFFER_FRAMES, DEVICE_UUID_NAMESPACE
+from .constants import DEFAULT_BUFFER_FRAMES, VOLUME_CONTROL_SOFTWARE
+from .player import LocalAudioPlayer, get_device_uuid
 
 if TYPE_CHECKING:
     from aiosendspin.server import ExternalStreamStartRequest, SendspinClient, SendspinServer
@@ -47,45 +35,29 @@ if TYPE_CHECKING:
     from .provider import LocalAudioProvider
 
 
-def _get_device_client_id(device_name: str, hostapi_index: int) -> str:
-    """Generate a stable Sendspin bridge client ID for a local audio device.
-
-    Uses UUIDv5 from device name + host API index to produce a deterministic ID
-    that persists across restarts as long as hardware doesn't change.
-
-    :param device_name: The device name reported by PortAudio.
-    :param hostapi_index: The host API index (e.g. CoreAudio=0, ALSA=0).
-    :return: A Sendspin bridge client ID (spb_ prefix).
-    """
-    device_uuid = uuid.uuid5(DEVICE_UUID_NAMESPACE, f"{device_name}:{hostapi_index}")
-    return bridge_client_id_from_uuid(str(device_uuid))
-
-
 class SendspinLocalAudioBridge:
-    """Manages the Sendspin to local soundcard bridge for a single device.
-
-    This class handles:
-    1. Registering the device as an external Sendspin client
-    2. Creating a BridgePlayerRole to receive audio from PushStream
-    3. Streaming audio to the soundcard via sounddevice RawOutputStream
-    """
+    """Manages the Sendspin to local soundcard bridge for a single device."""
 
     def __init__(
         self,
         provider: LocalAudioProvider,
+        player: LocalAudioPlayer,
         device_index: int,
         device_info: dict[str, Any],
         sendspin_server: SendspinServer,
     ) -> None:
-        """Initialize the bridge.
+        """
+        Initialize the bridge.
 
         :param provider: The Local Audio provider instance.
+        :param player: The LocalAudioPlayer that owns this bridge.
         :param device_index: The PortAudio device index.
         :param device_info: The device info dict from sounddevice.query_devices().
         :param sendspin_server: The Sendspin server to register with.
         """
         self.provider = provider
         self.mass = provider.mass
+        self.player = player
         self.sendspin_server = sendspin_server
         self.device_index = device_index
         self.device_name: str = device_info["name"]
@@ -99,8 +71,6 @@ class SendspinLocalAudioBridge:
         self._write_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
         self._writer_task: asyncio.Task[None] | None = None
         self._output_stream: sd.RawOutputStream | None = None
-        self._volume: int = 100
-        self._muted: bool = False
         self._lock = asyncio.Lock()
 
     @property
@@ -111,7 +81,15 @@ class SendspinLocalAudioBridge:
     async def start(self) -> None:
         """Register the local audio device as an external Sendspin client."""
         hostapi_index: int = self.device_info.get("hostapi", 0)
-        self._bridge_client_id = _get_device_client_id(self.device_name, hostapi_index)
+        device_uuid = get_device_uuid(self.device_name, hostapi_index)
+        self._bridge_client_id = bridge_client_id_from_uuid(device_uuid)
+
+        # Pre-register identifier so protocol linking matches our LocalAudioPlayer
+        if sendspin_prov := self._get_sendspin_provider():
+            sendspin_prov.register_bridge_identifiers(
+                self._bridge_client_id,
+                {IdentifierType.UUID: device_uuid},
+            )
 
         hello = ClientHelloPayload(
             client_id=self._bridge_client_id,
@@ -146,14 +124,13 @@ class SendspinLocalAudioBridge:
             hello, on_stream_start=self._on_stream_start
         )
 
-        # Retrieve the BridgePlayerRole and wire up callbacks.
         roles = self._sendspin_client.roles_by_family("player")
         if roles:
             self._bridge_role = cast("BridgePlayerRole", roles[0])
             self._bridge_role.set_callbacks(
                 on_audio_chunk=self._on_audio_chunk,
-                on_volume_change=self._on_volume_change,
-                on_mute_change=self._on_mute_change,
+                on_volume_change=lambda _vol: None,
+                on_mute_change=lambda _muted: None,
                 on_stream_start=self._on_bridge_stream_start,
                 on_stream_end=self._on_bridge_stream_end,
             )
@@ -163,6 +140,13 @@ class SendspinLocalAudioBridge:
             "Sendspin bridge registered for %s (client_id=%s)",
             self.device_name,
             self._bridge_client_id,
+        )
+
+    def _get_sendspin_provider(self) -> SendspinProvider | None:
+        """Get the Sendspin provider if available."""
+        return cast(
+            "SendspinProvider | None",
+            self.mass.get_provider("sendspin"),
         )
 
     async def stop(self) -> None:
@@ -177,11 +161,7 @@ class SendspinLocalAudioBridge:
         self.logger.debug("Sendspin bridge stopped for %s", self.device_name)
 
     def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
-        """Handle stream start request from Sendspin server.
-
-        Called when Sendspin wants to play audio to this bridge player.
-        Resets state before starting a new stream.
-        """
+        """Handle stream start request from Sendspin server."""
         self.logger.debug(
             "Sendspin stream start request for %s (reason=%s)",
             self.device_name,
@@ -190,7 +170,7 @@ class SendspinLocalAudioBridge:
         self._is_streaming = True
 
     def _on_bridge_stream_start(self) -> None:
-        """Start the writer task when PushStream begins delivering audio chunks."""
+        """Start the audio writer task for a new stream."""
         if self._writer_task is not None and not self._writer_task.done():
             self._writer_task.cancel()
 
@@ -209,43 +189,27 @@ class SendspinLocalAudioBridge:
         self.mass.create_task(self._stop_streaming_locked())
 
     def _on_audio_chunk(self, chunk: AudioChunk) -> None:
-        """Handle audio chunk from Sendspin PushStream."""
+        """Handle an incoming audio chunk."""
         if not self._is_streaming:
             return
+        self._write_queue.put_nowait(chunk.data)
 
-        data = chunk.data
-        if self._muted:
-            data = b"\x00" * len(data)
-        elif self._volume < 100:
-            data = self._apply_volume(data)
-
-        self._write_queue.put_nowait(data)
-
-    def _apply_volume(self, pcm_data: bytes) -> bytes:
-        """Apply software volume scaling to PCM data.
-
-        :param pcm_data: Raw 16-bit signed integer PCM data.
-        :return: Volume-adjusted PCM data.
-        """
+    def _apply_software_volume(self, pcm_data: bytes) -> bytes:
+        """Apply software volume scaling if configured, reading current player state."""
+        if self.player.volume_control_mode != VOLUME_CONTROL_SOFTWARE:
+            return pcm_data
+        if self.player.volume_muted:
+            return b"\x00" * len(pcm_data)
+        volume = self.player.volume_level
+        if volume is None or volume >= 100:
+            return pcm_data
         samples = np.frombuffer(pcm_data, dtype=np.int16).copy()
-        scale = self._volume / 100.0
+        scale = volume / 100.0
         samples = np.clip(samples * scale, -32768, 32767).astype(np.int16)
         return samples.tobytes()
 
-    def _on_volume_change(self, volume: int) -> None:
-        """Handle volume change from Sendspin."""
-        self._volume = volume
-
-    def _on_mute_change(self, muted: bool) -> None:
-        """Handle mute change from Sendspin."""
-        self._muted = muted
-
     async def _audio_writer(self) -> None:
-        """Write queued audio data to the soundcard via sounddevice.
-
-        Opens a RawOutputStream for the device, reads PCM data from the queue,
-        and writes it to the soundcard. A None sentinel signals end-of-stream.
-        """
+        """Write queued audio data to the soundcard."""
         loop = asyncio.get_running_loop()
         try:
             self._output_stream = sd.RawOutputStream(
@@ -264,12 +228,12 @@ class SendspinLocalAudioBridge:
                     break
                 if not self._is_streaming:
                     break
+                # Apply software volume right before writing to minimize latency
+                data = self._apply_software_volume(data)
                 try:
                     await loop.run_in_executor(None, self._output_stream.write, data)
                 except sd.PortAudioError as err:
-                    self.logger.error(
-                        "PortAudio error writing to %s: %s", self.device_name, err
-                    )
+                    self.logger.error("PortAudio error writing to %s: %s", self.device_name, err)
                     break
         except sd.PortAudioError as err:
             self.logger.error(
@@ -312,7 +276,8 @@ class LocalAudioBridgeManager:
     """Manages Sendspin bridges for all local audio output devices."""
 
     def __init__(self, provider: LocalAudioProvider) -> None:
-        """Initialize the bridge manager.
+        """
+        Initialize the bridge manager.
 
         :param provider: The Local Audio provider instance.
         """
@@ -323,22 +288,14 @@ class LocalAudioBridgeManager:
         self._lock = asyncio.Lock()
 
     @property
-    def sendspin_provider(self) -> SendspinProvider | None:
-        """Get the Sendspin provider if available."""
-        return cast(
-            "SendspinProvider | None",
-            self.mass.get_provider("sendspin"),
-        )
-
-    @property
     def sendspin_server(self) -> SendspinServer | None:
         """Get the Sendspin server if available."""
-        if provider := self.sendspin_provider:
+        if provider := cast("SendspinProvider | None", self.mass.get_provider("sendspin")):
             return provider.server_api
         return None
 
     async def discover_and_register(self) -> None:
-        """Enumerate local audio devices and register bridges for each."""
+        """Enumerate local audio devices, register players and Sendspin bridges."""
         sendspin_server = self.sendspin_server
         if not sendspin_server:
             self.logger.debug("Sendspin provider not available, skipping device enumeration")
@@ -364,14 +321,20 @@ class LocalAudioBridgeManager:
                 device_index: int = device["index"]
                 device_name: str = device["name"]
                 hostapi_index: int = device.get("hostapi", 0)
-                client_id = _get_device_client_id(device_name, hostapi_index)
+                device_uuid = get_device_uuid(device_name, hostapi_index)
+                client_id = bridge_client_id_from_uuid(device_uuid)
 
                 if client_id in self._bridges:
                     self.logger.debug("Bridge already exists for %s", device_name)
                     continue
 
+                # Register our own player with MA first
+                player = LocalAudioPlayer(self.provider, device_uuid, device_name, hostapi_index)
+                await self.mass.players.register(player)
+
+                # Then set up the Sendspin bridge with identifier for protocol linking
                 bridge = SendspinLocalAudioBridge(
-                    self.provider, device_index, device, sendspin_server
+                    self.provider, player, device_index, device, sendspin_server
                 )
                 try:
                     await bridge.start()
@@ -389,20 +352,12 @@ class LocalAudioBridgeManager:
 
     @staticmethod
     def _enumerate_output_devices() -> list[dict[str, Any]]:
-        """Enumerate available audio output devices via sounddevice.
-
-        Filters for devices with at least 2 output channels.
-        Runs in an executor since PortAudio device enumeration may block.
-
-        :return: List of device info dicts with an added 'index' key.
-        """
+        """Enumerate available audio output devices via sounddevice."""
         devices: list[dict[str, Any]] = []
+        # sd.query_devices() returns a DeviceList (not a plain list),
+        # where each element is a dict with device properties.
         all_devices = sd.query_devices()
-        if not isinstance(all_devices, list):
-            all_devices = [all_devices]
         for idx, dev in enumerate(all_devices):
-            if not isinstance(dev, dict):
-                continue
             max_output_channels: int = dev.get("max_output_channels", 0)
             if max_output_channels >= 2:
                 dev_with_index = dict(dev)

--- a/music_assistant/providers/local_audio/sendspin_bridge.py
+++ b/music_assistant/providers/local_audio/sendspin_bridge.py
@@ -240,6 +240,7 @@ class SendspinLocalAudioBridge:
                 "Failed to open audio output stream for %s: %s", self.device_name, err
             )
         finally:
+            self._is_streaming = False
             if self._output_stream is not None:
                 with suppress(Exception):
                     self._output_stream.stop()
@@ -328,11 +329,11 @@ class LocalAudioBridgeManager:
                     self.logger.debug("Bridge already exists for %s", device_name)
                     continue
 
-                # Register our own player with MA first
+                # Register (or update) our player with MA
                 player = LocalAudioPlayer(
                     self.provider, device_uuid, device_name, hostapi_index, device_index
                 )
-                await self.mass.players.register(player)
+                await self.mass.players.register_or_update(player)
 
                 # Then set up the Sendspin bridge with identifier for protocol linking
                 bridge = SendspinLocalAudioBridge(
@@ -344,9 +345,13 @@ class LocalAudioBridgeManager:
                     self.logger.warning("Failed to start bridge for %s", device_name)
                     with suppress(Exception):
                         await bridge.stop()
+                    player._attr_available = False
+                    player.update_state()
                     continue
 
                 if not bridge.is_registered:
+                    player._attr_available = False
+                    player.update_state()
                     continue
 
                 self._bridges[client_id] = bridge

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -70,6 +70,7 @@ shortuuid==1.0.13
 snapcast==2.3.7
 soco==0.30.14
 soundcloudpy==0.1.4
+sounddevice==0.5.5
 srptools>=1.0.0
 sxm==0.2.8
 unidecode==1.4.0


### PR DESCRIPTION
## Problem

There was no way to use locally attached soundcards (USB DACs, built-in speakers, HDMI audio) as players in Music Assistant.

## Changes

- New `local_audio` player provider that enumerates local audio output devices via PortAudio/sounddevice
- Registers as `PlayerType.PLAYER` with Sendspin as protocol for synchronized playback
- Per-device hardware volume control via CoreAudio (macOS) and ALSA/amixer (Linux), with software volume fallback
- Configurable volume control mode at provider level (hardware/software/disabled)
- Protocol linking via UUID identifiers for automatic Sendspin association
- `depends_on: sendspin` in manifest to ensure correct load order