### PR TITLE
Fix dynamic playlist refill discarding unplayed buffered tracks

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2154,12 +2154,11 @@ class PlayerQueuesController(CoreController):
                         queue.display_name,
                     )
                     return
-                cur_index = self._queues[queue_id].current_index or 0
                 await self.load(
                     queue_id,
                     queue_items,
-                    insert_at_index=cur_index + 1,
-                    keep_remaining=False,
+                    insert_at_index=len(self._queue_items[queue_id]),
+                    keep_remaining=True,
                     keep_played=True,
                 )
             except MusicAssistantError as err:


### PR DESCRIPTION
## Problem

When a dynamic playlist (radio station) provider returns fewer than 5 tracks per batch, the queue refill fires immediately on every track start and discards all unplayed buffered tracks.

**Root cause:** `_fill_radio_tracks` was inserting the new batch at `current_index + 1` with `keep_remaining=False`, which threw away all unplayed tracks ahead in the queue. The refill threshold is `queue.items - queue.current_index < 5`, so any provider returning <5 tracks would trigger refill continuously.

**Example with a 4-track batch:**
1. Load [1, 2, 3, 4], start playing track 1 → 3 remaining, `3 < 5` → refill fires
2. Tracks 2, 3, 4 are discarded and replaced with [new1, new2, new3, new4]
3. Play new1 → same thing repeats — only 1 track ever plays per batch

This affects any provider with small-batch APIs (e.g. Pandora, Apple Music radio stations).

## Fix

Switch to the same append behavior used by regular radio: insert at the end of the queue with `keep_remaining=True`. The new batch is appended rather than replacing unplayed tracks.