### PR TITLE
Reduce radio stream startup delay on Squeezelite players

### DIFF
--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -402,7 +402,9 @@ class AudioBuffer:
         if smart_fades_mode != SmartFadesMode.DISABLED:
             ready_threshold = 8
         elif streamdetails.volume_normalization_mode == VolumeNormalizationMode.DYNAMIC:
-            ready_threshold = 5
+            # radio streams are continuous so the normalization will converge quickly,
+            # use a lower threshold to reduce startup latency
+            ready_threshold = 3 if streamdetails.media_type == MediaType.RADIO else 5
         else:
             ready_threshold = 2
 

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -454,10 +454,16 @@ class SqueezelitePlayer(Player):
             self.extra_data["playlist repeat"] = REPEATMODE_MAP[queue.repeat_mode]
             self.extra_data["playlist shuffle"] = int(queue.shuffle_enabled)
         source_id = media.source_id or (media.custom_data or {}).get("source_id")
-        self._plugin_source_active = (
+        plugin_source_active = (
             source_id is not None and self.mass.players.get_plugin_source(source_id) is not None
         )
-        self._low_latency_stream = self._plugin_source_active or media.media_type == MediaType.RADIO
+        low_latency_stream = plugin_source_active or media.media_type == MediaType.RADIO
+        # set the flags on the player that owns the slimclient (may differ from self
+        # during group playback where self is the leader but slimplayer is a member)
+        target_player = self.mass.players.get_player(slimplayer.player_id)
+        if isinstance(target_player, SqueezelitePlayer):
+            target_player._plugin_source_active = plugin_source_active
+            target_player._low_latency_stream = low_latency_stream
         await slimplayer.play_url(
             url=url,
             mime_type=get_mime_type(url.rsplit(".", maxsplit=1)[-1].split("?", maxsplit=1)[0]),

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -101,6 +101,7 @@ class SqueezelitePlayer(Player):
         self._sync_playpoints: deque[SyncPlayPoint] = deque(maxlen=MIN_REQ_PLAYPOINTS)
         self._do_not_resync_before: float = 0.0
         self._plugin_source_active: bool = False
+        self._low_latency_stream: bool = False
         # TEMP: patch slimclient send_strm to adjust buffer thresholds
         # this can be removed when we did a new release of aioslimproto with this change
         # after this has been tested in beta for a while
@@ -456,6 +457,7 @@ class SqueezelitePlayer(Player):
         self._plugin_source_active = (
             source_id is not None and self.mass.players.get_plugin_source(source_id) is not None
         )
+        self._low_latency_stream = self._plugin_source_active or media.media_type == MediaType.RADIO
         await slimplayer.play_url(
             url=url,
             mime_type=get_mime_type(url.rsplit(".", maxsplit=1)[-1].split("?", maxsplit=1)[0]),
@@ -749,7 +751,7 @@ async def _patched_send_strm(  # noqa: PLR0913
     httpreq: bytes = b"",
 ) -> None:
     """Create stream request message based on given arguments."""
-    if player._plugin_source_active:
+    if player._low_latency_stream:
         threshold = 64  # KB of input buffer data before autostart or notify
         output_threshold = (
             1  # amount of output buffer data before playback starts, in tenths of second


### PR DESCRIPTION
Radio streams on Squeezelite/slimproto players have an ~8 second startup delay before audio begins. The same streams play in ~1 second in VLC.

The delay is caused by two stacked buffer thresholds that are too high for radio streams:
- Server-side audio buffer waits 5 seconds before signaling ready (when dynamic volume normalization is active, which is the default for radio)
- Slimproto player waits for 200KB input + 2.0s output buffer before starting playback

Changes:
- Reduce server-side ready_threshold from 5s to 3s for radio streams with dynamic volume normalization (radio is continuous so normalization converges quickly, 3s still provides enough headroom)
- Extend existing low-latency slimproto threshold logic (input: 64KB, output: 0.1s) to also apply to radio streams, not just plugin sources

Fixes https://github.com/music-assistant/support/issues/5103