### PR TITLE
Bump bundled Snapcast from 0.34.0 to 0.35.0

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -198,8 +198,8 @@ RUN set -x \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Snapcast 0.34.0 from GitHub releases (requires at least 0.27)
-ARG SNAPCAST_VERSION=0.34.0
+# Install Snapcast 0.35.0 from GitHub releases (requires at least 0.27)
+ARG SNAPCAST_VERSION=0.35.0
 ARG TARGETARCH
 RUN set -x \
     && if [ "$TARGETARCH" = "arm64" ]; then \


### PR DESCRIPTION
## Summary

Bumps `SNAPCAST_VERSION` in `Dockerfile.base` from `0.34.0` → `0.35.0`. Single-line change targeting the port-leak fix that affects multi-client setups using MA's built-in Snapserver.

## Motivation

Snapcast 0.34.0 has [issue #1497](https://github.com/badaix/snapcast/issues/1497) — `Stream.RemoveStream` doesn't close TCP sockets, causing the server-side port pool (4953-5153) to exhaust over time. Users with multiple Snapcast-backed players see:

```
WARNING [music_assistant.webserver] players/cmd/play_pause: Unable to create stream - No free port found?
```

MA's internal auto-recovery (reload Snapcast provider → stop/start built-in Snapserver) handles it within ~8 seconds, but the user's current action fails and must be retried.

**Snapcast 0.35.0 (released 2026-03-10) fixes exactly this bug.** From the [0.35.0 release notes](https://github.com/badaix/snapcast/releases/tag/v0.35.0):

> ## Bugfixes
> - Server: End control script when Stream.RemoveStream is called (Issue #1455)
> - **Server: Close TCP server when Stream.RemoveStream is called (Issue #1497)**

No breaking changes, no protocol changes — drop-in upgrade. (0.35.0 also adds an optional SDL2 client player and a server "default source" option as features; neither affects MA.)

## Empirical evidence

4-client setup running MA 2.8.1:

- **2026-04-13 09:44:39** — `No free port found?` (5h 44m after 04:00 MA restart)
- **2026-04-13 10:53:15** — same error again (1h 9m later under active use)

Each event triggers MA's internal `Stopping, built-in Snapserver → Starting builtin Snapserver` recovery (~4 seconds).

## Prior art

PR #3497 ([Draft] Rebuild Snapcast external Snapserver integration) included this bump bundled with a larger refactor — closed by the author for scope. This PR is the minimal standalone version-bump.

## Testing

The 0.35.0 debs at the existing GitHub-release URL pattern in Dockerfile.base are available for both arm64 and amd64 (verified HTTP 301 redirect to the new `snapcast/snapcast` org URL per snapcast issue #1458 — GitHub preserves these).
