### PR TITLE
Filter stale podcast episodes

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -684,12 +684,14 @@ class MusicController(CoreController):
 
         # An audiobook can be part of the library, in contrast to podcast episodes.
         # We then need to check the provider mappings table.
+        one_week_ago = int(utc_timestamp()) - (7 * 86400)
         query = (
             "SELECT p.item_id, p.media_type, p.name, p.image, p.provider "
             f"FROM {DB_TABLE_PLAYLOG} p "
             "WHERE p.media_type IN ('audiobook', 'podcast_episode') "
             "AND p.fully_played = 0 "
             "AND p.seconds_played > 0 "
+            f"AND (p.media_type != 'podcast_episode' OR p.timestamp >= {one_week_ago}) "
         )
         query += (
             "AND ( "


### PR DESCRIPTION
Fixes: https://github.com/music-assistant/support/issues/5028

The "Continue listening" row on the discover page can show podcast episodes that are no longer available — either because the podcast was removed from the library, or the podcast provider dropped old episodes. Clicking them causes errors. This happens because podcast episodes aren't stored in MA's database (they're fetched live from providers), but the playlog entries for them persist indefinitely with no link back to their parent podcast, making targeted cleanup impossible without architectural change.                                          

So the solution in this PR is to filter podcast episode entries older than 7 days from the in_progress_items query. Audiobooks are unaffected.

Deleting the playlog entry was considered but it was way more involved and in the end I decided that there is no downside to just hiding. The playlog already retains entries for every episode ever played regardless of this change — this filter only affects what appears in the "Continue listening" row. The playlog doesn't grow any larger than it did before. And by preserving the data, if a user re-adds the same podcast later, their resume positions and played/unplayed status are intact. If a user plays a previously hidden episode again, the timestamp updates and it immediately reappears in "Continue listening".