### PR TITLE
Harden AirPlay STOP command delivery and add teardown logging

### DIFF
--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -16,10 +16,22 @@ _LOGGER = logging.getLogger("named_pipe")
 class AsyncNamedPipeWriter:
     """Async writer for named pipes."""
 
-    def __init__(self, pipe_path: str) -> None:
-        """Initialize named pipe writer."""
+    def __init__(self, pipe_path: str, owner_id: str | None = None) -> None:
+        """
+        Initialize named pipe writer.
+
+        :param pipe_path: Filesystem path of the named pipe.
+        :param owner_id: Optional identifier (e.g. player_id) included in log
+            messages so silent failures can be correlated to a specific device.
+        """
         self._pipe_path = pipe_path
+        self._owner_id = owner_id
         self._write_fd: int | None = None
+
+    @property
+    def _log_owner(self) -> str:
+        """Return a short descriptor for logging (owner_id or pipe path)."""
+        return self._owner_id or self._pipe_path
 
     @property
     def path(self) -> str:
@@ -53,7 +65,11 @@ class AsyncNamedPipeWriter:
                     time.sleep(0.05)
                     continue
                 raise
-        _LOGGER.warning("Could not open pipe %s: no reader after retries", self._pipe_path)
+        _LOGGER.warning(
+            "Could not open pipe %s (owner=%s): no reader after retries",
+            self._pipe_path,
+            self._log_owner,
+        )
         return False
 
     async def write(self, data: bytes) -> None:
@@ -61,6 +77,12 @@ class AsyncNamedPipeWriter:
 
         def _write() -> None:
             if not self._ensure_write_fd():
+                _LOGGER.debug(
+                    "Named pipe write failed: no writable fd for pipe %s (owner=%s, %d bytes dropped)",
+                    self._pipe_path,
+                    self._log_owner,
+                    len(data),
+                )
                 return
             try:
                 assert self._write_fd is not None
@@ -72,6 +94,12 @@ class AsyncNamedPipeWriter:
                         with suppress(Exception):
                             os.close(self._write_fd)
                         self._write_fd = None
+                    _LOGGER.debug(
+                        "Named pipe write failed (EPIPE) on %s (owner=%s, %d bytes dropped): reader closed",
+                        self._pipe_path,
+                        self._log_owner,
+                        len(data),
+                    )
                 else:
                     raise
 

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -771,7 +771,7 @@ class AirPlayPlayer(Player):
                     if stream_session and len(stream_session.sync_clients) > 1:
                         # Other clients remain: remove only this leader client,
                         # session continues for remaining players (dynamic leader switch)
-                        await stream_session.remove_client(self)
+                        await stream_session.remove_client(self, reason="leader removed from group")
                     elif stream_session:
                         # Last client, stop the whole session
                         await stream_session.stop()
@@ -786,7 +786,9 @@ class AirPlayPlayer(Player):
                         if child_player.player_id in self._attr_group_members:
                             self._attr_group_members.remove(child_player.player_id)
                         if stream_session:
-                            await stream_session.remove_client(child_player)
+                            await stream_session.remove_client(
+                                child_player, reason="child removed from group"
+                            )
                         elif child_player.stream and child_player.stream.running:
                             # leader's stream is no longer running but child still has
                             # an active stream - stop it directly
@@ -828,7 +830,9 @@ class AirPlayPlayer(Player):
                         and child_player_to_add.stream.session
                         and child_player_to_add.stream.session != stream_session
                     ):
-                        await child_player_to_add.stream.session.remove_client(child_player_to_add)
+                        await child_player_to_add.stream.session.remove_client(
+                            child_player_to_add, reason="moving to different session"
+                        )
 
                 # add new child to the existing stream (RAOP or AirPlay2) session (if any)
                 self._attr_group_members.append(player_id)
@@ -958,7 +962,7 @@ class AirPlayPlayer(Player):
         if self.stream:
             # remove this player from the stream session if it is running
             if self.stream.running and self.stream.session:
-                await self.stream.session.remove_client(self)
+                await self.stream.session.remove_client(self, reason="player unloaded")
             self.stream = None
         if self._active_pairing:
             await self._active_pairing.close()

--- a/music_assistant/providers/airplay/protocols/_protocol.py
+++ b/music_assistant/providers/airplay/protocols/_protocol.py
@@ -53,6 +53,7 @@ class AirPlayProtocol(ABC):
         self._cli_proc: AsyncProcess | None = None
         self.commands_pipe = AsyncNamedPipeWriter(
             f"/tmp/{self.player.protocol.value}-{self.player.player_id}-{self.active_remote_id}-cmd",  # noqa: S108
+            owner_id=self.player.player_id,
         )
         self._stopped = False
         self._total_bytes_sent = 0
@@ -96,9 +97,15 @@ class AirPlayProtocol(ABC):
 
         :param force: If True, immediately kill the process without graceful shutdown.
         """
-        # always send stop command first
-        await self.send_cli_command("ACTION=STOP")
-        self._stopped = True
+        # Send STOP first and only flip ``_stopped`` once the write returns.
+        # Flipping the flag too early lets concurrent cleanup coroutines that
+        # check ``_stopped`` (e.g. ``send_cli_command`` short-circuit) assume
+        # teardown is done before STOP has actually reached the CLI child.
+        # Use try/finally so the flag still flips if the write raises.
+        try:
+            await self.send_cli_command("ACTION=STOP")
+        finally:
+            self._stopped = True
         await self.commands_pipe.remove()
         if force:
             # Kill immediately - skip write_eof() as it can block indefinitely

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -86,26 +86,37 @@ class AirPlayStreamSession:
             with suppress(asyncio.CancelledError):
                 await self._audio_source_task
         await asyncio.gather(
-            *[self.remove_client(x) for x in self.sync_clients],
+            *[self.remove_client(x, reason="session stop") for x in self.sync_clients],
         )
 
-    async def remove_client(self, airplay_player: AirPlayPlayer) -> None:
-        """Remove a sync client from the session."""
+    async def remove_client(
+        self, airplay_player: AirPlayPlayer, reason: str = "client removed"
+    ) -> None:
+        """
+        Remove a sync client from the session.
+
+        :param airplay_player: The player to remove from the session.
+        :param reason: Short human-readable reason for the removal, used in teardown logs.
+        """
         async with self._lock:
             if airplay_player not in self.sync_clients:
                 return
             self.sync_clients.remove(airplay_player)
-        await self._cleanup_after_removal(airplay_player)
+        await self._cleanup_after_removal(airplay_player, reason=reason)
 
-    async def _cleanup_after_removal(self, airplay_player: AirPlayPlayer) -> None:
-        """Clean up processes and state after a client has been removed from sync_clients.
+    async def _cleanup_after_removal(
+        self, airplay_player: AirPlayPlayer, reason: str = "client removed"
+    ) -> None:
+        """
+        Clean up processes and state after a client has been removed from sync_clients.
 
         :param airplay_player: The player whose processes should be stopped.
+        :param reason: Short human-readable reason, forwarded to stop_client for logging.
         """
         stream = airplay_player.stream
         if stream is not None and stream.session != self:
             stream = None
-        await self.stop_client(airplay_player)
+        await self.stop_client(airplay_player, reason=reason)
         # Only set IDLE if the player's stream still belongs to this session,
         # otherwise a re-add to a new session may have already set a new state.
         if stream is not None:
@@ -116,13 +127,21 @@ class AirPlayStreamSession:
         if should_stop:
             await self.stop()
 
-    async def stop_client(self, airplay_player: AirPlayPlayer) -> None:
+    async def stop_client(
+        self, airplay_player: AirPlayPlayer, reason: str = "stop_client called"
+    ) -> None:
         """
         Stop a client's stream and ffmpeg.
 
         :param airplay_player: The player to stop.
-        :param force: If True, kill CLI process immediately.
+        :param reason: Short human-readable reason for the teardown, used in debug logs.
         """
+        self.prov.logger.debug(
+            "AirPlay session teardown: session=%s client=%s reason=%s",
+            id(self),
+            airplay_player.player_id,
+            reason,
+        )
         ffmpeg = self._player_ffmpeg.pop(airplay_player.player_id, None)
         # note that we use kill instead of graceful close here,
         # because otherwise it can take a very long time for the process to exit.
@@ -232,7 +251,7 @@ class AirPlayStreamSession:
                     airplay_player.player_id,
                     err,
                 )
-                await self.stop_client(airplay_player)
+                await self.stop_client(airplay_player, reason="late joiner start/prime failed")
                 return
 
             # Now add to sync_clients — the audio streamer's next chunk
@@ -255,7 +274,7 @@ class AirPlayStreamSession:
                     airplay_player.player_id,
                     time.time() - now,
                 )
-                await self.remove_client(airplay_player)
+                await self.remove_client(airplay_player, reason="late joiner connection timeout")
 
     async def _audio_streamer(self, audio_source: AsyncGenerator[bytes, None]) -> None:
         """Stream audio to all players."""
@@ -318,7 +337,7 @@ class AirPlayStreamSession:
             results = await asyncio.gather(*write_tasks, return_exceptions=True)
 
             # Check for write errors or timeouts
-            players_to_remove: list[AirPlayPlayer] = []
+            players_to_remove: list[tuple[AirPlayPlayer, str]] = []
             for i, result in enumerate(results):
                 if i >= len(sync_clients):
                     continue
@@ -329,24 +348,24 @@ class AirPlayStreamSession:
                         "Removing player %s from session: stopped reading data (write timeout)",
                         player.player_id,
                     )
-                    players_to_remove.append(player)
+                    players_to_remove.append((player, "audio write timeout"))
                 elif isinstance(result, Exception):
                     self.prov.logger.warning(
                         "Removing player %s from session due to write error: %s",
                         player.player_id,
                         result,
                     )
-                    players_to_remove.append(player)
+                    players_to_remove.append((player, f"audio write error: {result}"))
 
             # Remove failed players from sync_clients immediately under the lock
             # so they are excluded from future write cycles. Only defer process
             # cleanup (_cleanup_after_removal) — this prevents fire-and-forget
             # remove_client calls from racing with a subsequent add_client when
             # a player is being moved between groups.
-            for player in players_to_remove:
+            for player, removal_reason in players_to_remove:
                 if player in self.sync_clients:
                     self.sync_clients.remove(player)
-                self.mass.create_task(self._cleanup_after_removal(player))
+                self.mass.create_task(self._cleanup_after_removal(player, reason=removal_reason))
 
             remaining_clients = len(sync_clients) - len(players_to_remove)
             return remaining_clients > 0


### PR DESCRIPTION
Production logs showed 100 `Starting cliraop process` lines but only 97 `Killing process cliraop`, i.e. at least one RAOP session leaked during the day — exactly the symptom behind an AirPlay-capable player still showing an active AirPlay stream while MA believes it is gone. Two silent failure paths in the STOP path explain it: the command-pipe write failure was logged without the owning player id (invisible in prod debug logs), and `AirPlayProtocol.stop()` flipped `_stopped = True` before the STOP write completed so a concurrent cleanup could short-circuit before STOP reached the wire.

- `AsyncNamedPipeWriter` takes an optional `owner_id` and includes it in DEBUG logs on every silent write-failure path (no reader fd, EPIPE).
- `AirPlayProtocol.stop()` wraps the STOP send in try/finally so `_stopped` flips only after the write returns and is still guaranteed to flip on exception.
- `AirPlayStreamSession.stop / remove_client / stop_client / _cleanup_after_removal` accept a reason string and emit a single DEBUG teardown log line, so starts and kills can be reconciled from a debug log.