### PR TITLE
Last FM: Add one-click auth

### DIFF
--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -1,10 +1,11 @@
 """Allows scrobbling of tracks with the help of PyLast."""
 
 import asyncio
+import enum
 import logging
 import time
-from collections.abc import Callable
-from typing import TYPE_CHECKING, cast
+from collections.abc import Callable, Mapping
+from typing import Final, cast
 
 import pylast
 from music_assistant_models.config_entries import (
@@ -20,6 +21,7 @@ from music_assistant_models.playback_progress_report import MediaItemPlaybackPro
 from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.constants import MASS_LOGGER_NAME
+from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
 from music_assistant.helpers.auth import AuthenticationHelper
 from music_assistant.helpers.scrobbler import (
     ScrobblerConfig,
@@ -30,15 +32,81 @@ from music_assistant.mass import MusicAssistant
 from music_assistant.models import ProviderInstanceType
 from music_assistant.models.plugin import PluginProvider
 
-SUPPORTED_FEATURES: set[ProviderFeature] = (
-    set()
-)  # we don't have any special supported features (yet)
+# Built-in Last.fm API credentials (not available for Libre.fm)
+_DEFAULT_API_KEY: str = app_var(12)
+_DEFAULT_API_SECRET: str = app_var(13)
+
+
+# we don't have any special supported features (yet)
+# TODO(@anyone): this really should be a frozenset, but that requires
+# updating the PluginProvider base class
+# as well as other similar classes that also use set[ProviderFeature].
+SUPPORTED_FEATURES: Final[set[ProviderFeature]] = set()
+
+# Configuration keys
+CONF_API_KEY: Final[str] = "_api_key"
+CONF_API_SECRET: Final[str] = "_api_secret"
+CONF_SESSION_KEY: Final[str] = "_api_session_key"
+CONF_USERNAME: Final[str] = "_username"
+CONF_PROVIDER: Final[str] = "_provider"
+
+# Configuration actions
+CONF_ACTION_AUTH: Final[str] = "_auth"
+
+
+class _NetworkType(enum.Enum):
+    """Available scrobbling network provider types.
+
+    This is a plain Enum class with string values.
+    Use ``.value`` when passing to ``ConfigEntry`` or ``ConfigValueOption``
+    which require raw strings.
+    """
+
+    LASTFM = "lastfm"
+    LIBREFM = "librefm"
+
+
+def _resolve_credentials(
+    values: Mapping[str, ConfigValueType],
+    network_type: _NetworkType = _NetworkType.LASTFM,
+) -> tuple[str, str]:
+    """Resolve the effective API key and secret.
+
+    Uses user-provided values if present, otherwise falls back to the
+    built-in Last.fm credentials. Libre.fm always requires user-provided values.
+
+    :param values: Config values dict that may contain user-provided key/secret.
+    :param network_type: The network provider type.
+    :returns: A tuple of (api_key, api_secret) strings.
+    :raises SetupFailedError: If credentials cannot be resolved.
+    """
+    key = cast("str | None", values.get(CONF_API_KEY))
+    secret = cast("str | None", values.get(CONF_API_SECRET))
+
+    has_custom_key = bool(key and key != SECURE_STRING_SUBSTITUTE)
+    has_custom_secret = bool(secret and secret != SECURE_STRING_SUBSTITUTE)
+
+    if has_custom_key and has_custom_secret:
+        return str(key), str(secret)
+    if has_custom_key or has_custom_secret:
+        err_msg = "Both API Key and Shared Secret are required (only one provided)."
+        raise SetupFailedError(err_msg)
+
+    match network_type:
+        case _NetworkType.LASTFM:
+            return str(_DEFAULT_API_KEY), str(_DEFAULT_API_SECRET)
+        case _:
+            err_msg = f"API Key and Secret are required for {network_type.value}. "
+            raise SetupFailedError(err_msg)
 
 
 async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
 ) -> ProviderInstanceType:
-    """Initialize provider(instance) with given configuration."""
+    """Initialize provider(instance) with given configuration.
+
+    :returns: A configured LastFMScrobbleProvider instance.
+    """
     provider = LastFMScrobbleProvider(mass, manifest, config, SUPPORTED_FEATURES)
     pylast.logger.setLevel(provider.logger.level)
 
@@ -54,29 +122,30 @@ async def setup(
 class LastFMScrobbleProvider(PluginProvider):
     """Plugin provider to support scrobbling of tracks."""
 
-    network: pylast._Network
+    _network: pylast._Network | None
     _on_unload: list[Callable[[], None]]
 
     async def handle_async_init(self) -> None:
         """Handle async setup."""
         self._on_unload: list[Callable[[], None]] = []
-
-        if not self.config.get_value(CONF_API_KEY) or not self.config.get_value(CONF_API_SECRET):
-            raise SetupFailedError("API Key and Secret need to be set")
+        self._network = None
 
         if not self.config.get_value(CONF_SESSION_KEY):
             self.logger.info("No session key available, don't forget to authenticate!")
             return
         # creating the network instance is (potentially) blocking IO
         # so run it in an executor thread to be safe
-        self.network = await asyncio.to_thread(get_network, self._get_network_config())
+        self._network = await asyncio.to_thread(get_network, self._get_network_config())
 
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
         await super().loaded_in_mass()
 
+        if self._network is None:
+            return
+
         # subscribe to media_item_played event
-        handler = LastFMEventHandler(self.network, self.logger, self.config)
+        handler = LastFMEventHandler(self._network, self.logger, self.config)
         self._on_unload.append(
             self.mass.subscribe(handler._on_mass_media_item_played, EventType.MEDIA_ITEM_PLAYED)
         )
@@ -90,6 +159,10 @@ class LastFMScrobbleProvider(PluginProvider):
             unload_cb()
 
     def _get_network_config(self) -> dict[str, ConfigValueType]:
+        """Build the network configuration dict from provider config values.
+
+        :returns: Dict of config keys to their current stored values.
+        """
         return {
             CONF_API_KEY: self.config.get_value(CONF_API_KEY),
             CONF_API_SECRET: self.config.get_value(CONF_API_SECRET),
@@ -100,22 +173,21 @@ class LastFMScrobbleProvider(PluginProvider):
 
 
 class LastFMEventHandler(ScrobblerHelper):
-    """Handles the event handling."""
-
-    network: pylast._Network
+    """Handle Last.fm event processing for scrobbling and now-playing updates."""
 
     def __init__(
         self, network: pylast._Network, logger: logging.Logger, config: ProviderConfig
     ) -> None:
         """Initialize."""
         super().__init__(logger, ScrobblerConfig.create_from_config(config))
-        self.network = network
+        self._network = network
 
     async def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Send a now-playing update to Last.fm."""
         # the lastfm client is not async friendly,
         # so we need to run it in a executor thread
         await asyncio.to_thread(
-            self.network.update_now_playing,
+            self._network.update_now_playing,
             report.artist,
             self.get_name(report),
             report.album,
@@ -124,12 +196,13 @@ class LastFMEventHandler(ScrobblerHelper):
         )
 
     async def _scrobble(self, report: MediaItemPlaybackProgressReport) -> None:
+        """Scrobble a track to Last.fm."""
         # the listenbrainz client is not async friendly,
         # so we need to run it in a executor thread
         # NOTE: album artist and track number are not available without an extra API call
         # so they won't be scrobbled
         await asyncio.to_thread(
-            self.network.scrobble,
+            self._network.scrobble,
             report.artist or "unknown artist",
             self.get_name(report),
             int(time.time()),
@@ -139,41 +212,28 @@ class LastFMEventHandler(ScrobblerHelper):
         )
 
 
-# configuration keys
-CONF_API_KEY = "_api_key"
-CONF_API_SECRET = "_api_secret"
-CONF_SESSION_KEY = "_api_session_key"
-CONF_USERNAME = "_username"
-CONF_PROVIDER = "_provider"
-
-# configuration actions
-CONF_ACTION_AUTH = "_auth"
-
-# available networks
-CONF_OPTION_LASTFM: str = "lastfm"
-CONF_OPTION_LIBREFM: str = "librefm"
-
-
 async def get_config_entries(
     mass: MusicAssistant,
     instance_id: str | None = None,  # noqa: ARG001
     action: str | None = None,
     values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
-    """
-    Return Config entries to setup this provider.
+    """Return config entries to setup this provider.
 
-    instance_id: id of an existing provider instance (None if new instance setup).
-    action: [optional] action key called from config entries UI.
-    values: the (intermediate) raw values for config entries sent with the action.
+    :param mass: The MusicAssistant instance.
+    :param instance_id: ID of an existing provider instance (None if new instance setup).
+    :param action: Optional action key called from config entries UI.
+    :param values: The (intermediate) raw values for config entries sent with the action.
+    :returns: Tuple of ConfigEntry objects for the frontend to render.
     """
     logger = logging.getLogger(MASS_LOGGER_NAME).getChild("lastfm")
 
-    provider: str = CONF_OPTION_LASTFM
-    if values is not None and values.get(CONF_PROVIDER) is not None:
-        provider = str(values.get(CONF_PROVIDER))
+    network_type: _NetworkType
+    if values is not None and (provider_val := values.get(CONF_PROVIDER)) is not None:
+        network_type = _NetworkType(str(provider_val))
+    else:
+        network_type = _NetworkType.LASTFM
 
-    # collect all config entries to show
     entries: list[ConfigEntry] = ScrobblerConfig.get_shared_config_entries(values)
     entries += [
         ConfigEntry(
@@ -183,25 +243,29 @@ async def get_config_entries(
             required=True,
             description="The endpoint to use, defaults to Last.fm",
             options=[
-                ConfigValueOption(title="Last.FM", value=CONF_OPTION_LASTFM),
-                ConfigValueOption(title="LibreFM", value=CONF_OPTION_LIBREFM),
+                ConfigValueOption(title="Last.FM", value=_NetworkType.LASTFM.value),
+                ConfigValueOption(title="LibreFM", value=_NetworkType.LIBREFM.value),
             ],
-            default_value=provider,
-            value=provider,
+            default_value=network_type.value,
+            value=network_type.value,
         ),
         ConfigEntry(
             key=CONF_API_KEY,
             type=ConfigEntryType.SECURE_STRING,
             label="API Key",
-            required=True,
+            required=network_type != _NetworkType.LASTFM,
+            description="Override the built-in Last.fm API key. Required for Libre.fm.",
             value=values.get(CONF_API_KEY) if values else None,
+            advanced=True,
         ),
         ConfigEntry(
             key=CONF_API_SECRET,
             type=ConfigEntryType.SECURE_STRING,
             label="Shared secret",
-            required=True,
+            required=network_type != _NetworkType.LASTFM,
+            description="Override the built-in Last.fm shared secret. Required for Libre.fm.",
             value=values.get(CONF_API_SECRET) if values else None,
+            advanced=True,
         ),
         # add user selection entry
         await create_scrobble_users_config_entry(mass),
@@ -215,7 +279,8 @@ async def get_config_entries(
         session_id = str(values.get("session_id"))
 
         async with AuthenticationHelper(mass, session_id) as auth_helper:
-            network = get_network(values)
+            api_key, api_secret = _resolve_credentials(values, network_type)
+            network = get_network({**values, CONF_API_KEY: api_key, CONF_API_SECRET: api_secret})
             skg = pylast.SessionKeyGenerator(network)
 
             # pylast says it does web auth, but actually does desktop auth
@@ -230,7 +295,7 @@ async def get_config_entries(
             logger.info("authenticating on %s", url)
             response = await auth_helper.authenticate(url)
             if response.get("token") is None:
-                raise LoginFailed(f"no token available in {provider} response")
+                raise LoginFailed(f"no token available in {network_type.value} response")
 
             session_key, username = skg.get_web_auth_session_key_username(
                 url, str(response.get("token"))
@@ -238,7 +303,7 @@ async def get_config_entries(
             values[CONF_USERNAME] = username
             values[CONF_SESSION_KEY] = session_key
 
-            entries += [
+            entries.append(
                 ConfigEntry(
                     key="save_reminder",
                     type=ConfigEntryType.ALERT,
@@ -247,21 +312,17 @@ async def get_config_entries(
                     label=f"Successfully logged in as {username}, "
                     "don't forget to hit save to complete the setup",
                 ),
-            ]
+            )
 
-    if values is None or not values.get(CONF_SESSION_KEY):
-        # unable to use the encrypted values during an action
-        # so we make sure fresh credentials need to be entered
-        values[CONF_API_KEY] = None
-        values[CONF_API_SECRET] = None
-        entries += [
+    if not values.get(CONF_SESSION_KEY):
+        entries.append(
             ConfigEntry(
                 key=CONF_ACTION_AUTH,
                 type=ConfigEntryType.ACTION,
-                label=f"Authorize with {provider}",
+                label=f"Authorize with {network_type.value}",
                 action=CONF_ACTION_AUTH,
             ),
-        ]
+        )
 
     entries += [
         ConfigEntry(
@@ -285,32 +346,28 @@ async def get_config_entries(
 
 
 def get_network(config: dict[str, ConfigValueType]) -> pylast._Network:
-    """Create a network instance."""
-    key = config.get(CONF_API_KEY)
-    secret = config.get(CONF_API_SECRET)
-    session_key = config.get(CONF_SESSION_KEY)
-    username = config.get(CONF_USERNAME)
+    """Create a pylast network instance with resolved credentials.
 
-    assert key
-    assert key != SECURE_STRING_SUBSTITUTE
-    assert secret
-    assert secret != SECURE_STRING_SUBSTITUTE
+    Called in two contexts:
+    1. during the auth flow (from ``get_config_entries``)
+       to build the authorization URL before any session exists
+    2. during provider startup (from ``handle_async_init``)
+       for scrobbling with a stored session.
 
-    if not key or not secret:
-        raise SetupFailedError("API Key and Secret need to be set")
+    Session key and username default to empty strings
+    because the auth flow legitimately needs a network without them.
 
-    provider: str = str(config.get(CONF_PROVIDER))
+    :param config: Config values dict containing provider type, credentials, etc.
+    :returns: A pylast LastFMNetwork or LibreFMNetwork instance.
+    :raises SetupFailedError: If the provider is unknown or credentials cannot be resolved.
+    """
+    network_type = _NetworkType(str(config.get(CONF_PROVIDER, _NetworkType.LASTFM.value)))
+    key, secret = _resolve_credentials(config, network_type)
+    session_key = str(config.get(CONF_SESSION_KEY) or "")
+    username = str(config.get(CONF_USERNAME) or "")
 
-    if TYPE_CHECKING:
-        key = cast("str", key)
-        secret = cast("str", secret)
-        session_key = cast("str", session_key)
-        username = cast("str", username)
-
-    match provider.lower():
-        case "lastfm":
+    match network_type:
+        case _NetworkType.LASTFM:
             return pylast.LastFMNetwork(key, secret, username=username, session_key=session_key)
-        case "librefm":
+        case _NetworkType.LIBREFM:
             return pylast.LibreFMNetwork(key, secret, username=username, session_key=session_key)
-        case _:
-            raise SetupFailedError(f"unknown provider {provider} configured")


### PR DESCRIPTION
## Last.fm Scrobbler: one-click auth with built-in API key

### Background

https://discord.com/channels/753947050995089438/1487828488277983413

### Changes

- Use built-in Last.fm API credentials (`app_var(12)`, `app_var(13)`) so users no longer need to register their own API application. For Last.fm, the "Authorize" button now works out of the box with zero configuration.
- Move the API key and shared secret config fields to advanced settings. They remain available for Libre.fm users (who must provide their own) or anyone who wants to override the built-in key.
- Add `_resolve_credentials()` helper that transparently falls back to built-in defaults when no custom credentials are provided. Validates that both key and secret are provided together.
- Introduce `_NetworkProvider` Enum for type-safe provider matching, using `.value` at serialization boundaries to remain compatible with the config system.
- Type `network` as `pylast._Network | None`: because built-in credentials now let the provider load without a session key, `handle_async_init` can return early without setting `self.network`. `loaded_in_mass` checks for `None` and returns early, letting the plugin load gracefully while unauthenticated.
- Fix incorrect "listenbrainz client" comment (copy-paste from ListenBrainz scrobbler) and add proper Sphinx-style docstrings throughout.

No breaking changes.
Existing configurations with user-provided API keys continue to work -- `_resolve_credentials` prefers user-provided values when present.

### Manual testing performed

Commands:

```sh
uv run pytest tests/core/test_scrobbler.py -v
uv run python -m music_assistant --log-level debug
```

<img width="829" height="251" alt="Screenshot 2026-04-19 at 1 13 21 pm" src="https://github.com/user-attachments/assets/a6039df0-958b-4598-b333-a6b96eb51f9b" />


Steps:

1. Open `http://localhost:8095` in a browser
2. Go to Settings > System > Webserver and ensure **Base URL** is set to `http://localhost:8095` (the URL must match how your browser reaches the server, so the auth callback is reachable)
3. Go to Settings > Providers > Add Provider > LastFM Scrobbler
4. Leave the default provider "Last.FM" selected
5. Do not expand advanced settings or enter any API key/secret
6. Click "Authorize with lastfm"
7. Verify you are redirected to the Last.fm website authorization page
8. Authorize the application on Last.fm
9. Verify you are redirected back and see "Successfully logged in as \<username\>"
10. Click Save
11. Play a track and verify it appears in your Last.fm listening history
12. Check your Last.fm account under Settings > Applications -- "Music Assistant" should appear as an authorized application
13. Check that Last.fm Now Playing status is updated
14. Check that Last.fm scrobbling history is updated

### Additional testing that might be helpful

#### Backward Compatibility with existing user-provided API key

1. If you have an existing Last.fm scrobbler instance with a custom API key/secret, reload the provider
2. Verify the existing session key still works and scrobbling continues
3. Verify the API key/secret fields appear under advanced settings with your stored values

#### Libre.fm with custom credentials

1. Add a new LastFM Scrobbler instance
2. Change the Provider dropdown to "LibreFM"
3. Verify that the API Key and Shared Secret fields are now marked as required
4. Attempt to click "Authorize with librefm" without entering credentials
5. Verify it fails with a clear error about credentials being required for Libre.fm
6. Enter valid Libre.fm API credentials and authorize
7. Verify scrobbling works against the Libre.fm endpoint
