### PR TITLE
Guard Sonos volume attribute update against uninitialized state

### DIFF
--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -487,11 +487,14 @@ class SonosPlayer(Player):
         self._attr_available = self.connected
         if not self.connected:
             return
-        if self.client.player.has_fixed_volume:
-            self._attr_volume_level = 100
-        elif not self.client.player.volume_muted or self.client.player.volume_level:
-            self._attr_volume_level = self.client.player.volume_level or 0
-        self._attr_volume_muted = self.client.player.volume_muted
+        # aiosonos does not expose a public "volume data initialized" accessor;
+        # guard against the race where a volume event arrives before async_init populates it
+        if getattr(self.client.player, "_volume_data", None) is not None:
+            if self.client.player.has_fixed_volume:
+                self._attr_volume_level = 100
+            elif not self.client.player.volume_muted or self.client.player.volume_level:
+                self._attr_volume_level = self.client.player.volume_level or 0
+            self._attr_volume_muted = self.client.player.volume_muted
 
         group_parent: SonosPlayer | None = None
         active_group: SonosGroup | None

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -487,14 +487,21 @@ class SonosPlayer(Player):
         self._attr_available = self.connected
         if not self.connected:
             return
-        # aiosonos does not expose a public "volume data initialized" accessor;
-        # guard against the race where a volume event arrives before async_init populates it
-        if getattr(self.client.player, "_volume_data", None) is not None:
-            if self.client.player.has_fixed_volume:
+        # guard against the race where a volume event arrives before aiosonos'
+        # async_init has populated _volume_data (the accessors raise AttributeError
+        # on None). The next event re-runs once the data is there.
+        try:
+            has_fixed_volume = self.client.player.has_fixed_volume
+            volume_muted = self.client.player.volume_muted
+            volume_level = self.client.player.volume_level
+        except AttributeError:
+            pass
+        else:
+            if has_fixed_volume:
                 self._attr_volume_level = 100
-            elif not self.client.player.volume_muted or self.client.player.volume_level:
-                self._attr_volume_level = self.client.player.volume_level or 0
-            self._attr_volume_muted = self.client.player.volume_muted
+            elif not volume_muted or volume_level:
+                self._attr_volume_level = volume_level or 0
+            self._attr_volume_muted = volume_muted
 
         group_parent: SonosPlayer | None = None
         active_group: SonosGroup | None


### PR DESCRIPTION
`update_attributes` hits `has_fixed_volume` (and other volume accessors) on the aiosonos player. On a fresh connect, `_volume_data` can still be `None` until `async_init` runs, and the aiosonos property then raises `AttributeError: 'NoneType' object has no attribute 'get'`. `on_player_event` already wraps the call in try/except so it's non-fatal, but the single event's attribute update is silently dropped.

- Guard the volume block in `update_attributes` so `has_fixed_volume`, `volume_muted` and `volume_level` are only read once `_volume_data` is populated; the next event re-runs once async_init has completed.