### PR TITLE
Add pactl to base Docker file

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -195,6 +195,8 @@ RUN set -x \
         libportaudio2 \
         # Allows pipewire devices to be detected when running in docker container. (local audio)
         pipewire-alsa \
+        # Allows pulse audio devices to be detected using pactl. (local audio)
+        pulseaudio-utils \
         libvorbisidec1 \
         libflac12 \
         libavahi-client3 \
@@ -203,7 +205,15 @@ RUN set -x \
         libconfig9 \
         libpopt0 \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f \
+        /usr/bin/parecord \
+        /usr/bin/paplay \
+        /usr/bin/parec \
+        /usr/bin/pamon \
+        /usr/bin/pacat \
+        /usr/bin/pasuspender \
+        /usr/bin/pacmd
 
 # Install Snapcast 0.34.0 from GitHub releases (requires at least 0.27)
 ARG SNAPCAST_VERSION=0.34.0


### PR DESCRIPTION
This a prerequisite to Extend Local Audio Out provider with PulseAudio support#3724.  With this PR the pactl binary will be available in the MA container for enumerating pulse audio sinks for the local_audio player provider. With pactl available in the container the pactl binary and libraries will not need to be included with the player provider.
