### PR TITLE
Allow Pipewire devices to be detected by Local Audio when using docker

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -44,6 +44,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxml2-dev \
     libssh-dev \
     liblzma-dev \
+    # Allows pipewire devices to be detected when running in docker container.
+    pipewire-alsa \
     # SSL/TLS support for HTTPS
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Only ALSA devices would show up when using docker container, but with this addition pipewire devices now also do.

You do also have to add some config to your docker-compose.yaml like so:
```yaml
user: "1000:1000"
 volumes:
      - /run/user/1000:/run/user/1000
      - ~/.config/pulse/cookie:/root/.config/pulse/cookie
 environment:
      - PULSE_SERVER=unix:/run/user/1000/pulse/native
      - PULSE_COOKIE=/run/user/1000/pulse/cookie
      - PIPEWIRE_RUNTIME_DIR=/run/user/1000
      - XDG_RUNTIME_DIR=/run/user/1000
 ```