### PR TITLE
Fix sync group members lost after dynamic leader switch

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -833,7 +833,10 @@ class AirPlayPlayer(Player):
                 # add new child to the existing stream (RAOP or AirPlay2) session (if any)
                 self._attr_group_members.append(player_id)
                 if stream_session and child_player_to_add is not None:
-                    await stream_session.add_client(child_player_to_add)
+                    # Skip add_client if the player is already streaming in this session
+                    # (e.g. after a dynamic leader switch where the stream continues)
+                    if child_player_to_add not in stream_session.sync_clients:
+                        await stream_session.add_client(child_player_to_add)
 
             # Ensure group leader includes itself in group_members when it has members
             # This is required for the synced_to property to work correctly

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -719,4 +719,13 @@ class SyncGroupPlayer(Player):
                 new_leader.display_name,
                 self.display_name,
             )
+            # Sync remaining members to the new leader at the protocol level.
+            # Without this, the new leader's protocol player won't know about
+            # the remaining group members, causing state tracking mismatches.
+            remaining_members = [m for m in self._attr_group_members if m != new_leader.player_id]
+            if remaining_members:
+                await self.mass.players.cmd_set_members(
+                    new_leader.player_id,
+                    player_ids_to_add=remaining_members,
+                )
         self.update_state()


### PR DESCRIPTION
When a sync group leader is removed during playback, the dynamic leader switch selects a new leader but never syncs the remaining members to it at the protocol level. This causes orphaned players that keep receiving audio (cliraop still running) but aren't visible in the UI and can't be managed.

Observed in production: Player A was playing audio from sync group's queue but didn't show as a group member after the sync leader switched from Player B to Player C.

**Changes:**
- `sync_group/player.py`: Call `cmd_set_members` on the new leader after dynamic leader switch to sync remaining members at protocol level
- `airplay/player.py`: Guard `add_client` in `set_members` to skip players already streaming in the same session (prevents duplicate cliraop processes after leader switch)