### PR TITLE
Fix party duplicate prevention race

### DIFF
--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -739,9 +739,9 @@ class PartyPlugin(PluginProvider):
             # Queue is not playing — resolve the item, insert, and start playback.
             # Hold the lock so concurrent guests don't both start playback.
             async with self._queue_lock:
-                if self.config.get_value(CONF_PREVENT_DUPLICATE_TRACKS) and self._queue_contains_uri(
-                    self.mass.player_queues.items(queue_id), uri
-                ):
+                if self.config.get_value(
+                    CONF_PREVENT_DUPLICATE_TRACKS
+                ) and self._queue_contains_uri(self.mass.player_queues.items(queue_id), uri):
                     raise InvalidDataError("This track is already in the queue")
                 media_item = await self.mass.music.get_item_by_uri(uri)
                 if not media_item or media_item.media_type not in (

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -726,13 +726,6 @@ class PartyPlugin(PluginProvider):
         if not queue:
             raise InvalidDataError(f"Queue not found: {queue_id}")
 
-        # Check for duplicate tracks if configured
-        if self.config.get_value(CONF_PREVENT_DUPLICATE_TRACKS):
-            queue_items = self.mass.player_queues.items(queue_id)
-            for queue_item in queue_items:
-                if queue_item.uri == uri:
-                    raise InvalidDataError("This track is already in the queue")
-
         # Handle different scenarios based on queue state and boost mode
         started_playback = False
 
@@ -746,6 +739,10 @@ class PartyPlugin(PluginProvider):
             # Queue is not playing — resolve the item, insert, and start playback.
             # Hold the lock so concurrent guests don't both start playback.
             async with self._queue_lock:
+                if self.config.get_value(CONF_PREVENT_DUPLICATE_TRACKS) and self._queue_contains_uri(
+                    self.mass.player_queues.items(queue_id), uri
+                ):
+                    raise InvalidDataError("This track is already in the queue")
                 media_item = await self.mass.music.get_item_by_uri(uri)
                 if not media_item or media_item.media_type not in (
                     MediaType.TRACK,
@@ -922,6 +919,10 @@ class PartyPlugin(PluginProvider):
         async with self._queue_lock:
             queue = self.mass.player_queues.get(queue_id)
             queue_items = self.mass.player_queues.items(queue_id)
+            if self.config.get_value(CONF_PREVENT_DUPLICATE_TRACKS) and self._queue_contains_uri(
+                queue_items, uri
+            ):
+                raise InvalidDataError("This track is already in the queue")
 
             # Use index_in_buffer when playing to avoid inserting before an already-buffered
             # track, which would cause the newly added song to be skipped
@@ -954,6 +955,11 @@ class PartyPlugin(PluginProvider):
         user = get_current_user()
         if not user or user.username != PARTY_GUEST_USER:
             raise InvalidDataError("This endpoint is only available to party guests")
+
+    @staticmethod
+    def _queue_contains_uri(queue_items: list[QueueItem], uri: str) -> bool:
+        """Return whether the queue already contains the given item URI."""
+        return any(queue_item.uri == uri for queue_item in queue_items)
 
     @staticmethod
     def _find_section_end(queue_items: list[QueueItem], current_index: int, attribute: str) -> int:

--- a/tests/core/test_party_plugin.py
+++ b/tests/core/test_party_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -44,23 +45,25 @@ def _create_party_plugin() -> PartyPlugin:
 async def test_add_to_queue_rechecks_duplicates_during_priority_insert() -> None:
     """Reject a duplicate that appears after the initial queue lookup."""
     plugin = _create_party_plugin()
+    player_queues = cast("MagicMock", plugin.mass.player_queues)
+    music = cast("MagicMock", plugin.mass.music)
     uri = "spotify://track/123"
 
     queue = MagicMock()
     queue.state = PlaybackState.PLAYING
     queue.current_index = 0
     queue.index_in_buffer = 0
-    plugin.mass.player_queues.get.return_value = queue
-    plugin.mass.player_queues.items.return_value = []
-    plugin.mass.player_queues.load = AsyncMock()
+    player_queues.get.return_value = queue
+    player_queues.items.return_value = []
+    player_queues.load = AsyncMock()
 
     async def mutate_queue_during_resolve(_uri: str) -> MagicMock:
         media_item = MagicMock()
         media_item.media_type = MediaType.TRACK
-        plugin.mass.player_queues.items.return_value = [MagicMock(uri=uri, extra_attributes={})]
+        player_queues.items.return_value = [MagicMock(uri=uri, extra_attributes={})]
         return media_item
 
-    plugin.mass.music.get_item_by_uri = AsyncMock(side_effect=mutate_queue_during_resolve)
+    music.get_item_by_uri = AsyncMock(side_effect=mutate_queue_during_resolve)
     queue_item = MagicMock()
     queue_item.extra_attributes = {}
 
@@ -70,8 +73,8 @@ async def test_add_to_queue_rechecks_duplicates_during_priority_insert() -> None
             return_value=SimpleNamespace(username=PARTY_GUEST_USER),
         ),
         patch("music_assistant.providers.party.QueueItem.from_media_item", return_value=queue_item),
+        pytest.raises(InvalidDataError, match="already in the queue"),
     ):
-        with pytest.raises(InvalidDataError, match="already in the queue"):
-            await plugin.add_to_queue(uri)
+        await plugin.add_to_queue(uri)
 
-    plugin.mass.player_queues.load.assert_not_awaited()
+    player_queues.load.assert_not_awaited()

--- a/tests/core/test_party_plugin.py
+++ b/tests/core/test_party_plugin.py
@@ -1,0 +1,77 @@
+"""Tests for duplicate prevention in the party plugin."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import MediaType, PlaybackState
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.providers.party import (
+    CONF_ENABLE_ADD_QUEUE,
+    CONF_ENABLE_BOOST,
+    CONF_ENABLE_GUEST_ACCESS,
+    CONF_PREVENT_DUPLICATE_TRACKS,
+    PARTY_GUEST_USER,
+    PartyPlugin,
+)
+
+
+def _create_party_plugin() -> PartyPlugin:
+    """Create a minimally configured party plugin for unit tests."""
+    plugin = PartyPlugin.__new__(PartyPlugin)
+    plugin.mass = MagicMock()
+    plugin.mass.music = MagicMock()
+    plugin.mass.player_queues = MagicMock()
+    plugin.logger = MagicMock()
+    plugin.config = MagicMock()
+    plugin._queue_lock = asyncio.Lock()
+    plugin.get_party_player = AsyncMock(return_value="party_queue")  # type: ignore[method-assign]
+    config_values = {
+        CONF_ENABLE_GUEST_ACCESS: True,
+        CONF_ENABLE_BOOST: True,
+        CONF_ENABLE_ADD_QUEUE: True,
+        CONF_PREVENT_DUPLICATE_TRACKS: True,
+    }
+    plugin.config.get_value.side_effect = config_values.__getitem__
+    return plugin
+
+
+@pytest.mark.asyncio
+async def test_add_to_queue_rechecks_duplicates_during_priority_insert() -> None:
+    """Reject a duplicate that appears after the initial queue lookup."""
+    plugin = _create_party_plugin()
+    uri = "spotify://track/123"
+
+    queue = MagicMock()
+    queue.state = PlaybackState.PLAYING
+    queue.current_index = 0
+    queue.index_in_buffer = 0
+    plugin.mass.player_queues.get.return_value = queue
+    plugin.mass.player_queues.items.return_value = []
+    plugin.mass.player_queues.load = AsyncMock()
+
+    async def mutate_queue_during_resolve(_uri: str) -> MagicMock:
+        media_item = MagicMock()
+        media_item.media_type = MediaType.TRACK
+        plugin.mass.player_queues.items.return_value = [MagicMock(uri=uri, extra_attributes={})]
+        return media_item
+
+    plugin.mass.music.get_item_by_uri = AsyncMock(side_effect=mutate_queue_during_resolve)
+    queue_item = MagicMock()
+    queue_item.extra_attributes = {}
+
+    with (
+        patch(
+            "music_assistant.providers.party.get_current_user",
+            return_value=SimpleNamespace(username=PARTY_GUEST_USER),
+        ),
+        patch("music_assistant.providers.party.QueueItem.from_media_item", return_value=queue_item),
+    ):
+        with pytest.raises(InvalidDataError, match="already in the queue"):
+            await plugin.add_to_queue(uri)
+
+    plugin.mass.player_queues.load.assert_not_awaited()


### PR DESCRIPTION
## Problem
Concurrent guest requests can still add the same track twice because duplicate prevention checked the queue before the locked insert path.

## Changes
- re-check duplicate URIs under the party queue lock for both idle and playing queue paths
- add a focused regression test for the playing-queue race
