### PR TITLE
Smart crossfade: Add gradual timestretching

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -73,7 +73,7 @@ from music_assistant.controllers.streams.constants import (
 )
 from music_assistant.controllers.streams.ogg_handler import get_chained_ogg_stream
 from music_assistant.controllers.streams.smart_fades import SmartFadesMixer
-from music_assistant.controllers.streams.smart_fades.fades import SMART_CROSSFADE_DURATION
+from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 from music_assistant.helpers import ssl as ssl_util
 from music_assistant.helpers.audio import (
     HTTP_HEADERS,

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -377,15 +377,7 @@ class SmartCrossFade(SmartFade):
         bpm_diff_percent: float,
         crossfade_duration: float,
     ) -> None:
-        """Apply gradual time stretch in the 10s window before the crossfade.
-
-        The S-curve ramp completes right when the crossfade begins, so both
-        tracks are at matched BPM during the entire overlap.
-
-        :param bpm_ratio: Target tempo ratio (fade_in_bpm / fade_out_bpm).
-        :param bpm_diff_percent: BPM difference as a percentage.
-        :param crossfade_duration: Duration of the crossfade in seconds.
-        """
+        """Apply gradual time stretch in the 10s window before the crossfade."""
         stretch_duration = 10.0
         crossfade_start = SMART_CROSSFADE_DURATION - crossfade_duration
         stretch_start = max(0.0, crossfade_start - stretch_duration)

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -257,7 +257,6 @@ class SmartCrossFade(SmartFade):
         # Extrapolate downbeats for better bar calculation
         self.extrapolated_fadeout_downbeats = extrapolate_downbeats(
             self.fade_out_downbeats,
-            tempo_factor=1.0,
             bpm=self.fade_out_bpm,
         )
 
@@ -300,10 +299,14 @@ class SmartCrossFade(SmartFade):
                 SMART_CROSSFADE_DURATION,
             )
 
-        # Adjust crossfade duration to align with outgoing track's downbeats
+        # Adjust crossfade duration to align with outgoing track's downbeats.
+        # When stretching, only consider downbeats after the stretch window
+        # to ensure the outgoing track has reached the target tempo.
+        crossfade_start = SMART_CROSSFADE_DURATION - crossfade_duration
         crossfade_duration = self._adjust_crossfade_to_downbeats(
             crossfade_duration=crossfade_duration,
             fadein_start_pos=fadein_start_pos,
+            min_downbeat_pos=crossfade_start if is_stretched else 0.0,
         )
 
         # Compensate crossfade duration for time-stretch compression.
@@ -417,13 +420,6 @@ class SmartCrossFade(SmartFade):
 
         self.filters.append(GradualTimeStretchFilter(self.logger, tempo_steps))
 
-        # Re-extrapolate downbeats with actual tempo factor for time-stretched audio
-        self.extrapolated_fadeout_downbeats = extrapolate_downbeats(
-            self.fade_out_downbeats,
-            tempo_factor=bpm_ratio,
-            bpm=self.fade_out_bpm,
-        )
-
     def _calculate_crossfade_duration(self, crossfade_bars: int) -> float:
         """Calculate final crossfade duration based on musical bars and BPM."""
         # Calculate crossfade duration based on incoming track's BPM
@@ -522,6 +518,7 @@ class SmartCrossFade(SmartFade):
         self,
         crossfade_duration: float,
         fadein_start_pos: float | None,
+        min_downbeat_pos: float = 0.0,
     ) -> float:
         """Adjust crossfade duration to align with outgoing track's downbeats."""
         # If we don't have downbeats or beat alignment is disabled, return original duration
@@ -547,6 +544,8 @@ class SmartCrossFade(SmartFade):
         later_downbeat = None
 
         for downbeat in self.extrapolated_fadeout_downbeats:
+            if downbeat < min_downbeat_pos:
+                continue
             if downbeat <= ideal_start_pos:
                 earlier_downbeat = downbeat
             elif downbeat > ideal_start_pos and later_downbeat is None:

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -19,8 +19,14 @@ from music_assistant.controllers.streams.smart_fades.filters import (
     CrossfadeFilter,
     Filter,
     FrequencySweepFilter,
-    TimeStretchFilter,
+    GradualTimeStretchFilter,
     TrimFilter,
+)
+from music_assistant.controllers.streams.smart_fades.helpers import (
+    SMART_CROSSFADE_DURATION,
+    compute_gradual_tempo_steps,
+    extrapolate_downbeats,
+    generate_synthetic_timestamps,
 )
 from music_assistant.helpers.audio import iter_pcm_slices
 from music_assistant.helpers.process import AsyncProcess
@@ -29,8 +35,6 @@ from music_assistant.models.audio_analysis import AudioAnalysisData
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat
-
-SMART_CROSSFADE_DURATION = 45
 
 
 class SmartFade(ABC):
@@ -274,20 +278,18 @@ class SmartCrossFade(SmartFade):
         # Calculate initial crossfade duration (may be adjusted later for downbeat alignment)
         crossfade_duration = self._calculate_crossfade_duration(crossfade_bars=crossfade_bars)
 
-        # Add time stretch filter if needed
-        if (
+        # Add gradual time stretch filter if needed
+        is_stretched = (
             0.1 < bpm_diff_percent <= self.time_stretch_bpm_percentage_threshold
             and crossfade_bars > 4
-        ):
-            self.filters.append(TimeStretchFilter(logger=self.logger, stretch_ratio=bpm_ratio))
-            # Re-extrapolate downbeats with actual tempo factor for time-stretched audio
-            self.extrapolated_fadeout_downbeats = extrapolate_downbeats(
-                self.fade_out_downbeats,
-                tempo_factor=bpm_ratio,
-                bpm=self.fade_out_bpm,
-            )
+        )
+        if is_stretched:
+            self._apply_gradual_time_stretch(bpm_ratio, bpm_diff_percent, crossfade_duration)
 
-        if fadein_start_pos and fadein_start_pos + crossfade_duration <= SMART_CROSSFADE_DURATION:
+        if (
+            fadein_start_pos is not None
+            and fadein_start_pos + crossfade_duration <= SMART_CROSSFADE_DURATION
+        ):
             self.filters.append(TrimFilter(logger=self.logger, fadein_start_pos=fadein_start_pos))
         else:
             self.logger.log(
@@ -303,6 +305,12 @@ class SmartCrossFade(SmartFade):
             crossfade_duration=crossfade_duration,
             fadein_start_pos=fadein_start_pos,
         )
+
+        # Compensate crossfade duration for time-stretch compression.
+        # acrossfade operates in output time, but downbeat alignment was done in input time.
+        # Stretching compresses the output, so we divide by bpm_ratio to keep alignment.
+        if is_stretched:
+            crossfade_duration = crossfade_duration / bpm_ratio
 
         # 90 BPM -> 1500Hz, 140 BPM -> 2500Hz
         avg_bpm = (self.fade_out_bpm + self.fade_in_bpm) / 2
@@ -362,6 +370,69 @@ class SmartCrossFade(SmartFade):
             logger=self.logger, crossfade_duration=crossfade_duration
         )
         self.filters.append(crossfade_filter)
+
+    def _apply_gradual_time_stretch(
+        self,
+        bpm_ratio: float,
+        bpm_diff_percent: float,
+        crossfade_duration: float,
+    ) -> None:
+        """Apply gradual time stretch in the 10s window before the crossfade.
+
+        The S-curve ramp completes right when the crossfade begins, so both
+        tracks are at matched BPM during the entire overlap.
+
+        :param bpm_ratio: Target tempo ratio (fade_in_bpm / fade_out_bpm).
+        :param bpm_diff_percent: BPM difference as a percentage.
+        :param crossfade_duration: Duration of the crossfade in seconds.
+        """
+        stretch_duration = 10.0
+        crossfade_start = SMART_CROSSFADE_DURATION - crossfade_duration
+        stretch_start = max(0.0, crossfade_start - stretch_duration)
+        stretch_end = crossfade_start
+
+        # Collect timing points within the stretch window
+        beat_mask = (self.fade_out_beats >= stretch_start) & (self.fade_out_beats <= stretch_end)
+        db_mask = (self.extrapolated_fadeout_downbeats >= stretch_start) & (
+            self.extrapolated_fadeout_downbeats <= stretch_end
+        )
+        window_beats = self.fade_out_beats[beat_mask] - stretch_start
+        window_downbeats = self.extrapolated_fadeout_downbeats[db_mask] - stretch_start
+
+        # >3% BPM diff: beat-level stepping (more steps = smoother)
+        # <=3%: downbeat-level stepping, fall back to beats if too few
+        if bpm_diff_percent > 3.0:
+            stretch_timestamps = window_beats
+        elif len(window_downbeats) >= 2:
+            stretch_timestamps = window_downbeats
+        else:
+            stretch_timestamps = window_beats
+
+        # Fall back to synthetic timestamps when < 2 real timestamps
+        if len(stretch_timestamps) < 2:
+            stretch_timestamps = generate_synthetic_timestamps(
+                stretch_end - stretch_start, self.fade_out_bpm
+            )
+
+        tempo_steps = compute_gradual_tempo_steps(
+            start_ratio=1.0,
+            end_ratio=bpm_ratio,
+            downbeats=stretch_timestamps,
+        )
+        if not tempo_steps:
+            tempo_steps = [(0.0, bpm_ratio)]
+
+        # Shift timestamps back to buffer-relative coordinates for FFmpeg
+        tempo_steps = [(ts + stretch_start, ratio) for ts, ratio in tempo_steps]
+
+        self.filters.append(GradualTimeStretchFilter(self.logger, tempo_steps))
+
+        # Re-extrapolate downbeats with actual tempo factor for time-stretched audio
+        self.extrapolated_fadeout_downbeats = extrapolate_downbeats(
+            self.fade_out_downbeats,
+            tempo_factor=bpm_ratio,
+            bpm=self.fade_out_bpm,
+        )
 
     def _calculate_crossfade_duration(self, crossfade_bars: int) -> float:
         """Calculate final crossfade duration based on musical bars and BPM."""
@@ -602,106 +673,3 @@ class StandardCrossFade(SmartFade):
         else:
             async for chunk in post_crossfade:
                 yield chunk
-
-
-# HELPER METHODS
-def get_bpm_diff_percentage(bpm1: float, bpm2: float) -> float:
-    """Calculate BPM difference percentage between two BPM values."""
-    return abs(1.0 - bpm1 / bpm2) * 100
-
-
-def extrapolate_downbeats(
-    downbeats: npt.NDArray[np.float32],
-    tempo_factor: float,
-    buffer_size: float = SMART_CROSSFADE_DURATION,
-    bpm: float | None = None,
-) -> npt.NDArray[np.float32]:
-    """Extrapolate downbeats based on actual intervals when detection is incomplete.
-
-    This is needed when we want to perform beat alignment in an 'atmospheric' outro
-    that does not have any detected downbeats.
-
-    Args:
-        downbeats: Array of detected downbeat positions in seconds
-        tempo_factor: Tempo adjustment factor for time stretching
-        buffer_size: Maximum buffer size in seconds
-        bpm: Optional BPM for validation when extrapolating with only 2 downbeats
-    """
-    # Handle case with exactly 2 downbeats (with BPM validation)
-    if len(downbeats) == 2 and bpm is not None:
-        interval = float(downbeats[1] - downbeats[0])
-
-        # Expected interval for this BPM (assuming 4/4 time signature)
-        expected_interval = (60.0 / bpm) * 4
-
-        # Only extrapolate if interval matches BPM within 15% tolerance
-        if abs(interval - expected_interval) / expected_interval < 0.15:
-            # Adjust detected downbeats for time stretching first
-            adjusted_downbeats = downbeats / tempo_factor
-            last_downbeat = adjusted_downbeats[-1]
-
-            # If the last downbeat is close to the buffer end, no extrapolation needed
-            if last_downbeat >= buffer_size - 5:
-                return adjusted_downbeats
-
-            # Adjust the interval for time stretching
-            adjusted_interval = interval / tempo_factor
-
-            # Extrapolate forward from last adjusted downbeat using adjusted interval
-            extrapolated = []
-            current_pos = last_downbeat + adjusted_interval
-            max_extrapolation_distance = 125.0  # Don't extrapolate more than 25s
-
-            while (
-                current_pos < buffer_size
-                and (current_pos - last_downbeat) <= max_extrapolation_distance
-            ):
-                extrapolated.append(current_pos)
-                current_pos += adjusted_interval
-
-            if extrapolated:
-                # Combine adjusted detected downbeats and extrapolated downbeats
-                return np.concatenate([adjusted_downbeats, np.array(extrapolated)])
-
-            return adjusted_downbeats
-        # else: interval doesn't match BPM, fall through to return original
-
-    if len(downbeats) < 2:
-        # Need at least 2 downbeats to extrapolate
-        return downbeats / tempo_factor
-
-    # Adjust detected downbeats for time stretching first
-    adjusted_downbeats = downbeats / tempo_factor
-    last_downbeat = adjusted_downbeats[-1]
-
-    # If the last downbeat is close to the buffer end, no extrapolation needed
-    if last_downbeat >= buffer_size - 5:
-        return adjusted_downbeats
-
-    # Calculate intervals from ORIGINAL downbeats (before time stretching)
-    intervals = np.diff(downbeats)
-    median_interval = float(np.median(intervals))
-    std_interval = float(np.std(intervals))
-
-    # Only extrapolate if intervals are consistent (low standard deviation)
-    if std_interval > 0.2:
-        return adjusted_downbeats
-
-    # Adjust the interval for time stretching
-    # When slowing down (tempo_factor < 1.0), intervals get longer
-    adjusted_interval = median_interval / tempo_factor
-
-    # Extrapolate forward from last adjusted downbeat using adjusted interval
-    extrapolated = []
-    current_pos = last_downbeat + adjusted_interval
-    max_extrapolation_distance = 25.0  # Don't extrapolate more than 25s
-
-    while current_pos < buffer_size and (current_pos - last_downbeat) <= max_extrapolation_distance:
-        extrapolated.append(current_pos)
-        current_pos += adjusted_interval
-
-    if extrapolated:
-        # Combine adjusted detected downbeats and extrapolated downbeats
-        return np.concatenate([adjusted_downbeats, np.array(extrapolated)])
-
-    return adjusted_downbeats

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -307,8 +307,6 @@ class SmartCrossFade(SmartFade):
         )
 
         # Compensate crossfade duration for time-stretch compression.
-        # acrossfade operates in output time, but downbeat alignment was done in input time.
-        # Stretching compresses the output, so we divide by bpm_ratio to keep alignment.
         if is_stretched:
             crossfade_duration = crossfade_duration / bpm_ratio
 

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -293,7 +293,7 @@ class SmartCrossFade(SmartFade):
         else:
             self.logger.log(
                 VERBOSE_LOG_LEVEL,
-                "Skipping beat alignment: not enough audio after trim (%.1fs + %.1fs > %.1fs)",
+                "Skipping beat alignment: not enough audio after trim (%s + %.1fs > %.1fs)",
                 fadein_start_pos,
                 crossfade_duration,
                 SMART_CROSSFADE_DURATION,

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -19,32 +19,46 @@ class Filter(ABC):
         """Apply the filter and return the FFmpeg filter strings."""
 
 
-class TimeStretchFilter(Filter):
-    """Filter that applies time stretching to match BPM using rubberband."""
+class GradualTimeStretchFilter(Filter):
+    """Gradual tempo change using asendcmd + rubberband with S-curve steps."""
 
-    output_fadeout_label: str = "fadeout_stretched"
+    output_fadeout_label: str = "fadeout_gradstretch"
     output_fadein_label: str = "fadein_unchanged"
 
-    def __init__(
-        self,
-        logger: logging.Logger,
-        stretch_ratio: float,
-    ):
-        """Initialize time stretch filter."""
-        self.stretch_ratio = stretch_ratio
+    def __init__(self, logger: logging.Logger, tempo_steps: list[tuple[float, float]]) -> None:
+        """Initialize with tempo steps from compute_gradual_tempo_steps.
+
+        :param logger: Logger for debug output.
+        :param tempo_steps: List of (timestamp_seconds, tempo_ratio) tuples.
+        """
         super().__init__(logger)
+        self.tempo_steps = tempo_steps
 
     def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
-        """Create FFmpeg filters to gradually adjust tempo from original BPM to target BPM."""
+        """Build FFmpeg filter string for gradual time stretching."""
+        if not self.tempo_steps:
+            self.output_fadeout_label = input_fadeout_label.strip("[]")
+            self.output_fadein_label = input_fadein_label.strip("[]")
+            return []
+
+        cmd_parts = [f"{ts:.3f} rubberband@rb tempo {ratio:.6f}" for ts, ratio in self.tempo_steps]
+        cmd_string = "; ".join(cmd_parts)
+        initial_ratio = self.tempo_steps[0][1]
+
         return [
-            f"{input_fadeout_label}rubberband=tempo={self.stretch_ratio:.6f}:transients=mixed:detector=soft:pitchq=quality"
-            f"[{self.output_fadeout_label}]",
-            f"{input_fadein_label}anull[{self.output_fadein_label}]",  # codespell:ignore anull
+            f"{input_fadeout_label} asendcmd=c='{cmd_string}',"
+            f"rubberband@rb=tempo={initial_ratio:.6f}"
+            f":transients=crisp:detector=compound:pitchq=quality"
+            f" [{self.output_fadeout_label}]",
+            f"{input_fadein_label} acopy [{self.output_fadein_label}]",
         ]
 
     def __repr__(self) -> str:
-        """Return string representation of TimeStretchFilter."""
-        return f"TimeStretch(ratio={self.stretch_ratio:.2f})"
+        """Return string representation."""
+        n = len(self.tempo_steps)
+        start = self.tempo_steps[0][1] if self.tempo_steps else 1.0
+        end = self.tempo_steps[-1][1] if self.tempo_steps else 1.0
+        return f"GradualTimeStretch(steps={n}, {start:.4f}->{end:.4f})"
 
 
 class TrimFilter(Filter):

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -26,12 +26,9 @@ class GradualTimeStretchFilter(Filter):
     output_fadein_label: str = "fadein_unchanged"
 
     def __init__(self, logger: logging.Logger, tempo_steps: list[tuple[float, float]]) -> None:
-        """Initialize with tempo steps from compute_gradual_tempo_steps.
-
-        :param logger: Logger for debug output.
-        :param tempo_steps: List of (timestamp_seconds, tempo_ratio) tuples.
-        """
+        """Initialize with tempo steps from compute_gradual_tempo_steps."""
         super().__init__(logger)
+        # each tempo step is a tuple of (timestamp, tempo_ratio)
         self.tempo_steps = tempo_steps
 
     def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:

--- a/music_assistant/controllers/streams/smart_fades/helpers.py
+++ b/music_assistant/controllers/streams/smart_fades/helpers.py
@@ -9,18 +9,8 @@ import numpy.typing as npt
 SMART_CROSSFADE_DURATION = 45
 
 
-def get_bpm_diff_percentage(bpm1: float, bpm2: float) -> float:
-    """Calculate BPM difference percentage between two BPM values.
-
-    :param bpm1: First BPM value.
-    :param bpm2: Second BPM value.
-    """
-    return abs(1.0 - bpm1 / bpm2) * 100
-
-
 def extrapolate_downbeats(
     downbeats: npt.NDArray[np.float32],
-    tempo_factor: float,
     buffer_size: float = SMART_CROSSFADE_DURATION,
     bpm: float | None = None,
 ) -> npt.NDArray[np.float32]:
@@ -30,7 +20,6 @@ def extrapolate_downbeats(
     that does not have any detected downbeats.
 
     :param downbeats: Array of detected downbeat positions in seconds.
-    :param tempo_factor: Tempo adjustment factor for time stretching.
     :param buffer_size: Maximum buffer size in seconds.
     :param bpm: Optional BPM for validation when extrapolating with only 2 downbeats.
     """
@@ -43,20 +32,15 @@ def extrapolate_downbeats(
 
         # Only extrapolate if interval matches BPM within 15% tolerance
         if abs(interval - expected_interval) / expected_interval < 0.15:
-            # Adjust detected downbeats for time stretching first
-            adjusted_downbeats = downbeats / tempo_factor
-            last_downbeat = adjusted_downbeats[-1]
+            last_downbeat = float(downbeats[-1])
 
             # If the last downbeat is close to the buffer end, no extrapolation needed
             if last_downbeat >= buffer_size - 5:
-                return adjusted_downbeats
+                return downbeats
 
-            # Adjust the interval for time stretching
-            adjusted_interval = interval / tempo_factor
-
-            # Extrapolate forward from last adjusted downbeat using adjusted interval
+            # Extrapolate forward from last downbeat
             extrapolated = []
-            current_pos = last_downbeat + adjusted_interval
+            current_pos = last_downbeat + interval
             max_extrapolation_distance = 25.0  # Don't extrapolate more than 25s
 
             while (
@@ -64,54 +48,45 @@ def extrapolate_downbeats(
                 and (current_pos - last_downbeat) <= max_extrapolation_distance
             ):
                 extrapolated.append(current_pos)
-                current_pos += adjusted_interval
+                current_pos += interval
 
             if extrapolated:
-                # Combine adjusted detected downbeats and extrapolated downbeats
-                return np.concatenate([adjusted_downbeats, np.array(extrapolated)])
+                return np.concatenate([downbeats, np.array(extrapolated)])
 
-            return adjusted_downbeats
+            return downbeats
         # else: interval doesn't match BPM, fall through to return original
 
     if len(downbeats) < 2:
-        # Need at least 2 downbeats to extrapolate
-        return downbeats / tempo_factor
+        return downbeats
 
-    # Adjust detected downbeats for time stretching first
-    adjusted_downbeats = downbeats / tempo_factor
-    last_downbeat = adjusted_downbeats[-1]
+    last_downbeat = float(downbeats[-1])
 
     # If the last downbeat is close to the buffer end, no extrapolation needed
     if last_downbeat >= buffer_size - 5:
-        return adjusted_downbeats
+        return downbeats
 
-    # Calculate intervals from ORIGINAL downbeats (before time stretching)
+    # Calculate intervals between downbeats
     intervals = np.diff(downbeats)
     median_interval = float(np.median(intervals))
     std_interval = float(np.std(intervals))
 
     # Only extrapolate if intervals are consistent (low standard deviation)
     if std_interval > 0.2:
-        return adjusted_downbeats
+        return downbeats
 
-    # Adjust the interval for time stretching
-    # When slowing down (tempo_factor < 1.0), intervals get longer
-    adjusted_interval = median_interval / tempo_factor
-
-    # Extrapolate forward from last adjusted downbeat using adjusted interval
+    # Extrapolate forward from last downbeat using median interval
     extrapolated = []
-    current_pos = last_downbeat + adjusted_interval
+    current_pos = last_downbeat + median_interval
     max_extrapolation_distance = 25.0  # Don't extrapolate more than 25s
 
     while current_pos < buffer_size and (current_pos - last_downbeat) <= max_extrapolation_distance:
         extrapolated.append(current_pos)
-        current_pos += adjusted_interval
+        current_pos += median_interval
 
     if extrapolated:
-        # Combine adjusted detected downbeats and extrapolated downbeats
-        return np.concatenate([adjusted_downbeats, np.array(extrapolated)])
+        return np.concatenate([downbeats, np.array(extrapolated)])
 
-    return adjusted_downbeats
+    return downbeats
 
 
 def compute_gradual_tempo_steps(
@@ -136,6 +111,13 @@ def compute_gradual_tempo_steps(
     n_steps = min(min_steps, len(downbeats))
     if n_steps < 1:
         return [(0.0, end_ratio)]
+
+    # Evenly sample timestamps across the full window when we have more than needed
+    if len(downbeats) > n_steps:
+        indices = np.round(np.linspace(0, len(downbeats) - 1, n_steps)).astype(int)
+        selected_downbeats = downbeats[indices]
+    else:
+        selected_downbeats = downbeats[:n_steps]
 
     # S-curve (sigmoid) with steepness adapted to keep max step within budget
     if n_steps == 1:
@@ -162,7 +144,7 @@ def compute_gradual_tempo_steps(
 
     steps: list[tuple[float, float]] = []
     for i in range(n_steps):
-        timestamp = float(downbeats[i]) if i < len(downbeats) else float(downbeats[-1])
+        timestamp = float(selected_downbeats[i])
         ratio = start_ratio + (end_ratio - start_ratio) * float(sigmoid_values[i])
         steps.append((timestamp, round(ratio, 6)))
 

--- a/music_assistant/controllers/streams/smart_fades/helpers.py
+++ b/music_assistant/controllers/streams/smart_fades/helpers.py
@@ -1,0 +1,188 @@
+"""Shared helpers for smart fades."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+# Buffer size in seconds for crossfade analysis
+SMART_CROSSFADE_DURATION = 45
+
+
+def get_bpm_diff_percentage(bpm1: float, bpm2: float) -> float:
+    """Calculate BPM difference percentage between two BPM values.
+
+    :param bpm1: First BPM value.
+    :param bpm2: Second BPM value.
+    """
+    return abs(1.0 - bpm1 / bpm2) * 100
+
+
+def extrapolate_downbeats(
+    downbeats: npt.NDArray[np.float32],
+    tempo_factor: float,
+    buffer_size: float = SMART_CROSSFADE_DURATION,
+    bpm: float | None = None,
+) -> npt.NDArray[np.float32]:
+    """Extrapolate downbeats based on actual intervals when detection is incomplete.
+
+    This is needed when we want to perform beat alignment in an 'atmospheric' outro
+    that does not have any detected downbeats.
+
+    :param downbeats: Array of detected downbeat positions in seconds.
+    :param tempo_factor: Tempo adjustment factor for time stretching.
+    :param buffer_size: Maximum buffer size in seconds.
+    :param bpm: Optional BPM for validation when extrapolating with only 2 downbeats.
+    """
+    # Handle case with exactly 2 downbeats (with BPM validation)
+    if len(downbeats) == 2 and bpm is not None:
+        interval = float(downbeats[1] - downbeats[0])
+
+        # Expected interval for this BPM (assuming 4/4 time signature)
+        expected_interval = (60.0 / bpm) * 4
+
+        # Only extrapolate if interval matches BPM within 15% tolerance
+        if abs(interval - expected_interval) / expected_interval < 0.15:
+            # Adjust detected downbeats for time stretching first
+            adjusted_downbeats = downbeats / tempo_factor
+            last_downbeat = adjusted_downbeats[-1]
+
+            # If the last downbeat is close to the buffer end, no extrapolation needed
+            if last_downbeat >= buffer_size - 5:
+                return adjusted_downbeats
+
+            # Adjust the interval for time stretching
+            adjusted_interval = interval / tempo_factor
+
+            # Extrapolate forward from last adjusted downbeat using adjusted interval
+            extrapolated = []
+            current_pos = last_downbeat + adjusted_interval
+            max_extrapolation_distance = 25.0  # Don't extrapolate more than 25s
+
+            while (
+                current_pos < buffer_size
+                and (current_pos - last_downbeat) <= max_extrapolation_distance
+            ):
+                extrapolated.append(current_pos)
+                current_pos += adjusted_interval
+
+            if extrapolated:
+                # Combine adjusted detected downbeats and extrapolated downbeats
+                return np.concatenate([adjusted_downbeats, np.array(extrapolated)])
+
+            return adjusted_downbeats
+        # else: interval doesn't match BPM, fall through to return original
+
+    if len(downbeats) < 2:
+        # Need at least 2 downbeats to extrapolate
+        return downbeats / tempo_factor
+
+    # Adjust detected downbeats for time stretching first
+    adjusted_downbeats = downbeats / tempo_factor
+    last_downbeat = adjusted_downbeats[-1]
+
+    # If the last downbeat is close to the buffer end, no extrapolation needed
+    if last_downbeat >= buffer_size - 5:
+        return adjusted_downbeats
+
+    # Calculate intervals from ORIGINAL downbeats (before time stretching)
+    intervals = np.diff(downbeats)
+    median_interval = float(np.median(intervals))
+    std_interval = float(np.std(intervals))
+
+    # Only extrapolate if intervals are consistent (low standard deviation)
+    if std_interval > 0.2:
+        return adjusted_downbeats
+
+    # Adjust the interval for time stretching
+    # When slowing down (tempo_factor < 1.0), intervals get longer
+    adjusted_interval = median_interval / tempo_factor
+
+    # Extrapolate forward from last adjusted downbeat using adjusted interval
+    extrapolated = []
+    current_pos = last_downbeat + adjusted_interval
+    max_extrapolation_distance = 25.0  # Don't extrapolate more than 25s
+
+    while current_pos < buffer_size and (current_pos - last_downbeat) <= max_extrapolation_distance:
+        extrapolated.append(current_pos)
+        current_pos += adjusted_interval
+
+    if extrapolated:
+        # Combine adjusted detected downbeats and extrapolated downbeats
+        return np.concatenate([adjusted_downbeats, np.array(extrapolated)])
+
+    return adjusted_downbeats
+
+
+def compute_gradual_tempo_steps(
+    start_ratio: float,
+    end_ratio: float,
+    downbeats: npt.NDArray[np.float32],
+    max_step_pct: float = 0.005,
+) -> list[tuple[float, float]]:
+    """Compute S-curve tempo steps aligned to downbeats.
+
+    :param start_ratio: Starting tempo ratio (e.g., 1.0).
+    :param end_ratio: Target tempo ratio (e.g., 1.05).
+    :param downbeats: Downbeat timestamps to align steps to.
+    :param max_step_pct: Maximum tempo change per step as a fraction.
+    :return: List of (timestamp_seconds, tempo_ratio) tuples.
+    """
+    total_change = abs(end_ratio - start_ratio)
+    if total_change < 1e-6:
+        return []
+
+    min_steps = max(1, int(np.ceil(total_change / max_step_pct)))
+    n_steps = min(min_steps, len(downbeats))
+    if n_steps < 1:
+        return [(0.0, end_ratio)]
+
+    # S-curve (sigmoid) with steepness adapted to keep max step within budget
+    if n_steps == 1:
+        sigmoid_values = np.array([1.0])
+    else:
+        # Binary search for the steepest k where max step <= max_step_pct
+        k_lo, k_hi = 0.1, 10.0
+        for _ in range(20):
+            k_mid = (k_lo + k_hi) / 2.0
+            x = np.linspace(-1, 1, n_steps)
+            s = 1.0 / (1.0 + np.exp(-k_mid * x))
+            s = (s - s[0]) / (s[-1] - s[0])
+            deltas = np.diff(s) * total_change
+            if float(np.max(deltas)) <= max_step_pct:
+                k_lo = k_mid
+            else:
+                k_hi = k_mid
+        k = k_lo
+        x = np.linspace(-1, 1, n_steps)
+        sigmoid_values = 1.0 / (1.0 + np.exp(-k * x))
+        sigmoid_values = (sigmoid_values - sigmoid_values[0]) / (
+            sigmoid_values[-1] - sigmoid_values[0]
+        )
+
+    steps: list[tuple[float, float]] = []
+    for i in range(n_steps):
+        timestamp = float(downbeats[i]) if i < len(downbeats) else float(downbeats[-1])
+        ratio = start_ratio + (end_ratio - start_ratio) * float(sigmoid_values[i])
+        steps.append((timestamp, round(ratio, 6)))
+
+    return steps
+
+
+def generate_synthetic_timestamps(
+    stretch_duration: float,
+    bpm: float,
+    n_min: int = 4,
+) -> npt.NDArray[np.float32]:
+    """Generate evenly-spaced synthetic timing points for gradual stretch.
+
+    Used when real beat/downbeat detection provides fewer than 2 timestamps
+    in the stretch window.
+
+    :param stretch_duration: Duration of the stretch window in seconds.
+    :param bpm: BPM of the track (used to approximate bar-level spacing).
+    :param n_min: Minimum number of timing points.
+    """
+    bar_duration = 4.0 * (60.0 / bpm)
+    n_points = max(n_min, int(stretch_duration / bar_duration))
+    return np.linspace(0, stretch_duration, n_points, dtype=np.float32)

--- a/music_assistant/controllers/streams/smart_fades/helpers.py
+++ b/music_assistant/controllers/streams/smart_fades/helpers.py
@@ -51,7 +51,7 @@ def extrapolate_downbeats(
                 current_pos += interval
 
             if extrapolated:
-                return np.concatenate([downbeats, np.array(extrapolated)])
+                return np.concatenate([downbeats, np.array(extrapolated, dtype=np.float32)])
 
             return downbeats
         # else: interval doesn't match BPM, fall through to return original
@@ -84,7 +84,7 @@ def extrapolate_downbeats(
         current_pos += median_interval
 
     if extrapolated:
-        return np.concatenate([downbeats, np.array(extrapolated)])
+        return np.concatenate([downbeats, np.array(extrapolated, dtype=np.float32)])
 
     return downbeats
 


### PR DESCRIPTION
A nice optimization to the smart crossfade. The bpm matching now uses  a gradual timestretch to slowly increase the bpm during a 10s period before the crossfade starts.

**Before**
t=0 -> bpm @ 120
t=1  -> bpm @ 125

**After**
t=0 -> bpm @ 120
t=1 -> bpm @ 121
t=2 -> bpm @ 122
t=3 -> bpm @ 123
t=4 -> bpm @ 124
t=5 -> bpm @ 125
