### PR TITLE
Small fixes for flow stream buffering and crossfade yielding

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1748,6 +1748,19 @@ class StreamsAudio:
                 except QueueEmpty:
                     break
 
+            if queue_track.media_type == MediaType.RADIO:
+                # radio streams should not be played in flow mode
+                # break out of the flow stream and let the queue controller
+                # restart playback using the single item stream
+                self.logger.info(
+                    "Radio item %s (%s) encountered in flow stream for queue %s "
+                    "- breaking out to single item stream",
+                    queue_track.queue_item_id,
+                    queue_track.name,
+                    queue.display_name,
+                )
+                break
+
             if queue_track.streamdetails is None:
                 self.logger.error(
                     "No StreamDetails for queue item %s (%s) on queue %s - skipping track",

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1488,6 +1488,9 @@ class StreamsAudio:
             if streamdetails.duration
             else crossfade_buffer_duration,
         )
+        # skip crossfade if buffer would be too small to be meaningful
+        if crossfade_buffer_duration < 5:
+            crossfade_buffer_duration = 0
         # Ensure crossfade buffer size is aligned to frame boundaries
         # Frame size = bytes_per_sample * channels
         bytes_per_sample = pcm_format.bit_depth // 8
@@ -1525,6 +1528,10 @@ class StreamsAudio:
             discard_seconds = streamdetails.seek_position
             discard_leftover = 0
 
+        # Yield the first crossfade_buffer_size worth of audio immediately
+        # so playback starts right away. Only after that, start accumulating
+        # the crossfade holdback buffer for the end-of-track crossfade.
+        warmup_bytes = 0
         total_chunks_received = 0
         async for chunk in self.get_queue_item_stream(
             queue_item,
@@ -1537,11 +1544,16 @@ class StreamsAudio:
                 chunk = chunk[discard_leftover:]  # noqa: PLW2901
                 discard_leftover = 0
 
-            buffer += chunk
-            del chunk
-            if len(buffer) < crossfade_buffer_size:
+            if warmup_bytes < crossfade_buffer_size:
+                # warmup: yield directly, don't buffer
+                yield chunk
+                warmup_bytes += len(chunk)
+                bytes_written += len(chunk)
+                del chunk
                 continue
 
+            buffer += chunk
+            del chunk
             # yield everything above the crossfade buffer
             while len(buffer) > crossfade_buffer_size:
                 yield buffer[: pcm_format.pcm_sample_size]
@@ -1798,6 +1810,9 @@ class StreamsAudio:
                 if queue_track.streamdetails.duration
                 else crossfade_buffer_duration,
             )
+            # skip crossfade if buffer would be too small to be meaningful
+            if crossfade_buffer_duration < 5:
+                crossfade_buffer_duration = 0
             # Ensure crossfade buffer size is aligned to frame boundaries
             # Frame size = bytes_per_sample * channels
             bytes_per_sample = pcm_format.bit_depth // 8
@@ -1808,6 +1823,7 @@ class StreamsAudio:
 
             bytes_written = 0
             crossfade_buffer = b""
+            warmup_bytes = 0
             first_chunk_received = False
 
             async for chunk in self.get_queue_item_stream(
@@ -1831,6 +1847,18 @@ class StreamsAudio:
                 if smart_fades_mode == SmartFadesMode.DISABLED:
                     # no cross/smart fade: yield chunks directly without intermediate buffer
                     yield chunk
+                    bytes_written += len(chunk)
+                    del chunk
+                    continue
+
+                # Warmup: yield chunks directly until we have streamed
+                # crossfade_buffer_size worth of audio, so playback starts
+                # immediately instead of waiting for the full buffer to fill.
+                # Skip warmup when crossfade data from the previous track
+                # is pending, as we need a full buffer for the mix.
+                if warmup_bytes < crossfade_buffer_size and not last_fadeout_part:
+                    yield chunk
+                    warmup_bytes += len(chunk)
                     bytes_written += len(chunk)
                     del chunk
                     continue
@@ -1890,6 +1918,7 @@ class StreamsAudio:
                     last_fadeout_part = b""
                     last_streamdetails = None
                     crossfade_buffer = b""
+                    warmup_bytes = 0
 
                 # yield everything above the crossfade buffer size
                 while len(crossfade_buffer) > crossfade_buffer_size:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -82,6 +82,7 @@ from music_assistant.helpers.audio import (
     get_normalization_mode,
     get_parts_from_position,
     is_grouping_preventing_dsp,
+    iter_pcm_slices,
     parse_extinf_metadata,
     resample_pcm_audio,
 )
@@ -1506,7 +1507,9 @@ class StreamsAudio:
                     yield _chunk
                     bytes_written += len(_chunk)
             else:
-                yield crossfade_data.data
+                for pcm_slice in iter_pcm_slices(crossfade_data.data, pcm_format, 1000):
+                    yield pcm_slice
+                    await asyncio.sleep(0)
                 bytes_written += len(crossfade_data.data)
             # skip past the audio already consumed by the crossfade
             fade_in_duration_seconds = (
@@ -1589,7 +1592,9 @@ class StreamsAudio:
         if not crossfade_allowed:
             # no crossfade enabled/allowed, just yield the buffer last part
             bytes_written += len(buffer)
-            yield buffer
+            for pcm_slice in iter_pcm_slices(buffer, pcm_format, 1000):
+                yield pcm_slice
+                await asyncio.sleep(0)
         else:
             assert next_queue_item is not None
             # the remaining buffer is the fade-out tail of the current track
@@ -1666,7 +1671,9 @@ class StreamsAudio:
                     err,
                 )
                 next_queue_item = None
-                yield fade_out_data
+                for pcm_slice in iter_pcm_slices(fade_out_data, pcm_format, 1000):
+                    yield pcm_slice
+                    await asyncio.sleep(0)
                 bytes_written += len(fade_out_data)
                 del fade_out_data
         # make sure the buffer gets cleaned up
@@ -1857,7 +1864,9 @@ class StreamsAudio:
                             queue_track.name,
                             mix_err,
                         )
-                        yield last_fadeout_part
+                        for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
+                            yield pcm_slice
+                            await asyncio.sleep(0)
                         # full tail was pre-counted and is now yielded as-is
                         crossfade_bytes_written = 0
                         remaining_bytes = crossfade_buffer
@@ -1873,7 +1882,9 @@ class StreamsAudio:
                                 fadeout_share - len(last_fadeout_part)
                             ) / pcm_sample_size
                     if remaining_bytes:
-                        yield remaining_bytes
+                        for pcm_slice in iter_pcm_slices(remaining_bytes, pcm_format, 1000):
+                            yield pcm_slice
+                            await asyncio.sleep(0)
                         bytes_written += len(remaining_bytes)
                         del remaining_bytes
                     last_fadeout_part = b""
@@ -1901,7 +1912,9 @@ class StreamsAudio:
             if last_fadeout_part:
                 # edge case: we did not get enough data to make the crossfade
                 # attribute these bytes to the previous track (they are its tail)
-                yield last_fadeout_part
+                for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
+                    yield pcm_slice
+                    await asyncio.sleep(0)
                 # full tail was pre-counted and is now yielded as-is
                 last_fadeout_part = b""
             if self.crossfade_allowed(
@@ -1915,12 +1928,16 @@ class StreamsAudio:
                 last_play_log_entry = play_log_entry
                 remaining_bytes = crossfade_buffer[:-crossfade_buffer_size]
                 if remaining_bytes:
-                    yield remaining_bytes
+                    for pcm_slice in iter_pcm_slices(remaining_bytes, pcm_format, 1000):
+                        yield pcm_slice
+                        await asyncio.sleep(0)
                     bytes_written += len(remaining_bytes)
                 del remaining_bytes
             elif smart_fades_mode != SmartFadesMode.DISABLED and crossfade_buffer:
                 bytes_written += len(crossfade_buffer)
-                yield crossfade_buffer
+                for pcm_slice in iter_pcm_slices(crossfade_buffer, pcm_format, 1000):
+                    yield pcm_slice
+                    await asyncio.sleep(0)
             crossfade_buffer = b""
 
             # update duration details based on the actual pcm data we sent
@@ -1947,7 +1964,9 @@ class StreamsAudio:
         #### HANDLE END OF QUEUE FLOW STREAM
         # end of queue flow: make sure we yield the last_fadeout_part
         if last_fadeout_part:
-            yield last_fadeout_part
+            for pcm_slice in iter_pcm_slices(last_fadeout_part, pcm_format, 1000):
+                yield pcm_slice
+                await asyncio.sleep(0)
             # correct seconds streamed/duration
             last_part_seconds = len(last_fadeout_part) / pcm_sample_size
             streamdetails = queue_track.streamdetails

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -399,8 +399,10 @@ class AudioBuffer:
             if streamdetails.queue_id and streamdetails.media_type == MediaType.TRACK
             else SmartFadesMode.DISABLED
         )
-        if smart_fades_mode != SmartFadesMode.DISABLED:
-            ready_threshold = 10
+        if smart_fades_mode == SmartFadesMode.SMART_CROSSFADE:
+            ready_threshold = 30
+        elif smart_fades_mode == SmartFadesMode.STANDARD_CROSSFADE:
+            ready_threshold = 8
         elif streamdetails.volume_normalization_mode == VolumeNormalizationMode.DYNAMIC:
             ready_threshold = 5
         else:

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -32,7 +32,6 @@ from music_assistant.controllers.streams.constants import (
     BufferMode,
     BufferSize,
 )
-from music_assistant.controllers.streams.smart_fades.fades import SMART_CROSSFADE_DURATION
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
 from music_assistant.models.smart_fades import SmartFadesMode
 
@@ -400,9 +399,7 @@ class AudioBuffer:
             if streamdetails.queue_id and streamdetails.media_type == MediaType.TRACK
             else SmartFadesMode.DISABLED
         )
-        if smart_fades_mode == SmartFadesMode.SMART_CROSSFADE:
-            ready_threshold = SMART_CROSSFADE_DURATION
-        elif smart_fades_mode == SmartFadesMode.STANDARD_CROSSFADE:
+        if smart_fades_mode != SmartFadesMode.DISABLED:
             ready_threshold = 8
         elif streamdetails.volume_normalization_mode == VolumeNormalizationMode.DYNAMIC:
             ready_threshold = 5
@@ -454,8 +451,7 @@ class AudioBuffer:
 
         if wait_ready:
             try:
-                wait_timeout = max(15, ready_threshold)
-                await asyncio.wait_for(audio_buffer.ready.wait(), timeout=wait_timeout)
+                await asyncio.wait_for(audio_buffer.ready.wait(), timeout=15)
             except TimeoutError:
                 raise AudioError("Timeout waiting for audio data") from audio_buffer._producer_error
             # ready was signaled but check if it was due to a producer error

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -437,7 +437,7 @@ class AudioBuffer:
             # smart fades analysis only when enabled and only for music tracks
             if (
                 streamdetails.media_type == MediaType.TRACK
-                and smart_fades_mode != SmartFadesMode.DISABLED
+                and smart_fades_mode == SmartFadesMode.SMART_CROSSFADE
             ):
                 mass.streams.smart_fades_analyzer.attach_to_buffer(audio_buffer, streamdetails)
             # audio analysis providers (beat tracking, key detection, etc.)

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -32,6 +32,7 @@ from music_assistant.controllers.streams.constants import (
     BufferMode,
     BufferSize,
 )
+from music_assistant.controllers.streams.smart_fades.fades import SMART_CROSSFADE_DURATION
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
 from music_assistant.models.smart_fades import SmartFadesMode
 
@@ -400,7 +401,7 @@ class AudioBuffer:
             else SmartFadesMode.DISABLED
         )
         if smart_fades_mode == SmartFadesMode.SMART_CROSSFADE:
-            ready_threshold = 30
+            ready_threshold = SMART_CROSSFADE_DURATION
         elif smart_fades_mode == SmartFadesMode.STANDARD_CROSSFADE:
             ready_threshold = 8
         elif streamdetails.volume_normalization_mode == VolumeNormalizationMode.DYNAMIC:
@@ -453,7 +454,8 @@ class AudioBuffer:
 
         if wait_ready:
             try:
-                await asyncio.wait_for(audio_buffer.ready.wait(), timeout=15)
+                wait_timeout = max(15, ready_threshold)
+                await asyncio.wait_for(audio_buffer.ready.wait(), timeout=wait_timeout)
             except TimeoutError:
                 raise AudioError("Timeout waiting for audio data") from audio_buffer._producer_error
             # ready was signaled but check if it was due to a producer error

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -944,7 +944,7 @@ class StreamsController(CoreController):
                     queue=queue, start_queue_item=start_queue_item, pcm_format=pcm_format
                 )
                 if use_flow_stream_buffering:
-                    return buffered(flow_stream, buffer_size=10)
+                    return buffered(flow_stream, buffer_size=10, min_buffer_before_yield=1)
                 return flow_stream
             # single item stream (e.g. radio or non-flow mode)
             queue_item = self.mass.player_queues.get_item(media.source_id, media.queue_item_id)

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -177,15 +177,8 @@ class AsyncProcess:
         if self.proc.stdin is None:
             return
         async with self._stdin_lock:
-            mv = memoryview(data)
-            chunk_size = 65536
-            with suppress(BrokenPipeError, ConnectionResetError):
-                for i in range(0, len(mv), chunk_size):
-                    self.proc.stdin.write(mv[i : i + chunk_size])
-                    await self.proc.stdin.drain()
-                    # yield to the event loop to prevent blocking when
-                    # drain() completes immediately (buffer not full)
-                    await asyncio.sleep(0)
+            self.proc.stdin.write(data)
+            await self.proc.stdin.drain()
 
     async def write_eof(self) -> None:
         """Write end of file to to process stdin."""

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -12,7 +12,6 @@ from music_assistant_models.enums import PlaybackState
 from music_assistant_models.errors import PlayerCommandFailed
 
 from music_assistant.constants import CONF_SYNC_ADJUST
-from music_assistant.helpers.audio import iter_pcm_slices
 from music_assistant.helpers.ffmpeg import FFMpeg
 
 from .constants import StreamingProtocol
@@ -198,36 +197,16 @@ class AirPlayStreamSession:
 
     async def _audio_streamer(self, audio_source: AsyncGenerator[bytes, None]) -> None:
         """Stream audio to all players."""
-        pcm_sample_size = self.pcm_format.pcm_sample_size
-        seconds_since_yield = 0.0
         stream_error: BaseException | None = None
         try:
             async for chunk in audio_source:
                 if not self.sync_clients:
                     break
 
-                # Cap chunks at ~1 second to prevent write timeouts on large
-                # segments (e.g. crossfades). Smaller source chunks pass through as-is.
-                for sub_chunk in iter_pcm_slices(chunk, self.pcm_format, target_duration_ms=1000):
-                    if not self.sync_clients:
-                        break
-                    has_running_clients = await self._write_chunk_to_all_players(sub_chunk)
-                    if not has_running_clients:
-                        self.prov.logger.debug(
-                            "No running clients remaining, stopping audio streamer"
-                        )
-                        break
-                    # seconds_streamed is updated inside _write_chunk_to_all_players
-                    # under the lock, so add_client reads a consistent value.
-                    seconds_since_yield += len(sub_chunk) / pcm_sample_size
-                    # Yield periodically (~every 0.5s of audio) so the event loop
-                    # can process other tasks without starving the audio pipeline.
-                    if seconds_since_yield >= 0.5:
-                        seconds_since_yield = 0.0
-                        await asyncio.sleep(0)
-                else:
-                    continue
-                break
+                has_running_clients = await self._write_chunk_to_all_players(chunk)
+                if not has_running_clients:
+                    self.prov.logger.debug("No running clients remaining, stopping audio streamer")
+                    break
         except asyncio.CancelledError:
             self.prov.logger.debug("Audio streamer cancelled after %.1fs", self.seconds_streamed)
             raise


### PR DESCRIPTION
## Problem

The flow stream had several issues causing audio glitches and suboptimal behavior:

- Large crossfade/fade-out buffers were yielded as single massive chunks, blocking the event loop and causing write timeouts on players (especially AirPlay)
- The buffered flow stream could stall at start because it required the buffer to fill before yielding any data
- Smart fades analysis was running even when only standard crossfade was enabled, wasting resources and delaying the ready threshold unnecessarily
- Radio items in flow mode caused issues since they shouldn't use crossfade/flow behavior
- The `AsyncProcess.write` method had unnecessary chunking that is now redundant
- With smart crossfade enabled, the crossfade buffer (up to 45s) had to fully accumulate before any audio was yielded to the player, causing a long delay before playback started
- Crossfade was attempted even with very short remaining audio (e.g. after seeking near the end of a track), which is pointless

## Changes

- Yield large PCM buffers (crossfade data, fade-out tails) in ~1s slices with `asyncio.sleep(0)` to keep the event loop responsive
- Allow the buffered flow stream to yield after just 1 chunk instead of waiting for the full buffer
- **Warmup phase for crossfade streams**: yield audio immediately during the crossfade buffer warmup, only start accumulating the holdback buffer after the first `crossfade_buffer_size` worth of audio has been streamed — applies to both single-item and flow stream modes
- **Skip crossfade when buffer duration < 5s**: no point attempting a crossfade with very little audio remaining
- Simplify ready threshold for smart fades modes to 8s (no longer needs to match full crossfade buffer since the stream yields immediately)
- Only run smart fades analysis when smart crossfade mode is actually enabled
- Break out of flow stream when a radio item is encountered
- Simplify `AsyncProcess.write` — remove redundant manual chunking now that callers yield in small slices
- Simplify AirPlay stream session — remove sub-chunking workaround that is no longer needed