### PR TITLE
Fix volume of Sendspin bridge players defaulting to 100%

### DIFF
--- a/music_assistant/providers/sendspin/bridge_role.py
+++ b/music_assistant/providers/sendspin/bridge_role.py
@@ -80,7 +80,10 @@ class BridgePlayerRole(Role):
         self._on_mute_change_cb = on_mute_change
         self._on_stream_start_cb = on_stream_start
         self._on_stream_end_cb = on_stream_end
+        volume_changed = self._volume != initial_volume
         self._volume = initial_volume
+        if volume_changed:
+            self._emit_volume_changed()
 
     @property
     def role_id(self) -> str:


### PR DESCRIPTION
Bridged AirPlay players were previously stuck at 100% volume, even after the volume got updated to the correct value through `BridgePlayerRole.set_callbacks`.
This fixes that by updating the cached volume in the `SendspinPlayer` to the correct value.