### PR TITLE
Fix Chromecast player disappearing after MA restart

### DIFF
--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -486,6 +486,7 @@ class SendspinBridgeManager:
         self._bridges: dict[str, SendspinChromecastBridge] = {}
         self._lock = asyncio.Lock()
         self._rebridge_unsubs: dict[str, Callable[[], None]] = {}
+        self._claimed_clients: dict[str, str] = {}
         self._unsub_config_updated = self.mass.subscribe(
             self._on_player_config_updated, EventType.PLAYER_CONFIG_UPDATED
         )
@@ -516,6 +517,13 @@ class SendspinBridgeManager:
 
             if player_id in self._bridges:
                 self.logger.debug("Bridge already exists for %s", cast_player.display_name)
+                return
+
+            if player_id in self._claimed_clients:
+                self.logger.debug(
+                    "Bridge already claimed for %s (waiting for JS client disconnect)",
+                    cast_player.display_name,
+                )
                 return
 
             # Skip audio groups (non-stereo-pair) — they have their own playback mechanism
@@ -576,6 +584,7 @@ class SendspinBridgeManager:
                         bridge_hello,
                     )
                     _write_default_static_delay(self.mass, existing_client_id, manufacturer, model)
+                    self._claimed_clients[player_id] = existing_client_id
                     self._subscribe_rebridge_on_disconnect(cast_player, existing_client_id)
                 return
 
@@ -614,6 +623,7 @@ class SendspinBridgeManager:
         async with self._lock:
             if bridge := self._bridges.pop(cast_player_id, None):
                 await bridge.stop()
+            self._claimed_clients.pop(cast_player_id, None)
 
             self.logger.debug("Sendspin bridge removed for Chromecast player %s", cast_player_id)
 
@@ -634,6 +644,7 @@ class SendspinBridgeManager:
             with suppress(Exception):
                 unsub()
         self._rebridge_unsubs.clear()
+        self._claimed_clients.clear()
         await self.stop_all()
 
     def _find_existing_sendspin_client(
@@ -691,6 +702,7 @@ class SendspinBridgeManager:
             if unsub is not None:
                 with suppress(Exception):
                     unsub()
+            self._claimed_clients.pop(cast_player.player_id, None)
             if self.mass.players.get_player(cast_player.player_id) is not cast_player:
                 return
             if cast_player.player_id in self._bridges:

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -623,7 +623,10 @@ class SendspinBridgeManager:
         async with self._lock:
             if bridge := self._bridges.pop(cast_player_id, None):
                 await bridge.stop()
-            self._claimed_clients.pop(cast_player_id, None)
+            claimed_client_id = self._claimed_clients.pop(cast_player_id, None)
+            if claimed_client_id and (unsub := self._rebridge_unsubs.pop(claimed_client_id, None)):
+                with suppress(Exception):
+                    unsub()
 
             self.logger.debug("Sendspin bridge removed for Chromecast player %s", cast_player_id)
 

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -578,7 +578,7 @@ class SendspinBridgeManager:
                 sendspin_provider = self.sendspin_provider
                 if sendspin_provider is not None:
                     bridge_hello = _build_bridge_hello(cast_player, existing_client_id)
-                    sendspin_provider.apply_bridge_claim(
+                    await sendspin_provider.apply_bridge_claim(
                         existing_client_id,
                         {IdentifierType.CAST_UUID: str(cast_player.cast_info.uuid)},
                         bridge_hello,

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -558,23 +558,9 @@ class SendspinBridgeManager:
                 )
                 return
 
-            # Detect an already-connected Sendspin client with this bridge client_id.
-            # Happens on MA restart when the JS Cast receiver reconnects to the
-            # Sendspin server before Chromecast discovery fires. Also check the
-            # LA-bit MAC variant (AirPlay uses locally-administered MAC, Chromecast
-            # uses the real one).
-            existing_client_id: str | None = None
-            if sendspin_server.get_client(bridge_client_id):
-                existing_client_id = bridge_client_id
-            elif not cast_player.cast_info.is_audio_group:
-                la_variant_mac = _toggle_locally_administered_bit(
-                    bridge_client_id[len(BRIDGE_PREFIX) :]
-                )
-                if la_variant_mac:
-                    la_variant_id = f"{BRIDGE_PREFIX}{la_variant_mac}"
-                    if sendspin_server.get_client(la_variant_id):
-                        existing_client_id = la_variant_id
-
+            existing_client_id = self._find_existing_sendspin_client(
+                sendspin_server, bridge_client_id, cast_player
+            )
             if existing_client_id:
                 self.logger.info(
                     "Sendspin client %s already registered — claiming existing player for %s",
@@ -649,6 +635,32 @@ class SendspinBridgeManager:
                 unsub()
         self._rebridge_unsubs.clear()
         await self.stop_all()
+
+    def _find_existing_sendspin_client(
+        self,
+        sendspin_server: SendspinServer,
+        bridge_client_id: str,
+        cast_player: ChromecastPlayer,
+    ) -> str | None:
+        """
+        Return a matching already-registered Sendspin client_id, if any.
+
+        Happens on MA restart when the JS Cast receiver reconnects to the
+        Sendspin server before Chromecast discovery fires. Also checks the
+        LA-bit MAC variant (AirPlay uses locally-administered MAC, Chromecast
+        uses the real one).
+        """
+        if sendspin_server.get_client(bridge_client_id):
+            return bridge_client_id
+        if cast_player.cast_info.is_audio_group:
+            return None
+        la_variant_mac = _toggle_locally_administered_bit(bridge_client_id[len(BRIDGE_PREFIX) :])
+        if not la_variant_mac:
+            return None
+        la_variant_id = f"{BRIDGE_PREFIX}{la_variant_mac}"
+        if sendspin_server.get_client(la_variant_id):
+            return la_variant_id
+        return None
 
     def _subscribe_rebridge_on_disconnect(
         self, cast_player: ChromecastPlayer, client_id: str

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -578,11 +578,17 @@ class SendspinBridgeManager:
                 sendspin_provider = self.sendspin_provider
                 if sendspin_provider is not None:
                     bridge_hello = _build_bridge_hello(cast_player, existing_client_id)
-                    await sendspin_provider.apply_bridge_claim(
-                        existing_client_id,
-                        {IdentifierType.CAST_UUID: str(cast_player.cast_info.uuid)},
-                        bridge_hello,
-                    )
+                    identifiers = {IdentifierType.CAST_UUID: str(cast_player.cast_info.uuid)}
+                    if not await sendspin_provider.apply_bridge_claim(
+                        existing_client_id, identifiers, bridge_hello
+                    ):
+                        # SendspinPlayer registration still in flight
+                        # (`_handle_client_added` waits up to 5 s for hello).
+                        # Pre-register identifiers so `_create_player` attaches
+                        # CAST_UUID when it runs.
+                        sendspin_provider.register_bridge_identifiers(
+                            existing_client_id, identifiers
+                        )
                     _write_default_static_delay(self.mass, existing_client_id, manufacturer, model)
                     self._claimed_clients[player_id] = existing_client_id
                     self._subscribe_rebridge_on_disconnect(cast_player, existing_client_id)

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
@@ -25,6 +26,7 @@ from aiosendspin.models.core import ClientHelloPayload
 from aiosendspin.models.core import DeviceInfo as SendspinDeviceInfo
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
 from aiosendspin.models.types import AudioCodec
+from aiosendspin.server import ClientRemovedEvent
 from music_assistant_models.enums import EventType, IdentifierType
 from pychromecast.controllers import BaseController
 
@@ -50,10 +52,16 @@ from music_assistant.providers.sendspin.helpers import (
 from .constants import SENDSPIN_CAST_APP_ID, SENDSPIN_CAST_BLOCKLIST, SENDSPIN_CAST_NAMESPACE
 
 if TYPE_CHECKING:
-    from aiosendspin.server import ExternalStreamStartRequest, SendspinClient, SendspinServer
+    from aiosendspin.server import (
+        ExternalStreamStartRequest,
+        SendspinClient,
+        SendspinEvent,
+        SendspinServer,
+    )
     from music_assistant_models.event import MassEvent
     from pychromecast.generated.cast_channel_pb2 import CastMessage
 
+    from music_assistant.mass import MusicAssistant
     from music_assistant.providers.sendspin.provider import SendspinProvider
 
     from .player import ChromecastPlayer
@@ -163,6 +171,48 @@ def is_sendspin_cast_blocked(manufacturer: str, model: str) -> bool:
     return False
 
 
+def _build_bridge_hello(cast_player: ChromecastPlayer, bridge_client_id: str) -> ClientHelloPayload:
+    """Build the Sendspin ClientHelloPayload used to register a Chromecast bridge."""
+    return ClientHelloPayload(
+        client_id=bridge_client_id,
+        name=f"{cast_player.display_name} (Cast)",
+        version=1,
+        supported_roles=[BRIDGE_ROLE_ID],
+        device_info=SendspinDeviceInfo(
+            product_name="Chromecast Bridge",
+            manufacturer=cast_player.device_info.manufacturer,
+        ),
+        player_support=ClientHelloPlayerSupport(
+            supported_formats=[
+                SupportedAudioFormat(
+                    codec=AudioCodec.PCM,
+                    channels=BRIDGE_CHANNELS,
+                    sample_rate=BRIDGE_SAMPLE_RATE,
+                    bit_depth=BRIDGE_BIT_DEPTH,
+                )
+            ],
+            buffer_capacity=1_000,
+            supported_commands=[],
+        ),
+    )
+
+
+def _write_default_static_delay(
+    mass: MusicAssistant, bridge_client_id: str, manufacturer: str, model: str
+) -> None:
+    """Persist the model-specific default static delay if no user value exists."""
+    raw_delay = mass.config.get_raw_player_config_value(
+        bridge_client_id, CONF_SENDSPIN_STATIC_DELAY
+    )
+    if raw_delay is not None:
+        return
+    model_default = get_cast_model_static_delay(manufacturer, model)
+    if model_default != DEFAULT_SENDSPIN_STATIC_DELAY:
+        mass.config.set_raw_player_config_value(
+            bridge_client_id, CONF_SENDSPIN_STATIC_DELAY, model_default
+        )
+
+
 class SendspinChromecastBridge:
     """Manages the Sendspin to Chromecast bridge for a single player.
 
@@ -213,28 +263,7 @@ class SendspinChromecastBridge:
 
     async def start(self) -> None:
         """Register the Chromecast player as an external Sendspin client."""
-        hello = ClientHelloPayload(
-            client_id=self._bridge_client_id,
-            name=f"{self.cast_player.display_name} (Cast)",
-            version=1,
-            supported_roles=[BRIDGE_ROLE_ID],
-            device_info=SendspinDeviceInfo(
-                product_name="Chromecast Bridge",
-                manufacturer=self.cast_player.device_info.manufacturer,
-            ),
-            player_support=ClientHelloPlayerSupport(
-                supported_formats=[
-                    SupportedAudioFormat(
-                        codec=AudioCodec.PCM,
-                        channels=BRIDGE_CHANNELS,
-                        sample_rate=BRIDGE_SAMPLE_RATE,
-                        bit_depth=BRIDGE_BIT_DEPTH,
-                    )
-                ],
-                buffer_capacity=1_000,
-                supported_commands=[],
-            ),
-        )
+        hello = _build_bridge_hello(self.cast_player, self._bridge_client_id)
 
         self.logger.debug(
             "Registering Sendspin bridge for %s with client_id=%s",
@@ -456,6 +485,7 @@ class SendspinBridgeManager:
         self.logger = provider.logger.getChild("bridge_manager")
         self._bridges: dict[str, SendspinChromecastBridge] = {}
         self._lock = asyncio.Lock()
+        self._rebridge_unsubs: dict[str, Callable[[], None]] = {}
         self._unsub_config_updated = self.mass.subscribe(
             self._on_player_config_updated, EventType.PLAYER_CONFIG_UPDATED
         )
@@ -528,31 +558,40 @@ class SendspinBridgeManager:
                 )
                 return
 
-            # Check if a bridge already exists for this client_id.
+            # Detect an already-connected Sendspin client with this bridge client_id.
+            # Happens on MA restart when the JS Cast receiver reconnects to the
+            # Sendspin server before Chromecast discovery fires. Also check the
+            # LA-bit MAC variant (AirPlay uses locally-administered MAC, Chromecast
+            # uses the real one).
+            existing_client_id: str | None = None
             if sendspin_server.get_client(bridge_client_id):
-                self.logger.debug(
-                    "Sendspin client %s already registered, skipping Chromecast bridge for %s",
-                    bridge_client_id,
-                    cast_player.display_name,
-                )
-                return
-
-            # For MAC-based IDs, also check the LA-bit variant.
-            # AirPlay uses locally-administered MAC, Chromecast uses the real MAC.
-            if not cast_player.cast_info.is_audio_group:
+                existing_client_id = bridge_client_id
+            elif not cast_player.cast_info.is_audio_group:
                 la_variant_mac = _toggle_locally_administered_bit(
                     bridge_client_id[len(BRIDGE_PREFIX) :]
                 )
                 if la_variant_mac:
                     la_variant_id = f"{BRIDGE_PREFIX}{la_variant_mac}"
                     if sendspin_server.get_client(la_variant_id):
-                        self.logger.debug(
-                            "Sendspin client %s already registered (LA variant), "
-                            "skipping Chromecast bridge for %s",
-                            la_variant_id,
-                            cast_player.display_name,
-                        )
-                        return
+                        existing_client_id = la_variant_id
+
+            if existing_client_id:
+                self.logger.info(
+                    "Sendspin client %s already registered — claiming existing player for %s",
+                    existing_client_id,
+                    cast_player.display_name,
+                )
+                sendspin_provider = self.sendspin_provider
+                if sendspin_provider is not None:
+                    bridge_hello = _build_bridge_hello(cast_player, existing_client_id)
+                    sendspin_provider.apply_bridge_claim(
+                        existing_client_id,
+                        {IdentifierType.CAST_UUID: str(cast_player.cast_info.uuid)},
+                        bridge_hello,
+                    )
+                    _write_default_static_delay(self.mass, existing_client_id, manufacturer, model)
+                    self._subscribe_rebridge_on_disconnect(cast_player, existing_client_id)
+                return
 
             bridge = SendspinChromecastBridge(
                 self.provider, cast_player, sendspin_server, bridge_client_id
@@ -565,16 +604,7 @@ class SendspinBridgeManager:
                     bridge_client_id,
                     {IdentifierType.CAST_UUID: str(cast_player.cast_info.uuid)},
                 )
-                # Write default value if no (user) saved delay exists.
-                raw_delay = self.mass.config.get_raw_player_config_value(
-                    bridge_client_id, CONF_SENDSPIN_STATIC_DELAY
-                )
-                if raw_delay is None:
-                    model_default = get_cast_model_static_delay(manufacturer, model)
-                    if model_default != DEFAULT_SENDSPIN_STATIC_DELAY:
-                        self.mass.config.set_raw_player_config_value(
-                            bridge_client_id, CONF_SENDSPIN_STATIC_DELAY, model_default
-                        )
+                _write_default_static_delay(self.mass, bridge_client_id, manufacturer, model)
 
             try:
                 await bridge.start()
@@ -614,7 +644,48 @@ class SendspinBridgeManager:
     async def close(self) -> None:
         """Stop all bridges and unsubscribe event listeners."""
         self._unsub_config_updated()
+        for unsub in list(self._rebridge_unsubs.values()):
+            with suppress(Exception):
+                unsub()
+        self._rebridge_unsubs.clear()
         await self.stop_all()
+
+    def _subscribe_rebridge_on_disconnect(
+        self, cast_player: ChromecastPlayer, client_id: str
+    ) -> None:
+        """
+        Subscribe a one-shot listener that re-runs setup_bridge on client disconnect.
+
+        After claiming an already-registered external client (JS Cast receiver),
+        the bridge's on_stream_start launch handler is not wired. When the JS
+        client eventually disconnects (idle exit, device reboot), re-run
+        setup_bridge so the fresh-client path registers the external player with
+        a proper launch handler.
+        """
+        sendspin_provider = self.sendspin_provider
+        if sendspin_provider is None:
+            return
+        if existing := self._rebridge_unsubs.pop(client_id, None):
+            with suppress(Exception):
+                existing()
+        server_api = sendspin_provider.server_api
+
+        def _listener(_server: SendspinServer, event: SendspinEvent) -> None:
+            if not isinstance(event, ClientRemovedEvent):
+                return
+            if event.client_id != client_id:
+                return
+            unsub = self._rebridge_unsubs.pop(client_id, None)
+            if unsub is not None:
+                with suppress(Exception):
+                    unsub()
+            if self.mass.players.get_player(cast_player.player_id) is not cast_player:
+                return
+            if cast_player.player_id in self._bridges:
+                return
+            self.mass.create_task(self.setup_bridge(cast_player))
+
+        self._rebridge_unsubs[client_id] = server_api.add_event_listener(_listener)
 
     def get_bridge(self, cast_player_id: str) -> SendspinChromecastBridge | None:
         """Get the bridge for a Chromecast player.

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from typing import TYPE_CHECKING, cast
 
+from aiosendspin.models.types import PlayerCommand
 from aiosendspin.server import (
     ClientAddedEvent,
     ClientRemovedEvent,
@@ -14,7 +15,12 @@ from aiosendspin.server import (
     SendspinEvent,
     SendspinServer,
 )
-from music_assistant_models.enums import IdentifierType, PlayerType, ProviderFeature
+from music_assistant_models.enums import (
+    IdentifierType,
+    PlayerFeature,
+    PlayerType,
+    ProviderFeature,
+)
 from music_assistant_models.errors import AlreadyRegisteredError
 
 from music_assistant.constants import CONF_ENABLED
@@ -124,6 +130,54 @@ class SendspinProvider(PlayerProvider):
         player (e.g. PlayerType.LIGHT for Hue Entertainment bridges).
         """
         self._bridge_player_types[client_id] = player_type
+
+    def apply_bridge_claim(
+        self,
+        client_id: str,
+        identifiers: dict[IdentifierType, str],
+        bridge_hello: ClientHelloPayload,
+    ) -> bool:
+        """
+        Post-claim an already-registered SendspinPlayer as a bridge client.
+
+        Used when a bridge manager reaches setup_bridge AFTER the external client
+        has already connected on its own (e.g. a JS Cast receiver reconnecting to
+        the server before the Chromecast bridge could register). Attaches the
+        bridge's protocol-specific identifiers so cross-protocol matching can
+        link the SendspinPlayer to its native peer, and replays the bridge
+        hello's supported_commands restriction on the player features.
+
+        :param client_id: The Sendspin client_id whose player should be claimed.
+        :param identifiers: Protocol-specific identifiers (e.g. CAST_UUID) to
+            attach to the player for cross-protocol matching.
+        :param bridge_hello: The bridge's intended ClientHelloPayload. Its
+            player_support.supported_commands gates which volume/mute features
+            the player is allowed to expose.
+        :return: True if a matching SendspinPlayer was found and updated.
+        """
+        player = self.mass.players.get_player(client_id)
+        if not isinstance(player, SendspinPlayer):
+            return False
+        for id_type, id_value in identifiers.items():
+            player.device_info.add_identifier(id_type, id_value)
+        bridge_supported_commands: list[PlayerCommand] = []
+        if bridge_hello.player_support:
+            bridge_supported_commands = list(bridge_hello.player_support.supported_commands)
+        if PlayerCommand.VOLUME in bridge_supported_commands:
+            player._attr_supported_features.add(PlayerFeature.VOLUME_SET)
+        else:
+            player._attr_supported_features.discard(PlayerFeature.VOLUME_SET)
+        if PlayerCommand.MUTE in bridge_supported_commands:
+            player._attr_supported_features.add(PlayerFeature.VOLUME_MUTE)
+        else:
+            player._attr_supported_features.discard(PlayerFeature.VOLUME_MUTE)
+        self.logger.info(
+            "Bridge claim applied to existing SendspinPlayer %s (client_id=%s)",
+            player.display_name,
+            client_id,
+        )
+        self.mass.players.trigger_player_update(client_id, force_update=True)
+        return True
 
     async def _apply_hass_name_override(self, player: SendspinBasePlayer, client_id: str) -> None:
         """Apply Home Assistant display name for ESPHome-backed Sendspin players."""

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -131,7 +131,7 @@ class SendspinProvider(PlayerProvider):
         """
         self._bridge_player_types[client_id] = player_type
 
-    def apply_bridge_claim(
+    async def apply_bridge_claim(
         self,
         client_id: str,
         identifiers: dict[IdentifierType, str],
@@ -184,7 +184,7 @@ class SendspinProvider(PlayerProvider):
             player.display_name,
             client_id,
         )
-        self.mass.players.trigger_player_update(client_id, force_update=True)
+        await self.mass.players.register_or_update(player)
         return True
 
     async def _apply_hass_name_override(self, player: SendspinBasePlayer, client_id: str) -> None:

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -171,6 +171,14 @@ class SendspinProvider(PlayerProvider):
             player._attr_supported_features.add(PlayerFeature.VOLUME_MUTE)
         else:
             player._attr_supported_features.discard(PlayerFeature.VOLUME_MUTE)
+        # Expose the claimed player as a protocol bridge, not a standalone web
+        # player. A JS Cast receiver advertises product_name="Web Browser" and
+        # would otherwise be classified as is_web_player → PlayerType.PLAYER
+        # (hidden). Restore protocol semantics so UI links it under its native peer.
+        player.is_web_player = False
+        player._attr_hidden_by_default = False
+        player._attr_expose_to_ha_by_default = True
+        player._attr_type = PlayerType.PROTOCOL
         self.logger.info(
             "Bridge claim applied to existing SendspinPlayer %s (client_id=%s)",
             player.display_name,


### PR DESCRIPTION
When the Sendspin Cast App is still running on the speaker, it will immediately try to reconnect to Music Assistant, even before the Chromecast mdns discovery fires. In that case the `SendspinPlayer` was left without a `CAST_UUID` identifier, and protocol linking coudn't join it with the native `ChromecastPlayer`.

## Summary

`setup_bridge` now claims an already-registered Sendspin client by attaching `CAST_UUID` to the existing player, replaying the bridge hello's empty `supported_commands` (so native Cast volume is preserved), and restoring `PlayerType.PROTOCOL` / `is_web_player=False` after the JS receiver's web-browser hello. A one-shot listener re-runs `setup_bridge` when the JS client later disconnects so the fresh-client path wires the `on_stream_start` launch handler. A `_claimed_clients` guard prevents re-entry while still claimed.

Related issue: music-assistant/support#5244