### PR TITLE
Include missing description in automatic artist metadata scan

### DIFF
--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -133,7 +133,7 @@ LOCALES = {
 DEFAULT_LANGUAGE = "en_US"
 REFRESH_INTERVAL = 60 * 60 * 24 * 90  # 90 days
 CONF_ENABLE_ONLINE_METADATA = "enable_online_metadata"
-MISSING_ARTIST_ARTWORK_SCAN_TASK_ID = "metadata_missing_artist_artwork_scan"
+MISSING_ARTIST_METADATA_SCAN_TASK_ID = "metadata_missing_artist_metadata_scan"
 PLAYLIST_METADATA_SCAN_TASK_ID = "metadata_playlist_metadata_scan"
 THUMB_CACHE_CLEANUP_TASK_ID = "metadata_thumb_cache_cleanup"
 METADATA_LOOKUP_TASK_ID_PREFIX = "metadata_lookup"
@@ -1004,12 +1004,12 @@ class MetaDataController(CoreController):
         utc_hour, utc_minute = local_clock_time_to_utc(4, 0)
         desired_schedule = TaskSchedule.daily(hour=utc_hour, minute=utc_minute)
         self.mass.tasks.register_scheduled_task(
-            task_id=MISSING_ARTIST_ARTWORK_SCAN_TASK_ID,
-            name="Scan missing artist artwork",
-            handler=self._scan_missing_artist_artwork,
+            task_id=MISSING_ARTIST_METADATA_SCAN_TASK_ID,
+            name="Scan missing artist metadata",
+            handler=self._scan_missing_artist_metadata,
             schedule=desired_schedule,
-            translation_key="background_task.scan_missing_artist_artwork",
-            metadata={"task_domain": "metadata_missing_artist_artwork_scan"},
+            translation_key="background_task.scan_missing_artist_metadata",
+            metadata={"task_domain": "metadata_missing_artist_metadata_scan"},
             allow_retry=True,
         )
         self.mass.tasks.register_scheduled_task(
@@ -1036,23 +1036,31 @@ class MetaDataController(CoreController):
         """Return deterministic task id for a metadata lookup."""
         return f"{METADATA_LOOKUP_TASK_ID_PREFIX}_{uuid5(NAMESPACE_URL, uri).hex}"
 
-    async def _scan_missing_artist_artwork(self) -> None:
-        """Refresh metadata for a small batch of artists missing artwork."""
-        update_current_task_progress_text("Searching for artists with missing artwork")
+    async def _scan_missing_artist_metadata(self) -> None:
+        """Refresh metadata for a small batch of artists missing artwork or description."""
+        update_current_task_progress_text("Searching for artists with missing metadata")
         refresh_before = int(time() - REFRESH_INTERVAL)
-        query = (
+        # find artists missing images or description that haven't been refreshed recently
+        missing_images = (
             f"(json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') ISNULL "
-            f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') = '[]') "
-            f"AND (json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') ISNULL "
+            f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') = '[]')"
+        )
+        missing_description = (
+            f"(json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') ISNULL "
+            f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') = '')"
+        )
+        stale_refresh = (
+            f"(json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') ISNULL "
             f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') < {refresh_before})"
         )
+        query = f"({missing_images} OR {missing_description}) AND {stale_refresh}"
         artists = await self.mass.music.artists.get_library_items_by_query(
             limit=METADATA_SCAN_BATCH_SIZE,
             order_by="random",
             extra_query_parts=[query],
         )
         if not artists:
-            update_current_task_progress_text("No artists with missing artwork found")
+            update_current_task_progress_text("No artists with missing metadata found")
             return
         for index, artist in enumerate(artists, 1):
             try:

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -1037,14 +1037,15 @@ class MetaDataController(CoreController):
         return f"{METADATA_LOOKUP_TASK_ID_PREFIX}_{uuid5(NAMESPACE_URL, uri).hex}"
 
     async def _scan_missing_artist_metadata(self) -> None:
-        """Refresh metadata for a small batch of artists missing artwork or description."""
+        """Scan for artists with missing metadata."""
         update_current_task_progress_text("Searching for artists with missing metadata")
         missing_images = (
             f"(json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') ISNULL "
             f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') = '[]')"
         )
         missing_description = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') ISNULL"
-        query = f"{missing_images} OR {missing_description}"
+        never_refreshed = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') ISNULL"
+        query = f"({missing_images} OR {missing_description}) AND {never_refreshed}"
         artists = await self.mass.music.artists.get_library_items_by_query(
             limit=METADATA_SCAN_BATCH_SIZE,
             order_by="random",

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -1044,7 +1044,8 @@ class MetaDataController(CoreController):
             f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') = '[]')"
         )
         missing_description = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') ISNULL"
-        query = f"{missing_images} OR {missing_description}"
+        never_refreshed = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') ISNULL"
+        query = f"({missing_images} OR {missing_description}) AND {never_refreshed}"
         artists = await self.mass.music.artists.get_library_items_by_query(
             limit=METADATA_SCAN_BATCH_SIZE,
             order_by="random",

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -1044,8 +1044,7 @@ class MetaDataController(CoreController):
             f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') = '[]')"
         )
         missing_description = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') ISNULL"
-        never_refreshed = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') ISNULL"
-        query = f"({missing_images} OR {missing_description}) AND {never_refreshed}"
+        query = f"{missing_images} OR {missing_description}"
         artists = await self.mass.music.artists.get_library_items_by_query(
             limit=METADATA_SCAN_BATCH_SIZE,
             order_by="random",

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -1039,21 +1039,12 @@ class MetaDataController(CoreController):
     async def _scan_missing_artist_metadata(self) -> None:
         """Refresh metadata for a small batch of artists missing artwork or description."""
         update_current_task_progress_text("Searching for artists with missing metadata")
-        refresh_before = int(time() - REFRESH_INTERVAL)
-        # find artists missing images or description that haven't been refreshed recently
         missing_images = (
             f"(json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') ISNULL "
             f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.images') = '[]')"
         )
-        missing_description = (
-            f"(json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') ISNULL "
-            f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') = '')"
-        )
-        stale_refresh = (
-            f"(json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') ISNULL "
-            f"OR json_extract({DB_TABLE_ARTISTS}.metadata,'$.last_refresh') < {refresh_before})"
-        )
-        query = f"({missing_images} OR {missing_description}) AND {stale_refresh}"
+        missing_description = f"json_extract({DB_TABLE_ARTISTS}.metadata,'$.description') ISNULL"
+        query = f"{missing_images} OR {missing_description}"
         artists = await self.mass.music.artists.get_library_items_by_query(
             limit=METADATA_SCAN_BATCH_SIZE,
             order_by="random",

--- a/tests/core/test_background_tasks.py
+++ b/tests/core/test_background_tasks.py
@@ -431,7 +431,7 @@ async def test_core_maintenance_tasks_register_nightly_schedules(
     metadata._register_maintenance_tasks()
 
     cache_task = tasks_controller.get_task("cache_database_cleanup")
-    artist_scan_task = tasks_controller.get_task("metadata_missing_artist_artwork_scan")
+    artist_scan_task = tasks_controller.get_task("metadata_missing_artist_metadata_scan")
     playlist_scan_task = tasks_controller.get_task("metadata_playlist_metadata_scan")
 
     assert cache_task.translation_key == "background_task.cache_database_cleanup"

--- a/tests/core/test_background_tasks.py
+++ b/tests/core/test_background_tasks.py
@@ -448,9 +448,9 @@ async def test_core_maintenance_tasks_register_nightly_schedules(
     assert provider_mapping_task.metadata == {"task_domain": "music_provider_mapping_correction"}
     assert genre_scan_task.schedule == maintenance_schedule
 
-    assert artist_scan_task.translation_key == "background_task.scan_missing_artist_artwork"
+    assert artist_scan_task.translation_key == "background_task.scan_missing_artist_metadata"
     assert artist_scan_task.schedule == maintenance_schedule
-    assert artist_scan_task.metadata == {"task_domain": "metadata_missing_artist_artwork_scan"}
+    assert artist_scan_task.metadata == {"task_domain": "metadata_missing_artist_metadata_scan"}
 
     assert playlist_scan_task.translation_key == "background_task.refresh_playlist_metadata"
     assert playlist_scan_task.schedule == maintenance_schedule


### PR DESCRIPTION
The scheduled metadata scan task for artists that have never had a metadata lookup only checked for missing artwork (images). This PR also includes missing description in the scan criteria, so artists without a biography are also picked up during the initial metadata lookup.