### PR TITLE
Fix sync group session lifecycle and AirPlay late joiner sync

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -981,7 +981,16 @@ class Player(ABC):
         set to True; otherwise the entire sync session must be torn down and
         re-formed with the new leader.
 
+        The ``new_leader`` must already be part of the live sync session (i.e.
+        its resolved protocol player must be a ``sync_client`` of the current
+        session). If it's a freshly-added player with no existing stream, this
+        method's ``cmd_set_members`` call will be a no-op at the protocol level
+        and the old session remains orphaned. The caller (typically
+        ``SyncGroupPlayer._dynamic_leader_switch``) should verify this
+        precondition before calling.
+
         :param new_leader: The player that should take over as sync leader.
+            Must already be a sync_client of the current session.
         :param remaining_members: Parent player ids (excluding ``new_leader``)
             that should be grouped onto ``new_leader`` after the handoff.
         """

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -157,11 +157,13 @@ class AirPlayStreamSession:
             first_byte_pos = self.seconds_streamed - buffer_seconds
             start_at = self.start_time + first_byte_pos
 
-            # The device needs at least ``wait_start`` of lead time after
-            # being told to start, plus a small safety margin for cliraop to
-            # connect / RAOP handshake. Anything below this and the device
-            # is effectively starting in the past.
-            min_headroom = max(2.0, self.wait_start)
+            # The audio we hand to ffmpeg → cliraop must be bit-aligned with
+            # ``start_at``: the first sample sent should be the one that should
+            # play at ``start_at``. cliraop buffers ``wait_start`` seconds of
+            # audio before starting playback, so we keep ``start_at`` at least
+            # that far in the future (using the larger of the session's
+            # existing wait_start and the late joiner's own).
+            min_headroom = max(self.wait_start, airplay_player.wait_start / 1000)
             target_start_at = now + min_headroom
             trim_seconds = 0.0
             if start_at < target_start_at:

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -121,15 +121,25 @@ class AirPlayStreamSession:
         """Add a sync client to the session as a late joiner.
 
         Uses the PCM ring buffer to prime the late joiner's pipeline so it
-        starts playing quickly.  All work happens under the lock to ensure
+        starts playing quickly. All work happens under the lock to ensure
         ``seconds_streamed`` and the buffer are consistent.
 
+        Devices generally cannot honour an NTP start anchor that is in the
+        past — they just play whatever the pipe gives them, trailing the
+        group by the deficit. To stay in sync we therefore push the late
+        joiner's ``start_at`` into the future (at least ``wait_start`` ahead
+        of now, with a small extra safety margin for connection setup) and
+        trim the corresponding amount from the head of the buffered PCM, so
+        the first sample we send maps to the correct future stream position.
+
         1. Snapshot the ring buffer and calculate how many seconds it holds.
-        2. NTP = ``start_time + (seconds_streamed - buffer_seconds)`` — the
-           first byte in the buffer maps to that stream position.
-        3. Start ffmpeg+CLI, write the buffer into ffmpeg (primes the pipe
-           while cliraop is still connecting), then add to sync_clients so
-           the audio streamer continues seamlessly from where the buffer ends.
+        2. Map the buffer's first byte to its stream position; if the
+           resulting NTP start is in the past, shift it forward to
+           ``now + min_headroom`` and trim that many seconds from the buffer
+           head so timing stays aligned with the rest of the group.
+        3. Start ffmpeg+CLI, write the (possibly trimmed) buffer into ffmpeg
+           to prime the pipe while cliraop is still connecting, then add to
+           sync_clients so the audio streamer continues seamlessly.
         """
         async with self._lock:
             if not self.sync_clients:
@@ -139,6 +149,7 @@ class AirPlayStreamSession:
                 return
             now = time.time()
             pcm_sample_size = self.pcm_format.pcm_sample_size
+            frame_size = (self.pcm_format.bit_depth // 8) * self.pcm_format.channels
             # Snapshot the buffer and calculate its duration
             buffered_pcm = bytes(self._pcm_buffer)
             buffer_seconds = len(buffered_pcm) / pcm_sample_size
@@ -146,35 +157,46 @@ class AirPlayStreamSession:
             first_byte_pos = self.seconds_streamed - buffer_seconds
             start_at = self.start_time + first_byte_pos
 
-            # If start_at is in the past (or too close to now), prepend silence
-            # to prime the pipeline while cliraop connects. The device will use
-            # NTP sync to discard past-due silence and start playing at the
-            # correct position — the silence just keeps the pipe fed.
-            # Scale the headroom with the configured AirPlay latency so devices
-            # with a longer wait_start still land with a positive start offset.
+            # The device needs at least ``wait_start`` of lead time after
+            # being told to start, plus a small safety margin for cliraop to
+            # connect / RAOP handshake. Anything below this and the device
+            # is effectively starting in the past.
             min_headroom = max(2.0, self.wait_start)
-            deficit = 0.0
-            if start_at < now + min_headroom:
-                deficit = (now + min_headroom) - start_at
-                silence_bytes = int(deficit * pcm_sample_size)
-                frame_size = (self.pcm_format.bit_depth // 8) * self.pcm_format.channels
-                silence_bytes -= silence_bytes % frame_size
-                if silence_bytes > 0:
-                    buffered_pcm = b"\x00" * silence_bytes + buffered_pcm
+            target_start_at = now + min_headroom
+            trim_seconds = 0.0
+            if start_at < target_start_at:
+                # Shift start_at forward so the device has time to prep, and
+                # trim the buffer head by the same amount so the first sample
+                # we send is the one that should play at the new start_at.
+                trim_seconds = target_start_at - start_at
+                trim_bytes = int(trim_seconds * pcm_sample_size)
+                trim_bytes -= trim_bytes % frame_size
+                if trim_bytes >= len(buffered_pcm):
+                    # Nothing left of the buffer after the trim. Drop it and
+                    # let the audio_streamer feed the late joiner from the
+                    # next chunk; align start_at to that chunk's first sample.
+                    buffered_pcm = b""
+                    start_at = self.start_time + self.seconds_streamed
+                else:
+                    buffered_pcm = buffered_pcm[trim_bytes:]
+                    start_at += trim_seconds
+                # Make sure start_at still leaves enough lead time for slow
+                # connections / very-far-behind joiners.
+                start_at = max(start_at, target_start_at)
 
             start_ntp = unix_time_to_ntp(start_at)
 
             self.prov.logger.debug(
                 "Late joiner %s: sending %.2fs of buffered audio, "
                 "stream_pos=%.2fs, first_byte_pos=%.2fs, "
-                "start_at is %.2fs from now (min_headroom=%.2fs, deficit=%.2fs)",
+                "start_at is %.2fs from now (min_headroom=%.2fs, trimmed=%.2fs)",
                 airplay_player.player_id,
                 len(buffered_pcm) / pcm_sample_size,
                 self.seconds_streamed,
                 first_byte_pos,
                 start_at - now,
                 min_headroom,
-                deficit,
+                trim_seconds,
             )
 
             # Start ffmpeg+CLI and immediately write the buffered PCM.

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -128,9 +128,9 @@ class AirPlayStreamSession:
         past — they just play whatever the pipe gives them, trailing the
         group by the deficit. To stay in sync we therefore push the late
         joiner's ``start_at`` into the future (at least ``wait_start`` ahead
-        of now, with a small extra safety margin for connection setup) and
-        trim the corresponding amount from the head of the buffered PCM, so
-        the first sample we send maps to the correct future stream position.
+        of now) and trim the corresponding amount from the head of the
+        buffered PCM, so the first sample we send maps to the correct future
+        stream position.
 
         1. Snapshot the ring buffer and calculate how many seconds it holds.
         2. Map the buffer's first byte to its stream position; if the

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -176,7 +176,9 @@ class AirPlayStreamSession:
                 if trim_bytes >= len(buffered_pcm):
                     # Nothing left of the buffer after the trim. Drop it and
                     # let the audio_streamer feed the late joiner from the
-                    # next chunk; align start_at to that chunk's first sample.
+                    # next chunk. Set start_at to the current live position;
+                    # the clamp below may still move it later to preserve
+                    # the required headroom.
                     buffered_pcm = b""
                     start_at = self.start_time + self.seconds_streamed
                 else:

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -181,7 +181,9 @@ class AirPlayStreamSession:
                     start_at = self.start_time + self.seconds_streamed
                 else:
                     buffered_pcm = buffered_pcm[trim_bytes:]
-                    start_at += trim_seconds
+                    # Advance start_at by exactly the trimmed duration so the
+                    # NTP anchor matches the first sample we actually send.
+                    start_at += trim_bytes / pcm_sample_size
                 # Make sure start_at still leaves enough lead time for slow
                 # connections / very-far-behind joiners.
                 start_at = max(start_at, target_start_at)

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -458,32 +458,15 @@ class SyncGroupPlayer(Player):
             )
 
             if was_playing and supports_handoff:
-                # protocol supports dynamic leader switching: remove only the departing
-                # leader from the stream session, remaining members keep playing
+                # protocol supports dynamic leader switching: try to remove
+                # only the departing leader and keep remaining members playing.
+                # _dynamic_leader_switch will fall back to dissolve+reform
+                # automatically if the chosen new leader isn't already part of
+                # the live session (e.g. a freshly-added player).
                 await self._dynamic_leader_switch(old_leader_id)
             else:
-                # protocol doesn't support dynamic leader switching or not playing:
-                # dissolve the entire syncgroup and re-form with a new leader
-                self.logger.info(
-                    "Removing current sync leader %s from group %s while it is active, "
-                    "dissolving the current syncgroup and will re-form it with a new leader",
-                    self.sync_leader.display_name,
-                    self.display_name,
-                )
-                # Use internal handler to stop the sync leader directly,
-                # bypassing group redirect that would loop back to this player.
-                await self.mass.players.wait_for_player_update(
-                    self.sync_leader.player_id,
-                    timeout=5,
-                    action=self.mass.players._handle_cmd_stop(self.sync_leader.player_id),
-                )
-                await self._dissolve_syncgroup()
-                # remove the old leader from the group members list
-                # so it won't be re-selected
-                if old_leader_id in self._attr_group_members:
-                    self._attr_group_members.remove(old_leader_id)
-                if was_playing and self._attr_group_members:
-                    await self.play()
+                # protocol doesn't support dynamic leader switching or not playing
+                await self._dissolve_and_reform(old_leader_id)
         elif self.sync_leader and (leader_removed or not self._attr_group_members):
             # we removed the current sync leader, and we have no members left in the group
             # or we just removed the last member from the group, so we dissolve the syncgroup
@@ -739,12 +722,76 @@ class SyncGroupPlayer(Player):
             return native_domain
         return domain
 
+    def _is_player_in_session(self, player: Player, session_player: Player | None) -> bool:
+        """Return True if ``player`` is already a sync_client of the live session.
+
+        A seamless leader handoff only works when the candidate's resolved
+        protocol player is already in the active ``AirPlayStreamSession`` (or
+        equivalent). If not (e.g. a freshly-added player that has never played
+        anything), we must fall back to dissolve + reform.
+
+        :param player: The candidate new leader.
+        :param session_player: The protocol player that owns the live session
+            (snapshot taken before the old leader was cleared via
+            ``_active_session_player()``).
+        """
+        if session_player is None:
+            return False
+        session = getattr(getattr(session_player, "stream", None), "session", None)
+        if session is None:
+            return False
+        # Resolve player to the protocol player that would own the session
+        target: Player = player
+        if (
+            player.active_output_protocol
+            and player.active_output_protocol != "native"
+            and (p := self.mass.players.get_player(player.active_output_protocol))
+        ):
+            target = p
+        return target in session.sync_clients
+
+    async def _dissolve_and_reform(
+        self, old_leader_id: str, leader_to_stop: Player | None = None
+    ) -> None:
+        """Stop the current sync session, dissolve the syncgroup, and re-form on a new leader.
+
+        Used when a seamless handoff isn't possible (e.g. the new leader is not
+        part of the live session). Accepts a brief audio gap in exchange for
+        correctness: the old session is fully torn down before a fresh one starts.
+
+        :param old_leader_id: The player_id of the departing leader.
+        :param leader_to_stop: The player to stop before dissolving. Defaults
+            to ``self.sync_leader`` but callers should pass the old leader
+            explicitly when ``self.sync_leader`` has already been cleared.
+        """
+        leader_to_stop = leader_to_stop or self.sync_leader
+        if leader_to_stop:
+            self.logger.info(
+                "Dissolving syncgroup %s (leader %s) and re-forming with a new leader",
+                self.display_name,
+                leader_to_stop.display_name,
+            )
+            await self.mass.players.wait_for_player_update(
+                leader_to_stop.player_id,
+                timeout=5,
+                action=self.mass.players._handle_cmd_stop(leader_to_stop.player_id),
+            )
+        await self._dissolve_syncgroup()
+        if old_leader_id in self._attr_group_members:
+            self._attr_group_members.remove(old_leader_id)
+        if self._attr_group_members:
+            await self.play()
+
     async def _dynamic_leader_switch(self, old_leader_id: str) -> None:
         """Switch the sync leader without tearing down the stream session.
 
         Used when the provider supports dynamic leader selection (e.g. AirPlay,
         Snapcast). The old leader is removed from the live session and the
         remaining members keep playing uninterrupted on a newly selected leader.
+
+        If the selected new leader is not already part of the live session (e.g.
+        a freshly-added player), a seamless handoff isn't possible. In that case
+        we fall back to dissolve + reform, accepting a brief audio gap.
 
         :param old_leader_id: The player_id of the leader being removed.
         """
@@ -757,9 +804,11 @@ class SyncGroupPlayer(Player):
             self.display_name,
         )
 
-        # Snapshot the currently active protocol so the new leader selection
-        # can bias toward a member supporting it.
+        # Snapshot the currently active protocol and session before clearing
+        # the leader — we need both for new-leader selection and for the
+        # handoff-eligibility check.
         preferred_domain = self.active_protocol_domain
+        session_player = self._active_session_player()
 
         # Remove the old leader from our group members list
         if old_leader_id in self._attr_group_members:
@@ -772,6 +821,18 @@ class SyncGroupPlayer(Player):
 
         if not new_leader:
             self.update_state()
+            return
+
+        # A seamless handoff requires the new leader to already be a
+        # sync_client of the live session. If it's a freshly-added player
+        # with no existing stream, fall back to dissolve + reform.
+        if not self._is_player_in_session(new_leader, session_player):
+            self.logger.info(
+                "New leader %s is not in the live session; dissolving and re-forming syncgroup %s",
+                new_leader.display_name,
+                self.display_name,
+            )
+            await self._dissolve_and_reform(old_leader_id, leader_to_stop=old_leader)
             return
 
         self.sync_leader = new_leader

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -755,7 +755,13 @@ class SyncGroupPlayer(Player):
             return False
         session = getattr(getattr(session_player, "stream", None), "session", None)
         if session is None:
-            return False
+            # No session object (e.g. Snapcast, Sendspin) — assume handoff is
+            # safe if the provider declared support for it.
+            return True
+        sync_clients = getattr(session, "sync_clients", None)
+        if sync_clients is None:
+            # Session exists but doesn't expose sync_clients — same assumption.
+            return True
         # Resolve player to the protocol player that would own the session
         target: Player = player
         if (
@@ -764,7 +770,7 @@ class SyncGroupPlayer(Player):
             and (p := self.mass.players.get_player(player.active_output_protocol))
         ):
             target = p
-        return target in session.sync_clients
+        return target in sync_clients
 
     async def _dissolve_and_reform(
         self,

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -833,7 +833,9 @@ class SyncGroupPlayer(Player):
 
         if not new_leader:
             # No remaining members to take over — stop the old leader's
-            # session and dissolve the group entirely.
+            # session and dissolve the group entirely. Restore sync_leader
+            # so _dissolve_syncgroup can properly ungroup protocol members.
+            self.sync_leader = old_leader
             self.logger.info(
                 "No remaining members for group %s after removing %s, stopping",
                 self.display_name,
@@ -856,6 +858,9 @@ class SyncGroupPlayer(Player):
                 new_leader.display_name,
                 self.display_name,
             )
+            # Restore sync_leader so _dissolve_and_reform -> _dissolve_syncgroup
+            # can properly ungroup protocol-level members.
+            self.sync_leader = old_leader
             await self._dissolve_and_reform(old_leader_id, leader_to_stop=old_leader)
             return
 

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -490,19 +490,6 @@ class SyncGroupPlayer(Player):
                 player_ids_to_add=final_players_to_add,
                 player_ids_to_remove=final_players_to_remove,
             )
-            # If the leader is now the only member left (all children removed),
-            # dissolve the syncgroup bookkeeping so the leader isn't treated as
-            # a group anymore. The leader keeps playing — it just continues as
-            # a solo player from here.
-            remaining = [m for m in self._attr_group_members if m != self.sync_leader.player_id]
-            if not remaining and final_players_to_remove:
-                self.logger.info(
-                    "All members removed from group %s, dissolving (leader %s keeps playing)",
-                    self.display_name,
-                    self.sync_leader.display_name,
-                )
-                self.sync_leader = None
-                self.update_state()
         # NOTE: If we weren't playing before, we don't need to do anything else,
         # since the syncing will be done once playback starts
         self.mass.players.trigger_player_update(self.player_id)

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -832,7 +832,19 @@ class SyncGroupPlayer(Player):
         new_leader = self._select_sync_leader(preferred_protocol_domain=preferred_domain)
 
         if not new_leader:
-            self.update_state()
+            # No remaining members to take over — stop the old leader's
+            # session and dissolve the group entirely.
+            self.logger.info(
+                "No remaining members for group %s after removing %s, stopping",
+                self.display_name,
+                old_leader.display_name,
+            )
+            await self.mass.players.wait_for_player_update(
+                old_leader.player_id,
+                timeout=5,
+                action=self.mass.players._handle_cmd_stop(old_leader.player_id),
+            )
+            await self._dissolve_syncgroup()
             return
 
         # A seamless handoff requires the new leader to already be a

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -466,7 +466,7 @@ class SyncGroupPlayer(Player):
                 await self._dynamic_leader_switch(old_leader_id)
             else:
                 # protocol doesn't support dynamic leader switching or not playing
-                await self._dissolve_and_reform(old_leader_id)
+                await self._dissolve_and_reform(old_leader_id, resume_playback=was_playing)
         elif self.sync_leader and (leader_removed or not self._attr_group_members):
             # we removed the current sync leader, and we have no members left in the group
             # or we just removed the last member from the group, so we dissolve the syncgroup
@@ -751,9 +751,12 @@ class SyncGroupPlayer(Player):
         return target in session.sync_clients
 
     async def _dissolve_and_reform(
-        self, old_leader_id: str, leader_to_stop: Player | None = None
+        self,
+        old_leader_id: str,
+        leader_to_stop: Player | None = None,
+        resume_playback: bool = True,
     ) -> None:
-        """Stop the current sync session, dissolve the syncgroup, and re-form on a new leader.
+        """Stop the current sync session, dissolve the syncgroup, and optionally re-form.
 
         Used when a seamless handoff isn't possible (e.g. the new leader is not
         part of the live session). Accepts a brief audio gap in exchange for
@@ -763,6 +766,9 @@ class SyncGroupPlayer(Player):
         :param leader_to_stop: The player to stop before dissolving. Defaults
             to ``self.sync_leader`` but callers should pass the old leader
             explicitly when ``self.sync_leader`` has already been cleared.
+        :param resume_playback: If True, call ``play()`` after dissolving to
+            restart playback on the new leader. Pass False when the group was
+            not actively playing (e.g. paused or idle).
         """
         leader_to_stop = leader_to_stop or self.sync_leader
         if leader_to_stop:
@@ -779,7 +785,7 @@ class SyncGroupPlayer(Player):
         await self._dissolve_syncgroup()
         if old_leader_id in self._attr_group_members:
             self._attr_group_members.remove(old_leader_id)
-        if self._attr_group_members:
+        if resume_playback and self._attr_group_members:
             await self.play()
 
     async def _dynamic_leader_switch(self, old_leader_id: str) -> None:

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -491,21 +491,18 @@ class SyncGroupPlayer(Player):
                 player_ids_to_remove=final_players_to_remove,
             )
             # If the leader is now the only member left (all children removed),
-            # stop it and dissolve the syncgroup — a lone leader should not keep
-            # streaming from an orphaned session.
+            # dissolve the syncgroup bookkeeping so the leader isn't treated as
+            # a group anymore. The leader keeps playing — it just continues as
+            # a solo player from here.
             remaining = [m for m in self._attr_group_members if m != self.sync_leader.player_id]
             if not remaining and final_players_to_remove:
                 self.logger.info(
-                    "All members removed from group %s, stopping lone leader %s",
+                    "All members removed from group %s, dissolving (leader %s keeps playing)",
                     self.display_name,
                     self.sync_leader.display_name,
                 )
-                await self.mass.players.wait_for_player_update(
-                    self.sync_leader.player_id,
-                    timeout=5,
-                    action=self.mass.players._handle_cmd_stop(self.sync_leader.player_id),
-                )
-                await self._dissolve_syncgroup()
+                self.sync_leader = None
+                self.update_state()
         # NOTE: If we weren't playing before, we don't need to do anything else,
         # since the syncing will be done once playback starts
         self.mass.players.trigger_player_update(self.player_id)

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -490,6 +490,22 @@ class SyncGroupPlayer(Player):
                 player_ids_to_add=final_players_to_add,
                 player_ids_to_remove=final_players_to_remove,
             )
+            # If the leader is now the only member left (all children removed),
+            # stop it and dissolve the syncgroup — a lone leader should not keep
+            # streaming from an orphaned session.
+            remaining = [m for m in self._attr_group_members if m != self.sync_leader.player_id]
+            if not remaining and final_players_to_remove:
+                self.logger.info(
+                    "All members removed from group %s, stopping lone leader %s",
+                    self.display_name,
+                    self.sync_leader.display_name,
+                )
+                await self.mass.players.wait_for_player_update(
+                    self.sync_leader.player_id,
+                    timeout=5,
+                    action=self.mass.players._handle_cmd_stop(self.sync_leader.player_id),
+                )
+                await self._dissolve_syncgroup()
         # NOTE: If we weren't playing before, we don't need to do anything else,
         # since the syncing will be done once playback starts
         self.mass.players.trigger_player_update(self.player_id)

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -169,10 +169,8 @@ async def test_late_join_no_running_session() -> None:
 @pytest.mark.asyncio
 async def test_late_join_trims_and_shifts_when_start_at_in_past() -> None:
     """When start_at would be in the past, trim from buffer head and shift start_at forward."""
-    now = time.time()
-    # Buffer alone would land start_at at now - 0.5s (in the past).
-    # buffer = 5.5s, seconds_streamed = 5.5, start_time = now → start_at = now → too close
-    # Make it negative: start_time = now - 0.5, buffer 5.0s, seconds_streamed 5.0
+    # Freeze time so both the test and the code under test agree on `now`.
+    now = 1_000_000.0
     start_time = now - 0.5
     seconds_streamed = 5.0
     session = _make_session(start_time, seconds_streamed)
@@ -197,34 +195,33 @@ async def test_late_join_trims_and_shifts_when_start_at_in_past() -> None:
             "music_assistant.providers.airplay.stream_session.unix_time_to_ntp",
             side_effect=capture_ntp,
         ),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
     ):
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    # start_at should be pushed to ~now + min_headroom (max(2.0, wait_start) = 2.0)
+    # start_at should be pushed to exactly now + min_headroom (max(2.0, wait_start) = 2.0)
     assert captured_start_at, "unix_time_to_ntp was never called"
-    assert captured_start_at[0] - now >= 1.9, (
-        f"start_at should be in the future, got offset {captured_start_at[0] - now:.2f}s"
-    )
-    assert captured_start_at[0] - now <= 2.5, (
-        f"start_at should be ~min_headroom, got offset {captured_start_at[0] - now:.2f}s"
+    assert captured_start_at[0] - now == pytest.approx(2.0, abs=0.01), (
+        f"start_at should be at now + min_headroom, got offset {captured_start_at[0] - now:.4f}s"
     )
 
     # The buffer should have been trimmed (and contain only \x01 bytes — no silence prepend)
     assert written_chunks, "No data was written to the player"
     written = written_chunks[0]
     assert b"\x00" not in written, "No silence should be prepended (trim+shift, not prepend)"
-    # We trimmed ~2.5s out of 5s, so ~2.5s of \x01 should remain
+    # We trimmed 2.5s out of 5s (start_at went from -0.5 to +2.0), so 2.5s of \x01 should remain
     remaining_seconds = len(written) / PCM_SAMPLE_SIZE
-    assert 2.0 <= remaining_seconds <= 3.0, (
-        f"expected ~2.5s remaining, got {remaining_seconds:.2f}s"
+    assert remaining_seconds == pytest.approx(2.5, abs=0.01), (
+        f"expected 2.5s remaining, got {remaining_seconds:.4f}s"
     )
 
 
 @pytest.mark.asyncio
 async def test_late_join_drops_buffer_when_trim_exceeds_buffer() -> None:
     """When the required trim exceeds the buffer, the buffer is dropped entirely."""
-    now = time.time()
+    # Freeze time so both the test and the code under test agree on `now`.
+    now = 1_000_000.0
     # start_at = now - 4.0 (way in the past). With 3s buffer the required trim
     # is 6s but buffer only holds 3s → buffer fully consumed.
     start_time = now - 4.0
@@ -250,11 +247,13 @@ async def test_late_join_drops_buffer_when_trim_exceeds_buffer() -> None:
             "music_assistant.providers.airplay.stream_session.unix_time_to_ntp",
             side_effect=capture_ntp,
         ),
+        patch("music_assistant.providers.airplay.stream_session.time.time", return_value=now),
     ):
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
     # No bytes should be written (buffer fully trimmed)
     assert written_chunks == [], "Buffer should have been dropped entirely"
-    # start_at should be at least min_headroom in the future
-    assert captured_start_at[0] - now >= 1.9
+    # start_at should be exactly now + min_headroom (since the next-chunk anchor would
+    # have landed at now - 1.0, which is below the target).
+    assert captured_start_at[0] - now == pytest.approx(2.0, abs=0.01)

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -200,7 +200,7 @@ async def test_late_join_trims_and_shifts_when_start_at_in_past() -> None:
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    # start_at should be pushed to exactly now + min_headroom (max(2.0, wait_start) = 2.0)
+    # start_at should be pushed to now + min_headroom (session.wait_start = 2.0)
     assert captured_start_at, "unix_time_to_ntp was never called"
     assert captured_start_at[0] - now == pytest.approx(2.0, abs=0.01), (
         f"start_at should be at now + min_headroom, got offset {captured_start_at[0] - now:.4f}s"

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -94,10 +94,12 @@ async def test_late_join_empty_buffer() -> None:
 
 
 @pytest.mark.asyncio
-async def test_late_join_with_buffered_pcm() -> None:
-    """Test that with a non-empty buffer, start_at accounts for buffer duration."""
+async def test_late_join_with_buffered_pcm_in_future() -> None:
+    """Late join with start_at already in the future leaves start_at unmodified."""
     now = time.time()
-    start_time = now - 10
+    # Place start_at well in the future: start_time = now + 5, buffer = 0 →
+    # start_at = now + 5 + (seconds_streamed - 0) = now + 17.5 (>> min_headroom)
+    start_time = now + 5
     seconds_streamed = 12.5
     session = _make_session(start_time, seconds_streamed)
     # Fill the ring buffer with 3 seconds of PCM
@@ -122,10 +124,10 @@ async def test_late_join_with_buffered_pcm() -> None:
         await session.add_client(player)
 
     assert captured_start_at, "unix_time_to_ntp was never called"
-    # NTP should be start_time + (seconds_streamed - 3.0)
+    # start_at should remain at start_time + (seconds_streamed - 3.0) — already in future
     expected = start_time + (seconds_streamed - 3.0)
     assert abs(captured_start_at[0] - expected) < 0.1, (
-        f"start_at should account for buffer, expected {expected}, got {captured_start_at[0]}"
+        f"start_at should match buffer position, expected {expected}, got {captured_start_at[0]}"
     )
 
 
@@ -165,18 +167,18 @@ async def test_late_join_no_running_session() -> None:
 
 
 @pytest.mark.asyncio
-async def test_late_join_silence_prepend_when_start_at_in_past() -> None:
-    """Test that silence is prepended when start_at is in the past."""
+async def test_late_join_trims_and_shifts_when_start_at_in_past() -> None:
+    """When start_at would be in the past, trim from buffer head and shift start_at forward."""
     now = time.time()
-    # start_time chosen so start_at = start_time + (seconds_streamed - 3.0)
-    # ends up ~2s in the past
-    start_time = now - 100
-    seconds_streamed = 101.0
+    # Buffer alone would land start_at at now - 0.5s (in the past).
+    # buffer = 5.5s, seconds_streamed = 5.5, start_time = now → start_at = now → too close
+    # Make it negative: start_time = now - 0.5, buffer 5.0s, seconds_streamed 5.0
+    start_time = now - 0.5
+    seconds_streamed = 5.0
     session = _make_session(start_time, seconds_streamed)
-    # Fill ring buffer with 3 seconds of non-silent PCM
-    pcm_data = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 3)
-    session._pcm_buffer = pcm_data
-    player = _make_late_joiner()
+    # Fill ring buffer with 5 seconds of non-silent PCM (so trim has something to take)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 5)
+    player = _make_late_joiner(wait_start_ms=2000)
 
     written_chunks: list[bytes] = []
     captured_start_at: list[float] = []
@@ -199,22 +201,60 @@ async def test_late_join_silence_prepend_when_start_at_in_past() -> None:
         mock_start.side_effect = _setup_stream(player)
         await session.add_client(player)
 
-    # start_at should NOT be modified — stays at start_time + (101 - 3) = now - 2
+    # start_at should be pushed to ~now + min_headroom (max(2.0, wait_start) = 2.0)
     assert captured_start_at, "unix_time_to_ntp was never called"
-    expected_start_at = start_time + (seconds_streamed - 3.0)
-    assert abs(captured_start_at[0] - expected_start_at) < 0.1
+    assert captured_start_at[0] - now >= 1.9, (
+        f"start_at should be in the future, got offset {captured_start_at[0] - now:.2f}s"
+    )
+    assert captured_start_at[0] - now <= 2.5, (
+        f"start_at should be ~min_headroom, got offset {captured_start_at[0] - now:.2f}s"
+    )
 
-    # The written buffer should be larger than the original 3s due to silence prepend
+    # The buffer should have been trimmed (and contain only \x01 bytes — no silence prepend)
     assert written_chunks, "No data was written to the player"
-    total_written = len(written_chunks[0])
-    original_size = PCM_SAMPLE_SIZE * 3
-    assert total_written > original_size, "Silence should have been prepended"
+    written = written_chunks[0]
+    assert b"\x00" not in written, "No silence should be prepended (trim+shift, not prepend)"
+    # We trimmed ~2.5s out of 5s, so ~2.5s of \x01 should remain
+    remaining_seconds = len(written) / PCM_SAMPLE_SIZE
+    assert 2.0 <= remaining_seconds <= 3.0, (
+        f"expected ~2.5s remaining, got {remaining_seconds:.2f}s"
+    )
 
-    # The prepended bytes should be silence (zeros)
-    silence_size = total_written - original_size
-    assert written_chunks[0][:silence_size] == b"\x00" * silence_size
-    # The original PCM data should follow the silence
-    assert written_chunks[0][silence_size:] == bytes(pcm_data)
 
-    # Silence should be frame-aligned (4 bytes per frame for 16-bit stereo)
-    assert silence_size % 4 == 0
+@pytest.mark.asyncio
+async def test_late_join_drops_buffer_when_trim_exceeds_buffer() -> None:
+    """When the required trim exceeds the buffer, the buffer is dropped entirely."""
+    now = time.time()
+    # start_at = now - 4.0 (way in the past). With 3s buffer the required trim
+    # is 6s but buffer only holds 3s → buffer fully consumed.
+    start_time = now - 4.0
+    seconds_streamed = 3.0
+    session = _make_session(start_time, seconds_streamed)
+    session._pcm_buffer = bytearray(b"\x01" * PCM_SAMPLE_SIZE * 3)
+    player = _make_late_joiner(wait_start_ms=2000)
+
+    written_chunks: list[bytes] = []
+    captured_start_at: list[float] = []
+
+    def capture_ntp(unix_ts: float) -> int:
+        captured_start_at.append(unix_ts)
+        return 1
+
+    async def capture_write(_player: Any, chunk: bytes) -> None:
+        written_chunks.append(chunk)
+
+    with (
+        patch.object(session, "_start_client", new_callable=AsyncMock) as mock_start,
+        patch.object(session, "_write_chunk_to_player", side_effect=capture_write),
+        patch(
+            "music_assistant.providers.airplay.stream_session.unix_time_to_ntp",
+            side_effect=capture_ntp,
+        ),
+    ):
+        mock_start.side_effect = _setup_stream(player)
+        await session.add_client(player)
+
+    # No bytes should be written (buffer fully trimmed)
+    assert written_chunks == [], "Buffer should have been dropped entirely"
+    # start_at should be at least min_headroom in the future
+    assert captured_start_at[0] - now >= 1.9

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -206,11 +206,9 @@ async def test_late_join_trims_and_shifts_when_start_at_in_past() -> None:
         f"start_at should be at now + min_headroom, got offset {captured_start_at[0] - now:.4f}s"
     )
 
-    # The buffer should have been trimmed (and contain only \x01 bytes — no silence prepend)
+    # Buffer should have been trimmed: 2.5s out of 5s (start_at shifted from -0.5 to +2.0)
     assert written_chunks, "No data was written to the player"
     written = written_chunks[0]
-    assert b"\x00" not in written, "No silence should be prepended (trim+shift, not prepend)"
-    # We trimmed 2.5s out of 5s (start_at went from -0.5 to +2.0), so 2.5s of \x01 should remain
     remaining_seconds = len(written) / PCM_SAMPLE_SIZE
     assert remaining_seconds == pytest.approx(2.5, abs=0.01), (
         f"expected 2.5s remaining, got {remaining_seconds:.4f}s"

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -257,7 +257,7 @@ class TestDynamicLeaderSwitch:
 
     @pytest.mark.asyncio
     async def test_dynamic_leader_switch_hands_off_to_new_leader(self) -> None:
-        """Dynamic leader switch removes the old leader and picks a new one."""
+        """When the new leader IS in the live session, seamless handoff is used."""
         mass = _make_mock_mass()
         sgp = _make_sync_group(mass)
 
@@ -269,6 +269,9 @@ class TestDynamicLeaderSwitch:
         )
         ap_only.is_native_player = False
 
+        # new_leader's AirPlay protocol player (must be in the session for handoff)
+        ap_new = _make_mock_player("ap_new", provider_domain="airplay")
+
         old_leader = _make_mock_player(
             "old_leader",
             provider_domain="sonos",
@@ -277,15 +280,24 @@ class TestDynamicLeaderSwitch:
         )
         old_leader.handoff_sync_leadership = AsyncMock()
         new_leader = _make_mock_player(
-            "new_leader", provider_domain="sonos", protocol_domains=["airplay"]
+            "new_leader",
+            provider_domain="sonos",
+            protocol_domains=["airplay"],
+            active_output_protocol="ap_new",
         )
         ap_protocol = _make_mock_player("ap_old", provider_domain="airplay")
+        # Set up the live session with new_leader's protocol player in sync_clients
+        mock_session = MagicMock()
+        mock_session.sync_clients = [ap_protocol, ap_new, ap_only]
+        ap_protocol.stream = MagicMock()
+        ap_protocol.stream.session = mock_session
 
         mass.players.get_player = _player_lookup(
             {
                 "old_leader": old_leader,
                 "new_leader": new_leader,
                 "ap_old": ap_protocol,
+                "ap_new": ap_new,
                 "ap_only": ap_only,
             }
         )
@@ -303,3 +315,51 @@ class TestDynamicLeaderSwitch:
         call_args = old_leader.handoff_sync_leadership.await_args
         assert call_args.args[0] == new_leader
         assert "ap_only" in call_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_dynamic_leader_switch_dissolves_when_new_leader_not_in_session(
+        self,
+    ) -> None:
+        """When the new leader is NOT in the live session, fall back to dissolve+reform."""
+        mass = _make_mock_mass()
+        mass.players.cmd_resume = AsyncMock()
+        sgp = _make_sync_group(mass)
+
+        old_leader = _make_mock_player(
+            "old_leader",
+            provider_domain="sonos",
+            active_output_protocol="ap_old",
+            protocol_domains=["airplay"],
+        )
+        old_leader.handoff_sync_leadership = AsyncMock()
+        # Freshly-added player — NOT in the live session
+        fresh_player = _make_mock_player(
+            "fresh_player", provider_domain="sonos", protocol_domains=["airplay"]
+        )
+        ap_protocol = _make_mock_player("ap_old", provider_domain="airplay")
+        # Session does NOT contain fresh_player's protocol player
+        mock_session = MagicMock()
+        mock_session.sync_clients = [ap_protocol]
+        ap_protocol.stream = MagicMock()
+        ap_protocol.stream.session = mock_session
+
+        mass.players.get_player = _player_lookup(
+            {
+                "old_leader": old_leader,
+                "fresh_player": fresh_player,
+                "ap_old": ap_protocol,
+            }
+        )
+
+        sgp.sync_leader = old_leader
+        sgp._attr_group_members = ["old_leader", "fresh_player"]
+
+        with patch.object(sgp, "update_state"):
+            await sgp._dynamic_leader_switch("old_leader")
+
+        # handoff_sync_leadership should NOT have been called
+        old_leader.handoff_sync_leadership.assert_not_awaited()
+        # Instead, dissolve+reform happened: wait_for_player_update was called
+        # with the old leader's player_id (which internally stops the session)
+        mass.players.wait_for_player_update.assert_awaited()
+        assert "old_leader" not in sgp._attr_group_members


### PR DESCRIPTION
## Problem

Several sync group session lifecycle issues:

- **Late-joiner out of sync**: AirPlay late joiners received a `start_at` NTP anchor in the past. Most non-Apple devices don't honour past-due NTP and just play from the head of the pipe, trailing the group.
- **Orphaned session on leader switch**: when a sync group's leader is removed and the new leader is a freshly-added player with no existing stream, `handoff_sync_leadership` becomes a no-op at the protocol level and the old session keeps streaming orphaned.
- **Orphaned session when all members removed at once**: `_dynamic_leader_switch` found no new leader candidate but returned without stopping the old leader's session.

## Changes

- **Late-joiner trim+shift**: when `start_at` would land before `now + wait_start`, push `start_at` forward and trim the corresponding seconds from the buffer head. First sample sent is bit-aligned with the shifted NTP anchor. If the trim exceeds the buffer, it's dropped and `start_at` anchors to the next chunk. `min_headroom` is `max(session.wait_start, joiner.wait_start)` — no arbitrary floor.
- **Session membership check before handoff**: `_dynamic_leader_switch` now checks whether the new leader's protocol player is actually in the live session (`_is_player_in_session`). If not, falls back to dissolve + reform. For providers without `sync_clients` (Snapcast, Sendspin), the handoff is allowed by default since they declared the capability.
- **Stop + dissolve when no new leader found**: when `_dynamic_leader_switch` finds no remaining candidate (all members removed), it now stops the old leader and dissolves the syncgroup instead of returning silently.
- Extracted `_dissolve_and_reform` helper with `resume_playback` flag so the dissolve path is shared and doesn't unexpectedly restart playback when the group was idle/paused.
- Restores `sync_leader` before calling `_dissolve_syncgroup` in the fallback paths so protocol-level members are properly ungrouped.