### PR TITLE
Prevent filesystem unavailability from removing all associated library items

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -448,17 +448,12 @@ class LocalFileSystemProvider(MusicProvider):
         base_path_reachable = await self._check_base_path_reachable()
         if scan_errors or not base_path_reachable:
             self.logger.error(
-                "Aborting sync for %s before the deletion phase to prevent data loss: "
-                "%d scan error(s) encountered, base path reachable=%s. "
-                "The previously indexed library items will be kept untouched.",
+                "Aborting sync for %s: %d scan error(s), base path reachable=%s",
                 self.name,
                 len(scan_errors),
                 base_path_reachable,
             )
-            report_current_task_failure(
-                "Sync aborted: filesystem became unavailable during the scan. "
-                "Library items were preserved."
-            )
+            report_current_task_failure("Sync aborted: filesystem unavailable during scan")
             return
 
         # work out deletions

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -20,6 +20,7 @@ import xmltodict
 from aiofiles.os import wrap
 from music_assistant_models.enums import (
     ContentType,
+    EventType,
     ExternalID,
     ImageType,
     MediaType,
@@ -449,6 +450,7 @@ class LocalFileSystemProvider(MusicProvider):
                 base_path_reachable,
             )
             report_current_task_failure("Sync aborted: filesystem unavailable during scan")
+            self._set_available(False)
             return
 
         # work out deletions
@@ -457,6 +459,9 @@ class LocalFileSystemProvider(MusicProvider):
 
         # process orphaned albums and artists
         await self._process_orphaned_albums_and_artists()
+
+        # flag provider as available again if an earlier sync had marked it down
+        self._set_available(True)
 
     async def _check_base_path_reachable(self) -> bool:
         """Return whether the provider's base path is currently reachable."""
@@ -470,6 +475,13 @@ class LocalFileSystemProvider(MusicProvider):
             return True
 
         return await asyncio.to_thread(_probe)
+
+    def _set_available(self, available: bool) -> None:
+        """Update the provider availability and notify listeners on change."""
+        if self.available == available:
+            return
+        self.available = available
+        self.mass.signal_event(EventType.PROVIDERS_UPDATED, data=self.mass.get_providers())
 
     async def _process_item_async(self, item: FileSystemItem, prev_checksum: str | None) -> bool:
         """Process a single item asynchronously.

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -97,7 +97,7 @@ from .constants import (
     CONF_ENTRY_PROPAGATE_GENRES,
     DEFAULT_AUDIOBOOK_PODCAST_GENRE,
     IMAGE_EXTENSIONS,
-    MASS_DELETE_GUARD_MIN_DELETES,
+    INCOMPLETE_DIRS_TASK_FAILURE_RATIO,
     MASS_DELETE_GUARD_MIN_PREV,
     MASS_DELETE_GUARD_RATIO,
     PLAYLIST_EXTENSIONS,
@@ -463,7 +463,9 @@ class LocalFileSystemProvider(MusicProvider):
         effective_prev = len(prev_filenames)
 
         # shield files under sub-directories that were not fully scanned
-        # (e.g. SMB auth expiry on one subtree, transient I/O errors)
+        # (e.g. SMB auth expiry on one subtree, transient I/O errors).
+        # get_relative_path yields platform-native separators, so os.sep on
+        # the prefix matches on both Linux and Windows.
         if incomplete_dirs:
             incomplete_prefixes = tuple(p + os.sep for p in incomplete_dirs)
             shielded = {f for f in prev_filenames if f.startswith(incomplete_prefixes)}
@@ -476,11 +478,21 @@ class LocalFileSystemProvider(MusicProvider):
                     self.name,
                 )
             deleted_files -= shielded
+            # surface the degraded sync as a task failure when a meaningful
+            # fraction of the library was not scanned, so the UI stops
+            # reporting a silent success
+            if (
+                prev_filenames
+                and len(shielded) / len(prev_filenames) >= INCOMPLETE_DIRS_TASK_FAILURE_RATIO
+            ):
+                report_current_task_failure(
+                    f"Sync degraded: {len(incomplete_dirs)} director(y/ies) could "
+                    f"not be fully scanned, {len(shielded)} item(s) were preserved"
+                )
 
         # sanity guard: refuse a mass deletion that looks like a wrong/empty mount
         if (
             effective_prev >= MASS_DELETE_GUARD_MIN_PREV
-            and len(deleted_files) >= MASS_DELETE_GUARD_MIN_DELETES
             and len(deleted_files) > effective_prev * MASS_DELETE_GUARD_RATIO
         ):
             self.logger.error(

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -97,6 +97,9 @@ from .constants import (
     CONF_ENTRY_PROPAGATE_GENRES,
     DEFAULT_AUDIOBOOK_PODCAST_GENRE,
     IMAGE_EXTENSIONS,
+    MASS_DELETE_GUARD_MIN_DELETES,
+    MASS_DELETE_GUARD_MIN_PREV,
+    MASS_DELETE_GUARD_RATIO,
     PLAYLIST_EXTENSIONS,
     PODCAST_EPISODE_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
@@ -377,8 +380,11 @@ class LocalFileSystemProvider(MusicProvider):
         ignore_album_playlists = self.media_content_type == "music" and self.config.get_value(
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS.key
         )
-        # populated by recursive_iter when the filesystem becomes unreachable
+        # populated by recursive_iter on root-scandir failure → triggers abort
         scan_errors: list[OSError] = []
+        # relative paths of sub-directories that were not fully scanned; used
+        # below to shield their contents from the deletion phase
+        incomplete_dirs: set[str] = set()
 
         def enumerate_files() -> None:
             """Enumerate all files, collecting changed items for processing."""
@@ -389,6 +395,7 @@ class LocalFileSystemProvider(MusicProvider):
                 SUPPORTED_EXTENSIONS,
                 self.logger,
                 scan_errors,
+                incomplete_dirs,
             ):
                 scanned += 1
                 if scanned % 500 == 0:
@@ -440,21 +447,56 @@ class LocalFileSystemProvider(MusicProvider):
         finally:
             self.sync_running = False
 
-        # do not run deletions if the filesystem is (or became) unreachable
-        base_path_reachable = await self._check_base_path_reachable()
-        if scan_errors or not base_path_reachable:
+        # abort the deletion phase if the root base path could not be scanned
+        # (provider is unreachable — wiping the library would be catastrophic)
+        if scan_errors:
             self.logger.error(
-                "Aborting sync for %s: %d scan error(s), base path reachable=%s",
+                "Aborting sync for %s: %d root scan error(s)",
                 self.name,
                 len(scan_errors),
-                base_path_reachable,
             )
             report_current_task_failure("Sync aborted: filesystem unavailable during scan")
             self._set_available(False)
             return
 
-        # work out deletions
         deleted_files = prev_filenames - cur_filenames
+        effective_prev = len(prev_filenames)
+
+        # shield files under sub-directories that were not fully scanned
+        # (e.g. SMB auth expiry on one subtree, transient I/O errors)
+        if incomplete_dirs:
+            incomplete_prefixes = tuple(p + os.sep for p in incomplete_dirs)
+            shielded = {f for f in prev_filenames if f.startswith(incomplete_prefixes)}
+            effective_prev -= len(shielded)
+            if shielded & deleted_files:
+                self.logger.warning(
+                    "Preserving %d item(s) under %d unscanned director(y/ies) for %s",
+                    len(shielded & deleted_files),
+                    len(incomplete_dirs),
+                    self.name,
+                )
+            deleted_files -= shielded
+
+        # sanity guard: refuse a mass deletion that looks like a wrong/empty mount
+        if (
+            effective_prev >= MASS_DELETE_GUARD_MIN_PREV
+            and len(deleted_files) >= MASS_DELETE_GUARD_MIN_DELETES
+            and len(deleted_files) > effective_prev * MASS_DELETE_GUARD_RATIO
+        ):
+            self.logger.error(
+                "Refusing mass deletion for %s: %d of %d expected items missing "
+                "(only %d found on disk). Verify the source and re-run the sync.",
+                self.name,
+                len(deleted_files),
+                effective_prev,
+                len(cur_filenames),
+            )
+            report_current_task_failure(
+                f"Refused mass deletion: only {len(cur_filenames)} of "
+                f"{effective_prev} expected files were found"
+            )
+            return
+
         await self._process_deletions(deleted_files)
 
         # process orphaned albums and artists
@@ -462,19 +504,6 @@ class LocalFileSystemProvider(MusicProvider):
 
         # flag provider as available again if an earlier sync had marked it down
         self._set_available(True)
-
-    async def _check_base_path_reachable(self) -> bool:
-        """Return whether the provider's base path is currently reachable."""
-
-        def _probe() -> bool:
-            try:
-                with os.scandir(self.base_path):
-                    pass
-            except OSError:
-                return False
-            return True
-
-        return await asyncio.to_thread(_probe)
 
     def _set_available(self, available: bool) -> None:
         """Update the provider availability and notify listeners on change."""

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -97,9 +97,6 @@ from .constants import (
     CONF_ENTRY_PROPAGATE_GENRES,
     DEFAULT_AUDIOBOOK_PODCAST_GENRE,
     IMAGE_EXTENSIONS,
-    INCOMPLETE_DIRS_TASK_FAILURE_RATIO,
-    MASS_DELETE_GUARD_MIN_PREV,
-    MASS_DELETE_GUARD_RATIO,
     PLAYLIST_EXTENSIONS,
     PODCAST_EPISODE_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
@@ -380,11 +377,8 @@ class LocalFileSystemProvider(MusicProvider):
         ignore_album_playlists = self.media_content_type == "music" and self.config.get_value(
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS.key
         )
-        # populated by recursive_iter on root-scandir failure → triggers abort
+        # populated by recursive_iter on a root-scandir failure
         scan_errors: list[OSError] = []
-        # relative paths of sub-directories that were not fully scanned; used
-        # below to shield their contents from the deletion phase
-        incomplete_dirs: set[str] = set()
 
         def enumerate_files() -> None:
             """Enumerate all files, collecting changed items for processing."""
@@ -395,7 +389,6 @@ class LocalFileSystemProvider(MusicProvider):
                 SUPPORTED_EXTENSIONS,
                 self.logger,
                 scan_errors,
-                incomplete_dirs,
             ):
                 scanned += 1
                 if scanned % 500 == 0:
@@ -447,71 +440,31 @@ class LocalFileSystemProvider(MusicProvider):
         finally:
             self.sync_running = False
 
-        # abort the deletion phase if the root base path could not be scanned
-        # (provider is unreachable — wiping the library would be catastrophic)
+        # do not run deletions if the root base path could not be scanned
         if scan_errors:
             self.logger.error(
-                "Aborting sync for %s: %d root scan error(s)",
-                self.name,
-                len(scan_errors),
+                "Aborting sync for %s: %d root scan error(s)", self.name, len(scan_errors)
             )
             report_current_task_failure("Sync aborted: filesystem unavailable during scan")
             self._set_available(False)
             return
 
-        deleted_files = prev_filenames - cur_filenames
-        effective_prev = len(prev_filenames)
-
-        # shield files under sub-directories that were not fully scanned
-        # (e.g. SMB auth expiry on one subtree, transient I/O errors).
-        # get_relative_path yields platform-native separators, so os.sep on
-        # the prefix matches on both Linux and Windows.
-        if incomplete_dirs:
-            incomplete_prefixes = tuple(p + os.sep for p in incomplete_dirs)
-            shielded = {f for f in prev_filenames if f.startswith(incomplete_prefixes)}
-            effective_prev -= len(shielded)
-            if shielded & deleted_files:
-                self.logger.warning(
-                    "Preserving %d item(s) under %d unscanned director(y/ies) for %s",
-                    len(shielded & deleted_files),
-                    len(incomplete_dirs),
-                    self.name,
-                )
-            deleted_files -= shielded
-            # surface the degraded sync as a task failure when a meaningful
-            # fraction of the library was not scanned, so the UI stops
-            # reporting a silent success
-            if (
-                prev_filenames
-                and len(shielded) / len(prev_filenames) >= INCOMPLETE_DIRS_TASK_FAILURE_RATIO
-            ):
-                report_current_task_failure(
-                    f"Sync degraded: {len(incomplete_dirs)} director(y/ies) could "
-                    f"not be fully scanned, {len(shielded)} item(s) were preserved"
-                )
-
-        # sanity guard: refuse a mass deletion that looks like a wrong/empty mount
-        if (
-            effective_prev >= MASS_DELETE_GUARD_MIN_PREV
-            and len(deleted_files) > effective_prev * MASS_DELETE_GUARD_RATIO
-        ):
+        # do not run deletions on a clean but empty scan of a previously non-empty library
+        # (wrong share mounted, empty backup mount, ...)
+        if prev_filenames and not cur_filenames:
             self.logger.error(
-                "Refusing mass deletion for %s: %d of %d expected items missing "
-                "(only %d found on disk). Verify the source and re-run the sync.",
+                "Aborting sync for %s: scan found no files but %d were previously indexed",
                 self.name,
-                len(deleted_files),
-                effective_prev,
-                len(cur_filenames),
+                len(prev_filenames),
             )
             report_current_task_failure(
-                f"Refused mass deletion: only {len(cur_filenames)} of "
-                f"{effective_prev} expected files were found"
+                f"Sync aborted: scan found no files but {len(prev_filenames)} "
+                "were previously indexed"
             )
             return
 
+        deleted_files = prev_filenames - cur_filenames
         await self._process_deletions(deleted_files)
-
-        # process orphaned albums and artists
         await self._process_orphaned_albums_and_artists()
 
         # flag provider as available again if an earlier sync had marked it down

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -376,12 +376,21 @@ class LocalFileSystemProvider(MusicProvider):
         ignore_album_playlists = self.media_content_type == "music" and self.config.get_value(
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS.key
         )
+        # Track critical errors that occur while walking the filesystem. If any
+        # directory fails to scan (e.g. a NAS share going offline), we must not
+        # run the deletion phase — otherwise we would wipe the library for items
+        # we simply couldn't see this time.
+        scan_errors: list[OSError] = []
 
         def enumerate_files() -> None:
             """Enumerate all files, collecting changed items for processing."""
             scanned = 0
             for item in recursive_iter(
-                self.base_path, self.base_path, SUPPORTED_EXTENSIONS, self.logger
+                self.base_path,
+                self.base_path,
+                SUPPORTED_EXTENSIONS,
+                self.logger,
+                scan_errors,
             ):
                 scanned += 1
                 if scanned % 500 == 0:
@@ -433,12 +442,51 @@ class LocalFileSystemProvider(MusicProvider):
         finally:
             self.sync_running = False
 
+        # Safeguard: verify the base path is still reachable before running any
+        # deletions. If it's not (e.g. NAS powered off), abort the sync to avoid
+        # wiping the entire library.
+        base_path_reachable = await self._check_base_path_reachable()
+        if scan_errors or not base_path_reachable:
+            self.logger.error(
+                "Aborting sync for %s before the deletion phase to prevent data loss: "
+                "%d scan error(s) encountered, base path reachable=%s. "
+                "The previously indexed library items will be kept untouched.",
+                self.name,
+                len(scan_errors),
+                base_path_reachable,
+            )
+            report_current_task_failure(
+                "Sync aborted: filesystem became unavailable during the scan. "
+                "Library items were preserved."
+            )
+            return
+
         # work out deletions
         deleted_files = prev_filenames - cur_filenames
         await self._process_deletions(deleted_files)
 
         # process orphaned albums and artists
         await self._process_orphaned_albums_and_artists()
+
+    async def _check_base_path_reachable(self) -> bool:
+        """Return whether the provider's base path is currently reachable."""
+
+        def _probe() -> bool:
+            try:
+                with os.scandir(self.base_path) as it:
+                    # force the directory handle to actually open by advancing
+                    # the iterator once; an empty directory is fine
+                    next(it, None)
+            except StopIteration:
+                return True
+            except OSError:
+                return False
+            return True
+
+        try:
+            return await asyncio.to_thread(_probe)
+        except OSError:
+            return False
 
     async def _process_item_async(self, item: FileSystemItem, prev_checksum: str | None) -> bool:
         """Process a single item asynchronously.

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -376,10 +376,7 @@ class LocalFileSystemProvider(MusicProvider):
         ignore_album_playlists = self.media_content_type == "music" and self.config.get_value(
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS.key
         )
-        # Track critical errors that occur while walking the filesystem. If any
-        # directory fails to scan (e.g. a NAS share going offline), we must not
-        # run the deletion phase — otherwise we would wipe the library for items
-        # we simply couldn't see this time.
+        # populated by recursive_iter when the filesystem becomes unreachable
         scan_errors: list[OSError] = []
 
         def enumerate_files() -> None:
@@ -442,9 +439,7 @@ class LocalFileSystemProvider(MusicProvider):
         finally:
             self.sync_running = False
 
-        # Safeguard: verify the base path is still reachable before running any
-        # deletions. If it's not (e.g. NAS powered off), abort the sync to avoid
-        # wiping the entire library.
+        # do not run deletions if the filesystem is (or became) unreachable
         base_path_reachable = await self._check_base_path_reachable()
         if scan_errors or not base_path_reachable:
             self.logger.error(
@@ -468,20 +463,13 @@ class LocalFileSystemProvider(MusicProvider):
 
         def _probe() -> bool:
             try:
-                with os.scandir(self.base_path) as it:
-                    # force the directory handle to actually open by advancing
-                    # the iterator once; an empty directory is fine
-                    next(it, None)
-            except StopIteration:
-                return True
+                with os.scandir(self.base_path):
+                    pass
             except OSError:
                 return False
             return True
 
-        try:
-            return await asyncio.to_thread(_probe)
-        except OSError:
-            return False
+        return await asyncio.to_thread(_probe)
 
     async def _process_item_async(self, item: FileSystemItem, prev_checksum: str | None) -> bool:
         """Process a single item asynchronously.

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -377,8 +377,9 @@ class LocalFileSystemProvider(MusicProvider):
         ignore_album_playlists = self.media_content_type == "music" and self.config.get_value(
             CONF_ENTRY_IGNORE_ALBUM_PLAYLISTS.key
         )
-        # populated by recursive_iter on a root-scandir failure
-        scan_errors: list[OSError] = []
+        # populated by recursive_iter when the provider's root base path cannot
+        # be scanned; sub-directory failures remain a silent skip as before
+        root_scan_errors: list[OSError] = []
 
         def enumerate_files() -> None:
             """Enumerate all files, collecting changed items for processing."""
@@ -388,7 +389,7 @@ class LocalFileSystemProvider(MusicProvider):
                 self.base_path,
                 SUPPORTED_EXTENSIONS,
                 self.logger,
-                scan_errors,
+                scan_errors=root_scan_errors,
             ):
                 scanned += 1
                 if scanned % 500 == 0:
@@ -441,9 +442,11 @@ class LocalFileSystemProvider(MusicProvider):
             self.sync_running = False
 
         # do not run deletions if the root base path could not be scanned
-        if scan_errors:
+        if root_scan_errors:
             self.logger.error(
-                "Aborting sync for %s: %d root scan error(s)", self.name, len(scan_errors)
+                "Aborting sync for %s: %d root scan error(s)",
+                self.name,
+                len(root_scan_errors),
             )
             report_current_task_failure("Sync aborted: filesystem unavailable during scan")
             self._set_available(False)

--- a/music_assistant/providers/filesystem_local/constants.py
+++ b/music_assistant/providers/filesystem_local/constants.py
@@ -189,15 +189,3 @@ CACHE_CATEGORY_AUDIOBOOK_CHAPTERS: Final[int] = 4
 CACHE_CATEGORY_PODCAST_METADATA: Final[int] = 5
 
 DEFAULT_AUDIOBOOK_PODCAST_GENRE: Final[str] = "Spoken Word"
-
-# sanity guard for the library sync deletion phase: refuse deletions when more
-# than this fraction of previously indexed items disappeared in one scan. A
-# wrong/empty mount is the most likely explanation; users can still curate
-# individual items manually through the UI.
-MASS_DELETE_GUARD_MIN_PREV: Final[int] = 10
-MASS_DELETE_GUARD_RATIO: Final[float] = 0.5
-
-# when incomplete_dirs shield at least this fraction of previously indexed
-# items, the sync surfaces a task failure so the user can tell a healthy
-# "nothing to delete" run apart from a partially broken one
-INCOMPLETE_DIRS_TASK_FAILURE_RATIO: Final[float] = 0.1

--- a/music_assistant/providers/filesystem_local/constants.py
+++ b/music_assistant/providers/filesystem_local/constants.py
@@ -190,9 +190,14 @@ CACHE_CATEGORY_PODCAST_METADATA: Final[int] = 5
 
 DEFAULT_AUDIOBOOK_PODCAST_GENRE: Final[str] = "Spoken Word"
 
-# sanity guard for the library sync deletion phase: refuse deletions when the
-# fraction of previously indexed items that disappeared in one scan is so high
-# that a wrong/empty mount is the most likely explanation
-MASS_DELETE_GUARD_MIN_PREV: Final[int] = 100
-MASS_DELETE_GUARD_MIN_DELETES: Final[int] = 50
+# sanity guard for the library sync deletion phase: refuse deletions when more
+# than this fraction of previously indexed items disappeared in one scan. A
+# wrong/empty mount is the most likely explanation; users can still curate
+# individual items manually through the UI.
+MASS_DELETE_GUARD_MIN_PREV: Final[int] = 10
 MASS_DELETE_GUARD_RATIO: Final[float] = 0.5
+
+# when incomplete_dirs shield at least this fraction of previously indexed
+# items, the sync surfaces a task failure so the user can tell a healthy
+# "nothing to delete" run apart from a partially broken one
+INCOMPLETE_DIRS_TASK_FAILURE_RATIO: Final[float] = 0.1

--- a/music_assistant/providers/filesystem_local/constants.py
+++ b/music_assistant/providers/filesystem_local/constants.py
@@ -189,3 +189,10 @@ CACHE_CATEGORY_AUDIOBOOK_CHAPTERS: Final[int] = 4
 CACHE_CATEGORY_PODCAST_METADATA: Final[int] = 5
 
 DEFAULT_AUDIOBOOK_PODCAST_GENRE: Final[str] = "Spoken Word"
+
+# sanity guard for the library sync deletion phase: refuse deletions when the
+# fraction of previously indexed items that disappeared in one scan is so high
+# that a wrong/empty mount is the most likely explanation
+MASS_DELETE_GUARD_MIN_PREV: Final[int] = 100
+MASS_DELETE_GUARD_MIN_DELETES: Final[int] = 50
+MASS_DELETE_GUARD_RATIO: Final[float] = 0.5

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -231,21 +231,13 @@ def get_absolute_path(base_path: str, path: str) -> str:
     return os.path.join(base_path, path)
 
 
-# Errors that are user/folder-specific and should not be treated as a signal that
-# the whole provider is unavailable. Everything else (connection loss, I/O error,
-# "no such file or directory" etc.) is assumed to indicate that the underlying
-# filesystem became unreachable and is propagated to the caller.
-_NON_FATAL_SCAN_ERRNOS = frozenset(
-    {
-        errno.EINVAL,  # unsupported characters in a name
-        errno.EACCES,  # permission denied on a single folder/file
-        errno.EPERM,  # operation not permitted on a single folder/file
-    }
-)
+# errnos that indicate a user/folder-specific problem rather than the whole
+# provider being unreachable
+_NON_FATAL_SCAN_ERRNOS = frozenset({errno.EINVAL, errno.EACCES, errno.EPERM})
 
 
 def _is_fatal_scan_error(err: OSError) -> bool:
-    """Return whether an OSError should abort a sync to prevent data loss."""
+    """Return whether an OSError indicates the filesystem provider is unreachable."""
     return err.errno not in _NON_FATAL_SCAN_ERRNOS
 
 
@@ -256,17 +248,15 @@ def recursive_iter(
     log: logging.Logger,
     scan_errors: list[OSError] | None = None,
 ) -> Iterator[FileSystemItem]:
-    """Recursively traverse directory entries yielding supported files.
+    """
+    Recursively traverse directory entries yielding supported files.
 
     :param path: The directory path to scan.
     :param base_path: The root base path for constructing relative paths.
     :param supported_extensions: Set of file extensions to include (lowercase, no dot).
     :param log: Logger instance to use for warnings/debug messages.
-    :param scan_errors: Optional list that will be populated with any critical OSErrors
-        encountered while scanning directories. Callers can inspect this to detect a
-        partially-failed scan (e.g. a NAS share becoming unavailable mid-sync) and
-        avoid taking destructive actions on the result. Per-folder permission issues
-        and other non-fatal errors are logged but are not recorded here.
+    :param scan_errors: Optional list that will be appended with any OSError that
+        indicates the provider became unreachable during the scan.
     """
     is_root = path == base_path
     try:
@@ -279,8 +269,7 @@ def recursive_iter(
             )
         else:
             log.warning("Unable to scan directory %s: %s", path, err)
-            # Always treat a failure to scan the root base path as fatal — it
-            # means the whole provider is unreachable.
+            # failure to scan the root base path is always fatal
             if scan_errors is not None and (is_root or _is_fatal_scan_error(err)):
                 scan_errors.append(err)
         return
@@ -291,9 +280,6 @@ def recursive_iter(
             except StopIteration:
                 break
             except OSError as err:
-                # The directory became unreadable mid-iteration (e.g. the NAS share
-                # went away). Record the error so the caller can abort destructive
-                # follow-up work and stop walking this directory.
                 log.warning("Error while scanning directory %s: %s", path, err)
                 if scan_errors is not None and (is_root or _is_fatal_scan_error(err)):
                     scan_errors.append(err)

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -231,11 +231,30 @@ def get_absolute_path(base_path: str, path: str) -> str:
     return os.path.join(base_path, path)
 
 
+# Errors that are user/folder-specific and should not be treated as a signal that
+# the whole provider is unavailable. Everything else (connection loss, I/O error,
+# "no such file or directory" etc.) is assumed to indicate that the underlying
+# filesystem became unreachable and is propagated to the caller.
+_NON_FATAL_SCAN_ERRNOS = frozenset(
+    {
+        errno.EINVAL,  # unsupported characters in a name
+        errno.EACCES,  # permission denied on a single folder/file
+        errno.EPERM,  # operation not permitted on a single folder/file
+    }
+)
+
+
+def _is_fatal_scan_error(err: OSError) -> bool:
+    """Return whether an OSError should abort a sync to prevent data loss."""
+    return err.errno not in _NON_FATAL_SCAN_ERRNOS
+
+
 def recursive_iter(
     path: str,
     base_path: str,
     supported_extensions: set[str],
     log: logging.Logger,
+    scan_errors: list[OSError] | None = None,
 ) -> Iterator[FileSystemItem]:
     """Recursively traverse directory entries yielding supported files.
 
@@ -243,7 +262,13 @@ def recursive_iter(
     :param base_path: The root base path for constructing relative paths.
     :param supported_extensions: Set of file extensions to include (lowercase, no dot).
     :param log: Logger instance to use for warnings/debug messages.
+    :param scan_errors: Optional list that will be populated with any critical OSErrors
+        encountered while scanning directories. Callers can inspect this to detect a
+        partially-failed scan (e.g. a NAS share becoming unavailable mid-sync) and
+        avoid taking destructive actions on the result. Per-folder permission issues
+        and other non-fatal errors are logged but are not recorded here.
     """
+    is_root = path == base_path
     try:
         scan_iter = os.scandir(path)
     except OSError as err:
@@ -254,9 +279,25 @@ def recursive_iter(
             )
         else:
             log.warning("Unable to scan directory %s: %s", path, err)
+            # Always treat a failure to scan the root base path as fatal — it
+            # means the whole provider is unreachable.
+            if scan_errors is not None and (is_root or _is_fatal_scan_error(err)):
+                scan_errors.append(err)
         return
     with scan_iter:
-        for item in scan_iter:
+        while True:
+            try:
+                item = next(scan_iter)
+            except StopIteration:
+                break
+            except OSError as err:
+                # The directory became unreadable mid-iteration (e.g. the NAS share
+                # went away). Record the error so the caller can abort destructive
+                # follow-up work and stop walking this directory.
+                log.warning("Error while scanning directory %s: %s", path, err)
+                if scan_errors is not None and (is_root or _is_fatal_scan_error(err)):
+                    scan_errors.append(err)
+                return
             if item.name in IGNORE_DIRS or item.name.startswith((".", "_")):
                 continue
             try:
@@ -268,9 +309,15 @@ def recursive_iter(
                         "Skipping '%s' - unsupported characters in name",
                         item.name,
                     )
+                else:
+                    log.warning("Unable to stat '%s': %s", item.path, err)
+                    if scan_errors is not None and _is_fatal_scan_error(err):
+                        scan_errors.append(err)
                 continue
             if is_dir:
-                yield from recursive_iter(item.path, base_path, supported_extensions, log)
+                yield from recursive_iter(
+                    item.path, base_path, supported_extensions, log, scan_errors
+                )
             elif is_file:
                 if "." not in item.name:
                     continue

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -231,14 +231,21 @@ def get_absolute_path(base_path: str, path: str) -> str:
     return os.path.join(base_path, path)
 
 
-# errnos that indicate a user/folder-specific problem rather than the whole
-# provider being unreachable
-_NON_FATAL_SCAN_ERRNOS = frozenset({errno.EINVAL, errno.EACCES, errno.EPERM})
-
-
-def _is_fatal_scan_error(err: OSError) -> bool:
-    """Return whether an OSError indicates the filesystem provider is unreachable."""
-    return err.errno not in _NON_FATAL_SCAN_ERRNOS
+def _record_dir_scan_failure(
+    path: str,
+    base_path: str,
+    is_root: bool,
+    err: OSError,
+    scan_errors: list[OSError] | None,
+    incomplete_dirs: set[str] | None,
+) -> None:
+    """Classify a directory scan failure as either fatal or per-subtree recoverable."""
+    if is_root:
+        if scan_errors is not None:
+            scan_errors.append(err)
+        return
+    if incomplete_dirs is not None and (rel := get_relative_path(base_path, path)):
+        incomplete_dirs.add(rel)
 
 
 def recursive_iter(
@@ -247,6 +254,7 @@ def recursive_iter(
     supported_extensions: set[str],
     log: logging.Logger,
     scan_errors: list[OSError] | None = None,
+    incomplete_dirs: set[str] | None = None,
 ) -> Iterator[FileSystemItem]:
     """
     Recursively traverse directory entries yielding supported files.
@@ -255,8 +263,12 @@ def recursive_iter(
     :param base_path: The root base path for constructing relative paths.
     :param supported_extensions: Set of file extensions to include (lowercase, no dot).
     :param log: Logger instance to use for warnings/debug messages.
-    :param scan_errors: Optional list that will be appended with any OSError that
-        indicates the provider became unreachable during the scan.
+    :param scan_errors: Optional list populated with OSErrors raised while scanning
+        the provider's root base path. Callers treat a non-empty list as "provider
+        unreachable" and abort the sync.
+    :param incomplete_dirs: Optional set populated with the relative paths of
+        sub-directories that could not be fully scanned. Callers use this to
+        exclude deletions under those subtrees.
     """
     is_root = path == base_path
     try:
@@ -267,11 +279,9 @@ def recursive_iter(
                 "Skipping directory '%s' - unsupported characters in path",
                 path,
             )
-        else:
-            log.warning("Unable to scan directory %s: %s", path, err)
-            # failure to scan the root base path is always fatal
-            if scan_errors is not None and (is_root or _is_fatal_scan_error(err)):
-                scan_errors.append(err)
+            return
+        log.warning("Unable to scan directory %s: %s", path, err)
+        _record_dir_scan_failure(path, base_path, is_root, err, scan_errors, incomplete_dirs)
         return
     with scan_iter:
         while True:
@@ -281,8 +291,9 @@ def recursive_iter(
                 break
             except OSError as err:
                 log.warning("Error while scanning directory %s: %s", path, err)
-                if scan_errors is not None and (is_root or _is_fatal_scan_error(err)):
-                    scan_errors.append(err)
+                _record_dir_scan_failure(
+                    path, base_path, is_root, err, scan_errors, incomplete_dirs
+                )
                 return
             if item.name in IGNORE_DIRS or item.name.startswith((".", "_")):
                 continue
@@ -296,13 +307,16 @@ def recursive_iter(
                         item.name,
                     )
                 else:
-                    log.warning("Unable to stat '%s': %s", item.path, err)
-                    if scan_errors is not None and _is_fatal_scan_error(err):
-                        scan_errors.append(err)
+                    log.debug("Skipping entry %s due to OS error: %s", item.path, err)
                 continue
             if is_dir:
                 yield from recursive_iter(
-                    item.path, base_path, supported_extensions, log, scan_errors
+                    item.path,
+                    base_path,
+                    supported_extensions,
+                    log,
+                    scan_errors,
+                    incomplete_dirs,
                 )
             elif is_file:
                 if "." not in item.name:

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -231,30 +231,12 @@ def get_absolute_path(base_path: str, path: str) -> str:
     return os.path.join(base_path, path)
 
 
-def _record_dir_scan_failure(
-    path: str,
-    base_path: str,
-    is_root: bool,
-    err: OSError,
-    scan_errors: list[OSError] | None,
-    incomplete_dirs: set[str] | None,
-) -> None:
-    """Classify a directory scan failure as either fatal or per-subtree recoverable."""
-    if is_root:
-        if scan_errors is not None:
-            scan_errors.append(err)
-        return
-    if incomplete_dirs is not None and (rel := get_relative_path(base_path, path)):
-        incomplete_dirs.add(rel)
-
-
 def recursive_iter(
     path: str,
     base_path: str,
     supported_extensions: set[str],
     log: logging.Logger,
     scan_errors: list[OSError] | None = None,
-    incomplete_dirs: set[str] | None = None,
 ) -> Iterator[FileSystemItem]:
     """
     Recursively traverse directory entries yielding supported files.
@@ -266,9 +248,6 @@ def recursive_iter(
     :param scan_errors: Optional list populated with OSErrors raised while scanning
         the provider's root base path. Callers treat a non-empty list as "provider
         unreachable" and abort the sync.
-    :param incomplete_dirs: Optional set populated with the relative paths of
-        sub-directories that could not be fully scanned. Callers use this to
-        exclude deletions under those subtrees.
     """
     is_root = path == base_path
     try:
@@ -281,7 +260,8 @@ def recursive_iter(
             )
             return
         log.warning("Unable to scan directory %s: %s", path, err)
-        _record_dir_scan_failure(path, base_path, is_root, err, scan_errors, incomplete_dirs)
+        if is_root and scan_errors is not None:
+            scan_errors.append(err)
         return
     with scan_iter:
         while True:
@@ -291,9 +271,8 @@ def recursive_iter(
                 break
             except OSError as err:
                 log.warning("Error while scanning directory %s: %s", path, err)
-                _record_dir_scan_failure(
-                    path, base_path, is_root, err, scan_errors, incomplete_dirs
-                )
+                if is_root and scan_errors is not None:
+                    scan_errors.append(err)
                 return
             if item.name in IGNORE_DIRS or item.name.startswith((".", "_")):
                 continue
@@ -306,17 +285,8 @@ def recursive_iter(
                         "Skipping '%s' - unsupported characters in name",
                         item.name,
                     )
-                elif err.errno == errno.ENOENT:
-                    # benign race: entry vanished between scandir and stat
-                    log.debug("Skipping entry %s - vanished during scan", item.path)
                 else:
-                    # ESTALE / EIO / EACCES on a single entry: we cannot trust
-                    # any entry in this directory, so treat the parent as
-                    # incomplete to shield the sibling files from deletion
-                    log.warning("Unable to stat %s: %s", item.path, err)
-                    _record_dir_scan_failure(
-                        path, base_path, is_root, err, scan_errors, incomplete_dirs
-                    )
+                    log.debug("Skipping entry %s due to OS error: %s", item.path, err)
                 continue
             if is_dir:
                 yield from recursive_iter(
@@ -325,7 +295,6 @@ def recursive_iter(
                     supported_extensions,
                     log,
                     scan_errors,
-                    incomplete_dirs,
                 )
             elif is_file:
                 if "." not in item.name:

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -306,8 +306,17 @@ def recursive_iter(
                         "Skipping '%s' - unsupported characters in name",
                         item.name,
                     )
+                elif err.errno == errno.ENOENT:
+                    # benign race: entry vanished between scandir and stat
+                    log.debug("Skipping entry %s - vanished during scan", item.path)
                 else:
-                    log.debug("Skipping entry %s due to OS error: %s", item.path, err)
+                    # ESTALE / EIO / EACCES on a single entry: we cannot trust
+                    # any entry in this directory, so treat the parent as
+                    # incomplete to shield the sibling files from deletion
+                    log.warning("Unable to stat %s: %s", item.path, err)
+                    _record_dir_scan_failure(
+                        path, base_path, is_root, err, scan_errors, incomplete_dirs
+                    )
                 continue
             if is_dir:
                 yield from recursive_iter(

--- a/tests/providers/filesystem/test_helpers.py
+++ b/tests/providers/filesystem/test_helpers.py
@@ -132,50 +132,6 @@ def _build_music_tree(root: Path) -> None:
     (root / "Artist2" / "track3.mp3").write_bytes(b"x")
 
 
-def _patched_scandir_with_stat_error(target_path: str, err: OSError):  # type: ignore[no-untyped-def]
-    """Return a context manager that patches os.scandir so the given path's is_dir raises err."""
-    real_scandir = os.scandir
-
-    class _EntryWrapper:
-        def __init__(self, entry: os.DirEntry[str]) -> None:
-            self._entry = entry
-            self.name = entry.name
-            self.path = entry.path
-
-        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
-            if self.path == target_path:
-                raise err
-            return self._entry.is_dir(follow_symlinks=follow_symlinks)
-
-        def is_file(self, *, follow_symlinks: bool = True) -> bool:
-            return self._entry.is_file(follow_symlinks=follow_symlinks)
-
-        def stat(self, *, follow_symlinks: bool = True) -> os.stat_result:
-            return self._entry.stat(follow_symlinks=follow_symlinks)
-
-    class _IterWrapper:
-        def __init__(self, inner) -> None:  # type: ignore[no-untyped-def]
-            self._inner = inner
-
-        def __iter__(self) -> "_IterWrapper":
-            return self
-
-        def __next__(self):  # type: ignore[no-untyped-def]
-            return _EntryWrapper(next(self._inner))
-
-        def __enter__(self) -> "_IterWrapper":
-            self._inner.__enter__()
-            return self
-
-        def __exit__(self, *exc: object) -> None:
-            self._inner.__exit__(*exc)
-
-    def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
-        return _IterWrapper(real_scandir(path))
-
-    return patch("os.scandir", side_effect=fake_scandir)
-
-
 def test_recursive_iter_happy_path(tmp_path: Path) -> None:
     """Test that a healthy scan yields all supported files and records no errors."""
     _build_music_tree(tmp_path)
@@ -216,14 +172,10 @@ def test_recursive_iter_root_unreachable_records_error(tmp_path: Path) -> None:
     assert errors[0].errno == errno.ENOENT
 
 
-def test_recursive_iter_root_fatal_even_for_eacces() -> None:
-    """Test that permission-denied on the root path is treated as fatal."""
+def test_recursive_iter_root_eacces_records_error() -> None:
+    """Test that permission-denied on the root path is reported via scan_errors."""
     errors: list[OSError] = []
-
-    def _raise_eacces(_path: str) -> None:
-        raise PermissionError(errno.EACCES, "denied")
-
-    with patch("os.scandir", side_effect=_raise_eacces):
+    with patch("os.scandir", side_effect=PermissionError(errno.EACCES, "denied")):
         items = list(
             helpers.recursive_iter(
                 "/fake/root",
@@ -238,48 +190,12 @@ def test_recursive_iter_root_fatal_even_for_eacces() -> None:
     assert errors[0].errno == errno.EACCES
 
 
-def test_recursive_iter_subfolder_eacces_recorded_in_incomplete_dirs(tmp_path: Path) -> None:
-    """Test that permission-denied on a sub-folder is recorded in incomplete_dirs."""
+def test_recursive_iter_subfolder_failure_is_not_fatal(tmp_path: Path) -> None:
+    """Test that a sub-folder scan failure does not populate scan_errors."""
     _build_music_tree(tmp_path)
     errors: list[OSError] = []
-    incomplete: set[str] = set()
-
     real_scandir = os.scandir
     bad_dir = str(tmp_path / "Artist1" / "Album1")
-
-    def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
-        if str(path) == bad_dir:
-            raise PermissionError(errno.EACCES, "denied")
-        return real_scandir(path)
-
-    with patch("os.scandir", side_effect=fake_scandir):
-        items = list(
-            helpers.recursive_iter(
-                str(tmp_path),
-                str(tmp_path),
-                SUPPORTED,
-                logging.getLogger("test"),
-                errors,
-                incomplete,
-            )
-        )
-
-    rel_paths = sorted(i.relative_path for i in items)
-    assert rel_paths == ["Artist2/track3.mp3"]
-    assert errors == []
-    assert incomplete == {"Artist1/Album1"}
-
-
-def test_recursive_iter_subfolder_io_error_recorded_in_incomplete_dirs(
-    tmp_path: Path,
-) -> None:
-    """Test that an EIO failure on a sub-folder is recorded in incomplete_dirs."""
-    _build_music_tree(tmp_path)
-    errors: list[OSError] = []
-    incomplete: set[str] = set()
-
-    real_scandir = os.scandir
-    bad_dir = str(tmp_path / "Artist2")
 
     def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
         if str(path) == bad_dir:
@@ -287,60 +203,6 @@ def test_recursive_iter_subfolder_io_error_recorded_in_incomplete_dirs(
         return real_scandir(path)
 
     with patch("os.scandir", side_effect=fake_scandir):
-        list(
-            helpers.recursive_iter(
-                str(tmp_path),
-                str(tmp_path),
-                SUPPORTED,
-                logging.getLogger("test"),
-                errors,
-                incomplete,
-            )
-        )
-
-    assert errors == []
-    assert incomplete == {"Artist2"}
-
-
-def test_recursive_iter_subfolder_mid_iter_failure(tmp_path: Path) -> None:
-    """Test that a mid-iteration OSError in a sub-folder is recorded in incomplete_dirs."""
-    (tmp_path / "Good" / "Album").mkdir(parents=True)
-    (tmp_path / "Good" / "Album" / "good.mp3").write_bytes(b"x")
-    (tmp_path / "Flaky").mkdir()
-
-    errors: list[OSError] = []
-    incomplete: set[str] = set()
-    real_scandir = os.scandir
-    flaky_dir = str(tmp_path / "Flaky")
-
-    class _FlakyIter:
-        def __init__(self) -> None:
-            self._raised = False
-
-        def __iter__(self) -> "_FlakyIter":
-            return self
-
-        def __next__(self):  # type: ignore[no-untyped-def]
-            if not self._raised:
-                self._raised = True
-                raise OSError(errno.EIO, "i/o error")
-            raise StopIteration
-
-        def __enter__(self) -> "_FlakyIter":
-            return self
-
-        def __exit__(self, *exc: object) -> None:
-            return None
-
-        def close(self) -> None:
-            return None
-
-    def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
-        if str(path) == flaky_dir:
-            return _FlakyIter()
-        return real_scandir(path)
-
-    with patch("os.scandir", side_effect=fake_scandir):
         items = list(
             helpers.recursive_iter(
                 str(tmp_path),
@@ -348,83 +210,18 @@ def test_recursive_iter_subfolder_mid_iter_failure(tmp_path: Path) -> None:
                 SUPPORTED,
                 logging.getLogger("test"),
                 errors,
-                incomplete,
             )
         )
 
     rel_paths = sorted(i.relative_path for i in items)
-    assert rel_paths == ["Good/Album/good.mp3"]
+    assert rel_paths == ["Artist2/track3.mp3"]
     assert errors == []
-    assert incomplete == {"Flaky"}
-
-
-def test_recursive_iter_per_item_enoent_is_silent(tmp_path: Path) -> None:
-    """Test that a per-item stat ENOENT race is silently skipped without tracking."""
-    (tmp_path / "Artist").mkdir()
-    (tmp_path / "Artist" / "good.mp3").write_bytes(b"x")
-    (tmp_path / "Artist" / "racy.mp3").write_bytes(b"x")
-
-    errors: list[OSError] = []
-    incomplete: set[str] = set()
-
-    with _patched_scandir_with_stat_error(
-        str(tmp_path / "Artist" / "racy.mp3"),
-        FileNotFoundError(errno.ENOENT, "vanished"),
-    ):
-        items = list(
-            helpers.recursive_iter(
-                str(tmp_path),
-                str(tmp_path),
-                SUPPORTED,
-                logging.getLogger("test"),
-                errors,
-                incomplete,
-            )
-        )
-
-    rel_paths = sorted(i.relative_path for i in items)
-    assert rel_paths == ["Artist/good.mp3"]
-    assert errors == []
-    assert incomplete == set()
-
-
-def test_recursive_iter_per_item_eio_marks_parent_incomplete(tmp_path: Path) -> None:
-    """Test that a per-item stat EIO on an entry marks its parent directory incomplete."""
-    (tmp_path / "Artist").mkdir()
-    (tmp_path / "Artist" / "good.mp3").write_bytes(b"x")
-    (tmp_path / "Artist" / "flaky.mp3").write_bytes(b"x")
-
-    errors: list[OSError] = []
-    incomplete: set[str] = set()
-
-    with _patched_scandir_with_stat_error(
-        str(tmp_path / "Artist" / "flaky.mp3"),
-        OSError(errno.EIO, "i/o error"),
-    ):
-        list(
-            helpers.recursive_iter(
-                str(tmp_path),
-                str(tmp_path),
-                SUPPORTED,
-                logging.getLogger("test"),
-                errors,
-                incomplete,
-            )
-        )
-
-    assert errors == []
-    assert incomplete == {"Artist"}
 
 
 def test_recursive_iter_einval_is_ignored() -> None:
     """Test that EINVAL from an unsupported path name is not recorded."""
     errors: list[OSError] = []
-    incomplete: set[str] = set()
-
-    def _raise_einval(_path: str) -> None:
-        raise OSError(errno.EINVAL, "invalid path")
-
-    with patch("os.scandir", side_effect=_raise_einval):
+    with patch("os.scandir", side_effect=OSError(errno.EINVAL, "invalid path")):
         items = list(
             helpers.recursive_iter(
                 "/weird/\udcff",
@@ -432,9 +229,7 @@ def test_recursive_iter_einval_is_ignored() -> None:
                 SUPPORTED,
                 logging.getLogger("test"),
                 errors,
-                incomplete,
             )
         )
     assert items == []
     assert errors == []
-    assert incomplete == set()

--- a/tests/providers/filesystem/test_helpers.py
+++ b/tests/providers/filesystem/test_helpers.py
@@ -194,10 +194,11 @@ def test_recursive_iter_root_fatal_even_for_eacces() -> None:
     assert errors[0].errno == errno.EACCES
 
 
-def test_recursive_iter_subfolder_eacces_is_not_fatal(tmp_path: Path) -> None:
-    """Test that permission-denied on a sub-folder does not poison the whole scan."""
+def test_recursive_iter_subfolder_eacces_recorded_in_incomplete_dirs(tmp_path: Path) -> None:
+    """Test that permission-denied on a sub-folder is recorded in incomplete_dirs."""
     _build_music_tree(tmp_path)
     errors: list[OSError] = []
+    incomplete: set[str] = set()
 
     real_scandir = os.scandir
     bad_dir = str(tmp_path / "Artist1" / "Album1")
@@ -215,18 +216,23 @@ def test_recursive_iter_subfolder_eacces_is_not_fatal(tmp_path: Path) -> None:
                 SUPPORTED,
                 logging.getLogger("test"),
                 errors,
+                incomplete,
             )
         )
 
     rel_paths = sorted(i.relative_path for i in items)
     assert rel_paths == ["Artist2/track3.mp3"]
     assert errors == []
+    assert incomplete == {"Artist1/Album1"}
 
 
-def test_recursive_iter_subfolder_io_error_is_fatal(tmp_path: Path) -> None:
-    """Test that an EIO failure on a sub-folder is recorded as fatal."""
+def test_recursive_iter_subfolder_io_error_recorded_in_incomplete_dirs(
+    tmp_path: Path,
+) -> None:
+    """Test that an EIO failure on a sub-folder is recorded in incomplete_dirs."""
     _build_music_tree(tmp_path)
     errors: list[OSError] = []
+    incomplete: set[str] = set()
 
     real_scandir = os.scandir
     bad_dir = str(tmp_path / "Artist2")
@@ -244,16 +250,140 @@ def test_recursive_iter_subfolder_io_error_is_fatal(tmp_path: Path) -> None:
                 SUPPORTED,
                 logging.getLogger("test"),
                 errors,
+                incomplete,
             )
         )
 
-    assert len(errors) == 1
-    assert errors[0].errno == errno.EIO
+    assert errors == []
+    assert incomplete == {"Artist2"}
+
+
+def test_recursive_iter_subfolder_mid_iter_failure(tmp_path: Path) -> None:
+    """Test that a mid-iteration OSError in a sub-folder is recorded in incomplete_dirs."""
+    (tmp_path / "Good" / "Album").mkdir(parents=True)
+    (tmp_path / "Good" / "Album" / "good.mp3").write_bytes(b"x")
+    (tmp_path / "Flaky").mkdir()
+
+    errors: list[OSError] = []
+    incomplete: set[str] = set()
+    real_scandir = os.scandir
+    flaky_dir = str(tmp_path / "Flaky")
+
+    class _FlakyIter:
+        def __init__(self) -> None:
+            self._raised = False
+
+        def __iter__(self) -> "_FlakyIter":
+            return self
+
+        def __next__(self):  # type: ignore[no-untyped-def]
+            if not self._raised:
+                self._raised = True
+                raise OSError(errno.EIO, "i/o error")
+            raise StopIteration
+
+        def __enter__(self) -> "_FlakyIter":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
+        if str(path) == flaky_dir:
+            return _FlakyIter()
+        return real_scandir(path)
+
+    with patch("os.scandir", side_effect=fake_scandir):
+        items = list(
+            helpers.recursive_iter(
+                str(tmp_path),
+                str(tmp_path),
+                SUPPORTED,
+                logging.getLogger("test"),
+                errors,
+                incomplete,
+            )
+        )
+
+    rel_paths = sorted(i.relative_path for i in items)
+    assert rel_paths == ["Good/Album/good.mp3"]
+    assert errors == []
+    assert incomplete == {"Flaky"}
+
+
+def test_recursive_iter_per_item_enoent_is_silent(tmp_path: Path) -> None:
+    """Test that a per-item stat ENOENT race is silently skipped without tracking."""
+    (tmp_path / "Artist").mkdir()
+    (tmp_path / "Artist" / "good.mp3").write_bytes(b"x")
+    (tmp_path / "Artist" / "racy.mp3").write_bytes(b"x")
+
+    errors: list[OSError] = []
+    incomplete: set[str] = set()
+    real_scandir = os.scandir
+    racy_path = str(tmp_path / "Artist" / "racy.mp3")
+
+    class _EntryWrapper:
+        def __init__(self, entry: os.DirEntry[str]) -> None:
+            self._entry = entry
+            self.name = entry.name
+            self.path = entry.path
+
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            if self.path == racy_path:
+                raise FileNotFoundError(errno.ENOENT, "vanished")
+            return self._entry.is_dir(follow_symlinks=follow_symlinks)
+
+        def is_file(self, *, follow_symlinks: bool = True) -> bool:
+            return self._entry.is_file(follow_symlinks=follow_symlinks)
+
+        def stat(self, *, follow_symlinks: bool = True) -> os.stat_result:
+            return self._entry.stat(follow_symlinks=follow_symlinks)
+
+    class _IterWrapper:
+        def __init__(self, inner) -> None:  # type: ignore[no-untyped-def]
+            self._inner = inner
+
+        def __iter__(self) -> "_IterWrapper":
+            return self
+
+        def __next__(self):  # type: ignore[no-untyped-def]
+            return _EntryWrapper(next(self._inner))
+
+        def __enter__(self) -> "_IterWrapper":
+            self._inner.__enter__()
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            self._inner.__exit__(*exc)
+
+    def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
+        return _IterWrapper(real_scandir(path))
+
+    with patch("os.scandir", side_effect=fake_scandir):
+        items = list(
+            helpers.recursive_iter(
+                str(tmp_path),
+                str(tmp_path),
+                SUPPORTED,
+                logging.getLogger("test"),
+                errors,
+                incomplete,
+            )
+        )
+
+    rel_paths = sorted(i.relative_path for i in items)
+    assert rel_paths == ["Artist/good.mp3"]
+    assert errors == []
+    assert incomplete == set()
 
 
 def test_recursive_iter_einval_is_ignored() -> None:
     """Test that EINVAL from an unsupported path name is not recorded."""
     errors: list[OSError] = []
+    incomplete: set[str] = set()
 
     def _raise_einval(_path: str) -> None:
         raise OSError(errno.EINVAL, "invalid path")
@@ -266,8 +396,9 @@ def test_recursive_iter_einval_is_ignored() -> None:
                 SUPPORTED,
                 logging.getLogger("test"),
                 errors,
+                incomplete,
             )
         )
     assert items == []
-    # EINVAL is explicitly non-fatal — bad path names should not abort a sync.
     assert errors == []
+    assert incomplete == set()

--- a/tests/providers/filesystem/test_helpers.py
+++ b/tests/providers/filesystem/test_helpers.py
@@ -132,6 +132,50 @@ def _build_music_tree(root: Path) -> None:
     (root / "Artist2" / "track3.mp3").write_bytes(b"x")
 
 
+def _patched_scandir_with_stat_error(target_path: str, err: OSError):  # type: ignore[no-untyped-def]
+    """Return a context manager that patches os.scandir so the given path's is_dir raises err."""
+    real_scandir = os.scandir
+
+    class _EntryWrapper:
+        def __init__(self, entry: os.DirEntry[str]) -> None:
+            self._entry = entry
+            self.name = entry.name
+            self.path = entry.path
+
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            if self.path == target_path:
+                raise err
+            return self._entry.is_dir(follow_symlinks=follow_symlinks)
+
+        def is_file(self, *, follow_symlinks: bool = True) -> bool:
+            return self._entry.is_file(follow_symlinks=follow_symlinks)
+
+        def stat(self, *, follow_symlinks: bool = True) -> os.stat_result:
+            return self._entry.stat(follow_symlinks=follow_symlinks)
+
+    class _IterWrapper:
+        def __init__(self, inner) -> None:  # type: ignore[no-untyped-def]
+            self._inner = inner
+
+        def __iter__(self) -> "_IterWrapper":
+            return self
+
+        def __next__(self):  # type: ignore[no-untyped-def]
+            return _EntryWrapper(next(self._inner))
+
+        def __enter__(self) -> "_IterWrapper":
+            self._inner.__enter__()
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            self._inner.__exit__(*exc)
+
+    def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
+        return _IterWrapper(real_scandir(path))
+
+    return patch("os.scandir", side_effect=fake_scandir)
+
+
 def test_recursive_iter_happy_path(tmp_path: Path) -> None:
     """Test that a healthy scan yields all supported files and records no errors."""
     _build_music_tree(tmp_path)
@@ -322,47 +366,11 @@ def test_recursive_iter_per_item_enoent_is_silent(tmp_path: Path) -> None:
 
     errors: list[OSError] = []
     incomplete: set[str] = set()
-    real_scandir = os.scandir
-    racy_path = str(tmp_path / "Artist" / "racy.mp3")
 
-    class _EntryWrapper:
-        def __init__(self, entry: os.DirEntry[str]) -> None:
-            self._entry = entry
-            self.name = entry.name
-            self.path = entry.path
-
-        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
-            if self.path == racy_path:
-                raise FileNotFoundError(errno.ENOENT, "vanished")
-            return self._entry.is_dir(follow_symlinks=follow_symlinks)
-
-        def is_file(self, *, follow_symlinks: bool = True) -> bool:
-            return self._entry.is_file(follow_symlinks=follow_symlinks)
-
-        def stat(self, *, follow_symlinks: bool = True) -> os.stat_result:
-            return self._entry.stat(follow_symlinks=follow_symlinks)
-
-    class _IterWrapper:
-        def __init__(self, inner) -> None:  # type: ignore[no-untyped-def]
-            self._inner = inner
-
-        def __iter__(self) -> "_IterWrapper":
-            return self
-
-        def __next__(self):  # type: ignore[no-untyped-def]
-            return _EntryWrapper(next(self._inner))
-
-        def __enter__(self) -> "_IterWrapper":
-            self._inner.__enter__()
-            return self
-
-        def __exit__(self, *exc: object) -> None:
-            self._inner.__exit__(*exc)
-
-    def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
-        return _IterWrapper(real_scandir(path))
-
-    with patch("os.scandir", side_effect=fake_scandir):
+    with _patched_scandir_with_stat_error(
+        str(tmp_path / "Artist" / "racy.mp3"),
+        FileNotFoundError(errno.ENOENT, "vanished"),
+    ):
         items = list(
             helpers.recursive_iter(
                 str(tmp_path),
@@ -378,6 +386,34 @@ def test_recursive_iter_per_item_enoent_is_silent(tmp_path: Path) -> None:
     assert rel_paths == ["Artist/good.mp3"]
     assert errors == []
     assert incomplete == set()
+
+
+def test_recursive_iter_per_item_eio_marks_parent_incomplete(tmp_path: Path) -> None:
+    """Test that a per-item stat EIO on an entry marks its parent directory incomplete."""
+    (tmp_path / "Artist").mkdir()
+    (tmp_path / "Artist" / "good.mp3").write_bytes(b"x")
+    (tmp_path / "Artist" / "flaky.mp3").write_bytes(b"x")
+
+    errors: list[OSError] = []
+    incomplete: set[str] = set()
+
+    with _patched_scandir_with_stat_error(
+        str(tmp_path / "Artist" / "flaky.mp3"),
+        OSError(errno.EIO, "i/o error"),
+    ):
+        list(
+            helpers.recursive_iter(
+                str(tmp_path),
+                str(tmp_path),
+                SUPPORTED,
+                logging.getLogger("test"),
+                errors,
+                incomplete,
+            )
+        )
+
+    assert errors == []
+    assert incomplete == {"Artist"}
 
 
 def test_recursive_iter_einval_is_ignored() -> None:

--- a/tests/providers/filesystem/test_helpers.py
+++ b/tests/providers/filesystem/test_helpers.py
@@ -120,21 +120,11 @@ def test_get_album_dir(album_name: str, track_dir: str, expected: str) -> None:
     assert helpers.get_album_dir(track_dir, album_name) == expected
 
 
-# ---------------------------------------------------------------------------
-# recursive_iter error-tracking tests
-#
-# These protect against the data-loss bug where a filesystem provider would
-# wipe the entire library when its base path (e.g. a NAS share) became
-# unavailable: recursive_iter used to silently return an empty iterator, which
-# the sync then treated as "all previously-indexed files were deleted".
-# ---------------------------------------------------------------------------
-
-
 SUPPORTED = {"mp3", "flac"}
 
 
 def _build_music_tree(root: Path) -> None:
-    """Create a small fake music tree used by the tests below."""
+    """Create a small music tree fixture."""
     (root / "Artist1" / "Album1").mkdir(parents=True)
     (root / "Artist1" / "Album1" / "track1.mp3").write_bytes(b"x")
     (root / "Artist1" / "Album1" / "track2.flac").write_bytes(b"x")
@@ -143,7 +133,7 @@ def _build_music_tree(root: Path) -> None:
 
 
 def test_recursive_iter_happy_path(tmp_path: Path) -> None:
-    """A healthy scan yields every supported file and records no errors."""
+    """Test that a healthy scan yields all supported files and records no errors."""
     _build_music_tree(tmp_path)
     errors: list[OSError] = []
     items = list(
@@ -165,12 +155,7 @@ def test_recursive_iter_happy_path(tmp_path: Path) -> None:
 
 
 def test_recursive_iter_root_unreachable_records_error(tmp_path: Path) -> None:
-    """If scanning the root path fails, the error must be recorded.
-
-    This is the exact NAS-offline scenario: we must never silently return an
-    empty iterator, or the caller would treat every previously-indexed file as
-    "deleted" and wipe the library.
-    """
+    """Test that a missing root path is reported via scan_errors."""
     errors: list[OSError] = []
     missing = tmp_path / "does-not-exist"
     items = list(
@@ -188,11 +173,7 @@ def test_recursive_iter_root_unreachable_records_error(tmp_path: Path) -> None:
 
 
 def test_recursive_iter_root_fatal_even_for_eacces() -> None:
-    """A permission-denied at the root is always fatal.
-
-    Per-sub-folder EACCES is expected to be logged-but-ignored, but losing
-    access to the base path itself means the provider is unreachable.
-    """
+    """Test that permission-denied on the root path is treated as fatal."""
     errors: list[OSError] = []
 
     def _raise_eacces(_path: str) -> None:
@@ -214,11 +195,7 @@ def test_recursive_iter_root_fatal_even_for_eacces() -> None:
 
 
 def test_recursive_iter_subfolder_eacces_is_not_fatal(tmp_path: Path) -> None:
-    """A permission error on a single sub-folder must not poison the whole scan.
-
-    Users legitimately have folders they can't read; treating those as "NAS is
-    gone" would block deletions forever.
-    """
+    """Test that permission-denied on a sub-folder does not poison the whole scan."""
     _build_music_tree(tmp_path)
     errors: list[OSError] = []
 
@@ -242,14 +219,12 @@ def test_recursive_iter_subfolder_eacces_is_not_fatal(tmp_path: Path) -> None:
         )
 
     rel_paths = sorted(i.relative_path for i in items)
-    # Album1 is unreadable, but Artist2 still surfaces.
     assert rel_paths == ["Artist2/track3.mp3"]
-    # EACCES on a sub-folder is expected to be non-fatal.
     assert errors == []
 
 
 def test_recursive_iter_subfolder_io_error_is_fatal(tmp_path: Path) -> None:
-    """An EIO-class failure on a sub-folder is treated as provider unavailability."""
+    """Test that an EIO failure on a sub-folder is recorded as fatal."""
     _build_music_tree(tmp_path)
     errors: list[OSError] = []
 
@@ -277,7 +252,7 @@ def test_recursive_iter_subfolder_io_error_is_fatal(tmp_path: Path) -> None:
 
 
 def test_recursive_iter_einval_is_ignored() -> None:
-    """EINVAL from a path with unsupported characters must not be recorded."""
+    """Test that EINVAL from an unsupported path name is not recorded."""
     errors: list[OSError] = []
 
     def _raise_einval(_path: str) -> None:

--- a/tests/providers/filesystem/test_helpers.py
+++ b/tests/providers/filesystem/test_helpers.py
@@ -1,5 +1,11 @@
 """Tests for utility/helper functions."""
 
+import errno
+import logging
+import os
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from music_assistant.providers.filesystem_local import helpers
@@ -112,3 +118,181 @@ def test_get_artist_dir() -> None:
 def test_get_album_dir(album_name: str, track_dir: str, expected: str) -> None:
     """Test the extraction of an album dir."""
     assert helpers.get_album_dir(track_dir, album_name) == expected
+
+
+# ---------------------------------------------------------------------------
+# recursive_iter error-tracking tests
+#
+# These protect against the data-loss bug where a filesystem provider would
+# wipe the entire library when its base path (e.g. a NAS share) became
+# unavailable: recursive_iter used to silently return an empty iterator, which
+# the sync then treated as "all previously-indexed files were deleted".
+# ---------------------------------------------------------------------------
+
+
+SUPPORTED = {"mp3", "flac"}
+
+
+def _build_music_tree(root: Path) -> None:
+    """Create a small fake music tree used by the tests below."""
+    (root / "Artist1" / "Album1").mkdir(parents=True)
+    (root / "Artist1" / "Album1" / "track1.mp3").write_bytes(b"x")
+    (root / "Artist1" / "Album1" / "track2.flac").write_bytes(b"x")
+    (root / "Artist2").mkdir()
+    (root / "Artist2" / "track3.mp3").write_bytes(b"x")
+
+
+def test_recursive_iter_happy_path(tmp_path: Path) -> None:
+    """A healthy scan yields every supported file and records no errors."""
+    _build_music_tree(tmp_path)
+    errors: list[OSError] = []
+    items = list(
+        helpers.recursive_iter(
+            str(tmp_path),
+            str(tmp_path),
+            SUPPORTED,
+            logging.getLogger("test"),
+            errors,
+        )
+    )
+    rel_paths = sorted(i.relative_path for i in items)
+    assert rel_paths == [
+        "Artist1/Album1/track1.mp3",
+        "Artist1/Album1/track2.flac",
+        "Artist2/track3.mp3",
+    ]
+    assert errors == []
+
+
+def test_recursive_iter_root_unreachable_records_error(tmp_path: Path) -> None:
+    """If scanning the root path fails, the error must be recorded.
+
+    This is the exact NAS-offline scenario: we must never silently return an
+    empty iterator, or the caller would treat every previously-indexed file as
+    "deleted" and wipe the library.
+    """
+    errors: list[OSError] = []
+    missing = tmp_path / "does-not-exist"
+    items = list(
+        helpers.recursive_iter(
+            str(missing),
+            str(missing),
+            SUPPORTED,
+            logging.getLogger("test"),
+            errors,
+        )
+    )
+    assert items == []
+    assert len(errors) == 1
+    assert errors[0].errno == errno.ENOENT
+
+
+def test_recursive_iter_root_fatal_even_for_eacces() -> None:
+    """A permission-denied at the root is always fatal.
+
+    Per-sub-folder EACCES is expected to be logged-but-ignored, but losing
+    access to the base path itself means the provider is unreachable.
+    """
+    errors: list[OSError] = []
+
+    def _raise_eacces(_path: str) -> None:
+        raise PermissionError(errno.EACCES, "denied")
+
+    with patch("os.scandir", side_effect=_raise_eacces):
+        items = list(
+            helpers.recursive_iter(
+                "/fake/root",
+                "/fake/root",
+                SUPPORTED,
+                logging.getLogger("test"),
+                errors,
+            )
+        )
+    assert items == []
+    assert len(errors) == 1
+    assert errors[0].errno == errno.EACCES
+
+
+def test_recursive_iter_subfolder_eacces_is_not_fatal(tmp_path: Path) -> None:
+    """A permission error on a single sub-folder must not poison the whole scan.
+
+    Users legitimately have folders they can't read; treating those as "NAS is
+    gone" would block deletions forever.
+    """
+    _build_music_tree(tmp_path)
+    errors: list[OSError] = []
+
+    real_scandir = os.scandir
+    bad_dir = str(tmp_path / "Artist1" / "Album1")
+
+    def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
+        if str(path) == bad_dir:
+            raise PermissionError(errno.EACCES, "denied")
+        return real_scandir(path)
+
+    with patch("os.scandir", side_effect=fake_scandir):
+        items = list(
+            helpers.recursive_iter(
+                str(tmp_path),
+                str(tmp_path),
+                SUPPORTED,
+                logging.getLogger("test"),
+                errors,
+            )
+        )
+
+    rel_paths = sorted(i.relative_path for i in items)
+    # Album1 is unreadable, but Artist2 still surfaces.
+    assert rel_paths == ["Artist2/track3.mp3"]
+    # EACCES on a sub-folder is expected to be non-fatal.
+    assert errors == []
+
+
+def test_recursive_iter_subfolder_io_error_is_fatal(tmp_path: Path) -> None:
+    """An EIO-class failure on a sub-folder is treated as provider unavailability."""
+    _build_music_tree(tmp_path)
+    errors: list[OSError] = []
+
+    real_scandir = os.scandir
+    bad_dir = str(tmp_path / "Artist2")
+
+    def fake_scandir(path: str | os.PathLike[str]):  # type: ignore[no-untyped-def]
+        if str(path) == bad_dir:
+            raise OSError(errno.EIO, "i/o error")
+        return real_scandir(path)
+
+    with patch("os.scandir", side_effect=fake_scandir):
+        list(
+            helpers.recursive_iter(
+                str(tmp_path),
+                str(tmp_path),
+                SUPPORTED,
+                logging.getLogger("test"),
+                errors,
+            )
+        )
+
+    assert len(errors) == 1
+    assert errors[0].errno == errno.EIO
+
+
+def test_recursive_iter_einval_is_ignored() -> None:
+    """EINVAL from a path with unsupported characters must not be recorded."""
+    errors: list[OSError] = []
+
+    def _raise_einval(_path: str) -> None:
+        raise OSError(errno.EINVAL, "invalid path")
+
+    with patch("os.scandir", side_effect=_raise_einval):
+        items = list(
+            helpers.recursive_iter(
+                "/weird/\udcff",
+                "/weird/\udcff",
+                SUPPORTED,
+                logging.getLogger("test"),
+                errors,
+            )
+        )
+    assert items == []
+    # EINVAL is explicitly non-fatal — bad path names should not abort a sync.
+    assert errors == []


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/5243

When a filesystem provider could not scan its base path — for example because a NAS share was offline — `recursive_iter()` silently returned an empty iterator. `sync_library()` then computed `deleted_files = prev_filenames - cur_filenames` against that empty set and removed every previously indexed track, album and artist from the library.

A closely related case is an empty-but-reachable mount: if the wrong share is mounted, a backup job has swapped the export, or a stale mount point presents as an empty directory, `recursive_iter()` returns cleanly with zero results and the same mass deletion happens.

This PR adds two guards to `sync_library()` and wires the provider's own available flag into the first one so the rest of the system reacts accordingly.