### PR TITLE
Fix group member players reporting idle instead of playing

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1481,10 +1481,11 @@ class Player(ABC):
                 protocol_player.state.elapsed_time,
                 protocol_player.state.elapsed_time_last_updated,
             )
-        # If we're synced, use the syncleader state for playback state and elapsed time
-        # NOTE: Don't do this for the active group player,
+        # If we're synced or part of an active group, use the parent/group player's state
+        # for playback state and elapsed time.
+        # NOTE: Don't do this for the active group player itself,
         # because the group player relies on the sync leader for state info.
-        parent_id = self.__final_synced_to
+        parent_id = self.__final_synced_to or self.__final_active_group
         if parent_id and (parent_player := self.mass.players.get_player(parent_id)):
             return (
                 parent_player.state.playback_state,


### PR DESCRIPTION
When a player is part of an active group, it incorrectly reports `idle` to Home Assistant instead of reflecting the group's `playing`/`paused` state.

**The problem:** `__final_playback_state` only checked `__final_synced_to` to inherit the parent player's state. Group members that aren't synced fell through to their native idle state.

**Changes:**
- Added `__final_active_group` as fallback in `__final_playback_state`, so group members inherit the group player's playback state
- This is consistent with `__final_current_media` and `__final_active_source` which already check both `__final_synced_to` and `__final_active_group`

Fixes music-assistant/support#5242