### PR TITLE
Forward Sendspin Cast app logs to Music Assistant

### DIFF
--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -17,6 +17,7 @@ The bridge:
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
@@ -25,6 +26,7 @@ from aiosendspin.models.core import DeviceInfo as SendspinDeviceInfo
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
 from aiosendspin.models.types import AudioCodec
 from music_assistant_models.enums import EventType, IdentifierType
+from pychromecast.controllers import BaseController
 
 from music_assistant.helpers.util import format_ip_for_url, is_valid_mac_address
 from music_assistant.providers.chromecast.constants import get_cast_model_static_delay
@@ -50,11 +52,65 @@ from .constants import SENDSPIN_CAST_APP_ID, SENDSPIN_CAST_BLOCKLIST, SENDSPIN_C
 if TYPE_CHECKING:
     from aiosendspin.server import ExternalStreamStartRequest, SendspinClient, SendspinServer
     from music_assistant_models.event import MassEvent
+    from pychromecast.generated.cast_channel_pb2 import CastMessage
 
     from music_assistant.providers.sendspin.provider import SendspinProvider
 
     from .player import ChromecastPlayer
     from .provider import ChromecastProvider
+
+
+_CAST_LOG_LEVEL_MAP: dict[str, int] = {
+    "error": logging.ERROR,
+    "warn": logging.WARNING,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+}
+
+
+class SendspinCastController(BaseController):
+    """Handles messages from the Sendspin Cast receiver app.
+
+    Processes receiver_log messages (forwarded console output) and
+    status messages (connection state, errors) from the Cast app.
+    """
+
+    def __init__(self, logger: logging.Logger) -> None:
+        """Initialize the controller.
+
+        :param logger: Logger to forward Cast receiver messages to.
+        """
+        super().__init__(SENDSPIN_CAST_NAMESPACE)
+        self._log = logger
+
+    def receive_message(self, _message: CastMessage, data: dict[str, Any]) -> bool:
+        """Handle incoming messages on the Sendspin namespace.
+
+        :param _message: The raw Cast protocol message.
+        :param data: The parsed JSON payload.
+        """
+        msg_type = data.get("type")
+        if msg_type == "receiver_log":
+            return self._handle_receiver_log(data)
+        if msg_type == "status":
+            return self._handle_status(data)
+        return False
+
+    def _handle_receiver_log(self, data: dict[str, Any]) -> bool:
+        """Forward a receiver console log to the Python logger."""
+        level = _CAST_LOG_LEVEL_MAP.get(data.get("level", ""), logging.DEBUG)
+        self._log.log(level, "[CastApp] %s", data.get("message", ""))
+        if stack := data.get("stack"):
+            self._log.log(level, "[CastApp] %s", stack)
+        return True
+
+    def _handle_status(self, data: dict[str, Any]) -> bool:
+        """Handle a status message from the Cast receiver."""
+        state = data.get("state")
+        message = data.get("message", "")
+        if state == "error":
+            self._log.error("[CastApp] Error: %s", message)
+        return True
 
 
 def get_bridge_client_id(cast_player: ChromecastPlayer) -> str | None:
@@ -140,6 +196,7 @@ class SendspinChromecastBridge:
         self._bridge_client_id: str = bridge_client_id
         self._bridge_role: BridgePlayerRole | None = None
         self._launch_task: asyncio.Task[None] | None = None
+        self._log_controller: SendspinCastController | None = None
 
     @property
     def bridge_client_id(self) -> str:
@@ -195,6 +252,10 @@ class SendspinChromecastBridge:
             self._bridge_role = cast("BridgePlayerRole", roles[0])
             self._bridge_role.setup_audio_requirements()
 
+        # Register log controller to receive receiver_log messages from the Cast app
+        self._log_controller = SendspinCastController(self.logger)
+        self.cast_player.cc.register_handler(self._log_controller)
+
         self.logger.info(
             "Sendspin bridge registered for %s (client_id=%s)",
             self.cast_player.display_name,
@@ -203,6 +264,10 @@ class SendspinChromecastBridge:
 
     async def stop(self) -> None:
         """Stop and unregister the Sendspin bridge."""
+        if self._log_controller is not None:
+            self.cast_player.cc.unregister_handler(self._log_controller)
+            self._log_controller = None
+
         if self._launch_task and not self._launch_task.done():
             self._launch_task.cancel()
             with suppress(asyncio.CancelledError):
@@ -285,6 +350,19 @@ class SendspinChromecastBridge:
                 err,
             )
 
+    def _get_receiver_log_level(self) -> str:
+        """Map the effective log level to a Cast receiver log level string."""
+        effective = self.logger.getEffectiveLevel()
+        if effective <= logging.DEBUG:
+            return "debug"
+        if effective <= logging.INFO:
+            return "info"
+        if effective <= logging.WARNING:
+            return "warn"
+        if effective <= logging.ERROR:
+            return "error"
+        return "off"
+
     async def _send_sendspin_config_with_retry(self, max_attempts: int = 3) -> None:
         """Send the Sendspin config to the Cast app, retrying on failure.
 
@@ -346,6 +424,7 @@ class SendspinChromecastBridge:
             "playerName": f"{self.cast_player.display_name} (Cast)",
             "syncDelay": sync_delay,
             "codecs": ["flac"],
+            "receiverLogLevel": self._get_receiver_log_level(),
         }
 
         def send() -> None:

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -105,7 +105,10 @@ class SendspinCastController(BaseController):
         return True
 
     def _handle_status(self, data: dict[str, Any]) -> bool:
-        """Handle a status message from the Cast receiver."""
+        """Handle a status message from the Cast receiver.
+
+        Only errors are logged. Non-error statuses are sent every second and would be too noisy.
+        """
         state = data.get("state")
         message = data.get("message", "")
         if state == "error":


### PR DESCRIPTION
Console output and errors from the Sendspin Cast receiver app are now forwarded to the Music Assistant logger for easier debugging. Log verbosity matches the Chromecast provider's log level.

Forwarded logs are prefixed with `[CastApp]` and look like this:

```
2026-04-16 09:25:36.678 DEBUG (Thread-14) [music_assistant.Chromecast.bridge.1d5e7151-8ca9-4bf3-9d60-6cfea3216f60] [CastApp] Sendspin: sync=+0.8ms corr=none q=224/1.6s resyncs=0 clock=estimated(cast-disabled) tf=synced(err=2.7ms,drift=0.000,n=5) lat=10ms mode=sync ctx=running gen=3
```