### PR TITLE
Automatically clean up loudness measurements on media item deletion

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -27,6 +27,7 @@ from music_assistant_models.media_items import (
 from music_assistant.constants import (
     DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
     DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+    DB_TABLE_LOUDNESS_MEASUREMENTS,
     DB_TABLE_PLAYLOG,
     DB_TABLE_PROVIDER_MAPPINGS,
     MASS_LOGGER_NAME,
@@ -243,6 +244,16 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                     "provider": prov_mapping.provider_instance,
                 },
             )
+            # cleanup loudness measurements for this provider mapping
+            for prov_key in (prov_mapping.provider_domain, prov_mapping.provider_instance):
+                await self.mass.music.database.delete(
+                    DB_TABLE_LOUDNESS_MEASUREMENTS,
+                    {
+                        "media_type": self.media_type.value,
+                        "item_id": prov_mapping.item_id,
+                        "provider": prov_key,
+                    },
+                )
         # delete genre exclusions for this media item
         await self.mass.music.database.delete(
             DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,


### PR DESCRIPTION
Cleans up loudness measurements on media item deletion. Allows people to get rid of incorrect measures, for example here https://github.com/music-assistant/support/issues/5291.

When we rewrite this as an audio analysis provider, we can simply only store the values in the `finalize()` step, making sure the entire pcm was properly analyzed, preventing this from happening.