### PR TITLE
Smart playlist plugin

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import asyncio
 import os
 import random
+import time
 import uuid as _uuid
 from collections.abc import Callable
 from contextlib import suppress
+from dataclasses import replace as dc_replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -195,12 +197,16 @@ class SmartPlaylistProvider(PluginProvider):
 
         Returns a full batch on page 0; empty list on subsequent pages.
         Because is_dynamic=True, MA always calls with force_refresh so results stay fresh.
+        For dynamic playlists a small buffer of 5 tracks is returned per call so that
+        dedup and shuffle stay effective across successive refreshes.
         """
         if page > 0:
             return []
         rules = self._rules_store.get(prov_playlist_id)
         if rules is None:
             return []
+        if rules.is_dynamic:
+            rules = dc_replace(rules, limit=5)
         return await self._evaluate_rules(rules)
 
     async def _on_media_item_deleted(self, event: MassEvent) -> None:
@@ -358,19 +364,17 @@ class SmartPlaylistProvider(PluginProvider):
             for playlist_id, rules in self._rules_store.items()
         ]
 
-    async def count_tracks(self, rules: dict[str, Any]) -> int:
-        """Return the number of tracks produced by the validated rules.
-
-        The count is based on the same evaluated result set used for playlist generation
-        and should be treated as approximate (limited by rules.limit and shuffling).
+    async def count_tracks(self, rules: dict[str, Any]) -> dict[str, Any]:
+        """Return the track count and approximate total duration for the given rules.
 
         :param rules: SmartPlaylistRules fields as dict.
-        :return: Number of matching tracks in the evaluated result set.
+        :return: Dict with ``count`` (int) and ``duration_seconds`` (int).
         """
         parsed_rules = SmartPlaylistRules.from_dict(rules)
         self._validate_rules(parsed_rules)
         tracks = await self._evaluate_rules(parsed_rules)
-        return len(tracks)
+        duration = sum(t.duration or 0 for t in tracks)
+        return {"count": len(tracks), "duration_seconds": duration}
 
     async def preview_tracks(
         self,
@@ -468,11 +472,24 @@ class SmartPlaylistProvider(PluginProvider):
         """Evaluate the rules and return a list of matching Track objects."""
         has_genre_filter = bool(rules.genre_ids)
 
-        if rules.seed_track_uri:
-            # Seed mode: the similar-tracks pool is the exclusive source.
-            # artist_ids and album_ids are ignored per design; genre, favorites,
-            # popularity and year are applied as post-filters on the pool.
-            tracks = await self._get_similar_tracks(rules.seed_track_uri, MAX_SIMILAR_TRACKS)
+        if rules.seed_track_uri or rules.seed_artist_uri:
+            # Seed mode: a similar-tracks/artists pool is the exclusive source.
+            # artist_ids and album_ids are ignored per design.
+            if rules.seed_track_uri:
+                tracks = await self._get_similar_tracks(rules.seed_track_uri, MAX_SIMILAR_TRACKS)
+            else:
+                tracks = await self._get_similar_artists_tracks(
+                    rules.seed_artist_uri,
+                    MAX_SIMILAR_TRACKS,  # type: ignore[arg-type]
+                    library_only=rules.seed_artist_library_only,
+                )
+            tracks = await self._apply_seed_post_filters(tracks, rules, has_genre_filter)
+        else:
+            if rules.logic == LOGIC_AND:
+                tracks = await self._evaluate_and(rules)
+            else:
+                tracks = await self._evaluate_or(rules)
+
             if rules.min_popularity is not None:
                 tracks = [
                     t
@@ -481,27 +498,7 @@ class SmartPlaylistProvider(PluginProvider):
                     and t.metadata.popularity is not None
                     and t.metadata.popularity >= rules.min_popularity
                 ]
-            if rules.favorites_only:
-                tracks = [t for t in tracks if t.favorite]
-            if has_genre_filter and rules.logic == LOGIC_AND:
-                # Best-effort: filter seed tracks by genre name.
-                # Resolve names from library for any IDs not already in genre_names.
-                # Tracks without genre metadata are kept (don't exclude for missing data).
-                genre_id_to_name = dict(rules.genre_names)
-                for genre_id in rules.genre_ids:
-                    if genre_id not in genre_id_to_name:
-                        with suppress(Exception):
-                            genre = await self.mass.music.genres.get_library_item(genre_id)
-                            genre_id_to_name[genre_id] = genre.name
-                allowed_genre_names = {v.lower() for v in genre_id_to_name.values()}
-                if allowed_genre_names:
-                    tracks = [
-                        t
-                        for t in tracks
-                        if not t.metadata
-                        or not t.metadata.genres
-                        or any(g.lower() in allowed_genre_names for g in t.metadata.genres)
-                    ]
+
             if rules.year_from is not None or rules.year_to is not None:
                 tracks = [
                     t
@@ -513,14 +510,40 @@ class SmartPlaylistProvider(PluginProvider):
                         and (rules.year_to is None or t.album.year <= rules.year_to)
                     )
                 ]
-            random.shuffle(tracks)
-            return tracks[: rules.limit]
 
-        if rules.logic == LOGIC_AND:
-            tracks = await self._evaluate_and(rules)
-        else:
-            tracks = await self._evaluate_or(rules)
+        # Apply exclusions and dedup regardless of source mode
+        tracks = self._apply_exclusions(tracks, rules)
+        if rules.dedup_hours is not None:
+            deduped = self._apply_dedup(tracks, rules.dedup_hours)
+            if len(deduped) >= rules.limit:
+                tracks = deduped
+            elif deduped:
+                # Pool partially exhausted: fill remainder with least-recently-played tracks
+                # so playback never stops when the dedup window covers most of the library.
+                deduped_uris = {t.uri for t in deduped}
+                played_remainder = sorted(
+                    (t for t in tracks if t.uri not in deduped_uris),
+                    key=lambda t: t.last_played,
+                )
+                tracks = deduped + played_remainder[: rules.limit - len(deduped)]
+            else:
+                # All matching tracks were played recently — ignore dedup entirely so
+                # the playlist never goes empty.
+                self.logger.debug(
+                    "dedup_hours=%d exhausted the full track pool; ignoring dedup",
+                    rules.dedup_hours,
+                )
 
+        random.shuffle(tracks)
+        return tracks[: rules.limit]
+
+    async def _apply_seed_post_filters(
+        self,
+        tracks: list[Track],
+        rules: SmartPlaylistRules,
+        has_genre_filter: bool,
+    ) -> list[Track]:
+        """Apply post-filters (popularity, favorites, genre, year) to a seed-derived track list."""
         if rules.min_popularity is not None:
             tracks = [
                 t
@@ -529,7 +552,26 @@ class SmartPlaylistProvider(PluginProvider):
                 and t.metadata.popularity is not None
                 and t.metadata.popularity >= rules.min_popularity
             ]
-
+        if rules.favorites_only:
+            tracks = [t for t in tracks if t.favorite]
+        if has_genre_filter and rules.logic == LOGIC_AND:
+            # Best-effort genre filter: resolve names then match against track genre metadata.
+            # Tracks without genre metadata are kept (don't exclude for missing data).
+            genre_id_to_name = dict(rules.genre_names)
+            for genre_id in rules.genre_ids:
+                if genre_id not in genre_id_to_name:
+                    with suppress(Exception):
+                        genre = await self.mass.music.genres.get_library_item(genre_id)
+                        genre_id_to_name[genre_id] = genre.name
+            allowed_genre_names = {v.lower() for v in genre_id_to_name.values()}
+            if allowed_genre_names:
+                tracks = [
+                    t
+                    for t in tracks
+                    if not t.metadata
+                    or not t.metadata.genres
+                    or any(g.lower() in allowed_genre_names for g in t.metadata.genres)
+                ]
         if rules.year_from is not None or rules.year_to is not None:
             tracks = [
                 t
@@ -541,9 +583,49 @@ class SmartPlaylistProvider(PluginProvider):
                     and (rules.year_to is None or t.album.year <= rules.year_to)
                 )
             ]
+        return tracks
 
-        random.shuffle(tracks)
-        return tracks[: rules.limit]
+    def _apply_exclusions(self, tracks: list[Track], rules: SmartPlaylistRules) -> list[Track]:
+        """Filter out tracks whose artist, album, or URI is in the exclusion lists."""
+        if (
+            not rules.excluded_artist_ids
+            and not rules.excluded_album_ids
+            and not rules.excluded_track_uris
+        ):
+            return tracks
+        excl_artists = set(rules.excluded_artist_ids)
+        excl_albums = set(rules.excluded_album_ids)
+        excl_uris = set(rules.excluded_track_uris)
+        result = []
+        for track in tracks:
+            if track.uri and track.uri in excl_uris:
+                continue
+            if excl_artists and {int(a.item_id) for a in track.artists if a.item_id} & excl_artists:
+                continue
+            if (
+                excl_albums
+                and track.album
+                and track.album.item_id
+                and int(track.album.item_id) in excl_albums
+            ):
+                continue
+            result.append(track)
+        return result
+
+    def _apply_dedup(self, tracks: list[Track], dedup_hours: int) -> list[Track]:
+        """Filter out tracks last played within dedup_hours hours."""
+        cutoff_ts = time.time() - dedup_hours * 3600
+        result = []
+        for track in tracks:
+            if track.last_played is None:
+                result.append(track)
+                continue
+            try:
+                if track.last_played.timestamp() < cutoff_ts:
+                    result.append(track)
+            except (OSError, OverflowError):
+                result.append(track)
+        return result
 
     async def _evaluate_and(self, rules: SmartPlaylistRules) -> list[Track]:
         """Evaluate rules with AND logic: track must match ALL active filters."""
@@ -657,6 +739,78 @@ class SmartPlaylistProvider(PluginProvider):
         except Exception as exc:
             self.logger.warning("Could not get similar tracks for %s: %s", seed_track_uri, exc)
             return []
+
+    async def _get_similar_artists_tracks(
+        self, seed_artist_uri: str, limit: int, library_only: bool = True
+    ) -> list[Track]:
+        """Get tracks for artists similar to the given seed artist URI."""
+        try:
+            _media_type, provider, item_id = await parse_uri(seed_artist_uri)
+        except Exception:
+            self.logger.warning("Cannot parse seed_artist_uri: %s", seed_artist_uri)
+            return []
+        try:
+            similar_artists = await self.mass.music.artists.similar_artists(
+                item_id=item_id,
+                provider_instance_id_or_domain=provider,
+                limit=20,
+            )
+        except Exception as exc:
+            self.logger.warning("Could not get similar artists for %s: %s", seed_artist_uri, exc)
+            return []
+
+        similar_names = {a.name.lower() for a in similar_artists}
+        if not similar_names:
+            return []
+
+        if library_only:
+            # Match against library tracks by artist name.
+            all_tracks = await self._get_library_tracks(limit=min(limit * 20, 2000))
+            result: dict[str, Track] = {}
+            for track in all_tracks:
+                for artist in track.artists:
+                    if artist.name.lower() in similar_names and track.uri:
+                        result[track.uri] = track
+                        break
+            return list(result.values())
+
+        # Provider mode: fetch top tracks for each similar artist directly from the provider.
+        result_provider: dict[str, Track] = {}
+        per_artist = max(1, limit // max(len(similar_artists), 1))
+        self.logger.debug(
+            "seed_artist provider mode: %d similar artists, per_artist=%d",
+            len(similar_artists),
+            per_artist,
+        )
+        for artist in similar_artists:
+            if len(result_provider) >= limit:
+                break
+            mapping = next(
+                (m for m in artist.provider_mappings if m.provider_instance == provider),
+                None,
+            ) or next(iter(artist.provider_mappings), None)
+            if not mapping:
+                self.logger.debug("No mapping found for artist %s", artist.name)
+                continue
+            try:
+                artist_tracks = await self.mass.music.artists.get_provider_artist_toptracks(
+                    item_id=mapping.item_id,
+                    provider_instance_id_or_domain=mapping.provider_instance,
+                )
+                self.logger.debug(
+                    "Artist %s (%s): %d top tracks",
+                    artist.name,
+                    mapping.item_id,
+                    len(artist_tracks),
+                )
+            except Exception as exc:
+                self.logger.debug("Error fetching tracks for artist %s: %s", artist.name, exc)
+                continue
+            for track in artist_tracks[:per_artist]:
+                if track.uri:
+                    result_provider[track.uri] = track
+        self.logger.debug("seed_artist provider mode: %d total tracks", len(result_provider))
+        return list(result_provider.values())
 
     async def _update_playlist_description(
         self, library_item_id: int | str, rules: SmartPlaylistRules

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -295,6 +295,9 @@ class SmartPlaylistProvider(PluginProvider):
         if tracks:
             uris = [t.uri for t in tracks if t.uri]
             if uris:
+                # Use the internal method directly: the public add_playlist_tracks() schedules
+                # a background task and returns immediately, but we need the tracks present
+                # before returning the final playlist to the caller.
                 await self.mass.music.playlists._handle_add_playlist_tracks(db_playlist_id, uris)
 
         final_playlist = await self.mass.music.playlists.get_library_item(db_playlist_id)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -378,6 +378,8 @@ class SmartPlaylistProvider(PluginProvider):
         """
         parsed_rules = SmartPlaylistRules.from_dict(rules)
         self._validate_rules(parsed_rules)
+        # Override limit so count reflects all matching tracks, not just the playback limit.
+        parsed_rules.limit = FETCH_LIMIT
         tracks = await self._evaluate_rules(parsed_rules)
         duration = sum(t.duration or 0 for t in tracks)
         return {"count": len(tracks), "duration_seconds": duration}
@@ -591,9 +593,6 @@ class SmartPlaylistProvider(PluginProvider):
                     and (rules.year_to is None or t.album.year <= rules.year_to)
                 )
             ]
-        if rules.excluded_genre_ids:
-            excluded_genre_names = await self._resolve_excluded_genre_names(rules)
-            tracks = self._apply_exclusions(tracks, rules, excluded_genre_names)
         return tracks
 
     def _apply_exclusions(
@@ -688,12 +687,18 @@ class SmartPlaylistProvider(PluginProvider):
             base_tracks = [
                 t
                 for t in base_tracks
-                if {int(a.item_id) for a in t.artists if a.item_id} & artist_id_set
+                if {int(a.item_id) for a in t.artists if a.item_id and str(a.item_id).isdigit()}
+                & artist_id_set
             ]
         if has_album:
             album_id_set = set(rules.album_ids)
             base_tracks = [
-                t for t in base_tracks if t.album and int(t.album.item_id) in album_id_set
+                t
+                for t in base_tracks
+                if t.album
+                and t.album.item_id
+                and str(t.album.item_id).isdigit()
+                and int(t.album.item_id) in album_id_set
             ]
         return base_tracks
 
@@ -720,13 +725,21 @@ class SmartPlaylistProvider(PluginProvider):
                 artist_id_set = set(rules.artist_ids)
                 for track in all_tracks:
                     if {
-                        int(a.item_id) for a in track.artists if a.item_id
+                        int(a.item_id)
+                        for a in track.artists
+                        if a.item_id and str(a.item_id).isdigit()
                     } & artist_id_set and track.uri:
                         track_sets[track.uri] = track
             if rules.album_ids:
                 album_id_set = set(rules.album_ids)
                 for track in all_tracks:
-                    if track.album and int(track.album.item_id) in album_id_set and track.uri:
+                    if (
+                        track.album
+                        and track.album.item_id
+                        and str(track.album.item_id).isdigit()
+                        and int(track.album.item_id) in album_id_set
+                        and track.uri
+                    ):
                         track_sets[track.uri] = track
 
         no_filters = (
@@ -734,7 +747,6 @@ class SmartPlaylistProvider(PluginProvider):
             and not rules.genre_ids
             and not rules.artist_ids
             and not rules.album_ids
-            and not rules.seed_track_uri
         )
         if no_filters:
             for track in await self._get_library_tracks(limit=fetch_limit):
@@ -775,7 +787,7 @@ class SmartPlaylistProvider(PluginProvider):
             return []
 
     async def _get_similar_artists_tracks(
-        self, seed_artist_uri: str, limit: int, library_only: bool = True
+        self, seed_artist_uri: str, limit: int, library_only: bool
     ) -> list[Track]:
         """Get tracks for artists similar to the given seed artist URI."""
         try:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -19,6 +19,7 @@ from music_assistant_models.enums import ImageType, MediaType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
     MediaItemImage,
+    MediaItemType,
     Playlist,
     ProviderMapping,
     Track,
@@ -192,6 +193,18 @@ class SmartPlaylistProvider(MusicProvider):
             self._names_store.pop(prov_item_id, None)
             await self._flush_rules_to_disk()
         return True
+
+    async def on_item_updated(self, item: MediaItemType) -> None:
+        """Sync library playlist name changes back to the in-memory/disk store."""
+        if not isinstance(item, Playlist):
+            return
+        for mapping in item.provider_mappings:
+            if mapping.provider_instance == self.instance_id:
+                prov_id = mapping.item_id
+                if prov_id in self._names_store and self._names_store[prov_id] != item.name:
+                    self._names_store[prov_id] = item.name
+                    await self._flush_rules_to_disk()
+                break
 
     # --- API commands ---
 

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -377,16 +377,6 @@ class SmartPlaylistProvider(MusicProvider):
                 and t.metadata.popularity >= rules.min_popularity
             ]
 
-        if rules.year_from is not None or rules.year_to is not None:
-            tracks = [
-                t
-                for t in tracks
-                if t.album is not None
-                and t.album.year is not None
-                and (rules.year_from is None or t.album.year >= rules.year_from)
-                and (rules.year_to is None or t.album.year <= rules.year_to)
-            ]
-
         if (
             has_seed_filter
             and not has_artist_filter
@@ -405,12 +395,32 @@ class SmartPlaylistProvider(MusicProvider):
             if rules.favorites_only:
                 seed_tracks = [t for t in seed_tracks if t.favorite]
             if has_genre_filter and rules.logic == LOGIC_AND:
-                seed_tracks = list(seed_tracks)
+                # Best-effort: filter seed tracks by genre name if the track has genre metadata.
+                # If a track has no genre metadata, keep it (don't exclude due to missing data).
+                allowed_genre_names = {g.lower() for g in rules.genre_names.values()}
+                seed_tracks = [
+                    t
+                    for t in seed_tracks
+                    if not t.metadata.genres
+                    or any(g.lower() in allowed_genre_names for g in t.metadata.genres)
+                ]
             existing_uris = {t.uri for t in tracks}
             for st in seed_tracks:
                 if st.uri not in existing_uris:
                     tracks.append(st)
                     existing_uris.add(st.uri)
+
+        if rules.year_from is not None or rules.year_to is not None:
+            tracks = [
+                t
+                for t in tracks
+                if t.album is None
+                or t.album.year is None
+                or (
+                    (rules.year_from is None or t.album.year >= rules.year_from)
+                    and (rules.year_to is None or t.album.year <= rules.year_to)
+                )
+            ]
 
         random.shuffle(tracks)
         return tracks[: rules.limit]
@@ -423,10 +433,12 @@ class SmartPlaylistProvider(MusicProvider):
         has_seed = bool(rules.seed_track_uri)
 
         no_structural_filter = not has_genre and not has_artist and not has_album
-        if has_seed and no_structural_filter and not rules.favorites_only:
-            return await self._get_library_tracks(
-                favorite=None, genre_ids=None, limit=rules.limit * 3
-            )
+
+        # When seed is active without genre/artist/album, the similar-tracks pool is the
+        # primary result. Returning library tracks here would pollute it with unrelated content.
+        if has_seed and not has_genre and not has_artist and not has_album:
+            return []
+
         if no_structural_filter and not rules.favorites_only and not has_seed:
             return await self._get_library_tracks(
                 favorite=None, genre_ids=None, limit=rules.limit * 3
@@ -521,7 +533,7 @@ class SmartPlaylistProvider(MusicProvider):
     async def _get_similar_tracks(self, seed_track_uri: str, limit: int) -> list[Track]:
         """Get similar tracks for the given seed track URI."""
         try:
-            _media_type, item_id, provider = await parse_uri(seed_track_uri)
+            _media_type, provider, item_id = await parse_uri(seed_track_uri)
         except Exception:
             self.logger.warning("Cannot parse seed_track_uri: %s", seed_track_uri)
             return []

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -125,10 +125,10 @@ class SmartPlaylistProvider(PluginProvider):
         )
         # Subscribe to library events to handle playlist deletion and renaming.
         self._unregister_handles.append(
-            self.mass.subscribe(self._on_media_item_deleted, EventType.media_item_deleted)
+            self.mass.subscribe(self._on_media_item_deleted, EventType.MEDIA_ITEM_DELETED)
         )
         self._unregister_handles.append(
-            self.mass.subscribe(self._on_media_item_updated, EventType.media_item_updated)
+            self.mass.subscribe(self._on_media_item_updated, EventType.MEDIA_ITEM_UPDATED)
         )
         self.logger.info(
             "Smart Playlist provider loaded with %d stored playlists", len(self._rules_store)
@@ -175,6 +175,8 @@ class SmartPlaylistProvider(PluginProvider):
             return []
         return [
             RecommendationFolder(
+                item_id="smart_playlists",
+                provider=self.domain,
                 name="Smart Playlists",
                 items=playlists,  # type: ignore[arg-type]
             )

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -93,6 +93,7 @@ class SmartPlaylistProvider(MusicProvider):
         )
         self.mass.register_api_command("smart_playlists/list", self.list_smart_playlists)
         self.mass.register_api_command("smart_playlists/preview_tracks", self.preview_tracks)
+        self.mass.register_api_command("smart_playlists/count_tracks", self.count_tracks)
         self.logger.info(
             "Smart Playlist provider loaded with %d stored playlists", len(self._rules_store)
         )
@@ -174,7 +175,9 @@ class SmartPlaylistProvider(MusicProvider):
         await self._save_rules(playlist_id, parsed_rules)
 
         playlist = self._build_playlist(playlist_id, parsed_rules)
-        return await self.mass.music.playlists.add_item_to_library(playlist)
+        library_playlist = await self.mass.music.playlists.add_item_to_library(playlist)
+        self.mass.metadata.schedule_update_metadata(library_playlist)
+        return library_playlist
 
     async def generate_playlist(
         self,
@@ -268,12 +271,24 @@ class SmartPlaylistProvider(MusicProvider):
             for playlist_id, rules in self._rules_store.items()
         ]
 
+    async def count_tracks(self, rules: dict[str, Any]) -> int:
+        """Return the total number of tracks matching the given rules.
+
+        :param rules: SmartPlaylistRules fields as dict.
+        :return: Number of matching tracks.
+        """
+        parsed_rules = SmartPlaylistRules.from_dict(rules)
+        self._validate_rules(parsed_rules)
+        parsed_rules.limit = 99999
+        tracks = await self._evaluate_rules(parsed_rules)
+        return len(tracks)
+
     async def preview_tracks(
         self,
         rules: dict[str, Any],
         limit: int = 20,
     ) -> list[dict[str, Any]]:
-        """Preview which tracks would be selected by the given rules.
+        """Return a preview of tracks matching the given rules.
 
         :param rules: SmartPlaylistRules fields as dict.
         :param limit: Maximum number of preview tracks to return.
@@ -320,7 +335,7 @@ class SmartPlaylistProvider(MusicProvider):
             item_id=playlist_id,
             provider=self.instance_id,
             name=name,
-            owner="smart_playlist",
+            owner="Smart Playlist",
             is_editable=True,
             provider_mappings={
                 ProviderMapping(
@@ -328,6 +343,7 @@ class SmartPlaylistProvider(MusicProvider):
                     provider_domain=self.domain,
                     provider_instance=self.instance_id,
                     is_unique=True,
+                    in_library=True,
                 )
             },
         )
@@ -517,7 +533,9 @@ class SmartPlaylistProvider(MusicProvider):
             playlist = await self.mass.music.playlists.get_library_item(library_item_id)
             updated = Playlist.from_dict(playlist.to_dict())
             updated.metadata.description = f"[Smart Playlist] {rules.human_readable()}"
-            await self.mass.music.playlists.update_item_in_library(library_item_id, updated)
+            await self.mass.music.playlists.update_item_in_library(
+                library_item_id, updated, overwrite=True
+            )
         except Exception as exc:
             self.logger.debug("Could not update description for %s: %s", library_item_id, exc)
 

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -2,6 +2,10 @@
 
 Allows creating rule-based playlists (dynamic or fixed) from library tracks,
 filtered by genres, artists, albums, favorites, popularity and similar tracks.
+
+# TODO (future PR): refactor this file into a package (e.g. __init__.py + evaluator.py +
+# filters.py) — it is growing large and the evaluation / filter logic would benefit from
+# being split into separate modules.
 """
 
 from __future__ import annotations
@@ -515,7 +519,8 @@ class SmartPlaylistProvider(PluginProvider):
                 ]
 
         # Apply exclusions and dedup regardless of source mode
-        tracks = self._apply_exclusions(tracks, rules)
+        excluded_genre_names = await self._resolve_excluded_genre_names(rules)
+        tracks = self._apply_exclusions(tracks, rules, excluded_genre_names)
         if rules.dedup_hours is not None:
             deduped = self._apply_dedup(tracks, rules.dedup_hours)
             if len(deduped) >= rules.limit:
@@ -586,14 +591,23 @@ class SmartPlaylistProvider(PluginProvider):
                     and (rules.year_to is None or t.album.year <= rules.year_to)
                 )
             ]
+        if rules.excluded_genre_ids:
+            excluded_genre_names = await self._resolve_excluded_genre_names(rules)
+            tracks = self._apply_exclusions(tracks, rules, excluded_genre_names)
         return tracks
 
-    def _apply_exclusions(self, tracks: list[Track], rules: SmartPlaylistRules) -> list[Track]:
-        """Filter out tracks whose artist, album, or URI is in the exclusion lists."""
+    def _apply_exclusions(
+        self,
+        tracks: list[Track],
+        rules: SmartPlaylistRules,
+        excluded_genre_names: set[str] | None = None,
+    ) -> list[Track]:
+        """Filter out tracks whose artist, album, URI, or genre is in the exclusion lists."""
         if (
             not rules.excluded_artist_ids
             and not rules.excluded_album_ids
             and not rules.excluded_track_uris
+            and not excluded_genre_names
         ):
             return tracks
         excl_artists = set(rules.excluded_artist_ids)
@@ -619,8 +633,27 @@ class SmartPlaylistProvider(PluginProvider):
                 and int(track.album.item_id) in excl_albums
             ):
                 continue
+            if (
+                excluded_genre_names
+                and track.metadata
+                and track.metadata.genres
+                and any(g.lower() in excluded_genre_names for g in track.metadata.genres)
+            ):
+                continue
             result.append(track)
         return result
+
+    async def _resolve_excluded_genre_names(self, rules: SmartPlaylistRules) -> set[str]:
+        """Resolve excluded_genre_ids to a lowercase name set for matching."""
+        if not rules.excluded_genre_ids:
+            return set()
+        genre_id_to_name = dict(rules.excluded_genre_names)
+        for genre_id in rules.excluded_genre_ids:
+            if genre_id not in genre_id_to_name:
+                with suppress(Exception):
+                    genre = await self.mass.music.genres.get_library_item(genre_id)
+                    genre_id_to_name[genre_id] = genre.name
+        return {v.lower() for v in genre_id_to_name.values() if v}
 
     def _apply_dedup(self, tracks: list[Track], dedup_hours: int) -> list[Track]:
         """Filter out tracks last played within dedup_hours hours."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -478,9 +478,10 @@ class SmartPlaylistProvider(PluginProvider):
             if rules.seed_track_uri:
                 tracks = await self._get_similar_tracks(rules.seed_track_uri, MAX_SIMILAR_TRACKS)
             else:
+                assert rules.seed_artist_uri is not None  # guaranteed by outer condition
                 tracks = await self._get_similar_artists_tracks(
                     rules.seed_artist_uri,
-                    MAX_SIMILAR_TRACKS,  # type: ignore[arg-type]
+                    MAX_SIMILAR_TRACKS,
                     library_only=rules.seed_artist_library_only,
                 )
             tracks = await self._apply_seed_post_filters(tracks, rules, has_genre_filter)
@@ -600,11 +601,13 @@ class SmartPlaylistProvider(PluginProvider):
         for track in tracks:
             if track.uri and track.uri in excl_uris:
                 continue
-            if excl_artists and {
-                int(a.item_id)
-                for a in track.artists
-                if a.item_id and str(a.item_id).isdigit()
-            } & excl_artists:
+            if (
+                excl_artists
+                and {
+                    int(a.item_id) for a in track.artists if a.item_id and str(a.item_id).isdigit()
+                }
+                & excl_artists
+            ):
                 continue
             if (
                 excl_albums
@@ -620,17 +623,8 @@ class SmartPlaylistProvider(PluginProvider):
     def _apply_dedup(self, tracks: list[Track], dedup_hours: int) -> list[Track]:
         """Filter out tracks last played within dedup_hours hours."""
         cutoff_ts = time.time() - dedup_hours * 3600
-        result = []
-        for track in tracks:
-            if track.last_played is None:
-                result.append(track)
-                continue
-            try:
-                if track.last_played.timestamp() < cutoff_ts:
-                    result.append(track)
-            except (OSError, OverflowError):
-                result.append(track)
-        return result
+        # last_played is a Unix timestamp (int); 0 means never played.
+        return [t for t in tracks if t.last_played == 0 or t.last_played < cutoff_ts]
 
     async def _evaluate_and(self, rules: SmartPlaylistRules) -> list[Track]:
         """Evaluate rules with AND logic: track must match ALL active filters."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -600,12 +600,17 @@ class SmartPlaylistProvider(PluginProvider):
         for track in tracks:
             if track.uri and track.uri in excl_uris:
                 continue
-            if excl_artists and {int(a.item_id) for a in track.artists if a.item_id} & excl_artists:
+            if excl_artists and {
+                int(a.item_id)
+                for a in track.artists
+                if a.item_id and str(a.item_id).isdigit()
+            } & excl_artists:
                 continue
             if (
                 excl_albums
                 and track.album
                 and track.album.item_id
+                and str(track.album.item_id).isdigit()
                 and int(track.album.item_id) in excl_albums
             ):
                 continue
@@ -786,7 +791,11 @@ class SmartPlaylistProvider(PluginProvider):
             if len(result_provider) >= limit:
                 break
             mapping = next(
-                (m for m in artist.provider_mappings if m.provider_instance == provider),
+                (
+                    m
+                    for m in artist.provider_mappings
+                    if provider in {m.provider_instance, m.provider_domain}
+                ),
                 None,
             ) or next(iter(artist.provider_mappings), None)
             if not mapping:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -377,6 +377,16 @@ class SmartPlaylistProvider(MusicProvider):
                 and t.metadata.popularity >= rules.min_popularity
             ]
 
+        if rules.year_from is not None or rules.year_to is not None:
+            tracks = [
+                t
+                for t in tracks
+                if t.album is not None
+                and t.album.year is not None
+                and (rules.year_from is None or t.album.year >= rules.year_from)
+                and (rules.year_to is None or t.album.year <= rules.year_to)
+            ]
+
         if (
             has_seed_filter
             and not has_artist_filter

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1,4 +1,4 @@
-"""Smart Playlist Music Provider for Music Assistant.
+"""Smart Playlist Plugin Provider for Music Assistant.
 
 Allows creating rule-based playlists (dynamic or fixed) from library tracks,
 filtered by genres, artists, albums, favorites, popularity and similar tracks.
@@ -10,18 +10,21 @@ import asyncio
 import os
 import random
 import uuid as _uuid
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.enums import ImageType, MediaType, ProviderFeature
+from music_assistant_models.enums import EventType, ImageType, MediaType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
+    BrowseFolder,
+    ItemMapping,
     MediaItemImage,
     MediaItemType,
     Playlist,
     ProviderMapping,
+    RecommendationFolder,
     Track,
     UniqueList,
 )
@@ -29,7 +32,7 @@ from music_assistant_models.media_items.metadata import MediaItemMetadata
 
 from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.uri import parse_uri
-from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.smart_playlist.helpers import (
     LOGIC_AND,
     MAX_SIMILAR_TRACKS,
@@ -41,15 +44,18 @@ from music_assistant.providers.smart_playlist.helpers import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+    from music_assistant_models.event import MassEvent
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
     from music_assistant.models import ProviderInstanceType
 
 SUPPORTED_FEATURES: set[ProviderFeature] = {
-    ProviderFeature.LIBRARY_PLAYLISTS,
-    ProviderFeature.LIBRARY_PLAYLISTS_EDIT,
+    ProviderFeature.BROWSE,
+    ProviderFeature.RECOMMENDATIONS,
 }
 
 
@@ -70,19 +76,14 @@ async def get_config_entries(
     return ()
 
 
-class SmartPlaylistProvider(MusicProvider):
-    """Smart Playlist music provider for Music Assistant."""
+class SmartPlaylistProvider(PluginProvider):
+    """Smart Playlist plugin provider for Music Assistant."""
 
     _rules_dir: str
     _rules_store: dict[str, SmartPlaylistRules]
     _names_store: dict[str, str]
     _unregister_handles: list[Callable[[], None]]
     _flush_lock: asyncio.Lock
-
-    @property
-    def is_streaming_provider(self) -> bool:
-        """Return False: library and catalog are identical (local rules)."""
-        return False
 
     async def handle_async_init(self) -> None:
         """Handle async initialization."""
@@ -122,6 +123,13 @@ class SmartPlaylistProvider(MusicProvider):
         self._unregister_handles.append(
             self.mass.register_api_command("smart_playlists/count_tracks", self.count_tracks)
         )
+        # Subscribe to library events to handle playlist deletion and renaming.
+        self._unregister_handles.append(
+            self.mass.subscribe(self._on_media_item_deleted, EventType.media_item_deleted)
+        )
+        self._unregister_handles.append(
+            self.mass.subscribe(self._on_media_item_updated, EventType.media_item_updated)
+        )
         self.logger.info(
             "Smart Playlist provider loaded with %d stored playlists", len(self._rules_store)
         )
@@ -154,12 +162,23 @@ class SmartPlaylistProvider(MusicProvider):
                 filepath = os.path.join(self._rules_dir, filename)
                 await asyncio.to_thread(os.remove, filepath)
 
-    # --- MusicProvider interface ---
+    # --- PluginProvider interface ---
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
-        """Yield all smart playlists."""
-        for playlist_id, rules in self._rules_store.items():
-            yield self._build_playlist(playlist_id, rules)
+    async def browse(self, path: str) -> Sequence[MediaItemType | ItemMapping | BrowseFolder]:
+        """Browse smart playlists."""
+        return [self._build_playlist(pid, rules) for pid, rules in self._rules_store.items()]
+
+    async def recommendations(self) -> list[RecommendationFolder]:
+        """Return smart playlists as a recommendation folder."""
+        playlists = [self._build_playlist(pid, r) for pid, r in self._rules_store.items()]
+        if not playlists:
+            return []
+        return [
+            RecommendationFolder(
+                name="Smart Playlists",
+                items=playlists,  # type: ignore[arg-type]
+            )
+        ]
 
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
         """Get playlist details by provider id."""
@@ -182,20 +201,22 @@ class SmartPlaylistProvider(MusicProvider):
             return []
         return await self._evaluate_rules(rules)
 
-    async def library_add(self, item: Playlist) -> bool:  # type: ignore[override]
-        """Mark the playlist as added to the library (no-op)."""
-        return True
+    async def _on_media_item_deleted(self, event: MassEvent) -> None:
+        """Remove the rules for a deleted smart playlist."""
+        item = event.data
+        if not isinstance(item, Playlist):
+            return
+        for mapping in item.provider_mappings:
+            if mapping.provider_instance == self.instance_id:
+                prov_id = mapping.item_id
+                self._rules_store.pop(prov_id, None)
+                self._names_store.pop(prov_id, None)
+                await self._flush_rules_to_disk()
+                break
 
-    async def library_remove(self, prov_item_id: str, media_type: MediaType) -> bool:
-        """Remove a smart playlist."""
-        if prov_item_id in self._rules_store:
-            del self._rules_store[prov_item_id]
-            self._names_store.pop(prov_item_id, None)
-            await self._flush_rules_to_disk()
-        return True
-
-    async def on_item_updated(self, item: MediaItemType) -> None:
+    async def _on_media_item_updated(self, event: MassEvent) -> None:
         """Sync library playlist name changes back to the in-memory/disk store."""
+        item = event.data
         if not isinstance(item, Playlist):
             return
         for mapping in item.provider_mappings:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
     from music_assistant.models import ProviderInstanceType
 
+FETCH_LIMIT = 2000
+
 SUPPORTED_FEATURES: set[ProviderFeature] = {
     ProviderFeature.BROWSE,
     ProviderFeature.RECOMMENDATIONS,
@@ -665,7 +667,7 @@ class SmartPlaylistProvider(PluginProvider):
     async def _evaluate_or(self, rules: SmartPlaylistRules) -> list[Track]:
         """Evaluate rules with OR logic: track must match ANY active filter."""
         track_sets: dict[str, Track] = {}
-        fetch_limit = min(rules.limit * 5, 2000)
+        fetch_limit = min(rules.limit * 5, FETCH_LIMIT)
 
         if rules.favorites_only:
             for track in await self._get_library_tracks(favorite=True, limit=fetch_limit):
@@ -680,7 +682,7 @@ class SmartPlaylistProvider(PluginProvider):
                     track_sets[track.uri] = track
 
         if rules.artist_ids or rules.album_ids:
-            all_tracks = await self._get_library_tracks(limit=fetch_limit * 2)
+            all_tracks = await self._get_library_tracks(limit=min(fetch_limit * 2, FETCH_LIMIT))
             if rules.artist_ids:
                 artist_id_set = set(rules.artist_ids)
                 for track in all_tracks:
@@ -837,14 +839,8 @@ class SmartPlaylistProvider(PluginProvider):
         try:
             data = await read_json(rules_file)
             for playlist_id, entry in data.items():
-                if isinstance(entry, dict) and "rules" in entry:
-                    # New format: {"name": "...", "rules": {...}}
-                    self._rules_store[playlist_id] = SmartPlaylistRules.from_dict(entry["rules"])
-                    self._names_store[playlist_id] = entry.get("name", playlist_id)
-                else:
-                    # Legacy format: entry is the rules dict directly
-                    self._rules_store[playlist_id] = SmartPlaylistRules.from_dict(entry)
-                    self._names_store[playlist_id] = playlist_id
+                self._rules_store[playlist_id] = SmartPlaylistRules.from_dict(entry["rules"])
+                self._names_store[playlist_id] = entry.get("name", playlist_id)
         except Exception as exc:
             self.logger.warning("Failed to load smart playlist rules: %s", exc)
 

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -13,9 +13,15 @@ import uuid as _uuid
 from collections.abc import AsyncGenerator, Sequence
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.enums import ImageType, MediaType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
-from music_assistant_models.media_items import Playlist, ProviderMapping, Track
+from music_assistant_models.media_items import (
+    MediaItemImage,
+    Playlist,
+    ProviderMapping,
+    Track,
+    UniqueList,
+)
 from music_assistant_models.media_items.metadata import MediaItemMetadata
 
 from music_assistant.constants import PlaylistPlayableItem
@@ -349,9 +355,27 @@ class SmartPlaylistProvider(MusicProvider):
         )
         playlist.is_dynamic = rules.is_dynamic
         playlist.metadata = MediaItemMetadata(
-            description=f"[Smart Playlist] {rules.human_readable()}"
+            description=f"[Smart Playlist] {rules.human_readable()}",
+            images=UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path="icon.svg",
+                        provider=self.instance_id,
+                        remotely_accessible=False,
+                    )
+                ]
+            ),
         )
         return playlist
+
+    async def resolve_image(self, path: str) -> str | bytes:
+        """Return the smart playlist provider icon as fallback image."""
+        if path == "icon.svg":
+            icon_path = os.path.join(os.path.dirname(__file__), "icon.svg")
+            async with asyncio.timeout(5):
+                return await asyncio.to_thread(lambda: open(icon_path, "rb").read())
+        return path
 
     def _validate_rules(self, rules: SmartPlaylistRules) -> None:
         """Delegate to module-level validate_rules helper."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -10,7 +10,7 @@ import asyncio
 import os
 import random
 import uuid as _uuid
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -25,7 +25,6 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.media_items.metadata import MediaItemMetadata
 
-from music_assistant.constants import PlaylistPlayableItem
 from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.music_provider import MusicProvider
@@ -108,6 +107,17 @@ class SmartPlaylistProvider(MusicProvider):
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
         if is_removed:
+            # Smart playlists only exist as long as this provider is installed.
+            # When the provider is removed, the playlists must be explicitly removed
+            # from the MA library — otherwise orphaned entries remain, because MA
+            # has no other mechanism to clean up provider-owned playlists on removal.
+            for playlist_id in list(self._rules_store):
+                try:
+                    await self.mass.music.remove_item_from_library(MediaType.PLAYLIST, playlist_id)
+                except Exception as exc:
+                    self.logger.debug(
+                        "Could not remove playlist %s from library: %s", playlist_id, exc
+                    )
             for filename in await asyncio.to_thread(os.listdir, self._rules_dir):
                 filepath = os.path.join(self._rules_dir, filename)
                 await asyncio.to_thread(os.remove, filepath)
@@ -127,9 +137,7 @@ class SmartPlaylistProvider(MusicProvider):
             raise MediaNotFoundError(msg)
         return self._build_playlist(prov_playlist_id, rules)
 
-    async def get_playlist_tracks(
-        self, prov_playlist_id: str, page: int = 0
-    ) -> Sequence[PlaylistPlayableItem]:
+    async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """Evaluate rules and return fresh tracks.
 
         Returns a full batch on page 0; empty list on subsequent pages.
@@ -496,7 +504,7 @@ class SmartPlaylistProvider(MusicProvider):
     async def _evaluate_or(self, rules: SmartPlaylistRules) -> list[Track]:
         """Evaluate rules with OR logic: track must match ANY active filter."""
         track_sets: dict[str, Track] = {}
-        fetch_limit = rules.limit * 5
+        fetch_limit = min(rules.limit * 5, 2000)
 
         if rules.favorites_only:
             for track in await self._get_library_tracks(favorite=True, limit=fetch_limit):
@@ -518,11 +526,7 @@ class SmartPlaylistProvider(MusicProvider):
                     track_sets[track.uri] = track
 
         if rules.album_ids:
-            all_tracks = (
-                await self._get_library_tracks(limit=fetch_limit * 2)
-                if not rules.artist_ids
-                else list(track_sets.values())
-            )
+            all_tracks = await self._get_library_tracks(limit=fetch_limit * 2)
             album_id_set = set(rules.album_ids)
             for track in all_tracks:
                 if track.album and int(track.album.item_id) in album_id_set and track.uri:
@@ -593,7 +597,7 @@ class SmartPlaylistProvider(MusicProvider):
         if not await asyncio.to_thread(os.path.isfile, rules_file):
             return
         try:
-            data = await asyncio.to_thread(read_json, rules_file)
+            data = await read_json(rules_file)
             for playlist_id, entry in data.items():
                 if isinstance(entry, dict) and "rules" in entry:
                     # New format: {"name": "...", "rules": {...}}
@@ -618,4 +622,4 @@ class SmartPlaylistProvider(MusicProvider):
             pid: {"name": self._names_store.get(pid, pid), "rules": r.to_dict()}
             for pid, r in self._rules_store.items()
         }
-        await asyncio.to_thread(write_json, rules_file, data)
+        await write_json(rules_file, data)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -10,7 +10,8 @@ import asyncio
 import os
 import random
 import uuid as _uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -74,6 +75,8 @@ class SmartPlaylistProvider(MusicProvider):
     _rules_dir: str
     _rules_store: dict[str, SmartPlaylistRules]
     _names_store: dict[str, str]
+    _unregister_handles: list[Callable[[], None]]
+    _flush_lock: asyncio.Lock
 
     @property
     def is_streaming_provider(self) -> bool:
@@ -84,6 +87,8 @@ class SmartPlaylistProvider(MusicProvider):
         """Handle async initialization."""
         self._rules_store = {}
         self._names_store = {}
+        self._unregister_handles = []
+        self._flush_lock = asyncio.Lock()
         self._rules_dir = os.path.join(self.mass.storage_path, "smart_playlists")
         if not await asyncio.to_thread(os.path.exists, self._rules_dir):
             await asyncio.to_thread(os.makedirs, self._rules_dir, exist_ok=True)
@@ -91,21 +96,40 @@ class SmartPlaylistProvider(MusicProvider):
 
     async def loaded_in_mass(self) -> None:
         """Register API commands after the provider is loaded."""
-        self.mass.register_api_command("smart_playlists/create", self.create_smart_playlist)
-        self.mass.register_api_command("smart_playlists/generate", self.generate_playlist)
-        self.mass.register_api_command("smart_playlists/get_rules", self.get_smart_playlist_rules)
-        self.mass.register_api_command(
-            "smart_playlists/update_rules", self.update_smart_playlist_rules
+        self._unregister_handles.append(
+            self.mass.register_api_command("smart_playlists/create", self.create_smart_playlist)
         )
-        self.mass.register_api_command("smart_playlists/list", self.list_smart_playlists)
-        self.mass.register_api_command("smart_playlists/preview_tracks", self.preview_tracks)
-        self.mass.register_api_command("smart_playlists/count_tracks", self.count_tracks)
+        self._unregister_handles.append(
+            self.mass.register_api_command("smart_playlists/generate", self.generate_playlist)
+        )
+        self._unregister_handles.append(
+            self.mass.register_api_command(
+                "smart_playlists/get_rules", self.get_smart_playlist_rules
+            )
+        )
+        self._unregister_handles.append(
+            self.mass.register_api_command(
+                "smart_playlists/update_rules", self.update_smart_playlist_rules
+            )
+        )
+        self._unregister_handles.append(
+            self.mass.register_api_command("smart_playlists/list", self.list_smart_playlists)
+        )
+        self._unregister_handles.append(
+            self.mass.register_api_command("smart_playlists/preview_tracks", self.preview_tracks)
+        )
+        self._unregister_handles.append(
+            self.mass.register_api_command("smart_playlists/count_tracks", self.count_tracks)
+        )
         self.logger.info(
             "Smart Playlist provider loaded with %d stored playlists", len(self._rules_store)
         )
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
+        for unregister in self._unregister_handles:
+            unregister()
+        self._unregister_handles.clear()
         if is_removed:
             # Smart playlists only exist as long as this provider is installed.
             # When the provider is removed, the playlists must be explicitly removed
@@ -221,7 +245,10 @@ class SmartPlaylistProvider(MusicProvider):
         parsed_rules = SmartPlaylistRules.from_dict(rules)
         self._validate_rules(parsed_rules)
 
-        if count is not None and count > 0:
+        if count is not None:
+            if not 1 <= count <= 2000:
+                msg = "Playlist count must be between 1 and 2000"
+                raise InvalidDataError(msg)
             parsed_rules.limit = count
 
         tracks = await self._evaluate_rules(parsed_rules)
@@ -232,7 +259,7 @@ class SmartPlaylistProvider(MusicProvider):
         if tracks:
             uris = [t.uri for t in tracks if t.uri]
             if uris:
-                await self.mass.music.playlists.add_playlist_tracks(db_playlist_id, uris)
+                await self.mass.music.playlists._handle_add_playlist_tracks(db_playlist_id, uris)
 
         final_playlist = await self.mass.music.playlists.get_library_item(db_playlist_id)
         # Schedule an immediate metadata refresh to build the collage image and detect genres
@@ -419,8 +446,15 @@ class SmartPlaylistProvider(MusicProvider):
                 tracks = [t for t in tracks if t.favorite]
             if has_genre_filter and rules.logic == LOGIC_AND:
                 # Best-effort: filter seed tracks by genre name.
+                # Resolve names from library for any IDs not already in genre_names.
                 # Tracks without genre metadata are kept (don't exclude for missing data).
-                allowed_genre_names = {g.lower() for g in rules.genre_names.values()}
+                genre_id_to_name = dict(rules.genre_names)
+                for genre_id in rules.genre_ids:
+                    if genre_id not in genre_id_to_name:
+                        with suppress(Exception):
+                            genre = await self.mass.music.genres.get_library_item(genre_id)
+                            genre_id_to_name[genre_id] = genre.name
+                allowed_genre_names = {v.lower() for v in genre_id_to_name.values()}
                 if allowed_genre_names:
                     tracks = [
                         t
@@ -518,26 +552,27 @@ class SmartPlaylistProvider(MusicProvider):
                 if track.uri:
                     track_sets[track.uri] = track
 
-        for genre_id in rules.genre_ids:
-            for track in await self._get_library_tracks(genre_ids=[genre_id], limit=fetch_limit):
+        if rules.genre_ids:
+            for track in await self._get_library_tracks(
+                genre_ids=rules.genre_ids, limit=fetch_limit
+            ):
                 if track.uri:
                     track_sets[track.uri] = track
 
-        if rules.artist_ids:
+        if rules.artist_ids or rules.album_ids:
             all_tracks = await self._get_library_tracks(limit=fetch_limit * 2)
-            artist_id_set = set(rules.artist_ids)
-            for track in all_tracks:
-                if {
-                    int(a.item_id) for a in track.artists if a.item_id
-                } & artist_id_set and track.uri:
-                    track_sets[track.uri] = track
-
-        if rules.album_ids:
-            all_tracks = await self._get_library_tracks(limit=fetch_limit * 2)
-            album_id_set = set(rules.album_ids)
-            for track in all_tracks:
-                if track.album and int(track.album.item_id) in album_id_set and track.uri:
-                    track_sets[track.uri] = track
+            if rules.artist_ids:
+                artist_id_set = set(rules.artist_ids)
+                for track in all_tracks:
+                    if {
+                        int(a.item_id) for a in track.artists if a.item_id
+                    } & artist_id_set and track.uri:
+                        track_sets[track.uri] = track
+            if rules.album_ids:
+                album_id_set = set(rules.album_ids)
+                for track in all_tracks:
+                    if track.album and int(track.album.item_id) in album_id_set and track.uri:
+                        track_sets[track.uri] = track
 
         no_filters = (
             not rules.favorites_only
@@ -624,9 +659,10 @@ class SmartPlaylistProvider(MusicProvider):
 
     async def _flush_rules_to_disk(self) -> None:
         """Write all rules + names to disk as a single JSON file."""
-        rules_file = os.path.join(self._rules_dir, RULES_FILENAME)
-        data = {
-            pid: {"name": self._names_store.get(pid, pid), "rules": r.to_dict()}
-            for pid, r in self._rules_store.items()
-        }
-        await write_json(rules_file, data)
+        async with self._flush_lock:
+            rules_file = os.path.join(self._rules_dir, RULES_FILENAME)
+            data = {
+                pid: {"name": self._names_store.get(pid, pid), "rules": r.to_dict()}
+                for pid, r in self._rules_store.items()
+            }
+            await write_json(rules_file, data)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1,0 +1,555 @@
+"""Smart Playlist Music Provider for Music Assistant.
+
+Allows creating rule-based playlists (dynamic or fixed) from library tracks,
+filtered by genres, artists, albums, favorites, popularity and similar tracks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+import uuid as _uuid
+from collections.abc import AsyncGenerator, Sequence
+from typing import TYPE_CHECKING, Any
+
+from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
+from music_assistant_models.media_items import Playlist, ProviderMapping, Track
+from music_assistant_models.media_items.metadata import MediaItemMetadata
+
+from music_assistant.constants import PlaylistPlayableItem
+from music_assistant.helpers.security import is_safe_name
+from music_assistant.helpers.uri import parse_uri
+from music_assistant.models.music_provider import MusicProvider
+from music_assistant.providers.smart_playlist.helpers import (
+    LOGIC_AND,
+    MAX_SIMILAR_TRACKS,
+    RULES_FILENAME,
+    SmartPlaylistRules,
+    read_json,
+    validate_rules,
+    write_json,
+)
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+    from music_assistant_models.provider import ProviderManifest
+
+    from music_assistant.mass import MusicAssistant
+    from music_assistant.models import ProviderInstanceType
+
+SUPPORTED_FEATURES: set[ProviderFeature] = {
+    ProviderFeature.LIBRARY_PLAYLISTS,
+    ProviderFeature.LIBRARY_PLAYLISTS_EDIT,
+}
+
+
+async def setup(
+    mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
+) -> ProviderInstanceType:
+    """Initialize provider(instance) with given configuration."""
+    return SmartPlaylistProvider(mass, manifest, config, SUPPORTED_FEATURES)
+
+
+async def get_config_entries(
+    mass: MusicAssistant,  # noqa: ARG001
+    instance_id: str | None = None,  # noqa: ARG001
+    action: str | None = None,  # noqa: ARG001
+    values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
+) -> tuple[ConfigEntry, ...]:
+    """Return Config entries to setup this provider."""
+    return ()
+
+
+class SmartPlaylistProvider(MusicProvider):
+    """Smart Playlist music provider for Music Assistant."""
+
+    _rules_dir: str
+    _rules_store: dict[str, SmartPlaylistRules]
+    _names_store: dict[str, str]
+
+    @property
+    def is_streaming_provider(self) -> bool:
+        """Return False: library and catalog are identical (local rules)."""
+        return False
+
+    async def handle_async_init(self) -> None:
+        """Handle async initialization."""
+        self._rules_store = {}
+        self._names_store = {}
+        self._rules_dir = os.path.join(self.mass.storage_path, "smart_playlists")
+        if not await asyncio.to_thread(os.path.exists, self._rules_dir):
+            await asyncio.to_thread(os.makedirs, self._rules_dir, exist_ok=True)
+        await self._load_rules_from_disk()
+
+    async def loaded_in_mass(self) -> None:
+        """Register API commands after the provider is loaded."""
+        self.mass.register_api_command("smart_playlists/create", self.create_smart_playlist)
+        self.mass.register_api_command("smart_playlists/generate", self.generate_playlist)
+        self.mass.register_api_command("smart_playlists/get_rules", self.get_smart_playlist_rules)
+        self.mass.register_api_command(
+            "smart_playlists/update_rules", self.update_smart_playlist_rules
+        )
+        self.mass.register_api_command("smart_playlists/list", self.list_smart_playlists)
+        self.mass.register_api_command("smart_playlists/preview_tracks", self.preview_tracks)
+        self.logger.info(
+            "Smart Playlist provider loaded with %d stored playlists", len(self._rules_store)
+        )
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Handle unload/close of the provider."""
+        if is_removed:
+            for filename in await asyncio.to_thread(os.listdir, self._rules_dir):
+                filepath = os.path.join(self._rules_dir, filename)
+                await asyncio.to_thread(os.remove, filepath)
+
+    # --- MusicProvider interface ---
+
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+        """Yield all smart playlists."""
+        for playlist_id, rules in self._rules_store.items():
+            yield self._build_playlist(playlist_id, rules)
+
+    async def get_playlist(self, prov_playlist_id: str) -> Playlist:
+        """Get playlist details by provider id."""
+        rules = self._rules_store.get(prov_playlist_id)
+        if rules is None:
+            msg = f"Smart playlist {prov_playlist_id} not found"
+            raise MediaNotFoundError(msg)
+        return self._build_playlist(prov_playlist_id, rules)
+
+    async def get_playlist_tracks(
+        self, prov_playlist_id: str, page: int = 0
+    ) -> Sequence[PlaylistPlayableItem]:
+        """Evaluate rules and return fresh tracks.
+
+        Returns a full batch on page 0; empty list on subsequent pages.
+        Because is_dynamic=True, MA always calls with force_refresh so results stay fresh.
+        """
+        if page > 0:
+            return []
+        rules = self._rules_store.get(prov_playlist_id)
+        if rules is None:
+            return []
+        return await self._evaluate_rules(rules)
+
+    async def library_add(self, item: Playlist) -> bool:  # type: ignore[override]
+        """Mark the playlist as added to the library (no-op)."""
+        return True
+
+    async def library_remove(self, prov_item_id: str, media_type: MediaType) -> bool:
+        """Remove a smart playlist."""
+        if prov_item_id in self._rules_store:
+            del self._rules_store[prov_item_id]
+            self._names_store.pop(prov_item_id, None)
+            await self._flush_rules_to_disk()
+        return True
+
+    # --- API commands ---
+
+    async def create_smart_playlist(
+        self,
+        name: str,
+        rules: dict[str, Any],
+        is_dynamic: bool = True,
+    ) -> Playlist:
+        """Create a new smart playlist with the given rules.
+
+        :param name: Name for the new playlist.
+        :param rules: Dictionary of SmartPlaylistRules fields.
+        :param is_dynamic: If True, tracks are re-evaluated fresh on each play.
+        :return: The created library Playlist.
+        """
+        if not is_safe_name(name):
+            msg = f"{name} is not a valid playlist name"
+            raise InvalidDataError(msg)
+
+        parsed_rules = SmartPlaylistRules.from_dict(rules)
+        parsed_rules.is_dynamic = is_dynamic
+        self._validate_rules(parsed_rules)
+
+        playlist_id = str(_uuid.uuid4())
+        self._names_store[playlist_id] = name
+        await self._save_rules(playlist_id, parsed_rules)
+
+        playlist = self._build_playlist(playlist_id, parsed_rules)
+        return await self.mass.music.playlists.add_item_to_library(playlist)
+
+    async def generate_playlist(
+        self,
+        name: str,
+        rules: dict[str, Any],
+        count: int | None = None,
+    ) -> Playlist:
+        """Evaluate rules once and create a static (non-dynamic) builtin playlist.
+
+        :param name: Name for the new playlist.
+        :param rules: Dictionary of SmartPlaylistRules fields.
+        :param count: Optional track count override.
+        :return: The created library Playlist.
+        """
+        if not is_safe_name(name):
+            msg = f"{name} is not a valid playlist name"
+            raise InvalidDataError(msg)
+
+        parsed_rules = SmartPlaylistRules.from_dict(rules)
+        self._validate_rules(parsed_rules)
+
+        if count is not None and count > 0:
+            parsed_rules.limit = count
+
+        tracks = await self._evaluate_rules(parsed_rules)
+
+        playlist = await self.mass.music.playlists.create_playlist(name)
+        db_playlist_id = int(playlist.item_id)
+
+        if tracks:
+            uris = [t.uri for t in tracks if t.uri]
+            if uris:
+                # Call directly (not background task) so tracks are added before we return
+                await self.mass.music.playlists._handle_add_playlist_tracks(db_playlist_id, uris)
+
+        final_playlist = await self.mass.music.playlists.get_library_item(db_playlist_id)
+        # Schedule an immediate metadata refresh to build the collage image and detect genres
+        self.mass.metadata.schedule_update_metadata(final_playlist)
+        return final_playlist
+
+    async def get_smart_playlist_rules(self, playlist_id: str) -> dict[str, Any] | None:
+        """Return the smart playlist rules for the given playlist id.
+
+        :param playlist_id: Provider playlist id (UUID) or library DB id (integer string).
+        :return: Rules dict or None if not found.
+        """
+        prov_id = await self._resolve_to_provider_id(playlist_id)
+        if prov_id is None:
+            return None
+        rules = self._rules_store.get(prov_id)
+        if rules is None:
+            return None
+        return rules.to_dict()
+
+    async def update_smart_playlist_rules(
+        self,
+        playlist_id: str,
+        rules: dict[str, Any],
+    ) -> None:
+        """Update the rules for an existing smart playlist.
+
+        :param playlist_id: Provider playlist id (UUID) or library DB id (integer string).
+        :param rules: Updated SmartPlaylistRules fields as dict.
+        """
+        prov_id = await self._resolve_to_provider_id(playlist_id)
+        if prov_id is None:
+            msg = f"Smart playlist {playlist_id} not found"
+            raise MediaNotFoundError(msg)
+        existing = self._rules_store.get(prov_id)
+        parsed_rules = SmartPlaylistRules.from_dict(rules)
+        if existing is not None:
+            parsed_rules.is_dynamic = existing.is_dynamic
+        self._validate_rules(parsed_rules)
+        await self._save_rules(prov_id, parsed_rules)
+
+        library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
+            prov_id, self.instance_id
+        )
+        if library_item:
+            await self._update_playlist_description(library_item.item_id, parsed_rules)
+
+    async def list_smart_playlists(self) -> list[dict[str, Any]]:
+        """Return list of all smart playlist IDs and their rule summaries."""
+        return [
+            {
+                "playlist_id": playlist_id,
+                "name": self._names_store.get(playlist_id, playlist_id),
+                "rules": rules.to_dict(),
+                "summary": rules.human_readable(),
+            }
+            for playlist_id, rules in self._rules_store.items()
+        ]
+
+    async def preview_tracks(
+        self,
+        rules: dict[str, Any],
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Preview which tracks would be selected by the given rules.
+
+        :param rules: SmartPlaylistRules fields as dict.
+        :param limit: Maximum number of preview tracks to return.
+        :return: List of track info dicts.
+        """
+        parsed_rules = SmartPlaylistRules.from_dict(rules)
+        self._validate_rules(parsed_rules)
+        original_limit = parsed_rules.limit
+        parsed_rules.limit = limit
+        tracks = await self._evaluate_rules(parsed_rules)
+        parsed_rules.limit = original_limit
+        return [
+            {
+                "item_id": t.item_id,
+                "uri": t.uri,
+                "name": t.name,
+                "artists": [a.name for a in t.artists],
+                "album": t.album.name if t.album else None,
+            }
+            for t in tracks
+        ]
+
+    # --- Internal helpers ---
+
+    async def _resolve_to_provider_id(self, playlist_id: str) -> str | None:
+        """Resolve a library DB id or provider UUID to the provider UUID."""
+        # If it's directly in the rules store, it's already a provider UUID
+        if playlist_id in self._rules_store:
+            return playlist_id
+        # Try to resolve as a library DB id
+        try:
+            library_item = await self.mass.music.playlists.get_library_item(playlist_id)
+            for mapping in library_item.provider_mappings:
+                if mapping.provider_instance == self.instance_id:
+                    return mapping.item_id
+        except Exception as err:
+            self.logger.debug("Could not resolve playlist id %s: %s", playlist_id, err)
+        return None
+
+    def _build_playlist(self, playlist_id: str, rules: SmartPlaylistRules) -> Playlist:
+        """Build a Playlist object from stored rules."""
+        name = self._names_store.get(playlist_id, playlist_id)
+        playlist = Playlist(
+            item_id=playlist_id,
+            provider=self.instance_id,
+            name=name,
+            owner="smart_playlist",
+            is_editable=True,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=playlist_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                    is_unique=True,
+                )
+            },
+        )
+        playlist.is_dynamic = rules.is_dynamic
+        playlist.metadata = MediaItemMetadata(
+            description=f"[Smart Playlist] {rules.human_readable()}"
+        )
+        return playlist
+
+    def _validate_rules(self, rules: SmartPlaylistRules) -> None:
+        """Delegate to module-level validate_rules helper."""
+        validate_rules(rules)
+
+    async def _evaluate_rules(self, rules: SmartPlaylistRules) -> list[Track]:
+        """Evaluate the rules and return a list of matching Track objects."""
+        has_genre_filter = bool(rules.genre_ids)
+        has_artist_filter = bool(rules.artist_ids)
+        has_seed_filter = bool(rules.seed_track_uri)
+
+        if rules.logic == LOGIC_AND:
+            tracks = await self._evaluate_and(rules)
+        else:
+            tracks = await self._evaluate_or(rules)
+
+        if rules.min_popularity is not None:
+            tracks = [
+                t
+                for t in tracks
+                if t.metadata
+                and t.metadata.popularity is not None
+                and t.metadata.popularity >= rules.min_popularity
+            ]
+
+        if (
+            has_seed_filter
+            and not has_artist_filter
+            and not rules.album_ids
+            and rules.seed_track_uri
+        ):
+            seed_tracks = await self._get_similar_tracks(rules.seed_track_uri, MAX_SIMILAR_TRACKS)
+            if rules.min_popularity is not None:
+                seed_tracks = [
+                    t
+                    for t in seed_tracks
+                    if t.metadata
+                    and t.metadata.popularity is not None
+                    and t.metadata.popularity >= rules.min_popularity
+                ]
+            if rules.favorites_only:
+                seed_tracks = [t for t in seed_tracks if t.favorite]
+            if has_genre_filter and rules.logic == LOGIC_AND:
+                seed_tracks = list(seed_tracks)
+            existing_uris = {t.uri for t in tracks}
+            for st in seed_tracks:
+                if st.uri not in existing_uris:
+                    tracks.append(st)
+                    existing_uris.add(st.uri)
+
+        random.shuffle(tracks)
+        return tracks[: rules.limit]
+
+    async def _evaluate_and(self, rules: SmartPlaylistRules) -> list[Track]:
+        """Evaluate rules with AND logic: track must match ALL active filters."""
+        has_genre = bool(rules.genre_ids)
+        has_artist = bool(rules.artist_ids)
+        has_album = bool(rules.album_ids)
+        has_seed = bool(rules.seed_track_uri)
+
+        no_structural_filter = not has_genre and not has_artist and not has_album
+        if has_seed and no_structural_filter and not rules.favorites_only:
+            return await self._get_library_tracks(
+                favorite=None, genre_ids=None, limit=rules.limit * 3
+            )
+        if no_structural_filter and not rules.favorites_only and not has_seed:
+            return await self._get_library_tracks(
+                favorite=None, genre_ids=None, limit=rules.limit * 3
+            )
+
+        favorite = True if rules.favorites_only else None
+        genre_ids = rules.genre_ids if has_genre else None
+        base_tracks = await self._get_library_tracks(
+            favorite=favorite, genre_ids=genre_ids, limit=rules.limit * 5
+        )
+
+        if not has_artist and not has_album:
+            return base_tracks
+
+        if has_artist:
+            artist_id_set = set(rules.artist_ids)
+            base_tracks = [
+                t
+                for t in base_tracks
+                if {int(a.item_id) for a in t.artists if a.item_id} & artist_id_set
+            ]
+        if has_album:
+            album_id_set = set(rules.album_ids)
+            base_tracks = [
+                t for t in base_tracks if t.album and int(t.album.item_id) in album_id_set
+            ]
+        return base_tracks
+
+    async def _evaluate_or(self, rules: SmartPlaylistRules) -> list[Track]:
+        """Evaluate rules with OR logic: track must match ANY active filter."""
+        track_sets: dict[str, Track] = {}
+        fetch_limit = rules.limit * 5
+
+        if rules.favorites_only:
+            for track in await self._get_library_tracks(favorite=True, limit=fetch_limit):
+                if track.uri:
+                    track_sets[track.uri] = track
+
+        for genre_id in rules.genre_ids:
+            for track in await self._get_library_tracks(genre_ids=[genre_id], limit=fetch_limit):
+                if track.uri:
+                    track_sets[track.uri] = track
+
+        if rules.artist_ids:
+            all_tracks = await self._get_library_tracks(limit=fetch_limit * 2)
+            artist_id_set = set(rules.artist_ids)
+            for track in all_tracks:
+                if {
+                    int(a.item_id) for a in track.artists if a.item_id
+                } & artist_id_set and track.uri:
+                    track_sets[track.uri] = track
+
+        if rules.album_ids:
+            all_tracks = (
+                await self._get_library_tracks(limit=fetch_limit * 2)
+                if not rules.artist_ids
+                else list(track_sets.values())
+            )
+            album_id_set = set(rules.album_ids)
+            for track in all_tracks:
+                if track.album and int(track.album.item_id) in album_id_set and track.uri:
+                    track_sets[track.uri] = track
+
+        no_filters = (
+            not rules.favorites_only
+            and not rules.genre_ids
+            and not rules.artist_ids
+            and not rules.album_ids
+            and not rules.seed_track_uri
+        )
+        if no_filters:
+            for track in await self._get_library_tracks(limit=fetch_limit):
+                if track.uri:
+                    track_sets[track.uri] = track
+
+        return list(track_sets.values())
+
+    async def _get_library_tracks(
+        self,
+        favorite: bool | None = None,
+        genre_ids: list[int] | None = None,
+        limit: int = 500,
+    ) -> list[Track]:
+        """Fetch library tracks with optional filters."""
+        return await self.mass.music.tracks.library_items(
+            favorite=favorite,
+            genre=genre_ids,
+            limit=limit,
+            order_by="random",
+        )
+
+    async def _get_similar_tracks(self, seed_track_uri: str, limit: int) -> list[Track]:
+        """Get similar tracks for the given seed track URI."""
+        try:
+            _media_type, item_id, provider = await parse_uri(seed_track_uri)
+        except Exception:
+            self.logger.warning("Cannot parse seed_track_uri: %s", seed_track_uri)
+            return []
+        try:
+            return await self.mass.music.tracks.similar_tracks(
+                item_id=item_id,
+                provider_instance_id_or_domain=provider,
+                limit=limit,
+            )
+        except Exception as exc:
+            self.logger.warning("Could not get similar tracks for %s: %s", seed_track_uri, exc)
+            return []
+
+    async def _update_playlist_description(
+        self, library_item_id: int | str, rules: SmartPlaylistRules
+    ) -> None:
+        """Update the library playlist description with the rules summary."""
+        try:
+            playlist = await self.mass.music.playlists.get_library_item(library_item_id)
+            updated = Playlist.from_dict(playlist.to_dict())
+            updated.metadata.description = f"[Smart Playlist] {rules.human_readable()}"
+            await self.mass.music.playlists.update_item_in_library(library_item_id, updated)
+        except Exception as exc:
+            self.logger.debug("Could not update description for %s: %s", library_item_id, exc)
+
+    async def _load_rules_from_disk(self) -> None:
+        """Load all persisted rules from the rules directory."""
+        rules_file = os.path.join(self._rules_dir, RULES_FILENAME)
+        if not await asyncio.to_thread(os.path.isfile, rules_file):
+            return
+        try:
+            data = await asyncio.to_thread(read_json, rules_file)
+            for playlist_id, entry in data.items():
+                if isinstance(entry, dict) and "rules" in entry:
+                    # New format: {"name": "...", "rules": {...}}
+                    self._rules_store[playlist_id] = SmartPlaylistRules.from_dict(entry["rules"])
+                    self._names_store[playlist_id] = entry.get("name", playlist_id)
+                else:
+                    # Legacy format: entry is the rules dict directly
+                    self._rules_store[playlist_id] = SmartPlaylistRules.from_dict(entry)
+                    self._names_store[playlist_id] = playlist_id
+        except Exception as exc:
+            self.logger.warning("Failed to load smart playlist rules: %s", exc)
+
+    async def _save_rules(self, playlist_id: str, rules: SmartPlaylistRules) -> None:
+        """Persist rules to disk and update in-memory store."""
+        self._rules_store[playlist_id] = rules
+        await self._flush_rules_to_disk()
+
+    async def _flush_rules_to_disk(self) -> None:
+        """Write all rules + names to disk as a single JSON file."""
+        rules_file = os.path.join(self._rules_dir, RULES_FILENAME)
+        data = {
+            pid: {"name": self._names_store.get(pid, pid), "rules": r.to_dict()}
+            for pid, r in self._rules_store.items()
+        }
+        await asyncio.to_thread(write_json, rules_file, data)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -113,7 +113,14 @@ class SmartPlaylistProvider(MusicProvider):
             # has no other mechanism to clean up provider-owned playlists on removal.
             for playlist_id in list(self._rules_store):
                 try:
-                    await self.mass.music.remove_item_from_library(MediaType.PLAYLIST, playlist_id)
+                    library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
+                        playlist_id, self.instance_id
+                    )
+                    if library_item is None:
+                        continue
+                    await self.mass.music.remove_item_from_library(
+                        MediaType.PLAYLIST, library_item.item_id
+                    )
                 except Exception as exc:
                     self.logger.debug(
                         "Could not remove playlist %s from library: %s", playlist_id, exc
@@ -313,7 +320,7 @@ class SmartPlaylistProvider(MusicProvider):
         parsed_rules = SmartPlaylistRules.from_dict(rules)
         self._validate_rules(parsed_rules)
         original_limit = parsed_rules.limit
-        parsed_rules.limit = limit
+        parsed_rules.limit = max(1, min(limit, 2000))
         tracks = await self._evaluate_rules(parsed_rules)
         parsed_rules.limit = original_limit
         return [
@@ -394,7 +401,47 @@ class SmartPlaylistProvider(MusicProvider):
     async def _evaluate_rules(self, rules: SmartPlaylistRules) -> list[Track]:
         """Evaluate the rules and return a list of matching Track objects."""
         has_genre_filter = bool(rules.genre_ids)
-        has_seed_filter = bool(rules.seed_track_uri)
+
+        if rules.seed_track_uri:
+            # Seed mode: the similar-tracks pool is the exclusive source.
+            # artist_ids and album_ids are ignored per design; genre, favorites,
+            # popularity and year are applied as post-filters on the pool.
+            tracks = await self._get_similar_tracks(rules.seed_track_uri, MAX_SIMILAR_TRACKS)
+            if rules.min_popularity is not None:
+                tracks = [
+                    t
+                    for t in tracks
+                    if t.metadata
+                    and t.metadata.popularity is not None
+                    and t.metadata.popularity >= rules.min_popularity
+                ]
+            if rules.favorites_only:
+                tracks = [t for t in tracks if t.favorite]
+            if has_genre_filter and rules.logic == LOGIC_AND:
+                # Best-effort: filter seed tracks by genre name.
+                # Tracks without genre metadata are kept (don't exclude for missing data).
+                allowed_genre_names = {g.lower() for g in rules.genre_names.values()}
+                if allowed_genre_names:
+                    tracks = [
+                        t
+                        for t in tracks
+                        if not t.metadata
+                        or not t.metadata.genres
+                        or any(g.lower() in allowed_genre_names for g in t.metadata.genres)
+                    ]
+            if rules.year_from is not None or rules.year_to is not None:
+                tracks = [
+                    t
+                    for t in tracks
+                    if t.album is None
+                    or t.album.year is None
+                    or (
+                        (rules.year_from is None or t.album.year >= rules.year_from)
+                        and (rules.year_to is None or t.album.year <= rules.year_to)
+                    )
+                ]
+            random.shuffle(tracks)
+            return tracks[: rules.limit]
 
         if rules.logic == LOGIC_AND:
             tracks = await self._evaluate_and(rules)
@@ -409,40 +456,6 @@ class SmartPlaylistProvider(MusicProvider):
                 and t.metadata.popularity is not None
                 and t.metadata.popularity >= rules.min_popularity
             ]
-
-        if has_seed_filter and rules.seed_track_uri:
-            # Seed mode: artist_ids and album_ids are ignored per design.
-            # Genre, favorites, popularity and year are applied as post-filters.
-            seed_tracks = await self._get_similar_tracks(rules.seed_track_uri, MAX_SIMILAR_TRACKS)
-            if rules.min_popularity is not None:
-                seed_tracks = [
-                    t
-                    for t in seed_tracks
-                    if t.metadata
-                    and t.metadata.popularity is not None
-                    and t.metadata.popularity >= rules.min_popularity
-                ]
-            if rules.favorites_only:
-                seed_tracks = [t for t in seed_tracks if t.favorite]
-            if has_genre_filter and rules.logic == LOGIC_AND:
-                # Best-effort: filter seed tracks by genre name.
-                # Only applied when genre_names is populated; skipped otherwise to avoid
-                # discarding all tracks due to unresolved names.
-                # Tracks without genre metadata are kept (don't exclude for missing data).
-                allowed_genre_names = {g.lower() for g in rules.genre_names.values()}
-                if allowed_genre_names:
-                    seed_tracks = [
-                        t
-                        for t in seed_tracks
-                        if not t.metadata
-                        or not t.metadata.genres
-                        or any(g.lower() in allowed_genre_names for g in t.metadata.genres)
-                    ]
-            existing_uris = {t.uri for t in tracks}
-            for st in seed_tracks:
-                if st.uri not in existing_uris:
-                    tracks.append(st)
-                    existing_uris.add(st.uri)
 
         if rules.year_from is not None or rules.year_to is not None:
             tracks = [
@@ -464,24 +477,18 @@ class SmartPlaylistProvider(MusicProvider):
         has_genre = bool(rules.genre_ids)
         has_artist = bool(rules.artist_ids)
         has_album = bool(rules.album_ids)
-        has_seed = bool(rules.seed_track_uri)
 
         no_structural_filter = not has_genre and not has_artist and not has_album
 
-        # When seed is active, the similar-tracks pool is the exclusive source.
-        # Genre/artist/album filters are applied as post-filters on that pool in _evaluate_rules.
-        if has_seed:
-            return []
-
-        if no_structural_filter and not rules.favorites_only and not has_seed:
+        if no_structural_filter and not rules.favorites_only:
             return await self._get_library_tracks(
-                favorite=None, genre_ids=None, limit=rules.limit * 3
+                favorite=None, genre_ids=None, limit=min(rules.limit * 3, 2000)
             )
 
         favorite = True if rules.favorites_only else None
         genre_ids = rules.genre_ids if has_genre else None
         base_tracks = await self._get_library_tracks(
-            favorite=favorite, genre_ids=genre_ids, limit=rules.limit * 5
+            favorite=favorite, genre_ids=genre_ids, limit=min(rules.limit * 5, 2000)
         )
 
         if not has_artist and not has_album:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -11,6 +11,7 @@ import os
 import random
 import uuid as _uuid
 from collections.abc import AsyncGenerator, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import ImageType, MediaType, ProviderFeature
@@ -216,8 +217,7 @@ class SmartPlaylistProvider(MusicProvider):
         if tracks:
             uris = [t.uri for t in tracks if t.uri]
             if uris:
-                # Call directly (not background task) so tracks are added before we return
-                await self.mass.music.playlists._handle_add_playlist_tracks(db_playlist_id, uris)
+                await self.mass.music.playlists.add_playlist_tracks(db_playlist_id, uris)
 
         final_playlist = await self.mass.music.playlists.get_library_item(db_playlist_id)
         # Schedule an immediate metadata refresh to build the collage image and detect genres
@@ -278,14 +278,16 @@ class SmartPlaylistProvider(MusicProvider):
         ]
 
     async def count_tracks(self, rules: dict[str, Any]) -> int:
-        """Return the total number of tracks matching the given rules.
+        """Return the number of tracks produced by the validated rules.
+
+        The count is based on the same evaluated result set used for playlist generation
+        and should be treated as approximate (limited by rules.limit and shuffling).
 
         :param rules: SmartPlaylistRules fields as dict.
-        :return: Number of matching tracks.
+        :return: Number of matching tracks in the evaluated result set.
         """
         parsed_rules = SmartPlaylistRules.from_dict(rules)
         self._validate_rules(parsed_rules)
-        parsed_rules.limit = 99999
         tracks = await self._evaluate_rules(parsed_rules)
         return len(tracks)
 
@@ -372,9 +374,9 @@ class SmartPlaylistProvider(MusicProvider):
     async def resolve_image(self, path: str) -> str | bytes:
         """Return the smart playlist provider icon as fallback image."""
         if path == "icon.svg":
-            icon_path = os.path.join(os.path.dirname(__file__), "icon.svg")
+            icon_path = Path(__file__).parent / "icon.svg"
             async with asyncio.timeout(5):
-                return await asyncio.to_thread(lambda: open(icon_path, "rb").read())
+                return await asyncio.to_thread(icon_path.read_bytes)
         return path
 
     def _validate_rules(self, rules: SmartPlaylistRules) -> None:
@@ -384,7 +386,6 @@ class SmartPlaylistProvider(MusicProvider):
     async def _evaluate_rules(self, rules: SmartPlaylistRules) -> list[Track]:
         """Evaluate the rules and return a list of matching Track objects."""
         has_genre_filter = bool(rules.genre_ids)
-        has_artist_filter = bool(rules.artist_ids)
         has_seed_filter = bool(rules.seed_track_uri)
 
         if rules.logic == LOGIC_AND:
@@ -401,12 +402,9 @@ class SmartPlaylistProvider(MusicProvider):
                 and t.metadata.popularity >= rules.min_popularity
             ]
 
-        if (
-            has_seed_filter
-            and not has_artist_filter
-            and not rules.album_ids
-            and rules.seed_track_uri
-        ):
+        if has_seed_filter and rules.seed_track_uri:
+            # Seed mode: artist_ids and album_ids are ignored per design.
+            # Genre, favorites, popularity and year are applied as post-filters.
             seed_tracks = await self._get_similar_tracks(rules.seed_track_uri, MAX_SIMILAR_TRACKS)
             if rules.min_popularity is not None:
                 seed_tracks = [
@@ -419,15 +417,19 @@ class SmartPlaylistProvider(MusicProvider):
             if rules.favorites_only:
                 seed_tracks = [t for t in seed_tracks if t.favorite]
             if has_genre_filter and rules.logic == LOGIC_AND:
-                # Best-effort: filter seed tracks by genre name if the track has genre metadata.
-                # If a track has no genre metadata, keep it (don't exclude due to missing data).
+                # Best-effort: filter seed tracks by genre name.
+                # Only applied when genre_names is populated; skipped otherwise to avoid
+                # discarding all tracks due to unresolved names.
+                # Tracks without genre metadata are kept (don't exclude for missing data).
                 allowed_genre_names = {g.lower() for g in rules.genre_names.values()}
-                seed_tracks = [
-                    t
-                    for t in seed_tracks
-                    if not t.metadata.genres
-                    or any(g.lower() in allowed_genre_names for g in t.metadata.genres)
-                ]
+                if allowed_genre_names:
+                    seed_tracks = [
+                        t
+                        for t in seed_tracks
+                        if not t.metadata
+                        or not t.metadata.genres
+                        or any(g.lower() in allowed_genre_names for g in t.metadata.genres)
+                    ]
             existing_uris = {t.uri for t in tracks}
             for st in seed_tracks:
                 if st.uri not in existing_uris:
@@ -458,9 +460,9 @@ class SmartPlaylistProvider(MusicProvider):
 
         no_structural_filter = not has_genre and not has_artist and not has_album
 
-        # When seed is active without genre/artist/album, the similar-tracks pool is the
-        # primary result. Returning library tracks here would pollute it with unrelated content.
-        if has_seed and not has_genre and not has_artist and not has_album:
+        # When seed is active, the similar-tracks pool is the exclusive source.
+        # Genre/artist/album filters are applied as post-filters on that pool in _evaluate_rules.
+        if has_seed:
             return []
 
         if no_structural_filter and not rules.favorites_only and not has_seed:

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -29,6 +29,8 @@ class SmartPlaylistRules:
     limit: int = DEFAULT_TRACK_LIMIT
     is_dynamic: bool = True
     genre_names: dict[int, str] = field(default_factory=dict)
+    artist_names: dict[int, str] = field(default_factory=dict)
+    album_names: dict[int, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dictionary."""
@@ -43,12 +45,16 @@ class SmartPlaylistRules:
             "limit": self.limit,
             "is_dynamic": self.is_dynamic,
             "genre_names": {str(k): v for k, v in self.genre_names.items()},
+            "artist_names": {str(k): v for k, v in self.artist_names.items()},
+            "album_names": {str(k): v for k, v in self.album_names.items()},
         }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SmartPlaylistRules:
         """Deserialize from dictionary."""
         raw_genre_names: dict[str, str] = data.get("genre_names", {})
+        raw_artist_names: dict[str, str] = data.get("artist_names", {})
+        raw_album_names: dict[str, str] = data.get("album_names", {})
         return cls(
             genre_ids=data.get("genre_ids", []),
             artist_ids=data.get("artist_ids", []),
@@ -60,6 +66,8 @@ class SmartPlaylistRules:
             limit=data.get("limit", DEFAULT_TRACK_LIMIT),
             is_dynamic=data.get("is_dynamic", True),
             genre_names={int(k): v for k, v in raw_genre_names.items()},
+            artist_names={int(k): v for k, v in raw_artist_names.items()},
+            album_names={int(k): v for k, v in raw_album_names.items()},
         )
 
     def human_readable(self) -> str:
@@ -71,10 +79,11 @@ class SmartPlaylistRules:
             names = [self.genre_names.get(gid, str(gid)) for gid in self.genre_ids]
             parts.append(f"Genres: {', '.join(names)}")
         if self.artist_ids:
-            parts.append(f"Artists: {', '.join(str(a) for a in self.artist_ids)}")
+            names = [self.artist_names.get(aid, str(aid)) for aid in self.artist_ids]
+            parts.append(f"Artists: {', '.join(names)}")
         if self.album_ids:
-            parts.append(f"Albums: {', '.join(str(a) for a in self.album_ids)}")
-        if self.seed_track_uri:
+            names = [self.album_names.get(aid, str(aid)) for aid in self.album_ids]
+            parts.append(f"Albums: {', '.join(names)}")
             parts.append(f"Similar to: {self.seed_track_uri}")
         if self.min_popularity is not None:
             parts.append(f"Min. popularity: {self.min_popularity}")

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -99,6 +99,8 @@ class SmartPlaylistRules:
     excluded_track_uris: list[str] = field(default_factory=list)
     excluded_artist_names: dict[int, str] = field(default_factory=dict)
     excluded_album_names: dict[int, str] = field(default_factory=dict)
+    excluded_genre_ids: list[int] = field(default_factory=list)
+    excluded_genre_names: dict[int, str] = field(default_factory=dict)
     dedup_hours: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -127,6 +129,8 @@ class SmartPlaylistRules:
             "excluded_track_uris": self.excluded_track_uris,
             "excluded_artist_names": {str(k): v for k, v in self.excluded_artist_names.items()},
             "excluded_album_names": {str(k): v for k, v in self.excluded_album_names.items()},
+            "excluded_genre_ids": self.excluded_genre_ids,
+            "excluded_genre_names": {str(k): v for k, v in self.excluded_genre_names.items()},
             "dedup_hours": self.dedup_hours,
         }
 
@@ -167,6 +171,12 @@ class SmartPlaylistRules:
             excluded_album_names=_coerce_int_keyed_dict(
                 data.get("excluded_album_names"), "excluded_album_names"
             ),
+            excluded_genre_ids=_coerce_id_list(
+                data.get("excluded_genre_ids"), "excluded_genre_ids"
+            ),
+            excluded_genre_names=_coerce_int_keyed_dict(
+                data.get("excluded_genre_names"), "excluded_genre_names"
+            ),
             dedup_hours=_coerce_optional_int(data.get("dedup_hours"), "dedup_hours"),
         )
 
@@ -200,6 +210,11 @@ class SmartPlaylistRules:
                 self.excluded_album_names.get(aid, str(aid)) for aid in self.excluded_album_ids
             ]
             parts.append(f"Excl. albums: {', '.join(names)}")
+        if self.excluded_genre_ids:
+            names = [
+                self.excluded_genre_names.get(gid, str(gid)) for gid in self.excluded_genre_ids
+            ]
+            parts.append(f"Excl. genres: {', '.join(names)}")
         if self.excluded_track_uris:
             parts.append(f"Excl. {len(self.excluded_track_uris)} track(s)")
         if self.dedup_hours is not None:

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -64,9 +64,9 @@ class SmartPlaylistRules:
         raw_artist_names: dict[str, str] = data.get("artist_names", {})
         raw_album_names: dict[str, str] = data.get("album_names", {})
         return cls(
-            genre_ids=data.get("genre_ids", []),
-            artist_ids=data.get("artist_ids", []),
-            album_ids=data.get("album_ids", []),
+            genre_ids=[int(x) for x in data.get("genre_ids", [])],
+            artist_ids=[int(x) for x in data.get("artist_ids", [])],
+            album_ids=[int(x) for x in data.get("album_ids", [])],
             favorites_only=data.get("favorites_only", False),
             seed_track_uri=data.get("seed_track_uri"),
             seed_track_name=data.get("seed_track_name"),

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -124,6 +124,16 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
     if rules.min_popularity is not None and not (0 <= rules.min_popularity <= 100):
         msg = f"min_popularity must be between 0 and 100, got {rules.min_popularity}"
         raise InvalidDataError(msg)
+    if (
+        rules.year_from is not None
+        and rules.year_to is not None
+        and rules.year_from > rules.year_to
+    ):
+        msg = (
+            f"year_from must be less than or equal to year_to, got "
+            f"{rules.year_from}>{rules.year_to}"
+        )
+        raise InvalidDataError(msg)
 
 
 async def read_json(path: str) -> dict[str, Any]:

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+import aiofiles
 from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.helpers.json import json_dumps, json_loads
 
 LOGIC_AND = "AND"
 LOGIC_OR = "OR"
@@ -124,13 +126,13 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
         raise InvalidDataError(msg)
 
 
-def read_json(path: str) -> dict[str, Any]:
-    """Read a JSON file and return its contents (blocking - run in a thread)."""
-    with open(path, encoding="utf-8") as fh:
-        return cast("dict[str, Any]", json.load(fh))
+async def read_json(path: str) -> dict[str, Any]:
+    """Read a JSON file and return its contents."""
+    async with aiofiles.open(path, encoding="utf-8") as fh:
+        return cast("dict[str, Any]", json_loads(await fh.read()))
 
 
-def write_json(path: str, data: dict[str, Any]) -> None:
-    """Write data as JSON to a file (blocking - run in a thread)."""
-    with open(path, "w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
+async def write_json(path: str, data: dict[str, Any]) -> None:
+    """Write data as JSON to a file."""
+    async with aiofiles.open(path, "w", encoding="utf-8") as fh:
+        await fh.write(json_dumps(data, indent=True))

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -31,6 +31,8 @@ class SmartPlaylistRules:
     genre_names: dict[int, str] = field(default_factory=dict)
     artist_names: dict[int, str] = field(default_factory=dict)
     album_names: dict[int, str] = field(default_factory=dict)
+    year_from: int | None = None
+    year_to: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dictionary."""
@@ -47,6 +49,8 @@ class SmartPlaylistRules:
             "genre_names": {str(k): v for k, v in self.genre_names.items()},
             "artist_names": {str(k): v for k, v in self.artist_names.items()},
             "album_names": {str(k): v for k, v in self.album_names.items()},
+            "year_from": self.year_from,
+            "year_to": self.year_to,
         }
 
     @classmethod
@@ -68,6 +72,8 @@ class SmartPlaylistRules:
             genre_names={int(k): v for k, v in raw_genre_names.items()},
             artist_names={int(k): v for k, v in raw_artist_names.items()},
             album_names={int(k): v for k, v in raw_album_names.items()},
+            year_from=data.get("year_from"),
+            year_to=data.get("year_to"),
         )
 
     def human_readable(self) -> str:
@@ -87,6 +93,13 @@ class SmartPlaylistRules:
             parts.append(f"Similar to: {self.seed_track_uri}")
         if self.min_popularity is not None:
             parts.append(f"Min. popularity: {self.min_popularity}")
+        if self.year_from is not None or self.year_to is not None:
+            if self.year_from is not None and self.year_to is not None:
+                parts.append(f"Year: {self.year_from}-{self.year_to}")
+            elif self.year_from is not None:
+                parts.append(f"Year: from {self.year_from}")
+            else:
+                parts.append(f"Year: to {self.year_to}")
         if not parts:
             return "No rules (all library tracks)"
         connector = f" {self.logic} "

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -36,6 +36,15 @@ class SmartPlaylistRules:
     album_names: dict[int, str] = field(default_factory=dict)
     year_from: int | None = None
     year_to: int | None = None
+    seed_artist_uri: str | None = None
+    seed_artist_name: str | None = None
+    seed_artist_library_only: bool = False
+    excluded_artist_ids: list[int] = field(default_factory=list)
+    excluded_album_ids: list[int] = field(default_factory=list)
+    excluded_track_uris: list[str] = field(default_factory=list)
+    excluded_artist_names: dict[int, str] = field(default_factory=dict)
+    excluded_album_names: dict[int, str] = field(default_factory=dict)
+    dedup_hours: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dictionary."""
@@ -55,6 +64,15 @@ class SmartPlaylistRules:
             "album_names": {str(k): v for k, v in self.album_names.items()},
             "year_from": self.year_from,
             "year_to": self.year_to,
+            "seed_artist_uri": self.seed_artist_uri,
+            "seed_artist_name": self.seed_artist_name,
+            "seed_artist_library_only": self.seed_artist_library_only,
+            "excluded_artist_ids": self.excluded_artist_ids,
+            "excluded_album_ids": self.excluded_album_ids,
+            "excluded_track_uris": self.excluded_track_uris,
+            "excluded_artist_names": {str(k): v for k, v in self.excluded_artist_names.items()},
+            "excluded_album_names": {str(k): v for k, v in self.excluded_album_names.items()},
+            "dedup_hours": self.dedup_hours,
         }
 
     @classmethod
@@ -79,6 +97,19 @@ class SmartPlaylistRules:
             album_names={int(k): v for k, v in raw_album_names.items()},
             year_from=data.get("year_from"),
             year_to=data.get("year_to"),
+            seed_artist_uri=data.get("seed_artist_uri"),
+            seed_artist_name=data.get("seed_artist_name"),
+            seed_artist_library_only=data.get("seed_artist_library_only", False),
+            excluded_artist_ids=[int(x) for x in data.get("excluded_artist_ids", [])],
+            excluded_album_ids=[int(x) for x in data.get("excluded_album_ids", [])],
+            excluded_track_uris=list(data.get("excluded_track_uris", [])),
+            excluded_artist_names={
+                int(k): v for k, v in data.get("excluded_artist_names", {}).items()
+            },
+            excluded_album_names={
+                int(k): v for k, v in data.get("excluded_album_names", {}).items()
+            },
+            dedup_hours=data.get("dedup_hours"),
         )
 
     def human_readable(self) -> str:
@@ -97,7 +128,24 @@ class SmartPlaylistRules:
             parts.append(f"Albums: {', '.join(names)}")
         if self.seed_track_uri:
             label = self.seed_track_name or self.seed_track_uri
-            parts.append(f"Similar to: {label}")
+            parts.append(f"Similar to track: {label}")
+        if self.seed_artist_uri:
+            label = self.seed_artist_name or self.seed_artist_uri
+            parts.append(f"Similar to artist: {label}")
+        if self.excluded_artist_ids:
+            names = [
+                self.excluded_artist_names.get(aid, str(aid)) for aid in self.excluded_artist_ids
+            ]
+            parts.append(f"Excl. artists: {', '.join(names)}")
+        if self.excluded_album_ids:
+            names = [
+                self.excluded_album_names.get(aid, str(aid)) for aid in self.excluded_album_ids
+            ]
+            parts.append(f"Excl. albums: {', '.join(names)}")
+        if self.excluded_track_uris:
+            parts.append(f"Excl. {len(self.excluded_track_uris)} track(s)")
+        if self.dedup_hours is not None:
+            parts.append(f"No repeat within {self.dedup_hours}h")
         if self.min_popularity is not None:
             parts.append(f"Min. popularity: {self.min_popularity}")
         if self.year_from is not None or self.year_to is not None:
@@ -133,6 +181,12 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
             f"year_from must be less than or equal to year_to, got "
             f"{rules.year_from}>{rules.year_to}"
         )
+        raise InvalidDataError(msg)
+    if rules.seed_track_uri and rules.seed_artist_uri:
+        msg = "seed_track_uri and seed_artist_uri are mutually exclusive"
+        raise InvalidDataError(msg)
+    if rules.dedup_hours is not None and not (1 <= rules.dedup_hours <= 8760):
+        msg = f"dedup_hours must be between 1 and 8760, got {rules.dedup_hours}"
         raise InvalidDataError(msg)
 
 

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -48,6 +48,15 @@ def _coerce_id_list(value: Any, field_name: str) -> list[int]:
     return result
 
 
+def _coerce_str_list(value: Any, field_name: str) -> list[str]:
+    """Coerce a value to a list of strs, raising InvalidDataError on bad input."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise InvalidDataError(f"Expected list for {field_name}, got {type(value).__name__}")
+    return [str(item) for item in value]
+
+
 def _coerce_int_keyed_dict(value: Any, field_name: str) -> dict[int, str]:
     """Coerce a value to a dict[int, str], raising InvalidDataError on bad input."""
     if value is None:
@@ -149,7 +158,9 @@ class SmartPlaylistRules:
             excluded_album_ids=_coerce_id_list(
                 data.get("excluded_album_ids"), "excluded_album_ids"
             ),
-            excluded_track_uris=list(data.get("excluded_track_uris") or []),
+            excluded_track_uris=_coerce_str_list(
+                data.get("excluded_track_uris"), "excluded_track_uris"
+            ),
             excluded_artist_names=_coerce_int_keyed_dict(
                 data.get("excluded_artist_names"), "excluded_artist_names"
             ),

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -17,6 +17,22 @@ MAX_SIMILAR_TRACKS = 50
 RULES_FILENAME = "smart_playlist_rules.json"
 
 
+def _coerce_int(value: Any, field_name: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as err:
+        raise InvalidDataError(f"Invalid value for {field_name}: {value!r}") from err
+
+
+def _coerce_optional_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as err:
+        raise InvalidDataError(f"Invalid value for {field_name}: {value!r}") from err
+
+
 @dataclass
 class SmartPlaylistRules:
     """Rules that define which tracks are included in a smart playlist."""
@@ -88,15 +104,15 @@ class SmartPlaylistRules:
             favorites_only=data.get("favorites_only", False),
             seed_track_uri=data.get("seed_track_uri"),
             seed_track_name=data.get("seed_track_name"),
-            min_popularity=data.get("min_popularity"),
+            min_popularity=_coerce_optional_int(data.get("min_popularity"), "min_popularity"),
             logic=data.get("logic", LOGIC_AND),
-            limit=data.get("limit", DEFAULT_TRACK_LIMIT),
+            limit=_coerce_int(data.get("limit", DEFAULT_TRACK_LIMIT), "limit"),
             is_dynamic=data.get("is_dynamic", True),
             genre_names={int(k): v for k, v in raw_genre_names.items()},
             artist_names={int(k): v for k, v in raw_artist_names.items()},
             album_names={int(k): v for k, v in raw_album_names.items()},
-            year_from=data.get("year_from"),
-            year_to=data.get("year_to"),
+            year_from=_coerce_optional_int(data.get("year_from"), "year_from"),
+            year_to=_coerce_optional_int(data.get("year_to"), "year_to"),
             seed_artist_uri=data.get("seed_artist_uri"),
             seed_artist_name=data.get("seed_artist_name"),
             seed_artist_library_only=data.get("seed_artist_library_only", False),
@@ -109,7 +125,7 @@ class SmartPlaylistRules:
             excluded_album_names={
                 int(k): v for k, v in data.get("excluded_album_names", {}).items()
             },
-            dedup_hours=data.get("dedup_hours"),
+            dedup_hours=_coerce_optional_int(data.get("dedup_hours"), "dedup_hours"),
         )
 
     def human_readable(self) -> str:

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -24,6 +24,7 @@ class SmartPlaylistRules:
     album_ids: list[int] = field(default_factory=list)
     favorites_only: bool = False
     seed_track_uri: str | None = None
+    seed_track_name: str | None = None
     min_popularity: int | None = None
     logic: str = LOGIC_AND
     limit: int = DEFAULT_TRACK_LIMIT
@@ -42,6 +43,7 @@ class SmartPlaylistRules:
             "album_ids": self.album_ids,
             "favorites_only": self.favorites_only,
             "seed_track_uri": self.seed_track_uri,
+            "seed_track_name": self.seed_track_name,
             "min_popularity": self.min_popularity,
             "logic": self.logic,
             "limit": self.limit,
@@ -65,6 +67,7 @@ class SmartPlaylistRules:
             album_ids=data.get("album_ids", []),
             favorites_only=data.get("favorites_only", False),
             seed_track_uri=data.get("seed_track_uri"),
+            seed_track_name=data.get("seed_track_name"),
             min_popularity=data.get("min_popularity"),
             logic=data.get("logic", LOGIC_AND),
             limit=data.get("limit", DEFAULT_TRACK_LIMIT),
@@ -90,7 +93,9 @@ class SmartPlaylistRules:
         if self.album_ids:
             names = [self.album_names.get(aid, str(aid)) for aid in self.album_ids]
             parts.append(f"Albums: {', '.join(names)}")
-            parts.append(f"Similar to: {self.seed_track_uri}")
+        if self.seed_track_uri:
+            label = self.seed_track_name or self.seed_track_uri
+            parts.append(f"Similar to: {label}")
         if self.min_popularity is not None:
             parts.append(f"Min. popularity: {self.min_popularity}")
         if self.year_from is not None or self.year_to is not None:

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -1,0 +1,109 @@
+"""Helpers for the Smart Playlist plugin: rules dataclass, validation, and JSON I/O."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from music_assistant_models.errors import InvalidDataError
+
+LOGIC_AND = "AND"
+LOGIC_OR = "OR"
+DEFAULT_TRACK_LIMIT = 100
+MAX_SIMILAR_TRACKS = 50
+RULES_FILENAME = "smart_playlist_rules.json"
+
+
+@dataclass
+class SmartPlaylistRules:
+    """Rules that define which tracks are included in a smart playlist."""
+
+    genre_ids: list[int] = field(default_factory=list)
+    artist_ids: list[int] = field(default_factory=list)
+    album_ids: list[int] = field(default_factory=list)
+    favorites_only: bool = False
+    seed_track_uri: str | None = None
+    min_popularity: int | None = None
+    logic: str = LOGIC_AND
+    limit: int = DEFAULT_TRACK_LIMIT
+    is_dynamic: bool = True
+    genre_names: dict[int, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "genre_ids": self.genre_ids,
+            "artist_ids": self.artist_ids,
+            "album_ids": self.album_ids,
+            "favorites_only": self.favorites_only,
+            "seed_track_uri": self.seed_track_uri,
+            "min_popularity": self.min_popularity,
+            "logic": self.logic,
+            "limit": self.limit,
+            "is_dynamic": self.is_dynamic,
+            "genre_names": {str(k): v for k, v in self.genre_names.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SmartPlaylistRules:
+        """Deserialize from dictionary."""
+        raw_genre_names: dict[str, str] = data.get("genre_names", {})
+        return cls(
+            genre_ids=data.get("genre_ids", []),
+            artist_ids=data.get("artist_ids", []),
+            album_ids=data.get("album_ids", []),
+            favorites_only=data.get("favorites_only", False),
+            seed_track_uri=data.get("seed_track_uri"),
+            min_popularity=data.get("min_popularity"),
+            logic=data.get("logic", LOGIC_AND),
+            limit=data.get("limit", DEFAULT_TRACK_LIMIT),
+            is_dynamic=data.get("is_dynamic", True),
+            genre_names={int(k): v for k, v in raw_genre_names.items()},
+        )
+
+    def human_readable(self) -> str:
+        """Return a human-readable summary of the rules."""
+        parts: list[str] = []
+        if self.favorites_only:
+            parts.append("Favorites only")
+        if self.genre_ids:
+            names = [self.genre_names.get(gid, str(gid)) for gid in self.genre_ids]
+            parts.append(f"Genres: {', '.join(names)}")
+        if self.artist_ids:
+            parts.append(f"Artists: {', '.join(str(a) for a in self.artist_ids)}")
+        if self.album_ids:
+            parts.append(f"Albums: {', '.join(str(a) for a in self.album_ids)}")
+        if self.seed_track_uri:
+            parts.append(f"Similar to: {self.seed_track_uri}")
+        if self.min_popularity is not None:
+            parts.append(f"Min. popularity: {self.min_popularity}")
+        if not parts:
+            return "No rules (all library tracks)"
+        connector = f" {self.logic} "
+        return connector.join(parts)
+
+
+def validate_rules(rules: SmartPlaylistRules) -> None:
+    """Raise InvalidDataError if any rule field is out of allowed range."""
+    if rules.logic not in (LOGIC_AND, LOGIC_OR):
+        msg = f"Invalid logic operator: {rules.logic}. Must be AND or OR."
+        raise InvalidDataError(msg)
+    if rules.limit < 1 or rules.limit > 2000:
+        msg = f"Track limit must be between 1 and 2000, got {rules.limit}"
+        raise InvalidDataError(msg)
+    if rules.min_popularity is not None and not (0 <= rules.min_popularity <= 100):
+        msg = f"min_popularity must be between 0 and 100, got {rules.min_popularity}"
+        raise InvalidDataError(msg)
+
+
+def read_json(path: str) -> dict[str, Any]:
+    """Read a JSON file and return its contents (blocking - run in a thread)."""
+    with open(path, encoding="utf-8") as fh:
+        return cast("dict[str, Any]", json.load(fh))
+
+
+def write_json(path: str, data: dict[str, Any]) -> None:
+    """Write data as JSON to a file (blocking - run in a thread)."""
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -33,6 +33,36 @@ def _coerce_optional_int(value: Any, field_name: str) -> int | None:
         raise InvalidDataError(f"Invalid value for {field_name}: {value!r}") from err
 
 
+def _coerce_id_list(value: Any, field_name: str) -> list[int]:
+    """Coerce a value to a list of ints, raising InvalidDataError on bad input."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise InvalidDataError(f"Expected list for {field_name}, got {type(value).__name__}")
+    result = []
+    for item in value:
+        try:
+            result.append(int(item))
+        except (TypeError, ValueError) as err:
+            raise InvalidDataError(f"Invalid id in {field_name}: {item!r}") from err
+    return result
+
+
+def _coerce_int_keyed_dict(value: Any, field_name: str) -> dict[int, str]:
+    """Coerce a value to a dict[int, str], raising InvalidDataError on bad input."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise InvalidDataError(f"Expected dict for {field_name}, got {type(value).__name__}")
+    result = {}
+    for k, v in value.items():
+        try:
+            result[int(k)] = str(v)
+        except (TypeError, ValueError) as err:
+            raise InvalidDataError(f"Invalid key in {field_name}: {k!r}") from err
+    return result
+
+
 @dataclass
 class SmartPlaylistRules:
     """Rules that define which tracks are included in a smart playlist."""
@@ -94,13 +124,10 @@ class SmartPlaylistRules:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SmartPlaylistRules:
         """Deserialize from dictionary."""
-        raw_genre_names: dict[str, str] = data.get("genre_names", {})
-        raw_artist_names: dict[str, str] = data.get("artist_names", {})
-        raw_album_names: dict[str, str] = data.get("album_names", {})
         return cls(
-            genre_ids=[int(x) for x in data.get("genre_ids", [])],
-            artist_ids=[int(x) for x in data.get("artist_ids", [])],
-            album_ids=[int(x) for x in data.get("album_ids", [])],
+            genre_ids=_coerce_id_list(data.get("genre_ids"), "genre_ids"),
+            artist_ids=_coerce_id_list(data.get("artist_ids"), "artist_ids"),
+            album_ids=_coerce_id_list(data.get("album_ids"), "album_ids"),
             favorites_only=data.get("favorites_only", False),
             seed_track_uri=data.get("seed_track_uri"),
             seed_track_name=data.get("seed_track_name"),
@@ -108,23 +135,27 @@ class SmartPlaylistRules:
             logic=data.get("logic", LOGIC_AND),
             limit=_coerce_int(data.get("limit", DEFAULT_TRACK_LIMIT), "limit"),
             is_dynamic=data.get("is_dynamic", True),
-            genre_names={int(k): v for k, v in raw_genre_names.items()},
-            artist_names={int(k): v for k, v in raw_artist_names.items()},
-            album_names={int(k): v for k, v in raw_album_names.items()},
+            genre_names=_coerce_int_keyed_dict(data.get("genre_names"), "genre_names"),
+            artist_names=_coerce_int_keyed_dict(data.get("artist_names"), "artist_names"),
+            album_names=_coerce_int_keyed_dict(data.get("album_names"), "album_names"),
             year_from=_coerce_optional_int(data.get("year_from"), "year_from"),
             year_to=_coerce_optional_int(data.get("year_to"), "year_to"),
             seed_artist_uri=data.get("seed_artist_uri"),
             seed_artist_name=data.get("seed_artist_name"),
             seed_artist_library_only=data.get("seed_artist_library_only", False),
-            excluded_artist_ids=[int(x) for x in data.get("excluded_artist_ids", [])],
-            excluded_album_ids=[int(x) for x in data.get("excluded_album_ids", [])],
-            excluded_track_uris=list(data.get("excluded_track_uris", [])),
-            excluded_artist_names={
-                int(k): v for k, v in data.get("excluded_artist_names", {}).items()
-            },
-            excluded_album_names={
-                int(k): v for k, v in data.get("excluded_album_names", {}).items()
-            },
+            excluded_artist_ids=_coerce_id_list(
+                data.get("excluded_artist_ids"), "excluded_artist_ids"
+            ),
+            excluded_album_ids=_coerce_id_list(
+                data.get("excluded_album_ids"), "excluded_album_ids"
+            ),
+            excluded_track_uris=list(data.get("excluded_track_uris") or []),
+            excluded_artist_names=_coerce_int_keyed_dict(
+                data.get("excluded_artist_names"), "excluded_artist_names"
+            ),
+            excluded_album_names=_coerce_int_keyed_dict(
+                data.get("excluded_album_names"), "excluded_album_names"
+            ),
             dedup_hours=_coerce_optional_int(data.get("dedup_hours"), "dedup_hours"),
         )
 

--- a/music_assistant/providers/smart_playlist/icon.svg
+++ b/music_assistant/providers/smart_playlist/icon.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <rect width="24" height="24" rx="4" fill="#18bcf2"/>
+  <rect width="24" height="24" fill="#18bcf2"/>
   <path fill="#ffffff" d="M17 19.1L19.5 20.6L18.8 17.8L21 15.9L18.1 15.7L17 13L15.9 15.6L13 15.9L15.2 17.8L14.5 20.6L17 19.1M3 14H11V16H3V14M3 6H15V8H3V6M3 10H15V12H3V10Z"/>
 </svg>

--- a/music_assistant/providers/smart_playlist/icon.svg
+++ b/music_assistant/providers/smart_playlist/icon.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <rect width="24" height="24" rx="4" fill="#18bcf2"/>
+  <path fill="#ffffff" d="M17 19.1L19.5 20.6L18.8 17.8L21 15.9L18.1 15.7L17 13L15.9 15.6L13 15.9L15.2 17.8L14.5 20.6L17 19.1M3 14H11V16H3V14M3 6H15V8H3V6M3 10H15V12H3V10Z"/>
+</svg>

--- a/music_assistant/providers/smart_playlist/manifest.json
+++ b/music_assistant/providers/smart_playlist/manifest.json
@@ -1,0 +1,13 @@
+{
+  "type": "music",
+  "stage": "experimental",
+  "domain": "smart_playlist",
+  "name": "Smart Playlists",
+  "description": "Create dynamic or fixed playlists based on rules like genres, artists, albums, favorites and similar tracks.",
+  "codeowners": [],
+  "requirements": [],
+  "documentation": "https://music-assistant.io/plugins/smart-playlists",
+  "multi_instance": false,
+  "builtin": false,
+  "icon": "playlist-star"
+}

--- a/music_assistant/providers/smart_playlist/manifest.json
+++ b/music_assistant/providers/smart_playlist/manifest.json
@@ -4,7 +4,7 @@
   "domain": "smart_playlist",
   "name": "Smart Playlists",
   "description": "Create dynamic or fixed playlists based on rules like genres, artists, albums, favorites and similar tracks.",
-  "codeowners": [],
+  "codeowners": ["@dmoo500"],
   "requirements": [],
   "documentation": "",
   "multi_instance": false,

--- a/music_assistant/providers/smart_playlist/manifest.json
+++ b/music_assistant/providers/smart_playlist/manifest.json
@@ -1,5 +1,5 @@
 {
-  "type": "music",
+  "type": "plugin",
   "stage": "experimental",
   "domain": "smart_playlist",
   "name": "Smart Playlists",

--- a/music_assistant/providers/smart_playlist/manifest.json
+++ b/music_assistant/providers/smart_playlist/manifest.json
@@ -6,7 +6,7 @@
   "description": "Create dynamic or fixed playlists based on rules like genres, artists, albums, favorites and similar tracks.",
   "codeowners": [],
   "requirements": [],
-  "documentation": "https://music-assistant.io/plugins/smart-playlists",
+  "documentation": "",
   "multi_instance": false,
   "builtin": false,
   "icon": "playlist-star"

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import datetime
 import time as _time
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -465,13 +464,13 @@ async def test_dedup_removes_recently_played() -> None:
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
     recent = _make_mock_track("1", "library://track/1")
-    recent.last_played = datetime.datetime.fromtimestamp(_time.time() - 60)  # 1 minute ago
+    recent.last_played = int(_time.time() - 60)  # 1 minute ago
 
     old = _make_mock_track("2", "library://track/2")
-    old.last_played = datetime.datetime.fromtimestamp(_time.time() - 7200)  # 2 hours ago
+    old.last_played = int(_time.time() - 7200)  # 2 hours ago
 
     never = _make_mock_track("3", "library://track/3")
-    never.last_played = None
+    never.last_played = 0  # never played
 
     cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[recent, old, never])
 
@@ -496,7 +495,7 @@ async def test_dedup_fallback_when_pool_exhausted() -> None:
     tracks = []
     for i in range(5):
         t = _make_mock_track(str(i), f"library://track/{i}")
-        t.last_played = datetime.datetime.fromtimestamp(_time.time() - 30)  # 30 sec ago
+        t.last_played = int(_time.time() - 30)  # 30 sec ago
         tracks.append(t)
 
     cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
@@ -568,7 +567,7 @@ async def test_count_tracks_returns_count_and_duration(tmp_path: Any) -> None:
     for i in range(3):
         t = _make_mock_track(str(i), f"library://track/{i}")
         t.duration = 200
-        t.last_played = None
+        t.last_played = 0  # never played
         tracks.append(t)
 
     cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import datetime
+import time as _time
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -348,3 +350,229 @@ async def test_limit_is_respected() -> None:
     rules = SmartPlaylistRules(limit=5)
     result = await plugin._evaluate_rules(rules)
     assert len(result) <= 5
+
+
+# ---------------------------------------------------------------------------
+# New feature tests: seed_artist, exclusions, dedup, validation, count_tracks
+# ---------------------------------------------------------------------------
+
+
+class TestNewValidation:
+    """Validate new mutual-exclusion and range checks."""
+
+    def _make_plugin(self) -> SmartPlaylistProvider:
+        mass = MagicMock()
+        manifest = MagicMock()
+        manifest.domain = "smart_playlist"
+        config = MagicMock()
+        config.get_value.return_value = "GLOBAL"
+        return SmartPlaylistProvider(mass, manifest, config, set())
+
+    def test_seed_track_and_seed_artist_mutually_exclusive(self) -> None:
+        """Setting both seed_track_uri and seed_artist_uri raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(
+            seed_track_uri="library://track/1",
+            seed_artist_uri="library://artist/2",
+        )
+        with pytest.raises(InvalidDataError, match="mutually exclusive"):
+            plugin._validate_rules(rules)
+
+    def test_dedup_hours_out_of_range_raises(self) -> None:
+        """dedup_hours outside 1-8760 raises InvalidDataError."""
+        plugin = self._make_plugin()
+        with pytest.raises(InvalidDataError, match="dedup_hours"):
+            plugin._validate_rules(SmartPlaylistRules(dedup_hours=0))
+        with pytest.raises(InvalidDataError, match="dedup_hours"):
+            plugin._validate_rules(SmartPlaylistRules(dedup_hours=9000))
+
+    def test_dedup_hours_valid_passes(self) -> None:
+        """dedup_hours within 1-8760 does not raise."""
+        plugin = self._make_plugin()
+        plugin._validate_rules(SmartPlaylistRules(dedup_hours=24))  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_seed_artist_uses_similar_artists_tracks() -> None:
+    """seed_artist_uri calls _get_similar_artists_tracks instead of _get_similar_tracks."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    similar_tracks = [_make_mock_track("10", "library://track/10")]
+    cast("Any", plugin)._get_similar_artists_tracks = AsyncMock(return_value=similar_tracks)
+    cast("Any", plugin)._get_similar_tracks = AsyncMock(return_value=[])
+
+    rules = SmartPlaylistRules(seed_artist_uri="library://artist/5", limit=10)
+    result = await plugin._evaluate_rules(rules)
+
+    cast("Any", plugin)._get_similar_artists_tracks.assert_awaited_once()
+    cast("Any", plugin)._get_similar_tracks.assert_not_awaited()
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_exclusion_filters_out_excluded_artist() -> None:
+    """Tracks from excluded artists are removed from the result."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    included = _make_mock_track("1", "library://track/1", artist_ids=["10"])
+    excluded = _make_mock_track("2", "library://track/2", artist_ids=["99"])
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[included, excluded])
+
+    rules = SmartPlaylistRules(excluded_artist_ids=[99], limit=10)
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris
+    assert "library://track/2" not in uris
+
+
+@pytest.mark.asyncio
+async def test_exclusion_filters_out_excluded_uri() -> None:
+    """Tracks whose URI is in excluded_track_uris are removed."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    t1 = _make_mock_track("1", "library://track/1")
+    t2 = _make_mock_track("2", "library://track/2")
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[t1, t2])
+
+    rules = SmartPlaylistRules(excluded_track_uris=["library://track/2"], limit=10)
+    result = await plugin._evaluate_rules(rules)
+    assert all(t.uri != "library://track/2" for t in result)
+
+
+@pytest.mark.asyncio
+async def test_dedup_removes_recently_played() -> None:
+    """Tracks played within dedup_hours are excluded; others are kept."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    recent = _make_mock_track("1", "library://track/1")
+    recent.last_played = datetime.datetime.fromtimestamp(_time.time() - 60)  # 1 minute ago
+
+    old = _make_mock_track("2", "library://track/2")
+    old.last_played = datetime.datetime.fromtimestamp(_time.time() - 7200)  # 2 hours ago
+
+    never = _make_mock_track("3", "library://track/3")
+    never.last_played = None
+
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[recent, old, never])
+
+    rules = SmartPlaylistRules(dedup_hours=1, limit=2)  # limit <= non-recent count
+    result = await plugin._evaluate_rules(rules)
+    uris = {t.uri for t in result}
+    assert "library://track/1" not in uris
+    assert "library://track/2" in uris
+    assert "library://track/3" in uris
+
+
+@pytest.mark.asyncio
+async def test_dedup_fallback_when_pool_exhausted() -> None:
+    """When all tracks were recently played, dedup is ignored and the full pool is returned."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    tracks = []
+    for i in range(5):
+        t = _make_mock_track(str(i), f"library://track/{i}")
+        t.last_played = datetime.datetime.fromtimestamp(_time.time() - 30)  # 30 sec ago
+        tracks.append(t)
+
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
+
+    rules = SmartPlaylistRules(dedup_hours=1, limit=5)
+    result = await plugin._evaluate_rules(rules)
+    # Pool exhausted → fallback to full pool
+    assert len(result) == 5
+
+
+@pytest.mark.asyncio
+async def test_get_playlist_tracks_dynamic_limit_5(tmp_path: Any) -> None:
+    """get_playlist_tracks uses limit=5 for dynamic playlists."""
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+    await plugin.handle_async_init()
+
+    tracks = [_make_mock_track(str(i), f"library://track/{i}") for i in range(50)]
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
+
+    rules = SmartPlaylistRules(limit=100, is_dynamic=True)
+    plugin._rules_store["abc"] = rules
+
+    result = await plugin.get_playlist_tracks("abc")
+    assert len(result) <= 5
+
+
+@pytest.mark.asyncio
+async def test_get_playlist_tracks_static_uses_full_limit(tmp_path: Any) -> None:
+    """get_playlist_tracks uses full rules.limit for static (non-dynamic) playlists."""
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+    await plugin.handle_async_init()
+
+    tracks = [_make_mock_track(str(i), f"library://track/{i}") for i in range(50)]
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
+
+    rules = SmartPlaylistRules(limit=20, is_dynamic=False)
+    plugin._rules_store["xyz"] = rules
+
+    result = await plugin.get_playlist_tracks("xyz")
+    assert len(result) <= 20
+    assert len(result) > 5  # proves limit was not capped at 5
+
+
+@pytest.mark.asyncio
+async def test_count_tracks_returns_count_and_duration(tmp_path: Any) -> None:
+    """count_tracks returns a dict with count and duration_seconds."""
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+    await plugin.handle_async_init()
+
+    tracks = []
+    for i in range(3):
+        t = _make_mock_track(str(i), f"library://track/{i}")
+        t.duration = 200
+        t.last_played = None
+        tracks.append(t)
+
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
+
+    result = await plugin.count_tracks(SmartPlaylistRules(limit=10).to_dict())
+    assert result["count"] == 3
+    assert result["duration_seconds"] == 600

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -156,15 +156,15 @@ async def test_rules_persist_to_disk(tmp_path: Any) -> None:
     config.get_value.return_value = "GLOBAL"
 
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
+    await plugin.handle_async_init()
     plugin._rules_dir = str(rules_dir)
-    plugin._rules_store = {}
-    plugin._names_store = {}
 
     rules = SmartPlaylistRules(genre_ids=[1, 2], favorites_only=True)
     await plugin._save_rules("42", rules)
 
     # Simulate reload
     plugin2 = SmartPlaylistProvider(mass, manifest, config, set())
+    await plugin2.handle_async_init()
     plugin2._rules_dir = str(rules_dir)
     plugin2._rules_store = {}
     plugin2._names_store = {}

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -1,0 +1,350 @@
+"""Tests for the Smart Playlist plugin provider."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.errors import InvalidDataError
+
+from music_assistant.providers.smart_playlist import (
+    SmartPlaylistProvider,
+)
+from music_assistant.providers.smart_playlist.helpers import (
+    LOGIC_AND,
+    LOGIC_OR,
+    SmartPlaylistRules,
+)
+
+# ---------------------------------------------------------------------------
+# SmartPlaylistRules unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSmartPlaylistRules:
+    """Tests for the SmartPlaylistRules dataclass."""
+
+    def test_defaults(self) -> None:
+        """Rules are created with sensible defaults."""
+        rules = SmartPlaylistRules()
+        assert rules.genre_ids == []
+        assert rules.artist_ids == []
+        assert rules.album_ids == []
+        assert rules.favorites_only is False
+        assert rules.seed_track_uri is None
+        assert rules.min_popularity is None
+        assert rules.logic == LOGIC_AND
+        assert rules.limit == 100
+
+    def test_round_trip_serialization(self) -> None:
+        """to_dict / from_dict round-trip preserves all fields."""
+        original = SmartPlaylistRules(
+            genre_ids=[1, 2, 3],
+            artist_ids=[10],
+            album_ids=[],
+            favorites_only=True,
+            seed_track_uri="library://track/42",
+            min_popularity=50,
+            logic=LOGIC_OR,
+            limit=25,
+        )
+        recovered = SmartPlaylistRules.from_dict(original.to_dict())
+        assert recovered == original
+
+    def test_from_dict_partial(self) -> None:
+        """from_dict tolerates missing keys by using defaults."""
+        rules = SmartPlaylistRules.from_dict({"favorites_only": True})
+        assert rules.favorites_only is True
+        assert rules.genre_ids == []
+        assert rules.logic == LOGIC_AND
+
+    def test_human_readable_no_rules(self) -> None:
+        """human_readable for empty rules returns fallback message."""
+        rules = SmartPlaylistRules()
+        assert "No rules" in rules.human_readable()
+
+    def test_human_readable_with_rules(self) -> None:
+        """human_readable includes all active filter names."""
+        rules = SmartPlaylistRules(
+            genre_ids=[1],
+            favorites_only=True,
+            min_popularity=60,
+            logic=LOGIC_AND,
+        )
+        summary = rules.human_readable()
+        assert "Favorites only" in summary
+        assert "Genre" in summary
+        assert "popularity" in summary.lower()
+        assert LOGIC_AND in summary
+
+    def test_human_readable_or_logic(self) -> None:
+        """human_readable uses OR as connector when logic=OR."""
+        rules = SmartPlaylistRules(
+            genre_ids=[1],
+            artist_ids=[5],
+            logic=LOGIC_OR,
+        )
+        assert LOGIC_OR in rules.human_readable()
+
+
+# ---------------------------------------------------------------------------
+# Plugin validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestRuleValidation:
+    """Tests for _validate_rules inside the plugin."""
+
+    def _make_plugin(self) -> SmartPlaylistProvider:
+        """Create a SmartPlaylistProvider with mocked mass."""
+        mass = MagicMock()
+        manifest = MagicMock()
+        manifest.domain = "smart_playlist"
+        config = MagicMock()
+        config.get_value.return_value = "GLOBAL"
+        return SmartPlaylistProvider(mass, manifest, config, set())
+
+    def test_valid_rules_pass(self) -> None:
+        """Valid rules do not raise."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(logic=LOGIC_AND, limit=50)
+        plugin._validate_rules(rules)  # should not raise
+
+    def test_invalid_logic_raises(self) -> None:
+        """Unknown logic operator raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(logic="XOR")
+        with pytest.raises(InvalidDataError, match="logic"):
+            plugin._validate_rules(rules)
+
+    def test_limit_out_of_range_raises(self) -> None:
+        """Limit outside 1-2000 raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(limit=0)
+        with pytest.raises(InvalidDataError, match="limit"):
+            plugin._validate_rules(rules)
+
+        rules_too_high = SmartPlaylistRules(limit=9999)
+        with pytest.raises(InvalidDataError, match="limit"):
+            plugin._validate_rules(rules_too_high)
+
+    def test_popularity_out_of_range_raises(self) -> None:
+        """min_popularity outside 0-100 raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(min_popularity=150)
+        with pytest.raises(InvalidDataError, match="popularity"):
+            plugin._validate_rules(rules)
+
+
+# ---------------------------------------------------------------------------
+# Persistence tests  (using tmp_path, no real MA instance needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rules_persist_to_disk(tmp_path: Any) -> None:
+    """Rules saved to disk survive plugin reload."""
+    rules_dir = tmp_path / "smart_playlists"
+    rules_dir.mkdir()
+
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+    plugin._rules_dir = str(rules_dir)
+    plugin._rules_store = {}
+    plugin._names_store = {}
+
+    rules = SmartPlaylistRules(genre_ids=[1, 2], favorites_only=True)
+    await plugin._save_rules("42", rules)
+
+    # Simulate reload
+    plugin2 = SmartPlaylistProvider(mass, manifest, config, set())
+    plugin2._rules_dir = str(rules_dir)
+    plugin2._rules_store = {}
+    plugin2._names_store = {}
+    await plugin2._load_rules_from_disk()
+
+    assert "42" in plugin2._rules_store
+    assert plugin2._rules_store["42"] == rules
+
+
+# ---------------------------------------------------------------------------
+# Evaluate-rules unit tests with mocked mass
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_track(
+    item_id: str = "1",
+    uri: str = "library://track/1",
+    artist_ids: list[str] | None = None,
+    album_id: str | None = None,
+    favorite: bool = False,
+    popularity: int | None = None,
+) -> MagicMock:
+    """Build a minimal mock Track object."""
+    track = MagicMock()
+    track.item_id = item_id
+    track.uri = uri
+    track.name = f"Track {item_id}"
+    track.favorite = favorite
+
+    artist = MagicMock()
+    artist.item_id = (artist_ids or ["100"])[0]
+    artist.name = "Artist"
+    track.artists = [artist]
+
+    album = MagicMock()
+    album.item_id = album_id or "200"
+    track.album = album
+
+    track.metadata = MagicMock()
+    track.metadata.popularity = popularity
+
+    return track
+
+
+@pytest.mark.asyncio
+async def test_evaluate_and_no_filters_returns_library() -> None:
+    """With no filters, AND logic returns the entire library."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    tracks = [_make_mock_track(str(i), f"library://track/{i}") for i in range(10)]
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
+
+    rules = SmartPlaylistRules(logic=LOGIC_AND, limit=10)
+    result = await plugin._evaluate_and(rules)
+    assert len(result) == 10
+
+
+@pytest.mark.asyncio
+async def test_evaluate_and_artist_filter() -> None:
+    """AND logic filters tracks to only those from the specified artists."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    artist_a = _make_mock_track("1", artist_ids=["10"])
+    artist_b = _make_mock_track("2", artist_ids=["20"])
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[artist_a, artist_b])
+
+    rules = SmartPlaylistRules(artist_ids=[10], logic=LOGIC_AND, limit=10)
+    result = await plugin._evaluate_and(rules)
+    assert len(result) == 1
+    assert result[0].item_id == "1"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_or_genre_and_artist_union() -> None:
+    """OR logic returns union of genre tracks and artist tracks."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    genre_track = _make_mock_track("1", uri="library://track/1", artist_ids=["99"])
+    artist_track = _make_mock_track("2", uri="library://track/2", artist_ids=["10"])
+
+    async def mock_get_library(**kwargs: Any) -> list[MagicMock]:
+        if kwargs.get("genre_ids"):
+            return [genre_track]
+        return [genre_track, artist_track]
+
+    cast("Any", plugin)._get_library_tracks = mock_get_library
+
+    rules = SmartPlaylistRules(
+        genre_ids=[5],
+        artist_ids=[10],
+        logic=LOGIC_OR,
+        limit=10,
+    )
+    result = await plugin._evaluate_or(rules)
+    uris = {t.uri for t in result}
+    assert "library://track/1" in uris
+    assert "library://track/2" in uris
+
+
+@pytest.mark.asyncio
+async def test_popularity_filter_applied() -> None:
+    """Tracks below min_popularity are filtered out."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    low_pop = _make_mock_track("1", uri="library://track/1", popularity=30)
+    high_pop = _make_mock_track("2", uri="library://track/2", popularity=80)
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[low_pop, high_pop])
+    cast("Any", plugin)._get_similar_tracks = AsyncMock(return_value=[])
+
+    rules = SmartPlaylistRules(min_popularity=50, logic=LOGIC_AND, limit=10)
+    result = await plugin._evaluate_rules(rules)
+    assert all(t.metadata.popularity is None or t.metadata.popularity >= 50 for t in result)
+    uris = [t.uri for t in result]
+    assert "library://track/1" not in uris
+    assert "library://track/2" in uris
+
+
+@pytest.mark.asyncio
+async def test_favorites_only_filter() -> None:
+    """favorites_only=True passes favorite=True to the DB query layer."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    fav = _make_mock_track("1", uri="library://track/1", favorite=True)
+    not_fav = _make_mock_track("2", uri="library://track/2", favorite=False)
+    all_tracks = [fav, not_fav]
+
+    async def mock_get_library(**kwargs: Any) -> list[MagicMock]:
+        if kwargs.get("favorite") is True:
+            return [t for t in all_tracks if t.favorite]
+        return all_tracks
+
+    cast("Any", plugin)._get_library_tracks = mock_get_library
+    cast("Any", plugin)._get_similar_tracks = AsyncMock(return_value=[])
+
+    rules = SmartPlaylistRules(favorites_only=True, logic=LOGIC_AND, limit=10)
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris
+    assert "library://track/2" not in uris
+
+
+@pytest.mark.asyncio
+async def test_limit_is_respected() -> None:
+    """Result is capped at rules.limit."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    tracks = [_make_mock_track(str(i), f"library://track/{i}") for i in range(50)]
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
+    cast("Any", plugin)._get_similar_tracks = AsyncMock(return_value=[])
+
+    rules = SmartPlaylistRules(limit=5)
+    result = await plugin._evaluate_rules(rules)
+    assert len(result) <= 5

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -88,6 +88,51 @@ class TestSmartPlaylistRules:
         )
         assert LOGIC_OR in rules.human_readable()
 
+    def test_from_dict_null_list_fields_treated_as_empty(self) -> None:
+        """from_dict treats null for list fields as empty list."""
+        rules = SmartPlaylistRules.from_dict(
+            {"genre_ids": None, "artist_ids": None, "album_ids": None}
+        )
+        assert rules.genre_ids == []
+        assert rules.artist_ids == []
+        assert rules.album_ids == []
+
+    def test_from_dict_null_dict_fields_treated_as_empty(self) -> None:
+        """from_dict treats null for dict fields as empty dict."""
+        rules = SmartPlaylistRules.from_dict(
+            {"genre_names": None, "artist_names": None, "album_names": None}
+        )
+        assert rules.genre_names == {}
+        assert rules.artist_names == {}
+        assert rules.album_names == {}
+
+    def test_from_dict_non_numeric_id_raises(self) -> None:
+        """from_dict raises InvalidDataError for non-numeric ids."""
+        with pytest.raises(InvalidDataError):
+            SmartPlaylistRules.from_dict({"genre_ids": ["abc"]})
+
+    def test_from_dict_wrong_type_for_names_dict_raises(self) -> None:
+        """from_dict raises InvalidDataError when a names field is not a dict."""
+        with pytest.raises(InvalidDataError):
+            SmartPlaylistRules.from_dict({"genre_names": "invalid"})
+
+    def test_from_dict_excluded_null_fields_treated_as_empty(self) -> None:
+        """from_dict treats null for excluded_* fields as empty."""
+        rules = SmartPlaylistRules.from_dict(
+            {
+                "excluded_artist_ids": None,
+                "excluded_album_ids": None,
+                "excluded_track_uris": None,
+                "excluded_artist_names": None,
+                "excluded_album_names": None,
+            }
+        )
+        assert rules.excluded_artist_ids == []
+        assert rules.excluded_album_ids == []
+        assert rules.excluded_track_uris == []
+        assert rules.excluded_artist_names == {}
+        assert rules.excluded_album_names == {}
+
 
 # ---------------------------------------------------------------------------
 # Plugin validation tests


### PR DESCRIPTION
## Smart Playlist Plugin

A new plugin provider that enables smart (rule-based) playlists in Music Assistant.

### Features

- **Filter rules**: Genre, Artist, Album, Favorites only, Min. popularity, Year range
- **Seed track dynamic mode**: pick a track → get similar tracks via `SIMILAR_TRACKS` (e.g. Apple Music, Spotify)
- **Seed artist dynamic mode**: pick an artist → get similar artists' tracks via `SIMILAR_ARTISTS` (e.g. Apple Music)
- **Exclusion filters**: exclude specific artists, albums or track URIs from results
- **Dedup**: skip tracks played within the last N hours (`dedup_hours`)
- **AND / OR logic** for combining filters
- Fixed and dynamic playlist modes (dynamic refreshes on every play, returning a small buffer of 5 tracks per call for effective dedup/shuffle)
- `count_tracks` returns both `count` and `duration_seconds`
- Human-readable rule summary stored as playlist description `[Smart Playlist] ...`
- REST API: `create`, `update_rules`, `get_rules`, `list`, `generate`, `count_tracks`, `preview_tracks`

### Seed track behaviour

When a seed track URI is set:
- `artist_ids` / `album_ids` are ignored (incompatible with similar-track lookup)
- Genre (AND mode), Favorites, Min. popularity and Year range are applied as post-filters on the returned similar tracks
- Year and genre filters are best-effort: tracks without those metadata fields are kept rather than excluded

### Seed artist behaviour

When a seed artist URI is set:
- similar artists are fetched via `SIMILAR_ARTISTS` and tracks from all of them are combined and filtered
- `seed_track_uri` and `seed_artist_uri` are mutually exclusive

### Dependencies
The similar_artists infrastructure (`ArtistsController.similar_artists()` / `MusicProvider.get_similar_artists()`) required by `seed_artist_uri` was merged via #3811. No blocking dependencies remain.
