### PR TITLE
Apple Music: Add content rating check for explicit tracks

### DIFF
--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -1101,6 +1101,8 @@ class AppleMusicProvider(MusicProvider):
             track.metadata.genres = set(genres)
         if composers := attributes.get("composerName"):
             track.metadata.performers = set(composers.split(", "))
+        if content_rating := attributes.get("contentRating"):
+            track.metadata.explicit = content_rating == "explicit"
         if isrc := attributes.get("isrc"):
             track.external_ids.add((ExternalID.ISRC, isrc))
         track.favorite = is_favourite or False


### PR DESCRIPTION
Re-submitting #3514 against `dev`. The previous PR was merged to `stable`
on 2026-03-30 but was overwritten a few days later by the `[Backport to
stable] 2.8.2` PR (#3564), which force-syncs `stable` from `dev`. Since
the fix never landed on `dev`, every subsequent release (2.8.2, 2.8.3,
2.8.4) has shipped without it.

Original description:

The Apple Music provider parses contentRating on albums (line 841) but
not on tracks, leaving track.metadata.explicit as None for all Apple
Music tracks. The Apple Music API does return contentRating on song
objects with values "explicit", "clean", or absent.

This prevents Music Assistant from distinguishing between explicit and
clean versions of the same track, affecting compare_track() matching
and any downstream integrations relying on the explicit flag.

Every other provider (Spotify, Tidal, Deezer, Qobuz, YouTube Music)
already sets metadata.explicit on tracks.

Ref: https://developer.apple.com/documentation/applemusicapi/songs/attributes-data.dictionary
