### PR TITLE
Subsonic: Add option to always request stream of raw file

### DIFF
--- a/music_assistant/providers/opensubsonic/__init__.py
+++ b/music_assistant/providers/opensubsonic/__init__.py
@@ -17,6 +17,7 @@ from .sonic_provider import (
     CONF_OVERRIDE_OFFSET,
     CONF_PAGE_SIZE,
     CONF_PLAYED_ALBUMS,
+    CONF_RAW_FILE,
     CONF_RECO_FAVES,
     CONF_RECO_SIZE,
     OpenSonicProvider,
@@ -158,6 +159,14 @@ async def get_config_entries(
             required=True,
             description="How many recommendations from each enabled type should be included.",
             default_value=10,
+        ),
+        ConfigEntry(
+            key=CONF_RAW_FILE,
+            type=ConfigEntryType.BOOLEAN,
+            label="No Transcoding For Streams",
+            required=False,
+            description="Request that the server provide the original source file without applying any transcoding rules.",
+            default_value=True,
         ),
         ConfigEntry(
             key=CONF_PAGE_SIZE,

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -83,6 +83,7 @@ CONF_NEW_ALBUMS = "recommend_new"
 CONF_PLAYED_ALBUMS = "recommend_played"
 CONF_RECO_SIZE = "recommendation_count"
 CONF_PAGE_SIZE = "pagination_size"
+CONF_RAW_FILE = "request_raw_file"
 
 CACHE_CATEGORY_PODCAST_CHANNEL = 1
 CACHE_CATEGORY_PODCAST_EPISODES = 2
@@ -104,6 +105,7 @@ class OpenSonicProvider(MusicProvider):
     _reco_limit: int = 10
     _pagination_size: int = 200
     _id_lyrics: bool = False
+    _raw_file: bool = True
 
     async def handle_async_init(self) -> None:
         """Set up the music provider and test the connection."""
@@ -147,6 +149,7 @@ class OpenSonicProvider(MusicProvider):
         self._reco_limit = int(str(self.config.get_value(CONF_RECO_SIZE)))
         self._pagination_size = int(str(self.config.get_value(CONF_PAGE_SIZE)))
         self._pagination_size = min(self._pagination_size, 500)
+        self._raw_file = bool(self.config.get_value(CONF_RAW_FILE))
 
     @property
     def is_streaming_provider(self) -> bool:
@@ -782,9 +785,11 @@ class OpenSonicProvider(MusicProvider):
             seek_position = 0
 
         self.logger.debug("Streaming %s", streamdetails.item_id)
+        fmat = "raw" if self._raw_file else None
+
         try:
             resp = await self.conn.stream(
-                streamdetails.item_id, time_offset=seek_position, estimate_length=True
+                streamdetails.item_id, time_offset=seek_position, estimate_length=True, tformat=fmat
             )
         except DataNotFoundError as err:
             msg = f"Item '{streamdetails.item_id}' not found"


### PR DESCRIPTION
In the case that either Subsonic is home hosted on the same network as MA or hosted in a place with enough outgoing bandwidth we want to stream the raw files rather than transcode. Make this a user configurable option that defaults to requesting raw.