### PR TITLE
Add Tidal starred tracks virtual playlist

### DIFF
--- a/music_assistant/providers/tidal/constants.py
+++ b/music_assistant/providers/tidal/constants.py
@@ -42,3 +42,6 @@ DEFAULT_LIMIT: Final[int] = 50
 CACHE_CATEGORY_DEFAULT: Final[int] = 0
 CACHE_CATEGORY_RECOMMENDATIONS: Final[int] = 1
 CACHE_CATEGORY_ISRC_MAP: Final[int] = 2
+
+# Virtual playlist IDs
+FAVORITE_TRACKS_PLAYLIST_ID: Final[str] = "favorite_tracks"

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -8,7 +8,13 @@ from aiohttp.client_exceptions import ClientError
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MediaNotFoundError, ResourceTemporarilyUnavailable
 
-from .parsers import parse_album, parse_artist, parse_playlist, parse_track
+from .parsers import (
+    parse_album,
+    parse_artist,
+    parse_favorite_tracks_playlist,
+    parse_playlist,
+    parse_track,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -63,6 +69,9 @@ class TidalLibraryManager:
         async for item in self.api.paginate(path):
             if item and item.get("playlist") and item["playlist"].get("uuid"):
                 yield parse_playlist(self.provider, item)
+
+        # 3. Get the virtual favorite tracks playlist
+        yield parse_favorite_tracks_playlist(self.provider)
 
     async def add_item(self, item: MediaItemType) -> bool:
         """Add item to library."""

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -10,7 +10,14 @@ from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import SearchResults
 
-from .parsers import parse_album, parse_artist, parse_playlist, parse_track
+from .constants import FAVORITE_TRACKS_PLAYLIST_ID
+from .parsers import (
+    parse_album,
+    parse_artist,
+    parse_favorite_tracks_playlist,
+    parse_playlist,
+    parse_track,
+)
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import Album, Artist, Playlist, Track
@@ -104,6 +111,9 @@ class TidalMediaManager:
 
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
         """Get playlist details."""
+        if prov_playlist_id == FAVORITE_TRACKS_PLAYLIST_ID:
+            return parse_favorite_tracks_playlist(self.provider)
+
         if prov_playlist_id.startswith("mix_"):
             return await self._get_mix_details(prov_playlist_id[4:])
 
@@ -182,6 +192,9 @@ class TidalMediaManager:
         page_size = 200
         offset = page * page_size
 
+        if prov_playlist_id == FAVORITE_TRACKS_PLAYLIST_ID:
+            return await self._get_favorite_tracks(page_size, offset)
+
         if prov_playlist_id.startswith("mix_"):
             return await self._get_mix_tracks(prov_playlist_id[4:], page_size, offset)
 
@@ -193,6 +206,22 @@ class TidalMediaManager:
             return self._process_tracks(data.get("items", []), offset)
         except MediaNotFoundError:
             return await self._get_mix_tracks(prov_playlist_id, page_size, offset)
+
+    async def _get_favorite_tracks(self, limit: int, offset: int) -> list[Track]:
+        """Get the user's favorite tracks in descending order (newest first)."""
+        try:
+            data = await self.api.get_data(
+                f"users/{self.provider.auth.user_id}/favorites/tracks",
+                params={
+                    "limit": limit,
+                    "offset": offset,
+                    "order": "DATE",
+                    "orderDirection": "DESC",
+                },
+            )
+            return self._process_tracks(data.get("items", []), offset)
+        except (ClientError, KeyError, ValueError) as err:
+            raise MediaNotFoundError("Starred tracks not found") from err
 
     async def _get_mix_tracks(self, mix_id: str, limit: int, offset: int) -> list[Track]:
         """Get tracks from a mix."""

--- a/music_assistant/providers/tidal/parsers.py
+++ b/music_assistant/providers/tidal/parsers.py
@@ -26,7 +26,7 @@ from music_assistant_models.media_items import (
 
 from music_assistant.helpers.util import infer_album_type, parse_title_and_version
 
-from .constants import BROWSE_URL, RESOURCES_URL
+from .constants import BROWSE_URL, FAVORITE_TRACKS_PLAYLIST_ID, RESOURCES_URL
 
 if TYPE_CHECKING:
     from .provider import TidalProvider
@@ -337,3 +337,29 @@ def parse_playlist(
         )
 
     return playlist
+
+
+def parse_favorite_tracks_playlist(provider: TidalProvider) -> Playlist:
+    """Build a virtual Playlist representing the user's favorited tracks."""
+    owner_name = str(provider.auth.user_id)
+    if provider.auth.user.profile_name:
+        owner_name = provider.auth.user.profile_name
+    elif provider.auth.user.user_name:
+        owner_name = provider.auth.user.user_name
+
+    return Playlist(
+        item_id=FAVORITE_TRACKS_PLAYLIST_ID,
+        provider=provider.instance_id,
+        name="Favorite Tracks",
+        owner=owner_name,
+        provider_mappings={
+            ProviderMapping(
+                item_id=FAVORITE_TRACKS_PLAYLIST_ID,
+                provider_domain=provider.domain,
+                provider_instance=provider.instance_id,
+                url=f"{BROWSE_URL}/my-collection/tracks",
+                is_unique=True,
+            )
+        },
+        is_editable=False,
+    )

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -148,9 +148,10 @@ async def test_get_playlists(
 
     playlists = [p async for p in library_manager.get_playlists()]
 
-    assert len(playlists) == 2
+    assert len(playlists) == 3
     assert playlists[0].item_id == "mix_1"
     assert playlists[1].item_id == "pl_1"
+    assert playlists[2].item_id == "favorite_tracks"
     assert mock_parse_playlist.call_count == 2
 
 
@@ -232,3 +233,17 @@ async def test_remove_item_playlist(
     await library_manager.remove_item("123", MediaType.PLAYLIST)
 
     provider_mock.api.delete.assert_called_with("users/12345/favorites/playlists/123")
+
+
+async def test_get_playlists_includes_favorite_tracks(
+    library_manager: TidalLibraryManager, provider_mock: Mock
+) -> None:
+    """Test that get_playlists yields the favorite tracks playlist as the first item."""
+    provider_mock.api.paginate.return_value = []
+
+    playlists = [p async for p in library_manager.get_playlists()]
+
+    assert len(playlists) >= 1
+    assert playlists[0].item_id == "favorite_tracks"
+    assert playlists[0].name == "Favorite Tracks"
+    assert not playlists[0].is_editable

--- a/tests/providers/tidal/test_media.py
+++ b/tests/providers/tidal/test_media.py
@@ -234,3 +234,33 @@ async def test_get_playlist_tracks(
         "playlists/1/tracks",
         params={"limit": 200, "offset": 0},
     )
+
+
+async def test_get_playlist_favorite_tracks(
+    media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_playlist returns the virtual favorite tracks playlist without an API call."""
+    playlist = await media_manager.get_playlist("favorite_tracks")
+
+    assert playlist.item_id == "favorite_tracks"
+    assert playlist.name == "Favorite Tracks"
+    assert not playlist.is_editable
+    provider_mock.api.get_data.assert_not_called()
+
+
+@patch("music_assistant.providers.tidal.media.parse_track")
+async def test_get_playlist_tracks_favorite_tracks(
+    mock_parse_track: Mock, media_manager: TidalMediaManager, provider_mock: Mock
+) -> None:
+    """Test get_playlist_tracks returns favorite tracks ordered by date descending."""
+    provider_mock.api.get_data.return_value = {"items": [{"item": {"id": 1}}]}
+    mock_parse_track.return_value = Mock(item_id="1")
+
+    tracks = await media_manager.get_playlist_tracks("favorite_tracks", page=0)
+
+    assert len(tracks) == 1
+    assert tracks[0].item_id == "1"
+    provider_mock.api.get_data.assert_called_with(
+        "users/12345/favorites/tracks",
+        params={"limit": 200, "offset": 0, "order": "DATE", "orderDirection": "DESC"},
+    )


### PR DESCRIPTION
I use this feature on the app a lot and was missing it in Music Assistant. 

There is already a workaround possible, by going to tracks -> sort them by recently added -> select multiple -> select all (which is taking a long time with large lists) -> start playing.

This approach is more clean, enabling to start playing this list directly from HA via actions. 