### PR TITLE
Subsonic: always request raw source file and let MA handle seeking

### DIFF
--- a/music_assistant/providers/opensubsonic/__init__.py
+++ b/music_assistant/providers/opensubsonic/__init__.py
@@ -14,7 +14,6 @@ from .sonic_provider import (
     CONF_ENABLE_LEGACY_AUTH,
     CONF_ENABLE_PODCASTS,
     CONF_NEW_ALBUMS,
-    CONF_OVERRIDE_OFFSET,
     CONF_PAGE_SIZE,
     CONF_PLAYED_ALBUMS,
     CONF_RECO_FAVES,
@@ -116,15 +115,6 @@ async def get_config_entries(
             label="Enable Legacy Auth",
             required=True,
             description='Enable OpenSubsonic "legacy" auth support',
-            default_value=False,
-        ),
-        ConfigEntry(
-            key=CONF_OVERRIDE_OFFSET,
-            type=ConfigEntryType.BOOLEAN,
-            label="Force Player Provider Seek",
-            required=True,
-            description="Some Subsonic implementations advertise that they support seeking when "
-            "they do not always. If seeking does not work for you, enable this.",
             default_value=False,
         ),
         ConfigEntry(

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -77,7 +77,6 @@ if TYPE_CHECKING:
 CONF_BASE_URL = "baseURL"
 CONF_ENABLE_PODCASTS = "enable_podcasts"
 CONF_ENABLE_LEGACY_AUTH = "enable_legacy_auth"
-CONF_OVERRIDE_OFFSET = "override_transcode_offest"
 CONF_RECO_FAVES = "recommend_favorites"
 CONF_NEW_ALBUMS = "recommend_new"
 CONF_PLAYED_ALBUMS = "recommend_played"
@@ -96,8 +95,6 @@ class OpenSonicProvider(MusicProvider):
 
     conn: SonicConnection
     _enable_podcasts: bool = True
-    _seek_support: bool = False
-    _ignore_offset: bool = False
     _show_faves: bool = True
     _show_new: bool = True
     _show_played: bool = True
@@ -131,16 +128,13 @@ class OpenSonicProvider(MusicProvider):
             )
             raise LoginFailed(msg) from e
         self._enable_podcasts = bool(self.config.get_value(CONF_ENABLE_PODCASTS))
-        self._ignore_offset = bool(self.config.get_value(CONF_OVERRIDE_OFFSET))
         try:
             extensions: list[OpenSubsonicExtension] = await self.conn.get_open_subsonic_extensions()
             for entry in extensions:
-                if entry.name == "transcodeOffset" and not self._ignore_offset:
-                    self._seek_support = True
                 if entry.name == "songLyrics":
                     self._id_lyrics = True
         except OSError:
-            self.logger.info("Server does not support transcodeOffset, seeking in player provider")
+            self.logger.debug("Server does not advertise OpenSubsonic extensions")
         self._show_faves = bool(self.config.get_value(CONF_RECO_FAVES))
         self._show_new = bool(self.config.get_value(CONF_NEW_ALBUMS))
         self._show_played = bool(self.config.get_value(CONF_PLAYED_ALBUMS))
@@ -677,7 +671,7 @@ class OpenSonicProvider(MusicProvider):
             item_id=item.id,
             provider=self.instance_id,
             allow_seek=True,
-            can_seek=self._seek_support,
+            can_seek=False,
             media_type=media_type,
             audio_format=AudioFormat(
                 content_type=ContentType.try_parse(mime_type),
@@ -776,16 +770,13 @@ class OpenSonicProvider(MusicProvider):
         self, streamdetails: StreamDetails, seek_position: int = 0
     ) -> AsyncGenerator[bytes, None]:
         """Provide a generator for the stream data."""
-        # ignore seek position if the server does not support it
-        # in that case we let the core handle seeking
-        if not self._seek_support:
-            seek_position = 0
-
+        # Always request the raw (untranscoded) source file and let MA's core stream
+        # pipeline handle decoding, seeking and any optional re-encoding. Server-side
+        # transcoding with timeOffset is unreliable across OpenSubsonic implementations
+        # (e.g. Navidrome ignores timeOffset for direct-passthrough codecs like opus).
         self.logger.debug("Streaming %s", streamdetails.item_id)
         try:
-            resp = await self.conn.stream(
-                streamdetails.item_id, time_offset=seek_position, estimate_length=True
-            )
+            resp = await self.conn.stream(streamdetails.item_id, tformat="raw")
         except DataNotFoundError as err:
             msg = f"Item '{streamdetails.item_id}' not found"
             raise MediaNotFoundError(msg) from err

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
 from asyncio import TaskGroup
 from datetime import datetime
+from hashlib import md5
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+from urllib.parse import urlencode
 
 from libopensonic import AsyncConnection as SonicConnection
 from libopensonic.errors import (
@@ -621,6 +624,28 @@ class OpenSonicProvider(MusicProvider):
             msg = f"Failed to remove songs from {prov_playlist_id}, check your permissions."
             raise ProviderPermissionDenied(msg) from ex
 
+    def _build_stream_url(self, item_id: str) -> str:
+        """Build a signed HTTP URL for the raw (untranscoded) stream endpoint."""
+        conn = self.conn
+        qdict: dict[str, str] = {
+            "f": "json",
+            "v": conn.api_version,
+            "c": conn.app_name,
+            "id": item_id,
+            "format": "raw",
+        }
+        if conn.api_key:
+            qdict["apiKey"] = conn.api_key
+        else:
+            qdict["u"] = conn.username
+            if conn.legacy_auth:
+                qdict["p"] = "enc:" + "".join(f"{ord(c):02X}" for c in conn.password)
+            else:
+                salt = md5(os.urandom(100)).hexdigest()[:16]
+                qdict["s"] = salt
+                qdict["t"] = md5((conn.password + salt).encode("utf-8")).hexdigest()
+        return f"{conn.base_url}:{conn.port}/{conn.server_path}/stream.view?{urlencode(qdict)}"
+
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Get the details needed to process a specified track."""
         item: SonicItem | SonicEpisode
@@ -631,19 +656,15 @@ class OpenSonicProvider(MusicProvider):
                 msg = f"Item {item_id} not found"
                 raise MediaNotFoundError(msg) from e
 
-            mime_type = item.transcoded_content_type or item.content_type
-
             self.logger.debug(
                 "Fetching stream details for id %s '%s' with format '%s'",
                 item.id,
                 item.title,
-                mime_type,
+                item.content_type,
             )
 
         elif media_type == MediaType.PODCAST_EPISODE:
             item = await self._get_podcast_episode(item_id)
-
-            mime_type = item.transcoded_content_type or item.content_type
 
             self.logger.debug(
                 "Fetching stream details for podcast episode '%s' with format '%s'",
@@ -654,32 +675,29 @@ class OpenSonicProvider(MusicProvider):
             msg = f"Unsupported media type encountered '{media_type}'"
             raise UnsupportedFeaturedException(msg)
 
-        if mime_type and mime_type.endswith("mp4"):
+        if item.content_type and item.content_type.endswith("mp4"):
             self.logger.warning(
                 "Due to the streaming method used by the subsonic API, M4A files "
                 "may fail. See provider documentation for more information."
             )
 
-        # We believe that reporting the container type here is causing playback problems and ffmpeg
-        # should be capable of guessing the correct container type for any media supported by
-        # OpenSubsonic servers. Better to let ffmpeg figure things out than tell it something
-        # confusing. We still go through the effort of figuring out what the server thinks the
-        # container is to warn about M4A files.
-        mime_type = "?"
-
+        # Let ffmpeg figure out the container type from the raw stream — it's better at
+        # this than trusting the server's reported MIME type, which has historically
+        # caused playback problems.
         return StreamDetails(
             item_id=item.id,
             provider=self.instance_id,
             allow_seek=True,
-            can_seek=False,
+            can_seek=True,
             media_type=media_type,
             audio_format=AudioFormat(
-                content_type=ContentType.try_parse(mime_type),
+                content_type=ContentType.UNKNOWN,
                 sample_rate=item.sampling_rate or 44100,
                 bit_depth=item.bit_depth or 16,
                 channels=item.channel_count or 2,
             ),
-            stream_type=StreamType.CUSTOM,
+            stream_type=StreamType.HTTP,
+            path=self._build_stream_url(item.id),
             duration=item.duration or 0,
         )
 
@@ -765,27 +783,6 @@ class OpenSonicProvider(MusicProvider):
                 )
         # If we get here, there is no bookmark
         return (False, 0, None)
-
-    async def get_audio_stream(
-        self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
-        """Provide a generator for the stream data."""
-        # Always request the raw (untranscoded) source file and let MA's core stream
-        # pipeline handle decoding, seeking and any optional re-encoding. Server-side
-        # transcoding with timeOffset is unreliable across OpenSubsonic implementations
-        # (e.g. Navidrome ignores timeOffset for direct-passthrough codecs like opus).
-        self.logger.debug("Streaming %s", streamdetails.item_id)
-        try:
-            resp = await self.conn.stream(streamdetails.item_id, tformat="raw")
-        except DataNotFoundError as err:
-            msg = f"Item '{streamdetails.item_id}' not found"
-            raise MediaNotFoundError(msg) from err
-        self.logger.debug("starting stream of item '%s'", streamdetails.item_id)
-        async with resp:
-            async for chunk in resp.content.iter_chunked(40960):
-                yield bytes(chunk)
-
-        self.logger.debug("Done streaming %s", streamdetails.item_id)
 
     async def _get_podcast_channel_async(self, chan_id: str) -> PodcastChannel | None:
         if cache := await self.mass.cache.get(


### PR DESCRIPTION
## Problem

Server-side seeking via the OpenSubsonic `transcodeOffset` extension is unreliable across implementations. Navidrome in particular ignores `timeOffset` for direct-passthrough codecs like **opus**, which causes playback to restart from the beginning when the user seeks (reported in 5210, earlier in 3464).

Additionally, any server-side transcoding was being thrown away and re-decoded by ffmpeg on MA's side — wasteful and lossy for no benefit.

## Changes

- Always pass `format=raw` to the Subsonic stream endpoint so MA receives the original source file
- Set `can_seek=False` on stream details so MA's core pipeline handles seeking for all codecs
- Drop the `transcodeOffset` extension probe and the `_seek_support` flag
- Remove the now-obsolete "Force Player Provider Seek" config option

Fixes  support issues 5210, 3464.