### PR TITLE
Forward syncgroup join/unjoin to the syncgroup player

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1148,6 +1148,25 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             msg = f"Player {parent_player.name} does not support group commands"
             raise UnsupportedFeaturedException(msg)
 
+        # if the target player is a member of an active group player (e.g. a syncgroup),
+        # redirect the command to that group player so it can manage the member change
+        if (
+            parent_player.type != PlayerType.GROUP
+            and parent_player.state.active_group
+            and (group_player := self.get_player(parent_player.state.active_group))
+            and group_player.type == PlayerType.GROUP
+            and PlayerFeature.SET_MEMBERS in group_player.state.supported_features
+        ):
+            self.logger.debug(
+                "Redirecting set_members from %s to its group player %s",
+                parent_player.name,
+                group_player.name,
+            )
+            await self.cmd_set_members(
+                parent_player.state.active_group, player_ids_to_add, player_ids_to_remove
+            )
+            return
+
         if parent_player.synced_to:
             # handle edge case: target player is already synced itself to another player
             # automatically ungroup it first and wait for state to propagate
@@ -2821,9 +2840,21 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             ):
                 continue  # already synced to this target
 
+            # also skip if the child is part of this group via its sync leader
+            # (e.g. synced to the sync leader of this syncgroup)
+            if (
+                child_player.state.active_group == target_player
+                and child_player_id in parent_player.state.group_members
+            ):
+                continue
+
             # handle edge case: child player is synced to a different player
             # automatically ungroup it first and wait for state to propagate
-            if child_player.state.synced_to and child_player.state.synced_to != target_player:
+            # but not if the child is already part of this group (via its sync leader)
+            if child_player.state.synced_to and target_player not in {
+                child_player.state.synced_to,
+                child_player.state.active_group,
+            }:
                 await self._auto_ungroup_if_synced(child_player, f"joining {parent_player.name}")
 
             # power on the player if needed

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -15,6 +15,7 @@ from music_assistant.constants import (
     CONF_DYNAMIC_GROUP_MEMBERS,
     CONF_GROUP_MEMBERS,
 )
+from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 
 from .constants import (
@@ -462,11 +463,16 @@ class SyncGroupPlayer(Player):
             # `active_protocol_domain` is derived from live state, so the
             # group will naturally downshift on the next leader selection if
             # the last protocol-requiring member was removed.
-            await self.mass.players.cmd_set_members(
-                self.sync_leader.player_id,
-                player_ids_to_add=final_players_to_add,
-                player_ids_to_remove=final_players_to_remove,
-            )
+            # use _handle_set_members directly to avoid the redirect loop
+            # (cmd_set_members redirects sync-leader targets back to this syncgroup)
+            async with self.mass.players.get_player_lock(
+                self.sync_leader.player_id, PlayerLockPurpose.PLAYBACK
+            ):
+                await self.mass.players._handle_set_members(
+                    self.sync_leader,
+                    player_ids_to_add=final_players_to_add,
+                    player_ids_to_remove=final_players_to_remove,
+                )
         # NOTE: If we weren't playing before, we don't need to do anything else,
         # since the syncing will be done once playback starts
         self.mass.players.trigger_player_update(self.player_id)
@@ -528,7 +534,14 @@ class SyncGroupPlayer(Player):
                     timeout=5,
                 ):
                     await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
-            await self.mass.players.cmd_set_members(self.sync_leader.player_id, members_to_sync)
+            # use _handle_set_members directly to avoid the redirect loop
+            # (cmd_set_members redirects sync-leader targets back to this syncgroup)
+            async with self.mass.players.get_player_lock(
+                self.sync_leader.player_id, PlayerLockPurpose.PLAYBACK
+            ):
+                await self.mass.players._handle_set_members(
+                    self.sync_leader, player_ids_to_add=members_to_sync
+                )
 
     async def _dissolve_syncgroup(self) -> None:
         """Dissolve the current syncgroup by ungrouping all members."""
@@ -539,11 +552,16 @@ class SyncGroupPlayer(Player):
             ]
             if sync_children:
                 # wait for the leader's state to reflect the ungroup
-                async with self.mass.players.wait_for_player_update(
-                    sync_leader.player_id, timeout=5
+                # use _handle_set_members directly to avoid the redirect loop
+                # (cmd_set_members redirects sync-leader targets back to this syncgroup)
+                async with (
+                    self.mass.players.wait_for_player_update(sync_leader.player_id, timeout=5),
+                    self.mass.players.get_player_lock(
+                        sync_leader.player_id, PlayerLockPurpose.PLAYBACK
+                    ),
                 ):
-                    await self.mass.players.cmd_set_members(
-                        sync_leader.player_id, [], sync_children
+                    await self.mass.players._handle_set_members(
+                        sync_leader, player_ids_to_remove=sync_children
                     )
         # Clear the leader's active protocol so it doesn't persist
         # after the sync group is dissolved. The controller's normal

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -26,6 +26,12 @@ def _make_mock_mass() -> MagicMock:
     mass.players._handle_cmd_resume = AsyncMock()
     mass.players._handle_play_media = AsyncMock()
     mass.players.cmd_set_members = AsyncMock()
+    mass.players._handle_set_members = AsyncMock()
+    # get_player_lock is an async context manager (used by syncgroup to lock the sync leader)
+    lock_ctx = AsyncMock()
+    lock_ctx.__aenter__.return_value = None
+    lock_ctx.__aexit__.return_value = False
+    mass.players.get_player_lock = MagicMock(return_value=lock_ctx)
     # wait_for_player_update is an async context manager — return one that no-ops.
     # __aexit__ must explicitly return False so exceptions inside the `async with`
     # body propagate (an unconfigured AsyncMock returns a truthy MagicMock and
@@ -488,7 +494,7 @@ class TestSetMembersDoesNotRegisterIncompatible:
         # and the leader was never asked to add it (the call may still happen
         # with empty lists since the member-changed path is taken, but the
         # incompatible id must not appear in either add or remove)
-        for call in mass.players.cmd_set_members.await_args_list:
+        for call in mass.players._handle_set_members.await_args_list:
             assert "incompatible" not in (call.kwargs.get("player_ids_to_add") or [])
             assert "incompatible" not in (call.kwargs.get("player_ids_to_remove") or [])
 
@@ -509,8 +515,8 @@ class TestSetMembersDoesNotRegisterIncompatible:
         await sgp.set_members(player_ids_to_add=["compatible"])
 
         assert "compatible" in sgp._attr_group_members
-        mass.players.cmd_set_members.assert_awaited_once()
-        kwargs = mass.players.cmd_set_members.await_args.kwargs
+        mass.players._handle_set_members.assert_awaited_once()
+        kwargs = mass.players._handle_set_members.await_args.kwargs
         assert kwargs.get("player_ids_to_add") == ["compatible"]
 
     @pytest.mark.asyncio
@@ -530,5 +536,5 @@ class TestSetMembersDoesNotRegisterIncompatible:
 
         # member is registered so a future _form_syncgroup can pick it as leader
         assert "member" in sgp._attr_group_members
-        # but cmd_set_members on the leader is not called (no leader yet)
-        mass.players.cmd_set_members.assert_not_awaited()
+        # but _handle_set_members on the leader is not called (no leader yet)
+        mass.players._handle_set_members.assert_not_awaited()


### PR DESCRIPTION
When external callers (HA automations, UI) target a sync leader directly with `cmd_set_members`, the command bypasses the syncgroup's member management logic. This causes spurious auto-ungrouping, unnecessary dissolve+reform cycles, and clunky protocol switches (e.g. when adding an AirPlay player to a Sonos-native syncgroup).

Changes:
- Redirect `cmd_set_members` targeting a sync leader to its parent syncgroup when one is active
- Update the syncgroup to call `_handle_set_members` directly (with explicit lock) to avoid redirect loops
- Skip auto-ungroup in `_handle_set_members` when a child player is already part of the target syncgroup via its sync leader