### PR TITLE
Add recommendation translation keys for QQ and NetEase

### DIFF
--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -1741,7 +1741,8 @@ class NeteaseCloudMusicProvider(MusicProvider):
             folder = RecommendationFolder(
                 item_id="daily_songs",
                 provider=self.instance_id,
-                name="Daily Songs",
+                name="Recommended tracks",
+                translation_key="recommended_tracks",
                 icon="mdi:star",
             )
             for song_obj in daily_songs:
@@ -1764,7 +1765,8 @@ class NeteaseCloudMusicProvider(MusicProvider):
             folder = RecommendationFolder(
                 item_id="recommended_new_songs",
                 provider=self.instance_id,
-                name="New Songs",
+                name="Recommended new tracks",
+                translation_key="recommended_new_tracks",
                 icon="mdi:music-note",
             )
             for item in raw_new_songs:
@@ -1790,7 +1792,8 @@ class NeteaseCloudMusicProvider(MusicProvider):
             folder = RecommendationFolder(
                 item_id="recommended_playlists",
                 provider=self.instance_id,
-                name="Recommended Playlists",
+                name="Recommended playlists",
+                translation_key="recommended_playlists",
                 icon="mdi:playlist-music",
             )
             for playlist_obj in raw_playlists:

--- a/music_assistant/providers/qqmusic/__init__.py
+++ b/music_assistant/providers/qqmusic/__init__.py
@@ -1365,7 +1365,8 @@ class QQMusicProvider(MusicProvider):
             guess_folder = RecommendationFolder(
                 item_id="guess_recommend",
                 provider=self.instance_id,
-                name="猜你喜欢",
+                name="Recommended tracks",
+                translation_key="recommended_tracks",
                 icon="mdi-lightbulb-on-outline",
             )
             for item in guess_tracks:
@@ -1410,7 +1411,8 @@ class QQMusicProvider(MusicProvider):
                 new_song_folder = RecommendationFolder(
                     item_id="new_songs",
                     provider=self.instance_id,
-                    name="推荐新歌",
+                    name="Recommended new tracks",
+                    translation_key="recommended_new_tracks",
                     icon="mdi-music-note-plus",
                 )
                 for item in new_tracks:
@@ -1441,7 +1443,8 @@ class QQMusicProvider(MusicProvider):
                 playlist_folder = RecommendationFolder(
                     item_id="recommended_playlists",
                     provider=self.instance_id,
-                    name="推荐歌单",
+                    name="Recommended playlists",
+                    translation_key="recommended_playlists",
                     icon="mdi-playlist-music",
                 )
                 _add_playlist_folder_items(playlist_folder, playlist_items)


### PR DESCRIPTION
## Summary
- Add recommendation translation keys to QQ Music recommendation folders.
- Add the same recommendation translation keys to NetEase Cloud Music recommendation folders.
- Align the fallback English names for recommended tracks, recommended new tracks, and recommended playlists.

## Notes
- This PR only adds backend translation keys.
- The frontend translations for recommended_tracks and recommended_playlists have not been added yet and can be handled separately.