### PR TITLE
Add Apple Music station recommendations to Discover page

### DIFF
--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -54,6 +54,7 @@ from music_assistant_models.media_items import (
     MediaItemType,
     Playlist,
     ProviderMapping,
+    RecommendationFolder,
     SearchResults,
     Track,
     UniqueList,
@@ -90,6 +91,7 @@ SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_PLAYLISTS,
     ProviderFeature.BROWSE,
     ProviderFeature.SEARCH,
+    ProviderFeature.RECOMMENDATIONS,
     ProviderFeature.ARTIST_ALBUMS,
     ProviderFeature.ARTIST_TOPTRACKS,
     ProviderFeature.SIMILAR_TRACKS,
@@ -417,6 +419,40 @@ class AppleMusicProvider(MusicProvider):
                     if playlist.name != station_id:
                         result.append(playlist)
         return result
+
+    async def recommendations(self) -> list[RecommendationFolder]:
+        """Get personalized station recommendations for the Discover page."""
+        response = await self._get_data(
+            "me/recommendations?include[personal-recommendation]=contents"
+        )
+        seen: set[str] = set()
+        folders: list[RecommendationFolder] = []
+        for recommendation in response.get("data", []):
+            attributes = recommendation.get("attributes", {})
+            title = attributes.get("title", {}).get("stringForDisplay", "")
+            if not title:
+                continue
+            folder = RecommendationFolder(
+                item_id=f"recommendations_{recommendation['id']}",
+                provider=self.instance_id,
+                name=title,
+            )
+            contents = recommendation.get("relationships", {}).get("contents", {})
+            for item in contents.get("data", []):
+                if item.get("type") != "stations":
+                    continue
+                station_id = item.get("id")
+                if not station_id or station_id in seen:
+                    continue
+                item_attributes = item.get("attributes", {})
+                if item_attributes.get("isLive", False):
+                    continue
+                if item_attributes.get("name"):
+                    seen.add(station_id)
+                    folder.items.append(self._parse_station_as_playlist(item))
+            if folder.items:
+                folders.append(folder)
+        return folders
 
     def _parse_station_as_playlist(self, station_obj: dict[str, Any]) -> Playlist:
         """Parse a station object from recommendations into a Playlist."""

--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -391,6 +391,7 @@ class AppleMusicProvider(MusicProvider):
             return await self._browse_stations()
         return await super().browse(path)
 
+    @use_cache(3600)
     async def _get_personal_recommendations(self) -> list[RecommendationFolder]:
         """Fetch personal recommendations grouped into folders by section title.
 

--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -402,10 +402,11 @@ class AppleMusicProvider(MusicProvider):
         seen: set[str] = set()
         folders: dict[str, RecommendationFolder] = {}
         for recommendation in response.get("data", []):
+            rec_id = recommendation.get("id", "")
             title = (
                 recommendation.get("attributes", {}).get("title", {}).get("stringForDisplay", "")
             )
-            if not title:
+            if not rec_id or not title:
                 continue
             contents = recommendation.get("relationships", {}).get("contents", {})
             for item in contents.get("data", []):
@@ -428,7 +429,7 @@ class AppleMusicProvider(MusicProvider):
                         continue
                 if title not in folders:
                     folders[title] = RecommendationFolder(
-                        item_id=f"recommendations_{title}",
+                        item_id=rec_id,
                         provider=self.instance_id,
                         name=title,
                     )

--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -447,9 +447,13 @@ class AppleMusicProvider(MusicProvider):
                 item_attributes = item.get("attributes", {})
                 if item_attributes.get("isLive", False):
                     continue
+                seen.add(station_id)
                 if item_attributes.get("name"):
-                    seen.add(station_id)
                     folder.items.append(self._parse_station_as_playlist(item))
+                else:
+                    playlist = await self.get_playlist(station_id)
+                    if playlist.name != station_id:
+                        folder.items.append(playlist)
             if folder.items:
                 folders.append(folder)
         return folders

--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -391,14 +391,22 @@ class AppleMusicProvider(MusicProvider):
             return await self._browse_stations()
         return await super().browse(path)
 
-    async def _browse_stations(self) -> Sequence[MediaItemType | ItemMapping | BrowseFolder]:
-        """Return recommended radio stations from personal recommendations."""
+    async def _get_personal_recommendations(self) -> list[RecommendationFolder]:
+        """Fetch personal recommendations grouped into folders by section title.
+
+        :return: Deduplicated, live-filtered list of RecommendationFolders.
+        """
         response = await self._get_data(
             "me/recommendations?include[personal-recommendation]=contents"
         )
         seen: set[str] = set()
-        result: list[MediaItemType | ItemMapping | BrowseFolder] = []
+        folders: dict[str, RecommendationFolder] = {}
         for recommendation in response.get("data", []):
+            title = (
+                recommendation.get("attributes", {}).get("title", {}).get("stringForDisplay", "")
+            )
+            if not title:
+                continue
             contents = recommendation.get("relationships", {}).get("contents", {})
             for item in contents.get("data", []):
                 if item.get("type") != "stations":
@@ -406,57 +414,36 @@ class AppleMusicProvider(MusicProvider):
                 station_id = item.get("id")
                 if not station_id or station_id in seen:
                     continue
-                seen.add(station_id)
                 attributes = item.get("attributes", {})
                 if attributes.get("isLive", False):
                     # Live broadcast stations (e.g. Apple Music 1) require Widevine DRM
                     # which is not supported; skip them.
                     continue
+                seen.add(station_id)
                 if attributes.get("name"):
-                    result.append(self._parse_station_as_playlist(item))
+                    playlist = self._parse_station_as_playlist(item)
                 else:
                     playlist = await self.get_playlist(station_id)
-                    if playlist.name != station_id:
-                        result.append(playlist)
-        return result
+                    if playlist.name == station_id:
+                        continue
+                if title not in folders:
+                    folders[title] = RecommendationFolder(
+                        item_id=f"recommendations_{title}",
+                        provider=self.instance_id,
+                        name=title,
+                    )
+                folders[title].items.append(playlist)
+        return list(folders.values())
+
+    async def _browse_stations(self) -> Sequence[MediaItemType | ItemMapping | BrowseFolder]:
+        """Return recommended radio stations from personal recommendations."""
+        return [
+            item for folder in await self._get_personal_recommendations() for item in folder.items
+        ]
 
     async def recommendations(self) -> list[RecommendationFolder]:
         """Get personalized station recommendations for the Discover page."""
-        response = await self._get_data(
-            "me/recommendations?include[personal-recommendation]=contents"
-        )
-        seen: set[str] = set()
-        folders: list[RecommendationFolder] = []
-        for recommendation in response.get("data", []):
-            attributes = recommendation.get("attributes", {})
-            title = attributes.get("title", {}).get("stringForDisplay", "")
-            if not title:
-                continue
-            folder = RecommendationFolder(
-                item_id=f"recommendations_{recommendation['id']}",
-                provider=self.instance_id,
-                name=title,
-            )
-            contents = recommendation.get("relationships", {}).get("contents", {})
-            for item in contents.get("data", []):
-                if item.get("type") != "stations":
-                    continue
-                station_id = item.get("id")
-                if not station_id or station_id in seen:
-                    continue
-                item_attributes = item.get("attributes", {})
-                if item_attributes.get("isLive", False):
-                    continue
-                seen.add(station_id)
-                if item_attributes.get("name"):
-                    folder.items.append(self._parse_station_as_playlist(item))
-                else:
-                    playlist = await self.get_playlist(station_id)
-                    if playlist.name != station_id:
-                        folder.items.append(playlist)
-            if folder.items:
-                folders.append(folder)
-        return folders
+        return await self._get_personal_recommendations()
 
     def _parse_station_as_playlist(self, station_obj: dict[str, Any]) -> Playlist:
         """Parse a station object from recommendations into a Playlist."""


### PR DESCRIPTION
Follow-up to #3433.

Exposes Apple Music algorithmic radio stations as Recommendations so they appear on the Discover page.

Uses the existing `me/recommendations` endpoint (same source as Browse → Radio Stations), groups results by section title, and filters out live broadcast stations. Each station is returned as a dynamic `Playlist` via the existing `_parse_station_as_playlist` helper.