### PR TITLE
Add secondary sort by year for album artist sorting

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -81,8 +81,8 @@ SORT_KEYS = {
     "year_desc": "year DESC",
     "position": "position ASC",
     "position_desc": "position DESC",
-    "artist_name": "artists.search_name ASC",
-    "artist_name_desc": "artists.search_name DESC",
+    "artist_name": "artists.search_name ASC, year ASC",
+    "artist_name_desc": "artists.search_name DESC, year ASC",
     "random": "RANDOM()",
     "random_play_count": "RANDOM(), play_count ASC",
 }

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -81,8 +81,8 @@ SORT_KEYS = {
     "year_desc": "year DESC",
     "position": "position ASC",
     "position_desc": "position DESC",
-    "artist_name": "artists.search_name ASC, year ASC",
-    "artist_name_desc": "artists.search_name DESC, year ASC",
+    "artist_name": "artists.search_name ASC, year DESC",
+    "artist_name_desc": "artists.search_name DESC, year DESC",
     "random": "RANDOM()",
     "random_play_count": "RANDOM(), play_count ASC",
 }


### PR DESCRIPTION
When sorting albums by artist name, add year as a secondary sort key so albums by the same artist appear in descending chronological order instead of arbitrary database order.