### PR TITLE
Exclude volume commands in Airplay when airplay is not the volume control

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1099,6 +1099,17 @@ class Player(ABC):
 
     @property
     @final
+    def is_volume_control_for_parent(self) -> bool:
+        """Check if this protocol player is the volume control for its parent."""
+        if not self.__attr_protocol_parent_id:
+            return False
+        parent = self.mass.players.get_player(self.__attr_protocol_parent_id)
+        if not parent:
+            return False
+        return parent.volume_control == self.player_id
+
+    @property
+    @final
     def active_output_protocol(self) -> str | None:
         """Return the currently active output protocol ID."""
         return self.__attr_active_output_protocol

--- a/music_assistant/providers/airplay/protocols/_protocol.py
+++ b/music_assistant/providers/airplay/protocols/_protocol.py
@@ -83,8 +83,9 @@ class AirPlayProtocol(ABC):
         # repeat sending the volume level to the player because some players seem
         # to ignore it the first time
         # https://github.com/music-assistant/support/issues/3330
-        volume = 0 if self.player.volume_muted else self.player.volume_level
-        self.mass.call_later(2, self.send_cli_command(f"VOLUME={volume}"))
+        if not self.player.protocol_parent_id or self.player.is_volume_control_for_parent:
+            volume = 0 if self.player.volume_muted else self.player.volume_level
+            self.mass.call_later(2, self.send_cli_command(f"VOLUME={volume}"))
         # we also need to send the metadata after connection, because some players (e.g. Sonos)
         # simply won't start playback until they receive the metadata ?!
         # reset checksum so the resend isn't blocked by deduplication

--- a/music_assistant/providers/airplay/protocols/raop.py
+++ b/music_assistant/providers/airplay/protocols/raop.py
@@ -72,6 +72,13 @@ class RaopStream(AirPlayProtocol):
         elif self.prov.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
             extra_args += ["-debug", "10"]
 
+        # Omit -volume when parent handles volume natively to avoid dB curve mismatch drift.
+        volume_args = (
+            ["-volume", str(self.player.volume_level)]
+            if not self.player.protocol_parent_id or self.player.is_volume_control_for_parent
+            else []
+        )
+
         cliraop_args = [
             cli_binary,
             "-ntpstart",
@@ -80,8 +87,7 @@ class RaopStream(AirPlayProtocol):
             str(self.player.raop_discovery_info.port),
             "-latency",
             str(self.player.output_buffer_duration_ms),
-            "-volume",
-            str(self.player.volume_level),
+            *volume_args,
             *extra_args,
             "-dacp",
             cast("AirPlayProvider", self.prov).dacp_id,

--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -288,6 +288,7 @@ class AirPlayProvider(PlayerProvider):
             ignore_volume_report = (
                 self.mass.config.get_raw_player_config_value(player_id, CONF_IGNORE_VOLUME, False)
                 or player.device_info.manufacturer.lower() == "apple"
+                or (player.protocol_parent_id and not player.is_volume_control_for_parent)
             )
             if path == "/ctrl-int/1/nextitem":
                 self.mass.create_task(self.mass.players.cmd_next_track(player_id))

--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -29,6 +29,7 @@ from music_assistant.providers.bluesound.const import (
     PLAYER_SOURCE_MAP,
     POLL_STATE_DYNAMIC,
     POLL_STATE_STATIC,
+    SOURCE_AIRPLAY,
 )
 
 if TYPE_CHECKING:
@@ -363,9 +364,9 @@ class BluesoundPlayer(Player):
         self._attr_elapsed_time = self.status.seconds
         self._attr_elapsed_time_last_updated = time.time()
 
-        # Only allow volume reports when playing Bluesound as native input
-        # E.g. Airplay reports are on a different scale, causing volume jumps
-        if self.status.input_id is None:
+        # Only allow volume reports when playing Bluesound as native input.
+        # AirPlay reports are on a different scale, causing volume jumps.
+        if self.status.input_id is None and self.status.service != SOURCE_AIRPLAY:
             if self.sync_status.volume == -1:
                 # -1 is fixed volume
                 self._attr_volume_level = 100

--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -29,7 +29,6 @@ from music_assistant.providers.bluesound.const import (
     PLAYER_SOURCE_MAP,
     POLL_STATE_DYNAMIC,
     POLL_STATE_STATIC,
-    SOURCE_AIRPLAY,
 )
 
 if TYPE_CHECKING:
@@ -364,9 +363,9 @@ class BluesoundPlayer(Player):
         self._attr_elapsed_time = self.status.seconds
         self._attr_elapsed_time_last_updated = time.time()
 
-        # Only allow volume reports when playing Bluesound as native input.
-        # AirPlay reports are on a different scale, causing volume jumps.
-        if self.status.input_id is None and self.status.service != SOURCE_AIRPLAY:
+        # Only allow volume reports when playing Bluesound as native input
+        # E.g. Airplay reports are on a different scale, causing volume jumps
+        if self.status.input_id is None:
             if self.sync_status.volume == -1:
                 # -1 is fixed volume
                 self._attr_volume_level = 100


### PR DESCRIPTION
**The issue:**
My Bluesound player uses a totally different volume curve than whatever Airplay uses, causing huge volume jumps throughout the day.

Volume control is set to 'Native' (which should be handled by the Bluesound provider)

**The race:**
1. I set my Bluesound volume to 12 in the morning (eg -50db)
2. When the Airplay session starts (eg I join an Airplay player), cliraop starts with `VOLUME=12`
3. This translates to a way louder volume on the bluesound device (eg -40db).
4. Bluesound reports volume back to MA as 20
5. When the Bluesound leaves the group and goes idle (eg I leave the room) the airplay session is removed
6. When I enter the room later, Airplay is started again with `VOLUME=20`
7. This translates to a way louder volume on the bluesound device (eg -35db). 
8. .... Repeat until your ears start bleeding

Now, I think we should just NOT send any volume commands to the Airplay process in the situation where Airplay is not the volume control. This prevents these weird situations where 2 protocols on the same device use different volume curves.