### PR TITLE
Fix AirPlay DACP volume control for Sonos speakers

### DIFF
--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -86,13 +86,12 @@ async def resolve_if_ip(mass: MusicAssistant, target_ip: str) -> str:
 
 
 def convert_airplay_volume(value: float) -> int:
-    """Remap AirPlay Volume to 0..100 scale."""
-    airplay_min = -30
-    airplay_max = 0
-    normal_min = 0
-    normal_max = 100
-    portion = (value - airplay_min) * (normal_max - normal_min) / (airplay_max - airplay_min)
-    return int(portion + normal_min)
+    """Remap AirPlay dB volume (-30..0) to 0..100 scale."""
+    airplay_min = -30.0
+    airplay_max = 0.0
+    value = max(airplay_min, min(airplay_max, value))
+    portion = (value - airplay_min) * 100.0 / (airplay_max - airplay_min)
+    return max(0, min(100, round(portion)))
 
 
 def get_model_info(info: AsyncServiceInfo) -> tuple[str, str]:  # noqa: PLR0911

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -864,7 +864,7 @@ class AirPlayPlayer(Player):
             return
 
         cur_volume = self.volume_level or 0
-        if abs(cur_volume - volume) > 3 or (time.time() - self.last_command_sent) > 3:
+        if abs(cur_volume - volume) > 1 or (time.time() - self.last_command_sent) > 3:
             self.mass.create_task(self.volume_set(volume))
         else:
             self._attr_volume_level = volume


### PR DESCRIPTION
When Sonos speakers receive volume changes (via their app or hardware buttons), they forward the request as DACP `dmcp.device-volume` messages with float dB values. Two issues caused poor volume control behavior:

1. **Small volume increments ignored** — The debounce threshold of 3 units combined with `int()` truncation meant that small dB steps (e.g. 0.6 dB increments from Sonos) were silently dropped when they arrived within 3 seconds of the last command.

2. **Volume 0 still audible** — `int()` truncation caused rounding errors in the dB-to-linear conversion, particularly at the lower end of the range.

### Changes

- Use `round()` instead of `int()` in `convert_airplay_volume()` to eliminate truncation bias
- Clamp converted volume to valid 0-100 range
- Lower debounce threshold from 3 to 1 units in `update_volume_from_device()` so small but intentional volume steps are forwarded