### PR TITLE
Add dynamic leader switching support for Sendspin sync groups

### DIFF
--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -340,6 +340,18 @@ class SendspinPlaybackSession:
 
     # -- Public API ------------------------------------------------------------
 
+    def transfer_to(self, new_player: SendspinPlayer) -> None:
+        """Transfer session ownership to a new player.
+
+        Used during dynamic leader switching to keep the push stream alive
+        while the old leader is removed from the sendspin group. The PushStream
+        and all internal state (pipelines, history, join-catchup) stay intact;
+        only the owning player reference is updated.
+
+        :param new_player: The SendspinPlayer that will take over as session owner.
+        """
+        self.player = new_player
+
     async def cancel(self, reason: str) -> None:
         """Cancel and await the active playback task, if any."""
         task = self.playback_task

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -340,7 +340,7 @@ class SendspinPlaybackSession:
 
     # -- Public API ------------------------------------------------------------
 
-    def transfer_to(self, new_player: SendspinPlayer) -> None:
+    async def transfer_to(self, new_player: SendspinPlayer) -> None:
         """Transfer session ownership to a new player.
 
         Used during dynamic leader switching to keep the push stream alive
@@ -348,9 +348,23 @@ class SendspinPlaybackSession:
         and all internal state (pipelines, history, join-catchup) stay intact;
         only the owning player reference is updated.
 
+        Cleans up the old leader's pipeline/channel state so its FFmpeg
+        processor is released.
+
         :param new_player: The SendspinPlayer that will take over as session owner.
         """
+        old_leader_id = self.player.player_id
         self.player = new_player
+        # Release the old leader's DSP pipeline -- it's no longer in the group
+        # and _refresh_member_mappings won't touch it since it only iterates
+        # current members + the (new) leader.
+        async with self._state_lock:
+            pipeline = self._member_pipelines.pop(old_leader_id, None)
+            self._pipeline_config_cache.pop(old_leader_id, None)
+            self._preassigned_channels.pop(old_leader_id, None)
+            self._mapping_dirty = True
+        if pipeline is not None and pipeline.processor is not None:
+            await self._close_member_ffmpeg(pipeline.processor)
 
     async def cancel(self, reason: str) -> None:
         """Cancel and await the active playback task, if any."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -447,9 +447,13 @@ class SendspinPlayer(Player):
                 bool(self._attr_group_members) and self._attr_group_members[0] == self.player_id
             )
             if was_leader and len(group.clients) > 0:
-                # We were removed as the group leader:
-                # stop playback on the old group before we continue as solo.
-                await group.stop()
+                # We were removed as the group leader but other clients remain.
+                # Don't stop the group -- the PushStream keeps running for
+                # remaining members (playback session was transferred in set_members).
+                self.logger.debug(
+                    "Player %s removed as group leader; group continues for remaining members",
+                    self.player_id,
+                )
             elif not was_leader:
                 self.logger.debug(
                     "Player %s removed from group as non-leader; keeping old group playing",
@@ -549,13 +553,35 @@ class SendspinPlayer(Player):
     ) -> None:
         """Handle SET_MEMBERS command on the player."""
         for player_id in player_ids_to_remove or []:
-            player = self.mass.players.get_player(player_id, True)
-            player = cast("SendspinPlayer", player)  # For type checking
-            await self.api.group.remove_client(player.api)
+            member_player = self.mass.players.get_player(player_id, True)
+            member_player = cast("SendspinPlayer", member_player)
+
+            # Dynamic leader switch: transfer the active playback session to the
+            # next remaining group member before removing ourselves from the group.
+            # This keeps the PushStream alive for the remaining members.
+            if (
+                player_id == self.player_id
+                and self.playback_session.playback_task is not None
+                and not self.playback_session.playback_task.done()
+            ):
+                remaining = [c for c in self.api.group.clients if c.client_id != self.player_id]
+                if remaining:
+                    new_owner_id = remaining[0].client_id
+                    new_owner = self.mass.players.get_player(new_owner_id)
+                    if isinstance(new_owner, SendspinPlayer):
+                        self.logger.info(
+                            "Transferring playback session to %s for dynamic leader switch",
+                            new_owner.display_name,
+                        )
+                        self.playback_session.transfer_to(new_owner)
+                        new_owner.playback_session = self.playback_session
+                        self.playback_session = SendspinPlaybackSession(self)
+
+            await self.api.group.remove_client(member_player.api)
         for player_id in player_ids_to_add or []:
-            player = self.mass.players.get_player(player_id, True)
-            player = cast("SendspinPlayer", player)  # For type checking
-            await self.api.group.add_client(player.api)
+            member_player = self.mass.players.get_player(player_id, True)
+            member_player = cast("SendspinPlayer", member_player)
+            await self.api.group.add_client(member_player.api)
         # self.group_members will be updated by the group event callback
 
     async def _send_album_artwork(self, current_item: QueueItem) -> str | None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -573,7 +573,7 @@ class SendspinPlayer(Player):
                             "Transferring playback session to %s for dynamic leader switch",
                             new_owner.display_name,
                         )
-                        self.playback_session.transfer_to(new_owner)
+                        await self.playback_session.transfer_to(new_owner)
                         new_owner.playback_session = self.playback_session
                         self.playback_session = SendspinPlaybackSession(self)
 

--- a/music_assistant/providers/sync_group/constants.py
+++ b/music_assistant/providers/sync_group/constants.py
@@ -26,18 +26,11 @@ SUPPORT_DYNAMIC_LEADER = {
     # and the music keeps playing uninterrupted.
     "airplay",
     "snapcast",
+    "sendspin",
     # TODO: Get this working with Sonos as well (need to handle range requests)
     # TODO: Add squeezelite support. Currently restarts the entire stream session
     #  on member changes (no late-join support), so removing the leader would still
     #  cause a gap. Needs late-join / stream transfer support first.
-    # TODO: Add sendspin support. The aiosendspin library already supports removing a
-    #  client from a group without stopping the PushStream (group.remove_client only
-    #  stops the removed client's roles). However, the MA sendspin provider ties the
-    #  SendspinPlaybackSession to the leader player — when the leader is removed, its
-    #  playback session is cancelled, cutting off the audio source. To fix this, the
-    #  playback session needs to be decoupled from the leader player (group-owned
-    #  instead of player-owned), and _handle_group_member_removed should not call
-    #  group.stop() when other clients remain.
 }
 
 


### PR DESCRIPTION
When the current sync leader is removed from a sync group, Sendspin would stop playback for all remaining members. This is because the `SendspinPlaybackSession` was tied to the leader player — removing the leader cancelled the session and called `group.stop()`, killing the PushStream for everyone.

The aiosendspin library already supports `group.remove_client()` without stopping the PushStream, so the fix transfers the active playback session to the next group member before removal.

### Changes

- Add `transfer_to()` on `SendspinPlaybackSession` to hand off session ownership to another player while keeping the PushStream and all internal state intact
- In `set_members()`, detect when the leader is being removed with active playback and transfer the session to the next remaining group member first
- Remove the `group.stop()` call in `_handle_group_member_removed` when other clients remain
- Add `"sendspin"` to `SUPPORT_DYNAMIC_LEADER` in sync group constants