### PR TITLE
Fix sync group not resetting active protocol on stop

### DIFF
--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -336,6 +336,9 @@ class SyncGroupPlayer(Player):
             # Use internal handler to target the sync leader directly,
             # bypassing group/sync redirect that would loop back to this player.
             await self.mass.players._handle_cmd_stop(sync_leader.player_id)
+        # Clear cached protocol domain so leader selection isn't biased
+        # if playback restarts before the group is dissolved.
+        self._active_protocol_domain = None
         # dissolve the sync group since we stopped playback
         self.mass.call_later(
             5, self._dissolve_syncgroup, task_id=f"syncgroup_dissolve_{self.player_id}"
@@ -573,6 +576,12 @@ class SyncGroupPlayer(Player):
                         sync_leader.player_id, [], sync_children
                     ),
                 )
+        # Clear the leader's active protocol so it doesn't persist
+        # after the sync group is dissolved. The controller's normal
+        # clearing (in _handle_cmd_stop) is skipped when the protocol
+        # player had multiple group members at stop time.
+        if sync_leader:
+            sync_leader.set_active_output_protocol(None)
         self.sync_leader = None
         self._active_protocol_domain = None
         self.update_state()

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -580,7 +580,7 @@ class SyncGroupPlayer(Player):
         # after the sync group is dissolved. The controller's normal
         # clearing (in _handle_cmd_stop) is skipped when the protocol
         # player had multiple group members at stop time.
-        if sync_leader:
+        if sync_leader and sync_leader.state.playback_state != PlaybackState.PLAYING:
             sync_leader.set_active_output_protocol(None)
         self.sync_leader = None
         self._active_protocol_domain = None


### PR DESCRIPTION
When a sync group with multiple AirPlay-synced members stops playback, the active output protocol on the sync leader is never cleared. This causes subsequent playback on that player to incorrectly reuse the AirPlay protocol instead of its native protocol (e.g. Sonos).

The root cause is that `_handle_cmd_stop` in the controller skips scheduling the protocol clear when the protocol player still has multiple group members (`len(target_player.group_members) > 1`). The dissolve that runs 5 seconds later also didn't clear the leader's `active_output_protocol`.

Changes:
- Clear `_active_protocol_domain` immediately in `stop()` so leader selection isn't biased if playback restarts before dissolution
- Clear the sync leader's `active_output_protocol` in `_dissolve_syncgroup()` since the controller's normal clearing is skipped for multi-member protocol players