### PR TITLE
Implement metadata provider priority

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -1034,3 +1034,7 @@ EXTERNAL_SOURCES: Final[set[str]] = {
     # external (hass_players)
     "external",
 }
+
+# Metadata image provider priority - providers listed first are preferred for images.
+# Used to sort images so higher quality sources appear first in the UI.
+METADATA_IMAGE_PROVIDER_PRIORITY: Final[tuple[str, ...]] = ("fanarttv", "theaudiodb")

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -1035,6 +1035,8 @@ EXTERNAL_SOURCES: Final[set[str]] = {
     "external",
 }
 
-# Metadata image provider priority - providers listed first are preferred for images.
-# Used to sort images so higher quality sources appear first in the UI.
-METADATA_IMAGE_PROVIDER_PRIORITY: Final[tuple[str, ...]] = ("fanarttv", "theaudiodb")
+# Metadata image provider priority (lower = more preferred)
+METADATA_IMAGE_PROVIDER_PRIORITY: Final[dict[str, int]] = {
+    "fanarttv": 10,
+    "theaudiodb": 20,
+}

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -1034,9 +1034,3 @@ EXTERNAL_SOURCES: Final[set[str]] = {
     # external (hass_players)
     "external",
 }
-
-# Metadata image provider priority (lower = more preferred)
-METADATA_IMAGE_PROVIDER_PRIORITY: Final[dict[str, int]] = {
-    "fanarttv": 10,
-    "theaudiodb": 20,
-}

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -46,6 +46,7 @@ from music_assistant.constants import (
     CONF_LANGUAGE,
     DB_TABLE_ARTISTS,
     DB_TABLE_PLAYLISTS,
+    METADATA_IMAGE_PROVIDER_PRIORITY,
     VARIOUS_ARTISTS_MBID,
     VARIOUS_ARTISTS_NAME,
     VERBOSE_LOG_LEVEL,
@@ -241,6 +242,37 @@ class MetaDataController(CoreController):
     def providers(self) -> list[MetadataProvider]:
         """Return all loaded/running MetadataProviders."""
         return cast("list[MetadataProvider]", self.mass.get_providers(ProviderType.METADATA))
+
+    # TODO: After radio-artist-artwork PR is merged, update get_track_metadata_by_name()
+    # to sort providers by METADATA_IMAGE_PROVIDER_PRIORITY when querying for images.
+    # This ensures Fanart.tv is queried first for radio stream artwork, falling back
+    # to TheAudioDB only if no images found. Use:
+    #   sorted(self.providers, key=lambda p: (
+    #       METADATA_IMAGE_PROVIDER_PRIORITY.index(p.domain)
+    #       if p.domain in METADATA_IMAGE_PROVIDER_PRIORITY else 999
+    #   ))
+
+    def _sort_images_by_priority(
+        self, images: UniqueList[MediaItemImage] | None
+    ) -> UniqueList[MediaItemImage] | None:
+        """Sort images by provider priority.
+
+        Images from providers listed in METADATA_IMAGE_PROVIDER_PRIORITY appear first.
+        Used after merging metadata from multiple providers to ensure preferred
+        sources are displayed first in the UI.
+
+        :param images: List of images to sort.
+        """
+        if not images:
+            return images
+
+        def get_priority(img: MediaItemImage) -> int:
+            try:
+                return METADATA_IMAGE_PROVIDER_PRIORITY.index(img.provider)
+            except ValueError:
+                return 999
+
+        return UniqueList(sorted(images, key=get_priority))
 
     @property
     def preferred_language(self) -> str:
@@ -664,6 +696,8 @@ class MetaDataController(CoreController):
                         artist.name,
                         provider.name,
                     )
+        # sort images by provider priority so preferred sources appear first
+        artist.metadata.images = self._sort_images_by_priority(artist.metadata.images)
         # update final item in library database
         # set timestamp, used to determine when this function was last called
         artist.metadata.last_refresh = int(time())
@@ -717,6 +751,8 @@ class MetaDataController(CoreController):
                         album.name,
                         provider.name,
                     )
+        # sort images by provider priority so preferred sources appear first
+        album.metadata.images = self._sort_images_by_priority(album.metadata.images)
         # update final item in library database
         # set timestamp, used to determine when this function was last called
         album.metadata.last_refresh = int(time())
@@ -769,6 +805,8 @@ class MetaDataController(CoreController):
                         track.name,
                         provider.name,
                     )
+        # sort images by provider priority so preferred sources appear first
+        track.metadata.images = self._sort_images_by_priority(track.metadata.images)
         # set timestamp, used to determine when this function was last called
         track.metadata.last_refresh = int(time())
         # update final item in library database

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -46,7 +46,6 @@ from music_assistant.constants import (
     CONF_LANGUAGE,
     DB_TABLE_ARTISTS,
     DB_TABLE_PLAYLISTS,
-    METADATA_IMAGE_PROVIDER_PRIORITY,
     VARIOUS_ARTISTS_MBID,
     VARIOUS_ARTISTS_NAME,
     VERBOSE_LOG_LEVEL,
@@ -241,32 +240,10 @@ class MetaDataController(CoreController):
     @property
     def providers(self) -> list[MetadataProvider]:
         """Return all loaded/running MetadataProviders."""
-        return cast("list[MetadataProvider]", self.mass.get_providers(ProviderType.METADATA))
-
-    # TODO: After radio-artist-artwork PR is merged, update get_track_metadata_by_name()
-    # to sort providers by METADATA_IMAGE_PROVIDER_PRIORITY when querying for images.
-    # This ensures Fanart.tv is queried first for radio stream artwork, falling back
-    # to other providers only if no images found. Use:
-    #   sorted(self.providers, key=lambda p: METADATA_IMAGE_PROVIDER_PRIORITY.get(p.domain, 999))
-
-    def _sort_images_by_priority(
-        self, images: UniqueList[MediaItemImage] | None
-    ) -> UniqueList[MediaItemImage] | None:
-        """Sort images by provider priority.
-
-        Images from providers listed in METADATA_IMAGE_PROVIDER_PRIORITY appear first.
-        Used after merging metadata from multiple providers to ensure preferred
-        sources are displayed first in the UI.
-
-        :param images: List of images to sort.
-        """
-        if not images:
-            return images
-
-        def get_priority(img: MediaItemImage) -> int:
-            return METADATA_IMAGE_PROVIDER_PRIORITY.get(img.provider, 999)
-
-        return UniqueList(sorted(images, key=get_priority))
+        return sorted(
+            cast("list[MetadataProvider]", self.mass.get_providers(ProviderType.METADATA)),
+            key=lambda p: p.priority,
+        )
 
     @property
     def preferred_language(self) -> str:
@@ -690,8 +667,6 @@ class MetaDataController(CoreController):
                         artist.name,
                         provider.name,
                     )
-        # sort images by provider priority so preferred sources appear first
-        artist.metadata.images = self._sort_images_by_priority(artist.metadata.images)
         # update final item in library database
         # set timestamp, used to determine when this function was last called
         artist.metadata.last_refresh = int(time())
@@ -745,8 +720,6 @@ class MetaDataController(CoreController):
                         album.name,
                         provider.name,
                     )
-        # sort images by provider priority so preferred sources appear first
-        album.metadata.images = self._sort_images_by_priority(album.metadata.images)
         # update final item in library database
         # set timestamp, used to determine when this function was last called
         album.metadata.last_refresh = int(time())
@@ -799,8 +772,6 @@ class MetaDataController(CoreController):
                         track.name,
                         provider.name,
                     )
-        # sort images by provider priority so preferred sources appear first
-        track.metadata.images = self._sort_images_by_priority(track.metadata.images)
         # set timestamp, used to determine when this function was last called
         track.metadata.last_refresh = int(time())
         # update final item in library database

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -246,11 +246,8 @@ class MetaDataController(CoreController):
     # TODO: After radio-artist-artwork PR is merged, update get_track_metadata_by_name()
     # to sort providers by METADATA_IMAGE_PROVIDER_PRIORITY when querying for images.
     # This ensures Fanart.tv is queried first for radio stream artwork, falling back
-    # to TheAudioDB only if no images found. Use:
-    #   sorted(self.providers, key=lambda p: (
-    #       METADATA_IMAGE_PROVIDER_PRIORITY.index(p.domain)
-    #       if p.domain in METADATA_IMAGE_PROVIDER_PRIORITY else 999
-    #   ))
+    # to other providers only if no images found. Use:
+    #   sorted(self.providers, key=lambda p: METADATA_IMAGE_PROVIDER_PRIORITY.get(p.domain, 999))
 
     def _sort_images_by_priority(
         self, images: UniqueList[MediaItemImage] | None
@@ -267,10 +264,7 @@ class MetaDataController(CoreController):
             return images
 
         def get_priority(img: MediaItemImage) -> int:
-            try:
-                return METADATA_IMAGE_PROVIDER_PRIORITY.index(img.provider)
-            except ValueError:
-                return 999
+            return METADATA_IMAGE_PROVIDER_PRIORITY.get(img.provider, 999)
 
         return UniqueList(sorted(images, key=get_priority))
 

--- a/music_assistant/models/metadata_provider.py
+++ b/music_assistant/models/metadata_provider.py
@@ -18,6 +18,11 @@ class MetadataProvider(Provider):
     Metadata Provider implementations should inherit from this base model.
     """
 
+    @property
+    def priority(self) -> int:
+        """Priority for this provider (lower = more preferred)."""
+        return 50
+
     async def get_artist_metadata(self, artist: Artist) -> MediaItemMetadata | None:
         """Retrieve metadata for an artist on this Metadata provider."""
         if ProviderFeature.ARTIST_METADATA in self.supported_features:

--- a/music_assistant/providers/coverartarchive/__init__.py
+++ b/music_assistant/providers/coverartarchive/__init__.py
@@ -54,6 +54,11 @@ class CoverArtArchiveMetadataProvider(MetadataProvider):
     Fetches album artwork from the Cover Art Archive using MusicBrainz release group IDs.
     """
 
+    @property
+    def priority(self) -> int:
+        """Priority for this provider (lower = more preferred)."""
+        return 40
+
     async def get_album_metadata(self, album: Album) -> MediaItemMetadata | None:
         """Retrieve metadata for an album.
 

--- a/music_assistant/providers/fanarttv/__init__.py
+++ b/music_assistant/providers/fanarttv/__init__.py
@@ -32,11 +32,16 @@ CONF_ENABLE_ARTIST_IMAGES = "enable_artist_images"
 CONF_ENABLE_ALBUM_IMAGES = "enable_album_images"
 CONF_CLIENT_KEY = "client_key"
 
-IMG_MAPPING = {
+ARTIST_IMG_MAPPING = {
     "artistthumb": ImageType.THUMB,
     "hdmusiclogo": ImageType.LOGO,
     "musicbanner": ImageType.BANNER,
     "artistbackground": ImageType.FANART,
+}
+
+ALBUM_IMG_MAPPING = {
+    "albumcover": ImageType.THUMB,
+    "cdart": ImageType.DISCART,
 }
 
 
@@ -91,6 +96,11 @@ class FanartTvMetadataProvider(MetadataProvider):
 
     throttler: Throttler
 
+    @property
+    def priority(self) -> int:
+        """Priority for this provider (lower = more preferred)."""
+        return 10
+
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self.cache = self.mass.cache
@@ -109,7 +119,7 @@ class FanartTvMetadataProvider(MetadataProvider):
         self.logger.debug("Fetching metadata for Artist %s on Fanart.tv", artist.name)
         if data := await self._get_data(f"music/{artist.mbid}"):
             metadata = MediaItemMetadata()
-            for key, img_type in IMG_MAPPING.items():
+            for key, img_type in ARTIST_IMG_MAPPING.items():
                 items = data.get(key)
                 if not items:
                     continue
@@ -122,6 +132,18 @@ class FanartTvMetadataProvider(MetadataProvider):
                             remotely_accessible=True,
                         )
                     )
+            if metadata.images:
+                self.logger.debug(
+                    "Found %d image(s) for Artist %s on Fanart.tv",
+                    len(metadata.images),
+                    artist.name,
+                )
+            else:
+                self.logger.debug(
+                    "No images found for Artist %s on Fanart.tv (available keys: %s)",
+                    artist.name,
+                    list(data.keys()),
+                )
             return metadata
         return None
 
@@ -134,11 +156,11 @@ class FanartTvMetadataProvider(MetadataProvider):
         self.logger.debug("Fetching metadata for Album %s on Fanart.tv", album.name)
         if data := await self._get_data(f"music/albums/{mbid}"):
             if data and data.get("albums"):
-                if album := data["albums"][mbid]:
+                if album_data := data["albums"].get(mbid):
                     metadata = MediaItemMetadata()
                     metadata.images = UniqueList()
-                    for key, img_type in IMG_MAPPING.items():
-                        items = album.get(key)
+                    for key, img_type in ALBUM_IMG_MAPPING.items():
+                        items = album_data.get(key)
                         if not items:
                             continue
                         for item in items:
@@ -150,6 +172,18 @@ class FanartTvMetadataProvider(MetadataProvider):
                                     remotely_accessible=True,
                                 )
                             )
+                    if metadata.images:
+                        self.logger.debug(
+                            "Found %d image(s) for Album %s on Fanart.tv",
+                            len(metadata.images),
+                            album.name,
+                        )
+                    else:
+                        self.logger.debug(
+                            "No images found for Album %s on Fanart.tv (available keys: %s)",
+                            album.name,
+                            list(album_data.keys()),
+                        )
                     return metadata
         return None
 

--- a/music_assistant/providers/theaudiodb/__init__.py
+++ b/music_assistant/providers/theaudiodb/__init__.py
@@ -138,6 +138,11 @@ class AudioDbMetadataProvider(MetadataProvider):
 
     throttler: Throttler
 
+    @property
+    def priority(self) -> int:
+        """Priority for this provider (lower = more preferred)."""
+        return 20
+
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         self.cache = self.mass.cache


### PR DESCRIPTION
Per discussion here https://discord.com/channels/753947050995089438/1470389250993422509

Added a priority property to the MetadataProvider base model (default 50, lower = preferred). The metadata controller now iterates providers in priority order so images from preferred sources appear first in the list.                                                                                             

Fix fanart.tv album lookups — A related problem that was preventing this from working as designed was the fanart.tv provider was using artist image keys (artistthumb, hdmusiclogo, etc.) for album responses too, so album cover art was silently ignored. Split into ARTIST_IMG_MAPPING and ALBUM_IMG_MAPPING (albumcover, cdart).                                                                                                          