### PR TITLE
Fix player/queue deadlock on multiple simultane (play) actions

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -188,7 +188,6 @@ class PlayerQueuesController(CoreController):
         self._queue_items: dict[str, list[QueueItem]] = {}
         self._prev_states: dict[str, CompareState] = {}
         self._transitioning_players: set[str] = set()
-        self._play_action_locks: dict[str, asyncio.Lock] = {}
         self._play_action_refcount: dict[str, int] = {}
         self.manifest.name = "Player Queues controller"
         self.manifest.description = (
@@ -514,8 +513,7 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        lock = self._play_action_locks.setdefault(queue_id, asyncio.Lock())
-        async with lock:
+        async with self.mass.players.get_player_lock(queue_id, "playback"):
             await self._handle_play_media(queue_id, media, option, radio_mode, start_item, username)
 
     @api_command("player_queues/move_item")
@@ -653,7 +651,9 @@ class PlayerQueuesController(CoreController):
         if (queue := self.get(queue_id)) and queue.active:
             if queue.state == PlaybackState.PLAYING:
                 queue.resume_pos = int(queue.corrected_elapsed_time)
-        # Use internal handler to avoid circular redirect deadlock
+        # Use internal handler to avoid circular redirect:
+        # public cmd_stop redirects to queue.stop when a queue is active,
+        # which would loop back here indefinitely.
         await self.mass.players._handle_cmd_stop(queue_id)
         self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
 
@@ -667,8 +667,7 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        lock = self._play_action_locks.setdefault(queue_id, asyncio.Lock())
-        async with lock:
+        async with self.mass.players.get_player_lock(queue_id, "playback"):
             await self._handle_play(queue_id)
 
     @api_command("player_queues/pause")
@@ -736,8 +735,7 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        lock = self._play_action_locks.setdefault(queue_id, asyncio.Lock())
-        async with lock:
+        async with self.mass.players.get_player_lock(queue_id, "playback"):
             await self._handle_next(queue_id)
 
     @api_command("player_queues/previous")
@@ -750,8 +748,7 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        lock = self._play_action_locks.setdefault(queue_id, asyncio.Lock())
-        async with lock:
+        async with self.mass.players.get_player_lock(queue_id, "playback"):
             await self._handle_previous(queue_id)
 
     @api_command("player_queues/skip")
@@ -918,11 +915,10 @@ class PlayerQueuesController(CoreController):
 
             # Reset flow_mode - the streams controller will set it if flow mode is used.
             queue.flow_mode = False
-            # Use _handle_play_media directly to bypass the play_media lock.
-            # The queue controller is an internal consumer and play_index is
-            # already serialized by _play_action_locks. Going through the public
-            # play_media would deadlock when called from within cmd_set_members
-            # (which holds the play_media lock during protocol switches).
+            # Use internal handler to target the specific player directly.
+            # The public play_media API has redirect + extra decorator logic
+            # that is not needed here since the queue controller manages its own
+            # player targeting. We resolve the redirect ourselves.
             player = self.mass.players._get_player_with_redirect(queue_id)
             await self.mass.players._handle_play_media(
                 player.player_id,
@@ -1134,7 +1130,6 @@ class PlayerQueuesController(CoreController):
         self._queue_items.pop(player_id, None)
         self._prev_states.pop(player_id, None)
         self._transitioning_players.discard(player_id)
-        self._play_action_locks.pop(player_id, None)
         self._play_action_refcount.pop(player_id, None)
 
     async def load_next_queue_item(

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -121,38 +121,41 @@ def handle_play_action[PlayerQueuesControllerT: "PlayerQueuesController", **P, R
     func: Callable[Concatenate[PlayerQueuesControllerT, P], Awaitable[R]],
 ) -> Callable[Concatenate[PlayerQueuesControllerT, P], Coroutine[Any, Any, R]]:
     """
-    Decorator to mark a play action in progress on the queue.
+    Decorator for queue playback actions.
 
-    Sets ATTR_PLAY_ACTION_IN_PROGRESS to True before calling the function
-    and resets it to False after completion. Uses an internal refcount so
-    concurrent actions don't clear the flag prematurely.
+    Acquires the shared playback lock for the queue's player (re-entrant)
+    and sets ATTR_PLAY_ACTION_IN_PROGRESS on the queue while the action runs.
+    Uses an internal refcount so nested actions don't clear the flag prematurely.
 
     :param func: The function to wrap.
     """  # noqa: D401
 
     @functools.wraps(func)
     async def wrapper(self: PlayerQueuesControllerT, *args: P.args, **kwargs: P.kwargs) -> R:
-        """Execute function with play action flag set."""
+        """Execute function with playback lock and play action flag set."""
         queue_id = kwargs.get("queue_id") or args[0]
         assert isinstance(queue_id, str)  # for type checking
         queue = self._queues.get(queue_id)
         if queue is None:
             return await func(self, *args, **kwargs)
-        prev_in_progress = queue.extra_attributes.get(ATTR_PLAY_ACTION_IN_PROGRESS, False)
-        try:
-            self._play_action_refcount[queue_id] = self._play_action_refcount.get(queue_id, 0) + 1
-            queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] = True
-            if not prev_in_progress:
-                self.signal_update(queue_id)
-            return await func(self, *args, **kwargs)
-        finally:
-            refcount = self._play_action_refcount.get(queue_id, 1) - 1
-            if refcount <= 0:
-                self._play_action_refcount.pop(queue_id, None)
-                queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] = False
-                self.signal_update(queue_id)
-            else:
-                self._play_action_refcount[queue_id] = refcount
+        async with self.mass.players.get_player_lock(queue_id, PlayerLockPurpose.PLAYBACK):
+            prev_in_progress = queue.extra_attributes.get(ATTR_PLAY_ACTION_IN_PROGRESS, False)
+            try:
+                self._play_action_refcount[queue_id] = (
+                    self._play_action_refcount.get(queue_id, 0) + 1
+                )
+                queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] = True
+                if not prev_in_progress:
+                    self.signal_update(queue_id)
+                return await func(self, *args, **kwargs)
+            finally:
+                refcount = self._play_action_refcount.get(queue_id, 1) - 1
+                if refcount <= 0:
+                    self._play_action_refcount.pop(queue_id, None)
+                    queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] = False
+                    self.signal_update(queue_id)
+                else:
+                    self._play_action_refcount[queue_id] = refcount
 
     return wrapper
 
@@ -514,8 +517,8 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        async with self.mass.players.get_player_lock(queue_id, PlayerLockPurpose.PLAYBACK):
-            await self._handle_play_media(queue_id, media, option, radio_mode, start_item, username)
+        # Lock is acquired by the @handle_play_action decorator on the internal handler
+        await self._handle_play_media(queue_id, media, option, radio_mode, start_item, username)
 
     @api_command("player_queues/move_item")
     def move_item(self, queue_id: str, queue_item_id: str, pos_shift: int = 1) -> None:
@@ -668,8 +671,7 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        async with self.mass.players.get_player_lock(queue_id, PlayerLockPurpose.PLAYBACK):
-            await self._handle_play(queue_id)
+        await self._handle_play(queue_id)
 
     @api_command("player_queues/pause")
     async def pause(self, queue_id: str) -> None:
@@ -727,6 +729,7 @@ class PlayerQueuesController(CoreController):
         await self.play(queue_id)
 
     @api_command("player_queues/next")
+    @handle_play_action
     async def next(self, queue_id: str) -> None:
         """
         Handle NEXT TRACK command for given queue.
@@ -734,12 +737,39 @@ class PlayerQueuesController(CoreController):
         :param queue_id: queue_id of the queue to handle the command.
         """
         self._check_player_permission(queue_id)
-        if not self.get(queue_id):
-            raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        async with self.mass.players.get_player_lock(queue_id, PlayerLockPurpose.PLAYBACK):
-            await self._handle_next(queue_id)
+        if (queue := self.get(queue_id)) is None or not queue.active:
+            raise InvalidCommand(f"Queue {queue_id} is not active")
+        self._transitioning_players.add(queue_id)
+        idx = self._queues[queue_id].current_index
+        if idx is None:
+            self.logger.warning("Queue %s has no current index", queue.display_name)
+            self._transitioning_players.discard(queue_id)
+            return
+        next_index = self._get_next_index(queue_id, idx, True)
+        if next_index is None:
+            self._transitioning_players.discard(queue_id)
+            return
+
+        # immediately update current item so UI shows the new track right away
+        queue.current_index = next_index
+        queue.current_item = self.get_item(queue_id, next_index)
+        queue.elapsed_time = 0
+        queue.elapsed_time_last_updated = time.time()
+        self.signal_update(queue_id)
+        if queue_player := self.mass.players.get_player(queue_id, True):
+            queue_player.update_state()
+
+        # debounce rapid next button presses using call_later
+        self.mass.call_later(
+            1,
+            self.play_index,
+            queue_id,
+            next_index,
+            task_id=f"queue_play_index_{queue_id}",
+        )
 
     @api_command("player_queues/previous")
+    @handle_play_action
     async def previous(self, queue_id: str) -> None:
         """
         Handle PREVIOUS TRACK command for given queue.
@@ -747,10 +777,35 @@ class PlayerQueuesController(CoreController):
         :param queue_id: queue_id of the queue to handle the command.
         """
         self._check_player_permission(queue_id)
-        if not self.get(queue_id):
-            raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        async with self.mass.players.get_player_lock(queue_id, PlayerLockPurpose.PLAYBACK):
-            await self._handle_previous(queue_id)
+        if (queue := self.get(queue_id)) is None or not queue.active:
+            raise InvalidCommand(f"Queue {queue_id} is not active")
+        self._transitioning_players.add(queue_id)
+        current_index = self._queues[queue_id].current_index
+        if current_index is None:
+            self._transitioning_players.discard(queue_id)
+            return
+        prev_index = int(current_index)
+        # restart current track if elapsed > 5s, otherwise go to previous
+        if self._queues[queue_id].elapsed_time < 5:
+            prev_index = max(current_index - 1, 0)
+
+        # immediately update current item so UI shows the new track right away
+        queue.current_index = prev_index
+        queue.current_item = self.get_item(queue_id, prev_index)
+        queue.elapsed_time = 0
+        queue.elapsed_time_last_updated = time.time()
+        self.signal_update(queue_id)
+        if queue_player := self.mass.players.get_player(queue_id, True):
+            queue_player.update_state()
+
+        # debounce rapid previous button presses using call_later
+        self.mass.call_later(
+            1,
+            self.play_index,
+            queue_id,
+            prev_index,
+            task_id=f"queue_play_index_{queue_id}",
+        )
 
     @api_command("player_queues/skip")
     async def skip(self, queue_id: str, seconds: int = 10) -> None:
@@ -1437,80 +1492,6 @@ class PlayerQueuesController(CoreController):
             return
         # player is not paused, perform resume instead
         await self.resume(queue_id)
-
-    @handle_play_action
-    async def _handle_next(self, queue_id: str) -> None:
-        """Handle next track without acquiring the queue lock."""
-        if (queue := self.get(queue_id)) is None or not queue.active:
-            raise InvalidCommand(f"Queue {queue_id} is not active")
-        # we set a flag to notify the update logic that we're transitioning to a new track
-        # NOTE that this flag is reset in the play_index method
-        self._transitioning_players.add(queue_id)
-        idx = self._queues[queue_id].current_index
-        if idx is None:
-            self.logger.warning("Queue %s has no current index", queue.display_name)
-            self._transitioning_players.discard(queue_id)
-            return
-        next_index = self._get_next_index(queue_id, idx, True)
-        if next_index is None:
-            self._transitioning_players.discard(queue_id)
-            return
-
-        # immediately update current item so UI shows the new track right away
-        queue.current_index = next_index
-        queue.current_item = self.get_item(queue_id, next_index)
-        queue.elapsed_time = 0
-        queue.elapsed_time_last_updated = time.time()
-        self.signal_update(queue_id)
-        if queue_player := self.mass.players.get_player(queue_id, True):
-            # also update player so it can update its 'current_media'
-            queue_player.update_state()
-
-        # debounce rapid next button presses using call_later
-        self.mass.call_later(
-            1,
-            self.play_index,
-            queue_id,
-            next_index,
-            task_id=f"queue_play_index_{queue_id}",
-        )
-
-    @handle_play_action
-    async def _handle_previous(self, queue_id: str) -> None:
-        """Handle previous track without acquiring the queue lock."""
-        if (queue := self.get(queue_id)) is None or not queue.active:
-            raise InvalidCommand(f"Queue {queue_id} is not active")
-        # we set a flag to notify the update logic that we're transitioning to a new track
-        # NOTE that this flag is reset in the play_index method
-        self._transitioning_players.add(queue_id)
-        current_index = self._queues[queue_id].current_index
-        if current_index is None:
-            self._transitioning_players.discard(queue_id)
-            return
-        prev_index = int(current_index)
-        # restart current track if current track has played longer than 4
-        # otherwise skip to previous track
-        if self._queues[queue_id].elapsed_time < 5:
-            prev_index = max(current_index - 1, 0)
-
-        # immediately update current item so UI shows the new track right away
-        queue.current_index = prev_index
-        queue.current_item = self.get_item(queue_id, prev_index)
-        queue.elapsed_time = 0
-        queue.elapsed_time_last_updated = time.time()
-        self.signal_update(queue_id)
-        if queue_player := self.mass.players.get_player(queue_id, True):
-            # also update player so it can update its 'current_media'
-            queue_player.update_state()
-
-        # debounce rapid previous button presses using call_later
-        self.mass.call_later(
-            1,
-            self.play_index,
-            queue_id,
-            prev_index,
-            task_id=f"queue_play_index_{queue_id}",
-        )
 
     async def _load_item(
         self,

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -916,13 +916,8 @@ class PlayerQueuesController(CoreController):
 
             # Reset flow_mode - the streams controller will set it if flow mode is used.
             queue.flow_mode = False
-            # Use internal handler to target the specific player directly.
-            # The public play_media API has redirect + extra decorator logic
-            # that is not needed here since the queue controller manages its own
-            # player targeting. We resolve the redirect ourselves.
-            player = self.mass.players._get_player_with_redirect(queue_id)
-            await self.mass.players._handle_play_media(
-                player.player_id,
+            await self.mass.players.play_media(
+                queue_id,
                 await self.player_media_from_queue_item(queue_item),
             )
             queue.current_index = index

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -76,6 +76,7 @@ from music_assistant.constants import (
     VERBOSE_LOG_LEVEL,
     PlaylistPlayableItem,
 )
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.api import api_command
@@ -513,7 +514,7 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        async with self.mass.players.get_player_lock(queue_id, "playback"):
+        async with self.mass.players.get_player_lock(queue_id, PlayerLockPurpose.PLAYBACK):
             await self._handle_play_media(queue_id, media, option, radio_mode, start_item, username)
 
     @api_command("player_queues/move_item")
@@ -667,7 +668,7 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        async with self.mass.players.get_player_lock(queue_id, "playback"):
+        async with self.mass.players.get_player_lock(queue_id, PlayerLockPurpose.PLAYBACK):
             await self._handle_play(queue_id)
 
     @api_command("player_queues/pause")
@@ -735,7 +736,7 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        async with self.mass.players.get_player_lock(queue_id, "playback"):
+        async with self.mass.players.get_player_lock(queue_id, PlayerLockPurpose.PLAYBACK):
             await self._handle_next(queue_id)
 
     @api_command("player_queues/previous")
@@ -748,7 +749,7 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
-        async with self.mass.players.get_player_lock(queue_id, "playback"):
+        async with self.mass.players.get_player_lock(queue_id, PlayerLockPurpose.PLAYBACK):
             await self._handle_previous(queue_id)
 
     @api_command("player_queues/skip")

--- a/music_assistant/controllers/players/constants.py
+++ b/music_assistant/controllers/players/constants.py
@@ -1,0 +1,10 @@
+"""Constants for the Player Controller."""
+
+from enum import StrEnum
+
+
+class PlayerLockPurpose(StrEnum):
+    """Lock categories for get_player_lock to serialize commands per player."""
+
+    PLAYBACK = "playback"
+    VOLUME = "volume"

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1149,7 +1149,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # by set_members. The lock is re-entrant via ContextVar so nested calls
         # (e.g. set_members -> protocol switch -> resume -> play_index -> form_syncgroup
         # -> set_members) won't deadlock.
-        async with self.get_player_lock(parent_player.player_id):
+        async with self.get_player_lock(parent_player.player_id, "playback"):
             await self._handle_set_members(parent_player, player_ids_to_add, player_ids_to_remove)
 
     @api_command("players/cmd/group")

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -21,7 +21,6 @@ import contextlib
 import time
 from collections.abc import AsyncIterator
 from contextlib import suppress
-from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import UserRole
@@ -124,12 +123,6 @@ if TYPE_CHECKING:
 
 CACHE_CATEGORY_PLAYER_POWER = 1
 
-# ContextVar tracking which player locks the current async task holds.
-# Used by get_player_lock to allow re-entrant acquisition without deadlocking.
-_held_player_locks: ContextVar[frozenset[str]] = ContextVar(
-    "_held_player_locks", default=frozenset()
-)
-
 
 class PlayerController(ProtocolLinkingMixin, CoreController):
     """Controller holding all logic to control registered players."""
@@ -149,6 +142,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         self._poll_task: asyncio.Task[None] | None = None
         self._player_throttlers: dict[str, Throttler] = {}
         self._player_command_locks: dict[str, asyncio.Lock] = {}
+        # Track which lock keys each async task holds (keyed by task id).
+        # Used by get_player_lock for re-entrant detection.
+        self._task_held_locks: dict[int, set[str]] = {}
         # Lock to prevent race conditions during player registration
         self._register_lock = asyncio.Lock()
         # Track pending protocol player evaluations (delayed to allow all protocols to register)
@@ -163,30 +159,33 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         Acquire a purpose-scoped lock for a player, with re-entrant support.
 
-        Uses a ContextVar to track locks held by the current async task.
-        If the current task already holds this exact lock (same player + purpose),
-        yields immediately without re-acquiring to prevent deadlocks in nested calls
-        (e.g. queue -> player -> syncgroup -> player).
+        Tracks lock ownership per asyncio Task so that nested calls within the same
+        task skip re-acquisition (preventing deadlocks), while deferred callbacks
+        (call_later / create_task) correctly acquire a fresh lock.
 
         :param player_id: The player to lock.
         :param purpose: Lock category. Commands with different purposes can run
             concurrently on the same player.
         """
         lock_key = f"{purpose.value}_{player_id}"
-        held = _held_player_locks.get()
+        task = asyncio.current_task()
+        task_id = id(task) if task else 0
 
-        if lock_key in held:
-            # Already holding this lock in the current call chain — re-entrant, skip
+        if lock_key in self._task_held_locks.get(task_id, set()):
             yield
             return
 
         lock = self._player_command_locks.setdefault(lock_key, asyncio.Lock())
         async with lock:
-            token = _held_player_locks.set(held | frozenset({lock_key}))
+            self._task_held_locks.setdefault(task_id, set()).add(lock_key)
             try:
                 yield
             finally:
-                _held_player_locks.reset(token)
+                held = self._task_held_locks.get(task_id)
+                if held is not None:
+                    held.discard(lock_key)
+                    if not held:
+                        del self._task_held_locks[task_id]
 
     async def get_config_entries(
         self,
@@ -540,7 +539,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             await self.cmd_play(player.player_id)
 
     @api_command("players/cmd/resume")
-    @handle_player_command
+    @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def cmd_resume(
         self, player_id: str, source: str | None = None, media: PlayerMedia | None = None
     ) -> None:
@@ -1507,7 +1506,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             return
         del self._players[player_id]
         self._player_throttlers.pop(player_id, None)
-        self._player_command_locks.pop(f"set_members_{player_id}", None)
+        # clean up all lock entries for this player
+        for prefix in [p.value for p in PlayerLockPurpose]:
+            self._player_command_locks.pop(f"{prefix}_{player_id}", None)
         if handle := self._pending_protocol_evaluations.pop(player_id, None):
             handle.cancel()
         self.mass.player_queues.on_player_remove(player_id, permanent=permanent)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -17,8 +17,11 @@ The playerstate is the object that is exposed to the outside world (via the API)
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
+from collections.abc import AsyncIterator
 from contextlib import suppress
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import UserRole
@@ -120,6 +123,12 @@ if TYPE_CHECKING:
 
 CACHE_CATEGORY_PLAYER_POWER = 1
 
+# ContextVar tracking which player locks the current async task holds.
+# Used by get_player_lock to allow re-entrant acquisition without deadlocking.
+_held_player_locks: ContextVar[frozenset[str]] = ContextVar(
+    "_held_player_locks", default=frozenset()
+)
+
 
 class PlayerController(ProtocolLinkingMixin, CoreController):
     """Controller holding all logic to control registered players."""
@@ -145,6 +154,38 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         self._pending_protocol_evaluations: dict[str, asyncio.TimerHandle] = {}
         # Serialize delayed evaluations to prevent race conditions
         self._delayed_evaluation_lock = asyncio.Lock()
+
+    @contextlib.asynccontextmanager
+    async def get_player_lock(
+        self, player_id: str, purpose: str = "playback"
+    ) -> AsyncIterator[None]:
+        """
+        Acquire a purpose-scoped lock for a player, with re-entrant support.
+
+        Uses a ContextVar to track locks held by the current async task.
+        If the current task already holds this exact lock (same player + purpose),
+        yields immediately without re-acquiring to prevent deadlocks in nested calls
+        (e.g. queue -> player -> syncgroup -> player).
+
+        :param player_id: The player to lock.
+        :param purpose: Lock category (e.g. "playback", "volume"). Commands with
+            different purposes can run concurrently on the same player.
+        """
+        lock_key = f"{purpose}_{player_id}"
+        held = _held_player_locks.get()
+
+        if lock_key in held:
+            # Already holding this lock in the current call chain — re-entrant, skip
+            yield
+            return
+
+        lock = self._player_command_locks.setdefault(lock_key, asyncio.Lock())
+        async with lock:
+            token = _held_player_locks.set(held | frozenset({lock_key}))
+            try:
+                yield
+            finally:
+                _held_player_locks.reset(token)
 
     async def get_config_entries(
         self,
@@ -1102,15 +1143,13 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             # automatically ungroup it first and wait for state to propagate
             await self._auto_ungroup_if_synced(parent_player, "setting members")
 
-        # Use the "play" lock category — same as play_media, play_announcement,
-        # enqueue_next_media — to prevent concurrent playback-related commands
-        # from racing with protocol switches triggered by set_members.
-        # Use resolved parent_player.player_id (not raw target_player) to match
-        # the lock key that handle_player_command produces after protocol resolution.
-        lock_key = f"play_{parent_player.player_id}"
-        if lock_key not in self._player_command_locks:
-            self._player_command_locks[lock_key] = asyncio.Lock()
-        async with self._player_command_locks[lock_key]:
+        # Use the shared playback lock — same lock used by play_media, play_announcement,
+        # enqueue_next_media, and queue play commands — to prevent concurrent
+        # playback-related commands from racing with protocol switches triggered
+        # by set_members. The lock is re-entrant via ContextVar so nested calls
+        # (e.g. set_members -> protocol switch -> resume -> play_index -> form_syncgroup
+        # -> set_members) won't deadlock.
+        async with self.get_player_lock(parent_player.player_id):
             await self._handle_set_members(parent_player, player_ids_to_add, player_ids_to_remove)
 
     @api_command("players/cmd/group")

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -104,6 +104,7 @@ from music_assistant.models.player import Player, PlayerMedia, PlayerState
 from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.models.plugin import PluginProvider, PluginSource
 
+from .constants import PlayerLockPurpose
 from .helpers import AnnounceData, handle_player_command, wait_for_power_on
 from .protocol_linking import ProtocolLinkingMixin
 
@@ -157,7 +158,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     @contextlib.asynccontextmanager
     async def get_player_lock(
-        self, player_id: str, purpose: str = "playback"
+        self, player_id: str, purpose: PlayerLockPurpose = PlayerLockPurpose.PLAYBACK
     ) -> AsyncIterator[None]:
         """
         Acquire a purpose-scoped lock for a player, with re-entrant support.
@@ -168,10 +169,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         (e.g. queue -> player -> syncgroup -> player).
 
         :param player_id: The player to lock.
-        :param purpose: Lock category (e.g. "playback", "volume"). Commands with
-            different purposes can run concurrently on the same player.
+        :param purpose: Lock category. Commands with different purposes can run
+            concurrently on the same player.
         """
-        lock_key = f"{purpose}_{player_id}"
+        lock_key = f"{purpose.value}_{player_id}"
         held = _held_player_locks.get()
 
         if lock_key in held:
@@ -474,7 +475,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
     # Player commands
 
     @api_command("players/cmd/stop")
-    @handle_player_command(lock="play")
+    @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def cmd_stop(self, player_id: str) -> None:
         """Send STOP command to given player.
 
@@ -654,7 +655,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         await self._handle_cmd_power(player_id, powered)
 
     @api_command("players/cmd/volume_set")
-    @handle_player_command
+    @handle_player_command(lock=PlayerLockPurpose.VOLUME)
     async def cmd_volume_set(self, player_id: str, volume_level: int) -> None:
         """Send VOLUME_SET command to given player.
 
@@ -802,7 +803,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             await asyncio.gather(*coros)
 
     @api_command("players/cmd/volume_mute")
-    @handle_player_command
+    @handle_player_command(lock=PlayerLockPurpose.VOLUME)
     async def cmd_volume_mute(self, player_id: str, muted: bool) -> None:
         """Send VOLUME_MUTE command to given player.
 
@@ -868,7 +869,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             return
 
     @api_command("players/cmd/play_announcement")
-    @handle_player_command(lock="play")
+    @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def play_announcement(
         self,
         player_id: str,
@@ -978,7 +979,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         finally:
             player.extra_data[ATTR_ANNOUNCEMENT_IN_PROGRESS] = False
 
-    @handle_player_command(lock="play")
+    @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def play_media(self, player_id: str, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on given player.
 
@@ -1099,7 +1100,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         with suppress(PlayerCommandFailed, PlayerUnavailableError, RuntimeError):
             await self._handle_cmd_stop(player_id)
 
-    @handle_player_command(lock="play")
+    @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def enqueue_next_media(self, player_id: str, media: PlayerMedia) -> None:
         """
         Handle enqueuing of a next media item on the player.
@@ -1143,13 +1144,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             # automatically ungroup it first and wait for state to propagate
             await self._auto_ungroup_if_synced(parent_player, "setting members")
 
-        # Use the shared playback lock — same lock used by play_media, play_announcement,
-        # enqueue_next_media, and queue play commands — to prevent concurrent
-        # playback-related commands from racing with protocol switches triggered
-        # by set_members. The lock is re-entrant via ContextVar so nested calls
-        # (e.g. set_members -> protocol switch -> resume -> play_index -> form_syncgroup
-        # -> set_members) won't deadlock.
-        async with self.get_player_lock(parent_player.player_id, "playback"):
+        # Serialize with playback commands to prevent protocol switches from
+        # racing with concurrent play_media / play_index / resume calls.
+        async with self.get_player_lock(parent_player.player_id, PlayerLockPurpose.PLAYBACK):
             await self._handle_set_members(parent_player, player_ids_to_add, player_ids_to_remove)
 
     @api_command("players/cmd/group")

--- a/music_assistant/controllers/players/helpers.py
+++ b/music_assistant/controllers/players/helpers.py
@@ -135,11 +135,18 @@ def handle_player_command[PlayerControllerT: "PlayerController", **P, R](
 
             if lock:
                 lock_category = lock if isinstance(lock, str) else fn.__name__
-                lock_key = f"{lock_category}_{player.player_id}"
-                if lock_key not in self._player_command_locks:
-                    self._player_command_locks[lock_key] = asyncio.Lock()
-                async with self._player_command_locks[lock_key]:
-                    await execute()
+                # Use the shared re-entrant player lock for "playback" category
+                # so that queue commands and player commands serialize properly.
+                # Other lock categories (e.g. volume) use their own locks.
+                if lock_category == "play":
+                    async with self.get_player_lock(player.player_id):
+                        await execute()
+                else:
+                    lock_key = f"{lock_category}_{player.player_id}"
+                    if lock_key not in self._player_command_locks:
+                        self._player_command_locks[lock_key] = asyncio.Lock()
+                    async with self._player_command_locks[lock_key]:
+                        await execute()
             else:
                 await execute()
 

--- a/music_assistant/controllers/players/helpers.py
+++ b/music_assistant/controllers/players/helpers.py
@@ -139,7 +139,7 @@ def handle_player_command[PlayerControllerT: "PlayerController", **P, R](
                 # so that queue commands and player commands serialize properly.
                 # Other lock categories (e.g. volume) use their own locks.
                 if lock_category == "play":
-                    async with self.get_player_lock(player.player_id):
+                    async with self.get_player_lock(player.player_id, "playback"):
                         await execute()
                 else:
                     lock_key = f"{lock_category}_{player.player_id}"

--- a/music_assistant/controllers/players/helpers.py
+++ b/music_assistant/controllers/players/helpers.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Concatenate, TypedDict, overload
 
 from music_assistant_models.errors import InsufficientPermissions, PlayerCommandFailed
 
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 
 if TYPE_CHECKING:
@@ -44,7 +45,7 @@ def handle_player_command[PlayerControllerT: "PlayerController", **P, R](
 def handle_player_command[PlayerControllerT: "PlayerController", **P, R](
     func: None = None,
     *,
-    lock: str | bool = False,
+    lock: PlayerLockPurpose | None = None,
 ) -> Callable[
     [Callable[Concatenate[PlayerControllerT, P], Awaitable[R]]],
     Callable[Concatenate[PlayerControllerT, P], Coroutine[Any, Any, R | None]],
@@ -54,7 +55,7 @@ def handle_player_command[PlayerControllerT: "PlayerController", **P, R](
 def handle_player_command[PlayerControllerT: "PlayerController", **P, R](
     func: Callable[Concatenate[PlayerControllerT, P], Awaitable[R]] | None = None,
     *,
-    lock: str | bool = False,
+    lock: PlayerLockPurpose | None = None,
 ) -> (
     Callable[Concatenate[PlayerControllerT, P], Coroutine[Any, Any, R | None]]
     | Callable[
@@ -69,10 +70,9 @@ def handle_player_command[PlayerControllerT: "PlayerController", **P, R](
     Also checks user permissions and optionally acquires a per-player lock.
 
     :param func: The function to wrap (when used without parentheses).
-    :param lock: Lock category string (e.g. "play", "volume") to serialize commands
-        in the same category per player. Commands with the same lock category on the
-        same player will not run concurrently. True uses the function name as category.
-        False (default) means no locking.
+    :param lock: PlayerLockPurpose to serialize commands in the same category per
+        player. Commands with the same lock purpose on the same player will not run
+        concurrently. None (default) means no locking.
     """  # noqa: D401
 
     def decorator(
@@ -134,25 +134,14 @@ def handle_player_command[PlayerControllerT: "PlayerController", **P, R](
                         raise PlayerCommandFailed(str(err)) from err
 
             if lock:
-                lock_category = lock if isinstance(lock, str) else fn.__name__
-                # Use the shared re-entrant player lock for "playback" category
-                # so that queue commands and player commands serialize properly.
-                # Other lock categories (e.g. volume) use their own locks.
-                if lock_category == "play":
-                    async with self.get_player_lock(player.player_id, "playback"):
-                        await execute()
-                else:
-                    lock_key = f"{lock_category}_{player.player_id}"
-                    if lock_key not in self._player_command_locks:
-                        self._player_command_locks[lock_key] = asyncio.Lock()
-                    async with self._player_command_locks[lock_key]:
-                        await execute()
+                async with self.get_player_lock(player.player_id, lock):
+                    await execute()
             else:
                 await execute()
 
         return wrapper
 
-    # Support both @handle_player_command and @handle_player_command(lock="play")
+    # Support both @handle_player_command and @handle_player_command(lock=...)
     if func is not None:
         return decorator(func)
     return decorator

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1889,8 +1889,6 @@ class ProtocolLinkingMixin:
                 else:
                     old_parent_members = []
                 # Resume playback on the new protocol and re-add migrated members.
-                # Use public API — the queue redirect is desired here, and the
-                # re-entrant playback lock prevents deadlocks in nested calls.
                 await self.mass.players.cmd_resume(parent_player.player_id)
                 if old_parent_members:
                     self.logger.debug(

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1883,17 +1883,23 @@ class ProtocolLinkingMixin:
                         parent_protocol_player.state.name,
                         old_parent_members,
                     )
+                    # Use internal handler to stop the specific protocol player,
+                    # bypassing group/sync redirect and queue redirect logic.
                     await self.mass.players._handle_cmd_stop(old_protocol_player.player_id)
                 else:
                     old_parent_members = []
                 # Resume playback on the new protocol and re-add migrated members.
-                await self.mass.players._handle_cmd_resume(parent_player.player_id)
+                # Use public API — the queue redirect is desired here, and the
+                # re-entrant playback lock prevents deadlocks in nested calls.
+                await self.mass.players.cmd_resume(parent_player.player_id)
                 if old_parent_members:
                     self.logger.debug(
                         "Re-adding migrated members %s to %s on new protocol",
                         old_parent_members,
                         parent_player.state.name,
                     )
+                    # Use internal handler because we are already inside a
+                    # _handle_set_members call chain that holds the play lock.
                     await self.mass.players._handle_set_members(
                         parent_player,
                         player_ids_to_add=old_parent_members,

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -333,6 +333,8 @@ class SyncGroupPlayer(Player):
         """Send STOP command to given player."""
         self._attr_current_media = None
         if sync_leader := self.sync_leader:
+            # Use internal handler to target the sync leader directly,
+            # bypassing group/sync redirect that would loop back to this player.
             await self.mass.players._handle_cmd_stop(sync_leader.player_id)
         # dissolve the sync group since we stopped playback
         self.mass.call_later(
@@ -341,7 +343,10 @@ class SyncGroupPlayer(Player):
 
     async def play(self) -> None:
         """Send PLAY (unpause) command to given player."""
-        await self.mass.players._handle_cmd_resume(
+        # Use the public API — the re-entrant playback lock prevents deadlocks,
+        # and the queue redirect in cmd_resume is the correct behavior here
+        # (the syncgroup IS the queue player, so no circular redirect risk).
+        await self.mass.players.cmd_resume(
             self.player_id, self._attr_active_source, self._attr_current_media
         )
 
@@ -351,6 +356,8 @@ class SyncGroupPlayer(Player):
         self._attr_active_source = media.source_id or None
         await self._form_syncgroup()
         if sync_leader := self.sync_leader:
+            # Use internal handler to target the sync leader directly,
+            # bypassing group/sync redirect that would loop back to this player.
             await self.mass.players._handle_play_media(sync_leader.player_id, media)
             self._update_active_protocol()
             self.update_state()
@@ -465,6 +472,8 @@ class SyncGroupPlayer(Player):
                     self.sync_leader.display_name,
                     self.display_name,
                 )
+                # Use internal handler to stop the sync leader directly,
+                # bypassing group redirect that would loop back to this player.
                 await self.mass.players.wait_for_player_update(
                     self.sync_leader.player_id,
                     timeout=5,
@@ -480,6 +489,8 @@ class SyncGroupPlayer(Player):
         elif self.sync_leader and (leader_removed or not self._attr_group_members):
             # we removed the current sync leader, and we have no members left in the group
             # or we just removed the last member from the group, so we dissolve the syncgroup
+            # Use internal handler to stop the sync leader directly,
+            # bypassing group redirect that would loop back to this player.
             await self.mass.players.wait_for_player_update(
                 self.sync_leader.player_id,
                 timeout=5,
@@ -543,6 +554,8 @@ class SyncGroupPlayer(Player):
             # If the sync leader is playing something independently, stop it first
             # to prevent protocol switching from trying to resume the previous playback
             # (we're about to start new playback on the syncgroup)
+            # Use internal handler to stop the sync leader directly,
+            # bypassing group redirect that would loop back to this player.
             if self.sync_leader.state.playback_state == PlaybackState.PLAYING:
                 await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
             await self.mass.players.cmd_set_members(self.sync_leader.player_id, members_to_sync)

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -343,9 +343,6 @@ class SyncGroupPlayer(Player):
 
     async def play(self) -> None:
         """Send PLAY (unpause) command to given player."""
-        # Use the public API — the re-entrant playback lock prevents deadlocks,
-        # and the queue redirect in cmd_resume is the correct behavior here
-        # (the syncgroup IS the queue player, so no circular redirect risk).
         await self.mass.players.cmd_resume(
             self.player_id, self._attr_active_source, self._attr_current_media
         )

--- a/tests/core/test_player_controller.py
+++ b/tests/core/test_player_controller.py
@@ -254,12 +254,14 @@ class TestUnregisterCleanup:
         controller._players = {"player_1": player}
         controller._player_throttlers = {"player_1": Throttler(1, 0.05)}
         controller._player_command_locks = {
-            "set_members_player_1": asyncio.Lock(),
+            "playback_player_1": asyncio.Lock(),
+            "volume_player_1": asyncio.Lock(),
         }
 
         asyncio.run(controller.unregister("player_1"))
 
-        assert "set_members_player_1" not in controller._player_command_locks
+        assert "playback_player_1" not in controller._player_command_locks
+        assert "volume_player_1" not in controller._player_command_locks
 
     def test_other_players_state_untouched(self, mock_mass: MagicMock) -> None:
         """Unregistering one player does not affect another player's state."""
@@ -274,16 +276,16 @@ class TestUnregisterCleanup:
             "player_b": Throttler(1, 0.05),
         }
         controller._player_command_locks = {
-            "set_members_player_a": asyncio.Lock(),
-            "set_members_player_b": asyncio.Lock(),
+            "playback_player_a": asyncio.Lock(),
+            "playback_player_b": asyncio.Lock(),
         }
 
         asyncio.run(controller.unregister("player_a"))
 
         assert "player_b" in controller._player_throttlers
-        assert "set_members_player_b" in controller._player_command_locks
+        assert "playback_player_b" in controller._player_command_locks
         assert "player_a" not in controller._player_throttlers
-        assert "set_members_player_a" not in controller._player_command_locks
+        assert "playback_player_a" not in controller._player_command_locks
 
     def test_suffix_player_id_not_over_matched(self, mock_mass: MagicMock) -> None:
         """Removing player 'b' must not remove locks for player 'a_b' (no suffix matching)."""
@@ -298,14 +300,14 @@ class TestUnregisterCleanup:
             "a_b": Throttler(1, 0.05),
         }
         controller._player_command_locks = {
-            "set_members_b": asyncio.Lock(),
-            "set_members_a_b": asyncio.Lock(),
+            "playback_b": asyncio.Lock(),
+            "playback_a_b": asyncio.Lock(),
         }
 
         asyncio.run(controller.unregister("b"))
 
-        assert "set_members_a_b" in controller._player_command_locks
-        assert "set_members_b" not in controller._player_command_locks
+        assert "playback_a_b" in controller._player_command_locks
+        assert "playback_b" not in controller._player_command_locks
 
     def test_pending_protocol_evaluation_cancelled(self, mock_mass: MagicMock) -> None:
         """Unregistering a player cancels and removes its pending protocol evaluation."""


### PR DESCRIPTION
## Problem

Play-related commands on the queue controller and the player controller used **separate locks** that didn't share state. This caused two issues when controlling Music Assistant from Home Assistant automations (rapid `set_members` + `play_media` calls on sync groups):

1. **Deadlock** — A protocol switch during `set_members` triggers a resume, which calls `play_index`, which re-forms the syncgroup, which calls `cmd_set_members` on the sync leader — trying to re-acquire a lock already held higher in the call stack. The queue gets permanently stuck with `play_action_in_progress` set.

2. **AirPlay desync** — Concurrent `queue.play_media` and `cmd_set_members` could interleave because they held different first locks, causing partially-applied protocol switches and NTP reference mismatches between group members.

## Changes

- Add `get_player_lock(player_id, purpose)` to `PlayerController` — a re-entrant async context manager backed by a `ContextVar` that detects when the current task already holds a lock and skips re-acquisition
- Replace the queue controller's separate `_play_action_locks` with `get_player_lock(queue_id, "playback")` so queue and player commands serialize on the **same** lock
- Route `handle_player_command(lock="play")` and `cmd_set_members` through the same `get_player_lock`
- Switch `SyncGroupPlayer.play()` and protocol-switch resume to use the public `cmd_resume` API (lock bypass was their only reason for using internals; redirect avoidance was not needed)
- Add explanatory comments to all remaining internal `_handle_*` calls documenting why they bypass the public API (redirect avoidance)