### PR TITLE
Protect library from mass deletion when NAS/SMB source is offline

### DIFF
--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -434,7 +434,25 @@ class LocalFileSystemProvider(MusicProvider):
             self.sync_running = False
 
         # work out deletions
+        # Safeguard: abort deletions if the source appears unavailable.
+        # When a NAS/SMB/NFS mount goes offline, scandir returns empty results
+        # which would incorrectly mark all files as deleted.
         deleted_files = prev_filenames - cur_filenames
+        if deleted_files:
+            if not await isdir(self.base_path):
+                self.logger.warning(
+                    "Source directory %s is no longer accessible - skipping deletion processing",
+                    self.base_path,
+                )
+                deleted_files = set()
+            elif len(prev_filenames) > 50 and len(deleted_files) > (len(prev_filenames) * 0.9):
+                self.logger.warning(
+                    "Skipping deletion processing: %d of %d items would be removed, "
+                    "which suggests the source may be temporarily unavailable",
+                    len(deleted_files),
+                    len(prev_filenames),
+                )
+                deleted_files = set()
         await self._process_deletions(deleted_files)
 
         # process orphaned albums and artists


### PR DESCRIPTION
## Problem

When a NAS or SMB mount goes temporarily offline during a sync cycle, `recursive_iter()` returns an empty set (the `OSError` is caught and logged). The sync then computes `deleted_files = prev_filenames - cur_filenames`, marking **all** previously known files as deleted — effectively wiping the library for that source.

Relates to music-assistant/support#5243

## Changes

- Add base path accessibility check before processing deletions — if the mount is gone, skip deletions entirely
- Add mass deletion threshold — if >90% of known items (min 50) would be removed, skip deletions as this indicates the source is likely temporarily unavailable rather than files being actually deleted
- Both cases log a warning so the user knows the sync was protective