### PR TITLE
Sendspin: guard against negative track_progress in metadata

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -806,7 +806,7 @@ class SendspinPlayer(SendspinBasePlayer):
             elapsed_time = current_media.corrected_elapsed_time
         if elapsed_time is None:
             elapsed_time = self.corrected_elapsed_time if is_playing else self.elapsed_time
-        track_progress = int(elapsed_time * 1000) if elapsed_time is not None else 0
+        track_progress = max(0, int(elapsed_time * 1000)) if elapsed_time is not None else 0
 
         metadata = Metadata(
             title=current_media.title,


### PR DESCRIPTION
## Problem

`SendspinPlayer.send_current_media_metadata` occasionally crashes with:

```
ValueError: track_progress must be non-negative, got -1000
```

`current_media.corrected_elapsed_time` can briefly extrapolate to a small negative value around track transitions / seek / clock jitter. Multiplied by 1000 it fails the strict non-negative validator in aiosendspin's `Progress` model and spams tracebacks in the log.

## Changes

- Clamp `track_progress` to `max(0, ...)` before passing it to the `Metadata` payload in `providers/sendspin/player.py`.