### PR TITLE
Fix AirPlay cleanup idling re-added clients

### DIFF
--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -115,6 +115,8 @@ class AirPlayStreamSession:
         :param airplay_player: The player whose processes should be stopped.
         """
         stream = airplay_player.stream
+        if stream is not None and stream.session != self:
+            stream = None
         await self.stop_client(airplay_player)
         # Only set IDLE if the player's stream still belongs to this session,
         # otherwise a re-add to a new session may have already set a new state.

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -115,8 +115,6 @@ class AirPlayStreamSession:
         :param airplay_player: The player whose processes should be stopped.
         """
         stream = airplay_player.stream
-        if stream is not None and stream.session != self:
-            stream = None
         await self.stop_client(airplay_player)
         # Only set IDLE if the player's stream still belongs to this session,
         # otherwise a re-add to a new session may have already set a new state.

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -255,3 +255,23 @@ async def test_late_join_drops_buffer_when_trim_exceeds_buffer() -> None:
     # start_at should be exactly now + min_headroom (since the next-chunk anchor would
     # have landed at now - 1.0, which is below the target).
     assert captured_start_at[0] - now == pytest.approx(2.0, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_after_removal_skips_idle_when_player_has_new_session_stream() -> None:
+    """Cleanup must not idle a player that was already re-added to another session."""
+    now = time.time()
+    session = _make_session(now - 10, 12.5)
+    player = _make_late_joiner()
+    player.set_state_from_stream = MagicMock()
+    player.stream = MagicMock()
+    player.stream.session = MagicMock()
+    session.sync_clients.clear()
+
+    with (
+        patch.object(session, "stop_client", new_callable=AsyncMock),
+        patch.object(session, "stop", new_callable=AsyncMock),
+    ):
+        await session._cleanup_after_removal(player)
+
+    player.set_state_from_stream.assert_not_called()

--- a/tests/providers/airplay/test_stream_session.py
+++ b/tests/providers/airplay/test_stream_session.py
@@ -263,9 +263,10 @@ async def test_cleanup_after_removal_skips_idle_when_player_has_new_session_stre
     now = time.time()
     session = _make_session(now - 10, 12.5)
     player = _make_late_joiner()
+    other_session = object()
     player.set_state_from_stream = MagicMock()
     player.stream = MagicMock()
-    player.stream.session = MagicMock()
+    player.stream.session = other_session
     session.sync_clients.clear()
 
     with (


### PR DESCRIPTION
Problem
AirPlay cleanup could mark a player idle after it had already been re-added to a new session.

Changes
- guard cleanup state updates so only the old session can idle the player
- add a regression test for the re-add race