### PR TITLE
Fix MPD player removal reappearing after reload

### DIFF
--- a/music_assistant/providers/mpd/provider.py
+++ b/music_assistant/providers/mpd/provider.py
@@ -73,5 +73,22 @@ class MPDPlayerProvider(PlayerProvider):
             await self.mass.players.register(player)
 
     async def remove_player(self, player_id: str) -> None:
-        """Remove a player and unregister it from MA."""
-        await self.mass.players.unregister(player_id)
+        """Remove a player and persist that removal in the provider config."""
+        host_port: tuple[str, int] | None = None
+        if player := self.mass.players.get_player(player_id):
+            if isinstance(player, MPDPlayer):
+                host_port = (player.host, player.port)
+        if host_port is None:
+            for entry in cast("list[str]", self.config.get_value(CONF_MANUAL_IPS) or []):
+                host, port = _parse_host_entry(entry)
+                if f"mpd_{host}_{port}" == player_id:
+                    host_port = (host, port)
+                    break
+        if host_port is not None:
+            entries = cast("list[str]", self.config.get_value(CONF_MANUAL_IPS) or [])
+            new_entries = [entry for entry in entries if _parse_host_entry(entry) != host_port]
+            if new_entries != entries:
+                self.mass.config.set_raw_provider_config_value(
+                    self.instance_id, CONF_MANUAL_IPS, new_entries
+                )
+        await self.mass.players.unregister(player_id, True)

--- a/music_assistant/providers/mpd/provider.py
+++ b/music_assistant/providers/mpd/provider.py
@@ -88,7 +88,5 @@ class MPDPlayerProvider(PlayerProvider):
             entries = cast("list[str]", self.config.get_value(CONF_MANUAL_IPS) or [])
             new_entries = [entry for entry in entries if _parse_host_entry(entry) != host_port]
             if new_entries != entries:
-                self.mass.config.set_raw_provider_config_value(
-                    self.instance_id, CONF_MANUAL_IPS, new_entries
-                )
+                self._update_config_value(CONF_MANUAL_IPS, new_entries)
         await self.mass.players.unregister(player_id, True)

--- a/tests/providers/mpd/__init__.py
+++ b/tests/providers/mpd/__init__.py
@@ -1,0 +1,1 @@
+"""MPD provider tests."""

--- a/tests/providers/mpd/test_provider.py
+++ b/tests/providers/mpd/test_provider.py
@@ -1,0 +1,33 @@
+"""Tests for the MPD player provider."""
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+from music_assistant.providers.mpd.provider import MPDPlayerProvider
+
+
+async def test_remove_player_prunes_manual_host_config() -> None:
+    """Removing an MPD player should also remove its host entry from provider config."""
+    provider = cast("Any", MPDPlayerProvider.__new__(MPDPlayerProvider))
+    provider.config = Mock()
+    provider.config.instance_id = "mpd_test"
+    provider.config.get_value.return_value = [
+        "kitchen.local:6600",
+        "office.local:6601",
+        "office.local:6601",
+        "bedroom.local",
+    ]
+    provider.mass = Mock()
+    provider.mass.config = Mock()
+    provider.mass.players = Mock()
+    provider.mass.players.get_player.return_value = None
+    provider.mass.players.unregister = AsyncMock()
+
+    await provider.remove_player("mpd_office.local_6601")
+
+    provider.mass.config.set_raw_provider_config_value.assert_called_once_with(
+        "mpd_test",
+        "manual_discovery_ip_addresses",
+        ["kitchen.local:6600", "bedroom.local"],
+    )
+    provider.mass.players.unregister.assert_awaited_once_with("mpd_office.local_6601", True)

--- a/tests/providers/mpd/test_provider.py
+++ b/tests/providers/mpd/test_provider.py
@@ -1,7 +1,7 @@
 """Tests for the MPD player provider."""
 
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 from music_assistant.providers.mpd.provider import MPDPlayerProvider
@@ -9,7 +9,7 @@ from music_assistant.providers.mpd.provider import MPDPlayerProvider
 
 async def test_remove_player_prunes_manual_host_config() -> None:
     """Removing an MPD player should also remove its host entry from provider config."""
-    provider = cast(Any, MPDPlayerProvider.__new__(MPDPlayerProvider))
+    provider = cast("MPDPlayerProvider", MPDPlayerProvider.__new__(MPDPlayerProvider))
     config_entries = {
         "manual_discovery_ip_addresses": SimpleNamespace(
             value=[

--- a/tests/providers/mpd/test_provider.py
+++ b/tests/providers/mpd/test_provider.py
@@ -23,9 +23,9 @@ async def test_remove_player_prunes_manual_host_config() -> None:
     provider.config = Mock()
     provider.config.instance_id = "mpd_test"
     provider.config.values = config_entries
-    provider.config.get_value.side_effect = lambda key, default=None: config_entries.get(
-        key, SimpleNamespace(value=default)
-    ).value
+    provider.config.get_value.side_effect = lambda key, default=None: (
+        config_entries.get(key, SimpleNamespace(value=default)).value
+    )
     original_entries = [
         "kitchen.local:6600",
         "office.local:6601",

--- a/tests/providers/mpd/test_provider.py
+++ b/tests/providers/mpd/test_provider.py
@@ -9,7 +9,7 @@ from music_assistant.providers.mpd.provider import MPDPlayerProvider
 
 async def test_remove_player_prunes_manual_host_config() -> None:
     """Removing an MPD player should also remove its host entry from provider config."""
-    provider = cast("Any", MPDPlayerProvider.__new__(MPDPlayerProvider))
+    provider = cast(Any, MPDPlayerProvider.__new__(MPDPlayerProvider))
     config_entries = {
         "manual_discovery_ip_addresses": SimpleNamespace(
             value=[

--- a/tests/providers/mpd/test_provider.py
+++ b/tests/providers/mpd/test_provider.py
@@ -1,5 +1,6 @@
 """Tests for the MPD player provider."""
 
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
@@ -9,9 +10,23 @@ from music_assistant.providers.mpd.provider import MPDPlayerProvider
 async def test_remove_player_prunes_manual_host_config() -> None:
     """Removing an MPD player should also remove its host entry from provider config."""
     provider = cast("Any", MPDPlayerProvider.__new__(MPDPlayerProvider))
+    config_entries = {
+        "manual_discovery_ip_addresses": SimpleNamespace(
+            value=[
+                "kitchen.local:6600",
+                "office.local:6601",
+                "office.local:6601",
+                "bedroom.local",
+            ]
+        )
+    }
     provider.config = Mock()
     provider.config.instance_id = "mpd_test"
-    provider.config.get_value.return_value = [
+    provider.config.values = config_entries
+    provider.config.get_value.side_effect = lambda key, default=None: config_entries.get(
+        key, SimpleNamespace(value=default)
+    ).value
+    original_entries = [
         "kitchen.local:6600",
         "office.local:6601",
         "office.local:6601",
@@ -29,5 +44,11 @@ async def test_remove_player_prunes_manual_host_config() -> None:
         "mpd_test",
         "manual_discovery_ip_addresses",
         ["kitchen.local:6600", "bedroom.local"],
+        False,
     )
+    assert config_entries["manual_discovery_ip_addresses"].value == [
+        "kitchen.local:6600",
+        "bedroom.local",
+    ]
+    assert original_entries != config_entries["manual_discovery_ip_addresses"].value
     provider.mass.players.unregister.assert_awaited_once_with("mpd_office.local_6601", True)

--- a/tests/providers/mpd/test_provider.py
+++ b/tests/providers/mpd/test_provider.py
@@ -1,7 +1,6 @@
 """Tests for the MPD player provider."""
 
 from types import SimpleNamespace
-from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 from music_assistant.providers.mpd.provider import MPDPlayerProvider
@@ -9,7 +8,7 @@ from music_assistant.providers.mpd.provider import MPDPlayerProvider
 
 async def test_remove_player_prunes_manual_host_config() -> None:
     """Removing an MPD player should also remove its host entry from provider config."""
-    provider = cast("MPDPlayerProvider", MPDPlayerProvider.__new__(MPDPlayerProvider))
+    provider = MPDPlayerProvider.__new__(MPDPlayerProvider)
     config_entries = {
         "manual_discovery_ip_addresses": SimpleNamespace(
             value=[


### PR DESCRIPTION
Problem
Removing an MPD player only unregistered it in memory. The manual host entry stayed in provider config, so the same player was rediscovered on the next provider reload.

Changes
- prune the matching manual MPD host entry when removing a player
- unregister MPD players as a permanent removal
- add a regression test for config pruning during player removal