### PR TITLE
Add Spotify recommendations API commands

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -23,6 +23,7 @@ from music_assistant_models.enums import (
     MediaType,
     ProviderFeature,
     ProviderType,
+    QueueOption,
     TaskStatus,
 )
 from music_assistant_models.errors import (
@@ -31,6 +32,7 @@ from music_assistant_models.errors import (
     InvalidProviderURI,
     MediaNotFoundError,
     MusicAssistantError,
+    UnsupportedFeaturedException,
 )
 from music_assistant_models.helpers import get_global_cache_value
 from music_assistant_models.media_items import (
@@ -812,6 +814,93 @@ class MusicController(CoreController):
         # return result from all providers while keeping index
         # so the result is sorted as each provider delivered
         return [item for sublist in zip_longest(*results_per_provider) for item in sublist if item]
+
+    @api_command("music/spotify_recommendations")
+    async def get_spotify_recommendations(
+        self,
+        seed_track_uris: list[str] | None = None,
+        seed_artist_uris: list[str] | None = None,
+        seed_genres: list[str] | None = None,
+        limit: int = 25,
+        audio_features: dict[str, float | int] | None = None,
+        queue_id: str | None = None,
+        queue_option: QueueOption = QueueOption.REPLACE,
+    ) -> list[Track]:
+        """Get track recommendations from Spotify's recommendations API.
+
+        Accepts MA item URIs as seeds (resolved to Spotify IDs internally).
+        At least one seed must be provided; total seeds cannot exceed 5.
+        If queue_id is given the tracks are also enqueued on that player queue.
+
+        :param seed_track_uris: MA track URIs to seed recommendations (e.g. "spotify://track/xyz").
+        :param seed_artist_uris: MA artist URIs to seed recommendations.
+        :param seed_genres: Genre names to seed recommendations (e.g. ["pop", "electronic"]).
+        :param limit: Number of tracks to return (1-100, default 25).
+        :param audio_features: Audio feature constraints passed to Spotify's API, e.g.
+            {"target_energy": 0.8, "min_tempo": 120, "max_valence": 0.6}.
+        :param queue_id: Player queue ID. When provided, tracks are enqueued after retrieval.
+        :param queue_option: How to add tracks to the queue (default: REPLACE).
+        """
+        # Lazily import to avoid circular dependency at module level
+        from music_assistant.providers.spotify.provider import SpotifyProvider  # noqa: PLC0415
+
+        spotify_prov: SpotifyProvider | None = next(
+            (p for p in self.providers if isinstance(p, SpotifyProvider)), None
+        )
+        if spotify_prov is None:
+            raise UnsupportedFeaturedException("Spotify provider is not available")
+
+        async def resolve_to_spotify_id(uri: str, media_type_label: str) -> str | None:
+            try:
+                item = await self.get_item_by_uri(uri)
+            except MusicAssistantError:
+                self.logger.warning("Could not resolve %s URI %s", media_type_label, uri)
+                return None
+            for mapping in item.provider_mappings:  # type: ignore[union-attr]
+                if mapping.provider_domain == "spotify":
+                    return mapping.item_id
+            self.logger.warning("No Spotify mapping found for %s URI %s", media_type_label, uri)
+            return None
+
+        seed_tracks = [
+            sid
+            for uri in (seed_track_uris or [])
+            if (sid := await resolve_to_spotify_id(uri, "track")) is not None
+        ]
+        seed_artists = [
+            sid
+            for uri in (seed_artist_uris or [])
+            if (sid := await resolve_to_spotify_id(uri, "artist")) is not None
+        ]
+
+        tracks = await spotify_prov.get_recommendations(
+            seed_tracks=seed_tracks or None,
+            seed_artists=seed_artists or None,
+            seed_genres=seed_genres or None,
+            limit=limit,
+            audio_features=audio_features,
+        )
+
+        if queue_id and tracks:
+            await self.mass.player_queues.play_media(
+                queue_id=queue_id,
+                media=tracks,
+                option=queue_option,
+            )
+
+        return tracks
+
+    @api_command("music/spotify_recommendation_genres")
+    async def get_spotify_recommendation_genres(self) -> list[str]:
+        """Return the list of genre seeds available for use with music/spotify_recommendations."""
+        from music_assistant.providers.spotify.provider import SpotifyProvider  # noqa: PLC0415
+
+        spotify_prov: SpotifyProvider | None = next(
+            (p for p in self.providers if isinstance(p, SpotifyProvider)), None
+        )
+        if spotify_prov is None:
+            raise UnsupportedFeaturedException("Spotify provider is not available")
+        return await spotify_prov.get_available_genre_seeds()
 
     @api_command("music/item")
     async def get_item(

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -362,6 +362,23 @@ class SpotifyProvider(MusicProvider):
         track_obj = await self._get_data(f"tracks/{prov_track_id}")
         return parse_track(track_obj, self)
 
+    async def get_tracks_batch(self, prov_track_ids: list[str]) -> list[Track]:
+        """Get multiple tracks by ID in a single batch request.
+
+        Uses Spotify's /tracks?ids=... endpoint which accepts up to 50 IDs per request,
+        significantly reducing API calls and rate limit impact vs individual fetches.
+
+        :param prov_track_ids: List of Spotify track IDs to fetch.
+        """
+        result: list[Track] = []
+        for i in range(0, len(prov_track_ids), 50):
+            chunk = prov_track_ids[i : i + 50]
+            data = await self._get_data("tracks", ids=",".join(chunk))
+            for track_obj in data.get("tracks", []):
+                if track_obj:
+                    result.append(parse_track(track_obj, self))
+        return result
+
     @use_cache()
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
         """Get full playlist details by id."""
@@ -687,6 +704,12 @@ class SpotifyProvider(MusicProvider):
         track_uris = [f"spotify:track:{track_id}" for track_id in prov_track_ids]
         data = {"uris": track_uris}
         await self._post_data(f"playlists/{prov_playlist_id}/items", data=data)
+        # Invalidate the etag cache for this playlist's tracks so the next read fetches
+        # fresh data from Spotify rather than returning the now-stale cached result.
+        await self.mass.cache.clear(
+            key_filter=f"playlists/{prov_playlist_id}/items",
+            provider_filter=self.instance_id,
+        )
 
     async def remove_playlist_tracks(
         self, prov_playlist_id: str, positions_to_remove: tuple[int, ...]
@@ -721,6 +744,59 @@ class SpotifyProvider(MusicProvider):
         items = await self._get_data(
             endpoint, seed_tracks=prov_track_id, limit=limit, use_global_session=True
         )
+        return [parse_track(item, self) for item in items["tracks"] if (item and item["id"])]
+
+    @use_cache(86400 * 7)  # 7 days - genre seeds are stable
+    async def get_available_genre_seeds(self) -> list[str]:
+        """Retrieve the list of genre seeds available for Spotify recommendations."""
+        result = await self._get_data(
+            "recommendations/available-genre-seeds", use_global_session=True
+        )
+        return cast("list[str]", result.get("genres", []))
+
+    async def get_recommendations(
+        self,
+        seed_tracks: list[str] | None = None,
+        seed_artists: list[str] | None = None,
+        seed_genres: list[str] | None = None,
+        limit: int = 25,
+        audio_features: dict[str, float | int] | None = None,
+    ) -> list[Track]:
+        """Retrieve track recommendations from Spotify based on seeds and audio features.
+
+        Wraps Spotify's /recommendations endpoint with full parameter support.
+        The recommendations endpoint is only available via the global (MA) session.
+        https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api
+
+        :param seed_tracks: Up to 5 Spotify track IDs to seed recommendations.
+        :param seed_artists: Up to 5 Spotify artist IDs to seed recommendations.
+        :param seed_genres: Up to 5 genre strings to seed recommendations.
+        :param limit: Number of tracks to return (1-100).
+        :param audio_features: Optional audio feature constraints, e.g.
+            {"target_energy": 0.8, "min_tempo": 120, "max_valence": 0.6}.
+            Supported prefixes: target_, min_, max_.
+            Supported attributes: acousticness, danceability, energy, instrumentalness,
+            liveness, loudness, popularity, speechiness, tempo, valence.
+        """
+        total_seeds = len(seed_tracks or []) + len(seed_artists or []) + len(seed_genres or [])
+        if total_seeds == 0:
+            msg = "At least one seed (track, artist, or genre) must be provided."
+            raise ValueError(msg)
+        if total_seeds > 5:
+            msg = "Total seeds (tracks + artists + genres) cannot exceed 5."
+            raise ValueError(msg)
+
+        kwargs: dict[str, Any] = {"limit": min(limit, 100), "use_global_session": True}
+        if seed_tracks:
+            kwargs["seed_tracks"] = ",".join(seed_tracks)
+        if seed_artists:
+            kwargs["seed_artists"] = ",".join(seed_artists)
+        if seed_genres:
+            kwargs["seed_genres"] = ",".join(seed_genres)
+        if audio_features:
+            kwargs.update(audio_features)
+
+        items = await self._get_data("recommendations", **kwargs)
         return [parse_track(item, self) for item in items["tracks"] if (item and item["id"])]
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:


### PR DESCRIPTION
## Summary

Adds two new API commands for building playlists from Spotify's recommendations engine, plus a batch track fetch helper on the Spotify provider.

- **`music/spotify_recommendations`** — Get track recommendations from Spotify's `/recommendations` endpoint. Accepts MA item URIs as seeds (resolved to Spotify IDs internally), supports audio feature targeting (`target_energy`, `min_tempo`, etc.), and can optionally enqueue the results on a player queue.
- **`music/spotify_recommendation_genres`** — Returns the list of genre seeds available for use with the recommendations command.
- **`SpotifyProvider.get_tracks_batch`** — Fetches up to 50 tracks per request via `/v1/tracks?ids=...`, reducing individual throttled API calls to a single batch request.
- **Cache invalidation fix** — `add_playlist_tracks` now clears the etag cache for the playlist items endpoint so the next read returns fresh data instead of stale cached results.

The recommendations endpoint requires the global (MA) session per Spotify's 2024 Web API changes.

## Test plan

- [ ] Call `music/spotify_recommendation_genres` and verify a list of genres is returned
- [ ] Call `music/spotify_recommendations` with seed_track_uris and verify tracks are returned
- [ ] Call with `queue_id` set and verify tracks are enqueued on the player queue
- [ ] Call with audio feature constraints (e.g. `{"target_energy": 0.8}`) and verify constraints are applied
- [ ] Verify validation: no seeds raises, >5 seeds raises
- [ ] Add tracks to a playlist and verify the next fetch returns fresh data (no stale cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)