### PR TITLE
Coalesce/debounce rapid sync group set_members calls

### DIFF
--- a/music_assistant/controllers/players/constants.py
+++ b/music_assistant/controllers/players/constants.py
@@ -2,6 +2,17 @@
 
 from enum import StrEnum
 
+# Debounce window (seconds) for coalescing rapid-fire cmd_set_members calls
+# against the same target player. Home Assistant automations often fire
+# several add/remove commands in quick succession; without this window each
+# one would trigger a full teardown+restart of protocol sessions (notably
+# AirPlay cliraop). 0.3s is tight enough to feel instant and wide enough to
+# absorb typical HA automation bursts.
+SET_MEMBERS_DEBOUNCE = 0.3
+
+# Prefix for the per-target-player task id used to key the debounce timer.
+SET_MEMBERS_TASK_ID_PREFIX = "set_members"
+
 
 class PlayerLockPurpose(StrEnum):
     """Lock categories for get_player_lock to serialize commands per player."""

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1276,9 +1276,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
             # Play lock prevents protocol switches from racing with
             # concurrent play_media / play_index / resume / stop calls.
-            async with self.get_player_lock(
-                parent_player.player_id, PlayerLockPurpose.PLAYBACK
-            ):
+            async with self.get_player_lock(parent_player.player_id, PlayerLockPurpose.PLAYBACK):
                 await self._handle_set_members(
                     parent_player,
                     player_ids_to_add or None,

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -21,6 +21,7 @@ import contextlib
 import time
 from collections.abc import AsyncIterator
 from contextlib import suppress
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.auth import UserRole
@@ -104,7 +105,11 @@ from music_assistant.models.player import Player, PlayerMedia, PlayerState
 from music_assistant.models.player_provider import PlayerProvider
 from music_assistant.models.plugin import PluginProvider, PluginSource
 
-from .constants import PlayerLockPurpose
+from .constants import (
+    SET_MEMBERS_DEBOUNCE,
+    SET_MEMBERS_TASK_ID_PREFIX,
+    PlayerLockPurpose,
+)
 from .helpers import AnnounceData, handle_player_command, wait_for_power_on
 from .protocol_linking import ProtocolLinkingMixin
 
@@ -125,6 +130,21 @@ CACHE_CATEGORY_PLAYER_POWER = 1
 
 # Sentinel used to detect omitted optional arguments where ``None`` is a valid value.
 _SENTINEL: Any = object()
+
+
+@dataclass
+class _SetMembersBatch:
+    """One open coalesce batch for cmd_set_members on a given target player.
+
+    Callers merge their delta into ``add`` / ``remove`` and await ``future``.
+    When the debounce timer fires the batch is removed from the open-batches
+    dict and flushed; the future is resolved after the flush completes, so
+    every caller that contributed to this batch unblocks together.
+    """
+
+    add: set[str] = field(default_factory=set)
+    remove: set[str] = field(default_factory=set)
+    future: asyncio.Future[None] = field(default_factory=asyncio.Future)
 
 
 class PlayerController(ProtocolLinkingMixin, CoreController):
@@ -154,6 +174,13 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         self._pending_protocol_evaluations: dict[str, asyncio.TimerHandle] = {}
         # Serialize delayed evaluations to prevent race conditions
         self._delayed_evaluation_lock = asyncio.Lock()
+        # Open coalesce batch per (resolved) target player id. Home Assistant
+        # automations often fire multiple add/remove commands in a burst against
+        # the same sync leader; batching here collapses that burst into one call
+        # to _handle_set_members, avoiding repeated protocol teardown+restart
+        # cycles (notably AirPlay cliraop). Callers await the batch's future so
+        # grouping commands still complete in order from the caller's POV.
+        self._open_set_members_batches: dict[str, _SetMembersBatch] = {}
         # Subscribers for player state updates (called with player + changed_values)
         self._state_update_subscribers: list[
             Callable[[Player, dict[str, tuple[Any, Any]]], None]
@@ -1133,7 +1160,18 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         Join/unjoin given player(s) to/from target player.
 
-        Will add the given player(s) to the target player (sync leader or group player).
+        Rapid-fire calls (e.g. a Home Assistant automation that fires several
+        add/remove commands at once) against the same resolved target are
+        coalesced into a single forwarded ``_handle_set_members`` call. Each
+        call merges its delta into a per-target open batch and (re)arms a
+        short debounce timer — avoiding the teardown/restart churn that
+        per-call forwarding would otherwise cause on protocol players (most
+        notably AirPlay cliraop processes). Covers sync groups, universal
+        groups, and direct Sonos/AirPlay/Snapcast/... grouping in one place.
+
+        The call blocks until the batch containing this call's delta has been
+        flushed, so command ordering from the caller's POV (e.g.
+        ``await cmd_ungroup(); await cmd_set_members(...)``) is preserved.
 
         :param target_player: player_id of the syncgroup leader or group player.
         :param player_ids_to_add: List of player_id's to add to the target player.
@@ -1149,7 +1187,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             raise UnsupportedFeaturedException(msg)
 
         # if the target player is a member of an active group player (e.g. a syncgroup),
-        # redirect the command to that group player so it can manage the member change
+        # redirect the command to that group player so it can manage the member change.
+        # Redirect synchronously (before debounce) so we coalesce against the
+        # final target, not the pre-redirect one.
         if (
             parent_player.type != PlayerType.GROUP
             and parent_player.state.active_group
@@ -1167,15 +1207,104 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             )
             return
 
-        if parent_player.synced_to:
-            # handle edge case: target player is already synced itself to another player
-            # automatically ungroup it first and wait for state to propagate
-            await self._auto_ungroup_if_synced(parent_player, "setting members")
+        # Merge this call's delta into the currently open batch for this target.
+        # An add supersedes a prior remove (and vice versa) on the same player.
+        # If there's no open batch (either no prior caller, or a prior batch has
+        # already started flushing), we start a fresh one so we can never see
+        # our future resolved by a flush that didn't include our delta.
+        target_id = parent_player.player_id
+        batch = self._open_set_members_batches.get(target_id)
+        if batch is None:
+            batch = _SetMembersBatch()
+            self._open_set_members_batches[target_id] = batch
+        for pid in player_ids_to_add or []:
+            batch.remove.discard(pid)
+            batch.add.add(pid)
+        for pid in player_ids_to_remove or []:
+            batch.add.discard(pid)
+            batch.remove.add(pid)
 
-        # Use lock for playback commands to prevent protocol switches from
-        # racing with concurrent play_media / play_index / resume calls.
-        async with self.get_player_lock(parent_player.player_id, PlayerLockPurpose.PLAYBACK):
-            await self._handle_set_members(parent_player, player_ids_to_add, player_ids_to_remove)
+        # (Re)arm the debounce timer. ``mass.call_later`` with ``task_id``
+        # cancels any already-pending timer for the same target — the debounce
+        # reset we want on rapid successive calls. The scheduled callback is a
+        # SYNC wrapper that spawns the async flush as an untracked task, so a
+        # re-armed timer can never abort the in-flight flush task.
+        self.mass.call_later(
+            SET_MEMBERS_DEBOUNCE,
+            self._schedule_set_members_flush,
+            target_id,
+            task_id=f"{SET_MEMBERS_TASK_ID_PREFIX}_{target_id}",
+        )
+
+        # Wait for the batch's flush to complete. Other callers that merge into
+        # the same batch await the same future, so they all unblock together.
+        await asyncio.shield(batch.future)
+
+    def _schedule_set_members_flush(self, target_player_id: str) -> None:
+        """Timer callback: start the flush as an untracked task (no task_id)."""
+        batch = self._open_set_members_batches.pop(target_player_id, None)
+        if batch is None:
+            return
+        self.mass.create_task(self._flush_set_members_batch(target_player_id, batch))
+
+    async def _flush_set_members_batch(
+        self, target_player_id: str, batch: _SetMembersBatch
+    ) -> None:
+        """Apply a sealed set_members batch and resolve its future."""
+        try:
+            if not batch.add and not batch.remove:
+                return
+            parent_player = self.get_player(target_player_id)
+            if parent_player is None:
+                self.logger.debug(
+                    "Dropping coalesced set_members for gone player %s", target_player_id
+                )
+                return
+            player_ids_to_add = sorted(batch.add)
+            player_ids_to_remove = sorted(batch.remove)
+            self.logger.debug(
+                "Flushing coalesced set_members on %s: add=%s remove=%s",
+                parent_player.name,
+                player_ids_to_add,
+                player_ids_to_remove,
+            )
+
+            if parent_player.synced_to:
+                # target player is itself synced to another player; ungroup it
+                # first and wait for state to propagate before forwarding.
+                await self._auto_ungroup_if_synced(parent_player, "setting members")
+
+            # Play lock prevents protocol switches from racing with
+            # concurrent play_media / play_index / resume / stop calls.
+            async with self.get_player_lock(
+                parent_player.player_id, PlayerLockPurpose.PLAYBACK
+            ):
+                await self._handle_set_members(
+                    parent_player,
+                    player_ids_to_add or None,
+                    player_ids_to_remove or None,
+                )
+        except Exception as err:
+            if not batch.future.done():
+                batch.future.set_exception(err)
+            raise
+        else:
+            if not batch.future.done():
+                batch.future.set_result(None)
+
+    def _cancel_pending_set_members(self, target_player_id: str) -> None:
+        """Cancel a pending debounced set_members for this target.
+
+        Only cancels the debounce timer and any open (not yet flushing) batch.
+        An already-running flush task is left alone — otherwise calling this
+        from inside the flush path (e.g. ``_dissolve_syncgroup`` during a
+        coalesced dissolve) would cancel ourselves and leave the group in an
+        inconsistent state.
+        """
+        self.mass.cancel_timer(f"{SET_MEMBERS_TASK_ID_PREFIX}_{target_player_id}")
+        batch = self._open_set_members_batches.pop(target_player_id, None)
+        if batch is not None and not batch.future.done():
+            batch.future.cancel()
 
     @api_command("players/cmd/group")
     @handle_player_command

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -355,7 +355,16 @@ class SyncGroupPlayer(Player):
         player_ids_to_add: list[str] | None = None,
         player_ids_to_remove: list[str] | None = None,
     ) -> None:
-        """Handle SET_MEMBERS command on the player."""
+        """Handle SET_MEMBERS command on the player.
+
+        Rapid-fire calls from controllers (e.g. a Home Assistant automation
+        that adds members one-by-one) are coalesced upstream in
+        ``PlayersController.cmd_set_members``, so by the time we get here the
+        delta already represents the net change across the debounce window.
+
+        :param player_ids_to_add: Player ids to add to the group.
+        :param player_ids_to_remove: Player ids to remove from the group.
+        """
         if not self.is_dynamic:
             raise UnsupportedFeaturedException(
                 f"Group {self.display_name} does not allow dynamically adding/removing members!"
@@ -457,7 +466,7 @@ class SyncGroupPlayer(Player):
                 await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
             await self._dissolve_syncgroup()
 
-        elif self.sync_leader:
+        elif self.sync_leader and (final_players_to_add or final_players_to_remove):
             # just a regular member(s) added/removed action,
             # we can simply update the syncgroup members on the sync leader.
             # `active_protocol_domain` is derived from live state, so the
@@ -483,6 +492,13 @@ class SyncGroupPlayer(Player):
         """Handle callback when a group member of the group player is updated."""
         self._update_attributes()
         super().on_group_member_updated(member_player, changed_values)
+
+    async def on_unload(self) -> None:
+        """Handle logic when the player is unloaded from the Player controller."""
+        # cancel any pending debounced set_members for this target so a late
+        # flush doesn't land on a gone group
+        self.mass.players._cancel_pending_set_members(self.player_id)
+        await super().on_unload()
 
     async def _form_syncgroup(self) -> None:
         """Form syncgroup by syncing all (possible) members."""
@@ -545,6 +561,8 @@ class SyncGroupPlayer(Player):
 
     async def _dissolve_syncgroup(self) -> None:
         """Dissolve the current syncgroup by ungrouping all members."""
+        # a pending coalesced set_members must not fire against a dissolved group
+        self.mass.players._cancel_pending_set_members(self.player_id)
         if sync_leader := self.sync_leader:
             # dissolve the temporary syncgroup from the sync leader
             sync_children = [

--- a/tests/core/test_player_controller.py
+++ b/tests/core/test_player_controller.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,6 +37,52 @@ def mock_mass() -> MagicMock:
     mass.config.set = MagicMock()
     mass.signal_event = MagicMock()
     mass.get_providers = MagicMock(return_value=[])
+
+    # cmd_set_members coalesces rapid-fire grouping calls via a debounce timer
+    # (mass.call_later) that spawns an async flush task (mass.create_task).
+    # Mimic the production behaviour: call_later schedules on the event loop
+    # with ~0 delay so concurrent callers can all merge into the same open
+    # batch before the timer fires on the next tick. A re-arm with the same
+    # task_id cancels the prior handle.
+    pending_timers: dict[str, asyncio.TimerHandle] = {}
+
+    def _call_later(
+        _delay: float, target: Any, *args: Any, task_id: str | None = None, **_kwargs: Any
+    ) -> asyncio.TimerHandle | MagicMock:
+        def _fire() -> None:
+            if task_id is not None:
+                pending_timers.pop(task_id, None)
+            result = target(*args)
+            if asyncio.iscoroutine(result):
+                asyncio.ensure_future(result)
+
+        # Sync tests may call through paths that schedule timers (e.g.
+        # update_state). When there's no running loop, returning a MagicMock
+        # is fine — those timers don't affect the test's behaviour.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return MagicMock()
+
+        if task_id is not None and (existing := pending_timers.get(task_id)):
+            existing.cancel()
+        handle = loop.call_later(0, _fire)
+        if task_id is not None:
+            pending_timers[task_id] = handle
+        return handle
+
+    def _cancel_timer(task_id: str) -> None:
+        if handle := pending_timers.pop(task_id, None):
+            handle.cancel()
+
+    def _create_task(target: Any, *args: Any, **_kwargs: Any) -> asyncio.Task[Any]:
+        coro = target if asyncio.iscoroutine(target) else target(*args)
+        return asyncio.ensure_future(coro)
+
+    mass.call_later = MagicMock(side_effect=_call_later)
+    mass.create_task = MagicMock(side_effect=_create_task)
+    mass.cancel_timer = MagicMock(side_effect=_cancel_timer)
+    mass.cancel_task = MagicMock()
     return mass
 
 
@@ -191,8 +238,10 @@ class TestGroupUngroup:
 
         controller._handle_cmd_power = mock_handle_cmd_power  # type: ignore[method-assign]
 
-        # Execute group command
+        # Execute group command. cmd_set_members defers _handle_set_members
+        # through mass.call_later (debounce); yield once to let the flush run.
         await controller.cmd_group("member", "leader")
+        await asyncio.sleep(0)
 
         # Verify set_members was called
         assert set_members_called
@@ -227,6 +276,249 @@ class TestPlayerAvailability:
         # This should either skip the unavailable player or raise an exception
         with contextlib.suppress(Exception):
             asyncio.run(controller.cmd_set_members("leader", player_ids_to_add=["member"]))
+
+
+class TestSetMembersDebounce:
+    """Test that rapid-fire cmd_set_members calls coalesce to one _handle call."""
+
+    async def test_rapid_adds_on_same_target_coalesce(self, mock_mass: MagicMock) -> None:
+        """Three back-to-back adds on the same target collapse into one handle call."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_can_group_with = {"test"}
+        leader._attr_group_members = []
+        member_a = MockPlayer(provider, "member_a", "Member A")
+        member_b = MockPlayer(provider, "member_b", "Member B")
+        member_c = MockPlayer(provider, "member_c", "Member C")
+        for p in (member_a, member_b, member_c):
+            p._attr_powered = True
+
+        controller._players = {
+            "leader": leader,
+            "member_a": member_a,
+            "member_b": member_b,
+            "member_c": member_c,
+        }
+        controller._player_throttlers = {
+            pid: Throttler(1, 0.05) for pid in ("leader", "member_a", "member_b", "member_c")
+        }
+        mock_mass.players = controller
+        leader.update_state(signal_event=False)
+        for p in (member_a, member_b, member_c):
+            p.update_state(signal_event=False)
+
+        handle_calls: list[tuple[set[str], set[str]]] = []
+
+        async def _track(
+            _parent: Any,
+            player_ids_to_add: list[str] | None = None,
+            player_ids_to_remove: list[str] | None = None,
+        ) -> None:
+            handle_calls.append((set(player_ids_to_add or []), set(player_ids_to_remove or [])))
+
+        controller._handle_set_members = _track  # type: ignore[assignment]
+
+        # Fire three adds concurrently so they all merge into the same open
+        # batch before the debounce timer fires on the next loop tick.
+        await asyncio.gather(
+            controller.cmd_set_members("leader", player_ids_to_add=["member_a"]),
+            controller.cmd_set_members("leader", player_ids_to_add=["member_b"]),
+            controller.cmd_set_members("leader", player_ids_to_add=["member_c"]),
+        )
+
+        assert len(handle_calls) == 1
+        adds, removes = handle_calls[0]
+        assert adds == {"member_a", "member_b", "member_c"}
+        assert removes == set()
+
+    async def test_add_then_remove_same_player_nets_to_remove(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """An add followed by a remove on the same player forwards only the remove."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_can_group_with = {"test"}
+        member_x = MockPlayer(provider, "member_x", "Member X")
+        member_x._attr_powered = True
+
+        controller._players = {"leader": leader, "member_x": member_x}
+        controller._player_throttlers = {
+            "leader": Throttler(1, 0.05),
+            "member_x": Throttler(1, 0.05),
+        }
+        mock_mass.players = controller
+        leader.update_state(signal_event=False)
+        member_x.update_state(signal_event=False)
+
+        handle_calls: list[tuple[set[str], set[str]]] = []
+
+        async def _track(
+            _parent: Any,
+            player_ids_to_add: list[str] | None = None,
+            player_ids_to_remove: list[str] | None = None,
+        ) -> None:
+            handle_calls.append((set(player_ids_to_add or []), set(player_ids_to_remove or [])))
+
+        controller._handle_set_members = _track  # type: ignore[assignment]
+
+        await asyncio.gather(
+            controller.cmd_set_members("leader", player_ids_to_add=["member_x"]),
+            controller.cmd_set_members("leader", player_ids_to_remove=["member_x"]),
+        )
+
+        assert len(handle_calls) == 1
+        adds, removes = handle_calls[0]
+        assert removes == {"member_x"}
+        assert "member_x" not in adds
+
+    async def test_unrelated_targets_dont_block_each_other(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Rapid adds on two different targets are each forwarded once."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        leader_a = MockPlayer(provider, "leader_a", "Leader A")
+        leader_a._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader_a._attr_can_group_with = {"test"}
+        leader_b = MockPlayer(provider, "leader_b", "Leader B")
+        leader_b._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader_b._attr_can_group_with = {"test"}
+        member_x = MockPlayer(provider, "member_x", "Member X")
+        member_x._attr_powered = True
+        member_y = MockPlayer(provider, "member_y", "Member Y")
+        member_y._attr_powered = True
+
+        controller._players = {
+            "leader_a": leader_a,
+            "leader_b": leader_b,
+            "member_x": member_x,
+            "member_y": member_y,
+        }
+        controller._player_throttlers = {
+            pid: Throttler(1, 0.05)
+            for pid in ("leader_a", "leader_b", "member_x", "member_y")
+        }
+        mock_mass.players = controller
+        for p in (leader_a, leader_b, member_x, member_y):
+            p.update_state(signal_event=False)
+
+        handle_calls: list[tuple[str, set[str]]] = []
+
+        async def _track(
+            parent: Any,
+            player_ids_to_add: list[str] | None = None,
+            _player_ids_to_remove: list[str] | None = None,
+        ) -> None:
+            handle_calls.append((parent.player_id, set(player_ids_to_add or [])))
+
+        controller._handle_set_members = _track  # type: ignore[assignment]
+
+        await asyncio.gather(
+            controller.cmd_set_members("leader_a", player_ids_to_add=["member_x"]),
+            controller.cmd_set_members("leader_b", player_ids_to_add=["member_y"]),
+        )
+
+        assert {c[0] for c in handle_calls} == {"leader_a", "leader_b"}
+        assert len(handle_calls) == 2
+
+    async def test_caller_awaits_until_flush_completes(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """cmd_set_members must not return before _handle_set_members ran."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_can_group_with = {"test"}
+        leader._attr_group_members = []
+        member = MockPlayer(provider, "member", "Member")
+        member._attr_powered = True
+
+        controller._players = {"leader": leader, "member": member}
+        controller._player_throttlers = {
+            "leader": Throttler(1, 0.05),
+            "member": Throttler(1, 0.05),
+        }
+        mock_mass.players = controller
+        leader.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+
+        handle_call_finished = False
+
+        async def _track(
+            _parent: Any,
+            _player_ids_to_add: list[str] | None = None,
+            _player_ids_to_remove: list[str] | None = None,
+        ) -> None:
+            nonlocal handle_call_finished
+            # Yield once inside the handler so the caller would clearly still
+            # be blocked if cmd_set_members was returning early.
+            await asyncio.sleep(0)
+            handle_call_finished = True
+
+        controller._handle_set_members = _track  # type: ignore[assignment]
+
+        await controller.cmd_set_members("leader", player_ids_to_add=["member"])
+        # when cmd_set_members returns, the flush must already have completed.
+        assert handle_call_finished
+
+    async def test_cancel_drops_pending_delta(self, mock_mass: MagicMock) -> None:
+        """_cancel_pending_set_members drops the open batch before the flush."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_can_group_with = {"test"}
+        member = MockPlayer(provider, "member", "Member")
+        member._attr_powered = True
+
+        controller._players = {"leader": leader, "member": member}
+        controller._player_throttlers = {
+            "leader": Throttler(1, 0.05),
+            "member": Throttler(1, 0.05),
+        }
+        mock_mass.players = controller
+        leader.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+
+        # Override call_later to defer firing entirely so we can cancel before
+        # the flush runs. cancel_timer is a real no-op here (the handle is a
+        # MagicMock from the default override).
+        def _deferred_call_later(
+            _delay: float, _target: Any, *_args: Any, **_kwargs: Any
+        ) -> MagicMock:
+            return MagicMock()
+
+        mock_mass.call_later = MagicMock(side_effect=_deferred_call_later)
+        mock_mass.cancel_timer = MagicMock()
+
+        handled = MagicMock()
+        controller._handle_set_members = handled  # type: ignore[method-assign]
+
+        # Spawn the caller as a task — with the deferred call_later, its
+        # await on batch.future will block indefinitely until we cancel.
+        caller = asyncio.create_task(
+            controller.cmd_set_members("leader", player_ids_to_add=["member"])
+        )
+        await asyncio.sleep(0)  # let cmd_set_members register the batch
+
+        assert "leader" in controller._open_set_members_batches
+        controller._cancel_pending_set_members("leader")
+
+        assert "leader" not in controller._open_set_members_batches
+        handled.assert_not_called()
+        # the awaiting caller is unblocked via cancelled future -> CancelledError
+        with contextlib.suppress(asyncio.CancelledError):
+            await caller
 
 
 class TestStateForwarding:

--- a/tests/core/test_player_controller.py
+++ b/tests/core/test_player_controller.py
@@ -334,9 +334,7 @@ class TestSetMembersDebounce:
         assert adds == {"member_a", "member_b", "member_c"}
         assert removes == set()
 
-    async def test_add_then_remove_same_player_nets_to_remove(
-        self, mock_mass: MagicMock
-    ) -> None:
+    async def test_add_then_remove_same_player_nets_to_remove(self, mock_mass: MagicMock) -> None:
         """An add followed by a remove on the same player forwards only the remove."""
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
@@ -377,9 +375,7 @@ class TestSetMembersDebounce:
         assert removes == {"member_x"}
         assert "member_x" not in adds
 
-    async def test_unrelated_targets_dont_block_each_other(
-        self, mock_mass: MagicMock
-    ) -> None:
+    async def test_unrelated_targets_dont_block_each_other(self, mock_mass: MagicMock) -> None:
         """Rapid adds on two different targets are each forwarded once."""
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
@@ -402,8 +398,7 @@ class TestSetMembersDebounce:
             "member_y": member_y,
         }
         controller._player_throttlers = {
-            pid: Throttler(1, 0.05)
-            for pid in ("leader_a", "leader_b", "member_x", "member_y")
+            pid: Throttler(1, 0.05) for pid in ("leader_a", "leader_b", "member_x", "member_y")
         }
         mock_mass.players = controller
         for p in (leader_a, leader_b, member_x, member_y):
@@ -428,9 +423,7 @@ class TestSetMembersDebounce:
         assert {c[0] for c in handle_calls} == {"leader_a", "leader_b"}
         assert len(handle_calls) == 2
 
-    async def test_caller_awaits_until_flush_completes(
-        self, mock_mass: MagicMock
-    ) -> None:
+    async def test_caller_awaits_until_flush_completes(self, mock_mass: MagicMock) -> None:
         """cmd_set_members must not return before _handle_set_members ran."""
         controller = PlayerController(mock_mass)
         provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -544,4 +544,3 @@ class TestSetMembersDoesNotRegisterIncompatible:
         assert "member" in sgp._attr_group_members
         # but _handle_set_members on the leader is not called (no leader yet)
         mass.players._handle_set_members.assert_not_awaited()
-

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,6 +29,7 @@ def _make_mock_mass() -> MagicMock:
     mass.players._handle_play_media = AsyncMock()
     mass.players.cmd_set_members = AsyncMock()
     mass.players._handle_set_members = AsyncMock()
+    mass.players._cancel_pending_set_members = MagicMock()
     # get_player_lock is an async context manager (used by syncgroup to lock the sync leader)
     lock_ctx = AsyncMock()
     lock_ctx.__aenter__.return_value = None
@@ -41,8 +44,14 @@ def _make_mock_mass() -> MagicMock:
     wait_ctx.__aexit__.return_value = False
     mass.players.wait_for_player_update = MagicMock(return_value=wait_ctx)
     mass.players.trigger_player_update = MagicMock()
-    mass.call_later = MagicMock()
-    mass.cancel_timer = MagicMock()
+
+    # create_task must produce a real asyncio.Task so anything scheduling
+    # internal tasks still works.
+    def _create_task(target: Any, *args: Any, **_kwargs: Any) -> asyncio.Task[Any]:
+        coro = target(*args) if inspect.iscoroutinefunction(target) else target
+        return asyncio.ensure_future(coro)
+
+    mass.create_task = MagicMock(side_effect=_create_task)
     mass.config = MagicMock()
     mass.config.get_base_player_config.return_value = MagicMock(
         name=None, default_name="Test Group", get_value=MagicMock(return_value=True)
@@ -488,7 +497,6 @@ class TestSetMembersDoesNotRegisterIncompatible:
         sgp._attr_group_members = ["leader"]
 
         await sgp.set_members(player_ids_to_add=["incompatible"])
-
         # incompatible must NOT linger in the internal member list
         assert "incompatible" not in sgp._attr_group_members
         # and the leader was never asked to add it (the call may still happen
@@ -513,7 +521,6 @@ class TestSetMembersDoesNotRegisterIncompatible:
         sgp._attr_group_members = ["leader"]
 
         await sgp.set_members(player_ids_to_add=["compatible"])
-
         assert "compatible" in sgp._attr_group_members
         mass.players._handle_set_members.assert_awaited_once()
         kwargs = mass.players._handle_set_members.await_args.kwargs
@@ -533,8 +540,8 @@ class TestSetMembersDoesNotRegisterIncompatible:
         sgp._attr_group_members = []
 
         await sgp.set_members(player_ids_to_add=["member"])
-
         # member is registered so a future _form_syncgroup can pick it as leader
         assert "member" in sgp._attr_group_members
         # but _handle_set_members on the leader is not called (no leader yet)
         mass.players._handle_set_members.assert_not_awaited()
+


### PR DESCRIPTION
Home Assistant automations often fire several `players/cmd/set_members` (add/remove) commands in quick succession against the same sync leader. Without coalescing each call was forwarded to the protocol layer as its own teardown+restart cycle — most visibly killing and re-spawning AirPlay cliraop with a 2.5 s late-joiner buffer replay — which is the main source of audio hiccups and CPU uptick observed in production logs.

Coalescing lives in `PlayersController.cmd_set_members` so every grouping entry point shares one debounce: sync groups, universal groups, and direct protocol-level syncing (Sonos↔Sonos, AirPlay ad-hoc groups, Snapcast, HEOS, ...).

- Pending add/remove deltas live on the controller, keyed by the resolved target player id. An add supersedes a prior remove and vice versa on the same player.
- Debounce timer via `mass.call_later(task_id=...)` per target, so unrelated groupings don't block each other. `_cancel_pending_set_members` covers both the sleeping timer and an already-running flush.
- Redirect-to-active-group and the synchronous `SET_MEMBERS` feature check still run per call (before debounce), so we coalesce against the final target and callers still get the right error class.
- `SyncGroupPlayer._dissolve_syncgroup` and `on_unload` call the controller's `_cancel_pending_set_members` so a pending delta can't land on a gone group.