### PR TITLE
Fix AirPlay late joiner sync issues from insufficient buffer headroom

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -944,7 +944,7 @@ class StreamsController(CoreController):
                     queue=queue, start_queue_item=start_queue_item, pcm_format=pcm_format
                 )
                 if use_flow_stream_buffering:
-                    return buffered(flow_stream, buffer_size=10, min_buffer_before_yield=1)
+                    return buffered(flow_stream, buffer_size=15, min_buffer_before_yield=1)
                 return flow_stream
             # single item stream (e.g. radio or non-flow mode)
             queue_item = self.mass.player_queues.get_item(media.source_id, media.queue_item_id)

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -147,17 +147,17 @@ class AirPlayStreamSession:
             start_at = self.start_time + first_byte_pos
 
             # If start_at is in the past (or too close to now), prepend silence
-            # so the late joiner has enough headroom to connect before real audio plays.
+            # to prime the pipeline while cliraop connects. The device will use
+            # NTP sync to discard past-due silence and start playing at the
+            # correct position — the silence just keeps the pipe fed.
             min_headroom = 1.0
             if start_at < now + min_headroom:
                 deficit = (now + min_headroom) - start_at
                 silence_bytes = int(deficit * pcm_sample_size)
-                # align to sample frame boundaries (16-bit stereo = 4 bytes per frame)
-                frame_size = (self.pcm_format.bit_depth // 8) * 2
+                frame_size = (self.pcm_format.bit_depth // 8) * self.pcm_format.channels
                 silence_bytes -= silence_bytes % frame_size
-                buffered_pcm = b"\x00" * silence_bytes + buffered_pcm
-                first_byte_pos -= deficit
-                start_at = self.start_time + first_byte_pos
+                if silence_bytes > 0:
+                    buffered_pcm = b"\x00" * silence_bytes + buffered_pcm
 
             start_ntp = unix_time_to_ntp(start_at)
 

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -145,13 +145,27 @@ class AirPlayStreamSession:
             # The first byte in the buffer corresponds to this stream position
             first_byte_pos = self.seconds_streamed - buffer_seconds
             start_at = self.start_time + first_byte_pos
+
+            # If start_at is in the past (or too close to now), prepend silence
+            # so the late joiner has enough headroom to connect before real audio plays.
+            min_headroom = 1.0
+            if start_at < now + min_headroom:
+                deficit = (now + min_headroom) - start_at
+                silence_bytes = int(deficit * pcm_sample_size)
+                # align to sample frame boundaries (16-bit stereo = 4 bytes per frame)
+                frame_size = (self.pcm_format.bit_depth // 8) * 2
+                silence_bytes -= silence_bytes % frame_size
+                buffered_pcm = b"\x00" * silence_bytes + buffered_pcm
+                first_byte_pos -= deficit
+                start_at = self.start_time + first_byte_pos
+
             start_ntp = unix_time_to_ntp(start_at)
 
             self.prov.logger.debug(
                 "Late joiner %s: sending %.2fs of buffered audio, "
                 "stream_pos=%.2fs, first_byte_pos=%.2fs, start_at is %.2fs from now",
                 airplay_player.player_id,
-                buffer_seconds,
+                len(buffered_pcm) / pcm_sample_size,
                 self.seconds_streamed,
                 first_byte_pos,
                 start_at - now,

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -25,6 +25,8 @@ def _make_session(
     pcm_format = MagicMock()
     pcm_format.pcm_sample_size = PCM_SAMPLE_SIZE
     pcm_format.sample_rate = 44100
+    pcm_format.bit_depth = 16
+    pcm_format.channels = 2
 
     leader = MagicMock()
     leader.stream = MagicMock()
@@ -160,3 +162,59 @@ async def test_late_join_no_running_session() -> None:
         await session.add_client(player)
         mock_start.assert_not_called()
         assert player not in session.sync_clients
+
+
+@pytest.mark.asyncio
+async def test_late_join_silence_prepend_when_start_at_in_past() -> None:
+    """Test that silence is prepended when start_at is in the past."""
+    now = time.time()
+    # start_time chosen so start_at = start_time + (seconds_streamed - 3.0)
+    # ends up ~2s in the past
+    start_time = now - 100
+    seconds_streamed = 101.0
+    session = _make_session(start_time, seconds_streamed)
+    # Fill ring buffer with 3 seconds of non-silent PCM
+    pcm_data = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 3)
+    session._pcm_buffer = pcm_data
+    player = _make_late_joiner()
+
+    written_chunks: list[bytes] = []
+    captured_start_at: list[float] = []
+
+    def capture_ntp(unix_ts: float) -> int:
+        captured_start_at.append(unix_ts)
+        return 1
+
+    async def capture_write(_player: Any, chunk: bytes) -> None:
+        written_chunks.append(chunk)
+
+    with (
+        patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
+        patch.object(session, "_write_chunk_to_player", side_effect=capture_write),
+        patch(
+            "music_assistant.providers.airplay.stream_session.unix_time_to_ntp",
+            side_effect=capture_ntp,
+        ),
+    ):
+        mock_start.side_effect = _setup_stream(player)
+        await session.add_client(player)
+
+    # start_at should NOT be modified — stays at start_time + (101 - 3) = now - 2
+    assert captured_start_at, "unix_time_to_ntp was never called"
+    expected_start_at = start_time + (seconds_streamed - 3.0)
+    assert abs(captured_start_at[0] - expected_start_at) < 0.1
+
+    # The written buffer should be larger than the original 3s due to silence prepend
+    assert written_chunks, "No data was written to the player"
+    total_written = len(written_chunks[0])
+    original_size = PCM_SAMPLE_SIZE * 3
+    assert total_written > original_size, "Silence should have been prepended"
+
+    # The prepended bytes should be silence (zeros)
+    silence_size = total_written - original_size
+    assert written_chunks[0][:silence_size] == b"\x00" * silence_size
+    # The original PCM data should follow the silence
+    assert written_chunks[0][silence_size:] == bytes(pcm_data)
+
+    # Silence should be frame-aligned (4 bytes per frame for 16-bit stereo)
+    assert silence_size % 4 == 0


### PR DESCRIPTION
When an AirPlay player re-joins a sync group as a late joiner, the NTP start timestamp can end up in the past if the flow stream buffer headroom has degraded over a long session. Combined with a slow device connection, this causes the player to start playback out of sync with the group.

- Increase flow stream buffer from 10s to 15s for more real-time headroom
- Prepend silence when the late joiner's calculated start_at is in the past (or < 1s in the future), so the device always has time to connect before real audio needs to play