### PR TITLE
Fix queue items showing zero/unknown duration

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1599,20 +1599,20 @@ class PlayerQueuesController(CoreController):
         # update queue_item.duration from streamdetails if we got a better value
         if queue_item.streamdetails.duration and not queue_item.duration:
             queue_item.duration = queue_item.streamdetails.duration
+            self.signal_update(queue_id, items_changed=True)
 
         # pre-initialize the AudioBuffer so audio is ready
         # when the player requests it. For the current/first track this ensures
         # immediate playback start. For preloaded next tracks we skip this and
         # initialize the buffer ~30s before the current track ends instead.
         if is_start:
-            buffer = await AudioBuffer.get_buffer(
+            await AudioBuffer.get_buffer(
                 self.mass,
                 queue_item.streamdetails,
                 seek_position_ms=seek_position * 1000,
                 wait_ready=True,
                 reason="prepare",
             )
-            self._register_duration_callback(buffer, queue_item)
 
     def track_loaded_in_buffer(self, queue_id: str, item_id: str) -> None:
         """Call when a player has (started) loading a track in the buffer."""
@@ -2259,24 +2259,6 @@ class PlayerQueuesController(CoreController):
             abort_existing=True,
         )
 
-    def _register_duration_callback(self, buffer: AudioBuffer, queue_item: QueueItem) -> None:
-        """Register a chunk callback on the buffer to update queue_item duration when known.
-
-        When the audio buffer finishes filling (EOF), the streamdetails duration
-        has been set from the actual PCM data. This callback propagates that
-        accurate duration to the queue_item so the UI can display it.
-        """
-        streamdetails = queue_item.streamdetails
-
-        async def _on_chunk(_position: int, _data: bytes, is_last: bool) -> None:
-            if not is_last:
-                return
-            if streamdetails and streamdetails.duration and not queue_item.duration:
-                queue_item.duration = streamdetails.duration
-                self.signal_update(queue_item.queue_id, items_changed=True)
-
-        buffer.register_chunk_callback(_on_chunk)
-
     def _prepare_next_audio_buffer(self, queue_id: str) -> None:
         """
         Prepare the AudioBuffer for the next track in the queue.
@@ -2312,13 +2294,12 @@ class PlayerQueuesController(CoreController):
                     next_item.name,
                     queue.display_name,
                 )
-                buffer = await AudioBuffer.get_buffer(
+                await AudioBuffer.get_buffer(
                     self.mass,
                     next_item.streamdetails,
                     reason="prepare_next",
                     wait_ready=True,
                 )
-                self._register_duration_callback(buffer, next_item)
             except (AudioError, MediaNotFoundError) as err:
                 self.logger.debug("Failed to prepare next audio buffer: %s", err)
 

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1596,19 +1596,23 @@ class PlayerQueuesController(CoreController):
             fade_in=fade_in,
             prefer_album_loudness=bool(playing_album_tracks),
         )
+        # update queue_item.duration from streamdetails if we got a better value
+        if queue_item.streamdetails.duration and not queue_item.duration:
+            queue_item.duration = queue_item.streamdetails.duration
 
         # pre-initialize the AudioBuffer so audio is ready
         # when the player requests it. For the current/first track this ensures
         # immediate playback start. For preloaded next tracks we skip this and
         # initialize the buffer ~30s before the current track ends instead.
         if is_start:
-            await AudioBuffer.get_buffer(
+            buffer = await AudioBuffer.get_buffer(
                 self.mass,
                 queue_item.streamdetails,
                 seek_position_ms=seek_position * 1000,
                 wait_ready=True,
                 reason="prepare",
             )
+            self._register_duration_callback(buffer, queue_item)
 
     def track_loaded_in_buffer(self, queue_id: str, item_id: str) -> None:
         """Call when a player has (started) loading a track in the buffer."""
@@ -2255,6 +2259,24 @@ class PlayerQueuesController(CoreController):
             abort_existing=True,
         )
 
+    def _register_duration_callback(self, buffer: AudioBuffer, queue_item: QueueItem) -> None:
+        """Register a chunk callback on the buffer to update queue_item duration when known.
+
+        When the audio buffer finishes filling (EOF), the streamdetails duration
+        has been set from the actual PCM data. This callback propagates that
+        accurate duration to the queue_item so the UI can display it.
+        """
+        streamdetails = queue_item.streamdetails
+
+        async def _on_chunk(_position: int, _data: bytes, is_last: bool) -> None:
+            if not is_last:
+                return
+            if streamdetails and streamdetails.duration and not queue_item.duration:
+                queue_item.duration = streamdetails.duration
+                self.signal_update(queue_item.queue_id, items_changed=True)
+
+        buffer.register_chunk_callback(_on_chunk)
+
     def _prepare_next_audio_buffer(self, queue_id: str) -> None:
         """
         Prepare the AudioBuffer for the next track in the queue.
@@ -2290,12 +2312,13 @@ class PlayerQueuesController(CoreController):
                     next_item.name,
                     queue.display_name,
                 )
-                await AudioBuffer.get_buffer(
+                buffer = await AudioBuffer.get_buffer(
                     self.mass,
                     next_item.streamdetails,
                     reason="prepare_next",
                     wait_ready=True,
                 )
+                self._register_duration_callback(buffer, next_item)
             except (AudioError, MediaNotFoundError) as err:
                 self.logger.debug("Failed to prepare next audio buffer: %s", err)
 

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1697,7 +1697,6 @@ class StreamsAudio:
         streamdetails.duration = int(streamdetails.seek_position + seconds_streamed)
         # propagate accurate duration to queue_item so UI displays it
         queue_item.duration = streamdetails.duration
-        self.mass.player_queues.signal_update(queue_item.queue_id, items_changed=True)
         self.logger.debug(
             "Finished Streaming queue track: %s (%s) on queue %s "
             "- crossfade data prepared for next track: %s",
@@ -1981,7 +1980,6 @@ class StreamsAudio:
             )
             # propagate accurate duration to queue_item so UI displays it
             queue_track.duration = queue_track.streamdetails.duration
-            self.mass.player_queues.signal_update(queue_track.queue_id, items_changed=True)
             play_log_entry.seconds_streamed = seconds_streamed
             play_log_entry.duration = queue_track.streamdetails.duration
             if last_play_log_entry is play_log_entry and last_fadeout_part:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -262,10 +262,10 @@ class StreamsAudio:
                 streamdetails.loudness = result[0]
                 streamdetails.loudness_album = result[1]
 
-        if not streamdetails.duration:
+        if streamdetails.duration is None:
             if queue_item.media_item and queue_item.media_item.duration:
                 streamdetails.duration = queue_item.media_item.duration
-            else:
+            elif queue_item.duration:
                 streamdetails.duration = queue_item.duration
         if seek_position and (not streamdetails.allow_seek or not streamdetails.duration):
             self.logger.warning("seeking is not possible on duration-less streams!")
@@ -1695,6 +1695,9 @@ class StreamsAudio:
         seconds_streamed = bytes_written / pcm_format.pcm_sample_size
         streamdetails.seconds_streamed = seconds_streamed
         streamdetails.duration = int(streamdetails.seek_position + seconds_streamed)
+        # propagate accurate duration to queue_item so UI displays it
+        queue_item.duration = streamdetails.duration
+        self.mass.player_queues.signal_update(queue_item.queue_id, items_changed=True)
         self.logger.debug(
             "Finished Streaming queue track: %s (%s) on queue %s "
             "- crossfade data prepared for next track: %s",
@@ -1976,6 +1979,9 @@ class StreamsAudio:
             queue_track.streamdetails.duration = int(
                 queue_track.streamdetails.seek_position + seconds_streamed
             )
+            # propagate accurate duration to queue_item so UI displays it
+            queue_track.duration = queue_track.streamdetails.duration
+            self.mass.player_queues.signal_update(queue_track.queue_id, items_changed=True)
             play_log_entry.seconds_streamed = seconds_streamed
             play_log_entry.duration = queue_track.streamdetails.duration
             if last_play_log_entry is play_log_entry and last_fadeout_part:


### PR DESCRIPTION
Some queue items display 00:00 duration because `queue_item.duration` was never updated after streaming resolved the actual duration from PCM data.

**Changes:**
- Fix falsy duration check in streamdetails fallback (`if not` → `if is None`) that treated explicit `0` same as "not set"
- Propagate accurate duration from streamdetails back to `queue_item.duration` after streaming completes
- Register buffer EOF callback to update duration as soon as audio decoding finishes (before consumer reads all data)
- Signal `QUEUE_ITEMS_UPDATED` when duration is resolved so the frontend displays it