### PR TITLE
Use original stream for ibroadcast

### DIFF
--- a/music_assistant/providers/ibroadcast/__init__.py
+++ b/music_assistant/providers/ibroadcast/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse, urlunparse
 
-from aiohttp import ClientSession
 from ibroadcastaio import IBroadcastClient
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
@@ -15,7 +15,7 @@ from music_assistant_models.enums import (
     ProviderFeature,
     StreamType,
 )
-from music_assistant_models.errors import InvalidDataError, LoginFailed
+from music_assistant_models.errors import InvalidDataError, LoginFailed, MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -105,21 +105,18 @@ class IBroadcastProvider(MusicProvider):
 
     _user_id: str
     _client: IBroadcastClient
-    _token: str
 
     async def handle_async_init(self) -> None:
         """Set up the iBroadcast provider."""
-        async with ClientSession() as session:
-            self._client = IBroadcastClient(session)
-            status = await self._client.login(
-                self.config.get_value(CONF_USERNAME),
-                self.config.get_value(CONF_PASSWORD),
-            )
-            self._user_id = status["user"]["id"]
-            self._token = status["user"]["token"]
+        self._client = IBroadcastClient(self.mass.http_session)
+        status = await self._client.login(
+            self.config.get_value(CONF_USERNAME),
+            self.config.get_value(CONF_PASSWORD),
+        )
+        self._user_id = status["user"]["id"]
 
-            # temporary call to refresh library until ibroadcast provides a detailed api
-            await self._client.refresh_library()
+        # temporary call to refresh library until ibroadcast provides a detailed api
+        await self._client.refresh_library()
 
     async def get_library_albums(self) -> AsyncGenerator[Album, None]:
         """Retrieve library albums from ibroadcast."""
@@ -219,6 +216,7 @@ class IBroadcastProvider(MusicProvider):
             playlist = await self._parse_playlist(playlist_obj)
         except (KeyError, TypeError, InvalidDataError, IndexError) as error:
             self.logger.debug("Parse playlist failed: %s", playlist_obj, exc_info=error)
+            raise MediaNotFoundError(f"Playlist {prov_playlist_id} could not be parsed") from error
         return playlist
 
     @use_cache(3600)  # Cache for 1 hour
@@ -240,12 +238,18 @@ class IBroadcastProvider(MusicProvider):
         # See https://devguide.ibroadcast.com/?p=streaming-server
         url = await self._client.get_full_stream_url(int(item_id), "music-assistant")
 
+        # Replace the bitrate path segment with "orig" to request the original upload format.
+        # By default the bitrate is always 128kbps.
+        parsed = urlparse(url)
+        path_parts = parsed.path.split("/")
+        if len(path_parts) > 1 and path_parts[1].isdigit():
+            path_parts[1] = "orig"
+            url = urlunparse(parsed._replace(path="/".join(path_parts)))
+
         return StreamDetails(
             provider=self.instance_id,
             item_id=item_id,
-            audio_format=AudioFormat(
-                content_type=ContentType.UNKNOWN,
-            ),
+            audio_format=AudioFormat(content_type=ContentType.UNKNOWN),
             stream_type=StreamType.HTTP,
             path=url,
             can_seek=True,
@@ -309,7 +313,7 @@ class IBroadcastProvider(MusicProvider):
                     item_id=album_id,
                     provider_domain=self.domain,
                     provider_instance=self.instance_id,
-                    audio_format=AudioFormat(content_type=ContentType.MPEG),
+                    audio_format=AudioFormat(content_type=ContentType.UNKNOWN),
                     url=f"https://media.ibroadcast.com/?view=container&container_id={album_id}&type=albums",
                 )
             },
@@ -369,9 +373,7 @@ class IBroadcastProvider(MusicProvider):
                     provider_domain=self.domain,
                     provider_instance=self.instance_id,
                     available=not track_obj["trashed"],
-                    audio_format=AudioFormat(
-                        content_type=ContentType.MPEG,
-                    ),
+                    audio_format=AudioFormat(content_type=ContentType.UNKNOWN),
                 )
             },
         )

--- a/music_assistant/providers/ibroadcast/manifest.json
+++ b/music_assistant/providers/ibroadcast/manifest.json
@@ -6,7 +6,7 @@
   "description": "Stream your personal iBroadcast music collection from anywhere.",
   "codeowners": ["@robsonke"],
   "credits": ["[ibroadcastaio](https://github.com/robsonke/ibroadcastaio)"],
-  "requirements": ["ibroadcastaio==0.4.0"],
+  "requirements": ["ibroadcastaio==0.5.0"],
   "documentation": "https://music-assistant.io/music-providers/ibroadcast/",
   "multi_instance": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ duration-parser==1.0.1
 getmac==0.9.5
 gql[all]==4.0.0
 hass-client==1.2.3
-ibroadcastaio==0.4.0
+ibroadcastaio==0.5.0
 ifaddr==0.2.0
 liblistenbrainz==0.7.0
 librosa==0.11.0


### PR DESCRIPTION
- Use the original file format that was uploaded into ibroadcast, let ffmpeg decide the rest.
- Some small stability fixes.