### PR TITLE
Fix muted player in group unmuting on group volume change

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3084,7 +3084,13 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
         # Check if player has mute lock (set when individually muted in a group)
         # If locked, don't auto-unmute when volume changes
+        # Also check the protocol parent player, because cmd_volume_mute stores
+        # the lock on the parent player while this method may be called with
+        # the protocol player ID (e.g. during group volume changes).
         has_mute_lock = player.extra_data.get(ATTR_MUTE_LOCK, False)
+        if not has_mute_lock and player.protocol_parent_id:
+            if parent := self.get_player(player.protocol_parent_id):
+                has_mute_lock = parent.extra_data.get(ATTR_MUTE_LOCK, False)
         if (
             not has_mute_lock
             and player.state.mute_control not in (PLAYER_CONTROL_NONE, PLAYER_CONTROL_FAKE)


### PR DESCRIPTION
When a protocol player (e.g. Sendspin) is individually muted within a group, changing the group volume incorrectly unmutes it.

The mute lock is stored on the parent player by `cmd_volume_mute`, but `_handle_cmd_volume_set` (called internally from `set_group_volume`) can receive the protocol player ID. Since it bypasses the `@handle_player_command` decorator, it checks the wrong player object for the lock and finds none — proceeding to unmute.

**Changes:**
- In `_handle_cmd_volume_set`, also check the protocol parent's `extra_data` for `ATTR_MUTE_LOCK` before deciding to unmute

Fixes music-assistant/support#5098