### PR TITLE
Fix syncgroup state derivation and tighten lifecycle handling

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2703,23 +2703,12 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if self.mass.closing:
             return
 
-        async def _update_all_players() -> None:
-            if self.mass.closing:
-                return
-
-            for player in self.all_players(
-                return_unavailable=True,
-                return_disabled=False,
-                return_protocol_players=True,
-            ):
-                # Use call_soon to schedule updates without blocking
-                # This spreads the updates across event loop iterations
-                self.mass.loop.call_soon(player.update_state)
-
-        # Use mass.call_later with task_id for automatic debouncing
-        # Each call resets the timer, so rapid registrations only trigger one update
-        task_id = "update_all_players_on_registration"
-        self.mass.call_later(delay, _update_all_players, task_id=task_id)
+        for player in self.all_players(
+            return_unavailable=True,
+            return_disabled=False,
+            return_protocol_players=True,
+        ):
+            self.trigger_player_update(player.player_id, debounce_delay=delay)
 
     async def _auto_ungroup_if_synced(self, player: Player, log_context: str) -> None:
         """

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -84,6 +84,7 @@ from music_assistant.constants import (
     CONF_PRE_ANNOUNCE_CHIME_URL,
     CONF_PROTOCOL_PARENT_ID,
     CONF_REPORTED_MAC,
+    VERBOSE_LOG_LEVEL,
 )
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
@@ -650,13 +651,16 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         raise UnsupportedFeaturedException(msg)
 
     @api_command("players/cmd/power")
-    @handle_player_command
+    @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def cmd_power(self, player_id: str, powered: bool) -> None:
         """Send POWER command to given player.
 
         :param player_id: player_id of the player to handle the command.
         :param powered: bool if player should be powered on or off.
         """
+        # Power is serialized with PLAYBACK because powering on a sync/group player
+        # forms the group (and powering off dissolves it) - this must not race with
+        # play_media / cmd_resume / cmd_set_members on the same player.
         await self._handle_cmd_power(player_id, powered)
 
     @api_command("players/cmd/volume_set")
@@ -1149,7 +1153,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             # automatically ungroup it first and wait for state to propagate
             await self._auto_ungroup_if_synced(parent_player, "setting members")
 
-        # Serialize with playback commands to prevent protocol switches from
+        # Use lock for playback commands to prevent protocol switches from
         # racing with concurrent play_media / play_index / resume calls.
         async with self.get_player_lock(parent_player.player_id, PlayerLockPurpose.PLAYBACK):
             await self._handle_set_members(parent_player, player_ids_to_add, player_ids_to_remove)
@@ -1583,7 +1587,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         for key in (conf_key, dsp_conf_key):
             self.mass.config.remove(key)
 
-    def signal_player_state_update(  # noqa: PLR0915
+    def signal_player_state_update(
         self,
         player: Player,
         changed_values: dict[str, tuple[Any, Any]],
@@ -1604,10 +1608,6 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if not player.state.enabled and ATTR_ENABLED not in changed_values:
             return
 
-        if len(changed_values) == 0 and not force_update:
-            # nothing changed
-            return
-
         # to prevent spamming the eventbus on small changes (e.g. elapsed time),
         # we check if there are only changes in the elapsed time and send
         # a lightweight event.
@@ -1615,6 +1615,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             "current_media.elapsed_time",
             "elapsed_time_last_updated",
         }
+        if len(clean_changed_keys) == 0 and not force_update:
+            # nothing changed
+            return
+
         if clean_changed_keys == {ATTR_ELAPSED_TIME} and not force_update:
             now = time.time()
             prev_elapsed, new_elapsed = changed_values[ATTR_ELAPSED_TIME]
@@ -1622,10 +1626,22 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             prev_corrected = (prev_elapsed or 0) + (now - (prev_updated or now))
             new_corrected = (new_elapsed or 0) + (now - (new_updated or now))
             if abs(prev_corrected - new_corrected) > 1.0:
+                # Significant elapsed_time drift / seek / jump - notify the queue and
+                # fan out to related players so derived elapsed_time on parents/groups
+                # stays in sync. Skipping the forward on small ticks avoids a per-second
+                # cascade through group → children → group.
                 self.mass.player_queues.on_player_elapsed_time_corrected(player)
-                if player.protocol_parent_id:
-                    self.trigger_player_update(player.protocol_parent_id)
+                if not skip_forward or force_update:
+                    self._forward_state_update(player, changed_values)
             return
+
+        if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+            self.logger.log(
+                VERBOSE_LOG_LEVEL,
+                "Player state updated for %s: changed fields: %s",
+                player.name,
+                ", ".join(changed_values.keys()),
+            )
 
         # signal update to the playerqueue
         if player.state.type != PlayerType.PROTOCOL:
@@ -1691,9 +1707,19 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 EventType.PLAYER_CONFIG_UPDATED, object_id=player_id, data=player.config
             )
 
-        if skip_forward and not force_update:
-            return
+        if not skip_forward or force_update:
+            self._forward_state_update(player, changed_values)
 
+        # trigger update of all players in a provider if group related fields changed
+        # this ensures that calculated fields like can_group_with are updated on all players
+        if any(key in changed_values for key in ("group_members", "synced_to", "available")):
+            for prov_player in player.provider.players:
+                self.trigger_player_update(prov_player.player_id, debounce_delay=2)
+
+    def _forward_state_update(
+        self, player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Forward a player state update to related players (groups, sync parent, protocols)."""
         # update/signal group player(s) child's when group updates
         if player.type == PlayerType.GROUP:
             for child_player in self.iter_group_members(player, exclude_self=True):
@@ -1721,12 +1747,6 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             for linked in player.linked_output_protocols:
                 if protocol_player := self.mass.players.get_player(linked.output_protocol_id):
                     protocol_player.on_protocol_parent_updated(player, changed_values)
-
-        # trigger update of all players in a provider if group related fields changed
-        # this ensures that calculated fields like can_group_with are updated on all players
-        if any(key in changed_values for key in ("group_members", "synced_to", "available")):
-            for prov_player in player.provider.players:
-                self.trigger_player_update(prov_player.player_id, debounce_delay=2)
 
     async def register_player_control(self, player_control: PlayerControl) -> None:
         """Register a new PlayerControl on the controller."""
@@ -3228,8 +3248,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 target_player.state.group_members,
             )
             player.set_active_output_protocol(output_protocol.output_protocol_id)
-        else:
-            # Native playback
+        elif player.type != PlayerType.GROUP:
+            # Native playback - group players don't have output protocols of their own
+            # (they delegate to a sync leader / member which manages its own protocol)
             self.logger.debug(
                 "Starting playback on %s via native, group_members=%s",
                 player.state.name,

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1686,36 +1686,38 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             return
 
         # update/signal group player(s) child's when group updates
-        for child_player in self.iter_group_members(player, exclude_self=True):
-            self.trigger_player_update(child_player.player_id)
+        if player.type == PlayerType.GROUP:
+            for child_player in self.iter_group_members(player, exclude_self=True):
+                child_player.on_group_updated(player, changed_values)
         # update/signal group player(s) when child updates
-        for group_player in self._get_player_groups(player, powered_only=False):
-            self.trigger_player_update(group_player.player_id)
-        # update/signal manually synced to player when child updates
-        if (synced_to := player.state.synced_to) and (
-            synced_to_player := self.get_player(synced_to)
+        else:
+            for group_player in self._get_player_groups(player, powered_only=False):
+                group_player.on_group_member_updated(player, changed_values)
+
+        # update/signal manually sync-parent player when child updates
+        if (_sync_parent_id := player.state.synced_to) and (
+            _sync_parent := self.get_player(_sync_parent_id)
         ):
-            self.trigger_player_update(synced_to_player.player_id)
-        # update/signal active groups when a group member updates
-        if (active_group := player.state.active_group) and (
-            active_group_player := self.get_player(active_group)
-        ):
-            self.trigger_player_update(active_group_player.player_id)
+            self.trigger_player_update(_sync_parent.player_id)
         # If this is a protocol player, forward the state update to the parent player
-        if player.protocol_parent_id and (
-            parent_player := self.mass.players.get_player(player.protocol_parent_id)
+        if (
+            player.type == PlayerType.PROTOCOL
+            and player.protocol_parent_id
+            and (_protocol_parent := self.mass.players.get_player(player.protocol_parent_id))
         ):
-            self.trigger_player_update(parent_player.player_id)
+            _protocol_parent.on_protocol_player_updated(player, changed_values)
         # If this is a parent player with linked protocols, forward state updates
         # to linked protocol players so their state reflects parent dependencies
         if player.state.type != PlayerType.PROTOCOL and player.linked_output_protocols:
             for linked in player.linked_output_protocols:
                 if protocol_player := self.mass.players.get_player(linked.output_protocol_id):
-                    self.mass.players.trigger_player_update(protocol_player.player_id)
+                    protocol_player.on_protocol_parent_updated(player, changed_values)
+
         # trigger update of all players in a provider if group related fields changed
+        # this ensures that calculated fields like can_group_with are updated on all players
         if any(key in changed_values for key in ("group_members", "synced_to", "available")):
             for prov_player in player.provider.players:
-                self.trigger_player_update(prov_player.player_id)
+                self.trigger_player_update(prov_player.player_id, debounce_delay=2)
 
     async def register_player_control(self, player_control: PlayerControl) -> None:
         """Register a new PlayerControl on the controller."""

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -108,7 +108,7 @@ from .helpers import AnnounceData, handle_player_command, wait_for_power_on
 from .protocol_linking import ProtocolLinkingMixin
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine, Iterator
+    from collections.abc import Callable, Iterator
 
     from music_assistant_models.config_entries import (
         ConfigEntry,
@@ -116,12 +116,14 @@ if TYPE_CHECKING:
         CoreConfig,
         PlayerConfig,
     )
-    from music_assistant_models.event import MassEvent
     from music_assistant_models.player_queue import PlayerQueue
 
     from music_assistant import MusicAssistant
 
 CACHE_CATEGORY_PLAYER_POWER = 1
+
+# Sentinel used to detect omitted optional arguments where ``None`` is a valid value.
+_SENTINEL: Any = object()
 
 
 class PlayerController(ProtocolLinkingMixin, CoreController):
@@ -151,6 +153,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         self._pending_protocol_evaluations: dict[str, asyncio.TimerHandle] = {}
         # Serialize delayed evaluations to prevent race conditions
         self._delayed_evaluation_lock = asyncio.Lock()
+        # Subscribers for player state updates (called with player + changed_values)
+        self._state_update_subscribers: list[
+            Callable[[Player, dict[str, tuple[Any, Any]]], None]
+        ] = []
 
     @contextlib.asynccontextmanager
     async def get_player_lock(
@@ -1577,7 +1583,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         for key in (conf_key, dsp_conf_key):
             self.mass.config.remove(key)
 
-    def signal_player_state_update(
+    def signal_player_state_update(  # noqa: PLR0915
         self,
         player: Player,
         changed_values: dict[str, tuple[Any, Any]],
@@ -1657,6 +1663,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         ) or (ATTR_ENABLED in changed_values and changed_values[ATTR_ENABLED][1] is False)
         if became_inactive and (player.state.active_group or player.state.synced_to):
             self.mass.create_task(self._cleanup_player_memberships(player.player_id))
+
+        # dispatch to internal state update subscribers (with changed_values)
+        self._dispatch_state_update_subscribers(player, changed_values)
 
         # signal player update on the eventbus
         if player.state.type != PlayerType.PROTOCOL:
@@ -1953,87 +1962,132 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                     continue
                 yield child_player
 
-    async def wait_for_state(
+    def subscribe_player_state_update(
+        self,
+        callback: Callable[[Player, dict[str, tuple[Any, Any]]], None],
+    ) -> Callable[[], None]:
+        """
+        Subscribe to player state update notifications.
+
+        The callback receives the Player and a dict of changed values
+        (mapping attribute name to a (previous, new) tuple).
+
+        :param callback: Function to invoke for each player state update.
+        :return: An unsubscribe function.
+        """
+        self._state_update_subscribers.append(callback)
+
+        def _unsub() -> None:
+            with suppress(ValueError):
+                self._state_update_subscribers.remove(callback)
+
+        return _unsub
+
+    def _dispatch_state_update_subscribers(
+        self, player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Notify all internal subscribers of a player state update."""
+        for subscriber in list(self._state_update_subscribers):
+            try:
+                subscriber(player, changed_values)
+            except Exception:
+                self.logger.exception(
+                    "Error in player state update subscriber for %s", player.player_id
+                )
+
+    async def _wait_for_playback_state(
         self,
         player: Player,
         wanted_state: PlaybackState,
-        timeout: float = 60.0,
+        timeout: float,
         minimal_time: float = 0,
     ) -> None:
-        """Wait for the given player to reach the given state."""
+        """Wait for a player to reach a playback state, with optional minimum wait time."""
         start_timestamp = time.time()
-        self.logger.debug(
-            "Waiting for player %s to reach state %s", player.state.name, wanted_state
-        )
-        try:
-            async with asyncio.timeout(timeout):
-                while player.state.playback_state != wanted_state:
-                    await asyncio.sleep(0.1)
+        async with self.wait_for_player_update(
+            player.player_id,
+            attribute_name="playback_state",
+            attribute_value=wanted_state,
+            timeout=timeout,
+        ):
+            pass
+        elapsed = time.time() - start_timestamp
+        if elapsed < minimal_time:
+            await asyncio.sleep(minimal_time - elapsed)
 
-        except TimeoutError:
-            self.logger.debug(
-                "Player %s did not reach state %s within the timeout of %s seconds",
-                player.state.name,
-                wanted_state,
-                timeout,
-            )
-        elapsed_time = round(time.time() - start_timestamp, 2)
-        if elapsed_time < minimal_time:
-            self.logger.debug(
-                "Player %s reached state %s too soon (%s vs %s seconds) - add fallback sleep...",
-                player.state.name,
-                wanted_state,
-                elapsed_time,
-                minimal_time,
-            )
-            await asyncio.sleep(minimal_time - elapsed_time)
-        else:
-            self.logger.debug(
-                "Player %s reached state %s within %s seconds",
-                player.state.name,
-                wanted_state,
-                elapsed_time,
-            )
-
+    @contextlib.asynccontextmanager
     async def wait_for_player_update(
         self,
         player_id: str,
+        attribute_name: str | None = None,
+        attribute_value: Any = _SENTINEL,
         timeout: float = 5.0,
-        action: Coroutine[Any, Any, Any] | None = None,
-    ) -> bool:
+    ) -> AsyncIterator[None]:
         """
-        Wait for a state update event on the given player.
+        Async context manager that waits for a player state update.
 
-        Subscribes to PLAYER_UPDATED events *before* executing the optional action,
-        so that state updates emitted synchronously during the action are not missed.
+        Subscribes to player state updates on entry, runs the body (typically
+        the action that triggers the expected update), then waits for a
+        matching update on exit. If ``attribute_name`` and ``attribute_value``
+        are both provided and the current value already matches at entry, the
+        wait is skipped.
+
+        Example::
+
+            async with mass.players.wait_for_player_update(
+                player_id, attribute_name="playback_state",
+                attribute_value=PlaybackState.IDLE, timeout=5,
+            ):
+                await mass.players._handle_cmd_stop(player_id)
 
         :param player_id: The player ID to wait for.
+        :param attribute_name: Optional state attribute to watch for changes
+            (e.g. ``"playback_state"``). If omitted, any state change satisfies
+            the wait.
+        :param attribute_value: Optional value the watched attribute must reach.
+            Only meaningful in combination with ``attribute_name``.
         :param timeout: Maximum time to wait in seconds.
-        :param action: Optional coroutine to execute while subscribed.
-        :return: True if a state update was received, False if timed out.
         """
         update_event = asyncio.Event()
 
-        def _on_event(_event: MassEvent) -> None:
-            update_event.set()
+        def _on_state_update(player: Player, changed_values: dict[str, tuple[Any, Any]]) -> None:
+            if player.player_id != player_id:
+                return
+            if attribute_name is None:
+                update_event.set()
+                return
+            if attribute_name not in changed_values:
+                return
+            if attribute_value is _SENTINEL:
+                update_event.set()
+                return
+            _prev, new_val = changed_values[attribute_name]
+            if new_val == attribute_value:
+                update_event.set()
 
-        unsub = self.mass.subscribe(
-            _on_event,
-            event_filter=EventType.PLAYER_UPDATED,
-            id_filter=player_id,
+        # short-circuit when the desired value is already the current state
+        already_satisfied = (
+            attribute_name is not None
+            and attribute_value is not _SENTINEL
+            and (player := self.get_player(player_id)) is not None
+            and getattr(player.state, attribute_name, _SENTINEL) == attribute_value
         )
+
+        unsub = self.subscribe_player_state_update(_on_state_update)
         try:
-            if action is not None:
-                await action
-            async with asyncio.timeout(timeout):
-                await update_event.wait()
-                return True
-        except TimeoutError:
-            self.logger.debug(
-                "Timed out waiting for state update on player %s, proceeding optimistically",
-                player_id,
-            )
-            return False
+            yield
+            if already_satisfied:
+                return
+            try:
+                async with asyncio.timeout(timeout):
+                    await update_event.wait()
+            except TimeoutError:
+                self.logger.debug(
+                    "Timed out waiting for player update on %s (attr=%s value=%s)",
+                    player_id,
+                    attribute_name,
+                    attribute_value,
+                )
         finally:
             unsub()
 
@@ -2228,7 +2282,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             )
             await self._handle_cmd_stop(player.player_id)
             # wait for the player to stop
-            await self.wait_for_state(player, PlaybackState.IDLE, 10, 0.4)
+            await self._wait_for_playback_state(player, PlaybackState.IDLE, 10, 0.4)
         # adjust volume if needed
         # in case of a (sync) group, we need to do this for all child players
         prev_volumes: dict[str, int] = {}
@@ -2278,7 +2332,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         )
         await self._handle_play_media(player.player_id, announcement)
         # wait for the player(s) to play
-        await self.wait_for_state(player, PlaybackState.PLAYING, 10, minimal_time=0.1)
+        await self._wait_for_playback_state(player, PlaybackState.PLAYING, 10, minimal_time=0.1)
         # wait for the player to stop playing
         if not announcement.duration:
             if not announcement.custom_data:
@@ -2291,7 +2345,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if announcement.duration is None:
             raise ValueError("Announcement duration could not be determined")
 
-        await self.wait_for_state(
+        await self._wait_for_playback_state(
             player,
             PlaybackState.IDLE,
             timeout=announcement.duration + 10,
@@ -2687,13 +2741,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         synced_to = player.state.synced_to or player.state.active_group
         if synced_to and (parent := self.get_player(synced_to)):
             try:
-                await self.wait_for_player_update(
-                    player.player_id,
-                    timeout=5,
-                    action=self._handle_set_members(
-                        parent, player_ids_to_remove=[player.player_id]
-                    ),
-                )
+                async with self.wait_for_player_update(player.player_id, timeout=5):
+                    await self._handle_set_members(parent, player_ids_to_remove=[player.player_id])
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -2996,9 +3045,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             and player_state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
         ):
             # wait for the stop command to process and prevent race conditions
-            await self.wait_for_player_update(
-                player_id, timeout=5, action=self._handle_cmd_stop(player_id)
-            )
+            async with self.wait_for_player_update(player_id, timeout=5):
+                await self._handle_cmd_stop(player_id)
 
         # power off all synced childs when player is a sync leader
         elif not powered and player_state.type == PlayerType.PLAYER and player_state.group_members:
@@ -3257,9 +3305,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if prev_source and source != prev_source:
             with suppress(PlayerCommandFailed, RuntimeError):
                 # just try to stop (regardless of state)
-                await self.wait_for_player_update(
-                    player_id, timeout=5, action=self._handle_cmd_stop(player_id)
-                )
+                async with self.wait_for_player_update(player_id, timeout=5):
+                    await self._handle_cmd_stop(player_id)
         # check if source is a pluginsource
         # in that case the source id is the instance_id of the plugin provider
         if plugin_prov := self.mass.get_provider(source):

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -664,6 +664,38 @@ class Player(ABC):
         # current media is updated (after applying group/sync membership logic).
         # for instance to update any display information on the physical player.
 
+    def on_protocol_player_updated(
+        self, protocol_player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Handle callback when one of the linked protocol players of the player is updated."""
+        # optional callback
+        # default implementation will simply trigger an update for the state of the player
+        self.mass.players.trigger_player_update(self.player_id)
+
+    def on_protocol_parent_updated(
+        self, protocol_parent: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Handle callback when the parent protocol player of the player is updated."""
+        # optional callback
+        # default implementation will simply trigger an update for the state of the player
+        self.mass.players.trigger_player_update(self.player_id)
+
+    def on_group_member_updated(
+        self, member_player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Handle callback when a group member of the group player is updated."""
+        # optional callback
+        # default implementation will simply trigger an update for the state of the player
+        self.mass.players.trigger_player_update(self.player_id)
+
+    def on_group_updated(
+        self, group_player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Handle callback when a group player is updated this player is a member of."""
+        # optional callback
+        # default implementation will simply trigger an update for the state of the player
+        self.mass.players.trigger_player_update(self.player_id)
+
     # DO NOT OVERWRITE BELOW !
     # These properties and methods are either managed by core logic or they
     # are used to perform a very specific function. Overwriting these may
@@ -1667,7 +1699,11 @@ class Player(ABC):
                 continue
             if group_player.player_id == self.player_id:
                 continue
-            if group_player.playback_state not in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+            if group_player.powered is False or (
+                group_player.powered is None and group_player.playback_state == PlaybackState.IDLE
+            ):
+                # a group is only considered active if it supports power and is powered on,
+                # or if it doesn't support power but is not idle
                 continue
             if self.player_id in group_player.state.group_members:
                 return group_player.player_id

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -984,74 +984,6 @@ class Player(ABC):
         """
         return self._check_feature_with_active_protocol(PlayerFeature.GAPLESS_PLAYBACK)
 
-    async def handoff_sync_leadership(
-        self,
-        new_leader: Player,
-        remaining_members: list[str] | None = None,
-    ) -> None:
-        """
-        Hand off sync leadership of the live session from this player to ``new_leader``.
-
-        Call on the current sync leader when it should step down and leave the
-        remaining group members playing uninterrupted on a new leader — for
-        example when the current leader is removed from a sync group while
-        playback is active and another member should take over.
-
-        The handoff is two atomic halves:
-          1. Remove this player from the live sync session on the player that
-             owns it (the active output protocol player if a non-native
-             protocol is in use, otherwise this native player itself). The
-             removal intentionally bypasses ``cmd_set_members`` on the
-             controller, which would otherwise interpret self-removal as
-             "dissolve the entire group".
-          2. Attach ``remaining_members`` to ``new_leader`` via the normal
-             controller path so protocol linking/grouping runs correctly on
-             the new leader.
-
-        Only safe to call when the provider of the current leader's active
-        session target has :attr:`PlayerProvider.supports_dynamic_leader_switching`
-        set to True; otherwise the entire sync session must be torn down and
-        re-formed with the new leader.
-
-        The ``new_leader`` must already be part of the live sync session (i.e.
-        its resolved protocol player must be a ``sync_client`` of the current
-        session). If it's a freshly-added player with no existing stream, this
-        method's ``cmd_set_members`` call will be a no-op at the protocol level
-        and the old session remains orphaned. The caller (typically
-        ``SyncGroupPlayer._dynamic_leader_switch``) should verify this
-        precondition before calling.
-
-        :param new_leader: The player that should take over as sync leader.
-            Must already be a sync_client of the current session.
-        :param remaining_members: Parent player ids (excluding ``new_leader``)
-            that should be grouped onto ``new_leader`` after the handoff.
-        """
-        # Resolve this (old) leader's active session target.
-        old_target: Player = self
-        if (
-            self.active_output_protocol
-            and self.active_output_protocol != "native"
-            and (protocol_player := self.mass.players.get_player(self.active_output_protocol))
-        ):
-            old_target = protocol_player
-        # Guard: this operation requires that the provider actually supports
-        # removing the leader without tearing down the session. Callers should
-        # check the capability first, but enforce it defensively here too.
-        if not old_target.provider.supports_dynamic_leader_switching:
-            raise NotImplementedError(
-                f"Provider {old_target.provider.domain} does not support dynamic leader "
-                "switching; the sync session must be torn down and re-formed instead."
-            )
-        # Step out of the live session (bypasses cmd_set_members self-dissolve).
-        await old_target.set_members(player_ids_to_remove=[old_target.player_id])
-        # Attach remaining members to the new leader via the normal controller
-        # path (handles protocol linking/grouping).
-        if remaining_members:
-            await self.mass.players.cmd_set_members(
-                new_leader.player_id,
-                player_ids_to_add=remaining_members,
-            )
-
     @property
     @final
     def state(self) -> PlayerState:
@@ -1570,11 +1502,8 @@ class Player(ABC):
         elapsed_time: float | None
         elapsed_time_last_updated: float | None
 
-        # If an output protocol is active (and not native), use the protocol player's state
-        # as the source of truth — including when the protocol player is IDLE. Falling
-        # through to the parent/group when the protocol is IDLE creates a circular
-        # dependency (group state derives from sync leader → sync leader → group), which
-        # strands the player in PLAYING forever when the protocol's stream actually ended.
+        # If an output protocol is active (and not native),
+        # use the protocol player's state as the source of truth
         if (
             self.__attr_active_output_protocol
             and self.__attr_active_output_protocol != "native"
@@ -1585,11 +1514,9 @@ class Player(ABC):
             playback_state = protocol_player.state.playback_state
             elapsed_time = protocol_player.state.elapsed_time
             elapsed_time_last_updated = protocol_player.state.elapsed_time_last_updated
-        # If we're synced or part of an active group, use the parent/group player's state
-        # for playback state and elapsed time.
-        # NOTE: Don't do this for the active group player itself,
-        # because the group player relies on the sync leader for state info.
-        elif (parent_id := self.__final_synced_to or self.__final_active_group) and (
+        # If we're synced to another player, mirror the leader's state so that
+        # synced clients report the same playback info as their leader.
+        elif (parent_id := self.__final_synced_to) and (
             parent_player := self.mass.players.get_player(parent_id)
         ):
             playback_state = parent_player.state.playback_state

--- a/music_assistant/models/player_provider.py
+++ b/music_assistant/models/player_provider.py
@@ -20,22 +20,6 @@ class PlayerProvider(Provider):
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
 
-    @property
-    def supports_dynamic_leader_switching(self) -> bool:
-        """
-        Return if players from this provider support dynamic leader switching.
-
-        If a sync group removes its current leader while playing, providers that
-        return True keep the remaining members playing uninterrupted (a new
-        leader is selected without tearing down the stream session). Providers
-        that return False require the full sync group to be dissolved and
-        re-formed with a new leader on leader removal.
-        """
-        # TODO: promote this to a ProviderFeature on music_assistant_models so
-        # providers can declare it via supported_features instead of overriding
-        # a property here.
-        return False
-
     def on_player_enabled(self, player_id: str) -> None:
         """Call (by config manager) when a player gets enabled."""
         # default implementation: trigger discovery - feel free to override

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -51,11 +51,6 @@ class AirPlayProvider(PlayerProvider):
         """Return the Sendspin bridge manager."""
         return self._bridge_manager
 
-    @property
-    def supports_dynamic_leader_switching(self) -> bool:
-        """Return True: AirPlay supports removing the leader without stream teardown."""
-        return True
-
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
         # Initialize Sendspin bridge manager for protocol linking

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -47,11 +47,6 @@ class SendspinProvider(PlayerProvider):
     _client_event_task_counts: dict[str, int]
     _unloading: bool
 
-    @property
-    def supports_dynamic_leader_switching(self) -> bool:
-        """Return True: Sendspin supports removing the leader without stream teardown."""
-        return True
-
     def __init__(
         self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
     ) -> None:

--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -81,11 +81,6 @@ class SnapCastProvider(PlayerProvider):
     _snapcast_ma_streams_lock: asyncio.Lock
 
     @property
-    def supports_dynamic_leader_switching(self) -> bool:
-        """Return True: Snapcast supports removing the leader without stream teardown."""
-        return True
-
-    @property
     def queue_control_available(self) -> bool:
         """Return whether queue-based control scripts are available.
 

--- a/music_assistant/providers/sync_group/README.md
+++ b/music_assistant/providers/sync_group/README.md
@@ -210,7 +210,7 @@ This mirrors how a typical AVR or stereo system behaves: turn it on, it's an act
 2. play_media(media)
    │
    ├─► Optimistically set _attr_current_media / _attr_active_source
-   ├─► await power(True)            # forms the group if not already
+   ├─► _form_syncgroup()            # idempotent - recovers if dissolved-but-powered
    └─► _handle_play_media(sync_leader, media)   # leader actually plays
    │
 3. Leader starts playback, synced members follow
@@ -260,7 +260,7 @@ When `SET_MEMBERS` is called on a dynamic group:
 
 1. Remove from the internal member list (static members cannot be removed)
 2. If removing the **sync leader** while playing:
-   - If the active protocol supports dynamic leader switching (e.g. AirPlay, Snapcast), perform a **seamless handoff**: pick a new leader from the live session, hand off via the protocol player's `handoff_sync_leadership`, remaining members keep playing
+   - If the active protocol supports dynamic leader switching (provider domain is in `PROVIDERS_WITH_DYNAMIC_LEADER_SWITCH` — currently AirPlay, Snapcast, Sendspin), perform a **seamless handoff** at the protocol level: pick a new leader from the live session, then call `set_members(player_ids_to_remove=[old_leader_protocol])` on the old session player and `set_members(player_ids_to_add=[remaining_protocol_ids])` on the new leader's protocol player. Remaining members keep playing.
    - If the chosen new leader is not part of the live session (e.g. a freshly-added player), or the protocol doesn't support handoff: fall back to **dissolve + re-form** (brief audio gap)
 3. If removing a non-leader member: forward to `cmd_set_members` on the leader
 

--- a/music_assistant/providers/sync_group/README.md
+++ b/music_assistant/providers/sync_group/README.md
@@ -73,19 +73,22 @@ The sync group doesn't directly play audio. Instead, it delegates to a **sync le
 
 ### Sync Leader Selection
 
-The sync leader is automatically selected when playback starts:
+The sync leader is selected when the group is powered on (which forms the group). Selection is also re-evaluated when the current leader is removed from the group or becomes unavailable.
 
-1. **Check current leader**: If a leader exists and is available, keep it
-2. **Prioritize static members**: For static groups, prefer members from the configured list
-3. **First available**: Select the first available member as leader
+1. **Keep current leader**: If a leader exists and is still available, keep it
+2. **Prefer protocol continuity**: When re-selecting after a leader change while playing, prefer a member that supports the currently active output protocol so the live session can continue without a teardown
+3. **Prioritize static members**: For static groups, prefer members from the configured list
+4. **First available**: Otherwise pick the first available member as leader
 
 ### Leader Responsibilities
 
-The sync leader:
+The sync leader is the **source of truth** for the group's playback state:
 - Receives the actual `play_media` command
 - Syncs all other group members to itself
-- Reports playback state (elapsed time, playback state) to the group
-- Contributes features (enqueue, gapless, volume) to the group
+- Reports playback state, elapsed time, current media, and active source to the group (via the group's `_update_attributes` reading the leader's raw values)
+- Contributes features (enqueue, gapless, volume, DSP) to the group
+
+> **State derivation note:** The leader's own `__final_playback_state` does **not** mirror its parent group — that would create a circular dependency (group derives from leader → leader derives from group → both stuck at last value). Members of an active group always report their own raw playback state; only manually-synced clients (`synced_to`) mirror their leader's state.
 
 ## Group Types
 
@@ -173,23 +176,44 @@ In this scenario, the Denon AVR has three output protocols available. Since the 
 
 For detailed information on protocol linking, output protocol selection, and how devices with multiple protocols are handled, see the [Player Controller README](../../controllers/players/README.md#multi-protocol-player-system).
 
-## Playback Flow
+## Group Lifecycle
+
+The group's lifecycle is driven by **power**:
+
+- `power(True)` **forms** the group: selects a sync leader and syncs all members to it
+- `power(False)` **dissolves** the group: ungroups all members from the leader and clears the sync leader
+- `stop()` only stops the leader — it does **not** dissolve the group; the group remains powered and ready to resume
+
+This mirrors how a typical AVR or stereo system behaves: turn it on, it's an active output; turn it off, it's gone.
+
+### Powering On
+
+```
+1. cmd_power(syncgroup, True)  (also called implicitly by play_media / play)
+   │
+2. _form_syncgroup() runs
+   │
+   ├─► Ensure static members are included in _attr_group_members
+   ├─► Select sync leader (if not already set)
+   ├─► Move sync leader to the front of the member list
+   ├─► If leader is currently playing something else, stop it (and wait for IDLE)
+   └─► cmd_set_members on the leader to sync the remaining members
+   │
+3. _attr_powered = True ; state event emitted
+```
 
 ### Starting Playback
 
 ```
 1. User starts playback on SyncGroupPlayer
    │
-2. _form_syncgroup() called
+2. play_media(media)
    │
-   ├─► Cancel any pending dissolve timer
-   ├─► Ensure static members are included
-   ├─► Select sync leader (if not already set)
-   └─► Sync all members to the leader
+   ├─► Optimistically set _attr_current_media / _attr_active_source
+   ├─► await power(True)            # forms the group if not already
+   └─► _handle_play_media(sync_leader, media)   # leader actually plays
    │
-3. play_media() forwarded to sync leader
-   │
-4. Leader starts playback, synced members follow
+3. Leader starts playback, synced members follow
 ```
 
 ### Stopping Playback
@@ -197,18 +221,28 @@ For detailed information on protocol linking, output protocol selection, and how
 ```
 1. User stops playback on SyncGroupPlayer
    │
-2. stop() forwarded to sync leader
-   │
-3. Schedule dissolve after 5 seconds
-   │
-4. _dissolve_syncgroup() called
-   │
-   ├─► Unsync all members from leader
-   ├─► Clear sync_leader reference
-   └─► Update group state
+2. stop() forwarded to sync leader (group stays powered & formed)
 ```
 
-The 5-second delay before dissolving prevents unnecessary sync/unsync cycles during brief pauses or track changes.
+### Powering Off
+
+```
+1. cmd_power(syncgroup, False)
+   │
+2. If currently playing/paused: stop() first
+   │
+3. _dissolve_syncgroup()
+   │
+   ├─► cmd_set_members on leader to remove all sync children (waits for state)
+   ├─► Clear leader's active_output_protocol (when leader is not still playing)
+   └─► sync_leader = None
+   │
+4. _attr_powered = False ; state event emitted
+```
+
+### State Polling
+
+While the group is playing, `SyncGroupPlayer.poll()` is called every 1 second to refresh `elapsed_time` from the sync leader. When idle, the poll interval drops to 30 seconds. This avoids the per-second eventbus cascade that would happen if we forwarded every elapsed_time tick from the leader through the group's update chain.
 
 ## Dynamic Member Management
 
@@ -216,23 +250,23 @@ When `SET_MEMBERS` is called on a dynamic group:
 
 ### Adding Members
 
-1. Validate member is available
-2. Check compatibility with current sync leader
-3. Add to internal member list
-4. If playing, sync new member to leader
+1. Validate the member exists, is available, and is not in the members filter
+2. If there is no sync leader yet (empty / unpowered group): just register the member; sync happens when the group is next formed
+3. Otherwise check compatibility with the current sync leader's `can_group_with` (which already includes all of the leader's linked output protocols, so e.g. an AirPlay-only player IS valid for a Sonos leader that has AirPlay as a linked protocol)
+4. Incompatible members are **not** registered (avoids stranding orphan entries in the group)
+5. Compatible members are appended to the internal member list and forwarded to `cmd_set_members` on the leader, which handles protocol selection (and possibly switching the leader to a different output protocol so the new member can be grouped via that protocol)
 
 ### Removing Members
 
-1. Remove from internal member list
-2. If removing the sync leader while playing:
-   - Stop current playback
-   - Dissolve sync group
-   - Re-form with new leader
-   - Resume playback (if was playing)
+1. Remove from the internal member list (static members cannot be removed)
+2. If removing the **sync leader** while playing:
+   - If the active protocol supports dynamic leader switching (e.g. AirPlay, Snapcast), perform a **seamless handoff**: pick a new leader from the live session, hand off via the protocol player's `handoff_sync_leadership`, remaining members keep playing
+   - If the chosen new leader is not part of the live session (e.g. a freshly-added player), or the protocol doesn't support handoff: fall back to **dissolve + re-form** (brief audio gap)
+3. If removing a non-leader member: forward to `cmd_set_members` on the leader
 
 ### Removing Last Member
 
-If the last member is removed, the sync group becomes empty and cannot play until members are added.
+If the last member is removed, the group is dissolved (leader stopped, sync_leader cleared).
 
 ## Feature Inheritance
 
@@ -240,6 +274,7 @@ The SyncGroupPlayer has limited base features but inherits additional capabiliti
 
 ### Base Features
 - `PLAY_MEDIA` - Always supported
+- `POWER` - Always supported (powered state is the canonical "is this group active" signal)
 
 ### Features from Sync Leader (when active)
 - `ENQUEUE` - Queue next track
@@ -286,16 +321,19 @@ The Sync Group provider is:
 
 ## State Properties
 
-The SyncGroupPlayer delegates most state to the sync leader:
+The SyncGroupPlayer reads most state from the sync leader's **raw** attributes (deliberately not `.state.*`, see the leader-responsibilities note above):
 
 | Property | Source |
 |----------|--------|
-| `playback_state` | Sync leader (or IDLE if no leader) |
-| `elapsed_time` | Sync leader |
-| `elapsed_time_last_updated` | Sync leader |
-| `current_media` | Stored on group itself |
-| `group_members` | Sync leader's reported members (preferred) or internal list |
-| `can_group_with` | Computed from leader or first available member |
+| `powered` | `_attr_powered` — set by `power()`, the canonical "is this group active" signal |
+| `playback_state` | Sync leader's raw `state.playback_state` (or IDLE if no leader) |
+| `elapsed_time` | Sync leader's raw `state.elapsed_time` |
+| `elapsed_time_last_updated` | Sync leader's raw `state.elapsed_time_last_updated` |
+| `current_media` | Sync leader's raw `current_media` (set optimistically in `play_media`) |
+| `active_source` | Sync leader's raw `active_source` (set optimistically in `play_media`) |
+| `group_members` | Sync leader's reported `state.group_members` (preferred) or internal list |
+| `can_group_with` | Aggregated from all current members' `can_group_with` |
+| `supported_features` | Base features + features inherited from the active sync leader |
 
 ## Related Documentation
 

--- a/music_assistant/providers/sync_group/constants.py
+++ b/music_assistant/providers/sync_group/constants.py
@@ -27,3 +27,15 @@ EXTRA_FEATURES_FROM_MEMBERS: Final[set[PlayerFeature]] = {
     PlayerFeature.VOLUME_MUTE,
     PlayerFeature.MULTI_DEVICE_DSP,
 }
+
+
+# Provider domains whose live sync session can survive removal of the current
+# leader (the protocol promotes another sync_client to leader at the protocol
+# level). When the active session is owned by one of these providers the sync
+# group can do a seamless leader handoff; otherwise it must dissolve and
+# re-form (with a brief audio gap) on leader change.
+PROVIDERS_WITH_DYNAMIC_LEADER_SWITCH: Final[tuple[str, ...]] = (
+    "airplay",
+    "snapcast",
+    "sendspin",
+)

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, PlaybackState, PlayerFeature, PlayerType
@@ -17,11 +17,7 @@ from music_assistant.constants import (
 )
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 
-from .constants import (
-    CONF_ENTRY_SGP_NOTE,
-    CONF_MEMBERS_FILTER,
-    EXTRA_FEATURES_FROM_MEMBERS,
-)
+from .constants import CONF_ENTRY_SGP_NOTE, CONF_MEMBERS_FILTER, EXTRA_FEATURES_FROM_MEMBERS
 
 if TYPE_CHECKING:
     from music_assistant_models.player import PlayerSource
@@ -46,6 +42,8 @@ class SyncGroupPlayer(Player):
         self._attr_name = self.config.name or self.config.default_name or f"SyncGroup {player_id}"
         self._attr_available = True
         self._attr_device_info = DeviceInfo(model=provider.name, manufacturer=APPLICATION_NAME)
+        self._attr_powered = False  # group players are always powered off by default
+        self._update_attributes()
 
     @cached_property
     def is_dynamic(self) -> bool:
@@ -90,10 +88,11 @@ class SyncGroupPlayer(Player):
     @property
     def supported_features(self) -> set[PlayerFeature]:
         """Return the supported features of the player."""
-        # by default we don't have any features, except play_media
+        # by default we don't have any features, except play_media and power
         # but we can gain some features based on the capabilities of the members
-        # set_members is only supported if it's a dynamic group
-        base_features: set[PlayerFeature] = {PlayerFeature.PLAY_MEDIA}
+        # NOTE: set_members is only supported if it's a dynamic group
+        # we use the power feature as a proxy for "is group active/formed"
+        base_features: set[PlayerFeature] = {PlayerFeature.PLAY_MEDIA, PlayerFeature.POWER}
         if self.is_dynamic:
             base_features.add(PlayerFeature.SET_MEMBERS)
         if self.sync_leader:
@@ -118,57 +117,6 @@ class SyncGroupPlayer(Player):
         if leader := self.sync_leader:
             return leader.flow_mode
         return False
-
-    @property
-    def playback_state(self) -> PlaybackState:
-        """Return the current playback state of the player."""
-        return self.sync_leader.state.playback_state if self.sync_leader else PlaybackState.IDLE
-
-    @property
-    def elapsed_time(self) -> float | None:
-        """Return the elapsed time in (fractional) seconds of the current track (if any)."""
-        # NOTE: Not using 'state' here as we need the 'raw' value provided by the sync leader player
-        if sync_leader := self.sync_leader:
-            # If an output protocol is active (and not native), use the protocol player's state
-            if (
-                sync_leader.active_output_protocol
-                and sync_leader.active_output_protocol != "native"
-                and (
-                    protocol_player := self.mass.players.get_player(
-                        sync_leader.active_output_protocol
-                    )
-                )
-                and protocol_player.playback_state != PlaybackState.IDLE
-            ):
-                return protocol_player.elapsed_time
-            return sync_leader.elapsed_time
-        return None
-
-    @property
-    def elapsed_time_last_updated(self) -> float | None:
-        """Return when the elapsed time was last updated."""
-        # NOTE: Not using 'state' here as we need the 'raw' value provided by the sync leader player
-        if sync_leader := self.sync_leader:
-            # If an output protocol is active (and not native), use the protocol player's state
-            if (
-                sync_leader.active_output_protocol
-                and sync_leader.active_output_protocol != "native"
-                and (
-                    protocol_player := self.mass.players.get_player(
-                        sync_leader.active_output_protocol
-                    )
-                )
-                and protocol_player.playback_state != PlaybackState.IDLE
-            ):
-                return protocol_player.elapsed_time_last_updated
-            return sync_leader.elapsed_time_last_updated
-        return None
-
-    @property
-    def current_media(self) -> PlayerMedia | None:
-        """Return the currently playing media (if any)."""
-        # NOTE: Not using 'state' here as we need the 'raw' value provided by the sync leader player
-        return self.sync_leader.current_media if self.sync_leader else None
 
     @property
     def active_source(self) -> str | None:
@@ -261,10 +209,8 @@ class SyncGroupPlayer(Player):
     def group_members(self) -> list[str]:
         """Return the list of parent player id's that are part of this sync group."""
         if (sync_leader := self.sync_leader) and sync_leader.state.group_members:
-            # The sync leader's group_members may contain protocol IDs (e.g. apc...)
-            # when playing via a protocol. Translate back to parent IDs so callers
-            # always get protocol-independent IDs.
-            return self._translate_to_parent_ids(sync_leader.state.group_members)
+            # use state.group_members here so protocol specific id's get correctly translated
+            return sync_leader.state.group_members
         return self._attr_group_members
 
     async def get_config_entries(
@@ -328,6 +274,32 @@ class SyncGroupPlayer(Player):
         ]
         return entries
 
+    async def power(self, powered: bool) -> None:
+        """Handle POWER command to group player."""
+        # always stop at power off
+        if not powered and self.playback_state in (
+            PlaybackState.PLAYING,
+            PlaybackState.PAUSED,
+        ):
+            await self.stop()
+
+        if powered == self.powered:
+            # no change, do nothing
+            return
+
+        # optimistically set the group state
+        self._attr_powered = powered
+
+        if powered:
+            # form syncgroup when powering on
+            await self._form_syncgroup()
+        else:
+            # dissolve syncgroup when powering off
+            await self._dissolve_syncgroup()
+
+        self._update_attributes()
+        self.update_state()
+
     async def stop(self) -> None:
         """Send STOP command to given player."""
         self._attr_current_media = None
@@ -335,13 +307,10 @@ class SyncGroupPlayer(Player):
             # Use internal handler to target the sync leader directly,
             # bypassing group/sync redirect that would loop back to this player.
             await self.mass.players._handle_cmd_stop(sync_leader.player_id)
-        # dissolve the sync group since we stopped playback
-        self.mass.call_later(
-            5, self._dissolve_syncgroup, task_id=f"syncgroup_dissolve_{self.player_id}"
-        )
 
     async def play(self) -> None:
         """Send PLAY (unpause) command to given player."""
+        await self.power(True)
         await self.mass.players.cmd_resume(
             self.player_id, self._attr_active_source, self._attr_current_media
         )
@@ -350,7 +319,7 @@ class SyncGroupPlayer(Player):
         """Handle PLAY MEDIA on given player."""
         self._attr_current_media = media
         self._attr_active_source = media.source_id or None
-        await self._form_syncgroup()
+        await self.power(True)
         if sync_leader := self.sync_leader:
             # Use internal handler to target the sync leader directly,
             # bypassing group/sync redirect that would loop back to this player.
@@ -369,26 +338,16 @@ class SyncGroupPlayer(Player):
             # Use internal handler to bypass group redirect logic and avoid infinite loop
             await self.mass.players._handle_enqueue_next_media(sync_leader.player_id, media)
 
-    async def set_members(
+    async def set_members(  # noqa: PLR0915
         self,
         player_ids_to_add: list[str] | None = None,
         player_ids_to_remove: list[str] | None = None,
     ) -> None:
         """Handle SET_MEMBERS command on the player."""
-        await self._set_members(player_ids_to_add, player_ids_to_remove)
-
-    async def _set_members(  # noqa: PLR0915
-        self,
-        player_ids_to_add: list[str] | None = None,
-        player_ids_to_remove: list[str] | None = None,
-    ) -> None:
-        """Handle SET_MEMBERS command (serialized by controller's play lock)."""
         if not self.is_dynamic:
             raise UnsupportedFeaturedException(
                 f"Group {self.display_name} does not allow dynamically adding/removing members!"
             )
-        # Cancel any pending dissolve from a previous stop() call
-        self.mass.cancel_timer(f"syncgroup_dissolve_{self.player_id}")
         sync_leader = self.sync_leader or self._select_sync_leader(new_members=player_ids_to_add)
         was_playing = self.playback_state == PlaybackState.PLAYING
 
@@ -495,9 +454,15 @@ class SyncGroupPlayer(Player):
         # since the syncing will be done once playback starts
         self.mass.players.trigger_player_update(self.player_id)
 
+    def on_group_member_updated(
+        self, member_player: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Handle callback when a group member of the group player is updated."""
+        self._update_attributes()
+        super().on_group_member_updated(member_player, changed_values)
+
     async def _form_syncgroup(self) -> None:
         """Form syncgroup by syncing all (possible) members."""
-        self.mass.cancel_timer(f"syncgroup_dissolve_{self.player_id}")
         self.logger.debug(
             "Forming syncgroup %s, _attr_group_members=%s, sync_leader=%s",
             self.display_name,
@@ -565,6 +530,7 @@ class SyncGroupPlayer(Player):
         if sync_leader and sync_leader.state.playback_state != PlaybackState.PLAYING:
             sync_leader.set_active_output_protocol(None)
         self.sync_leader = None
+        self._update_attributes()
         self.update_state()
 
     def _select_sync_leader(
@@ -722,6 +688,36 @@ class SyncGroupPlayer(Player):
         if domain != native_domain and not self._any_member_requires_protocol_domain(domain):
             return native_domain
         return domain
+
+    def _update_attributes(self) -> None:
+        """Update dynamic attributes."""
+        # NOTE: Not using 'state' here as we need the 'raw' value provided by the sync leader player
+        if (sync_leader := self.sync_leader) is None:
+            # no sync leader, reset playback-related attributes to default values
+            self._attr_playback_state = PlaybackState.IDLE
+            self._attr_elapsed_time = None
+            self._attr_elapsed_time_last_updated = None
+            self._attr_current_media = None
+            self._attr_active_source = None
+            return
+        if (
+            sync_leader.active_output_protocol
+            and sync_leader.active_output_protocol != "native"
+            and (
+                protocol_player := self.mass.players.get_player(sync_leader.active_output_protocol)
+            )
+        ):
+            # sync leader active output protocol is carrying the stream, so we use its state for playback info
+            self._attr_playback_state = protocol_player.state.playback_state
+            self._attr_elapsed_time = protocol_player.elapsed_time
+            self._attr_elapsed_time_last_updated = protocol_player.elapsed_time_last_updated
+            self._attr_current_media = protocol_player.current_media
+            return
+        # sync leader itself is carrying the stream, use its state for playback info
+        self._attr_playback_state = sync_leader.state.playback_state
+        self._attr_elapsed_time = sync_leader.elapsed_time
+        self._attr_elapsed_time_last_updated = sync_leader.elapsed_time_last_updated
+        self._attr_current_media = sync_leader.current_media
 
     def _is_player_in_session(self, player: Player, session_player: Player | None) -> bool:
         """Return True if ``player`` is already a sync_client of the live session.

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -432,11 +432,10 @@ class SyncGroupPlayer(Player):
             # or we just removed the last member from the group, so we dissolve the syncgroup
             # Use internal handler to stop the sync leader directly,
             # bypassing group redirect that would loop back to this player.
-            await self.mass.players.wait_for_player_update(
-                self.sync_leader.player_id,
-                timeout=5,
-                action=self.mass.players._handle_cmd_stop(self.sync_leader.player_id),
-            )
+            async with self.mass.players.wait_for_player_update(
+                self.sync_leader.player_id, timeout=5
+            ):
+                await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
             await self._dissolve_syncgroup()
 
         elif self.sync_leader:
@@ -500,11 +499,17 @@ class SyncGroupPlayer(Player):
         if members_to_sync:
             # If the sync leader is playing something independently, stop it first
             # to prevent protocol switching from trying to resume the previous playback
-            # (we're about to start new playback on the syncgroup)
-            # Use internal handler to stop the sync leader directly,
-            # bypassing group redirect that would loop back to this player.
+            # (we're about to start new playback on the syncgroup).
+            # Wait for the leader to actually reach IDLE before adding members,
+            # since some providers reject set_members while still playing.
             if self.sync_leader.state.playback_state == PlaybackState.PLAYING:
-                await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
+                async with self.mass.players.wait_for_player_update(
+                    self.sync_leader.player_id,
+                    attribute_name="playback_state",
+                    attribute_value=PlaybackState.IDLE,
+                    timeout=5,
+                ):
+                    await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
             await self.mass.players.cmd_set_members(self.sync_leader.player_id, members_to_sync)
 
     async def _dissolve_syncgroup(self) -> None:
@@ -516,13 +521,12 @@ class SyncGroupPlayer(Player):
             ]
             if sync_children:
                 # wait for the leader's state to reflect the ungroup
-                await self.mass.players.wait_for_player_update(
-                    sync_leader.player_id,
-                    timeout=5,
-                    action=self.mass.players.cmd_set_members(
+                async with self.mass.players.wait_for_player_update(
+                    sync_leader.player_id, timeout=5
+                ):
+                    await self.mass.players.cmd_set_members(
                         sync_leader.player_id, [], sync_children
-                    ),
-                )
+                    )
         # Clear the leader's active protocol so it doesn't persist
         # after the sync group is dissolved. The controller's normal
         # clearing (in _handle_cmd_stop) is skipped when the protocol
@@ -780,11 +784,10 @@ class SyncGroupPlayer(Player):
                 self.display_name,
                 leader_to_stop.display_name,
             )
-            await self.mass.players.wait_for_player_update(
-                leader_to_stop.player_id,
-                timeout=5,
-                action=self.mass.players._handle_cmd_stop(leader_to_stop.player_id),
-            )
+            async with self.mass.players.wait_for_player_update(
+                leader_to_stop.player_id, timeout=5
+            ):
+                await self.mass.players._handle_cmd_stop(leader_to_stop.player_id)
         await self._dissolve_syncgroup()
         if old_leader_id in self._attr_group_members:
             self._attr_group_members.remove(old_leader_id)
@@ -793,15 +796,21 @@ class SyncGroupPlayer(Player):
             # re-forming. Providers like Sonos propagate group state
             # asynchronously — the children can still report synced_to for
             # a few seconds after the leader's ungroup command returns.
-            for _ in range(10):
-                if all(
-                    (player := self.mass.players.get_player(m)) is not None
-                    and player.synced_to is None
-                    for m in self._attr_group_members
-                ):
-                    break
-                await asyncio.sleep(0.5)
+            await asyncio.gather(
+                *(self._wait_member_unsynced(m) for m in self._attr_group_members),
+                return_exceptions=True,
+            )
             await self.play()
+
+    async def _wait_member_unsynced(self, member_id: str, timeout: float = 5.0) -> None:
+        """Wait until the given member reports as unsynced (synced_to is None)."""
+        async with self.mass.players.wait_for_player_update(
+            member_id,
+            attribute_name="synced_to",
+            attribute_value=None,
+            timeout=timeout,
+        ):
+            pass
 
     async def _dynamic_leader_switch(self, old_leader_id: str) -> None:
         """Switch the sync leader without tearing down the stream session.
@@ -850,11 +859,8 @@ class SyncGroupPlayer(Player):
                 self.display_name,
                 old_leader.display_name,
             )
-            await self.mass.players.wait_for_player_update(
-                old_leader.player_id,
-                timeout=5,
-                action=self.mass.players._handle_cmd_stop(old_leader.player_id),
-            )
+            async with self.mass.players.wait_for_player_update(old_leader.player_id, timeout=5):
+                await self.mass.players._handle_cmd_stop(old_leader.player_id)
             await self._dissolve_syncgroup()
             return
 

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -17,7 +17,12 @@ from music_assistant.constants import (
 )
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 
-from .constants import CONF_ENTRY_SGP_NOTE, CONF_MEMBERS_FILTER, EXTRA_FEATURES_FROM_MEMBERS
+from .constants import (
+    CONF_ENTRY_SGP_NOTE,
+    CONF_MEMBERS_FILTER,
+    EXTRA_FEATURES_FROM_MEMBERS,
+    PROVIDERS_WITH_DYNAMIC_LEADER_SWITCH,
+)
 
 if TYPE_CHECKING:
     from music_assistant_models.player import PlayerSource
@@ -43,6 +48,7 @@ class SyncGroupPlayer(Player):
         self._attr_available = True
         self._attr_device_info = DeviceInfo(model=provider.name, manufacturer=APPLICATION_NAME)
         self._attr_powered = False  # group players are always powered off by default
+        self._attr_needs_poll = True
         self._update_attributes()
 
     @cached_property
@@ -283,13 +289,6 @@ class SyncGroupPlayer(Player):
         ):
             await self.stop()
 
-        if powered == self.powered:
-            # no change, do nothing
-            return
-
-        # optimistically set the group state
-        self._attr_powered = powered
-
         if powered:
             # form syncgroup when powering on
             await self._form_syncgroup()
@@ -297,8 +296,10 @@ class SyncGroupPlayer(Player):
             # dissolve syncgroup when powering off
             await self._dissolve_syncgroup()
 
-        self._update_attributes()
-        self.update_state()
+        if self._attr_powered != powered:
+            self._attr_powered = powered
+            self._update_attributes()
+            self.update_state()
 
     async def stop(self) -> None:
         """Send STOP command to given player."""
@@ -310,21 +311,31 @@ class SyncGroupPlayer(Player):
 
     async def play(self) -> None:
         """Send PLAY (unpause) command to given player."""
-        await self.power(True)
+        # The controller has already powered us on, but the group may not be
+        # formed (e.g. after _dissolve_and_reform left us powered with no leader).
+        # _form_syncgroup is idempotent so calling it here is cheap when already formed.
+        await self._form_syncgroup()
         await self.mass.players.cmd_resume(
             self.player_id, self._attr_active_source, self._attr_current_media
         )
+
+    async def poll(self) -> None:
+        """Poll player for state updates."""
+        self._update_attributes()
+        self.update_state()
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on given player."""
         self._attr_current_media = media
         self._attr_active_source = media.source_id or None
-        await self.power(True)
+        # The controller has already powered us on, but the group may not be
+        # formed (e.g. after _dissolve_and_reform left us powered with no leader).
+        # _form_syncgroup is idempotent so calling it here is cheap when already formed.
+        await self._form_syncgroup()
         if sync_leader := self.sync_leader:
             # Use internal handler to target the sync leader directly,
             # bypassing group/sync redirect that would loop back to this player.
             await self.mass.players._handle_play_media(sync_leader.player_id, media)
-            self.update_state()
         else:
             raise RuntimeError("An empty group cannot play media, consider adding members first")
 
@@ -373,16 +384,23 @@ class SyncGroupPlayer(Player):
             member = self.mass.players.get_player(member_id)
             if member is None or not member.available:
                 continue
-            if member_id not in self._attr_group_members:
-                self._attr_group_members.append(member_id)
             if not sync_leader:
+                # no leader yet (e.g. empty group) - just register the member
+                # the leader and protocol selection happen on the next form/play
+                if member_id not in self._attr_group_members:
+                    self._attr_group_members.append(member_id)
                 continue
             if member_id != sync_leader.player_id and member_id not in can_group_with:
+                # incompatible with the current leader's protocols - do NOT register
+                # the member or it will linger in _attr_group_members forever without
+                # ever actually being synced.
                 self.logger.debug(
                     f"Cannot add {member.display_name} to group {self.display_name} since it's "
                     f"not compatible with the (current) sync leader"
                 )
                 continue
+            if member_id not in self._attr_group_members:
+                self._attr_group_members.append(member_id)
             if member_id != sync_leader.player_id:
                 final_players_to_add.append(member_id)
 
@@ -414,7 +432,7 @@ class SyncGroupPlayer(Player):
             session_player = self._active_session_player()
             supports_handoff = (
                 session_player is not None
-                and session_player.provider.supports_dynamic_leader_switching
+                and session_player.provider.domain in PROVIDERS_WITH_DYNAMIC_LEADER_SWITCH
             )
 
             if was_playing and supports_handoff:
@@ -695,7 +713,10 @@ class SyncGroupPlayer(Player):
 
     def _update_attributes(self) -> None:
         """Update dynamic attributes."""
-        # NOTE: Not using 'state' here as we need the 'raw' value provided by the sync leader player
+        # NOTE: Always read the *raw* attributes (not `.state.*`) from the sync leader.
+        # The leader's `state.playback_state` is derived through __final_playback_state which,
+        # when this group is powered, treats us as the leader's active_group and routes its
+        # state back to ours - creating a circular dependency that strands both at IDLE.
         if (sync_leader := self.sync_leader) is None:
             # no sync leader, reset playback-related attributes to default values
             self._attr_playback_state = PlaybackState.IDLE
@@ -703,25 +724,18 @@ class SyncGroupPlayer(Player):
             self._attr_elapsed_time_last_updated = None
             self._attr_current_media = None
             self._attr_active_source = None
+            self._attr_poll_interval = 30
             return
-        if (
-            sync_leader.active_output_protocol
-            and sync_leader.active_output_protocol != "native"
-            and (
-                protocol_player := self.mass.players.get_player(sync_leader.active_output_protocol)
-            )
-        ):
-            # sync leader active output protocol is carrying the stream, so we use its state for playback info
-            self._attr_playback_state = protocol_player.state.playback_state
-            self._attr_elapsed_time = protocol_player.elapsed_time
-            self._attr_elapsed_time_last_updated = protocol_player.elapsed_time_last_updated
-            self._attr_current_media = protocol_player.current_media
-            return
-        # sync leader itself is carrying the stream, use its state for playback info
         self._attr_playback_state = sync_leader.state.playback_state
-        self._attr_elapsed_time = sync_leader.elapsed_time
-        self._attr_elapsed_time_last_updated = sync_leader.elapsed_time_last_updated
+        self._attr_elapsed_time = sync_leader.state.elapsed_time
+        self._attr_elapsed_time_last_updated = sync_leader.state.elapsed_time_last_updated
+        # don't use 'state' for current_media here since that points back to this group
+        # player when we're active_group, we need the 'raw' value from the sync leader
+        # itself to avoid circular dependency and ensure it reflects the actual media
+        # on the leader rather than the group.
         self._attr_current_media = sync_leader.current_media
+        self._attr_active_source = sync_leader.active_source
+        self._attr_poll_interval = 1 if self._attr_playback_state == PlaybackState.PLAYING else 30
 
     def _is_player_in_session(self, player: Player, session_player: Player | None) -> bool:
         """Return True if ``player`` is already a sync_client of the live session.
@@ -890,8 +904,55 @@ class SyncGroupPlayer(Player):
             new_leader.display_name,
             self.display_name,
         )
-        # Hand off the session in one call: old leader steps out, remaining
-        # members get grouped onto the new leader.
-        remaining_members = [m for m in self._attr_group_members if m != new_leader.player_id]
-        await old_leader.handoff_sync_leadership(new_leader, remaining_members)
+
+        # Hand off at the protocol level. We already know:
+        # - the old session player (the protocol player that owns the live session)
+        # - the active protocol domain
+        # - the new leader (a parent player whose protocol player is in the session)
+        # So we can talk to the protocol players directly and skip the controller's
+        # protocol-translation overhead in cmd_set_members.
+        new_target = self._resolve_session_target(new_leader, preferred_domain)
+        remaining_protocol_ids: list[str] = []
+        for member_id in self._attr_group_members:
+            if member_id == new_leader.player_id:
+                continue
+            if member := self.mass.players.get_player(member_id):
+                if target := self._resolve_session_target(member, preferred_domain):
+                    remaining_protocol_ids.append(target.player_id)
+
+        # 1. Old leader's session protocol player steps out of the session.
+        # Direct call (the controller's cmd_set_members would interpret this
+        # self-removal as "dissolve the entire group"). The provider's set_members
+        # implementation handles "remove self while other clients remain" by
+        # promoting another sync_client at the protocol level.
+        if session_player is not None:
+            await session_player.set_members(player_ids_to_remove=[session_player.player_id])
+
+        # 2. New leader's protocol player takes over ownership tracking of the
+        # remaining members. The members are already in the live session at the
+        # protocol level (sync_clients), this just transfers the bookkeeping so
+        # the new leader's protocol player reports them as its group members.
+        if remaining_protocol_ids and new_target is not None:
+            await new_target.set_members(player_ids_to_add=remaining_protocol_ids)
+
         self.update_state()
+
+    def _resolve_session_target(self, player: Player, domain: str | None) -> Player | None:
+        """Resolve the player that participates in the live session for ``domain``.
+
+        For a player whose own provider domain matches, returns the player itself.
+        For a parent player with a linked protocol on that domain, returns the
+        corresponding protocol player. Returns ``None`` when nothing matches.
+
+        :param player: The player to resolve (parent or protocol player).
+        :param domain: The protocol domain string of the active session
+            (e.g. "airplay"). May be None, in which case ``player`` is returned.
+        """
+        if domain is None:
+            return player
+        if player.provider.domain == domain:
+            return player
+        for linked in player.linked_output_protocols:
+            if linked.protocol_domain == domain and linked.available:
+                return self.mass.players.get_player(linked.output_protocol_id)
+        return None

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -218,21 +218,19 @@ class UniversalGroupPlayer(Player):
                             other_group.supports_feature(PlayerFeature.SET_MEMBERS)
                             and member.player_id not in other_group.static_group_members
                         ):
-                            await self.mass.players.wait_for_player_update(
-                                member.player_id,
-                                timeout=5,
-                                action=other_group.set_members(
+                            async with self.mass.players.wait_for_player_update(
+                                member.player_id, timeout=5
+                            ):
+                                await other_group.set_members(
                                     player_ids_to_remove=[member.player_id]
-                                ),
-                            )
+                                )
                         else:
                             # if the other group does not support SET_MEMBERS or it is a static
                             # member, we need to power it off to leave the group
-                            await self.mass.players.wait_for_player_update(
-                                member.player_id,
-                                timeout=5,
-                                action=other_group.power(False),
-                            )
+                            async with self.mass.players.wait_for_player_update(
+                                member.player_id, timeout=5
+                            ):
+                                await other_group.power(False)
                 if member.synced_to:
                     # edge case: the member is part of a syncgroup - ungroup it first
                     await member.ungroup()

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -26,7 +26,8 @@ def _make_mock_mass() -> MagicMock:
     mass.players._handle_cmd_resume = AsyncMock()
     mass.players._handle_play_media = AsyncMock()
     mass.players.cmd_set_members = AsyncMock()
-    mass.players.wait_for_player_update = AsyncMock(return_value=True)
+    # wait_for_player_update is an async context manager — return one that no-ops.
+    mass.players.wait_for_player_update = MagicMock(return_value=AsyncMock())
     mass.players.trigger_player_update = MagicMock()
     mass.call_later = MagicMock()
     mass.cancel_timer = MagicMock()
@@ -359,7 +360,7 @@ class TestDynamicLeaderSwitch:
 
         # handoff_sync_leadership should NOT have been called
         old_leader.handoff_sync_leadership.assert_not_awaited()
-        # Instead, dissolve+reform happened: wait_for_player_update was called
-        # with the old leader's player_id (which internally stops the session)
-        mass.players.wait_for_player_update.assert_awaited()
+        # Instead, dissolve+reform happened: wait_for_player_update was used
+        # to wrap the stop of the old leader (which internally stops the session)
+        mass.players.wait_for_player_update.assert_called()
         assert "old_leader" not in sgp._attr_group_members

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -27,7 +27,13 @@ def _make_mock_mass() -> MagicMock:
     mass.players._handle_play_media = AsyncMock()
     mass.players.cmd_set_members = AsyncMock()
     # wait_for_player_update is an async context manager — return one that no-ops.
-    mass.players.wait_for_player_update = MagicMock(return_value=AsyncMock())
+    # __aexit__ must explicitly return False so exceptions inside the `async with`
+    # body propagate (an unconfigured AsyncMock returns a truthy MagicMock and
+    # would silently swallow real test failures).
+    wait_ctx = AsyncMock()
+    wait_ctx.__aenter__.return_value = None
+    wait_ctx.__aexit__.return_value = False
+    mass.players.wait_for_player_update = MagicMock(return_value=wait_ctx)
     mass.players.trigger_player_update = MagicMock()
     mass.call_later = MagicMock()
     mass.cancel_timer = MagicMock()

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -63,6 +63,8 @@ def _make_mock_player(
         proto = MagicMock(spec=OutputProtocol)
         proto.protocol_domain = domain
         proto.available = True
+        # default to a synthetic protocol id; tests that need a specific id can override
+        proto.output_protocol_id = f"{player_id}_{domain}_proto"
         protocols.append(proto)
     player.linked_output_protocols = protocols
 
@@ -87,7 +89,8 @@ def _make_sync_group(mass: MagicMock, player_id: str = "syncgroup_test") -> Sync
     provider.mass = mass
 
     def _config_get_value(key: str, default: object = None) -> object:
-        if key == "dynamic_group_members":
+        # CONF_DYNAMIC_GROUP_MEMBERS resolves to "dynamic_members"
+        if key == "dynamic_members":
             return True
         if key == "members_filter":
             return []
@@ -258,7 +261,7 @@ class TestDynamicLeaderSwitch:
 
     @pytest.mark.asyncio
     async def test_dynamic_leader_switch_hands_off_to_new_leader(self) -> None:
-        """When the new leader IS in the live session, seamless handoff is used."""
+        """When the new leader IS in the live session, seamless protocol-level handoff is used."""
         mass = _make_mock_mass()
         sgp = _make_sync_group(mass)
 
@@ -279,13 +282,19 @@ class TestDynamicLeaderSwitch:
             active_output_protocol="ap_old",
             protocol_domains=["airplay"],
         )
-        old_leader.handoff_sync_leadership = AsyncMock()
         new_leader = _make_mock_player(
             "new_leader",
             provider_domain="sonos",
             protocol_domains=["airplay"],
             active_output_protocol="ap_new",
         )
+        # Wire the linked airplay protocols on the parents to point to the
+        # corresponding protocol player ids so _resolve_session_target can find them.
+        new_leader.linked_output_protocols[0].output_protocol_id = "ap_new"
+        ap_only.linked_output_protocols[0].output_protocol_id = "ap_only_proto"
+        # ap_only's airplay protocol player needs to exist for the protocol-id resolution
+        ap_only_proto = _make_mock_player("ap_only_proto", provider_domain="airplay")
+
         ap_protocol = _make_mock_player("ap_old", provider_domain="airplay")
         # Set up the live session with new_leader's protocol player in sync_clients
         mock_session = MagicMock()
@@ -300,6 +309,7 @@ class TestDynamicLeaderSwitch:
                 "ap_old": ap_protocol,
                 "ap_new": ap_new,
                 "ap_only": ap_only,
+                "ap_only_proto": ap_only_proto,
             }
         )
 
@@ -311,11 +321,20 @@ class TestDynamicLeaderSwitch:
 
         assert sgp.sync_leader == new_leader
         assert "old_leader" not in sgp._attr_group_members
-        # Old leader got the handoff call with the new leader + remaining members
-        old_leader.handoff_sync_leadership.assert_awaited_once()
-        call_args = old_leader.handoff_sync_leadership.await_args
-        assert call_args.args[0] == new_leader
-        assert "ap_only" in call_args.args[1]
+
+        # 1. Old leader's session protocol player got told to step out (self-remove)
+        ap_protocol.set_members.assert_any_await(player_ids_to_remove=["ap_old"])
+
+        # 2. New leader's protocol player got the remaining members added.
+        # ap_only is already a protocol player on the airplay domain (its own
+        # provider is universal_player but its linked airplay protocol resolves
+        # via _resolve_session_target). The exact id depends on the mock wiring,
+        # but the call must have happened.
+        ap_new.set_members.assert_awaited()
+        add_call = ap_new.set_members.await_args
+        assert add_call.kwargs.get("player_ids_to_add"), (
+            "expected new leader's protocol player to receive the remaining members"
+        )
 
     @pytest.mark.asyncio
     async def test_dynamic_leader_switch_dissolves_when_new_leader_not_in_session(
@@ -332,7 +351,6 @@ class TestDynamicLeaderSwitch:
             active_output_protocol="ap_old",
             protocol_domains=["airplay"],
         )
-        old_leader.handoff_sync_leadership = AsyncMock()
         # Freshly-added player — NOT in the live session
         fresh_player = _make_mock_player(
             "fresh_player", provider_domain="sonos", protocol_domains=["airplay"]
@@ -358,9 +376,153 @@ class TestDynamicLeaderSwitch:
         with patch.object(sgp, "update_state"):
             await sgp._dynamic_leader_switch("old_leader")
 
-        # handoff_sync_leadership should NOT have been called
-        old_leader.handoff_sync_leadership.assert_not_awaited()
-        # Instead, dissolve+reform happened: wait_for_player_update was used
-        # to wrap the stop of the old leader (which internally stops the session)
+        # The old protocol player must NOT have been told to self-remove
+        # (that path is only for the seamless handoff). Instead, dissolve+reform
+        # happened: wait_for_player_update was used to wrap the stop.
+        ap_protocol.set_members.assert_not_awaited()
         mass.players.wait_for_player_update.assert_called()
         assert "old_leader" not in sgp._attr_group_members
+
+
+class TestPowerLifecycle:
+    """Test that power(True/False) drives the group's form/dissolve lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_power_on_forms_group_and_picks_leader(self) -> None:
+        """power(True) should select a sync leader and mark the group powered."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader})
+        sgp._attr_group_members = ["leader"]
+
+        with patch.object(sgp, "update_state"):
+            await sgp.power(True)
+
+        assert sgp.sync_leader == leader
+        assert sgp._attr_powered is True
+
+    @pytest.mark.asyncio
+    async def test_power_on_with_no_members_stays_unformed(self) -> None:
+        """power(True) on an empty group should leave sync_leader as None but mark powered."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        with patch.object(sgp, "update_state"):
+            await sgp.power(True)
+
+        assert sgp.sync_leader is None
+        # group is powered (intent to be active) even though no leader could be picked
+        assert sgp._attr_powered is True
+
+    @pytest.mark.asyncio
+    async def test_power_off_dissolves_group(self) -> None:
+        """power(False) should clear the sync leader and mark unpowered."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]
+        sgp._attr_powered = True
+
+        with patch.object(sgp, "update_state"):
+            await sgp.power(False)
+
+        # use getattr to defeat mypy's narrowing of these attributes after the
+        # earlier assignments, since it can't see that power(False) mutates them.
+        assert getattr(sgp, "sync_leader") is None  # noqa: B009
+        assert getattr(sgp, "_attr_powered") is False  # noqa: B009
+
+    @pytest.mark.asyncio
+    async def test_stop_does_not_dissolve_group(self) -> None:
+        """stop() should stop the leader but leave the group formed and powered."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]
+        sgp._attr_powered = True
+
+        await sgp.stop()
+
+        # leader was stopped via the internal handler
+        mass.players._handle_cmd_stop.assert_awaited_once_with("leader")
+        # but the group is still formed: sync_leader and powered are unchanged
+        assert sgp.sync_leader == leader
+        assert sgp._attr_powered is True
+
+
+class TestSetMembersDoesNotRegisterIncompatible:
+    """Regression test for: incompatible members must NOT be added to _attr_group_members."""
+
+    @pytest.mark.asyncio
+    async def test_incompatible_member_is_not_registered(self) -> None:
+        """A member that fails the can_group_with check must not be appended."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        # leader's can_group_with does NOT include the incompatible member
+        leader.state.can_group_with = {"leader"}
+        incompatible = _make_mock_player("incompatible", provider_domain="alien_protocol")
+
+        mass.players.get_player = _player_lookup({"leader": leader, "incompatible": incompatible})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]
+
+        await sgp.set_members(player_ids_to_add=["incompatible"])
+
+        # incompatible must NOT linger in the internal member list
+        assert "incompatible" not in sgp._attr_group_members
+        # and the leader was never asked to add it (the call may still happen
+        # with empty lists since the member-changed path is taken, but the
+        # incompatible id must not appear in either add or remove)
+        for call in mass.players.cmd_set_members.await_args_list:
+            assert "incompatible" not in (call.kwargs.get("player_ids_to_add") or [])
+            assert "incompatible" not in (call.kwargs.get("player_ids_to_remove") or [])
+
+    @pytest.mark.asyncio
+    async def test_compatible_member_is_registered_and_forwarded(self) -> None:
+        """A compatible member should be appended and forwarded to the leader."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        leader.state.can_group_with = {"compatible"}
+        compatible = _make_mock_player("compatible", provider_domain="sonos")
+
+        mass.players.get_player = _player_lookup({"leader": leader, "compatible": compatible})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]
+
+        await sgp.set_members(player_ids_to_add=["compatible"])
+
+        assert "compatible" in sgp._attr_group_members
+        mass.players.cmd_set_members.assert_awaited_once()
+        kwargs = mass.players.cmd_set_members.await_args.kwargs
+        assert kwargs.get("player_ids_to_add") == ["compatible"]
+
+    @pytest.mark.asyncio
+    async def test_member_added_when_no_leader_yet(self) -> None:
+        """Adding to an empty/unformed group must register the member regardless."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        member = _make_mock_player("member", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"member": member})
+
+        # no sync leader, empty group
+        sgp.sync_leader = None
+        sgp._attr_group_members = []
+
+        await sgp.set_members(player_ids_to_add=["member"])
+
+        # member is registered so a future _form_syncgroup can pick it as leader
+        assert "member" in sgp._attr_group_members
+        # but cmd_set_members on the leader is not called (no leader yet)
+        mass.players.cmd_set_members.assert_not_awaited()


### PR DESCRIPTION
## Problem

Group players (sync groups) were stuck reporting `IDLE` while their sync leader was actually playing. Root cause: a circular dependency in `__final_playback_state` where the leader's state derived from its parent group, and the group's state derived from the leader — both ended up frozen at the last value once the group became powered.

This also surfaced a few related lifecycle / locking issues that are bundled in this PR.

## Changes

- **State derivation**: drop `__final_active_group` derivation from `__final_playback_state` for `playback_state` / `elapsed_time`. Members of an active group now report their own raw playback state; only manually-synced clients (`synced_to`) mirror their leader.
- **Forward updates from the elapsed-time short-circuit**: extracted `_forward_state_update` so the syncgroup's `on_group_member_updated` runs even when the leader's update is otherwise lightweight (gated on >1s drift to avoid event storms).
- **PLAYBACK lock on `cmd_power`**: prevents power on/off racing with `play_media` / `cmd_resume` / `cmd_set_members` on the same player. Re-entrant per asyncio task so existing nested call chains stay safe.
- **`set_members` no longer registers incompatible members**: members that fail the leader's `can_group_with` check are no longer appended to `_attr_group_members`, so they can't linger as ghost entries.
- **Skip `set_active_output_protocol` on group players**: groups don't have output protocols of their own; they delegate to the leader.
- **No more double `_form_syncgroup` on play**: `SyncGroupPlayer.play` / `play_media` now call `_form_syncgroup` directly instead of `power(True)`, avoiding the redundant power-state mutation while still recovering from a dissolved-but-still-powered state (e.g. after `_dissolve_and_reform` with no replacement member).
- **Inlined dynamic leader handoff**: `_dynamic_leader_switch` now talks to protocol players directly (`session_player.set_members(remove=[self])` + `new_target.set_members(add=remaining_protocol_ids)`) instead of going through `cmd_set_members` and the now-removed `Player.handoff_sync_leadership` / `PlayerProvider.supports_dynamic_leader_switching`. The list of provider domains capable of dynamic leader switching now lives in `sync_group/constants.py` instead of as a base-class property.
- **README + tests**: refreshed the syncgroup README for the new lifecycle and added tests for the power lifecycle, `stop()` not dissolving, incompatible member filtering, and the protocol-level handoff.