### PR TITLE
Rename icon in audio analysis manifest.json

### DIFF
--- a/music_assistant/providers/loudness_analysis/manifest.json
+++ b/music_assistant/providers/loudness_analysis/manifest.json
@@ -8,6 +8,6 @@
   "multi_instance": false,
   "builtin": true,
   "allow_disable": false,
-  "icon": "volume-variant-high",
+  "icon": "volume-high",
   "documentation": "https://music-assistant.io/audio-analysis-providers/loudness-analysis/"
 }


### PR DESCRIPTION
Research suggests the current name in the manifest is no longer in use. This PR replaces it with the new name