### PR TITLE
Fix is_dynamic guard not firing for playlists not yet synced to library

### DIFF
--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -120,6 +120,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
     ) -> AsyncGenerator[PlaylistPlayableItem, None]:
         """Return playlist tracks for the given provider playlist id."""
         library_item: Playlist | None = None
+        provider_item: Playlist | None = None
         if provider_instance_id_or_domain == "library":
             library_item = await self.get_library_item(item_id)
             provider_instance_id_or_domain, item_id = self._select_provider_id(library_item)
@@ -127,6 +128,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
             library_item = await self.get_library_item_by_prov_id(
                 item_id, provider_instance_id_or_domain
             )
+            if library_item is None:
+                with suppress(Exception):
+                    prov = self.mass.get_provider(provider_instance_id_or_domain)
+                    if isinstance(prov, MusicProvider):
+                        provider_item = await prov.get_playlist(item_id)
 
         # Dynamic playlists always need fresh tracks from the provider.
         if allow_dynamic_tracks:
@@ -135,7 +141,9 @@ class PlaylistController(MediaControllerBase[Playlist]):
         # Dynamic playlists should not expose a static track list in browse/refresh views.
         # Only the playback queue may request tracks for dynamic refill.
         if not allow_dynamic_tracks:
-            if library_item is not None and library_item.is_dynamic:
+            if (library_item is not None and library_item.is_dynamic) or (
+                provider_item is not None and provider_item.is_dynamic
+            ):
                 return
 
         # playlist tracks are not stored in the db,

--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -129,10 +129,11 @@ class PlaylistController(MediaControllerBase[Playlist]):
                 item_id, provider_instance_id_or_domain
             )
             if library_item is None:
-                with suppress(Exception):
-                    prov = self.mass.get_provider(provider_instance_id_or_domain)
-                    if isinstance(prov, MusicProvider):
-                        provider_item = await prov.get_playlist(item_id)
+                with suppress(ProviderUnavailableError, MediaNotFoundError, NotImplementedError):
+                    provider_item = cast(
+                        "Playlist",
+                        await self.get_provider_item(item_id, provider_instance_id_or_domain),
+                    )
 
         # Dynamic playlists always need fresh tracks from the provider.
         if allow_dynamic_tracks:

--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -130,9 +130,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
             )
             if library_item is None:
                 with suppress(ProviderUnavailableError, MediaNotFoundError, NotImplementedError):
-                    provider_item = cast(
-                        "Playlist",
-                        await self.get_provider_item(item_id, provider_instance_id_or_domain),
+                    provider_item = await self.get_provider_item(
+                        item_id, provider_instance_id_or_domain
                     )
 
         # Dynamic playlists always need fresh tracks from the provider.


### PR DESCRIPTION
## Problem

The `is_dynamic` guard in `PlaylistController.tracks()` only fires when the playlist has already been synced to the local library (`library_item is not None`). If a provider returns a dynamic playlist but no library sync has run yet, `library_item` is `None` and the guard is skipped — causing the static track list path to call `get_playlist_tracks()` on the provider anyway.

This affects any provider that sets `is_dynamic=True` on its playlists/stations (e.g. Apple Music stations, Pandora stations) before they appear in the library DB. The detail view calling `tracks()` would drain the provider's dynamic buffer before playback even starts.

## Fix

When `library_item is None`, fetch the playlist object directly from the provider via the existing `get_provider_item()` cache path and check its `is_dynamic` flag. If the provider item is dynamic, return early just as the existing guard does for library items.

The provider call is wrapped in `suppress(ProviderUnavailableError, MediaNotFoundError, NotImplementedError)` so only expected failure modes are silenced (provider not available, item not found, feature not implemented) while unexpected errors still surface. Any failure falls through to the existing behavior without breaking anything.