### PR TITLE
Fix sync leader child state forwarding

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1720,8 +1720,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         self, player: Player, changed_values: dict[str, tuple[Any, Any]]
     ) -> None:
         """Forward a player state update to related players (groups, sync parent, protocols)."""
-        # update/signal group player(s) child's when group updates
-        if player.type == PlayerType.GROUP:
+        # Propagate leader/group updates to child players. This must also cover
+        # regular sync leaders (not just virtual group players) because synced
+        # children derive playback/current-media state from their leader.
+        if player.state.group_members:
             for child_player in self.iter_group_members(player, exclude_self=True):
                 child_player.on_group_updated(player, changed_values)
         # update/signal group player(s) when child updates

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1720,12 +1720,13 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         self, player: Player, changed_values: dict[str, tuple[Any, Any]]
     ) -> None:
         """Forward a player state update to related players (groups, sync parent, protocols)."""
-        # Propagate leader/group updates to child players. This must also cover
-        # regular sync leaders (not just virtual group players) because synced
-        # children derive playback/current-media state from their leader.
+        # Propagate group or sync-leader updates to child players.
         if player.state.group_members:
             for child_player in self.iter_group_members(player, exclude_self=True):
-                child_player.on_group_updated(player, changed_values)
+                if player.type == PlayerType.GROUP:
+                    child_player.on_group_updated(player, changed_values)
+                else:
+                    child_player.on_sync_parent_updated(player, changed_values)
         # update/signal group player(s) when child updates
         else:
             for group_player in self._get_player_groups(player, powered_only=False):

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -696,6 +696,14 @@ class Player(ABC):
         # default implementation will simply trigger an update for the state of the player
         self.mass.players.trigger_player_update(self.player_id)
 
+    def on_sync_parent_updated(
+        self, sync_parent: Player, changed_values: dict[str, tuple[Any, Any]]
+    ) -> None:
+        """Handle callback when the sync parent of this player is updated."""
+        # optional callback
+        # default implementation will simply trigger an update for the state of the player
+        self.mass.players.trigger_player_update(self.player_id)
+
     # DO NOT OVERWRITE BELOW !
     # These properties and methods are either managed by core logic or they
     # are used to perform a very specific function. Overwriting these may

--- a/tests/core/test_player_controller.py
+++ b/tests/core/test_player_controller.py
@@ -14,7 +14,7 @@ import contextlib
 from unittest.mock import MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import PlaybackState, PlayerFeature
+from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.errors import UnsupportedFeaturedException
 
 from music_assistant.controllers.players import PlayerController
@@ -232,8 +232,8 @@ class TestPlayerAvailability:
 class TestStateForwarding:
     """Test forwarding of player state changes to related players."""
 
-    def test_sync_leader_updates_are_forwarded_to_children(self, mock_mass: MagicMock) -> None:
-        """A regular sync leader must still notify its grouped/synced children."""
+    def test_sync_leader_updates_are_forwarded_to_sync_children(self, mock_mass: MagicMock) -> None:
+        """A regular sync leader must notify children via the sync-parent callback."""
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
 
@@ -251,16 +251,56 @@ class TestStateForwarding:
         leader.update_state(signal_event=False)
         child.update_state(signal_event=False)
 
-        with patch.object(child, "on_group_updated") as on_group_updated:
+        with (
+            patch.object(child, "on_sync_parent_updated") as on_sync_parent_updated,
+            patch.object(child, "on_group_updated") as on_group_updated,
+        ):
             controller._forward_state_update(
                 leader,
                 {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)},
             )
 
-        on_group_updated.assert_called_once_with(
+        on_sync_parent_updated.assert_called_once_with(
             leader,
             {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)},
         )
+        on_group_updated.assert_not_called()
+
+    def test_group_updates_are_forwarded_to_children_via_group_callback(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A group player must continue to notify children via the group callback."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        group_player = MockPlayer(provider, "group", "Group", player_type=PlayerType.GROUP)
+        child = MockPlayer(provider, "child", "Child")
+
+        controller._players = {"group": group_player, "child": child}
+        controller._player_throttlers = {
+            "group": Throttler(1, 0.05),
+            "child": Throttler(1, 0.05),
+        }
+        mock_mass.players = controller
+
+        group_player._attr_group_members = ["group", "child"]
+        group_player.update_state(signal_event=False)
+        child.update_state(signal_event=False)
+
+        with (
+            patch.object(child, "on_group_updated") as on_group_updated,
+            patch.object(child, "on_sync_parent_updated") as on_sync_parent_updated,
+        ):
+            controller._forward_state_update(
+                group_player,
+                {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)},
+            )
+
+        on_group_updated.assert_called_once_with(
+            group_player,
+            {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)},
+        )
+        on_sync_parent_updated.assert_not_called()
 
 
 class TestUnregisterCleanup:

--- a/tests/core/test_player_controller.py
+++ b/tests/core/test_player_controller.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from music_assistant_models.enums import PlayerFeature
+from music_assistant_models.enums import PlaybackState, PlayerFeature
 from music_assistant_models.errors import UnsupportedFeaturedException
 
 from music_assistant.controllers.players import PlayerController
@@ -227,6 +227,40 @@ class TestPlayerAvailability:
         # This should either skip the unavailable player or raise an exception
         with contextlib.suppress(Exception):
             asyncio.run(controller.cmd_set_members("leader", player_ids_to_add=["member"]))
+
+
+class TestStateForwarding:
+    """Test forwarding of player state changes to related players."""
+
+    def test_sync_leader_updates_are_forwarded_to_children(self, mock_mass: MagicMock) -> None:
+        """A regular sync leader must still notify its grouped/synced children."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        child = MockPlayer(provider, "child", "Child")
+
+        controller._players = {"leader": leader, "child": child}
+        controller._player_throttlers = {
+            "leader": Throttler(1, 0.05),
+            "child": Throttler(1, 0.05),
+        }
+        mock_mass.players = controller
+
+        leader._attr_group_members = ["leader", "child"]
+        leader.update_state(signal_event=False)
+        child.update_state(signal_event=False)
+
+        with patch.object(child, "on_group_updated") as on_group_updated:
+            controller._forward_state_update(
+                leader,
+                {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)},
+            )
+
+        on_group_updated.assert_called_once_with(
+            leader,
+            {"playback_state": (PlaybackState.IDLE, PlaybackState.PLAYING)},
+        )
 
 
 class TestUnregisterCleanup:


### PR DESCRIPTION
Problem
Sync leader state updates stopped propagating to regular synced children after the recent state forwarding refactor, so child playback state could go stale.

Changes
- forward child updates for any leader with group members, not only virtual group players
- add a regression test covering non-group sync leaders
