### PR TITLE
Improve loudness measurement robustness

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -166,6 +166,11 @@ DB_TABLE_GENRES: Final[str] = "genres"
 DB_TABLE_GENRE_MEDIA_ITEM_MAPPING: Final[str] = "genre_media_item_mapping"
 DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION: Final[str] = "genre_media_item_exclusion"
 
+# Loudness measurements at or below this value are considered unreliable:
+# ebur128 reports ~-70 LUFS when it receives near-silence or very little
+# audio (e.g. when a stream was cancelled early).
+LOUDNESS_MEASUREMENT_MIN_LUFS: Final[float] = -50.0
+
 
 def load_genre_mapping() -> list[dict[str, Any]]:
     """Load default genre mapping from JSON file.

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -165,6 +165,11 @@ DB_TABLE_GENRES: Final[str] = "genres"
 DB_TABLE_GENRE_MEDIA_ITEM_MAPPING: Final[str] = "genre_media_item_mapping"
 DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION: Final[str] = "genre_media_item_exclusion"
 
+# Loudness measurements at or below this value are considered unreliable:
+# ebur128 reports ~-70 LUFS when it receives near-silence or very little
+# audio (e.g. when a stream was cancelled early).
+LOUDNESS_MEASUREMENT_MIN_LUFS: Final[float] = -50.0
+
 
 def load_genre_mapping() -> list[dict[str, Any]]:
     """Load default genre mapping from JSON file.

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1116,7 +1116,10 @@ class MusicController(CoreController):
             "provider": prov_key,
             "loudness": loudness,
         }
-        if album_loudness not in (None, inf, -inf):
+        if (
+            album_loudness not in (None, inf, -inf)
+            and album_loudness > LOUDNESS_MEASUREMENT_MIN_LUFS
+        ):
             values["loudness_album"] = album_loudness
         await self.database.insert_or_replace(DB_TABLE_LOUDNESS_MEASUREMENTS, values)
 

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -71,6 +71,7 @@ from music_assistant.constants import (
     DB_TABLE_TRACK_ARTISTS,
     DB_TABLE_TRACKS,
     DEFAULT_GENRE_MAPPING,
+    LOUDNESS_MEASUREMENT_MIN_LUFS,
     PROVIDERS_WITH_SHAREABLE_URLS,
 )
 from music_assistant.controllers.streams.smart_fades.fades import SMART_CROSSFADE_DURATION
@@ -113,7 +114,7 @@ CONF_RESET_DB = "reset_db"
 DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
-DB_SCHEMA_VERSION: Final[int] = 36
+DB_SCHEMA_VERSION: Final[int] = 37
 
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10
 DATABASE_CLEANUP_TASK_ID: Final[str] = "music_database_cleanup"
@@ -1104,7 +1105,7 @@ class MusicController(CoreController):
         """Store (EBU-R128) Integrated Loudness Measurement for a mediaitem in db."""
         if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
             return
-        if loudness in (None, inf, -inf) or loudness <= -50:
+        if loudness in (None, inf, -inf) or loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
             # skip invalid or unreliable values (ebur128 reports -70 LUFS on near-silence)
             return
         # prefer domain for streaming providers as the catalog is the same across instances
@@ -2747,6 +2748,20 @@ class MusicController(CoreController):
                 f"  AND provider_domain = 'apple_music' "
                 f"  AND provider_item_id LIKE 'ra.%'"
                 f")"
+            )
+
+        if prev_version <= 36:
+            # purge unreliable loudness measurements persisted by earlier versions
+            # (ebur128 reports ~-70 LUFS on near-silence / early-cancelled streams,
+            # which caused huge gain corrections on subsequent plays)
+            await self._database.execute(
+                f"DELETE FROM {DB_TABLE_LOUDNESS_MEASUREMENTS} "
+                f"WHERE loudness <= {LOUDNESS_MEASUREMENT_MIN_LUFS}"
+            )
+            await self._database.execute(
+                f"UPDATE {DB_TABLE_LOUDNESS_MEASUREMENTS} "
+                f"SET loudness_album = NULL "
+                f"WHERE loudness_album <= {LOUDNESS_MEASUREMENT_MIN_LUFS}"
             )
 
         # save changes

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1104,8 +1104,8 @@ class MusicController(CoreController):
         """Store (EBU-R128) Integrated Loudness Measurement for a mediaitem in db."""
         if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
             return
-        if loudness in (None, inf, -inf):
-            # skip invalid values
+        if loudness in (None, inf, -inf) or loudness <= -50:
+            # skip invalid or unreliable values (ebur128 reports -70 LUFS on near-silence)
             return
         # prefer domain for streaming providers as the catalog is the same across instances
         prov_key = provider.domain if provider.is_streaming_provider else provider.instance_id

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -69,6 +69,7 @@ from music_assistant.constants import (
     DB_TABLE_TRACK_ARTISTS,
     DB_TABLE_TRACKS,
     DEFAULT_GENRE_MAPPING,
+    LOUDNESS_MEASUREMENT_MIN_LUFS,
     PROVIDERS_WITH_SHAREABLE_URLS,
 )
 from music_assistant.controllers.tasks.context import update_current_task_progress_text
@@ -109,7 +110,7 @@ CONF_RESET_DB = "reset_db"
 DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
-DB_SCHEMA_VERSION: Final[int] = 37
+DB_SCHEMA_VERSION: Final[int] = 38
 
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10
 DATABASE_CLEANUP_TASK_ID: Final[str] = "music_database_cleanup"
@@ -1102,7 +1103,7 @@ class MusicController(CoreController):
         """Store (EBU-R128) Integrated Loudness Measurement for a mediaitem in db."""
         if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
             return
-        if loudness in (None, inf, -inf) or loudness <= -50:
+        if loudness in (None, inf, -inf) or loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
             # skip invalid or unreliable values (ebur128 reports -70 LUFS on near-silence)
             return
         # prefer domain for streaming providers as the catalog is the same across instances
@@ -2687,6 +2688,20 @@ class MusicController(CoreController):
             # drop legacy smart_fades_analysis table — analysis is now handled by
             # audio analysis providers and stored in the audio_analysis table.
             await self._database.execute("DROP TABLE IF EXISTS smart_fades_analysis")
+
+        if prev_version <= 37:
+            # purge unreliable loudness measurements persisted by earlier versions
+            # (ebur128 reports ~-70 LUFS on near-silence / early-cancelled streams,
+            # which caused huge gain corrections on subsequent plays)
+            await self._database.execute(
+                f"DELETE FROM {DB_TABLE_LOUDNESS_MEASUREMENTS} "
+                f"WHERE loudness <= {LOUDNESS_MEASUREMENT_MIN_LUFS}"
+            )
+            await self._database.execute(
+                f"UPDATE {DB_TABLE_LOUDNESS_MEASUREMENTS} "
+                f"SET loudness_album = NULL "
+                f"WHERE loudness_album <= {LOUDNESS_MEASUREMENT_MIN_LUFS}"
+            )
 
         # save changes
         await self._database.commit()

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1102,8 +1102,8 @@ class MusicController(CoreController):
         """Store (EBU-R128) Integrated Loudness Measurement for a mediaitem in db."""
         if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
             return
-        if loudness in (None, inf, -inf):
-            # skip invalid values
+        if loudness in (None, inf, -inf) or loudness <= -50:
+            # skip invalid or unreliable values (ebur128 reports -70 LUFS on near-silence)
             return
         # prefer domain for streaming providers as the catalog is the same across instances
         prov_key = provider.domain if provider.is_streaming_provider else provider.instance_id

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1114,7 +1114,10 @@ class MusicController(CoreController):
             "provider": prov_key,
             "loudness": loudness,
         }
-        if album_loudness not in (None, inf, -inf):
+        if (
+            album_loudness not in (None, inf, -inf)
+            and album_loudness > LOUDNESS_MEASUREMENT_MIN_LUFS
+        ):
             values["loudness_album"] = album_loudness
         await self.database.insert_or_replace(DB_TABLE_LOUDNESS_MEASUREMENTS, values)
 

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -58,6 +58,7 @@ from music_assistant.constants import (
     CONF_VOLUME_NORMALIZATION_FIXED_GAIN_TRACKS,
     CONF_VOLUME_NORMALIZATION_TARGET,
     INTERNAL_PCM_FORMAT,
+    LOUDNESS_MEASUREMENT_MIN_LUFS,
     MASS_LOGGER_NAME,
     VERBOSE_LOG_LEVEL,
 )
@@ -866,7 +867,8 @@ class StreamsAudio:
         self,
         audio_buffer: AudioBuffer,
         streamdetails: StreamDetails,
-        max_duration_seconds: int = 120,
+        max_duration_seconds: int = 600,
+        min_duration_seconds: int = 10,
     ) -> None:
         """
         Attach a loudness measurement job to an AudioBuffer.
@@ -878,6 +880,7 @@ class StreamsAudio:
         :param audio_buffer: The AudioBuffer to observe.
         :param streamdetails: Stream details for the track being buffered.
         :param max_duration_seconds: Maximum seconds of audio to analyze.
+        :param min_duration_seconds: Minimum seconds of audio required to persist the result.
         """
         item_id = streamdetails.item_id
         provider = streamdetails.provider
@@ -923,12 +926,13 @@ class StreamsAudio:
                 ) as ffmpeg_proc:
                     await ffmpeg_proc.wait()
 
-                    if chunks_received < 5:
+                    if chunks_received < min_duration_seconds:
                         self.logger.debug(
                             "Loudness analysis for %s skipped: "
-                            "insufficient audio data (%s chunks received)",
+                            "insufficient audio data (%s/%s seconds analyzed)",
                             streamdetails.uri,
                             chunks_received,
+                            min_duration_seconds,
                         )
                         return
 
@@ -947,12 +951,13 @@ class StreamsAudio:
                         )
                         return
 
-                    if loudness <= -50:
+                    if loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
                         self.logger.debug(
                             "Loudness measurement for %s discarded: "
-                            "%s LUFS is below the reliability threshold",
+                            "%s LUFS is below the reliability threshold (%s LUFS)",
                             streamdetails.uri,
                             loudness,
+                            LOUDNESS_MEASUREMENT_MIN_LUFS,
                         )
                         return
 

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -922,6 +922,16 @@ class StreamsAudio:
                     loglevel="info",
                 ) as ffmpeg_proc:
                     await ffmpeg_proc.wait()
+
+                    if chunks_received < 5:
+                        self.logger.debug(
+                            "Loudness analysis for %s skipped: "
+                            "insufficient audio data (%s chunks received)",
+                            streamdetails.uri,
+                            chunks_received,
+                        )
+                        return
+
                     log_lines_str = "\n".join(ffmpeg_proc.log_history)
                     try:
                         loudness_str = (
@@ -934,6 +944,15 @@ class StreamsAudio:
                         self.logger.debug(
                             "Could not determine loudness of %s from buffer analysis",
                             streamdetails.uri,
+                        )
+                        return
+
+                    if loudness <= -50:
+                        self.logger.debug(
+                            "Loudness measurement for %s discarded: "
+                            "%s LUFS is below the reliability threshold",
+                            streamdetails.uri,
+                            loudness,
                         )
                         return
 


### PR DESCRIPTION
## Problem

When track playback fails very early (e.g. a transient network error), the loudness analyzer only feeds a tiny amount of audio into ffmpeg's `ebur128` filter, which then reports its floor value (~-70 LUFS). That bogus value is persisted in the `loudness_measurements` table, and on subsequent plays a massive ~+53 dB gain correction is applied (target -17 LUFS − stored -70 LUFS), causing severe clipping. Removing and re-adding the track does not clear the stored value.

Reported in music-assistant/support#5291.

## Changes

- New `LOUDNESS_MEASUREMENT_MIN_LUFS` constant (-50 LUFS); measurements at or below it are rejected by both the analyzer and `MusicController.set_loudness`.
- Require at least 10s of audio before persisting a measurement (ebur128 needs enough windows for a stable integrated value).
- Raise the analyzer's max duration to 10 minutes so radio streams converge to a stable reading (tracks still stop at EOF).
- Add DB migration (schema v37) that purges unreliable loudness rows left behind by earlier versions so existing installs self-heal on upgrade.

When a valid measurement can't be obtained, the existing fallback (dynamic normalization / fixed gain) kicks in automatically, so playback is unaffected.