### PR TITLE
Enrich Sendspin metadata with track number, year, album artist, and artist artwork

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -50,7 +50,7 @@ from music_assistant_models.enums import (
     PlayerType,
     RepeatMode,
 )
-from music_assistant_models.media_items import Album, Artist, is_track
+from music_assistant_models.media_items import Album, Artist, ItemMapping, is_track
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
 
@@ -751,7 +751,7 @@ class SendspinPlayer(SendspinBasePlayer):
     async def _send_artist_artwork(self, current_item: QueueItem) -> None:
         """Send artist artwork to the sendspin group."""
         artist_artwork_url: str | None = None
-        fetch_target: Artist | None = None
+        fetch_target: Artist | ItemMapping | None = None
 
         if current_item.media_item is not None and is_track(current_item.media_item):
             artists = current_item.media_item.artists
@@ -762,16 +762,19 @@ class SendspinPlayer(SendspinBasePlayer):
                 result = await self.mass.music.get_library_item_by_prov_id(
                     MediaType.ARTIST, primary_artist.item_id, primary_artist.provider
                 )
-                fetch_target = result if isinstance(result, Artist) else None
-                image = fetch_target.image if fetch_target else primary_artist.image
-                if image is not None:
-                    artist_artwork_url = self.mass.metadata.get_image_url(image)
+                if isinstance(result, Artist):
+                    fetch_target = result
+                elif primary_artist.image is not None:
+                    fetch_target = primary_artist
+                if fetch_target is not None and fetch_target.image is not None:
+                    artist_artwork_url = self.mass.metadata.get_image_url(fetch_target.image)
 
         if artist_artwork_url != self.last_sent_artist_artwork_url:
             self.last_sent_artist_artwork_url = artist_artwork_url
             if artist_artwork_url is not None and fetch_target is not None:
                 artist_image_data = await self.mass.metadata.get_image_data_for_item(
-                    fetch_target, img_type=ImageType.THUMB
+                    fetch_target,  # type: ignore[arg-type]
+                    img_type=ImageType.THUMB,
                 )
                 if artist_image_data is not None:
                     artist_image = await asyncio.to_thread(Image.open, BytesIO(artist_image_data))
@@ -785,7 +788,11 @@ class SendspinPlayer(SendspinBasePlayer):
         if self.synced_to is not None:
             # Only leader sends metadata
             return
-        self.mass.create_task(self.send_current_media_metadata())
+        self.mass.create_task(
+            self.send_current_media_metadata(),
+            task_id=f"sendspin_metadata_{self.player_id}",
+            abort_existing=True,
+        )
 
     async def _clear_current_media_metadata(self) -> None:
         """Clear all metadata and artwork from the sendspin group."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -43,14 +43,13 @@ from music_assistant_models.constants import PLAYER_CONTROL_NONE
 from music_assistant_models.enums import (
     ConfigEntryType,
     IdentifierType,
-    ImageType,
     MediaType,
     PlaybackState,
     PlayerFeature,
     PlayerType,
     RepeatMode,
 )
-from music_assistant_models.media_items import Album, Artist, ItemMapping, is_track
+from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
 
@@ -751,7 +750,6 @@ class SendspinPlayer(SendspinBasePlayer):
     async def _send_artist_artwork(self, current_item: QueueItem) -> None:
         """Send artist artwork to the sendspin group."""
         artist_artwork_url: str | None = None
-        fetch_target: Artist | ItemMapping | None = None
 
         if current_item.media_item is not None and is_track(current_item.media_item):
             artists = current_item.media_item.artists
@@ -762,21 +760,20 @@ class SendspinPlayer(SendspinBasePlayer):
                 result = await self.mass.music.get_library_item_by_prov_id(
                     MediaType.ARTIST, primary_artist.item_id, primary_artist.provider
                 )
-                if isinstance(result, Artist):
-                    fetch_target = result
-                elif primary_artist.image is not None:
-                    fetch_target = primary_artist
-                if fetch_target is not None and fetch_target.image is not None:
-                    artist_artwork_url = self.mass.metadata.get_image_url(fetch_target.image)
+                artist_item = result if isinstance(result, Artist) else None
+                image = artist_item.image if artist_item is not None else primary_artist.image
+                if image is not None:
+                    artist_artwork_url = self.mass.metadata.get_image_url(image)
 
         if artist_artwork_url != self.last_sent_artist_artwork_url:
             self.last_sent_artist_artwork_url = artist_artwork_url
-            if artist_artwork_url is not None and fetch_target is not None:
-                artist_image_data = await self.mass.metadata.get_image_data_for_item(
-                    fetch_target,  # type: ignore[arg-type]
-                    img_type=ImageType.THUMB,
+            if artist_artwork_url is not None:
+                # Fetch bytes from the already-resolved URL to avoid the secondary
+                # provider lookup that get_image_data_for_item triggers for ItemMappings.
+                artist_image_data = await self.mass.metadata.get_thumbnail(
+                    artist_artwork_url, provider="builtin"
                 )
-                if artist_image_data is not None:
+                if isinstance(artist_image_data, bytes):
                     artist_image = await asyncio.to_thread(Image.open, BytesIO(artist_image_data))
                     if (artwork_role := self._artwork_role) is not None:
                         await artwork_role.set_artist_artwork(artist_image)

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -44,11 +44,13 @@ from music_assistant_models.enums import (
     ConfigEntryType,
     IdentifierType,
     ImageType,
+    MediaType,
     PlaybackState,
     PlayerFeature,
     PlayerType,
     RepeatMode,
 )
+from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
 
@@ -747,35 +749,34 @@ class SendspinPlayer(SendspinBasePlayer):
         return artwork_url
 
     async def _send_artist_artwork(self, current_item: QueueItem) -> None:
-        """
-        Send artist artwork to the sendspin group.
+        """Send artist artwork to the sendspin group."""
+        artist_artwork_url: str | None = None
+        fetch_target: Artist | None = None
 
-        Args:
-            current_item: The current queue item.
-        """
-        # Extract primary artist if available
-        artist_artwork_url = None
-        if current_item.media_item is not None and hasattr(current_item.media_item, "artists"):
-            artists = getattr(current_item.media_item, "artists", None)
-            if artists and len(artists) > 0:
+        if current_item.media_item is not None and is_track(current_item.media_item):
+            artists = current_item.media_item.artists
+            if artists:
                 primary_artist = artists[0]
-                if hasattr(primary_artist, "image"):
-                    artist_image = getattr(primary_artist, "image", None)
-                    if artist_image is not None:
-                        artist_artwork_url = self.mass.metadata.get_image_url(artist_image)
+                # Prefer a full library artist (has reliable up-to-date artwork) over
+                # the ItemMapping in the queue item, which often has image=None.
+                result = await self.mass.music.get_library_item_by_prov_id(
+                    MediaType.ARTIST, primary_artist.item_id, primary_artist.provider
+                )
+                fetch_target = result if isinstance(result, Artist) else None
+                image = fetch_target.image if fetch_target else primary_artist.image
+                if image is not None:
+                    artist_artwork_url = self.mass.metadata.get_image_url(image)
 
         if artist_artwork_url != self.last_sent_artist_artwork_url:
-            # Artist image changed, resend the artwork
             self.last_sent_artist_artwork_url = artist_artwork_url
-            if artist_artwork_url is not None:
+            if artist_artwork_url is not None and fetch_target is not None:
                 artist_image_data = await self.mass.metadata.get_image_data_for_item(
-                    primary_artist, img_type=ImageType.THUMB
+                    fetch_target, img_type=ImageType.THUMB
                 )
                 if artist_image_data is not None:
                     artist_image = await asyncio.to_thread(Image.open, BytesIO(artist_image_data))
                     if (artwork_role := self._artwork_role) is not None:
                         await artwork_role.set_artist_artwork(artist_image)
-            # Clear artist artwork if none available
             elif (artwork_role := self._artwork_role) is not None:
                 await artwork_role.set_artist_artwork(None)
 
@@ -784,13 +785,17 @@ class SendspinPlayer(SendspinBasePlayer):
         if self.synced_to is not None:
             # Only leader sends metadata
             return
-
-        if self.state.current_media is None:
-            # Clear metadata when no media loaded
-            if (metadata_role := self._metadata_role) is not None:
-                metadata_role.set_metadata(Metadata())
-            return
         self.mass.create_task(self.send_current_media_metadata())
+
+    async def _clear_current_media_metadata(self) -> None:
+        """Clear all metadata and artwork from the sendspin group."""
+        if (metadata_role := self._metadata_role) is not None:
+            metadata_role.set_metadata(Metadata())
+        if (artwork_role := self._artwork_role) is not None:
+            await artwork_role.set_album_artwork(None)
+            await artwork_role.set_artist_artwork(None)
+        self.last_sent_artwork_url = None
+        self.last_sent_artist_artwork_url = None
 
     async def send_current_media_metadata(self) -> None:
         """Send the current media metadata to the sendspin group."""
@@ -798,6 +803,7 @@ class SendspinPlayer(SendspinBasePlayer):
             return
         current_media = self.state.current_media
         if current_media is None:
+            await self._clear_current_media_metadata()
             return
         # check if we are playing a MA queue item
         queue_item: QueueItem | None = None
@@ -812,6 +818,26 @@ class SendspinPlayer(SendspinBasePlayer):
         if queue_item:
             await self._send_album_artwork(queue_item)
             await self._send_artist_artwork(queue_item)
+
+        track_number: int | None = None
+        year: int | None = None
+        album_artist: str | None = None
+        if queue_item and queue_item.media_item and is_track(queue_item.media_item):
+            track = queue_item.media_item
+            track_number = track.track_number or None
+            album_mapping = track.album
+            if album_mapping is not None:
+                year = album_mapping.year
+                if not isinstance(album_mapping, Album):
+                    # Cheap DB-only lookup, no external API call; None if not in library
+                    result = await self.mass.music.get_library_item_by_prov_id(
+                        MediaType.ALBUM, album_mapping.item_id, album_mapping.provider
+                    )
+                    full_album: Album | None = result if isinstance(result, Album) else None
+                else:
+                    full_album = album_mapping
+                if full_album and full_album.artists:
+                    album_artist = full_album.artist_str
 
         track_duration = current_media.duration or 0
         repeat = SendspinRepeatMode.OFF
@@ -837,11 +863,11 @@ class SendspinPlayer(SendspinBasePlayer):
         metadata = Metadata(
             title=current_media.title,
             artist=current_media.artist,
-            album_artist=None,
+            album_artist=album_artist,
             album=current_media.album,
             artwork_url=current_media.image_url,
-            year=None,
-            track=None,
+            year=year,
+            track=track_number,
             track_duration=track_duration * 1000 if track_duration is not None else None,
             track_progress=track_progress,
             playback_speed=1000 if is_playing else 0,


### PR DESCRIPTION
## Summary

Adds missing metadata fields to the Sendspin player and fixes artist artwork not being sent.

Fixes https://github.com/music-assistant/support/issues/5369
Replaces #2825

### Missing metadata fields (track number, year, album artist)

The `Metadata` object sent to Sendspin clients had `track`, `year`, and `album_artist` hardcoded to `None`. This PR populates them:

- **`track_number`** and **`year`**: read directly from the `QueueItem` — `Track.track_number` is already on the queue item, and `ItemMapping.year` is preserved from the full `Album` when the queue item is created. Zero extra cost.
- **`album_artist`**: fetched via `mass.music.get_library_item_by_prov_id(MediaType.ALBUM, ...)` — a pure SQLite library lookup with no external API call. Gracefully absent (`None`) for tracks not in the local library.

This is the approach suggested in #2825 as an alternative to the heavy `get_item_by_uri` call that caused that PR to be shelved.

### Artist artwork fix

`_send_artist_artwork` was not sending artwork in practice because artists in a `QueueItem` are simplified to `ItemMapping` objects, which often have `image=None` (the image is only preserved if the artist's THUMB was already in `metadata.images` at queue-creation time). Additionally, the fallback code path was dead — `artist_artwork_url` was set but the subsequent guard skipped the actual send.

The fix uses the same library DB lookup to retrieve the full `Artist` object (with reliable, up-to-date artwork), falling back to the `ItemMapping` if the artist is not in the library.

### Clearing metadata on media unload

When `current_media` becomes `None` (e.g. queue ends), the metadata role was cleared but the artwork roles were not — leaving stale artwork on the client. Both album and artist artwork are now cleared, and the URL cache is reset so the next track's artwork is always re-sent.