### PR TITLE
Fix queue restore: ensure enqueued_media_items and radio_source are proper objects

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1070,22 +1070,33 @@ class PlayerQueuesController(CoreController):
                 )
                 queue_items = [QueueItem.from_cache(item_data) for item_data in prev_items]
                 if queue.enqueued_media_items:
-                    # after deserialization from cache, enqueued_media_items are dicts
-                    queue.enqueued_media_items = [
-                        cast("MediaItemType", media_from_dict(cast("dict[str, Any]", item)))
-                        for item in queue.enqueued_media_items
-                    ]
+                    # mashumaro may deserialize list[MediaItemType] as plain dicts or as
+                    # proper objects depending on the version — handle both.
+                    queue.enqueued_media_items = cast(
+                        "list[MediaItemType]",
+                        [
+                            media_from_dict(item) if isinstance(item, dict) else item
+                            for item in cast(
+                                "list[dict[str, Any] | MediaItemType]",
+                                queue.enqueued_media_items,
+                            )
+                        ],
+                    )
                 if queue.radio_source:
-                    # radio_source suffers from the same deserialisation issue as
-                    # enqueued_media_items: after restoring from cache the items are
-                    # plain dicts, not MediaItemType objects. Without this step the
-                    # isinstance(item, Playlist) check in _fill_radio_tracks() always
-                    # returns False, causing dynamic playlists to fall back to regular
-                    # radio mode and raise UnsupportedFeaturedException.
-                    queue.radio_source = [
-                        cast("MediaItemType", media_from_dict(cast("dict[str, Any]", item)))
-                        for item in queue.radio_source
-                    ]
+                    # radio_source: mashumaro may deserialize list[MediaItemType] as plain
+                    # dicts or as proper objects depending on the version. Ensure all items
+                    # are proper objects so isinstance checks (e.g. Playlist) work correctly
+                    # in _fill_radio_tracks().
+                    queue.radio_source = cast(
+                        "list[MediaItemType]",
+                        [
+                            media_from_dict(item) if isinstance(item, dict) else item
+                            for item in cast(
+                                "list[dict[str, Any] | MediaItemType]",
+                                queue.radio_source,
+                            )
+                        ],
+                    )
             except Exception as err:
                 self.logger.warning(
                     "Failed to restore the queue(items) for %s - %s",

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1062,6 +1062,9 @@ class PlayerQueuesController(CoreController):
                 # reset the play action in progress flag on restore
                 # this can happen if MA was killed while a play action was in progress
                 queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] = False
+                # from_cache fixes up radio_source and enqueued_media_items,
+                # which mashumaro deserializes as plain dicts instead of MediaItemType objects
+                queue.from_cache(prev_state)
                 prev_items = await self.mass.cache.get(
                     key=queue_id,
                     provider=self.domain,
@@ -1069,34 +1072,6 @@ class PlayerQueuesController(CoreController):
                     default=[],
                 )
                 queue_items = [QueueItem.from_cache(item_data) for item_data in prev_items]
-                if queue.enqueued_media_items:
-                    # mashumaro may deserialize list[MediaItemType] as plain dicts or as
-                    # proper objects depending on the version — handle both.
-                    queue.enqueued_media_items = cast(
-                        "list[MediaItemType]",
-                        [
-                            media_from_dict(item) if isinstance(item, dict) else item
-                            for item in cast(
-                                "list[dict[str, Any] | MediaItemType]",
-                                queue.enqueued_media_items,
-                            )
-                        ],
-                    )
-                if queue.radio_source:
-                    # radio_source: mashumaro may deserialize list[MediaItemType] as plain
-                    # dicts or as proper objects depending on the version. Ensure all items
-                    # are proper objects so isinstance checks (e.g. Playlist) work correctly
-                    # in _fill_radio_tracks().
-                    queue.radio_source = cast(
-                        "list[MediaItemType]",
-                        [
-                            media_from_dict(item) if isinstance(item, dict) else item
-                            for item in cast(
-                                "list[dict[str, Any] | MediaItemType]",
-                                queue.radio_source,
-                            )
-                        ],
-                    )
             except Exception as err:
                 self.logger.warning(
                     "Failed to restore the queue(items) for %s - %s",

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1075,6 +1075,17 @@ class PlayerQueuesController(CoreController):
                         cast("MediaItemType", media_from_dict(cast("dict[str, Any]", item)))
                         for item in queue.enqueued_media_items
                     ]
+                if queue.radio_source:
+                    # radio_source suffers from the same deserialisation issue as
+                    # enqueued_media_items: after restoring from cache the items are
+                    # plain dicts, not MediaItemType objects. Without this step the
+                    # isinstance(item, Playlist) check in _fill_radio_tracks() always
+                    # returns False, causing dynamic playlists to fall back to regular
+                    # radio mode and raise UnsupportedFeaturedException.
+                    queue.radio_source = [
+                        cast("MediaItemType", media_from_dict(cast("dict[str, Any]", item)))
+                        for item in queue.radio_source
+                    ]
             except Exception as err:
                 self.logger.warning(
                     "Failed to restore the queue(items) for %s - %s",


### PR DESCRIPTION
## Problem

When a player queue is restored from cache after a restart, `radio_source` and `enqueued_media_items` may be deserialized inconsistently by mashumaro:

- If mashumaro fails to resolve the `list[MediaItemType]` union, items come back as plain `dict` objects — causing `isinstance(item, Playlist)` checks in `_fill_radio_tracks()` to always return `False`, so dynamic playlists fall back to regular radio mode and raise `UnsupportedFeaturedException`.
- If mashumaro *succeeds* in deserializing, items come back as proper objects — calling `media_from_dict()` on them then raises `argument of type 'Artist' is not a container or iterable`.

Both scenarios need to be handled.

## Fix

The fix is split across two PRs:

- **music-assistant/models#212**: Adds `radio_source` reconstruction to `PlayerQueue.from_cache()`, using the same `media_from_dict` pattern that already exists for `enqueued_media_items`.
- **This PR** (depends on models#212): Replaces the previous inline cast blocks in `on_player_register()` with a single `queue.from_cache(prev_state)` call after `from_dict`, delegating the deserialization fix to the models layer.