### PR TITLE
Fix Nugs.net get_track NotImplementedError

### DIFF
--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -173,9 +173,16 @@ class NugsProvider(MusicProvider):
                     return track
         raise MediaNotFoundError(f"Track {prov_track_id} not found")
 
-    @use_cache(3600 * 24 * 14)  # Cache for 14 days
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get all album tracks for given album id."""
+        tracks = await self._get_album_tracks(prov_album_id)
+        for track in tracks:
+            self._track_album_mapping[track.item_id] = prov_album_id
+        return tracks
+
+    @use_cache(3600 * 24 * 14)  # Cache for 14 days
+    async def _get_album_tracks(self, prov_album_id: str) -> list[Track]:
+        """Fetch album tracks from the API (cached)."""
         endpoint = f"shows/{prov_album_id}"
         response = await self._get_data("catalog", endpoint)
         album_data = response["Response"]
@@ -184,14 +191,11 @@ class NugsProvider(MusicProvider):
             MediaType.ALBUM, album_data["containerID"], album_data["containerInfo"]
         )
         image = f"https://api.livedownloads.com{album_data['img']['url']}"
-        tracks = [
+        return [
             self._parse_track(item, artist=artist, album=album, image_url=image)
             for item in album_data["tracks"]
             if item["trackID"]
         ]
-        for track in tracks:
-            self._track_album_mapping[track.item_id] = prov_album_id
-        return tracks
 
     @use_cache(3600)  # Cache for 1 hour
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:

--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -210,7 +210,7 @@ class NugsProvider(MusicProvider):
         return result
 
     async def _cache_tracks(self, tracks: list[Track]) -> None:
-        """Persistently cache individual tracks for later lookup by get_track."""
+        """Cache individual tracks persistently for later lookup by get_track."""
         for track in tracks:
             await self.mass.cache.set(
                 f"nugs_track_{track.item_id}",

--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -106,7 +106,6 @@ class NugsProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        self._track_album_mapping: dict[str, str] = {}
         await self.login()
 
     async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
@@ -167,22 +166,17 @@ class NugsProvider(MusicProvider):
 
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
-        if prov_album_id := self._track_album_mapping.get(prov_track_id):
-            for track in await self.get_album_tracks(prov_album_id):
-                if track.item_id == prov_track_id:
-                    return track
+        cache_key = f"nugs_track_{prov_track_id}"
+        cached: Track | None = await self.mass.cache.get(
+            cache_key, provider=self.instance_id, base_class=Track
+        )
+        if cached:
+            return cached
         raise MediaNotFoundError(f"Track {prov_track_id} not found")
 
+    @use_cache(3600 * 24 * 14)  # Cache for 14 days
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get all album tracks for given album id."""
-        tracks = await self._get_album_tracks(prov_album_id)
-        for track in tracks:
-            self._track_album_mapping[track.item_id] = prov_album_id
-        return tracks
-
-    @use_cache(3600 * 24 * 14)  # Cache for 14 days
-    async def _get_album_tracks(self, prov_album_id: str) -> list[Track]:
-        """Fetch album tracks from the API (cached)."""
         endpoint = f"shows/{prov_album_id}"
         response = await self._get_data("catalog", endpoint)
         album_data = response["Response"]
@@ -191,11 +185,13 @@ class NugsProvider(MusicProvider):
             MediaType.ALBUM, album_data["containerID"], album_data["containerInfo"]
         )
         image = f"https://api.livedownloads.com{album_data['img']['url']}"
-        return [
+        tracks = [
             self._parse_track(item, artist=artist, album=album, image_url=image)
             for item in album_data["tracks"]
             if item["trackID"]
         ]
+        await self._cache_tracks(tracks)
+        return tracks
 
     @use_cache(3600)  # Cache for 1 hour
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
@@ -210,7 +206,19 @@ class NugsProvider(MusicProvider):
             track = self._parse_track(item)
             track.position = index
             result.append(track)
+        await self._cache_tracks(result)
         return result
+
+    async def _cache_tracks(self, tracks: list[Track]) -> None:
+        """Persistently cache individual tracks for later lookup by get_track."""
+        for track in tracks:
+            await self.mass.cache.set(
+                f"nugs_track_{track.item_id}",
+                track.to_dict(),
+                expiration=3600 * 24 * 14,
+                provider=self.instance_id,
+                persistent=True,
+            )
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Return the content details for the given track when it will be streamed."""

--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -106,6 +106,7 @@ class NugsProvider(MusicProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
+        self._track_album_mapping: dict[str, str] = {}
         await self.login()
 
     async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
@@ -164,6 +165,14 @@ class NugsProvider(MusicProvider):
         response = await self._get_data("stash", endpoint)
         return self._parse_playlist(response["items"])
 
+    async def get_track(self, prov_track_id: str) -> Track:
+        """Get full track details by id."""
+        if prov_album_id := self._track_album_mapping.get(prov_track_id):
+            for track in await self.get_album_tracks(prov_album_id):
+                if track.item_id == prov_track_id:
+                    return track
+        raise MediaNotFoundError(f"Track {prov_track_id} not found")
+
     @use_cache(3600 * 24 * 14)  # Cache for 14 days
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get all album tracks for given album id."""
@@ -175,11 +184,14 @@ class NugsProvider(MusicProvider):
             MediaType.ALBUM, album_data["containerID"], album_data["containerInfo"]
         )
         image = f"https://api.livedownloads.com{album_data['img']['url']}"
-        return [
+        tracks = [
             self._parse_track(item, artist=artist, album=album, image_url=image)
             for item in album_data["tracks"]
             if item["trackID"]
         ]
+        for track in tracks:
+            self._track_album_mapping[track.item_id] = prov_album_id
+        return tracks
 
     @use_cache(3600)  # Cache for 1 hour
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:


### PR DESCRIPTION
The Nugs provider was missing a `get_track` implementation, causing `NotImplementedError` when:
- Clicking a track to play
- Favoriting a track
- Viewing playlists containing Nugs tracks

Since the Nugs.net API has no direct track-by-ID endpoint, this fix:
- Persistently caches each track individually in `mass.cache` when `get_album_tracks` or `get_playlist_tracks` is called
- `get_track` retrieves the cached track by its ID

Fixes music-assistant/support#5126