### PR TITLE
Fix AirPlay late joiner sync on Linux

### DIFF
--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections import deque
 from collections.abc import AsyncGenerator
 from contextlib import suppress
 from typing import TYPE_CHECKING
@@ -51,16 +50,10 @@ class AirPlayStreamSession:
         self._audio_source_task: asyncio.Task[None] | None = None
         self._player_ffmpeg: dict[str, FFMpeg] = {}
         self._lock = asyncio.Lock()
-        self._chunk_available = asyncio.Condition(self._lock)
         self.start_ntp: int = 0
         self.start_time: float = 0.0
         self.wait_start: float = 0.0
         self.seconds_streamed: float = 0
-        # Ring buffer for late joiners: stores (chunk_data, seconds_offset) tuples.
-        # Chunks are at most ~1s each. 5 entries = ~5s of history.
-        # If this isn't enough to reach the ideal start position, we simply
-        # start from the oldest available chunk (postponing the start time).
-        self._chunk_buffer: deque[tuple[bytes, float]] = deque(maxlen=5)
 
     async def start(self, audio_source: AsyncGenerator[bytes, None]) -> None:
         """Initialize stream session for all players."""
@@ -122,30 +115,20 @@ class AirPlayStreamSession:
     async def add_client(self, airplay_player: AirPlayPlayer) -> None:
         """Add a sync client to the session as a late joiner.
 
-        Reference clock model:
-        - ``self.start_time`` is the wall-clock instant when stream position 0
-          plays on the speakers.  Stream position P plays at
-          ``self.start_time + P``.
-        - ``self.seconds_streamed`` is the PCM position written to ffmpeg so far.
-          Due to pipeline buffering (ffmpeg + CLI), this is ahead of what is
-          currently audible on the speakers.
-        - The ring buffer holds the most recent PCM chunks (already written to
-          existing players' ffmpeg), giving us a window of "near-future" audio
-          we can replay for the late joiner.
+        Instead of feeding buffered audio from a ring buffer (which blocks
+        the audio streamer and existing players), we:
 
-        Late-join strategy:
-        1. Determine the earliest stream position the device can start playing:
-           ``target_position = (now + wait_start) - start_time``.
-        2. Collect matching ring buffer audio to prime the pipeline.
-        3. The NTP start time is derived from the first byte's stream position
-           via the reference clock: ``start_ntp = start_time + first_byte_pos``.
-        4. While holding the session lock, start ffmpeg+CLI, add the player
-           to sync_clients, and feed the buffered chunks. Keeping this under
-           the lock prevents the audio streamer from interleaving writes with
-           the buffered catch-up, so the late joiner transitions to live
-           playback at a consistent stream position.
-        5. Release the lock so the audio streamer includes the new player in
-           real-time writes going forward.
+        1. Calculate the NTP start time for the position ``seconds_streamed``
+           (the next chunk the audio streamer will write).
+        2. Start ffmpeg+CLI immediately with that NTP.
+        3. Add the player to sync_clients so the audio streamer starts
+           writing to it from the next chunk onwards.
+        4. The device takes ``wait_start`` ms to connect and buffer, during
+           which audio accumulates in the pipe — this is expected.
+
+        The trade-off: the late joiner takes longer to start playing
+        (it must wait for the pipeline to fill), but sync is guaranteed
+        because the NTP precisely matches the first byte written.
         """
         if not self.sync_clients:
             return
@@ -153,85 +136,26 @@ class AirPlayStreamSession:
         if not first_client.stream or not first_client.stream.running:
             return
 
-        async with self._chunk_available:
-            now = time.time()
-            buffered_chunks = self._collect_buffered_chunks(airplay_player, now)
+        now = time.time()
+        # The next chunk the audio streamer writes is at seconds_streamed.
+        # NTP for that position = start_time + seconds_streamed.
+        start_at = self.start_time + self.seconds_streamed
 
-            # If no usable chunks yet (stream just started), wait for the audio
-            # streamer to produce data so we get an accurate start position.
-            if (
-                not buffered_chunks
-                and self._audio_source_task
-                and not self._audio_source_task.done()
-            ):
-                wait_start_seconds = airplay_player.wait_start / 1000
-                self.prov.logger.debug(
-                    "Late joiner %s: waiting for buffered audio (stream position=%.2fs)",
-                    airplay_player.player_id,
-                    self.seconds_streamed,
-                )
-                try:
-                    await asyncio.wait_for(
-                        self._chunk_available.wait_for(
-                            lambda: bool(self._collect_buffered_chunks(airplay_player))
-                        ),
-                        timeout=wait_start_seconds + 5.0,
-                    )
-                    now = time.time()
-                    buffered_chunks = self._collect_buffered_chunks(airplay_player, now)
-                except TimeoutError:
-                    self.prov.logger.warning(
-                        "Late joiner %s: timed out waiting for audio data (stream position=%.2fs)",
-                        airplay_player.player_id,
-                        self.seconds_streamed,
-                    )
-                    return
+        self.prov.logger.debug(
+            "Late joiner %s: stream_pos=%.2fs, start_at is %.2fs from now",
+            airplay_player.player_id,
+            self.seconds_streamed,
+            start_at - now,
+        )
 
-            if not buffered_chunks:
-                self.prov.logger.warning(
-                    "Late joiner %s: no usable buffered audio available (stream position=%.2fs)",
-                    airplay_player.player_id,
-                    self.seconds_streamed,
-                )
-                return
+        start_ntp = unix_time_to_ntp(start_at)
 
-            # Derive NTP from the reference clock: the first byte's stream
-            # position maps to a wall-clock instant via start_time.
-            first_chunk_position = buffered_chunks[0][1]
-            start_at = self.start_time + first_chunk_position
-            buffered_seconds = sum(
-                len(c) / self.pcm_format.pcm_sample_size for c, _ in buffered_chunks
-            )
-
-            self.prov.logger.debug(
-                "Late joiner %s: sending %.2fs of buffered audio (%d chunks), "
-                "stream_pos=%.2fs, first_byte_pos=%.2fs, start_at is %.2fs from now",
-                airplay_player.player_id,
-                buffered_seconds,
-                len(buffered_chunks),
-                self.seconds_streamed,
-                first_chunk_position,
-                start_at - now,
-            )
-
-            start_ntp = unix_time_to_ntp(start_at)
-
+        async with self._lock:
             if airplay_player not in self.sync_clients:
                 self.sync_clients.append(airplay_player)
-
-            # Start ffmpeg+CLI and feed buffered audio inside the lock.
-            # The pipe may block while the CLI connects (~0.6s for RAOP,
-            # ~4s for AP2), but that is fine: the audio streamer is paused
-            # so seconds_streamed stays frozen, and existing players survive
-            # on their pipeline buffer (~5-10s).  Once the CLI connects it
-            # drains the pipe and our writes complete.  The next live chunk
-            # continues seamlessly from where the buffered data ended.
             await self._start_client(airplay_player, start_ntp)
-            await self._feed_buffered_chunks(airplay_player, buffered_chunks)
 
-        # Wait for device connection — the CLI has been connecting in
-        # parallel while we fed buffered data, so this usually returns
-        # immediately.
+        # Wait for device connection outside the lock.
         if airplay_player.stream:
             try:
                 await airplay_player.stream.wait_for_connection()
@@ -316,12 +240,6 @@ class AirPlayStreamSession:
             if not sync_clients:
                 return False
 
-            # Add chunk to ring buffer for late joiners (before seconds_streamed is updated)
-            chunk_position = self.seconds_streamed
-            self._chunk_buffer.append((chunk, chunk_position))
-            # Notify late joiners waiting for buffered data
-            self._chunk_available.notify_all()
-
             # Write chunk to all players
             write_tasks = [self._write_chunk_to_player(x, chunk) for x in sync_clients if x.stream]
             results = await asyncio.gather(*write_tasks, return_exceptions=True)
@@ -361,80 +279,6 @@ class AirPlayStreamSession:
             if ffmpeg.closed:
                 return
             await asyncio.wait_for(ffmpeg.write(chunk), timeout=35.0)
-
-    async def _feed_buffered_chunks(
-        self,
-        airplay_player: AirPlayPlayer,
-        buffered_chunks: list[tuple[bytes, float]],
-    ) -> None:
-        """Feed buffered chunks to a late joiner to prime the ffmpeg pipeline.
-
-        :param airplay_player: The late joiner player.
-        :param buffered_chunks: List of (chunk_data, position) tuples to send.
-        """
-        try:
-            for chunk, _position in buffered_chunks:
-                await self._write_chunk_to_player(airplay_player, chunk)
-        except Exception as err:
-            self.prov.logger.warning(
-                "Failed to feed buffered chunks to late joiner %s: %s",
-                airplay_player.player_id,
-                err,
-            )
-            # Remove the client if feeding buffered chunks fails
-            self.mass.create_task(self.remove_client(airplay_player))
-
-    def _collect_buffered_chunks(
-        self,
-        airplay_player: AirPlayPlayer,
-        now: float | None = None,
-    ) -> list[tuple[bytes, float]]:
-        """Collect buffered chunks to prime a late joiner's pipeline.
-
-        Uses the reference clock (``self.start_time``) and the device's
-        ``wait_start`` to determine the earliest playable stream position.
-        Chunks before that position are discarded; a straddling chunk is
-        trimmed so byte 0 aligns exactly with the target position.
-
-        Returns all eligible chunks from the ring buffer. The buffer is sized
-        to cover the full pipeline depth (~15s), which is needed for the NTP
-        start time to land close to ``now + wait_start``.
-
-        :param airplay_player: The late joiner player.
-        :param now: Current wall-clock time. If None, uses time.time().
-        :return: List of (chunk_data, stream_position) tuples.
-        """
-        if now is None:
-            now = time.time()
-
-        # Earliest stream position the device can play:
-        # it needs wait_start seconds from now to connect + fill its buffer.
-        wait_start_seconds = airplay_player.wait_start / 1000
-        min_position = (now + wait_start_seconds) - self.start_time
-
-        pcm_sample_size = self.pcm_format.pcm_sample_size
-        bytes_per_sample = pcm_sample_size // self.pcm_format.sample_rate
-        candidates: list[tuple[bytes, float]] = []
-
-        for chunk, pos in self._chunk_buffer:
-            chunk_duration = len(chunk) / pcm_sample_size
-            chunk_end = pos + chunk_duration
-
-            if chunk_end <= min_position:
-                continue
-
-            if pos >= min_position:
-                candidates.append((chunk, pos))
-            else:
-                # Straddles min_position — trim so byte 0 aligns exactly.
-                trim_seconds = min_position - pos
-                trim_bytes = int(trim_seconds * pcm_sample_size)
-                trim_bytes = (trim_bytes // bytes_per_sample) * bytes_per_sample
-                trimmed = chunk[trim_bytes:]
-                if trimmed:
-                    candidates.append((trimmed, pos + trim_bytes / pcm_sample_size))
-
-        return candidates
 
     async def _write_eof_to_player(self, airplay_player: AirPlayPlayer) -> None:
         """Write EOF to a specific player."""

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -161,9 +161,18 @@ class AirPlayStreamSession:
             # Start ffmpeg+CLI and immediately write the buffered PCM.
             # ffmpeg accepts data on stdin right away; it queues in the pipe
             # while cliraop is still connecting to the device.
-            await self._start_client(airplay_player, start_ntp)
-            if buffered_pcm:
-                await self._write_chunk_to_player(airplay_player, buffered_pcm)
+            try:
+                await self._start_client(airplay_player, start_ntp)
+                if buffered_pcm:
+                    await self._write_chunk_to_player(airplay_player, buffered_pcm)
+            except Exception as err:
+                self.prov.logger.warning(
+                    "Late joiner %s: failed to start/prime pipeline: %s",
+                    airplay_player.player_id,
+                    err,
+                )
+                await self.stop_client(airplay_player)
+                return
 
             # Now add to sync_clients — the audio streamer's next chunk
             # continues exactly from seconds_streamed where the buffer ended.

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -57,10 +57,10 @@ class AirPlayStreamSession:
         self.wait_start: float = 0.0
         self.seconds_streamed: float = 0
         # Ring buffer for late joiners: stores (chunk_data, seconds_offset) tuples.
-        # Audio is sliced into ~100ms chunks.  The buffer must cover the full
-        # pipeline depth (ffmpeg + CLI internal buffering) which can be up to
-        # ~10s for AP2.  150 entries ≈ 15s — enough headroom for any protocol.
-        self._chunk_buffer: deque[tuple[bytes, float]] = deque(maxlen=150)
+        # Chunks are at most ~1s each. 5 entries = ~5s of history.
+        # If this isn't enough to reach the ideal start position, we simply
+        # start from the oldest available chunk (postponing the start time).
+        self._chunk_buffer: deque[tuple[bytes, float]] = deque(maxlen=5)
 
     async def start(self, audio_source: AsyncGenerator[bytes, None]) -> None:
         """Initialize stream session for all players."""
@@ -258,9 +258,9 @@ class AirPlayStreamSession:
                 if not self.sync_clients:
                     break
 
-                # Split into ~100ms sub-chunks for predictable ring-buffer
-                # granularity and to prevent write timeouts on large segments.
-                for sub_chunk in iter_pcm_slices(chunk, self.pcm_format, target_duration_ms=100):
+                # Cap chunks at ~1 second to prevent write timeouts on large
+                # segments (e.g. crossfades). Smaller source chunks pass through as-is.
+                for sub_chunk in iter_pcm_slices(chunk, self.pcm_format, target_duration_ms=1000):
                     if not self.sync_clients:
                         break
                     has_running_clients = await self._write_chunk_to_all_players(sub_chunk)

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -195,9 +195,9 @@ class AirPlayStreamSession:
                             "No running clients remaining, stopping audio streamer"
                         )
                         break
-                    sub_duration = len(sub_chunk) / pcm_sample_size
-                    self.seconds_streamed += sub_duration
-                    seconds_since_yield += sub_duration
+                    # seconds_streamed is updated inside _write_chunk_to_all_players
+                    # under the lock, so add_client reads a consistent value.
+                    seconds_since_yield += len(sub_chunk) / pcm_sample_size
                     # Yield periodically (~every 0.5s of audio) so the event loop
                     # can process other tasks without starving the audio pipeline.
                     if seconds_since_yield >= 0.5:
@@ -241,6 +241,10 @@ class AirPlayStreamSession:
             sync_clients = [x for x in self.sync_clients if x.stream and x.stream.running]
             if not sync_clients:
                 return False
+
+            # Update seconds_streamed under the lock so add_client always
+            # reads a value consistent with what has been written.
+            self.seconds_streamed += len(chunk) / self.pcm_format.pcm_sample_size
 
             # Write chunk to all players
             write_tasks = [self._write_chunk_to_player(x, chunk) for x in sync_clients if x.stream]

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -54,6 +54,12 @@ class AirPlayStreamSession:
         self.start_time: float = 0.0
         self.wait_start: float = 0.0
         self.seconds_streamed: float = 0
+        # Raw PCM ring buffer for late joiners.  Capped at ~5 seconds.
+        # When a late joiner arrives we send this buffer to prime its
+        # pipeline so it starts playing quickly instead of waiting for
+        # the full pipeline to fill from scratch.
+        self._pcm_buffer = bytearray()
+        self._pcm_buffer_max = pcm_format.pcm_sample_size * 5  # 5 seconds
 
     async def start(self, audio_source: AsyncGenerator[bytes, None]) -> None:
         """Initialize stream session for all players."""
@@ -115,20 +121,16 @@ class AirPlayStreamSession:
     async def add_client(self, airplay_player: AirPlayPlayer) -> None:
         """Add a sync client to the session as a late joiner.
 
-        Instead of feeding buffered audio from a ring buffer (which blocks
-        the audio streamer and existing players), we:
+        Uses the PCM ring buffer to prime the late joiner's pipeline so it
+        starts playing quickly.  All work happens under the lock to ensure
+        ``seconds_streamed`` and the buffer are consistent.
 
-        1. Calculate the NTP start time for the position ``seconds_streamed``
-           (the next chunk the audio streamer will write).
-        2. Start ffmpeg+CLI immediately with that NTP.
-        3. Add the player to sync_clients so the audio streamer starts
-           writing to it from the next chunk onwards.
-        4. The device takes ``wait_start`` ms to connect and buffer, during
-           which audio accumulates in the pipe — this is expected.
-
-        The trade-off: the late joiner takes longer to start playing
-        (it must wait for the pipeline to fill), but sync is guaranteed
-        because the NTP precisely matches the first byte written.
+        1. Snapshot the ring buffer and calculate how many seconds it holds.
+        2. NTP = ``start_time + (seconds_streamed - buffer_seconds)`` — the
+           first byte in the buffer maps to that stream position.
+        3. Start ffmpeg+CLI, write the buffer into ffmpeg (primes the pipe
+           while cliraop is still connecting), then add to sync_clients so
+           the audio streamer continues seamlessly from where the buffer ends.
         """
         if not self.sync_clients:
             return
@@ -139,23 +141,36 @@ class AirPlayStreamSession:
         now = time.time()
 
         async with self._lock:
-            # Read seconds_streamed under the lock so the value matches
-            # exactly the position where the audio streamer will next write
-            # to this player. Any mismatch causes the late joiner to be
-            # ahead or behind.
-            start_at = self.start_time + self.seconds_streamed
+            pcm_sample_size = self.pcm_format.pcm_sample_size
+            # Snapshot the buffer and calculate its duration
+            buffered_pcm = bytes(self._pcm_buffer)
+            buffer_seconds = len(buffered_pcm) / pcm_sample_size
+            # The first byte in the buffer corresponds to this stream position
+            first_byte_pos = self.seconds_streamed - buffer_seconds
+            start_at = self.start_time + first_byte_pos
             start_ntp = unix_time_to_ntp(start_at)
 
             self.prov.logger.debug(
-                "Late joiner %s: stream_pos=%.2fs, start_at is %.2fs from now",
+                "Late joiner %s: sending %.2fs of buffered audio, "
+                "stream_pos=%.2fs, first_byte_pos=%.2fs, start_at is %.2fs from now",
                 airplay_player.player_id,
+                buffer_seconds,
                 self.seconds_streamed,
+                first_byte_pos,
                 start_at - now,
             )
 
+            # Start ffmpeg+CLI and immediately write the buffered PCM.
+            # ffmpeg accepts data on stdin right away; it queues in the pipe
+            # while cliraop is still connecting to the device.
+            await self._start_client(airplay_player, start_ntp)
+            if buffered_pcm:
+                await self._write_chunk_to_player(airplay_player, buffered_pcm)
+
+            # Now add to sync_clients — the audio streamer's next chunk
+            # continues exactly from seconds_streamed where the buffer ended.
             if airplay_player not in self.sync_clients:
                 self.sync_clients.append(airplay_player)
-            await self._start_client(airplay_player, start_ntp)
 
         # Wait for device connection outside the lock.
         if airplay_player.stream:
@@ -242,9 +257,13 @@ class AirPlayStreamSession:
             if not sync_clients:
                 return False
 
-            # Update seconds_streamed under the lock so add_client always
-            # reads a value consistent with what has been written.
+            # Update seconds_streamed and ring buffer under the lock so
+            # add_client always reads consistent values.
             self.seconds_streamed += len(chunk) / self.pcm_format.pcm_sample_size
+            self._pcm_buffer.extend(chunk)
+            overflow = len(self._pcm_buffer) - self._pcm_buffer_max
+            if overflow > 0:
+                del self._pcm_buffer[:overflow]
 
             # Write chunk to all players
             write_tasks = [self._write_chunk_to_player(x, chunk) for x in sync_clients if x.stream]

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -137,20 +137,22 @@ class AirPlayStreamSession:
             return
 
         now = time.time()
-        # The next chunk the audio streamer writes is at seconds_streamed.
-        # NTP for that position = start_time + seconds_streamed.
-        start_at = self.start_time + self.seconds_streamed
-
-        self.prov.logger.debug(
-            "Late joiner %s: stream_pos=%.2fs, start_at is %.2fs from now",
-            airplay_player.player_id,
-            self.seconds_streamed,
-            start_at - now,
-        )
-
-        start_ntp = unix_time_to_ntp(start_at)
 
         async with self._lock:
+            # Read seconds_streamed under the lock so the value matches
+            # exactly the position where the audio streamer will next write
+            # to this player. Any mismatch causes the late joiner to be
+            # ahead or behind.
+            start_at = self.start_time + self.seconds_streamed
+            start_ntp = unix_time_to_ntp(start_at)
+
+            self.prov.logger.debug(
+                "Late joiner %s: stream_pos=%.2fs, start_at is %.2fs from now",
+                airplay_player.player_id,
+                self.seconds_streamed,
+                start_at - now,
+            )
+
             if airplay_player not in self.sync_clients:
                 self.sync_clients.append(airplay_player)
             await self._start_client(airplay_player, start_ntp)

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -132,15 +132,14 @@ class AirPlayStreamSession:
            while cliraop is still connecting), then add to sync_clients so
            the audio streamer continues seamlessly from where the buffer ends.
         """
-        if not self.sync_clients:
-            return
-        first_client = self.sync_clients[0]
-        if not first_client.stream or not first_client.stream.running:
-            return
-
         now = time.time()
 
         async with self._lock:
+            if not self.sync_clients:
+                return
+            first_client = self.sync_clients[0]
+            if not first_client.stream or not first_client.stream.running:
+                return
             pcm_sample_size = self.pcm_format.pcm_sample_size
             # Snapshot the buffer and calculate its duration
             buffered_pcm = bytes(self._pcm_buffer)

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -132,14 +132,13 @@ class AirPlayStreamSession:
            while cliraop is still connecting), then add to sync_clients so
            the audio streamer continues seamlessly from where the buffer ends.
         """
-        now = time.time()
-
         async with self._lock:
             if not self.sync_clients:
                 return
             first_client = self.sync_clients[0]
             if not first_client.stream or not first_client.stream.running:
                 return
+            now = time.time()
             pcm_sample_size = self.pcm_format.pcm_sample_size
             # Snapshot the buffer and calculate its duration
             buffered_pcm = bytes(self._pcm_buffer)

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -40,7 +40,7 @@ def _make_session(
     session.start_ntp = 1  # dummy
     session.wait_start = 2.0
 
-    session._chunk_buffer = deque(maxlen=150)
+    session._chunk_buffer = deque(maxlen=5)
     for pos in chunk_positions:
         session._chunk_buffer.append((b"\x00" * PCM_SAMPLE_SIZE, pos))
 

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -1,7 +1,6 @@
 """Unit tests for AirPlay stream session late-join logic."""
 
 import time
-from collections import deque
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -10,19 +9,16 @@ import pytest
 from music_assistant.providers.airplay.stream_session import AirPlayStreamSession
 
 PCM_SAMPLE_SIZE = 176400  # 44.1kHz / 16-bit / 2ch
-BYTES_PER_SAMPLE = 4  # 16-bit * 2ch
 
 
 def _make_session(
     start_time: float,
     seconds_streamed: float,
-    chunk_positions: list[float],
 ) -> AirPlayStreamSession:
-    """Create a stream session with pre-filled ring buffer for testing.
+    """Create a stream session for testing.
 
     :param start_time: The wall-clock time when the stream was started.
     :param seconds_streamed: How many seconds of audio have been streamed.
-    :param chunk_positions: List of stream positions for each chunk in the ring buffer.
     """
     prov = MagicMock()
 
@@ -40,18 +36,11 @@ def _make_session(
     session.start_ntp = 1  # dummy
     session.wait_start = 2.0
 
-    session._chunk_buffer = deque(maxlen=5)
-    for pos in chunk_positions:
-        session._chunk_buffer.append((b"\x00" * PCM_SAMPLE_SIZE, pos))
-
     return session
 
 
 def _make_late_joiner(wait_start_ms: int = 2000) -> MagicMock:
-    """Create a mock AirPlay player for late-join testing.
-
-    :param wait_start_ms: The wait_start value in milliseconds.
-    """
+    """Create a mock AirPlay player for late-join testing."""
     player = MagicMock()
     player.player_id = "late_joiner"
     player.wait_start = wait_start_ms
@@ -72,24 +61,27 @@ def _setup_stream(player: MagicMock) -> Any:
     return _side_effect
 
 
-async def _run_add_client(
-    session: AirPlayStreamSession,
-    player: MagicMock,
-) -> tuple[float, list[tuple[bytes, float]]]:
-    """Run add_client and return (captured_start_at, fed_chunks).
+@pytest.mark.asyncio
+async def test_late_join_start_at_matches_seconds_streamed() -> None:
+    """Test that start_at = start_time + seconds_streamed.
 
-    Patches unix_time_to_ntp to capture the start_at value and
-    _start_client/_feed_buffered_chunks to avoid real I/O.
+    The late joiner starts from the current stream position. The NTP
+    tells the device to play byte 0 at start_time + seconds_streamed.
     """
+    now = time.time()
+    start_time = now - 10
+    seconds_streamed = 12.5
+    session = _make_session(start_time, seconds_streamed)
+    player = _make_late_joiner(wait_start_ms=2000)
+
     captured_start_at: list[float] = []
 
     def capture_ntp(unix_ts: float) -> int:
         captured_start_at.append(unix_ts)
-        return 1  # dummy NTP value
+        return 1
 
     with (
         patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
-        patch.object(session, "_feed_buffered_chunks", new_callable=AsyncMock) as mock_feed,
         patch(
             "music_assistant.providers.airplay.stream_session.unix_time_to_ntp",
             side_effect=capture_ntp,
@@ -98,147 +90,44 @@ async def _run_add_client(
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-        fed_chunks: list[tuple[bytes, float]] = []
-        if mock_feed.called:
-            fed_chunks = list(mock_feed.call_args.args[1])
-
     assert captured_start_at, "unix_time_to_ntp was never called"
-    return captured_start_at[0], fed_chunks
-
-
-@pytest.mark.asyncio
-async def test_late_join_start_at_never_in_the_past() -> None:
-    """Test that start_at is always >= now + wait_start.
-
-    AirPlay 2 cannot handle receiving an NTP start time in the past.
-    """
-    now = time.time()
-    wait_start_ms = 2000
-    # Stream running for 20s, ring buffer has chunks at positions 10-19.
-    # With wait_start=2s, min_position = (now+2) - (now-10) = 12.
-    # Chunks at 12-19 pass the filter.
-    start_time = now - 10
-    session = _make_session(start_time, 20.0, [float(i) for i in range(10, 20)])
-    player = _make_late_joiner(wait_start_ms=wait_start_ms)
-
-    start_at, _ = await _run_add_client(session, player)
-
-    min_start_at = now + wait_start_ms / 1000
-    assert start_at >= min_start_at - 0.1, (
-        f"start_at must be >= now + wait_start, got {start_at - now:.2f}s from now"
+    expected = start_time + seconds_streamed
+    assert abs(captured_start_at[0] - expected) < 0.1, (
+        f"start_at should be start_time + seconds_streamed, "
+        f"got diff={captured_start_at[0] - expected:.4f}s"
     )
 
 
 @pytest.mark.asyncio
-async def test_late_join_start_at_matches_first_byte() -> None:
-    """Test that start_at corresponds to the stream position of the first byte fed.
-
-    The CLI maps byte 0 to start_ntp, so they must match for sync.
-    """
+async def test_late_join_adds_to_sync_clients() -> None:
+    """Test that the late joiner is added to sync_clients."""
     now = time.time()
-    # With wait_start=2s, min_position = (now+2) - start_time.
-    # Place chunks so some are at or after min_position.
-    # start_time = now - 10, min_position = 12, chunks at 10-19.
-    start_time = now - 10
-    session = _make_session(start_time, 20.0, [float(i) for i in range(10, 20)])
-    player = _make_late_joiner(wait_start_ms=2000)
+    session = _make_session(now - 10, 12.5)
+    player = _make_late_joiner()
 
-    start_at, fed_chunks = await _run_add_client(session, player)
+    with patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start:
+        mock_start.side_effect = _setup_stream(player)
+        with patch(
+            "music_assistant.providers.airplay.stream_session.unix_time_to_ntp",
+            return_value=1,
+        ):
+            await session.add_client(player)
 
-    assert fed_chunks, "Expected buffered chunks to be fed"
-    first_chunk_pos = fed_chunks[0][1]
-    expected = start_time + first_chunk_pos
-    assert abs(start_at - expected) < 0.01, (
-        f"start_at must equal start_time + first_chunk_pos, got diff={start_at - expected:.4f}s"
-    )
+    assert player in session.sync_clients
 
 
 @pytest.mark.asyncio
-async def test_late_join_trims_first_chunk() -> None:
-    """Test that the first chunk is trimmed when it straddles min_position."""
+async def test_late_join_no_running_session() -> None:
+    """Test that add_client is a no-op when no session is running."""
     now = time.time()
-    # With wait_start=2s, min_position = (now+2) - start_time = 52.
-    # Place a chunk at position 51 that extends to 52 (straddles min_position).
-    start_time = now - 50
-    session = _make_session(start_time, 53.0, [51.0, 52.0, 53.0])
-    player = _make_late_joiner(wait_start_ms=2000)
+    session = _make_session(now - 10, 12.5)
+    # Make the leader's stream not running
+    leader = session.sync_clients[0]
+    leader.stream = MagicMock()
+    leader.stream.running = False
+    player = _make_late_joiner()
 
-    start_at, fed_chunks = await _run_add_client(session, player)
-
-    assert fed_chunks, "Expected buffered chunks to be fed"
-    first_data, first_pos = fed_chunks[0]
-
-    # start_at must match the first byte and be >= now + wait_start
-    assert start_at >= now + 2.0 - 0.1
-    assert abs(start_at - (session.start_time + first_pos)) < 0.01
-
-    # First chunk should be at min_position (52.0), not 51.0
-    assert first_pos >= 52.0 - 0.1
-
-    # If trimmed from position 51, it should be smaller than a full chunk
-    # (the chunk at 52.0 passes the filter directly, so trimming only happens
-    # if no full chunks are >= min_position)
-    assert len(first_data) <= PCM_SAMPLE_SIZE
-    assert len(first_data) % BYTES_PER_SAMPLE == 0
-
-
-@pytest.mark.asyncio
-async def test_late_join_always_trims_straddling_chunk() -> None:
-    """Test that a chunk straddling min_position is included even when later chunks pass the filter.
-
-    Previously, trimming only happened when no full chunks passed the >= filter.
-    With 1-second chunks this meant we always snapped to the next boundary, losing
-    up to 1 second of usable buffered audio. The improved logic always includes
-    the partial straddling chunk, giving the late joiner more buffer and a more
-    precise start time.
-    """
-    now = time.time()
-    # start_time = now - 50, wait_start = 2s, min_position = 52.0
-    # But let's make min_position fall mid-chunk by adjusting start_time slightly.
-    # With start_time = now - 50.5, min_position = (now+2) - (now-50.5) = 52.5
-    start_time = now - 50.5
-    session = _make_session(start_time, 54.0, [52.0, 53.0])
-    player = _make_late_joiner(wait_start_ms=2000)
-
-    start_at, fed_chunks = await _run_add_client(session, player)
-
-    assert fed_chunks, "Expected buffered chunks to be fed"
-    first_data, first_pos = fed_chunks[0]
-
-    # The chunk at position 52.0 straddles min_position (52.5).
-    # It should be trimmed so first_pos is ~52.5, NOT skipped in favour of 53.0.
-    assert first_pos < 53.0, f"First chunk should be trimmed from 52.0, not 53.0 (got {first_pos})"
-    assert first_pos >= 52.5 - 0.1
-    # Trimmed chunk should be smaller than a full 1-second chunk
-    assert len(first_data) < PCM_SAMPLE_SIZE
-    assert len(first_data) % BYTES_PER_SAMPLE == 0
-    # start_at should match first byte position
-    assert abs(start_at - (session.start_time + first_pos)) < 0.01
-    # We should have 2 chunks (trimmed + the one at 53.0)
-    assert len(fed_chunks) == 2
-
-
-@pytest.mark.asyncio
-async def test_late_join_no_buffer_returns_early() -> None:
-    """Test that with no usable buffered audio, the late joiner is not added.
-
-    When the ring buffer has no chunks at the target position, adding the
-    player would cause a sync mismatch (NTP targets a future position but
-    audio data starts from the current position). Instead, add_client
-    should return without starting the player.
-    """
-    now = time.time()
-    start_time = now - 50
-    session = _make_session(start_time, 50.0, chunk_positions=[])
-    player = _make_late_joiner(wait_start_ms=2000)
-
-    with (
-        patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
-        patch.object(session, "_feed_buffered_chunks", new_callable=AsyncMock) as mock_feed,
-    ):
+    with patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start:
         await session.add_client(player)
-
-        # Player should NOT have been started or added since there's no usable audio
         mock_start.assert_not_called()
-        mock_feed.assert_not_called()
         assert player not in session.sync_clients

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -62,12 +62,8 @@ def _setup_stream(player: MagicMock) -> Any:
 
 
 @pytest.mark.asyncio
-async def test_late_join_start_at_matches_seconds_streamed() -> None:
-    """Test that start_at = start_time + seconds_streamed.
-
-    The late joiner starts from the current stream position. The NTP
-    tells the device to play byte 0 at start_time + seconds_streamed.
-    """
+async def test_late_join_empty_buffer() -> None:
+    """Test that with an empty buffer, start_at = start_time + seconds_streamed."""
     now = time.time()
     start_time = now - 10
     seconds_streamed = 12.5
@@ -92,9 +88,42 @@ async def test_late_join_start_at_matches_seconds_streamed() -> None:
 
     assert captured_start_at, "unix_time_to_ntp was never called"
     expected = start_time + seconds_streamed
+    assert abs(captured_start_at[0] - expected) < 0.1
+
+
+@pytest.mark.asyncio
+async def test_late_join_with_buffered_pcm() -> None:
+    """Test that with a non-empty buffer, start_at accounts for buffer duration."""
+    now = time.time()
+    start_time = now - 10
+    seconds_streamed = 12.5
+    session = _make_session(start_time, seconds_streamed)
+    # Fill the ring buffer with 3 seconds of PCM
+    session._pcm_buffer = bytearray(b"\x00" * PCM_SAMPLE_SIZE * 3)
+    player = _make_late_joiner(wait_start_ms=2000)
+
+    captured_start_at: list[float] = []
+
+    def capture_ntp(unix_ts: float) -> int:
+        captured_start_at.append(unix_ts)
+        return 1
+
+    with (
+        patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
+        patch.object(session, "_write_chunk_to_player", new_callable=AsyncMock),
+        patch(
+            "music_assistant.providers.airplay.stream_session.unix_time_to_ntp",
+            side_effect=capture_ntp,
+        ),
+    ):
+        mock_start.side_effect = _setup_stream(player)
+        await session.add_client(player)
+
+    assert captured_start_at, "unix_time_to_ntp was never called"
+    # NTP should be start_time + (seconds_streamed - 3.0)
+    expected = start_time + (seconds_streamed - 3.0)
     assert abs(captured_start_at[0] - expected) < 0.1, (
-        f"start_at should be start_time + seconds_streamed, "
-        f"got diff={captured_start_at[0] - expected:.4f}s"
+        f"start_at should account for buffer, expected {expected}, got {captured_start_at[0]}"
     )
 
 


### PR DESCRIPTION
## Problem

AirPlay late joiners were consistently out of sync on Linux (HAOS), while working on macOS. Root causes:

- `seconds_streamed` was updated outside the lock, causing a race with `add_client` — the NTP could be off by one chunk (~1 second) depending on timing
- The previous chunk-based ring buffer approach caused excessive CPU usage (100ms chunks = 10x lock cycles/sec) and pipe-blocking issues on constrained systems
- 100ms chunk splitting was unnecessary overhead for this use case

## Changes

- Replace chunk-based ring buffer with a simple 5-second raw PCM `bytearray` buffer
- Late joiner receives the buffered PCM to prime its pipeline (fast start ~3-5s instead of ~8s)
- NTP calculated as `start_time + (seconds_streamed - buffer_seconds)` — first byte aligns exactly
- All buffer/counter updates happen under the lock to prevent race conditions
- Switch back to 1-second chunk splitting (caps large source chunks, small ones pass through)