### PR TITLE
Remove protocol player power control forwarding

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -971,6 +971,8 @@ ACTIVE_PROTOCOL_FEATURES: Final[set[PlayerFeature]] = {
     PlayerFeature.PAUSE,
 }
 
+PLAYER_CONTROL_PROTOCOL: Final[str] = "follow_protocol"
+
 DEFAULT_PROVIDERS: Final[set[tuple[str, bool]]] = {
     # list of providers that are setup by default once
     # (and they can be removed/disabled by the user if they want to)

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -100,6 +100,7 @@ from music_assistant.constants import (
     DEFAULT_PROVIDER_CONFIG_ENTRIES,
     ENCRYPT_SUFFIX,
     NON_HTTP_PROVIDERS,
+    PLAYER_CONTROL_PROTOCOL,
 )
 from music_assistant.controllers.streams.constants import (
     CONF_BUFFER_SIZE,
@@ -1833,7 +1834,7 @@ class ConfigController:
         volume_controls = [x for x in all_controls if x.supports_volume]
         mute_controls = [x for x in all_controls if x.supports_mute]
         auto_option = ConfigValueOption(
-            title="Auto-select (based on active/preferred protocol)", value="auto"
+            title="Auto-select (based on active/preferred protocol)", value=PLAYER_CONTROL_PROTOCOL
         )
         # work out player supported features
         power_options: list[ConfigValueOption] = []
@@ -1842,7 +1843,9 @@ class ConfigController:
                 ConfigValueOption(title="Native power control", value=PLAYER_CONTROL_NATIVE),
             )
         volume_options: list[ConfigValueOption] = []
+        has_native_volume_control = False
         if player.supports_feature(PlayerFeature.VOLUME_SET):
+            has_native_volume_control = True
             volume_options.append(
                 ConfigValueOption(title="Native volume control", value=PLAYER_CONTROL_NATIVE),
             )
@@ -1851,18 +1854,37 @@ class ConfigController:
             mute_options.append(
                 ConfigValueOption(title="Native mute control", value=PLAYER_CONTROL_NATIVE),
             )
-        # add 'auto' option if any linked protocol players support the feature
+        # add player protocols as volume controls if native player has no volume control
         for linked_protocol in player.linked_output_protocols:
-            if protocol_player := self.mass.players.get_player(linked_protocol.output_protocol_id):
-                if protocol_player.supports_feature(PlayerFeature.VOLUME_SET):
-                    if auto_option not in volume_options:
-                        volume_options.append(auto_option)
-                if protocol_player.supports_feature(PlayerFeature.VOLUME_MUTE):
-                    if auto_option not in mute_options:
-                        mute_options.append(auto_option)
-                if protocol_player.supports_feature(PlayerFeature.POWER):
-                    if auto_option not in power_options:
-                        power_options.append(auto_option)
+            if has_native_volume_control:
+                break
+            protocol_player = self.mass.players.get_player(linked_protocol.output_protocol_id)
+            if not protocol_player or not protocol_player.available:
+                continue
+            if protocol_player.supports_feature(PlayerFeature.VOLUME_SET):
+                if auto_option not in volume_options:
+                    volume_options.append(auto_option)
+                if linked_protocol.protocol_domain in ("chromecast", "dlna"):
+                    # for chromecast/dlna we can use the protocol player for volume control
+                    # even if the protocol player is not the active protocol
+                    volume_options.append(
+                        ConfigValueOption(
+                            title=protocol_player.provider.name,
+                            value=protocol_player.player_id,
+                        )
+                    )
+            if protocol_player.supports_feature(PlayerFeature.VOLUME_MUTE):
+                if auto_option not in mute_options:
+                    mute_options.append(auto_option)
+                if linked_protocol.protocol_domain in ("chromecast", "dlna"):
+                    # for chromecast/dlna we can use the protocol player for volume control
+                    # even if the protocol player is not the active protocol
+                    mute_options.append(
+                        ConfigValueOption(
+                            title=protocol_player.provider.name,
+                            value=protocol_player.player_id,
+                        )
+                    )
 
         # append none+fake options
         power_options += [

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3044,16 +3044,6 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             else:
                 assert player_control.power_off is not None  # for type checking
                 await player_control.power_off()
-        # handle protocol player power control
-        elif protocol_player := self.get_player(player.state.power_control):
-            self.logger.debug(
-                "Redirecting power command to protocol player %s",
-                protocol_player.provider.manifest.name,
-            )
-            await self._handle_cmd_power(protocol_player.player_id, powered, True)
-            if powered:
-                await wait_for_power_on(self.logger, protocol_player)
-
         # always trigger a state update to update the UI
         player.update_state()
 

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -56,6 +56,7 @@ from music_assistant.constants import (
     CONF_PREFERRED_OUTPUT_PROTOCOL,
     CONF_VOLUME_CONTROL,
     EXTERNAL_SOURCES,
+    PLAYER_CONTROL_PROTOCOL,
     PROTOCOL_FEATURES,
     PROTOCOL_PRIORITY,
 )
@@ -764,23 +765,13 @@ class Player(ABC):
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             # the control type is explicitly set in the config, use that
             return str(conf)
-        if conf and conf != "auto":
-            # the control type is explicitly set to a (protocol) player_id or player control,
-            # check if it exists and is (currently) available
-            if (_player := self.mass.players.get_player(str(conf))) and _player.available:
-                return _player.player_id
-            if _control := self.mass.players.get_player_control(str(conf)):
-                return _control.id
+        if conf and (_control := self.mass.players.get_player_control(str(conf))):
+            # the control type is explicitly set to a player control,
+            return _control.id
         # handle auto-select logic if not explicitly set in config
         if PlayerFeature.POWER in self.supported_features:
             # player supports native power control, always prefer that
             return PLAYER_CONTROL_NATIVE
-        # check if the active (or preferred) protocol player supports power control
-        # check for protocol player with power support, and use that if found
-        if protocol_player := self._get_protocol_player_for_feature(
-            PlayerFeature.POWER, require_active=True
-        ):
-            return protocol_player.player_id
         return PLAYER_CONTROL_NONE
 
     @cached_property
@@ -791,7 +782,7 @@ class Player(ABC):
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             # the control type is explicitly set in the config, use that
             return str(conf)
-        if conf and conf != "auto":
+        if conf and conf != PLAYER_CONTROL_PROTOCOL:
             # the control type is explicitly set to a (protocol) player_id or player control,
             # check if it exists and is (currently) available
             if (_player := self.mass.players.get_player(str(conf))) and _player.available:
@@ -817,7 +808,7 @@ class Player(ABC):
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             # the control type is explicitly set in the config, use that
             return str(conf)
-        if conf and conf != "auto":
+        if conf and conf != PLAYER_CONTROL_PROTOCOL:
             # the control type is explicitly set to a (protocol) player_id or player control,
             # check if it exists and is (currently) available
             if (_player := self.mass.players.get_player(str(conf))) and _player.available:
@@ -1344,13 +1335,7 @@ class Player(ABC):
             return self
         # prefer active (or preferred) protocol player with the feature
         active_protocol = self.active_output_protocol
-        if not active_protocol:
-            preferred = self.mass.config.get_raw_player_config_value(
-                self.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL
-            )
-            if preferred and preferred not in ("auto", "native"):
-                active_protocol = str(preferred)
-        if active_protocol:
+        if active_protocol and active_protocol != "native":
             protocol_player = self.mass.players.get_player(active_protocol)
             if (
                 protocol_player
@@ -1362,6 +1347,19 @@ class Player(ABC):
             # if we require active and the active protocol
             # doesn't support the feature, return None
             return None
+
+        # fallback to preferred protocol from config
+        preferred_conf = self.mass.config.get_raw_player_config_value(
+            self.player_id, CONF_PREFERRED_OUTPUT_PROTOCOL
+        )
+        if preferred_conf and preferred_conf not in ("auto", "native"):
+            preferred_protocol = str(preferred_conf)
+            if (
+                (_player := self.mass.players.get_player(preferred_protocol))
+                and _player.available
+                and feature in _player.supported_features
+            ):
+                return _player
 
         # Otherwise, use the first available linked protocol.
         # Prefer protocols that can process commands without active streaming

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -782,7 +782,7 @@ class Player(ABC):
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             # the control type is explicitly set in the config, use that
             return str(conf)
-        if conf and conf != PLAYER_CONTROL_PROTOCOL:
+        if conf and conf not in (PLAYER_CONTROL_PROTOCOL, "auto"):
             # the control type is explicitly set to a (protocol) player_id or player control,
             # check if it exists and is (currently) available
             if (_player := self.mass.players.get_player(str(conf))) and _player.available:
@@ -808,7 +808,7 @@ class Player(ABC):
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
             # the control type is explicitly set in the config, use that
             return str(conf)
-        if conf and conf != PLAYER_CONTROL_PROTOCOL:
+        if conf and conf not in (PLAYER_CONTROL_PROTOCOL, "auto"):
             # the control type is explicitly set to a (protocol) player_id or player control,
             # check if it exists and is (currently) available
             if (_player := self.mass.players.get_player(str(conf))) and _player.available:

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -82,7 +82,6 @@ class ChromecastPlayer(Player):
         # set static variables
         self._attr_supported_features = {
             PlayerFeature.PLAY_MEDIA,
-            PlayerFeature.POWER,
             PlayerFeature.VOLUME_SET,
             PlayerFeature.VOLUME_MUTE,
             PlayerFeature.PAUSE,
@@ -92,7 +91,6 @@ class ChromecastPlayer(Player):
         }
         self._attr_name = self.cast_info.friendly_name
         self._attr_available = False
-        self._attr_powered = False
         self._attr_needs_poll = True
         self._attr_type = player_type
         # Disable TV's by default
@@ -163,7 +161,10 @@ class ChromecastPlayer(Player):
 
     async def stop(self) -> None:
         """Send STOP command to given player."""
-        await asyncio.to_thread(self.cc.media_controller.stop)
+        if self.type == PlayerType.GROUP:
+            await asyncio.to_thread(self.cc.media_controller.stop)
+        else:
+            await asyncio.to_thread(self.cc.quit_app)
 
     async def play(self) -> None:
         """Send PLAY command to given player."""
@@ -186,7 +187,7 @@ class ChromecastPlayer(Player):
         await asyncio.to_thread(self.cc.media_controller.seek, position)
 
     async def power(self, powered: bool) -> None:
-        """Send POWER command to given player."""
+        """Send POWER command to given player (only for Cast Groups)."""
         if powered:
             await self._launch_app()
             self._attr_active_source = None
@@ -258,9 +259,7 @@ class ChromecastPlayer(Player):
 
     async def poll(self) -> None:
         """Poll player for state updates."""
-        # only update status of media controller if player is on
-        if not self.powered:
-            return
+        # only update status of media controller if media controller is active
         if not self.cc.media_controller.is_active:
             return
         try:
@@ -289,7 +288,7 @@ class ChromecastPlayer(Player):
 
     def _on_player_media_updated(self) -> None:
         """Handle callback when the current media of the player is updated."""
-        if not self.powered:
+        if self.powered is False:
             return
         if not self.cc.media_controller.status.player_is_playing:
             return
@@ -436,24 +435,20 @@ class ChromecastPlayer(Player):
             self._attr_static_group_members = self._attr_group_members.copy()
             self._attr_supported_features = {
                 PlayerFeature.PLAY_MEDIA,
+                # only cast groups can be powered on/off as a group,
+                # so only add the POWER feature for groups
                 PlayerFeature.POWER,
                 PlayerFeature.VOLUME_SET,
                 PlayerFeature.VOLUME_MUTE,
                 PlayerFeature.PAUSE,
                 PlayerFeature.ENQUEUE,
             }
+            self._attr_powered = self.cc.app_id is not None and self.cc.app_id != IDLE_APP_ID
 
         # update player status
         self._attr_name = self.cast_info.friendly_name
         self._attr_volume_level = round(status.volume_level * 100)
         self._attr_volume_muted = status.volume_muted
-        new_powered = self.cc.app_id is not None and self.cc.app_id != IDLE_APP_ID
-        self._attr_powered = new_powered
-        if self._attr_powered and not new_powered and self.type == PlayerType.GROUP:
-            # group is being powered off, update group childs
-            for child_id in self.group_members:
-                if child := self.mass.players.get_player(child_id):
-                    child.update_state()
         self.update_state()
 
     def on_new_media_status(self, status: MediaStatus) -> None:

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -59,7 +59,9 @@ if TYPE_CHECKING:
     from .provider import SqueezelitePlayerProvider
 
 
-CACHE_CATEGORY_PREV_STATE = 0  # category for caching previous player state
+CACHE_CATEGORY_PREV_STATE = (
+    1  # category for caching previous player state (bumped to invalidate old format)
+)
 
 PLAYER_DEVICE_TYPES = {
     # list of device types that are considered real hardware players

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -88,7 +88,6 @@ class SqueezelitePlayer(Player):
         # Set static player attributes
         self._attr_supported_features = {
             PlayerFeature.PLAY_MEDIA,
-            PlayerFeature.POWER,
             PlayerFeature.SET_MEMBERS,
             PlayerFeature.MULTI_DEVICE_DSP,
             PlayerFeature.VOLUME_SET,
@@ -120,17 +119,17 @@ class SqueezelitePlayer(Player):
         self.logger.info("Player %s connected", self.client.name or player_id)
         # update all dynamic attributes
         self.update_attributes()
-        # restore volume and power state
+        # restore volume state
         if last_state := await self.mass.cache.get(
             key=player_id, provider=self.provider.instance_id, category=CACHE_CATEGORY_PREV_STATE
         ):
-            init_power = last_state[0]
+            init_muted = last_state[0]
             init_volume = last_state[1]
         else:
+            init_muted = False
             init_volume = DEFAULT_PLAYER_VOLUME
-            init_power = False
-        await self.client.power(init_power)
         await self.client.stop()
+        await self.client.mute(init_muted)
         await self.client.volume_set(init_volume)
         await self.mass.players.register_or_update(self)
 
@@ -174,24 +173,13 @@ class SqueezelitePlayer(Player):
             ),
         ]
 
-    async def power(self, powered: bool) -> None:
-        """Handle POWER command on the player."""
-        await self.client.power(powered)
-        # store last state in cache
-        await self.mass.cache.set(
-            key=self.player_id,
-            data=[powered, self.client.volume_level],
-            provider=self.provider.instance_id,
-            category=CACHE_CATEGORY_PREV_STATE,
-        )
-
     async def volume_set(self, volume_level: int) -> None:
         """Handle VOLUME_SET command on the player."""
         await self.client.volume_set(volume_level)
         # store last state in cache
         await self.mass.cache.set(
             key=self.player_id,
-            data=[self.client.powered, volume_level],
+            data=[self.client.muted, volume_level],
             provider=self.provider.instance_id,
             category=CACHE_CATEGORY_PREV_STATE,
         )
@@ -199,6 +187,13 @@ class SqueezelitePlayer(Player):
     async def volume_mute(self, muted: bool) -> None:
         """Handle VOLUME MUTE command on the player."""
         await self.client.mute(muted)
+        # store last state in cache
+        await self.mass.cache.set(
+            key=self.player_id,
+            data=[muted, self.client.volume_level],
+            provider=self.provider.instance_id,
+            category=CACHE_CATEGORY_PREV_STATE,
+        )
 
     async def stop(self) -> None:
         """Handle STOP command on the player."""
@@ -393,7 +388,6 @@ class SqueezelitePlayer(Player):
         )
         self._attr_available = self.client.connected
         self._attr_name = self.client.name
-        self._attr_powered = self.client.powered
         old_state = self._attr_playback_state
         self._attr_playback_state = STATE_MAP[self.client.state]
         self._attr_volume_level = self.client.volume_level

--- a/tests/core/test_player_controls.py
+++ b/tests/core/test_player_controls.py
@@ -141,8 +141,8 @@ class TestPowerControlExplicitConfig:
         player = _create_player(mock_mass, features={PlayerFeature.POWER})
         assert player.power_control == PLAYER_CONTROL_NONE
 
-    def test_explicit_protocol_player_id(self, mock_mass: MagicMock) -> None:
-        """Power control returns protocol player ID when explicitly set and available."""
+    def test_explicit_protocol_player_id_ignored(self, mock_mass: MagicMock) -> None:
+        """Protocol player IDs are not valid for power control; falls through to auto-select."""
         protocol = _create_protocol_player(
             mock_mass, "protocol_1", {PlayerFeature.POWER}, available=True
         )
@@ -150,8 +150,10 @@ class TestPowerControlExplicitConfig:
             side_effect=_make_config_side_effect({CONF_POWER_CONTROL: "protocol_1"})
         )
         mock_mass.players.get_player = MagicMock(return_value=protocol)
+        mock_mass.players.get_player_control = MagicMock(return_value=None)
         player = _create_player(mock_mass)
-        assert player.power_control == "protocol_1"
+        # protocol players handle their own power at the protocol level
+        assert player.power_control == PLAYER_CONTROL_NONE
 
     def test_explicit_protocol_player_unavailable_falls_through(self, mock_mass: MagicMock) -> None:
         """When explicitly set to unavailable protocol player, falls to auto-select."""
@@ -187,8 +189,8 @@ class TestPowerControlAutoSelect:
         player = _create_player(mock_mass, features={PlayerFeature.POWER})
         assert player.power_control == PLAYER_CONTROL_NATIVE
 
-    def test_auto_falls_back_to_active_protocol_player(self, mock_mass: MagicMock) -> None:
-        """Auto-select returns active protocol player when no native support."""
+    def test_auto_does_not_use_protocol_player(self, mock_mass: MagicMock) -> None:
+        """Auto-select does not use protocol players for power; they handle it themselves."""
         protocol = _create_protocol_player(mock_mass, "proto_power", {PlayerFeature.POWER})
         mock_mass.players.get_player = MagicMock(return_value=protocol)
         player = _create_player(mock_mass)
@@ -197,7 +199,7 @@ class TestPowerControlAutoSelect:
             [_make_output_protocol("proto_power", "Proto Power")],
             active_protocol_id="proto_power",
         )
-        assert player.power_control == "proto_power"
+        assert player.power_control == PLAYER_CONTROL_NONE
 
     def test_auto_returns_none_without_active_protocol(self, mock_mass: MagicMock) -> None:
         """Auto-select returns NONE when protocol exists but is not active."""
@@ -377,8 +379,8 @@ class TestProtocolPlayerPreferActive:
         # no active protocol set -> power returns NONE
         assert player.power_control == PLAYER_CONTROL_NONE
 
-    def test_power_returns_active_protocol(self, mock_mass: MagicMock) -> None:
-        """Power auto-select returns the active protocol when it supports POWER."""
+    def test_power_ignores_active_protocol(self, mock_mass: MagicMock) -> None:
+        """Power auto-select does not use protocol players even when active."""
         proto_a = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.POWER})
         mock_mass.players.get_player = MagicMock(
             side_effect=self._get_player_lookup({"proto_a": proto_a})
@@ -389,7 +391,7 @@ class TestProtocolPlayerPreferActive:
             [_make_output_protocol("proto_a", "Proto A", priority=0)],
             active_protocol_id="proto_a",
         )
-        assert player.power_control == "proto_a"
+        assert player.power_control == PLAYER_CONTROL_NONE
 
     def test_volume_skips_unavailable_protocol_player(self, mock_mass: MagicMock) -> None:
         """Volume auto-select skips unavailable protocol players."""
@@ -424,8 +426,8 @@ class TestPreferredOutputProtocolAutoValue:
 
         return _lookup
 
-    def test_preferred_auto_uses_active_for_power(self, mock_mass: MagicMock) -> None:
-        """With preferred='auto', power control uses active protocol if available."""
+    def test_preferred_auto_power_ignores_protocol(self, mock_mass: MagicMock) -> None:
+        """With preferred='auto', power control does not use protocol players."""
         proto = _create_protocol_player(mock_mass, "proto_a", {PlayerFeature.POWER})
         mock_mass.players.get_player = MagicMock(
             side_effect=self._get_player_lookup({"proto_a": proto})
@@ -439,7 +441,7 @@ class TestPreferredOutputProtocolAutoValue:
             [_make_output_protocol("proto_a", "Proto A")],
             active_protocol_id="proto_a",
         )
-        assert player.power_control == "proto_a"
+        assert player.power_control == PLAYER_CONTROL_NONE
 
     def test_preferred_auto_falls_back_for_volume(self, mock_mass: MagicMock) -> None:
         """With preferred='auto', volume control falls back to any linked protocol."""


### PR DESCRIPTION
## Problem

When a universal player has multiple output protocols (e.g. Chromecast, AirPlay, DLNA) with a preferred protocol set, the power control would forward power on/off commands to the preferred protocol player even when a different protocol was about to be used. This caused a bounce effect or stream failure — for example, powering on Chromecast when AirPlay playback was about to start.

## Changes

- Remove protocol player power forwarding from `_handle_cmd_power` — protocol providers (Chromecast, Squeezelite) handle their own power at the protocol level when streaming starts/stops
- Remove `PlayerFeature.POWER` from Chromecast individual players (keep for Cast Groups only) — Chromecast app activation is handled implicitly
- Remove `PlayerFeature.POWER` and power state persistence from Squeezelite — was just an activation mechanism, not real power control
- Chromecast `stop()` now quits the app entirely for individual players (groups still use media stop)
- Clean up config options: protocol players no longer offered as power controls, volume/mute protocol options only shown when player lacks native support
- Update tests to reflect that protocol players are no longer used for power control resolution

NOTE: if people still need/want to see a power button (and off state in HA), they can assign the fake power control to reinstate that behavior. Technically it is not needed at all, the power control for chromecast and squeezelite was there with no reason, just to cause issues.