### PR TITLE
Migrate loudness analyzer to audio analysis provider

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -25,9 +25,9 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.constants import (
+    DB_TABLE_AUDIO_ANALYSIS,
     DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
     DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
-    DB_TABLE_LOUDNESS_MEASUREMENTS,
     DB_TABLE_PLAYLOG,
     DB_TABLE_PROVIDER_MAPPINGS,
     MASS_LOGGER_NAME,
@@ -244,10 +244,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                     "provider": prov_mapping.provider_instance,
                 },
             )
-            # cleanup loudness measurements for this provider mapping
+            # cleanup audio analysis rows for this provider mapping
             for prov_key in (prov_mapping.provider_domain, prov_mapping.provider_instance):
                 await self.mass.music.database.delete(
-                    DB_TABLE_LOUDNESS_MEASUREMENTS,
+                    DB_TABLE_AUDIO_ANALYSIS,
                     {
                         "media_type": self.media_type.value,
                         "item_id": prov_mapping.item_id,

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -11,7 +11,6 @@ from contextlib import suppress
 from copy import deepcopy
 from datetime import datetime
 from itertools import zip_longest
-from math import inf
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from music_assistant_models.background_task import BackgroundTask, TaskMetadata, TaskSchedule
@@ -110,7 +109,7 @@ CONF_RESET_DB = "reset_db"
 DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
-DB_SCHEMA_VERSION: Final[int] = 38
+DB_SCHEMA_VERSION: Final[int] = 39
 
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10
 DATABASE_CLEANUP_TASK_ID: Final[str] = "music_database_cleanup"
@@ -1091,64 +1090,6 @@ class MusicController(CoreController):
         await ctrl.match_providers(library_item)
         await self.mass.metadata.update_metadata(library_item, force_refresh=True)
         return library_item
-
-    async def set_loudness(
-        self,
-        item_id: str,
-        provider_instance_id_or_domain: str,
-        loudness: float,
-        album_loudness: float | None = None,
-        media_type: MediaType = MediaType.TRACK,
-    ) -> None:
-        """Store (EBU-R128) Integrated Loudness Measurement for a mediaitem in db."""
-        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
-            return
-        if loudness in (None, inf, -inf) or loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
-            # skip invalid or unreliable values (ebur128 reports -70 LUFS on near-silence)
-            return
-        # prefer domain for streaming providers as the catalog is the same across instances
-        prov_key = provider.domain if provider.is_streaming_provider else provider.instance_id
-        values = {
-            "item_id": item_id,
-            "media_type": media_type.value,
-            "provider": prov_key,
-            "loudness": loudness,
-        }
-        if (
-            album_loudness not in (None, inf, -inf)
-            and album_loudness > LOUDNESS_MEASUREMENT_MIN_LUFS
-        ):
-            values["loudness_album"] = album_loudness
-        await self.database.insert_or_replace(DB_TABLE_LOUDNESS_MEASUREMENTS, values)
-
-    async def get_loudness(
-        self,
-        item_id: str,
-        provider_instance_id_or_domain: str,
-        media_type: MediaType = MediaType.TRACK,
-    ) -> tuple[float, float | None] | None:
-        """Get (EBU-R128) Integrated Loudness Measurement for a mediaitem in db."""
-        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
-            return None
-        # prefer domain for streaming providers as the catalog is the same across instances
-        prov_key = provider.domain if provider.is_streaming_provider else provider.instance_id
-        db_row = await self.database.get_row(
-            DB_TABLE_LOUDNESS_MEASUREMENTS,
-            {
-                "item_id": item_id,
-                "media_type": media_type.value,
-                "provider": prov_key,
-            },
-        )
-        if db_row and db_row["loudness"] != inf and db_row["loudness"] != -inf:
-            loudness = round(db_row["loudness"], 2)
-            loudness_album = db_row["loudness_album"]
-            loudness_album = (
-                None if loudness_album in (None, inf, -inf) else round(loudness_album, 2)
-            )
-            return (loudness, loudness_album)
-
-        return None
 
     @api_command("music/mark_played")
     async def mark_item_played(
@@ -2706,6 +2647,25 @@ class MusicController(CoreController):
                 f"WHERE loudness_album <= {LOUDNESS_MEASUREMENT_MIN_LUFS}"
             )
 
+        if prev_version <= 38:
+            # migrate loudness measurements to the unified audio_analysis table
+            # under the new builtin loudness_analysis provider, then drop the
+            # legacy table. album loudness rides along when present.
+            await self._database.execute(
+                f"INSERT OR IGNORE INTO {DB_TABLE_AUDIO_ANALYSIS} "
+                f"(media_type, item_id, provider, aa_provider_domain, "
+                f" analysis_data, analysis_version) "
+                f"SELECT media_type, item_id, provider, 'loudness_analysis', "
+                f"       json_object("
+                f"           'loudness_integrated', loudness, "
+                f"           'loudness_album', loudness_album"
+                f"       ), 1 "
+                f"FROM {DB_TABLE_LOUDNESS_MEASUREMENTS} "
+                f"WHERE loudness IS NOT NULL "
+                f"  AND loudness > {LOUDNESS_MEASUREMENT_MIN_LUFS}"
+            )
+            await self._database.execute(f"DROP TABLE IF EXISTS {DB_TABLE_LOUDNESS_MEASUREMENTS}")
+
         # save changes
         await self._database.commit()
 
@@ -2975,17 +2935,6 @@ class MusicController(CoreController):
         )
 
         await self.database.execute(
-            f"""CREATE TABLE IF NOT EXISTS {DB_TABLE_LOUDNESS_MEASUREMENTS}(
-                    [id] INTEGER PRIMARY KEY AUTOINCREMENT,
-                    [media_type] TEXT NOT NULL,
-                    [item_id] TEXT NOT NULL,
-                    [provider] TEXT NOT NULL,
-                    [loudness] REAL,
-                    [loudness_album] REAL,
-                    UNIQUE(media_type,item_id,provider));"""
-        )
-
-        await self.database.execute(
             f"""CREATE TABLE IF NOT EXISTS {DB_TABLE_AUDIO_ANALYSIS}(
                     [id] INTEGER PRIMARY KEY AUTOINCREMENT,
                     [media_type] TEXT NOT NULL,
@@ -3098,11 +3047,6 @@ class MusicController(CoreController):
         await self.database.execute(
             f"CREATE INDEX IF NOT EXISTS {DB_TABLE_ALBUM_ARTISTS}_artist_id_idx "
             f"on {DB_TABLE_ALBUM_ARTISTS}(artist_id);"
-        )
-        # index on loudness measurements table
-        await self.database.execute(
-            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_LOUDNESS_MEASUREMENTS}_idx "
-            f"on {DB_TABLE_LOUDNESS_MEASUREMENTS}(media_type,item_id,provider);"
         )
         # indexes on genre_media_item_mapping table
         await self.database.execute(

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -58,7 +58,6 @@ from music_assistant.constants import (
     CONF_VOLUME_NORMALIZATION_FIXED_GAIN_TRACKS,
     CONF_VOLUME_NORMALIZATION_TARGET,
     INTERNAL_PCM_FORMAT,
-    LOUDNESS_MEASUREMENT_MIN_LUFS,
     MASS_LOGGER_NAME,
     VERBOSE_LOG_LEVEL,
 )
@@ -256,12 +255,6 @@ class StreamsAudio:
                         self._update_hls_radio_metadata
                     )
                     streamdetails.stream_metadata_update_interval = 5
-            # handle volume normalization details
-            if result := await mass.music.get_loudness(
-                streamdetails.item_id, streamdetails.provider, media_type=queue_item.media_type
-            ):
-                streamdetails.loudness = result[0]
-                streamdetails.loudness_album = result[1]
 
         if streamdetails.duration is None:
             if queue_item.media_item and queue_item.media_item.duration:
@@ -863,136 +856,6 @@ class StreamsAudio:
         finally:
             await remove_file(temp_file)
 
-    def attach_loudness_analyzer(
-        self,
-        audio_buffer: AudioBuffer,
-        streamdetails: StreamDetails,
-        max_duration_seconds: int = 600,
-        min_duration_seconds: int = 10,
-    ) -> None:
-        """
-        Attach a loudness measurement job to an AudioBuffer.
-
-        Registers a chunk callback that feeds raw PCM into an FFmpeg ebur128 process.
-        After max_duration_seconds of audio (or EOF), the measurement is finalized
-        and stored via mass.music.set_loudness.
-
-        :param audio_buffer: The AudioBuffer to observe.
-        :param streamdetails: Stream details for the track being buffered.
-        :param max_duration_seconds: Maximum seconds of audio to analyze.
-        :param min_duration_seconds: Minimum seconds of audio required to persist the result.
-        """
-        item_id = streamdetails.item_id
-        provider = streamdetails.provider
-        media_type = streamdetails.media_type
-        pcm_format = audio_buffer.pcm_format
-
-        chunk_queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=10)
-        chunks_received = 0
-
-        async def _on_chunk(position_seconds: int, pcm_data: bytes, is_last_chunk: bool) -> None:  # noqa: ARG001
-            nonlocal chunks_received
-            if chunks_received >= max_duration_seconds:
-                return
-            if is_last_chunk:
-                # EOF
-                await chunk_queue.put(None)
-                return
-            chunks_received += 1
-            await chunk_queue.put(pcm_data)
-            if chunks_received >= max_duration_seconds:
-                # signal we have enough data
-                await chunk_queue.put(None)
-
-        async def _chunk_generator() -> AsyncGenerator[bytes, None]:
-            """Yield chunks from the queue until None (EOF/done)."""
-            while True:
-                chunk = await chunk_queue.get()
-                if chunk is None:
-                    break
-                yield chunk
-
-        async def _run_analysis() -> None:
-            """Run the ebur128 measurement in a background FFmpeg process."""
-            try:
-                async with FFMpeg(
-                    audio_input=_chunk_generator(),
-                    input_format=pcm_format,
-                    output_format=pcm_format,
-                    audio_output="NULL",
-                    filter_params=["ebur128=framelog=verbose"],
-                    collect_log_history=True,
-                    loglevel="info",
-                ) as ffmpeg_proc:
-                    await ffmpeg_proc.wait()
-
-                    if chunks_received < min_duration_seconds:
-                        self.logger.debug(
-                            "Loudness analysis for %s skipped: "
-                            "insufficient audio data (%s/%s seconds analyzed)",
-                            streamdetails.uri,
-                            chunks_received,
-                            min_duration_seconds,
-                        )
-                        return
-
-                    log_lines_str = "\n".join(ffmpeg_proc.log_history)
-                    try:
-                        loudness_str = (
-                            log_lines_str.split("Integrated loudness")[1]
-                            .split("I:")[1]
-                            .split("LUFS")[0]
-                        )
-                        loudness = float(loudness_str.strip())
-                    except (IndexError, ValueError, AttributeError):
-                        self.logger.debug(
-                            "Could not determine loudness of %s from buffer analysis",
-                            streamdetails.uri,
-                        )
-                        return
-
-                    if loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
-                        self.logger.debug(
-                            "Loudness measurement for %s discarded: "
-                            "%s LUFS is below the reliability threshold (%s LUFS)",
-                            streamdetails.uri,
-                            loudness,
-                            LOUDNESS_MEASUREMENT_MIN_LUFS,
-                        )
-                        return
-
-                    await self.mass.music.set_loudness(
-                        item_id, provider, loudness, media_type=media_type
-                    )
-                    # update the in-memory streamdetails so subsequent seeks
-                    # can use measurement-based normalization instead of dynamic
-                    streamdetails.loudness = loudness
-                    self.logger.debug(
-                        "Loudness measurement for %s: %s LUFS",
-                        streamdetails.uri,
-                        loudness,
-                    )
-            except Exception as err:
-                self.logger.debug("Loudness analysis from buffer failed: %s", err)
-
-        async def _attach() -> None:
-            # check if loudness already exists
-            if await self.mass.music.get_loudness(item_id, provider, media_type=media_type):
-                return
-            self.logger.debug("Attached loudness analyzer to buffer for %s", streamdetails.uri)
-            audio_buffer.register_chunk_callback(_on_chunk)
-
-            def _on_cancel() -> None:
-                if chunk_queue.full():
-                    chunk_queue.get_nowait()
-                chunk_queue.put_nowait(None)
-
-            audio_buffer.register_cancel_callback(_on_cancel)
-            # start the FFmpeg analysis process
-            await _run_analysis()
-
-        self.mass.create_task(_attach)
-
     def get_player_dsp_details(
         self, player: Player, group_preventing_dsp: bool = False
     ) -> DSPDetails:
@@ -1282,6 +1145,21 @@ class StreamsAudio:
         filter_params: list[str] = []
 
         logger = self.logger.getChild("queue_item_stream")
+
+        # hydrate loudness from audio analysis (just-in-time, so that a measurement
+        # completed during a previous play is picked up here). A live analyzer run
+        # may have already populated streamdetails.loudness in memory — don't clobber
+        # that, and don't clobber a value set upstream by the music provider.
+        if streamdetails.loudness is None:
+            if analysis := await self.mass.streams.audio_analysis.get_audio_analysis(
+                streamdetails.item_id,
+                streamdetails.provider,
+                media_type=streamdetails.media_type,
+            ):
+                if analysis.loudness_integrated is not None:
+                    streamdetails.loudness = round(analysis.loudness_integrated, 2)
+                if analysis.loudness_album is not None and streamdetails.loudness_album is None:
+                    streamdetails.loudness_album = round(analysis.loudness_album, 2)
 
         # re-evaluate normalization mode: the background loudness analyzer may have
         # updated streamdetails.loudness since get_stream_details was called

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -7,9 +7,15 @@ import contextlib
 from math import inf
 from typing import TYPE_CHECKING
 
-from music_assistant_models.enums import MediaType, ProviderType
+from music_assistant_models.background_task import TaskSchedule
+from music_assistant_models.enums import MediaType, ProviderType, StreamType
 
-from music_assistant.constants import DB_TABLE_AUDIO_ANALYSIS, LOUDNESS_MEASUREMENT_MIN_LUFS
+from music_assistant.constants import (
+    DB_TABLE_AUDIO_ANALYSIS,
+    DB_TABLE_PROVIDER_MAPPINGS,
+    LOUDNESS_MEASUREMENT_MIN_LUFS,
+)
+from music_assistant.helpers.datetime import local_clock_time_to_utc
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
@@ -17,6 +23,15 @@ from music_assistant.models.music_provider import MusicProvider
 
 CHUNK_PROCESS_TIMEOUT = 0.8
 LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
+BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
+BACKGROUND_SCAN_BATCH_SIZE = 250
+BACKGROUND_SCAN_SLEEP_BETWEEN_ITEMS = 2.0
+# providers whose tracks can be analyzed from their local filesystem path
+FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
+    "filesystem_local",
+    "filesystem_smb",
+    "filesystem_nfs",
+)
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat
@@ -39,6 +54,17 @@ class AudioAnalysisController:
         self.logger = self.mass.logger.getChild("audio_analysis")
         self._active_sessions: dict[str, set[str]] = {}
         self._workers: dict[str, asyncio.Task[None]] = {}
+
+    def setup(self) -> None:
+        """Register the nightly background scan task."""
+        utc_hour, utc_minute = local_clock_time_to_utc(0, 0)
+        self.mass.tasks.register_scheduled_task(
+            task_id=BACKGROUND_SCAN_TASK_ID,
+            name="Audio analysis — background scan of local files",
+            handler=self._run_background_scan,
+            schedule=TaskSchedule.daily(hour=utc_hour, minute=utc_minute),
+            metadata={"task_domain": "audio_analysis"},
+        )
 
     @property
     def providers(self) -> list[AudioAnalysisProvider]:
@@ -286,6 +312,133 @@ class AudioAnalysisController:
         if not row:
             return None
         return int(row["analysis_version"])
+
+    async def _run_background_scan(self) -> None:
+        """
+        Run the nightly background scan across all audio analysis providers.
+
+        Iterates each available provider, queries tracks from local-filesystem
+        music providers that do not yet have analysis for that provider, and
+        hands each one to the provider's `analyze_file` hook. Results are
+        persisted via `set_audio_analysis`. The batch aborts for a given
+        provider if its storage backend goes offline.
+        """
+        providers = self.providers
+        if not providers:
+            return
+
+        for provider in providers:
+            candidates = await self._find_tracks_missing_analysis(
+                provider.domain, BACKGROUND_SCAN_BATCH_SIZE
+            )
+            if not candidates:
+                continue
+
+            self.logger.info(
+                "Background %s analysis: %d track(s) pending",
+                provider.domain,
+                len(candidates),
+            )
+            processed = 0
+            for row in candidates:
+                if not provider.available:
+                    # provider was disabled mid-run
+                    break
+                item_id = str(row["item_id"])
+                provider_instance = str(row["provider_instance"])
+                music_prov = self.mass.get_provider(provider_instance, provider_type=MusicProvider)
+                if music_prov is None or not music_prov.available:
+                    # storage may be offline right now (e.g. NAS asleep) — stop the
+                    # batch rather than churning through failures for the remaining
+                    # tracks
+                    self.logger.debug(
+                        "Background %s analysis: provider %s unavailable, aborting batch",
+                        provider.domain,
+                        provider_instance,
+                    )
+                    break
+
+                try:
+                    streamdetails = await music_prov.get_stream_details(item_id, MediaType.TRACK)
+                except Exception as err:
+                    self.logger.debug(
+                        "Background %s analysis: skipping %s (stream details failed: %s)",
+                        provider.domain,
+                        item_id,
+                        err,
+                    )
+                    continue
+
+                if streamdetails.stream_type != StreamType.LOCAL_FILE:
+                    continue
+                if not isinstance(streamdetails.path, str) or not streamdetails.path:
+                    continue
+
+                try:
+                    result = await provider.analyze_file(streamdetails)
+                except Exception as err:
+                    self.logger.warning(
+                        "Background %s analysis failed for %s: %s",
+                        provider.domain,
+                        item_id,
+                        err,
+                    )
+                    result = None
+
+                if result is not None:
+                    await self.set_audio_analysis(
+                        item_id=item_id,
+                        provider_instance_id_or_domain=music_prov.instance_id,
+                        aa_provider_domain=provider.domain,
+                        analysis=result,
+                        analysis_version=provider.analysis_version,
+                    )
+                    processed += 1
+
+                await asyncio.sleep(BACKGROUND_SCAN_SLEEP_BETWEEN_ITEMS)
+
+            self.logger.info(
+                "Background %s analysis: analyzed %d/%d track(s)",
+                provider.domain,
+                processed,
+                len(candidates),
+            )
+
+    async def _find_tracks_missing_analysis(
+        self, aa_provider_domain: str, limit: int
+    ) -> list[dict[str, object]]:
+        """Return up to N local-filesystem tracks without analysis for the given AA provider."""
+        filesystem_domains = tuple(
+            domain
+            for domain in FILESYSTEM_PROVIDER_DOMAINS
+            if any(
+                p.domain == domain and p.available
+                for p in self.mass.get_providers(ProviderType.MUSIC)
+            )
+        )
+        if not filesystem_domains:
+            return []
+
+        domains_sql = ", ".join(f"'{d}'" for d in filesystem_domains)
+        track_media_type = MediaType.TRACK.value
+        # audio_analysis.item_id holds the provider-native item id,
+        # so join against provider_mappings.provider_item_id (not pm.item_id,
+        # which is the integer library-row id)
+        query = (
+            f"SELECT pm.provider_item_id AS item_id, "
+            f"       pm.provider_instance AS provider_instance "
+            f"FROM {DB_TABLE_PROVIDER_MAPPINGS} pm "
+            f"LEFT JOIN {DB_TABLE_AUDIO_ANALYSIS} aa "
+            f"  ON aa.item_id = pm.provider_item_id "
+            f"  AND aa.provider = pm.provider_instance "
+            f"  AND aa.aa_provider_domain = '{aa_provider_domain}' "
+            f"  AND aa.media_type = '{track_media_type}' "
+            f"WHERE pm.media_type = '{track_media_type}' "
+            f"  AND pm.provider_domain IN ({domains_sql}) "
+            f"  AND aa.id IS NULL"
+        )
+        rows = await self.mass.music.database.get_rows_from_query(query, limit=limit)
+        return [dict(r) for r in rows]
 
     async def _start_analysis_on_providers(
         self,

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -4,17 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from math import inf
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import MediaType, ProviderType
 
-from music_assistant.constants import DB_TABLE_AUDIO_ANALYSIS
+from music_assistant.constants import DB_TABLE_AUDIO_ANALYSIS, LOUDNESS_MEASUREMENT_MIN_LUFS
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
 from music_assistant.models.music_provider import MusicProvider
 
 CHUNK_PROCESS_TIMEOUT = 0.8
+LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat
@@ -209,6 +211,46 @@ class AudioAnalysisController:
             merged.update(row_data)
             found = True
         return merged if found else None
+
+    async def set_track_loudness(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+        loudness: float,
+        loudness_album: float | None = None,
+        media_type: MediaType = MediaType.TRACK,
+    ) -> None:
+        """
+        Store track loudness measurement from an external source (tags, ReplayGain, etc).
+
+        Persists the loudness values under the builtin loudness_analysis provider so
+        the runtime ebur128 analysis will not re-analyze the track on playback.
+
+        :param item_id: Provider-native item ID.
+        :param provider_instance_id_or_domain: Music provider instance ID or domain.
+        :param loudness: Integrated track loudness in LUFS.
+        :param loudness_album: Optional album-level integrated loudness in LUFS.
+        :param media_type: The media type of the item.
+        """
+        if loudness in (None, inf, -inf) or loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
+            return
+        if (
+            loudness_album is None
+            or loudness_album in (inf, -inf)
+            or loudness_album <= LOUDNESS_MEASUREMENT_MIN_LUFS
+        ):
+            loudness_album = None
+        analysis = AudioAnalysisData(
+            loudness_integrated=loudness,
+            loudness_album=loudness_album,
+        )
+        await self.set_audio_analysis(
+            item_id=item_id,
+            provider_instance_id_or_domain=provider_instance_id_or_domain,
+            aa_provider_domain=LOUDNESS_ANALYSIS_DOMAIN,
+            analysis=analysis,
+            media_type=media_type,
+        )
 
     async def get_audio_analysis_version(
         self,

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -433,10 +433,7 @@ class AudioBuffer:
 
         # attach analyze jobs for ahead-of-time processing
         if seek_position_ms == 0:
-            # TODO: Remove loudness after it has been implemented as an audio analysis provider
-            # loudness analysis for all streams (tracks and radio)
-            mass.streams.audio.attach_loudness_analyzer(audio_buffer, streamdetails)
-            # audio analysis providers (beat tracking, key detection, etc.)
+            # audio analysis providers (loudness, beat tracking, key detection, etc.)
             await mass.streams.audio_analysis.start_analysis(audio_buffer, streamdetails)
 
         # start filling from the media stream (seek in seconds for FFmpeg)

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -258,6 +258,7 @@ class StreamsController(CoreController):
         """Async initialize of module."""
         # initialize the audio sub-controller (needs mass.streams to be set)
         self.audio.setup()
+        self._audio_analysis.setup()
         # copy log level to audio/ffmpeg loggers
         self.audio.logger.setLevel(self.logger.level)
         FFMPEG_LOGGER.setLevel(self.logger.level)

--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -18,7 +18,8 @@ from music_assistant_models.enums import AlbumType
 from music_assistant_models.errors import InvalidDataError
 from mutagen._vorbis import VCommentDict
 from mutagen.apev2 import APEv2
-from mutagen.mp4 import MP4Tags
+from mutagen.id3 import ID3, TXXX  # type: ignore[attr-defined]
+from mutagen.mp4 import AtomDataType, MP4FreeForm, MP4Tags
 
 from music_assistant.constants import MASS_LOGGER_NAME, UNKNOWN_ARTIST
 from music_assistant.helpers.json import json_loads
@@ -1385,3 +1386,64 @@ async def get_embedded_image(input_file: str) -> bytes | None:
         args, stdin=False, stdout=True, stderr=None, name="ffmpeg_image"
     ) as ffmpeg:
         return await ffmpeg.read(-1)
+
+
+async def write_replaygain_track_gain(path: str, track_gain_db: float) -> bool:
+    """
+    Write the REPLAYGAIN_TRACK_GAIN tag to an audio file.
+
+    Returns True when the tag was successfully written and saved, False
+    when the file format is unsupported or the file cannot be written to.
+
+    :param path: Absolute path to the audio file.
+    :param track_gain_db: ReplayGain value in dB (gain correction, not loudness).
+    """
+    return await asyncio.to_thread(_write_replaygain_track_gain_sync, path, track_gain_db)
+
+
+def _write_replaygain_track_gain_sync(path: str, track_gain_db: float) -> bool:
+    try:
+        audio = mutagen.File(path)  # type: ignore[attr-defined]
+    except Exception as err:
+        LOGGER.debug("mutagen could not open %s: %s", path, err)
+        return False
+    if audio is None:
+        return False
+
+    if audio.tags is None:
+        try:
+            audio.add_tags()
+        except Exception as err:
+            LOGGER.debug("could not initialise tags on %s: %s", path, err)
+            return False
+
+    # ReplayGain 2.0 format: "-5.30 dB" (two decimals, space, dB suffix)
+    gain_str = f"{track_gain_db:.2f} dB"
+    tags = audio.tags
+
+    try:
+        if isinstance(tags, ID3):
+            tags.delall("TXXX:REPLAYGAIN_TRACK_GAIN")  # type: ignore[no-untyped-call]
+            tags.add(  # type: ignore[no-untyped-call]
+                TXXX(  # type: ignore[no-untyped-call]
+                    encoding=3, desc="REPLAYGAIN_TRACK_GAIN", text=gain_str
+                )
+            )
+        elif isinstance(tags, MP4Tags):
+            tags["----:com.apple.iTunes:REPLAYGAIN_TRACK_GAIN"] = [
+                MP4FreeForm(  # type: ignore[no-untyped-call]
+                    gain_str.encode("utf-8"), dataformat=AtomDataType.UTF8
+                )
+            ]
+        elif isinstance(tags, (VCommentDict, APEv2)):
+            tags["REPLAYGAIN_TRACK_GAIN"] = gain_str
+        else:
+            return False
+        audio.save()
+        return True
+    except (OSError, PermissionError) as err:
+        LOGGER.debug("could not write replaygain tag to %s: %s", path, err)
+        return False
+    except Exception as err:
+        LOGGER.warning("unexpected failure writing replaygain tag to %s: %s", path, err)
+        return False

--- a/music_assistant/models/audio_analysis.py
+++ b/music_assistant/models/audio_analysis.py
@@ -24,6 +24,8 @@ class AudioAnalysisData(DataClassDictMixin):
 
     # EBU R128 integrated loudness in LUFS (typical range: -70.0 to 0.0).
     loudness_integrated: float | None = None
+    # EBU R128 integrated album loudness in LUFS, from provider metadata/tags.
+    loudness_album: float | None = None
     # EBU R128 loudness range in LU (typical range: 1.0 to 30.0).
     loudness_range: float | None = None
     # ITU-R BS.1770-4 true peak in dBTP (typical range: -20.0 to +3.0).

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from music_assistant_models.streamdetails import StreamDetails
 
     from music_assistant.mass import MusicAssistant
+    from music_assistant.models.audio_analysis import AudioAnalysisData
 
 
 @dataclass
@@ -141,6 +142,23 @@ class AudioAnalysisProvider(Provider):
             await self._finalize(session_id)
         finally:
             self._sessions.pop(session_id, None)
+
+    async def analyze_file(
+        self,
+        streamdetails: StreamDetails,
+    ) -> AudioAnalysisData | None:
+        """
+        Run analysis directly on a local audio file.
+
+        Used by the AudioAnalysisController's background scan. Providers that can
+        analyze a file without going through live PCM streaming (e.g. by handing
+        the path to FFmpeg/librosa/etc.) should override this. Default returns
+        None, meaning the provider does not support file-based analysis.
+
+        :param streamdetails: StreamDetails for the item being analyzed.
+            Contains the local file path and audio format.
+        """
+        return None
 
     async def cancel(self, session_id: str) -> None:
         """Cancel an in-progress analysis session."""

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1075,7 +1075,7 @@ class LocalFileSystemProvider(MusicProvider):
         # handle (optional) loudness measurement tag(s)
         if tags.track_loudness is not None:
             self.mass.create_task(
-                self.mass.music.set_loudness(
+                self.mass.streams.audio_analysis.set_track_loudness(
                     track.item_id,
                     self.instance_id,
                     tags.track_loudness,
@@ -1331,7 +1331,7 @@ class LocalFileSystemProvider(MusicProvider):
         # handle (optional) loudness measurement tag(s)
         if tags.track_loudness is not None:
             self.mass.create_task(
-                self.mass.music.set_loudness(
+                self.mass.streams.audio_analysis.set_track_loudness(
                     audio_book.item_id,
                     self.instance_id,
                     tags.track_loudness,
@@ -1459,7 +1459,7 @@ class LocalFileSystemProvider(MusicProvider):
         # handle (optional) loudness measurement tag(s)
         if tags.track_loudness is not None:
             self.mass.create_task(
-                self.mass.music.set_loudness(
+                self.mass.streams.audio_analysis.set_track_loudness(
                     episode.item_id,
                     self.instance_id,
                     tags.track_loudness,

--- a/music_assistant/providers/loudness_analysis/__init__.py
+++ b/music_assistant/providers/loudness_analysis/__init__.py
@@ -7,11 +7,7 @@ from typing import TYPE_CHECKING
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType
 
-from .provider import (
-    CONF_ANALYZE_LOCAL_FILES_BACKGROUND,
-    CONF_WRITE_REPLAYGAIN_TAGS,
-    LoudnessAnalysisProvider,
-)
+from .provider import CONF_WRITE_REPLAYGAIN_TAGS, LoudnessAnalysisProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
@@ -41,29 +37,16 @@ async def get_config_entries(
     """Return config entries for this provider."""
     return (
         ConfigEntry(
-            key=CONF_ANALYZE_LOCAL_FILES_BACKGROUND,
-            type=ConfigEntryType.BOOLEAN,
-            label="Analyze loudness of local files in the background",
-            description=(
-                "Run a nightly background job that measures EBU R128 integrated "
-                "loudness for tracks from local filesystem providers that do not "
-                "yet have a loudness measurement. Processes up to 250 tracks per "
-                "run, one by one. Skips automatically if the storage provider is "
-                "offline at the time of the run."
-            ),
-            default_value=True,
-            required=False,
-        ),
-        ConfigEntry(
             key=CONF_WRITE_REPLAYGAIN_TAGS,
             type=ConfigEntryType.BOOLEAN,
             label="Write REPLAYGAIN_TRACK_GAIN tags back to files",
             description=(
-                "When the background loudness job produces a measurement, also "
-                "write the corresponding REPLAYGAIN_TRACK_GAIN tag back into the "
-                "audio file. Useful if other apps on your network read these tags "
-                "for their own volume normalization. Requires write access to the "
-                "file; read-only files are silently skipped."
+                "When the background audio-analysis scan produces a loudness "
+                "measurement, also write the corresponding REPLAYGAIN_TRACK_GAIN "
+                "tag back into the audio file. Useful if other apps on your "
+                "network read these tags for their own volume normalization. "
+                "Requires write access to the file; read-only files are silently "
+                "skipped."
             ),
             default_value=False,
             required=False,

--- a/music_assistant/providers/loudness_analysis/__init__.py
+++ b/music_assistant/providers/loudness_analysis/__init__.py
@@ -1,0 +1,71 @@
+"""Loudness Analysis audio analysis provider."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from .provider import (
+    CONF_ANALYZE_LOCAL_FILES_BACKGROUND,
+    CONF_WRITE_REPLAYGAIN_TAGS,
+    LoudnessAnalysisProvider,
+)
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
+    from music_assistant_models.enums import ProviderFeature
+    from music_assistant_models.provider import ProviderManifest
+
+    from music_assistant.mass import MusicAssistant
+
+SUPPORTED_FEATURES: set[ProviderFeature] = set()
+
+
+async def setup(
+    mass: MusicAssistant,
+    manifest: ProviderManifest,
+    config: ProviderConfig,
+) -> LoudnessAnalysisProvider:
+    """Set up the Loudness Analysis provider."""
+    return LoudnessAnalysisProvider(mass, manifest, config, SUPPORTED_FEATURES)
+
+
+async def get_config_entries(
+    mass: MusicAssistant,  # noqa: ARG001
+    instance_id: str | None = None,  # noqa: ARG001
+    action: str | None = None,  # noqa: ARG001
+    values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
+) -> tuple[ConfigEntry, ...]:
+    """Return config entries for this provider."""
+    return (
+        ConfigEntry(
+            key=CONF_ANALYZE_LOCAL_FILES_BACKGROUND,
+            type=ConfigEntryType.BOOLEAN,
+            label="Analyze loudness of local files in the background",
+            description=(
+                "Run a nightly background job that measures EBU R128 integrated "
+                "loudness for tracks from local filesystem providers that do not "
+                "yet have a loudness measurement. Processes up to 250 tracks per "
+                "run, one by one. Skips automatically if the storage provider is "
+                "offline at the time of the run."
+            ),
+            default_value=True,
+            required=False,
+        ),
+        ConfigEntry(
+            key=CONF_WRITE_REPLAYGAIN_TAGS,
+            type=ConfigEntryType.BOOLEAN,
+            label="Write REPLAYGAIN_TRACK_GAIN tags back to files",
+            description=(
+                "When the background loudness job produces a measurement, also "
+                "write the corresponding REPLAYGAIN_TRACK_GAIN tag back into the "
+                "audio file. Useful if other apps on your network read these tags "
+                "for their own volume normalization. Requires write access to the "
+                "file; read-only files are silently skipped."
+            ),
+            default_value=False,
+            required=False,
+        ),
+    )

--- a/music_assistant/providers/loudness_analysis/manifest.json
+++ b/music_assistant/providers/loudness_analysis/manifest.json
@@ -8,5 +8,6 @@
   "multi_instance": false,
   "builtin": true,
   "allow_disable": false,
-  "icon": "volume-variant-high"
+  "icon": "volume-variant-high",
+  "documentation": "https://music-assistant.io/audio-analysis-providers/loudness-analysis/"
 }

--- a/music_assistant/providers/loudness_analysis/manifest.json
+++ b/music_assistant/providers/loudness_analysis/manifest.json
@@ -1,0 +1,12 @@
+{
+  "type": "audio_analysis",
+  "domain": "loudness_analysis",
+  "name": "Loudness Analysis",
+  "description": "EBU R128 integrated loudness measurement used for volume normalization.",
+  "codeowners": ["@music-assistant"],
+  "requirements": [],
+  "multi_instance": false,
+  "builtin": true,
+  "allow_disable": false,
+  "icon": "volume-variant-high"
+}

--- a/music_assistant/providers/loudness_analysis/provider.py
+++ b/music_assistant/providers/loudness_analysis/provider.py
@@ -316,15 +316,20 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
             return []
 
         domains_sql = ", ".join(f"'{d}'" for d in filesystem_domains)
+        track_media_type = MediaType.TRACK.value
+        # audio_analysis.item_id holds the provider-native item id,
+        # so join against provider_mappings.provider_item_id (not pm.item_id,
+        # which is the integer library-row id)
         query = (
-            f"SELECT pm.item_id AS item_id, pm.provider_instance AS provider_instance "
+            f"SELECT pm.provider_item_id AS item_id, "
+            f"       pm.provider_instance AS provider_instance "
             f"FROM {DB_TABLE_PROVIDER_MAPPINGS} pm "
             f"LEFT JOIN {DB_TABLE_AUDIO_ANALYSIS} aa "
-            f"  ON aa.item_id = pm.item_id "
+            f"  ON aa.item_id = pm.provider_item_id "
             f"  AND aa.provider = pm.provider_instance "
             f"  AND aa.aa_provider_domain = 'loudness_analysis' "
-            f"  AND aa.media_type = 'track' "
-            f"WHERE pm.media_type = 'track' "
+            f"  AND aa.media_type = '{track_media_type}' "
+            f"WHERE pm.media_type = '{track_media_type}' "
             f"  AND pm.provider_domain IN ({domains_sql}) "
             f"  AND aa.id IS NULL"
         )

--- a/music_assistant/providers/loudness_analysis/provider.py
+++ b/music_assistant/providers/loudness_analysis/provider.py
@@ -2,31 +2,19 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from music_assistant_models.background_task import TaskSchedule
-from music_assistant_models.enums import (
-    MediaType,
-    ProviderType,
-    StreamType,
-    VolumeNormalizationMode,
-)
+from music_assistant_models.enums import VolumeNormalizationMode
 
-from music_assistant.constants import (
-    DB_TABLE_AUDIO_ANALYSIS,
-    DB_TABLE_PROVIDER_MAPPINGS,
-    LOUDNESS_MEASUREMENT_MIN_LUFS,
-)
-from music_assistant.helpers.datetime import local_clock_time_to_utc
+from music_assistant.constants import LOUDNESS_MEASUREMENT_MIN_LUFS
 from music_assistant.helpers.ffmpeg import FFMpeg
 from music_assistant.helpers.tags import write_replaygain_track_gain
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
-from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ProviderConfig
@@ -40,17 +28,11 @@ if TYPE_CHECKING:
 MAX_DURATION_SECONDS = 600
 MIN_DURATION_SECONDS = 10
 
-CONF_ANALYZE_LOCAL_FILES_BACKGROUND = "analyze_local_files_background"
 CONF_WRITE_REPLAYGAIN_TAGS = "write_replaygain_tags"
 
-BACKGROUND_TASK_ID = "loudness_analysis_background"
-BACKGROUND_BATCH_SIZE = 250
-BACKGROUND_SLEEP_BETWEEN_TRACKS = 2.0
-FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
-    "filesystem_local",
-    "filesystem_smb",
-    "filesystem_nfs",
-)
+_INTEGRATED_RE = re.compile(r"Integrated loudness:.*?I:\s*(-?\d+(?:\.\d+)?)\s*LUFS", re.DOTALL)
+_LRA_RE = re.compile(r"Loudness range:.*?LRA:\s*(-?\d+(?:\.\d+)?)\s*LU", re.DOTALL)
+_TRUE_PEAK_RE = re.compile(r"True peak:.*?Peak:\s*(-?\d+(?:\.\d+)?)\s*dBTP", re.DOTALL)
 
 
 @dataclass
@@ -78,19 +60,6 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
         super().__init__(mass, manifest, config, supported_features)
         self._data: dict[str, LoudnessSessionData] = {}
 
-    async def loaded_in_mass(self) -> None:
-        """Register the scheduled background analysis task (if enabled)."""
-        await super().loaded_in_mass()
-        if self.config.get_value(CONF_ANALYZE_LOCAL_FILES_BACKGROUND):
-            utc_hour, utc_minute = local_clock_time_to_utc(0, 0)
-            self.mass.tasks.register_scheduled_task(
-                task_id=BACKGROUND_TASK_ID,
-                name="Loudness analysis for local files",
-                handler=self._analyze_local_files_background,
-                schedule=TaskSchedule.daily(hour=utc_hour, minute=utc_minute),
-                metadata={"task_domain": "loudness_analysis"},
-            )
-
     async def process_pcm_chunk(
         self,
         session_id: str,
@@ -114,10 +83,29 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
                 await data.ffmpeg.close()
         await super().cancel(session_id)
 
-    async def unload(self, is_removed: bool = False) -> None:
-        """Unregister the scheduled background task on provider unload."""
-        self.mass.tasks.unregister_scheduled_task(BACKGROUND_TASK_ID)
-        await super().unload(is_removed)
+    async def analyze_file(self, streamdetails: StreamDetails) -> AudioAnalysisData | None:
+        """Run ebur128 directly on a local audio file and return the measurement."""
+        if not isinstance(streamdetails.path, str) or not streamdetails.path:
+            return None
+        metrics = await _run_ebur128_on_file(streamdetails.path, streamdetails.audio_format)
+        if metrics is None:
+            return None
+        loudness, loudness_range, true_peak = metrics
+        if loudness is None or loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
+            return None
+        if self.config.get_value(CONF_WRITE_REPLAYGAIN_TAGS):
+            # ReplayGain 2.0: track_gain_db = -18 - loudness_lufs
+            track_gain_db = -18.0 - loudness
+            ok = await write_replaygain_track_gain(streamdetails.path, track_gain_db)
+            if ok:
+                self.logger.debug(
+                    "Background loudness: wrote ReplayGain tag to %s", streamdetails.path
+                )
+        return AudioAnalysisData(
+            loudness_integrated=round(loudness, 2),
+            loudness_range=round(loudness_range, 2) if loudness_range is not None else None,
+            true_peak=round(true_peak, 2) if true_peak is not None else None,
+        )
 
     async def _start_analysis(
         self,
@@ -157,7 +145,7 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
             await data.ffmpeg.close()
             return
 
-        loudness = _parse_integrated_loudness(data.ffmpeg.log_history)
+        metrics = _parse_ebur128_metrics(data.ffmpeg.log_history)
         await data.ffmpeg.close()
 
         session = self._sessions.get(session_id)
@@ -174,6 +162,7 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
             )
             return
 
+        loudness, loudness_range, true_peak = metrics
         if loudness is None:
             self.logger.debug(
                 "Could not determine loudness of %s from buffer analysis",
@@ -193,7 +182,11 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
             )
             return
 
-        analysis = AudioAnalysisData(loudness_integrated=loudness)
+        analysis = AudioAnalysisData(
+            loudness_integrated=round(loudness, 2),
+            loudness_range=round(loudness_range, 2) if loudness_range is not None else None,
+            true_peak=round(true_peak, 2) if true_peak is not None else None,
+        )
         await self.mass.streams.audio_analysis.set_audio_analysis(
             item_id=session.streamdetails.item_id,
             provider_instance_id_or_domain=session.streamdetails.provider,
@@ -206,9 +199,11 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
         # instead of dynamic normalization
         session.streamdetails.loudness = round(loudness, 2)
         self.logger.debug(
-            "Loudness measurement for %s: %s LUFS",
+            "Loudness measurement for %s: %s LUFS (LRA=%s LU, peak=%s dBTP)",
             session.streamdetails.uri,
             loudness,
+            loudness_range,
+            true_peak,
         )
 
     async def _send_eof(self, data: LoudnessSessionData) -> None:
@@ -219,136 +214,32 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
         with contextlib.suppress(Exception):
             await data.ffmpeg.write_eof()
 
-    async def _analyze_local_files_background(self) -> None:
-        """Run one background batch of loudness analysis for local file tracks."""
-        if not self.config.get_value(CONF_ANALYZE_LOCAL_FILES_BACKGROUND):
-            return
 
-        rows = await self._find_local_tracks_missing_loudness(BACKGROUND_BATCH_SIZE)
-        if not rows:
-            self.logger.debug("Background loudness: no local tracks pending analysis")
-            return
-
-        write_tags = bool(self.config.get_value(CONF_WRITE_REPLAYGAIN_TAGS))
-        self.logger.info(
-            "Background loudness: analyzing %d local track(s), write_tags=%s",
-            len(rows),
-            write_tags,
-        )
-
-        processed = 0
-        for row in rows:
-            item_id = str(row["item_id"])
-            provider_instance = str(row["provider_instance"])
-            music_prov = self.mass.get_provider(provider_instance, provider_type=MusicProvider)
-            if music_prov is None or not music_prov.available:
-                # storage may be offline right now (e.g. NAS asleep) — stop the batch
-                # rather than churning through failures for the remaining tracks
-                self.logger.debug(
-                    "Background loudness: provider %s unavailable, aborting batch",
-                    provider_instance,
-                )
-                break
-
-            if await self._analyze_single_file(music_prov, item_id, write_tags):
-                processed += 1
-            await asyncio.sleep(BACKGROUND_SLEEP_BETWEEN_TRACKS)
-
-        self.logger.info("Background loudness: analyzed %d/%d track(s)", processed, len(rows))
-
-    async def _analyze_single_file(
-        self,
-        music_prov: MusicProvider,
-        item_id: str,
-        write_tags: bool,
-    ) -> bool:
-        """Analyze a single local file and persist the measurement."""
-        try:
-            streamdetails = await music_prov.get_stream_details(item_id, MediaType.TRACK)
-        except Exception as err:
-            self.logger.debug(
-                "Background loudness: skipping %s (stream details failed: %s)",
-                item_id,
-                err,
-            )
-            return False
-
-        if streamdetails.stream_type != StreamType.LOCAL_FILE:
-            return False
-        if not isinstance(streamdetails.path, str) or not streamdetails.path:
-            return False
-
-        loudness = await _run_ebur128_on_file(streamdetails.path, streamdetails.audio_format)
-        if loudness is None or loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
-            self.logger.debug(
-                "Background loudness: could not measure %s (result=%s)", item_id, loudness
-            )
-            return False
-
-        await self.mass.streams.audio_analysis.set_track_loudness(
-            item_id=item_id,
-            provider_instance_id_or_domain=music_prov.instance_id,
-            loudness=loudness,
-        )
-        self.logger.debug("Background loudness: %s = %.2f LUFS", item_id, loudness)
-
-        if write_tags:
-            # ReplayGain 2.0: track_gain_db = -18 - loudness_lufs
-            track_gain_db = -18.0 - loudness
-            ok = await write_replaygain_track_gain(streamdetails.path, track_gain_db)
-            if ok:
-                self.logger.debug(
-                    "Background loudness: wrote ReplayGain tag to %s", streamdetails.path
-                )
-        return True
-
-    async def _find_local_tracks_missing_loudness(self, limit: int) -> list[dict[str, object]]:
-        """Return up to N tracks from filesystem providers without a loudness measurement."""
-        filesystem_domains = tuple(
-            domain
-            for domain in FILESYSTEM_PROVIDER_DOMAINS
-            if any(
-                p.domain == domain and p.available
-                for p in self.mass.get_providers(ProviderType.MUSIC)
-            )
-        )
-        if not filesystem_domains:
-            return []
-
-        domains_sql = ", ".join(f"'{d}'" for d in filesystem_domains)
-        track_media_type = MediaType.TRACK.value
-        # audio_analysis.item_id holds the provider-native item id,
-        # so join against provider_mappings.provider_item_id (not pm.item_id,
-        # which is the integer library-row id)
-        query = (
-            f"SELECT pm.provider_item_id AS item_id, "
-            f"       pm.provider_instance AS provider_instance "
-            f"FROM {DB_TABLE_PROVIDER_MAPPINGS} pm "
-            f"LEFT JOIN {DB_TABLE_AUDIO_ANALYSIS} aa "
-            f"  ON aa.item_id = pm.provider_item_id "
-            f"  AND aa.provider = pm.provider_instance "
-            f"  AND aa.aa_provider_domain = 'loudness_analysis' "
-            f"  AND aa.media_type = '{track_media_type}' "
-            f"WHERE pm.media_type = '{track_media_type}' "
-            f"  AND pm.provider_domain IN ({domains_sql}) "
-            f"  AND aa.id IS NULL"
-        )
-        rows = await self.mass.music.database.get_rows_from_query(query, limit=limit)
-        return [dict(r) for r in rows]
-
-
-def _parse_integrated_loudness(log_lines: Iterable[str]) -> float | None:
-    """Extract the Integrated loudness value (LUFS) from an ebur128 ffmpeg log."""
+def _parse_ebur128_metrics(
+    log_lines: Iterable[str],
+) -> tuple[float | None, float | None, float | None]:
+    """Extract (integrated_loudness, loudness_range, true_peak) from an ebur128 log."""
     log = "\n".join(log_lines)
+    integrated = _match_float(_INTEGRATED_RE, log)
+    lra = _match_float(_LRA_RE, log)
+    true_peak = _match_float(_TRUE_PEAK_RE, log)
+    return integrated, lra, true_peak
+
+
+def _match_float(pattern: re.Pattern[str], text: str) -> float | None:
+    match = pattern.search(text)
+    if not match:
+        return None
     try:
-        loudness_str = log.split("Integrated loudness")[1].split("I:")[1].split("LUFS")[0]
-        return float(loudness_str.strip())
-    except (IndexError, ValueError, AttributeError):
+        return float(match.group(1))
+    except ValueError:
         return None
 
 
-async def _run_ebur128_on_file(file_path: str, audio_format: AudioFormat) -> float | None:
-    """Run ebur128 on a local audio file and return the integrated loudness (LUFS)."""
+async def _run_ebur128_on_file(
+    file_path: str, audio_format: AudioFormat
+) -> tuple[float | None, float | None, float | None] | None:
+    """Run ebur128 on a local audio file and return the (I, LRA, TP) tuple."""
     try:
         async with FFMpeg(
             audio_input=file_path,
@@ -360,6 +251,6 @@ async def _run_ebur128_on_file(file_path: str, audio_format: AudioFormat) -> flo
             loglevel="info",
         ) as ffmpeg:
             await ffmpeg.wait()
-            return _parse_integrated_loudness(ffmpeg.log_history)
+            return _parse_ebur128_metrics(ffmpeg.log_history)
     except Exception:
         return None

--- a/music_assistant/providers/loudness_analysis/provider.py
+++ b/music_assistant/providers/loudness_analysis/provider.py
@@ -1,0 +1,360 @@
+"""Loudness Analysis provider - measures EBU R128 integrated loudness via FFmpeg ebur128."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from music_assistant_models.background_task import TaskSchedule
+from music_assistant_models.enums import (
+    MediaType,
+    ProviderType,
+    StreamType,
+    VolumeNormalizationMode,
+)
+
+from music_assistant.constants import (
+    DB_TABLE_AUDIO_ANALYSIS,
+    DB_TABLE_PROVIDER_MAPPINGS,
+    LOUDNESS_MEASUREMENT_MIN_LUFS,
+)
+from music_assistant.helpers.datetime import local_clock_time_to_utc
+from music_assistant.helpers.ffmpeg import FFMpeg
+from music_assistant.helpers.tags import write_replaygain_track_gain
+from music_assistant.models.audio_analysis import AudioAnalysisData
+from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
+from music_assistant.models.music_provider import MusicProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.enums import ProviderFeature
+    from music_assistant_models.media_items import AudioFormat
+    from music_assistant_models.provider import ProviderManifest
+    from music_assistant_models.streamdetails import StreamDetails
+
+    from music_assistant.mass import MusicAssistant
+
+MAX_DURATION_SECONDS = 600
+MIN_DURATION_SECONDS = 10
+
+CONF_ANALYZE_LOCAL_FILES_BACKGROUND = "analyze_local_files_background"
+CONF_WRITE_REPLAYGAIN_TAGS = "write_replaygain_tags"
+
+BACKGROUND_TASK_ID = "loudness_analysis_background"
+BACKGROUND_BATCH_SIZE = 250
+BACKGROUND_SLEEP_BETWEEN_TRACKS = 2.0
+FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
+    "filesystem_local",
+    "filesystem_smb",
+    "filesystem_nfs",
+)
+
+
+@dataclass
+class LoudnessSessionData:
+    """Per-session state for a loudness analysis job."""
+
+    ffmpeg: FFMpeg
+    chunks_received: int = 0
+    eof_sent: bool = False
+
+
+class LoudnessAnalysisProvider(AudioAnalysisProvider):
+    """Audio analysis provider that measures EBU R128 integrated loudness."""
+
+    analysis_version: int = 1
+
+    def __init__(
+        self,
+        mass: MusicAssistant,
+        manifest: ProviderManifest,
+        config: ProviderConfig,
+        supported_features: set[ProviderFeature],
+    ) -> None:
+        """Initialize the provider."""
+        super().__init__(mass, manifest, config, supported_features)
+        self._data: dict[str, LoudnessSessionData] = {}
+
+    async def loaded_in_mass(self) -> None:
+        """Register the scheduled background analysis task (if enabled)."""
+        await super().loaded_in_mass()
+        if self.config.get_value(CONF_ANALYZE_LOCAL_FILES_BACKGROUND):
+            utc_hour, utc_minute = local_clock_time_to_utc(0, 0)
+            self.mass.tasks.register_scheduled_task(
+                task_id=BACKGROUND_TASK_ID,
+                name="Loudness analysis for local files",
+                handler=self._analyze_local_files_background,
+                schedule=TaskSchedule.daily(hour=utc_hour, minute=utc_minute),
+                metadata={"task_domain": "loudness_analysis"},
+            )
+
+    async def process_pcm_chunk(
+        self,
+        session_id: str,
+        pcm_chunk: bytes,
+    ) -> None:
+        """Feed a PCM chunk to the session's ebur128 ffmpeg process."""
+        data = self._data.get(session_id)
+        if not data or data.eof_sent:
+            return
+        data.chunks_received += 1
+        await data.ffmpeg.write(pcm_chunk)
+        if data.chunks_received >= MAX_DURATION_SECONDS:
+            # cap the analysis window for very long streams
+            await self._send_eof(data)
+
+    async def cancel(self, session_id: str) -> None:
+        """Abort an in-progress loudness analysis session."""
+        data = self._data.pop(session_id, None)
+        if data:
+            with contextlib.suppress(Exception):
+                await data.ffmpeg.close()
+        await super().cancel(session_id)
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Unregister the scheduled background task on provider unload."""
+        self.mass.tasks.unregister_scheduled_task(BACKGROUND_TASK_ID)
+        await super().unload(is_removed)
+
+    async def _start_analysis(
+        self,
+        session_id: str,
+        streamdetails: StreamDetails,
+        audio_format: AudioFormat,
+    ) -> bool:
+        """Prepare provider state for a new analysis session."""
+        # skip when the requesting player has explicitly opted out of normalization;
+        # the nightly background job will pick up the measurement if ever needed
+        if streamdetails.volume_normalization_mode == VolumeNormalizationMode.DISABLED:
+            return False
+        ffmpeg = FFMpeg(
+            audio_input="-",
+            input_format=audio_format,
+            output_format=audio_format,
+            audio_output="NULL",
+            filter_params=["ebur128=framelog=verbose"],
+            collect_log_history=True,
+            loglevel="info",
+        )
+        await ffmpeg.start()
+        self._data[session_id] = LoudnessSessionData(ffmpeg=ffmpeg)
+        return True
+
+    async def _finalize(self, session_id: str) -> None:
+        """Persist the final loudness measurement for the session."""
+        data = self._data.pop(session_id, None)
+        if not data:
+            return
+
+        await self._send_eof(data)
+        try:
+            await data.ffmpeg.wait()
+        except Exception as err:
+            self.logger.debug("Loudness analysis ffmpeg failed: %s", err)
+            await data.ffmpeg.close()
+            return
+
+        loudness = _parse_integrated_loudness(data.ffmpeg.log_history)
+        await data.ffmpeg.close()
+
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+
+        if data.chunks_received < MIN_DURATION_SECONDS:
+            self.logger.debug(
+                "Loudness analysis for %s skipped: "
+                "insufficient audio data (%s/%s seconds analyzed)",
+                session.streamdetails.uri,
+                data.chunks_received,
+                MIN_DURATION_SECONDS,
+            )
+            return
+
+        if loudness is None:
+            self.logger.debug(
+                "Could not determine loudness of %s from buffer analysis",
+                session.streamdetails.uri,
+            )
+            return
+
+        if loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
+            # ebur128 reports ~-70 LUFS on near-silence / cancelled streams,
+            # which would cause huge gain corrections on subsequent plays.
+            self.logger.debug(
+                "Loudness measurement for %s discarded: "
+                "%s LUFS is below the reliability threshold (%s LUFS)",
+                session.streamdetails.uri,
+                loudness,
+                LOUDNESS_MEASUREMENT_MIN_LUFS,
+            )
+            return
+
+        analysis = AudioAnalysisData(loudness_integrated=loudness)
+        await self.mass.streams.audio_analysis.set_audio_analysis(
+            item_id=session.streamdetails.item_id,
+            provider_instance_id_or_domain=session.streamdetails.provider,
+            aa_provider_domain=self.domain,
+            analysis=analysis,
+            analysis_version=self.analysis_version,
+            media_type=session.streamdetails.media_type,
+        )
+        # update in-memory streamdetails so subsequent seeks use the measurement
+        # instead of dynamic normalization
+        session.streamdetails.loudness = round(loudness, 2)
+        self.logger.debug(
+            "Loudness measurement for %s: %s LUFS",
+            session.streamdetails.uri,
+            loudness,
+        )
+
+    async def _send_eof(self, data: LoudnessSessionData) -> None:
+        """Signal end-of-input to the session's ffmpeg process (idempotent)."""
+        if data.eof_sent:
+            return
+        data.eof_sent = True
+        with contextlib.suppress(Exception):
+            await data.ffmpeg.write_eof()
+
+    async def _analyze_local_files_background(self) -> None:
+        """Run one background batch of loudness analysis for local file tracks."""
+        if not self.config.get_value(CONF_ANALYZE_LOCAL_FILES_BACKGROUND):
+            return
+
+        rows = await self._find_local_tracks_missing_loudness(BACKGROUND_BATCH_SIZE)
+        if not rows:
+            self.logger.debug("Background loudness: no local tracks pending analysis")
+            return
+
+        write_tags = bool(self.config.get_value(CONF_WRITE_REPLAYGAIN_TAGS))
+        self.logger.info(
+            "Background loudness: analyzing %d local track(s), write_tags=%s",
+            len(rows),
+            write_tags,
+        )
+
+        processed = 0
+        for row in rows:
+            item_id = str(row["item_id"])
+            provider_instance = str(row["provider_instance"])
+            music_prov = self.mass.get_provider(provider_instance, provider_type=MusicProvider)
+            if music_prov is None or not music_prov.available:
+                # storage may be offline right now (e.g. NAS asleep) — stop the batch
+                # rather than churning through failures for the remaining tracks
+                self.logger.debug(
+                    "Background loudness: provider %s unavailable, aborting batch",
+                    provider_instance,
+                )
+                break
+
+            if await self._analyze_single_file(music_prov, item_id, write_tags):
+                processed += 1
+            await asyncio.sleep(BACKGROUND_SLEEP_BETWEEN_TRACKS)
+
+        self.logger.info("Background loudness: analyzed %d/%d track(s)", processed, len(rows))
+
+    async def _analyze_single_file(
+        self,
+        music_prov: MusicProvider,
+        item_id: str,
+        write_tags: bool,
+    ) -> bool:
+        """Analyze a single local file and persist the measurement."""
+        try:
+            streamdetails = await music_prov.get_stream_details(item_id, MediaType.TRACK)
+        except Exception as err:
+            self.logger.debug(
+                "Background loudness: skipping %s (stream details failed: %s)",
+                item_id,
+                err,
+            )
+            return False
+
+        if streamdetails.stream_type != StreamType.LOCAL_FILE:
+            return False
+        if not isinstance(streamdetails.path, str) or not streamdetails.path:
+            return False
+
+        loudness = await _run_ebur128_on_file(streamdetails.path, streamdetails.audio_format)
+        if loudness is None or loudness <= LOUDNESS_MEASUREMENT_MIN_LUFS:
+            self.logger.debug(
+                "Background loudness: could not measure %s (result=%s)", item_id, loudness
+            )
+            return False
+
+        await self.mass.streams.audio_analysis.set_track_loudness(
+            item_id=item_id,
+            provider_instance_id_or_domain=music_prov.instance_id,
+            loudness=loudness,
+        )
+        self.logger.debug("Background loudness: %s = %.2f LUFS", item_id, loudness)
+
+        if write_tags:
+            # ReplayGain 2.0: track_gain_db = -18 - loudness_lufs
+            track_gain_db = -18.0 - loudness
+            ok = await write_replaygain_track_gain(streamdetails.path, track_gain_db)
+            if ok:
+                self.logger.debug(
+                    "Background loudness: wrote ReplayGain tag to %s", streamdetails.path
+                )
+        return True
+
+    async def _find_local_tracks_missing_loudness(self, limit: int) -> list[dict[str, object]]:
+        """Return up to N tracks from filesystem providers without a loudness measurement."""
+        filesystem_domains = tuple(
+            domain
+            for domain in FILESYSTEM_PROVIDER_DOMAINS
+            if any(
+                p.domain == domain and p.available
+                for p in self.mass.get_providers(ProviderType.MUSIC)
+            )
+        )
+        if not filesystem_domains:
+            return []
+
+        domains_sql = ", ".join(f"'{d}'" for d in filesystem_domains)
+        query = (
+            f"SELECT pm.item_id AS item_id, pm.provider_instance AS provider_instance "
+            f"FROM {DB_TABLE_PROVIDER_MAPPINGS} pm "
+            f"LEFT JOIN {DB_TABLE_AUDIO_ANALYSIS} aa "
+            f"  ON aa.item_id = pm.item_id "
+            f"  AND aa.provider = pm.provider_instance "
+            f"  AND aa.aa_provider_domain = 'loudness_analysis' "
+            f"  AND aa.media_type = 'track' "
+            f"WHERE pm.media_type = 'track' "
+            f"  AND pm.provider_domain IN ({domains_sql}) "
+            f"  AND aa.id IS NULL"
+        )
+        rows = await self.mass.music.database.get_rows_from_query(query, limit=limit)
+        return [dict(r) for r in rows]
+
+
+def _parse_integrated_loudness(log_lines: Iterable[str]) -> float | None:
+    """Extract the Integrated loudness value (LUFS) from an ebur128 ffmpeg log."""
+    log = "\n".join(log_lines)
+    try:
+        loudness_str = log.split("Integrated loudness")[1].split("I:")[1].split("LUFS")[0]
+        return float(loudness_str.strip())
+    except (IndexError, ValueError, AttributeError):
+        return None
+
+
+async def _run_ebur128_on_file(file_path: str, audio_format: AudioFormat) -> float | None:
+    """Run ebur128 on a local audio file and return the integrated loudness (LUFS)."""
+    try:
+        async with FFMpeg(
+            audio_input=file_path,
+            input_format=audio_format,
+            output_format=audio_format,
+            audio_output="NULL",
+            filter_params=["ebur128=framelog=verbose"],
+            collect_log_history=True,
+            loglevel="info",
+        ) as ffmpeg:
+            await ffmpeg.wait()
+            return _parse_integrated_loudness(ffmpeg.log_history)
+    except Exception:
+        return None

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -190,7 +190,7 @@ class OpenSonicProvider(MusicProvider):
                 else None
             )
             self.mass.create_task(
-                self.mass.music.set_loudness(
+                self.mass.streams.audio_analysis.set_track_loudness(
                     item.id,
                     self.instance_id,
                     track_loudness,

--- a/tests/core/test_tags.py
+++ b/tests/core/test_tags.py
@@ -1,7 +1,11 @@
 """Tests for parsing audio file tags (ID3, MP4/AAC, Vorbis, APEv2, etc.)."""
 
 import pathlib
+import shutil
 from unittest.mock import MagicMock
+
+import mutagen
+import pytest
 
 from music_assistant.constants import UNKNOWN_ARTIST
 from music_assistant.helpers import tags
@@ -10,6 +14,7 @@ from music_assistant.helpers.tags import (
     _parse_vorbis_tags,
     parse_tags_mutagen,
     split_artists,
+    write_replaygain_track_gain,
 )
 
 RESOURCES_DIR = pathlib.Path(__file__).parent.parent.resolve().joinpath("fixtures")
@@ -694,3 +699,53 @@ def test_id3_albumartist_tag_semicolon_single_mbid() -> None:
     # Single MB Album Artist ID = single artist, no splitting
     assert audio_tags.album_artists == ("ave;new",)
     assert audio_tags.musicbrainz_albumartistids == ("2ade7b3c-a6f1-4d00-b7f7-fc60abf25dba",)
+
+
+def _read_replaygain_track_gain(path: str) -> str | None:
+    """Read REPLAYGAIN_TRACK_GAIN from a file using mutagen (format-agnostic)."""
+    audio = mutagen.File(path)  # type: ignore[attr-defined]
+    if audio is None or audio.tags is None:
+        return None
+    tag_key_mp4 = "----:com.apple.iTunes:REPLAYGAIN_TRACK_GAIN"
+    if tag_key_mp4 in audio.tags:
+        val = audio.tags[tag_key_mp4][0]
+        return val.decode("utf-8") if isinstance(val, bytes) else str(val)
+    if "TXXX:REPLAYGAIN_TRACK_GAIN" in audio.tags:
+        return str(audio.tags["TXXX:REPLAYGAIN_TRACK_GAIN"].text[0])
+    if "REPLAYGAIN_TRACK_GAIN" in audio.tags:
+        return str(audio.tags["REPLAYGAIN_TRACK_GAIN"][0])
+    return None
+
+
+@pytest.mark.parametrize(
+    "source",
+    [FILE_MP3, FILE_M4A, FILE_FLAC, FILE_WV],
+)
+async def test_write_replaygain_track_gain_roundtrip(tmp_path: pathlib.Path, source: str) -> None:
+    """Write a REPLAYGAIN_TRACK_GAIN tag and verify the value is read back."""
+    dest = tmp_path / pathlib.Path(source).name
+    shutil.copy(source, dest)
+
+    assert await write_replaygain_track_gain(str(dest), -5.3) is True
+    assert _read_replaygain_track_gain(str(dest)) == "-5.30 dB"
+
+    # verify overwrite replaces the previous value
+    assert await write_replaygain_track_gain(str(dest), -2.1) is True
+    assert _read_replaygain_track_gain(str(dest)) == "-2.10 dB"
+
+
+async def test_write_replaygain_track_gain_missing_file(tmp_path: pathlib.Path) -> None:
+    """Return False if the file does not exist or cannot be opened."""
+    assert await write_replaygain_track_gain(str(tmp_path / "nope.mp3"), -5.0) is False
+
+
+async def test_write_replaygain_track_gain_read_only(tmp_path: pathlib.Path) -> None:
+    """Return False if the file cannot be written to."""
+    dest = tmp_path / "readonly.mp3"
+    shutil.copy(FILE_MP3, dest)
+    dest.chmod(0o444)
+    try:
+        assert await write_replaygain_track_gain(str(dest), -5.0) is False
+    finally:
+        # restore permissions so tmp_path cleanup can remove the file
+        dest.chmod(0o644)


### PR DESCRIPTION
## Problem
Volume-loudness detection was the last analyzer still hand-rolled in the streams and music controllers, storing measurements in its own `loudness_measurements` table. Every other analyzer already uses the `AudioAnalysisProvider` pattern. Keeping loudness separate meant duplicated plumbing, a bespoke DB table, and no reuse of the PCM chunk fan-out the new controller already does.

## Changes
- New builtin `loudness_analysis` audio analysis provider (always enabled) - ebur128 on live PCM via the shared audio-analysis fan-out
- Removes `attach_loudness_analyzer` from the streams controller and `set_loudness` / `get_loudness` from the music controller; `filesystem_local` and `opensubsonic` now use `mass.streams.audio_analysis.set_track_loudness(...)`
- Adds `loudness_album` field to `AudioAnalysisData` so album-level loudness from tags survives the unified format
- DB migration 38→39: copies valid rows (`> -50 LUFS`) from `loudness_measurements` into `audio_analysis` under `aa_provider_domain='loudness_analysis'`; drops the old table
- Loudness hydration on `streamdetails` moved to just-in-time in `get_queue_item_stream`, so a measurement completed during a previous play is picked up without restart
- Provider skips analysis when `streamdetails.volume_normalization_mode == DISABLED` (respects per-player opt-out); the base-class version gating already skips tracks that already have a measurement
- Optional nightly background task (default on): batches 250 local-filesystem tracks without a loudness row, runs ebur128 directly on the file path, 2s spacing, aborts if the storage provider goes offline mid-run
- Opt-in `write_replaygain_tags` config (default off): writes `REPLAYGAIN_TRACK_GAIN` back to the file (ID3/MP4/Vorbis/APEv2) via a new `write_replaygain_track_gain` mutagen helper