### PR TITLE
Add ability to take over Pandora stream during concurrent streaming error

### DIFF
--- a/music_assistant/providers/pandora/__init__.py
+++ b/music_assistant/providers/pandora/__init__.py
@@ -59,7 +59,7 @@ async def get_config_entries(
     if action == CONF_TAKEOVER_ACTION and instance_id:
         provider = cast("PandoraProvider|None", mass.get_provider(instance_id))
         if provider is not None:
-            await provider._takeover_stream()
+            await provider.takeover_stream()
 
     return (
         ConfigEntry(

--- a/music_assistant/providers/pandora/__init__.py
+++ b/music_assistant/providers/pandora/__init__.py
@@ -112,6 +112,7 @@ async def get_config_entries(
                 "Pandora terminate any existing stream on other devices and allow streaming here. "
                 "You must manually restart playback after performing this action."
             ),
+            action=CONF_TAKEOVER_ACTION,
             required=False,
         ),
     )

--- a/music_assistant/providers/pandora/__init__.py
+++ b/music_assistant/providers/pandora/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
@@ -10,7 +10,7 @@ from music_assistant_models.errors import SetupFailedError
 
 from music_assistant.constants import CONF_PASSWORD, CONF_SOCKS_URL, CONF_USERNAME
 
-from .constants import CONF_QUALITY, QUALITY_HIGH, QUALITY_STANDARD
+from .constants import CONF_QUALITY, CONF_TAKEOVER_ACTION, QUALITY_HIGH, QUALITY_STANDARD
 from .provider import PandoraProvider
 
 if TYPE_CHECKING:
@@ -56,6 +56,11 @@ async def get_config_entries(
 ) -> tuple[ConfigEntry, ...]:
     """Return configuration entries for this provider."""
     # ruff: noqa: ARG001
+    if action == CONF_TAKEOVER_ACTION and instance_id:
+        provider = cast("PandoraProvider|None", mass.get_provider(instance_id))
+        if provider is not None:
+            await provider._takeover_stream()
+
     return (
         ConfigEntry(
             key=CONF_USERNAME,
@@ -97,5 +102,16 @@ async def get_config_entries(
             required=False,
             default_value="",
             advanced=True,
+        ),
+        ConfigEntry(
+            key=CONF_TAKEOVER_ACTION,
+            type=ConfigEntryType.ACTION,
+            label="Take over stream",
+            description=(
+                "Pandora only allows one active stream at a time per account. You can request that "
+                "Pandora terminate any existing stream on other devices and allow streaming here. "
+                "You must manually restart playback after performing this action."
+            ),
+            required=False,
         ),
     )

--- a/music_assistant/providers/pandora/constants.py
+++ b/music_assistant/providers/pandora/constants.py
@@ -51,6 +51,9 @@ PANDORA_ERROR_CODES = {
     1039: "Device not found",
 }
 
+RETRY_REASON_AUTH = "auth"
+RETRY_REASON_STREAM_VIOLATION = "stream_violation"
+
 CONF_TAKEOVER_ACTION = "takeover_stream"
 CONF_QUALITY = "quality"
 QUALITY_HIGH = "high"

--- a/music_assistant/providers/pandora/constants.py
+++ b/music_assistant/providers/pandora/constants.py
@@ -5,6 +5,7 @@ API_BASE = "https://www.pandora.com/api/v1"
 LOGIN_ENDPOINT = f"{API_BASE}/auth/login"
 STATIONS_ENDPOINT = f"{API_BASE}/station/getStations"
 PLAYLIST_FRAGMENT_ENDPOINT = f"{API_BASE}/playlist/getFragment"
+PLAYBACK_RESUMED_ENDPOINT = f"{API_BASE}/station/playbackResumed"
 
 # Pandora Error Code Categories
 # Authentication and authorization failures
@@ -50,6 +51,7 @@ PANDORA_ERROR_CODES = {
     1039: "Device not found",
 }
 
+CONF_TAKEOVER_ACTION = "takeover_stream"
 CONF_QUALITY = "quality"
 QUALITY_HIGH = "high"
 QUALITY_STANDARD = "standard"

--- a/music_assistant/providers/pandora/helpers.py
+++ b/music_assistant/providers/pandora/helpers.py
@@ -23,7 +23,8 @@ def generate_csrf_token() -> str:
 
 
 def handle_pandora_error(response_data: dict[str, Any]) -> None:
-    """Handle Pandora API error responses.
+    """
+    Handle Pandora API error responses.
 
     Maps Pandora API error codes to appropriate Music Assistant exceptions.
 
@@ -53,7 +54,8 @@ def handle_pandora_error(response_data: dict[str, Any]) -> None:
 
 
 async def get_csrf_token(session: aiohttp.ClientSession) -> str:
-    """Get CSRF token from Pandora website.
+    """
+    Get CSRF token from Pandora website.
 
     Attempts to retrieve CSRF token from Pandora cookies.
 
@@ -83,7 +85,8 @@ async def get_csrf_token(session: aiohttp.ClientSession) -> str:
 
 
 def create_auth_headers(csrf_token: str, auth_token: str | None = None) -> dict[str, str]:
-    """Create authentication headers for Pandora API requests.
+    """
+    Create authentication headers for Pandora API requests.
 
     Args:
         csrf_token: CSRF token for request validation

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -212,7 +213,13 @@ class PandoraProvider(MusicProvider):
                 if response.status == 429:
                     # Another device may already be streaming on this account.
                     # Parse the body to confirm it is a STREAM_VIOLATION.
-                    error_body: dict[str, Any] = await response.json()
+                    try:
+                        error_body: dict[str, Any] = await response.json()
+                    except (aiohttp.ContentTypeError, json.JSONDecodeError) as err:
+                        await self.close()
+                        raise InvalidDataError(
+                            "Unable to parse error 429 response body from Pandora"
+                        ) from err
                     if error_body.get("errorString") == "STREAM_VIOLATION":
                         if retry:
                             # If we are allowed to retry, takeover and re-attempt the request
@@ -220,7 +227,7 @@ class PandoraProvider(MusicProvider):
                                 "Pandora stream is already active on another device. "
                                 "Automatically taking over the stream and retrying the request."
                             )
-                            await self._takeover_stream()
+                            await self.takeover_stream()
                             return await self._api_request(method, url, data, retry=False)
                         await self.close()
                         raise InvalidDataError("STREAM_VIOLATION")
@@ -594,7 +601,7 @@ class PandoraProvider(MusicProvider):
         """
         return self._high_quality_available and self.config.get_value(CONF_QUALITY) == QUALITY_HIGH
 
-    async def _takeover_stream(self) -> None:
+    async def takeover_stream(self) -> None:
         """Force Pandora to end any other active session and resume here.
 
         This sends "forceActive=true" to the playbackResumed endpoint, which instructs Pandora to
@@ -606,4 +613,6 @@ class PandoraProvider(MusicProvider):
             "POST",
             PLAYBACK_RESUMED_ENDPOINT,
             data={"forceActive": True},
+            # Don't retry takeover attempts, otherwise we could get into an infinite loop
+            retry=False,
         )

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -252,7 +252,6 @@ class PandoraProvider(MusicProvider):
                                 exhausted_retry_reasons=exhausted_retry_reasons
                                 | {RETRY_REASON_STREAM_VIOLATION},
                             )
-                        await self.close()
                         raise StreamViolationError("STREAM_VIOLATION")
                     # This is some other, not concurrent streaming error kind of 429
                     await self.close()
@@ -442,7 +441,6 @@ class PandoraProvider(MusicProvider):
                 "To manually take over the stream on this device, use the "
                 "'Take over stream' button on the provider configuration page.",
             )
-            await self.close()
             raise
         except InvalidDataError as err:
             self.logger.error("Invalid fragment data for station %s: %s", session.station_id, err)

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -40,6 +40,7 @@ from .constants import (
     ACCOUNT_FLAG_HIGH_QUALITY,
     CONF_QUALITY,
     LOGIN_ENDPOINT,
+    PLAYBACK_RESUMED_ENDPOINT,
     PLAYLIST_FRAGMENT_ENDPOINT,
     QUALITY_HIGH,
     STATIONS_ENDPOINT,
@@ -183,7 +184,7 @@ class PandoraProvider(MusicProvider):
         :param method: HTTP method (GET, POST, etc.)
         :param url: API endpoint URL
         :param data: Optional JSON data to send
-        :param retry: Whether to retry once on 401 authentication errors
+        :param retry: Whether to retry once on 401 authentication errors or 429 stream violations
         """
         if not self._csrf_token or not self._auth_token:
             await self.close()
@@ -205,10 +206,27 @@ class PandoraProvider(MusicProvider):
                         return await self._api_request(method, url, data, retry=False)
                     await self.close()
                     raise LoginFailed("Pandora authentication failed after retry")
-
                 if response.status == 404:
                     await self.close()
                     raise MediaNotFoundError("Resource not found")
+                if response.status == 429:
+                    # Another device may already be streaming on this account.
+                    # Parse the body to confirm it is a STREAM_VIOLATION.
+                    error_body: dict[str, Any] = await response.json()
+                    if error_body.get("errorString") == "STREAM_VIOLATION":
+                        if retry:
+                            # If we are allowed to retry, takeover and re-attempt the request
+                            self.logger.warning(
+                                "Pandora stream is already active on another device. "
+                                "Automatically taking over the stream and retrying the request."
+                            )
+                            await self._takeover_stream()
+                            return await self._api_request(method, url, data, retry=False)
+                        await self.close()
+                        raise InvalidDataError("STREAM_VIOLATION")
+                    # This is some other, not concurrent streaming error kind of 429
+                    await self.close()
+                    raise ProviderUnavailableError(f"Pandora rate-limited (HTTP 429): {error_body}")
                 if response.status >= 500:
                     await self.close()
                     raise ProviderUnavailableError("Pandora server error")
@@ -331,9 +349,11 @@ class PandoraProvider(MusicProvider):
             if cached is not None:
                 return cached
 
+        is_stream_start = fragment_index == 0
+
         fragment_data = {
             "stationId": session.station_id,
-            "isStationStart": fragment_index == 0,
+            "isStationStart": is_stream_start,
             "fragmentRequestReason": "Normal",
             "audioFormat": "mp3-hifi" if self._use_high_quality() else "aacplus",
             "startingAtTrackId": None,
@@ -346,6 +366,7 @@ class PandoraProvider(MusicProvider):
                 "POST",
                 PLAYLIST_FRAGMENT_ENDPOINT,
                 data=fragment_data,
+                retry=is_stream_start,  # Only retry on initial stream start
             )
 
             # Store in session cache
@@ -381,8 +402,17 @@ class PandoraProvider(MusicProvider):
             await self.close()
             raise
         except InvalidDataError as err:
+            if str(err) == "STREAM_VIOLATION":
+                self.logger.warning(
+                    "Pandora stream is already active on another device. "
+                    "To manually take over the stream on this device, use the "
+                    "'Take over stream' button on the provider configuration page.",
+                )
+            else:
+                self.logger.error(
+                    "Invalid fragment data for station %s: %s", session.station_id, err
+                )
             await self.close()
-            self.logger.error("Invalid fragment data for station %s: %s", session.station_id, err)
             raise
 
     async def _handle_stream_request(self, request: web.Request) -> web.Response:
@@ -563,3 +593,17 @@ class PandoraProvider(MusicProvider):
         high-quality streaming, while still respecting the user's preference if they are eligible.
         """
         return self._high_quality_available and self.config.get_value(CONF_QUALITY) == QUALITY_HIGH
+
+    async def _takeover_stream(self) -> None:
+        """Force Pandora to end any other active session and resume here.
+
+        This sends "forceActive=true" to the playbackResumed endpoint, which instructs Pandora to
+        terminate any conflicting stream on other devices. The user must manually restart playback
+        in MA after clicking the config button that triggers this call.
+        """
+        self.logger.debug("Sending playbackResumed request to Pandora to attempt stream takeover.")
+        await self._api_request(
+            "POST",
+            PLAYBACK_RESUMED_ENDPOINT,
+            data={"forceActive": True},
+        )

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -234,7 +234,6 @@ class PandoraProvider(MusicProvider):
                     try:
                         error_body: dict[str, Any] = await response.json()
                     except (aiohttp.ContentTypeError, json.JSONDecodeError) as err:
-                        await self.close()
                         raise InvalidDataError(
                             "Unable to parse error 429 response body from Pandora"
                         ) from err
@@ -254,7 +253,6 @@ class PandoraProvider(MusicProvider):
                             )
                         raise StreamViolationError("STREAM_VIOLATION")
                     # This is some other, not concurrent streaming error kind of 429
-                    await self.close()
                     raise ProviderUnavailableError(f"Pandora rate-limited (HTTP 429): {error_body}")
                 if response.status >= 500:
                     await self.close()

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -56,7 +56,8 @@ class PandoraStationSession:
     """Manages streaming state for a single Pandora station."""
 
     def __init__(self, station_id: str):
-        """Initialize a new station streaming session.
+        """
+        Initialize a new station streaming session.
 
         Args:
             station_id: The Pandora station ID.
@@ -180,7 +181,8 @@ class PandoraProvider(MusicProvider):
     async def _api_request(
         self, method: str, url: str, data: dict[str, Any] | None = None, retry: bool = True
     ) -> dict[str, Any]:
-        """Make an API request to Pandora.
+        """
+        Make an API request to Pandora.
 
         :param method: HTTP method (GET, POST, etc.)
         :param url: API endpoint URL
@@ -423,7 +425,8 @@ class PandoraProvider(MusicProvider):
             raise
 
     async def _handle_stream_request(self, request: web.Request) -> web.Response:
-        """Handle dynamic stream request.
+        """
+        Handle dynamic stream request.
 
         Map track numbers to Pandora fragments and redirect to audio URLs.
         """
@@ -594,7 +597,8 @@ class PandoraProvider(MusicProvider):
             await self.http_session.close()
 
     def _use_high_quality(self) -> bool:
-        """Whether high quality audio should be requested from Pandora.
+        """
+        Whether high quality audio should be requested from Pandora.
 
         This allows a graceful fallback to standard quality if the account is not eligible for
         high-quality streaming, while still respecting the user's preference if they are eligible.
@@ -602,7 +606,8 @@ class PandoraProvider(MusicProvider):
         return self._high_quality_available and self.config.get_value(CONF_QUALITY) == QUALITY_HIGH
 
     async def takeover_stream(self) -> None:
-        """Force Pandora to end any other active session and resume here.
+        """
+        Force Pandora to end any other active session and resume here.
 
         This sends "forceActive=true" to the playbackResumed endpoint, which instructs Pandora to
         terminate any conflicting stream on other devices. The user must manually restart playback

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -44,6 +44,8 @@ from .constants import (
     PLAYBACK_RESUMED_ENDPOINT,
     PLAYLIST_FRAGMENT_ENDPOINT,
     QUALITY_HIGH,
+    RETRY_REASON_AUTH,
+    RETRY_REASON_STREAM_VIOLATION,
     STATIONS_ENDPOINT,
 )
 from .helpers import create_auth_headers, get_csrf_token, handle_pandora_error
@@ -183,7 +185,11 @@ class PandoraProvider(MusicProvider):
             ) from err
 
     async def _api_request(
-        self, method: str, url: str, data: dict[str, Any] | None = None, retry: bool = True
+        self,
+        method: str,
+        url: str,
+        data: dict[str, Any] | None = None,
+        exhausted_retry_reasons: frozenset[str] = frozenset(),
     ) -> dict[str, Any]:
         """
         Make an API request to Pandora.
@@ -191,7 +197,8 @@ class PandoraProvider(MusicProvider):
         :param method: HTTP method (GET, POST, etc.)
         :param url: API endpoint URL
         :param data: Optional JSON data to send
-        :param retry: Whether to retry once on 401 authentication errors or 429 stream violations
+        :param exhausted_retry_reasons: Set of retry reasons already attempted for this request.
+            Pass a pre-populated set to prevent specific retry strategies from being attempted.
         """
         if not self._csrf_token or not self._auth_token:
             await self.close()
@@ -205,12 +212,17 @@ class PandoraProvider(MusicProvider):
             ) as response:
                 # Check status BEFORE parsing JSON
                 if response.status == 401:
-                    if retry:
+                    if RETRY_REASON_AUTH not in exhausted_retry_reasons:
                         # Auth token expired, re-authenticate and retry once
                         username = str(self.config.get_value(CONF_USERNAME))
                         password = str(self.config.get_value(CONF_PASSWORD))
                         await self._authenticate(username, password)
-                        return await self._api_request(method, url, data, retry=False)
+                        return await self._api_request(
+                            method,
+                            url,
+                            data,
+                            exhausted_retry_reasons=exhausted_retry_reasons | {RETRY_REASON_AUTH},
+                        )
                     await self.close()
                     raise LoginFailed("Pandora authentication failed after retry")
                 if response.status == 404:
@@ -227,14 +239,19 @@ class PandoraProvider(MusicProvider):
                             "Unable to parse error 429 response body from Pandora"
                         ) from err
                     if error_body.get("errorString") == "STREAM_VIOLATION":
-                        if retry:
-                            # If we are allowed to retry, takeover and re-attempt the request
+                        if RETRY_REASON_STREAM_VIOLATION not in exhausted_retry_reasons:
                             self.logger.warning(
                                 "Pandora stream is already active on another device. "
                                 "Automatically taking over the stream and retrying the request."
                             )
                             await self.takeover_stream()
-                            return await self._api_request(method, url, data, retry=False)
+                            return await self._api_request(
+                                method,
+                                url,
+                                data,
+                                exhausted_retry_reasons=exhausted_retry_reasons
+                                | {RETRY_REASON_STREAM_VIOLATION},
+                            )
                         await self.close()
                         raise StreamViolationError("STREAM_VIOLATION")
                     # This is some other, not concurrent streaming error kind of 429
@@ -379,7 +396,12 @@ class PandoraProvider(MusicProvider):
                 "POST",
                 PLAYLIST_FRAGMENT_ENDPOINT,
                 data=fragment_data,
-                retry=is_stream_start,  # Only retry on initial stream start
+                # Mark stream violation retry as already exhausted for non-initial fragments
+                # this prevents us from fighting with the concurrent streaming limit
+                # if the user starts a stream on a different device while MA is already playing.
+                exhausted_retry_reasons=frozenset()
+                if is_stream_start
+                else frozenset({RETRY_REASON_STREAM_VIOLATION}),
             )
 
             # Store in session cache
@@ -621,6 +643,7 @@ class PandoraProvider(MusicProvider):
             "POST",
             PLAYBACK_RESUMED_ENDPOINT,
             data={"forceActive": True},
-            # Don't retry takeover attempts, otherwise we could get into an infinite loop
-            retry=False,
+            # This is called as part of handling a STREAM_VIOLATION 429, so mark that reason as
+            # already exhausted to prevent _api_request from retrying on another 429.
+            exhausted_retry_reasons=frozenset({RETRY_REASON_STREAM_VIOLATION}),
         )

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -81,6 +81,10 @@ class PandoraStationSession:
         return int(tracks[track_idx].get("trackLength", 0))
 
 
+class StreamViolationError(InvalidDataError):
+    """Error raised when Pandora detects concurrent streaming on multiple devices."""
+
+
 class PandoraProvider(MusicProvider):
     """Pandora Music Provider."""
 
@@ -232,7 +236,7 @@ class PandoraProvider(MusicProvider):
                             await self.takeover_stream()
                             return await self._api_request(method, url, data, retry=False)
                         await self.close()
-                        raise InvalidDataError("STREAM_VIOLATION")
+                        raise StreamViolationError("STREAM_VIOLATION")
                     # This is some other, not concurrent streaming error kind of 429
                     await self.close()
                     raise ProviderUnavailableError(f"Pandora rate-limited (HTTP 429): {error_body}")
@@ -410,17 +414,16 @@ class PandoraProvider(MusicProvider):
         except MediaNotFoundError:
             await self.close()
             raise
+        except StreamViolationError:
+            self.logger.warning(
+                "Pandora stream is already active on another device. "
+                "To manually take over the stream on this device, use the "
+                "'Take over stream' button on the provider configuration page.",
+            )
+            await self.close()
+            raise
         except InvalidDataError as err:
-            if str(err) == "STREAM_VIOLATION":
-                self.logger.warning(
-                    "Pandora stream is already active on another device. "
-                    "To manually take over the stream on this device, use the "
-                    "'Take over stream' button on the provider configuration page.",
-                )
-            else:
-                self.logger.error(
-                    "Invalid fragment data for station %s: %s", session.station_id, err
-                )
+            self.logger.error("Invalid fragment data for station %s: %s", session.station_id, err)
             await self.close()
             raise
 


### PR DESCRIPTION
Pandora only allows a single stream per account. If you transition from one device to another, or restart MA, or otherwise get a new auth session with Pandora, you will receive an error until a sufficient delay has occurred to prevent concurrent streaming.

This provides a button in the provider configuration to manually issue a takeover request to Pandora to disconnect other devices and allow streaming from this session.

Additionally, if the concurrent streaming error occurs when the stream is first started, it will automatically issue the takeover request if required.

It will not automatically issue a takeover request if the error occurs after the stream has already started to prevent MA from fighting for control with other devices (for example, when starting Pandora in a car after forgetting to stop MA first).