### PR TITLE
Fix sync group dissolve+reform race with async providers

### DIFF
--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
@@ -792,6 +793,18 @@ class SyncGroupPlayer(Player):
         if old_leader_id in self._attr_group_members:
             self._attr_group_members.remove(old_leader_id)
         if resume_playback and self._attr_group_members:
+            # Wait for the remaining members to report as unsynced before
+            # re-forming. Providers like Sonos propagate group state
+            # asynchronously — the children can still report synced_to for
+            # a few seconds after the leader's ungroup command returns.
+            for _ in range(10):
+                if all(
+                    (player := self.mass.players.get_player(m)) is not None
+                    and player.synced_to is None
+                    for m in self._attr_group_members
+                ):
+                    break
+                await asyncio.sleep(0.5)
             await self.play()
 
     async def _dynamic_leader_switch(self, old_leader_id: str) -> None:


### PR DESCRIPTION
## Problem

When the sync leader is removed from a native (Sonos) sync group that doesn't support dynamic leader switching, `_dissolve_and_reform` tears down the old group and immediately calls `play()` to re-form on a new leader. But Sonos propagates group state asynchronously — the children still report `synced_to` pointing at the old leader for several seconds after the ungroup command returns. This caused `_form_syncgroup` to reject the new leader (`Player can not accept play_media command, it is synced to another player`) and music stopped instead of continuing on the remaining members.

## Changes

After dissolving and before calling `play()`, poll for up to 5 seconds until all remaining members report `synced_to=None`. This gives async providers like Sonos time to propagate the ungroup before the new group is formed.