### PR TITLE
fix: replace -re with -readrate in plugin source streaming

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -1110,7 +1110,7 @@ class StreamsController(CoreController):
                 input_format=plugin_source.audio_format,
                 output_format=output_format,
                 filter_params=player_filter_params,
-                extra_input_args=["-y", "-re"],
+                extra_input_args=["-y", "-readrate", "1.1", "-readrate_initial_burst", "5"],
             ):
                 if plugin_source.in_use_by != player_id:
                     # another player took over or the stream ended, stop streaming

--- a/tests/core/test_plugin_source_stream.py
+++ b/tests/core/test_plugin_source_stream.py
@@ -1,0 +1,81 @@
+"""Tests for get_plugin_source_stream ffmpeg arguments.
+
+Verifies that the plugin source stream uses -readrate with initial burst
+instead of -re, matching the queue flow stream behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import ContentType, StreamType
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.controllers.streams.controller import StreamsController
+from music_assistant.models.plugin import PluginSource
+
+
+async def _fake_ffmpeg_stream(**_kwargs: Any) -> Any:
+    """Fake ffmpeg stream that yields one chunk then stops."""
+    yield b"audio-data"
+
+
+@pytest.fixture
+def mock_streams_controller() -> MagicMock:
+    """Create a minimal StreamsController-like object with get_plugin_source_stream."""
+    ctrl = MagicMock(spec=StreamsController)
+    ctrl.logger = MagicMock()
+    ctrl.mass = MagicMock()
+    # Use the real method, bound to our mock
+    ctrl.get_plugin_source_stream = StreamsController.get_plugin_source_stream.__get__(ctrl)
+    return ctrl
+
+
+@pytest.mark.asyncio
+async def test_plugin_source_stream_uses_readrate(mock_streams_controller: MagicMock) -> None:
+    """Plugin source stream must use -readrate + initial_burst, not -re."""
+    plugin_source = PluginSource(
+        id="test_plugin",
+        name="Test",
+        stream_type=StreamType.CUSTOM,
+        audio_format=AudioFormat(content_type=ContentType.PCM_S16LE),
+    )
+    plugin_source.in_use_by = "player1"
+
+    mock_prov = MagicMock()
+    mock_prov.get_source.return_value = plugin_source
+    mock_prov.get_audio_stream = AsyncMock()
+    mock_streams_controller.mass.get_provider.return_value = mock_prov
+
+    output_format = AudioFormat(content_type=ContentType.FLAC)
+
+    with patch(
+        "music_assistant.controllers.streams.controller.get_ffmpeg_stream",
+    ) as mock_ffmpeg:
+        mock_ffmpeg.side_effect = lambda **kw: _fake_ffmpeg_stream(**kw)
+
+        chunks = []
+        async for chunk in mock_streams_controller.get_plugin_source_stream(
+            plugin_source_id="test_plugin",
+            output_format=output_format,
+            player_id="player1",
+        ):
+            chunks.append(chunk)
+
+        mock_ffmpeg.assert_called_once()
+        call_kwargs = mock_ffmpeg.call_args.kwargs
+        extra_args = call_kwargs["extra_input_args"]
+
+        # Must NOT contain -re
+        assert "-re" not in extra_args, f"Found -re in extra_input_args: {extra_args}"
+
+        # Must contain -readrate with burst
+        assert "-readrate" in extra_args
+        assert "1.1" in extra_args
+        assert "-readrate_initial_burst" in extra_args
+        assert "5" in extra_args
+
+        # Also keep -y
+        assert "-y" in extra_args


### PR DESCRIPTION
## Problem

Plugin source streams (`get_plugin_source_stream`) use `extra_input_args=["-y", "-re"]` which forces ffmpeg to read input at exactly 1× realtime from the very first byte. This causes **15-20 second buffering delays** before playback starts for all plugin source providers (Spotify Connect, Ynison, etc.).

Queue flow streams (`serve_queue_flow_stream`) already use `-readrate 1.1 -readrate_initial_burst 5` at [line 661](https://github.com/music-assistant/server/blob/dev/music_assistant/controllers/streams/controller.py#L661), which starts playback in 1-2 seconds.

## Change

Replace `-re` with `-readrate 1.1 -readrate_initial_burst 5` in `get_plugin_source_stream` (line 1113), matching the proven pattern used by:
- `serve_queue_flow_stream` (controller.py:661) — Chromecast and flow mode
- `ugp_stream.py:109` — universal group player streams

## How it works

| Flag | Behavior |
|------|----------|
| `-re` (before) | Read input at 1× from byte 0. Player must buffer 15-20s before play. |
| `-readrate_initial_burst 5` (after) | First 5 seconds of audio data burst through at max speed |
| `-readrate 1.1` (after) | Then read at 1.1× — slightly faster than realtime, prevents unbounded buffer growth |

**Result**: Playback starts in **1-2 seconds** instead of 15-20 seconds.

## Safety

1. **Proven pattern** — queue flow stream and UGP use identical args, stable in production
2. **HTTP backpressure** — if a player cannot consume data fast enough, `resp.write()` blocks, ffmpeg pipe fills up, ffmpeg automatically slows down
3. **DLNA sender-paced** — `DLNA_CONTENT_FEATURES_REALTIME` header (0x80000000) already signals server-paced streaming
4. **Single line change** — minimal risk, easy to revert

## What is NOT changed

- `snapcast/ma_stream.py:307` — separate provider, different considerations
- `audio.py:386` — HLS radio with `-stream_loop`, different code path

## Test

Added `tests/core/test_plugin_source_stream.py` verifying that `get_plugin_source_stream` passes the correct `extra_input_args` to `get_ffmpeg_stream`.

Ref: #3717 (where `-readrate` was originally introduced for queue flow streams)