### PR TITLE
Add reset normalisation value API call

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1213,6 +1213,33 @@ class MusicController(CoreController):
 
         return None
 
+    @api_command("music/reset_loudness")
+    async def reset_loudness(
+        self,
+        item_id: str | int,
+        media_type: MediaType = MediaType.TRACK,
+    ) -> None:
+        """
+        Reset (EBU-R128) Integrated Loudness Measurement for a library item.
+
+        :param item_id: The library item ID.
+        :param media_type: The media type of the item.
+        """
+        ctrl = self.get_controller(media_type)
+        library_item = await ctrl.get_library_item(item_id)
+        for prov_mapping in library_item.provider_mappings:
+            if not (provider := self.mass.get_provider(prov_mapping.provider_instance)):
+                continue
+            prov_key = provider.domain if provider.is_streaming_provider else provider.instance_id
+            await self.database.delete(
+                DB_TABLE_LOUDNESS_MEASUREMENTS,
+                {
+                    "item_id": prov_mapping.item_id,
+                    "media_type": media_type.value,
+                    "provider": prov_key,
+                },
+            )
+
     @api_command("music/mark_played")
     async def mark_item_played(
         self,


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/5291 once support is added to the frontend.

Readng the issue, having some playback failure while doing the dynamic calculation is very random but it happened. I cant think of any other user friendly way to fix this other than add this new API endpoint and then provide a menu item in the track context menu. Documentatiion will be updated to say that doing a REFRESH ITEM will reload the loudness value from the tags or other replaygain sources if this button is clicked accidentally.

If there is a better way I'm all ears!