### PR TITLE
Preserve builtin playlist cover images on M3U rewrites

### DIFF
--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -682,7 +682,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
             provider_instance_id_or_domain="library",
         ):
             items.append(media_item_to_playlist_item(track))
-        return generate_m3u(playlist.name, items)
+        playlist_image_url = playlist.image.path if playlist.image else None
+        return generate_m3u(playlist.name, items, playlist_image_url)
 
     async def import_playlist(
         self,

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -651,7 +651,7 @@ class BuiltinProvider(MusicProvider):
             parsed_items,
             playlist_image_url,
         )
-        return playlist
+        return await self.get_playlist(playlist.item_id)
 
     async def import_radios(self, m3u_data: str) -> int:
         """Import radio stations from M3U8 format.

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -455,6 +455,11 @@ class BuiltinProvider(MusicProvider):
                 break
         self.mass.config.set(key, stored_items)
 
+    @staticmethod
+    def _get_playlist_image_url(playlist: Playlist) -> str | None:
+        """Return the playlist-level image URL to persist in the M3U header."""
+        return playlist.image.path if playlist.image else None
+
     async def _update_playlist_metadata(
         self, playlist_id: str, new_name: str, image_url: str | None
     ) -> None:
@@ -561,7 +566,12 @@ class BuiltinProvider(MusicProvider):
                 entries.append(entry)
             # write updated M3U file
             playlist = await self.get_playlist(prov_playlist_id)
-            await self._write_m3u_file(prov_playlist_id, playlist.name, entries)
+            await self._write_m3u_file(
+                prov_playlist_id,
+                playlist.name,
+                entries,
+                self._get_playlist_image_url(playlist),
+            )
 
     async def remove_playlist_tracks(
         self, prov_playlist_id: str, positions_to_remove: tuple[int, ...]
@@ -574,7 +584,12 @@ class BuiltinProvider(MusicProvider):
             for i in sorted(positions_to_remove, reverse=True):
                 del existing_items[i - 1]
             playlist = await self.get_playlist(prov_playlist_id)
-            await self._write_m3u_file(prov_playlist_id, playlist.name, list(existing_items))
+            await self._write_m3u_file(
+                prov_playlist_id,
+                playlist.name,
+                list(existing_items),
+                self._get_playlist_image_url(playlist),
+            )
 
     async def create_playlist(self, name: str, media_types: set[MediaType]) -> Playlist:
         """Create a new playlist on provider with given name.
@@ -626,10 +641,16 @@ class BuiltinProvider(MusicProvider):
             playlist_name,
             media_types={MediaType.TRACK, MediaType.RADIO},
         )
+        playlist_image_url = parse_m3u_playlist_image(m3u_data)
         # Write the parsed items directly as the M3U file, preserving all
         # metadata from the source. This avoids re-resolving items that
         # already have rich metadata (e.g. exported from another MA instance).
-        await self._write_m3u_file(playlist.item_id, playlist_name, parsed_items)
+        await self._write_m3u_file(
+            playlist.item_id,
+            playlist_name,
+            parsed_items,
+            playlist_image_url,
+        )
         return playlist
 
     async def import_radios(self, m3u_data: str) -> int:
@@ -717,7 +738,12 @@ class BuiltinProvider(MusicProvider):
 
         if changed:
             playlist = await self.get_playlist(prov_playlist_id)
-            await self._write_m3u_file(prov_playlist_id, playlist.name, parsed_items)
+            await self._write_m3u_file(
+                prov_playlist_id,
+                playlist.name,
+                parsed_items,
+                self._get_playlist_image_url(playlist),
+            )
 
         self.logger.info(
             "Import matching: %d matched, %d unmatched out of %d items",
@@ -1423,7 +1449,12 @@ class BuiltinProvider(MusicProvider):
                         item.path,
                     )
             if has_changes:
-                await self._write_m3u_file(playlist_id, playlist.name, list(all_items))
+                await self._write_m3u_file(
+                    playlist_id,
+                    playlist.name,
+                    list(all_items),
+                    self._get_playlist_image_url(playlist),
+                )
                 self.logger.info("Updated playlist '%s' with enriched metadata", playlist.name)
             if errors > 25:
                 raise RuntimeError("Too many errors during playlist migration")

--- a/tests/core/test_import_matching.py
+++ b/tests/core/test_import_matching.py
@@ -320,6 +320,9 @@ async def test_import_playlist_preserves_playlist_image() -> None:
     prov = _make_provider()
     prov_any = cast("Any", prov)
     prov_any.create_playlist = AsyncMock(return_value=_make_playlist("Imported Playlist"))
+    prov_any.get_playlist = AsyncMock(
+        return_value=_make_playlist("Imported Playlist", "https://img.example.com/cover.jpg")
+    )
     prov_any._write_m3u_file = AsyncMock()
 
     m3u_data = generate_m3u(
@@ -328,13 +331,15 @@ async def test_import_playlist_preserves_playlist_image() -> None:
         "https://img.example.com/cover.jpg",
     )
 
-    await prov.import_playlist(m3u_data)
+    result = await prov.import_playlist(m3u_data)
 
     assert prov_any._write_m3u_file.await_args is not None
     args = prov_any._write_m3u_file.await_args.args
     assert args[0] == "playlist_1"
     assert args[1] == "Imported Playlist"
     assert args[3] == "https://img.example.com/cover.jpg"
+    assert result.image is not None
+    assert result.image.path == "https://img.example.com/cover.jpg"
 
 
 async def test_remove_playlist_tracks_preserves_playlist_image() -> None:

--- a/tests/core/test_import_matching.py
+++ b/tests/core/test_import_matching.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 from music_assistant_models.enums import ExternalID, ImageType, MediaType
@@ -317,8 +318,9 @@ def test_export_radios_round_trip() -> None:
 async def test_import_playlist_preserves_playlist_image() -> None:
     """Test that importing an M3U keeps the playlist-level image."""
     prov = _make_provider()
-    prov.create_playlist = AsyncMock(return_value=_make_playlist("Imported Playlist"))
-    prov._write_m3u_file = AsyncMock()
+    prov_any = cast(Any, prov)
+    prov_any.create_playlist = AsyncMock(return_value=_make_playlist("Imported Playlist"))
+    prov_any._write_m3u_file = AsyncMock()
 
     m3u_data = generate_m3u(
         "Imported Playlist",
@@ -328,7 +330,8 @@ async def test_import_playlist_preserves_playlist_image() -> None:
 
     await prov.import_playlist(m3u_data)
 
-    args = prov._write_m3u_file.await_args.args
+    assert prov_any._write_m3u_file.await_args is not None
+    args = prov_any._write_m3u_file.await_args.args
     assert args[0] == "playlist_1"
     assert args[1] == "Imported Playlist"
     assert args[3] == "https://img.example.com/cover.jpg"
@@ -338,7 +341,8 @@ async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
     """Test that rewriting a playlist after track removal keeps the playlist image."""
     prov = _make_provider()
     prov._playlist_locks = {}
-    prov._read_m3u_file = AsyncMock(
+    prov_any = cast(Any, prov)
+    prov_any._read_m3u_file = AsyncMock(
         return_value=generate_m3u(
             "My Playlist",
             [
@@ -348,14 +352,15 @@ async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
             "https://img.example.com/cover.jpg",
         )
     )
-    prov.get_playlist = AsyncMock(
+    prov_any.get_playlist = AsyncMock(
         return_value=_make_playlist("My Playlist", "https://img.example.com/cover.jpg")
     )
-    prov._write_m3u_file = AsyncMock()
+    prov_any._write_m3u_file = AsyncMock()
 
     await prov.remove_playlist_tracks("playlist_1", (1,))
 
-    args = prov._write_m3u_file.await_args.args
+    assert prov_any._write_m3u_file.await_args is not None
+    args = prov_any._write_m3u_file.await_args.args
     assert args[0] == "playlist_1"
     assert args[1] == "My Playlist"
     assert len(args[2]) == 1

--- a/tests/core/test_import_matching.py
+++ b/tests/core/test_import_matching.py
@@ -318,7 +318,7 @@ def test_export_radios_round_trip() -> None:
 async def test_import_playlist_preserves_playlist_image() -> None:
     """Test that importing an M3U keeps the playlist-level image."""
     prov = _make_provider()
-    prov_any = cast(Any, prov)
+    prov_any = cast("Any", prov)
     prov_any.create_playlist = AsyncMock(return_value=_make_playlist("Imported Playlist"))
     prov_any._write_m3u_file = AsyncMock()
 
@@ -341,7 +341,7 @@ async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
     """Test that rewriting a playlist after track removal keeps the playlist image."""
     prov = _make_provider()
     prov._playlist_locks = {}
-    prov_any = cast(Any, prov)
+    prov_any = cast("Any", prov)
     prov_any._read_m3u_file = AsyncMock(
         return_value=generate_m3u(
             "My Playlist",

--- a/tests/core/test_import_matching.py
+++ b/tests/core/test_import_matching.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
-from music_assistant_models.enums import ExternalID, MediaType
+from music_assistant_models.enums import ExternalID, ImageType, MediaType
 from music_assistant_models.media_items import (
     Artist,
     ItemMapping,
+    MediaItemImage,
+    MediaItemMetadata,
+    Playlist,
     ProviderMapping,
     Track,
     UniqueList,
@@ -92,6 +95,35 @@ def _make_playlist_item(
         length=length,
         metadata=metadata,
         providers=providers or [],
+    )
+
+
+def _make_playlist(name: str, image_url: str | None = None) -> Playlist:
+    """Build a Playlist for builtin provider tests."""
+    metadata = MediaItemMetadata()
+    if image_url:
+        metadata.images = UniqueList(
+            [
+                MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=image_url,
+                    provider="builtin",
+                    remotely_accessible=True,
+                )
+            ]
+        )
+    return Playlist(
+        item_id="playlist_1",
+        provider="builtin",
+        name=name,
+        metadata=metadata,
+        provider_mappings={
+            ProviderMapping(
+                item_id="playlist_1",
+                provider_domain="builtin",
+                provider_instance="builtin",
+            )
+        },
     )
 
 
@@ -280,3 +312,51 @@ def test_export_radios_round_trip() -> None:
     assert parsed[1].path == "http://stream.example.com/radio2"
     assert parsed[1].title == "Classic Rock Radio"
     assert parse_m3u_playlist_name(m3u_data) == "Radio Stations"
+
+
+async def test_import_playlist_preserves_playlist_image() -> None:
+    """Test that importing an M3U keeps the playlist-level image."""
+    prov = _make_provider()
+    prov.create_playlist = AsyncMock(return_value=_make_playlist("Imported Playlist"))
+    prov._write_m3u_file = AsyncMock()
+
+    m3u_data = generate_m3u(
+        "Imported Playlist",
+        [PlaylistItem(path="spotify://track/abc123", title="Test", length="120")],
+        "https://img.example.com/cover.jpg",
+    )
+
+    await prov.import_playlist(m3u_data)
+
+    args = prov._write_m3u_file.await_args.args
+    assert args[0] == "playlist_1"
+    assert args[1] == "Imported Playlist"
+    assert args[3] == "https://img.example.com/cover.jpg"
+
+
+async def test_remove_playlist_tracks_preserves_playlist_image() -> None:
+    """Test that rewriting a playlist after track removal keeps the playlist image."""
+    prov = _make_provider()
+    prov._playlist_locks = {}
+    prov._read_m3u_file = AsyncMock(
+        return_value=generate_m3u(
+            "My Playlist",
+            [
+                PlaylistItem(path="spotify://track/one", title="One", length="120"),
+                PlaylistItem(path="spotify://track/two", title="Two", length="180"),
+            ],
+            "https://img.example.com/cover.jpg",
+        )
+    )
+    prov.get_playlist = AsyncMock(
+        return_value=_make_playlist("My Playlist", "https://img.example.com/cover.jpg")
+    )
+    prov._write_m3u_file = AsyncMock()
+
+    await prov.remove_playlist_tracks("playlist_1", (1,))
+
+    args = prov._write_m3u_file.await_args.args
+    assert args[0] == "playlist_1"
+    assert args[1] == "My Playlist"
+    assert len(args[2]) == 1
+    assert args[3] == "https://img.example.com/cover.jpg"

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -20,6 +20,7 @@ from music_assistant.helpers.playlists import (
     media_item_to_playlist_item,
     parse_extinf_title,
     parse_m3u,
+    parse_m3u_playlist_image,
     parse_m3u_playlist_name,
 )
 
@@ -224,6 +225,24 @@ def test_parse_m3u_playlist_name_missing() -> None:
     assert parse_m3u_playlist_name(m3u_data) is None
 
 
+def test_parse_m3u_playlist_image() -> None:
+    """Test extracting a playlist-level cover image from #EXTIMG."""
+    m3u_data = (
+        "#EXTM3U\n"
+        "#EXTIMG:https://img.example.com/cover.jpg\n"
+        "#PLAYLIST:My Playlist\n"
+        "#EXTINF:120,Test\n"
+        "test.mp3\n"
+    )
+    assert parse_m3u_playlist_image(m3u_data) == "https://img.example.com/cover.jpg"
+
+
+def test_parse_m3u_playlist_image_missing() -> None:
+    """Test that None is returned when no playlist-level image exists."""
+    m3u_data = "#EXTM3U\n#PLAYLIST:My Playlist\n#EXTINF:120,Test\ntest.mp3\n"
+    assert parse_m3u_playlist_image(m3u_data) is None
+
+
 # --------------------------------------------------------------------------- #
 #  generate_m3u                                                                #
 # --------------------------------------------------------------------------- #
@@ -298,6 +317,15 @@ def test_generate_m3u_with_images() -> None:
     ]
     result = generate_m3u("Test", items)
     assert "#EXTIMG:thumb||https://img.jpg||spotify||true\n" in result
+
+
+def test_generate_m3u_with_playlist_image() -> None:
+    """Test M3U generation with a playlist-level cover image."""
+    items = [PlaylistItem(path="spotify://track/abc123", title="Test", length="120")]
+    result = generate_m3u("Test", items, "https://img.example.com/cover.jpg")
+    assert result.startswith(
+        "#EXTM3U\n#EXTIMG:https://img.example.com/cover.jpg\n#PLAYLIST:Test\n"
+    )
 
 
 def test_generate_m3u_empty() -> None:

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -323,9 +323,7 @@ def test_generate_m3u_with_playlist_image() -> None:
     """Test M3U generation with a playlist-level cover image."""
     items = [PlaylistItem(path="spotify://track/abc123", title="Test", length="120")]
     result = generate_m3u("Test", items, "https://img.example.com/cover.jpg")
-    assert result.startswith(
-        "#EXTM3U\n#EXTIMG:https://img.example.com/cover.jpg\n#PLAYLIST:Test\n"
-    )
+    assert result.startswith("#EXTM3U\n#EXTIMG:https://img.example.com/cover.jpg\n#PLAYLIST:Test\n")
 
 
 def test_generate_m3u_empty() -> None:


### PR DESCRIPTION
## Problem
Builtin playlist cover images were only persisted in the explicit metadata update path, so other M3U rewrite flows dropped the playlist-level `#EXTIMG` header.

## Changes
- preserve playlist images when builtin playlists are rewritten after track edits, import matching, and migration updates
- preserve playlist images on playlist import and export
- add focused regression coverage for playlist-level image round-tripping