### PR TITLE
Fix DLNA pause fallback for stale transport actions

### DIFF
--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -42,7 +42,7 @@ def catch_request_errors[DLNAPlayerT: "DLNAPlayer", **P, R](
                 func.__name__,
                 self.display_name,
             )
-        if not self.available:
+        if not self.available and func.__name__ not in ("pause", "stop"):
             self.logger.warning("Device disappeared when trying to call %s", func.__name__)
             return None
         try:
@@ -417,7 +417,14 @@ class DLNAPlayer(Player):
     async def stop(self) -> None:
         """Send STOP command to given player."""
         assert self.device is not None  # for type checking
-        await self.device.async_stop()
+        if self.device.can_stop:
+            await self.device.async_stop()
+            return
+        # Some devices report stale/empty CurrentTransportActions while still
+        # accepting AVTransport Stop. Force-call Stop when action exists.
+        action = self.device._action("AVT", "Stop")
+        if action is not None:
+            await action.async_call(InstanceID=0)
 
     @catch_request_errors
     async def play(self) -> None:
@@ -474,8 +481,16 @@ class DLNAPlayer(Player):
         assert self.device is not None  # for type checking
         if self.device.can_pause:
             await self.device.async_pause()
-        else:
-            await self.device.async_stop()
+            return
+        # Some devices expose Pause but report stale CurrentTransportActions.
+        # Force-call Pause when action exists; otherwise fallback to Stop.
+        pause_action = self.device._action("AVT", "Pause")
+        if pause_action is not None:
+            await pause_action.async_call(InstanceID=0)
+            return
+        stop_action = self.device._action("AVT", "Stop")
+        if stop_action is not None:
+            await stop_action.async_call(InstanceID=0)
 
     @catch_request_errors
     async def volume_set(self, volume_level: int) -> None:


### PR DESCRIPTION
## Summary
This PR improves DLNA pause/stop compatibility for devices that expose stale or empty CurrentTransportActions.

Validated device: HUAWEI AI SPEAKER2.

### Changes
- Allow pause/stop command paths to still attempt execution even when device availability briefly reports unavailable.
- In DLNA stop(): if can_stop is false, directly call AVTransport Stop action when present.
- In DLNA pause(): if can_pause is false, directly call AVTransport Pause; fallback to AVTransport Stop if needed.

## Why
On HUAWEI AI SPEAKER2, can_pause/can_stop can be reported as false while the device still accepts AVTransport Pause/Stop. Existing logic could no-op and send no SOAP action.

## Validation scope
- Verified on: HUAWEI AI SPEAKER2.
- Not yet broadly validated across many different DLNA renderers.

## Risks
- Some DLNA devices may log an extra failed action attempt when temporarily offline or when action support is inconsistent.
- Behavior depends on vendor implementation quality.

## Known limitations
- This PR does not solve all resume-position inconsistencies after pause on every DLNA renderer.
- For some renderers, resume behavior may still depend on device-side stream/session handling.

## Notes
- Scope is intentionally minimal and focused on pause/stop reliability.
- If maintainers prefer, I can narrow this further (vendor/model gate or config flag).