### PR TITLE
Bump `aiosendspin` to 5.1.1 to fix audio stuttering

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin[server]==5.1.0", "av==16.1.0"],
+  "requirements": ["aiosendspin[server]==5.1.1", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ aiohttp-socks==0.11.0
 aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
-aiosendspin[server]==5.1.0
+aiosendspin[server]==5.1.1
 aioslimproto==3.1.8
 aiosonos==0.1.12
 aiosqlite==0.22.1


### PR DESCRIPTION
Bumps `aiosendspin` to 5.1.1.

## Resampling stutter

Fixes audio stuttering on players that require resampling (e.g. 44.1kHz/16-bit clients). The drift detection in the standalone resampler was firing on every call with the soxr resampler, rebuilding the graph every time and dropping a significant portion of audio on any resampling target.

See https://github.com/Sendspin/aiosendspin/pull/219 for details.

## Other changes

- Fix timestamp drift after extended playback (https://github.com/Sendspin/aiosendspin/pull/217)
- Avoid reconnect when mDNS re-advertises same endpoint (https://github.com/Sendspin/aiosendspin/pull/216)