### PR TITLE
local audio: allow to select bitrate/depth from gui

### DIFF
--- a/music_assistant/providers/local_audio/sendspin_bridge.py
+++ b/music_assistant/providers/local_audio/sendspin_bridge.py
@@ -77,13 +77,35 @@ class SendspinLocalAudioBridge:
     def is_registered(self) -> bool:
         """Return whether the bridge is registered with Sendspin."""
         return self._sendspin_client is not None
+        
+    @property
+    def _configured_audio_format(self) -> tuple[int, int]:
+        """Return (sample_rate, bit_depth) from player config, defaulting to bridge defaults."""
+        if not self._bridge_client_id:
+            return BRIDGE_SAMPLE_RATE, BRIDGE_BIT_DEPTH
+        raw = self.mass.config.get_raw_player_config_value(
+            self._bridge_client_id, "sample_rates", None
+        )
+        if not raw or not isinstance(raw, list) or not raw:
+            return BRIDGE_SAMPLE_RATE, BRIDGE_BIT_DEPTH
+        # Take the highest configured sample rate/bit depth
+        best_rate, best_depth = BRIDGE_SAMPLE_RATE, BRIDGE_BIT_DEPTH
+        for entry in raw:
+            try:
+                rate_str, depth_str = entry.split("||")
+                rate, depth = int(rate_str), int(depth_str)
+                if rate > best_rate or (rate == best_rate and depth > best_depth):
+                    best_rate, best_depth = rate, depth
+            except (ValueError, AttributeError):
+                continue
+        return best_rate, best_depth        
 
     async def start(self) -> None:
         """Register the local audio device as an external Sendspin client."""
         hostapi_index: int = self.device_info.get("hostapi", 0)
         device_uuid = get_device_uuid(self.device_name, hostapi_index)
         self._bridge_client_id = bridge_client_id_from_uuid(device_uuid)
-
+        sample_rate, bit_depth = self._configured_audio_format
         # Pre-register identifier so protocol linking matches our LocalAudioPlayer
         if sendspin_prov := self._get_sendspin_provider():
             sendspin_prov.register_bridge_identifiers(
@@ -105,8 +127,8 @@ class SendspinLocalAudioBridge:
                     SupportedAudioFormat(
                         codec=AudioCodec.PCM,
                         channels=BRIDGE_CHANNELS,
-                        sample_rate=BRIDGE_SAMPLE_RATE,
-                        bit_depth=BRIDGE_BIT_DEPTH,
+                        sample_rate=sample_rate,
+                        bit_depth=bit_depth,
                     )
                 ],
                 buffer_capacity=1_000,
@@ -134,7 +156,7 @@ class SendspinLocalAudioBridge:
                 on_stream_start=self._on_bridge_stream_start,
                 on_stream_end=self._on_bridge_stream_end,
             )
-            self._bridge_role.setup_audio_requirements()
+            self._bridge_role.setup_audio_requirements(sample_rate=sample_rate, bit_depth=bit_depth)
 
         self.logger.info(
             "Sendspin bridge registered for %s (client_id=%s)",
@@ -204,6 +226,8 @@ class SendspinLocalAudioBridge:
 
     def _apply_software_volume(self, pcm_data: bytes) -> bytes:
         """Apply software volume scaling if configured, reading current player state."""
+        sample_rate, bit_depth = self._configured_audio_format
+        dtype = np.int16 if bit_depth == 16 else np.int32
         if self.player.volume_control_mode != VOLUME_CONTROL_SOFTWARE:
             return pcm_data
         if self.player.volume_muted:
@@ -211,24 +235,29 @@ class SendspinLocalAudioBridge:
         volume = self.player.volume_level
         if volume is None or volume >= 100:
             return pcm_data
-        samples = np.frombuffer(pcm_data, dtype=np.int16).copy()
+        samples = np.frombuffer(pcm_data, dtype=dtype).copy()
         scale = volume / 100.0
-        samples = np.clip(samples * scale, -32768, 32767).astype(np.int16)
+        clip_max = 32767 if bit_depth == 16 else 2147483647
+        clip_min = -32768 if bit_depth == 16 else -2147483648
+        samples = np.clip(samples * scale, clip_min, clip_max).astype(dtype)
         return samples.tobytes()
 
     async def _audio_writer(self) -> None:
         """Write queued audio data to the soundcard."""
         loop = asyncio.get_running_loop()
+        sample_rate, bit_depth = self._configured_audio_format
+        dtype = "int16" if bit_depth == 16 else "int32"
         try:
             self._output_stream = sd.RawOutputStream(
                 device=self.device_index,
-                samplerate=BRIDGE_SAMPLE_RATE,
+                samplerate=sample_rate,
                 channels=BRIDGE_CHANNELS,
-                dtype="int16",
+                dtype=dtype,
                 blocksize=DEFAULT_BUFFER_FRAMES,
             )
             self._output_stream.start()
             self.logger.debug("Audio output stream opened for %s", self.device_name)
+            self.logger.info("Audio output stream rate: %s", sample_rate)
 
             while True:
                 data = await self._write_queue.get()

--- a/music_assistant/providers/sendspin/bridge_role.py
+++ b/music_assistant/providers/sendspin/bridge_role.py
@@ -92,13 +92,17 @@ class BridgePlayerRole(Role):
         """Return role family name."""
         return "player"
 
-    def setup_audio_requirements(self) -> None:
+    def setup_audio_requirements(
+        self,
+        sample_rate: int = BRIDGE_SAMPLE_RATE,
+        bit_depth: int = BRIDGE_BIT_DEPTH,
+        ) -> None:
         """Set up audio requirements for bridge PCM format."""
         self._audio_requirements = AudioRequirements(
-            sample_rate=BRIDGE_SAMPLE_RATE,
-            bit_depth=BRIDGE_BIT_DEPTH,
+            sample_rate=sample_rate,
+            bit_depth=bit_depth,
             channels=BRIDGE_CHANNELS,
-            transformer=None,  # Raw PCM, no encoding
+            transformer=None,
         )
 
     def get_audio_requirements(self) -> AudioRequirements | None:

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -1162,10 +1162,13 @@ class SendspinPlaybackSession:
                             channels=preferred_fmt.channels,
                         )
                 elif isinstance(role, BridgePlayerRole):
+                    req = role.get_audio_requirements()
+                    sample_rate = req.sample_rate if req else BRIDGE_SAMPLE_RATE
+                    bit_depth = req.bit_depth if req else BRIDGE_BIT_DEPTH
                     return AudioFormat(
                         content_type=ContentType.from_bit_depth(BRIDGE_BIT_DEPTH),
-                        sample_rate=BRIDGE_SAMPLE_RATE,
-                        bit_depth=BRIDGE_BIT_DEPTH,
+                        sample_rate=sample_rate,
+                        bit_depth=bit_depth,
                         channels=BRIDGE_CHANNELS,
                     )
         return _PCM_FORMAT

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -54,10 +54,11 @@ from PIL import Image
 
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player, PlayerMedia
-
+from music_assistant.constants import create_sample_rates_config_entry
 from .constants import (
     CONF_SENDSPIN_STATIC_DELAY,
     DEFAULT_SENDSPIN_STATIC_DELAY,
+    BRIDGE_PREFIX,
 )
 from .helpers import mac_from_bridge_client_id
 from .playback import SendspinPlaybackSession
@@ -914,7 +915,8 @@ class SendspinPlayer(SendspinBasePlayer):
                     advanced=False,
                 )
             )
-
+        if self.player_id.startswith(BRIDGE_PREFIX):
+            entries.append(create_sample_rates_config_entry(max_sample_rate=192000, max_bit_depth=24))
         return entries
 
     async def on_unload(self) -> None:


### PR DESCRIPTION
background/context:
I would like to stream locallly via HDMI, which is connected to my (Denon) receiver, from my ubuntu laptop 24.04
There is a mismatch between what MASS sends out and what HDMI handles, i.e. 44.1k vs. 48k. There are manual workarounds but they require docker volumes/updates and a lot of knowledge, not for the ordinary user.
This PR proposes to be able to select the bitrate and bitdepth via the GUI, in line with other providers.
Notes:
- although it works for me, it may lack things (see below)
- aside the rate/depth, maybe the buffer needs to be addressed too, let me know

Disclaimer: I lack an overall architectural view of MASS so this may be out of tune :)


<img width="609" height="383" alt="image" src="https://github.com/user-attachments/assets/97e63dd3-40de-4909-a3a6-a2a1bf56b904" />
