### PR TITLE
Fix ffmpeg process leak in smart fades mixer on aborted playback

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -167,12 +167,19 @@ class SmartFade(ABC):
                         got_output = True
                         yield chunk
                 finally:
-                    if not feed_task.done():
-                        feed_task.cancel()
-                    with suppress(asyncio.CancelledError):
-                        await feed_task
-                    with suppress(asyncio.CancelledError):
-                        await stderr_task
+                    # Cancel both helper tasks so neither can block this finally.
+                    # stderr_task blocks on readline() until ffmpeg closes stderr,
+                    # which only happens after proc.close() closes stdin — but
+                    # proc.close() runs via the async-with __aexit__ *after* this
+                    # finally. If the consumer aborts (GeneratorExit), awaiting
+                    # stderr_task here would deadlock and the ffmpeg process (and
+                    # temp file) would leak.
+                    for task in (feed_task, stderr_task):
+                        if not task.done():
+                            task.cancel()
+                    for task in (feed_task, stderr_task):
+                        with suppress(asyncio.CancelledError):
+                            await task
 
             if proc.returncode not in (None, 0) or not got_output:
                 stderr_msg = "; ".join(stderr_lines) if stderr_lines else "(no stderr)"

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -167,19 +167,18 @@ class SmartFade(ABC):
                         got_output = True
                         yield chunk
                 finally:
-                    # Cancel both helper tasks so neither can block this finally.
-                    # stderr_task blocks on readline() until ffmpeg closes stderr,
-                    # which only happens after proc.close() closes stdin — but
-                    # proc.close() runs via the async-with __aexit__ *after* this
-                    # finally. If the consumer aborts (GeneratorExit), awaiting
-                    # stderr_task here would deadlock and the ffmpeg process (and
-                    # temp file) would leak.
-                    for task in (feed_task, stderr_task):
-                        if not task.done():
-                            task.cancel()
-                    for task in (feed_task, stderr_task):
-                        with suppress(asyncio.CancelledError):
-                            await task
+                    if not feed_task.done():
+                        feed_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await feed_task
+                    # Bounded wait on stderr_task so its output is still captured
+                    # for error reporting on the happy/error paths, but we don't
+                    # hang on consumer abort — ffmpeg is still alive then and
+                    # stderr won't EOF until proc.close() closes stdin, which
+                    # only runs via the async-with __aexit__ *after* this finally.
+                    # wait_for cancels stderr_task on timeout so cleanup proceeds.
+                    with suppress(TimeoutError, asyncio.CancelledError):
+                        await asyncio.wait_for(stderr_task, timeout=2)
 
             if proc.returncode not in (None, 0) or not got_output:
                 stderr_msg = "; ".join(stderr_lines) if stderr_lines else "(no stderr)"


### PR DESCRIPTION
## Problem

When playback is aborted while the smart fades mixer is crossfading, the ffmpeg process started for the crossfade keeps lingering indefinitely.

Root cause is in `SmartFade.apply`: on `GeneratorExit`, the inner `finally` only cancels the stdin feeder task, not the stderr drain task. Because the feeder is cancelled mid-write, ffmpeg's stdin never closes, ffmpeg never exits, stderr never EOFs, and the `await stderr_task` hangs forever — preventing the `async with proc:` `__aexit__` from running `proc.close()` that would terminate the process.

## Changes

- Cancel both the feed and stderr helper tasks in the finally block so neither can block cleanup.
- This lets the `async with proc:` exit run `proc.close()` normally, which properly terminates ffmpeg and also releases the temp file cleanup.