### PR TITLE
Fix flow stream playlog pre-count and use 50/50 crossfade split

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1845,12 +1845,7 @@ class StreamsAudio:
                             mix_err,
                         )
                         yield last_fadeout_part
-                        if last_play_log_entry:
-                            assert last_play_log_entry.seconds_streamed is not None
-                            # Add the remaining half (pre-count was only half the tail)
-                            last_play_log_entry.seconds_streamed += (
-                                len(last_fadeout_part) / pcm_sample_size / 2
-                            )
+                        # full tail was pre-counted and is now yielded as-is
                         crossfade_bytes_written = 0
                         remaining_bytes = crossfade_buffer
                     if crossfade_bytes_written:
@@ -1860,9 +1855,9 @@ class StreamsAudio:
                         bytes_written += fadein_share
                         if last_play_log_entry:
                             assert last_play_log_entry.seconds_streamed is not None
-                            # Correct estimated pre-count to actual share
+                            # Correct pre-counted full tail to actual half of crossfade output
                             last_play_log_entry.seconds_streamed += (
-                                fadeout_share - len(last_fadeout_part) / 2
+                                fadeout_share - len(last_fadeout_part)
                             ) / pcm_sample_size
                     if remaining_bytes:
                         yield remaining_bytes
@@ -1894,12 +1889,7 @@ class StreamsAudio:
                 # edge case: we did not get enough data to make the crossfade
                 # attribute these bytes to the previous track (they are its tail)
                 yield last_fadeout_part
-                if last_play_log_entry:
-                    assert last_play_log_entry.seconds_streamed is not None
-                    # Add the remaining half (pre-count was only half the tail)
-                    last_play_log_entry.seconds_streamed += (
-                        len(last_fadeout_part) / pcm_sample_size / 2
-                    )
+                # full tail was pre-counted and is now yielded as-is
                 last_fadeout_part = b""
             if self.crossfade_allowed(
                 queue_track,
@@ -1930,11 +1920,10 @@ class StreamsAudio:
             play_log_entry.seconds_streamed = seconds_streamed
             play_log_entry.duration = queue_track.streamdetails.duration
             if last_play_log_entry is play_log_entry and last_fadeout_part:
-                # Pre-count an estimated share of the crossfade tail so the queue index
-                # calculation doesn't undercount while waiting for the next track's
-                # crossfade mix. During crossfade, approximately half the tail is attributed
-                # to this track. This estimate is corrected once the mix actually completes.
-                play_log_entry.seconds_streamed += len(last_fadeout_part) / pcm_sample_size / 2
+                # Pre-count the full crossfade tail so the queue index calculation
+                # doesn't undercount while waiting for the next track's crossfade mix.
+                # This will be corrected to crossfade_total/2 once the mix completes.
+                play_log_entry.seconds_streamed += len(last_fadeout_part) / pcm_sample_size
             total_bytes_sent += bytes_written
             self.logger.debug(
                 "Finished Streaming queue track: %s (%s) on queue %s",
@@ -1957,8 +1946,7 @@ class StreamsAudio:
             # also update the play log entry so elapsed time tracking stays in sync
             if last_play_log_entry:
                 assert last_play_log_entry.seconds_streamed is not None
-                # Add the remaining half (pre-count was only half the tail)
-                last_play_log_entry.seconds_streamed += last_part_seconds / 2
+                # full tail was pre-counted and is now yielded as-is
                 last_play_log_entry.duration = streamdetails.duration
             last_fadeout_part = b""
         total_bytes_sent += bytes_written

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1845,25 +1845,24 @@ class StreamsAudio:
                             mix_err,
                         )
                         yield last_fadeout_part
-                        # crossfade tail was pre-counted in seconds_streamed, no adjustment needed
+                        if last_play_log_entry:
+                            assert last_play_log_entry.seconds_streamed is not None
+                            # Add the remaining half (pre-count was only half the tail)
+                            last_play_log_entry.seconds_streamed += (
+                                len(last_fadeout_part) / pcm_sample_size / 2
+                            )
                         crossfade_bytes_written = 0
                         remaining_bytes = crossfade_buffer
                     if crossfade_bytes_written:
-                        # distribute the crossfade output proportionally based on
-                        # each input's size rather than a blind 50/50 split
-                        total_input = len(last_fadeout_part) + len(fadein_part)
-                        if total_input > 0:
-                            fadeout_ratio = len(last_fadeout_part) / total_input
-                        else:
-                            fadeout_ratio = 0.5
-                        fadeout_share = int(crossfade_bytes_written * fadeout_ratio)
+                        # split crossfade output 50/50 between both tracks
+                        fadeout_share = crossfade_bytes_written // 2
                         fadein_share = crossfade_bytes_written - fadeout_share
                         bytes_written += fadein_share
                         if last_play_log_entry:
                             assert last_play_log_entry.seconds_streamed is not None
-                            # Correct pre-counted tail to actual proportional share
+                            # Correct estimated pre-count to actual share
                             last_play_log_entry.seconds_streamed += (
-                                fadeout_share - len(last_fadeout_part)
+                                fadeout_share - len(last_fadeout_part) / 2
                             ) / pcm_sample_size
                     if remaining_bytes:
                         yield remaining_bytes
@@ -1895,7 +1894,12 @@ class StreamsAudio:
                 # edge case: we did not get enough data to make the crossfade
                 # attribute these bytes to the previous track (they are its tail)
                 yield last_fadeout_part
-                # crossfade tail was pre-counted in seconds_streamed, no adjustment needed
+                if last_play_log_entry:
+                    assert last_play_log_entry.seconds_streamed is not None
+                    # Add the remaining half (pre-count was only half the tail)
+                    last_play_log_entry.seconds_streamed += (
+                        len(last_fadeout_part) / pcm_sample_size / 2
+                    )
                 last_fadeout_part = b""
             if self.crossfade_allowed(
                 queue_track,
@@ -1926,10 +1930,11 @@ class StreamsAudio:
             play_log_entry.seconds_streamed = seconds_streamed
             play_log_entry.duration = queue_track.streamdetails.duration
             if last_play_log_entry is play_log_entry and last_fadeout_part:
-                # Pre-count the crossfade tail so the queue index calculation
-                # doesn't undercount while waiting for the next track's crossfade mix.
-                # This will be corrected to the actual proportional share once the mix completes.
-                play_log_entry.seconds_streamed += len(last_fadeout_part) / pcm_sample_size
+                # Pre-count an estimated share of the crossfade tail so the queue index
+                # calculation doesn't undercount while waiting for the next track's
+                # crossfade mix. During crossfade, approximately half the tail is attributed
+                # to this track. This estimate is corrected once the mix actually completes.
+                play_log_entry.seconds_streamed += len(last_fadeout_part) / pcm_sample_size / 2
             total_bytes_sent += bytes_written
             self.logger.debug(
                 "Finished Streaming queue track: %s (%s) on queue %s",
@@ -1952,7 +1957,8 @@ class StreamsAudio:
             # also update the play log entry so elapsed time tracking stays in sync
             if last_play_log_entry:
                 assert last_play_log_entry.seconds_streamed is not None
-                # crossfade tail was pre-counted in seconds_streamed, only update duration
+                # Add the remaining half (pre-count was only half the tail)
+                last_play_log_entry.seconds_streamed += last_part_seconds / 2
                 last_play_log_entry.duration = streamdetails.duration
             last_fadeout_part = b""
         total_bytes_sent += bytes_written


### PR DESCRIPTION
## Problem

Follow-up to #3586. The previous fix pre-counted the **full** crossfade tail in `seconds_streamed`, causing the UI to now stay on the previous track ~10-15s too long (overcorrection).

## Changes

- Pre-count only **half** the crossfade tail as the estimate, since the crossfade mix output is split evenly between both tracks
- Simplify crossfade output attribution to a 50/50 split instead of proportional split based on input sizes
- Add back the remaining half in fallback/edge-case paths where the full tail is yielded as-is