### PR TITLE
Fix YTMusic stream format selection

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -1036,7 +1036,8 @@ class YoutubeMusicProvider(MusicProvider):
                 except yt_dlp.utils.DownloadError as err:
                     raise UnplayableMediaError(err) from err
                 format_selector = ydl.build_format_selector("m4a/bestaudio")
-                if not (stream_format := next(format_selector({"formats": info["formats"]})), None):
+                stream_format = next(format_selector({"formats": info["formats"]}), None)
+                if not stream_format:
                     raise UnplayableMediaError("No stream formats found")
                 return stream_format
 


### PR DESCRIPTION
### This fixes a YTMusic provider bug in stream format selection.

**Problem:**
The current code uses an invalid next(...) expression when selecting the best audio format. In failure paths this can leak StopIteration through the async setup path and break provider setup instead of raising the intended UnplayableMediaError.

**Change:**
- replace the broken next(...) expression with a proper next(generator, None) call
- explicitly check for a missing result before raising No stream formats found

**Why:**
This is a logic bug in the provider itself and is independent of deployment environment. It was reproducible during YTMusic setup and caused setup failures instead of the expected provider error handling.