### PR TITLE
Fix audiobook controller not using userid in library_items call

### DIFF
--- a/music_assistant/controllers/media/audiobooks.py
+++ b/music_assistant/controllers/media/audiobooks.py
@@ -87,6 +87,9 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
+        extra_join_parts: list[str] = []
+        if session_user := get_current_user():
+            extra_join_parts = [f"AND playlog.userid = '{session_user.user_id}'"]
         result = await self.get_library_items_by_query(
             favorite=favorite,
             search=search,
@@ -97,6 +100,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             provider_filter=self._ensure_provider_filter(provider),
             extra_query_parts=extra_query_parts,
             extra_query_params=extra_query_params,
+            extra_join_parts=extra_join_parts,
             in_library_only=True,
         )
         if search and len(result) < 25 and not offset:
@@ -114,6 +118,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                 provider_filter=self._ensure_provider_filter(provider),
                 extra_query_parts=extra_query_parts,
                 extra_query_params=extra_query_params,
+                extra_join_parts=extra_join_parts,
                 in_library_only=True,
             )
         return result


### PR DESCRIPTION
Small fix which ensures, that the in_progress/finished icons in the frontend refer to the correct user.

Shall we backport this one?