### PR TITLE
Fix flow mode queue tracking drift on AirPlay dynamic leader switch

### DIFF
--- a/music_assistant/providers/airplay/protocols/_protocol.py
+++ b/music_assistant/providers/airplay/protocols/_protocol.py
@@ -60,6 +60,7 @@ class AirPlayProtocol(ABC):
         self._connected = asyncio.Event()
         self._metadata_checksum = ""
         self._last_metadata_sent: float = 0.0
+        self._elapsed_time_offset: float | None = None
 
     @property
     def running(self) -> bool:

--- a/music_assistant/providers/airplay/protocols/airplay2.py
+++ b/music_assistant/providers/airplay/protocols/airplay2.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import PlaybackState
@@ -149,9 +150,11 @@ class AirPlay2Stream(AirPlayProtocol):
             elif "Restarted at" in line:
                 player.set_state_from_stream(state=PlaybackState.PLAYING, stream=self)
             elif "Starting at" in line:
-                # streaming has started
+                # streaming has started - derive elapsed time from the stream
+                # session start_time to handle dynamic leader switching correctly
+                elapsed_time = (time.time() - self.session.start_time) if self.session else 0
                 player.set_state_from_stream(
-                    state=PlaybackState.PLAYING, elapsed_time=0, stream=self
+                    state=PlaybackState.PLAYING, elapsed_time=elapsed_time, stream=self
                 )
             if "put delay detected" in line:
                 if "resetting all outputs" in line:

--- a/music_assistant/providers/airplay/protocols/airplay2.py
+++ b/music_assistant/providers/airplay/protocols/airplay2.py
@@ -154,7 +154,7 @@ class AirPlay2Stream(AirPlayProtocol):
                 # session start_time and this process start to handle dynamic
                 # leader switching where a new process starts mid-session.
                 if self._elapsed_time_offset is None and self.session:
-                    self._elapsed_time_offset = time.time() - self.session.start_time
+                    self._elapsed_time_offset = max(0, time.time() - self.session.start_time)
                 elapsed_time = self._elapsed_time_offset or 0
                 player.set_state_from_stream(
                     state=PlaybackState.PLAYING, elapsed_time=elapsed_time, stream=self

--- a/music_assistant/providers/airplay/protocols/airplay2.py
+++ b/music_assistant/providers/airplay/protocols/airplay2.py
@@ -150,9 +150,12 @@ class AirPlay2Stream(AirPlayProtocol):
             elif "Restarted at" in line:
                 player.set_state_from_stream(state=PlaybackState.PLAYING, stream=self)
             elif "Starting at" in line:
-                # streaming has started - derive elapsed time from the stream
-                # session start_time to handle dynamic leader switching correctly
-                elapsed_time = (time.time() - self.session.start_time) if self.session else 0
+                # streaming has started - compute a fixed offset between the
+                # session start_time and this process start to handle dynamic
+                # leader switching where a new process starts mid-session.
+                if self._elapsed_time_offset is None and self.session:
+                    self._elapsed_time_offset = time.time() - self.session.start_time
+                elapsed_time = self._elapsed_time_offset or 0
                 player.set_state_from_stream(
                     state=PlaybackState.PLAYING, elapsed_time=elapsed_time, stream=self
                 )

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -135,7 +135,9 @@ class RaopStream(AirPlayProtocol):
                 # this handles dynamic leader switching where a new cliraop process
                 # reports from 0 while the flow stream started much earlier.
                 if self._elapsed_time_offset is None and self.session:
-                    self._elapsed_time_offset = time.time() - self.session.start_time - elapsed_time
+                    self._elapsed_time_offset = max(
+                        0, time.time() - self.session.start_time - elapsed_time
+                    )
                 if self._elapsed_time_offset:
                     elapsed_time += self._elapsed_time_offset
                 player.set_state_from_stream(elapsed_time=elapsed_time, stream=self)

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -122,21 +122,22 @@ class RaopStream(AirPlayProtocol):
             elif "Restarted at" in line or "restarting w/ pause" in line:
                 player.set_state_from_stream(state=PlaybackState.PLAYING, stream=self)
             elif "restarting w/o pause" in line:
-                # streaming has started - derive elapsed time from the stream
-                # session start_time to handle dynamic leader switching correctly
-                elapsed_time = (time.time() - self.session.start_time) if self.session else 0
+                # streaming has started
                 player.set_state_from_stream(
-                    state=PlaybackState.PLAYING, elapsed_time=elapsed_time, stream=self
+                    state=PlaybackState.PLAYING, elapsed_time=0, stream=self
                 )
             elif "elapsed milliseconds:" in line:
-                # cliraop reports elapsed milliseconds from its own process start,
-                # but we need elapsed time relative to the stream session start
-                # to handle dynamic leader switching correctly.
-                if self.session:
-                    elapsed_time = time.time() - self.session.start_time
-                else:
-                    millis = int(line.split("elapsed milliseconds: ")[1])
-                    elapsed_time = millis / 1000
+                # this is received more or less every second while playing
+                millis = int(line.split("elapsed milliseconds: ")[1])
+                elapsed_time = millis / 1000
+                # on the first elapsed time report, compute a fixed offset between
+                # the session start_time and this cliraop process start.
+                # this handles dynamic leader switching where a new cliraop process
+                # reports from 0 while the flow stream started much earlier.
+                if self._elapsed_time_offset is None and self.session:
+                    self._elapsed_time_offset = time.time() - self.session.start_time - elapsed_time
+                if self._elapsed_time_offset:
+                    elapsed_time += self._elapsed_time_offset
                 player.set_state_from_stream(elapsed_time=elapsed_time)
             elif "Password required, but none supplied." in line:
                 logger.error(

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -138,7 +138,7 @@ class RaopStream(AirPlayProtocol):
                     self._elapsed_time_offset = time.time() - self.session.start_time - elapsed_time
                 if self._elapsed_time_offset:
                     elapsed_time += self._elapsed_time_offset
-                player.set_state_from_stream(elapsed_time=elapsed_time)
+                player.set_state_from_stream(elapsed_time=elapsed_time, stream=self)
             elif "Password required, but none supplied." in line:
                 logger.error(
                     f"Player {self.player.name} requires a password. "

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
+import time
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import PlaybackState
@@ -121,14 +122,21 @@ class RaopStream(AirPlayProtocol):
             elif "Restarted at" in line or "restarting w/ pause" in line:
                 player.set_state_from_stream(state=PlaybackState.PLAYING, stream=self)
             elif "restarting w/o pause" in line:
-                # streaming has started
+                # streaming has started - derive elapsed time from the stream
+                # session start_time to handle dynamic leader switching correctly
+                elapsed_time = (time.time() - self.session.start_time) if self.session else 0
                 player.set_state_from_stream(
-                    state=PlaybackState.PLAYING, elapsed_time=0, stream=self
+                    state=PlaybackState.PLAYING, elapsed_time=elapsed_time, stream=self
                 )
             elif "elapsed milliseconds:" in line:
-                # this is received more or less every second while playing
-                millis = int(line.split("elapsed milliseconds: ")[1])
-                elapsed_time = millis / 1000
+                # cliraop reports elapsed milliseconds from its own process start,
+                # but we need elapsed time relative to the stream session start
+                # to handle dynamic leader switching correctly.
+                if self.session:
+                    elapsed_time = time.time() - self.session.start_time
+                else:
+                    millis = int(line.split("elapsed milliseconds: ")[1])
+                    elapsed_time = millis / 1000
                 player.set_state_from_stream(elapsed_time=elapsed_time)
             elif "Password required, but none supplied." in line:
                 logger.error(


### PR DESCRIPTION
When a sync group dynamically switches its AirPlay leader (e.g. when removing a group member), the cliraop process is restarted for the new leader. The new process reports `elapsed milliseconds` starting from 0, while the flow stream and its play log continue from the original session start. This causes the queue to display a track from much earlier in the session instead of what's actually playing — the drift grows with each leader switch.

**Changes:**
- RAOP: derive elapsed_time from `session.start_time` instead of cliraop-reported milliseconds
- AirPlay2: derive elapsed_time from `session.start_time` on stream start instead of hardcoded 0
- Snapcast and Sendspin were verified to already handle dynamic leader switching correctly