### PR TITLE
Raise smart fades chunk timeout to 1s and log block duration

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -21,7 +21,7 @@ from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
 from music_assistant.models.music_provider import MusicProvider
 
-CHUNK_PROCESS_TIMEOUT = 0.8
+CHUNK_PROCESS_TIMEOUT = 1.0
 LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
 BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_SCAN_BATCH_SIZE = 250

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -283,9 +283,11 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
     async def _process_block(self, data: SmartFadesData, *, last: bool = False) -> None:
         """Resample accumulated PCM buffer and extract features."""
+        start_time = time.perf_counter()
         pcm_raw = np.concatenate(data.pcm_buffer)
         data.pcm_buffer.clear()
         data.pcm_samples = 0
+        num_samples = len(pcm_raw)
 
         if data.resampler is not None:
             pcm_22k = await asyncio.to_thread(data.resampler.resample_chunk, pcm_raw, last)
@@ -294,17 +296,18 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         data.total_pcm_samples += len(pcm_22k)
 
-        start_time = time.perf_counter()
         feats, _ = await asyncio.gather(
             data.features.process_pcm(pcm_22k),
             asyncio.to_thread(self._compute_energy_and_spectral_centroids, pcm_22k, data),
         )
-        elapsed_ms = (time.perf_counter() - start_time) * 1000
 
         if feats.size:
             data.beats_feature_blocks.append(feats)
 
-        self.logger.log(VERBOSE_LOG_LEVEL, "Processed 10s of PCM chunks in %.1fms", elapsed_ms)
+        elapsed_ms = (time.perf_counter() - start_time) * 1000
+        self.logger.debug(
+            "_process_block took %.1f ms (block len=%d samples)", elapsed_ms, num_samples
+        )
 
     def _compute_energy_and_spectral_centroids(
         self, pcm_22k: np.ndarray, data: SmartFadesData

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -306,7 +306,11 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         self.logger.debug(
-            "_process_block took %.1f ms (block len=%d samples)", elapsed_ms, num_samples
+            "_process_block took %.1f ms (%d samples at %d Hz, resampled to %d samples)",
+            elapsed_ms,
+            num_samples,
+            data.input_audio_format.sample_rate,
+            len(pcm_22k),
         )
 
     def _compute_energy_and_spectral_centroids(


### PR DESCRIPTION
Production logs showed ~45 occurrences a day of `Provider smart_fades timed out processing chunk for <uri>, removing from session`, each one silently ejecting the smart fades analyser from that track. Root cause is the 0.8 s per-chunk timeout in `audio_analysis`, which isn't enough headroom when `_process_block` (torch mel-spectrogram + librosa RMS/centroid on a 10 s block) runs under CPU pressure. 1 s is still tight enough not to starve the audio buffer upstream.

- Raise `CHUNK_PROCESS_TIMEOUT` from 0.8 s to 1.0 s.
- Log the real `_process_block` wall-clock duration at DEBUG on every block (replaces the narrower gather-only log), so we can build a distribution and tune further if needed.