### PR TITLE
Fix tidal recommendations

### DIFF
--- a/music_assistant/providers/tidal/constants.py
+++ b/music_assistant/providers/tidal/constants.py
@@ -8,6 +8,8 @@ BASE_URL_V2 = "https://api.tidal.com/v2"
 OPEN_API_URL = "https://openapi.tidal.com/v2"
 BROWSE_URL = "https://tidal.com/browse"
 RESOURCES_URL = "https://resources.tidal.com/images"
+# Base host for the /pages/* feed.
+WEB_BASE_URL = "https://tidal.com/v1"
 
 # Authentication
 TOKEN_TYPE = "Bearer"

--- a/music_assistant/providers/tidal/recommendations.py
+++ b/music_assistant/providers/tidal/recommendations.py
@@ -17,7 +17,7 @@ from music_assistant_models.media_items import (
     UniqueList,
 )
 
-from .constants import CACHE_CATEGORY_RECOMMENDATIONS
+from .constants import CACHE_CATEGORY_RECOMMENDATIONS, WEB_BASE_URL
 from .tidal_page_parser import TidalPageParser
 
 if TYPE_CHECKING:
@@ -128,7 +128,7 @@ class TidalRecommendationManager:
             locale = self.mass.metadata.locale.replace("_", "-")
             api_result = await self.api.get(
                 page_path,
-                base_url="https://tidal.com/v1",
+                base_url=WEB_BASE_URL,
                 params={
                     "locale": locale,
                     "deviceType": "BROWSER",

--- a/music_assistant/providers/tidal/recommendations.py
+++ b/music_assistant/providers/tidal/recommendations.py
@@ -114,8 +114,8 @@ class TidalRecommendationManager:
                     )
                 )
 
-        except Exception as err:
-            self.logger.warning("Error fetching recommendations: %s", err)
+        except Exception:
+            self.logger.exception("Error fetching recommendations")
 
         return results
 
@@ -128,7 +128,7 @@ class TidalRecommendationManager:
             locale = self.mass.metadata.locale.replace("_", "-")
             api_result = await self.api.get(
                 page_path,
-                base_url="https://listen.tidal.com/v1",
+                base_url="https://tidal.com/v1",
                 params={
                     "locale": locale,
                     "deviceType": "BROWSER",
@@ -153,4 +153,5 @@ class TidalRecommendationManager:
             )
             return parser
         except Exception:
+            self.logger.exception("Error fetching Tidal page %s", page_path)
             return TidalPageParser(self.provider)


### PR DESCRIPTION
A new redirect was added by tidal, aiohttp strips auth on redirects hence missing recommendations. Using base domain fixes the issue.
Fixes [#5271](https://github.com/music-assistant/support/issues/5271)
