### PR TITLE
Add audio quality option for Pandora provider

### DIFF
--- a/music_assistant/providers/pandora/__init__.py
+++ b/music_assistant/providers/pandora/__init__.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError
 
 from music_assistant.constants import CONF_PASSWORD, CONF_SOCKS_URL, CONF_USERNAME
 
+from .constants import CONF_QUALITY, QUALITY_HIGH, QUALITY_STANDARD
 from .provider import PandoraProvider
 
 if TYPE_CHECKING:
@@ -69,6 +70,22 @@ async def get_config_entries(
             label="Password",
             description="Your Pandora password",
             required=True,
+        ),
+        ConfigEntry(
+            key=CONF_QUALITY,
+            type=ConfigEntryType.STRING,
+            label="Stream quality",
+            description=(
+                "Audio quality to request from Pandora. High quality is only available with an "
+                "active Pandora subscription. If your account is not eligible for high-quality "
+                "streaming, standard quality will be used regardless of this setting."
+            ),
+            required=True,
+            default_value=QUALITY_STANDARD,
+            options=[
+                ConfigValueOption("Standard (64 kbps AAC+)", QUALITY_STANDARD),
+                ConfigValueOption("High (192 kbps MP3)", QUALITY_HIGH),
+            ],
         ),
         ConfigEntry(
             key=CONF_SOCKS_URL,

--- a/music_assistant/providers/pandora/__init__.py
+++ b/music_assistant/providers/pandora/__init__.py
@@ -74,7 +74,7 @@ async def get_config_entries(
         ConfigEntry(
             key=CONF_QUALITY,
             type=ConfigEntryType.STRING,
-            label="Stream quality",
+            label="Audio quality",
             description=(
                 "Audio quality to request from Pandora. High quality is only available with an "
                 "active Pandora subscription. If your account is not eligible for high-quality "

--- a/music_assistant/providers/pandora/constants.py
+++ b/music_assistant/providers/pandora/constants.py
@@ -49,3 +49,9 @@ PANDORA_ERROR_CODES = {
     1037: "Device already associated to account",
     1039: "Device not found",
 }
+
+CONF_QUALITY = "quality"
+QUALITY_HIGH = "high"
+QUALITY_STANDARD = "standard"
+
+ACCOUNT_FLAG_HIGH_QUALITY = "highQualityStreamingAvailable"

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -37,8 +37,11 @@ from music_assistant.helpers.compare import compare_strings
 from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
+    ACCOUNT_FLAG_HIGH_QUALITY,
+    CONF_QUALITY,
     LOGIN_ENDPOINT,
     PLAYLIST_FRAGMENT_ENDPOINT,
+    QUALITY_HIGH,
     STATIONS_ENDPOINT,
 )
 from .helpers import create_auth_headers, get_csrf_token, handle_pandora_error
@@ -83,6 +86,7 @@ class PandoraProvider(MusicProvider):
     _csrf_token: str | None = None
     _sessions: dict[str, PandoraStationSession]
     _socks_proxy: bool = False
+    _high_quality_available: bool = False
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
@@ -150,7 +154,16 @@ class PandoraProvider(MusicProvider):
                     raise LoginFailed("No auth token received from Pandora")
 
                 self._user_id = response_data.get("listenerId")
-                self.logger.info("Successfully authenticated with Pandora")
+
+                # Check whether the account is eligible for high-quality streaming.
+                flags: list[str] = response_data.get("config", {}).get("flags", [])
+                self._high_quality_available = ACCOUNT_FLAG_HIGH_QUALITY in flags
+
+                self.logger.info(
+                    "Successfully authenticated with Pandora "
+                    "(high-quality streaming available: %s)",
+                    self._high_quality_available,
+                )
 
         except aiohttp.ClientError as err:
             await self.close()
@@ -291,7 +304,7 @@ class PandoraProvider(MusicProvider):
             provider=self.instance_id,
             item_id=item_id,
             audio_format=AudioFormat(
-                content_type=ContentType.AAC,
+                content_type=ContentType.MP3 if self._use_high_quality() else ContentType.AAC,
             ),
             media_type=MediaType.RADIO,
             stream_type=StreamType.HTTP,
@@ -319,7 +332,7 @@ class PandoraProvider(MusicProvider):
             "stationId": session.station_id,
             "isStationStart": fragment_index == 0,
             "fragmentRequestReason": "Normal",
-            "audioFormat": "aacplus",
+            "audioFormat": "mp3-hifi" if self._use_high_quality() else "aacplus",
             "startingAtTrackId": None,
             "onDemandArtistMessageArtistUidHex": None,
             "onDemandArtistMessageIdHex": None,
@@ -539,3 +552,11 @@ class PandoraProvider(MusicProvider):
         """Handle closing of http session if using socks."""
         if self._socks_proxy and self.http_session:
             await self.http_session.close()
+
+    def _use_high_quality(self) -> bool:
+        """Whether high quality audio should be requested from Pandora.
+
+        This allows a graceful fallback to standard quality if the account is not eligible for
+        high-quality streaming, while still respecting the user's preference if they are eligible.
+        """
+        return self._high_quality_available and self.config.get_value(CONF_QUALITY) == QUALITY_HIGH

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -156,8 +156,11 @@ class PandoraProvider(MusicProvider):
                 self._user_id = response_data.get("listenerId")
 
                 # Check whether the account is eligible for high-quality streaming.
-                flags: list[str] = response_data.get("config", {}).get("flags", [])
-                self._high_quality_available = ACCOUNT_FLAG_HIGH_QUALITY in flags
+                try:
+                    flags: list[str] = response_data.get("config", {}).get("flags", [])
+                    self._high_quality_available = ACCOUNT_FLAG_HIGH_QUALITY in flags
+                except (AttributeError, TypeError):
+                    self._high_quality_available = False
 
                 self.logger.info(
                     "Successfully authenticated with Pandora "


### PR DESCRIPTION
I have been running this modification locally for a few weeks now, successfully receiving higher quality audio from the Pandora API.

It's done in a way that if a users account is not eligible for higher quality audio (they do not have an active subscription) then standard quality will be used instead.

It defaults to standard quality audio, so if you do have a paid account, you will need to adjust the provider config to use the high quality audio. We could also change this to default to high quality audio, which would then gracefully fallback to standard for non-paid accounts.