### PR TITLE
Bump aiohttp to 3.13.5 and ibroadcastaio to 0.6.0

### DIFF
--- a/music_assistant/providers/ibroadcast/manifest.json
+++ b/music_assistant/providers/ibroadcast/manifest.json
@@ -6,7 +6,7 @@
   "description": "Stream your personal iBroadcast music collection from anywhere.",
   "codeowners": ["@robsonke"],
   "credits": ["[ibroadcastaio](https://github.com/robsonke/ibroadcastaio)"],
-  "requirements": ["ibroadcastaio==0.5.0"],
+  "requirements": ["ibroadcastaio>=0.5.0"],
   "documentation": "https://music-assistant.io/music-providers/ibroadcast/",
   "multi_instance": true
 }

--- a/music_assistant/providers/ibroadcast/manifest.json
+++ b/music_assistant/providers/ibroadcast/manifest.json
@@ -6,7 +6,7 @@
   "description": "Stream your personal iBroadcast music collection from anywhere.",
   "codeowners": ["@robsonke"],
   "credits": ["[ibroadcastaio](https://github.com/robsonke/ibroadcastaio)"],
-  "requirements": ["ibroadcastaio>=0.5.0"],
+  "requirements": ["ibroadcastaio==0.6.0"],
   "documentation": "https://music-assistant.io/music-providers/ibroadcast/",
   "multi_instance": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "pycares==4.11.0",
   "aiohttp_asyncmdnsresolver==0.1.1",
   "Brotli>=1.0.9",
-  "aiohttp==3.13.4",
+  "aiohttp==3.13.5",
   "aiohttp-fast-zlib==0.3.0",
   "aiohttp-socks==0.11.0",
   "aiofiles==24.1.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,7 +6,7 @@ Brotli>=1.0.9
 aioaudiobookshelf==0.1.20
 aiodns>=3.2.0
 aiofiles==24.1.0
-aiohttp==3.13.4
+aiohttp==3.13.5
 aiohttp_asyncmdnsresolver==0.1.1
 aiohttp-fast-zlib==0.3.0
 aiohttp-socks==0.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -38,7 +38,7 @@ duration-parser==1.0.1
 getmac==0.9.5
 gql[all]==4.0.0
 hass-client==1.2.3
-ibroadcastaio==0.5.0
+ibroadcastaio>=0.5.0
 ifaddr==0.2.0
 liblistenbrainz==0.7.0
 librosa==0.11.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -38,7 +38,7 @@ duration-parser==1.0.1
 getmac==0.9.5
 gql[all]==4.0.0
 hass-client==1.2.3
-ibroadcastaio>=0.5.0
+ibroadcastaio==0.6.0
 ifaddr==0.2.0
 liblistenbrainz==0.7.0
 librosa==0.11.0


### PR DESCRIPTION
Closes https://github.com/music-assistant/support/issues/5249

@marcelveldt @MarvinSchenkel it seems there is an issue with current version of aiohttp that was fixed in https://github.com/aio-libs/aiohttp/releases/tag/v3.13.5 that is causing the authentication issue some users are experiencing.

Note: it was required to bump ibroadcastaio since it was pinning to aiohttp 3.13.4.