### PR TITLE
Set PlayerFeature.SELECT_SOURCE when the FINAL source list is multi-entry

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1915,6 +1915,8 @@ class Player(ABC):
             base_features.add(PlayerFeature.VOLUME_MUTE)
         else:
             base_features.discard(PlayerFeature.VOLUME_MUTE)
+        if sum(1 for s in self.__final_source_list if not s.passive) >= 2:
+            base_features.add(PlayerFeature.SELECT_SOURCE)
         return base_features
 
     @cached_property

--- a/tests/core/test_player_state_select_source.py
+++ b/tests/core/test_player_state_select_source.py
@@ -1,0 +1,49 @@
+"""Tests for auto-derivation of PlayerFeature.SELECT_SOURCE."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import PlayerFeature
+
+from music_assistant.models.plugin import PluginSource
+from tests.common import MockPlayer, MockProvider
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock MusicAssistant instance."""
+    mass = MagicMock()
+    mass.config.get_raw_player_config_value = MagicMock(return_value="auto")
+    return mass
+
+
+@pytest.fixture
+def provider(mock_mass: MagicMock) -> MockProvider:
+    """Create a mock provider."""
+    return MockProvider("test_provider", mass=mock_mass)
+
+
+class TestSelectSourceAutoDerivation:
+    """SELECT_SOURCE is auto-set when the FINAL source list has 2+ non-passive entries."""
+
+    def test_plugin_source_grants_bit(self, mock_mass: MagicMock, provider: MockProvider) -> None:
+        """MA Queue + one plugin source → SELECT_SOURCE."""
+        mock_mass.players.get_plugin_sources = MagicMock(
+            return_value=[PluginSource(id="airplay_receiver", name="AirPlay Receiver")]
+        )
+        player = MockPlayer(provider, "player_1", "Player")
+
+        features = player._Player__final_supported_features  # type: ignore[attr-defined]
+        assert PlayerFeature.SELECT_SOURCE in features
+
+    def test_no_extra_sources_does_not_grant_bit(
+        self, mock_mass: MagicMock, provider: MockProvider
+    ) -> None:
+        """MA Queue alone → SELECT_SOURCE not set."""
+        mock_mass.players.get_plugin_sources = MagicMock(return_value=[])
+        player = MockPlayer(provider, "player_2", "Player")
+
+        features = player._Player__final_supported_features  # type: ignore[attr-defined]
+        assert PlayerFeature.SELECT_SOURCE not in features


### PR DESCRIPTION
## Motivation

My Music Assistant players all support two sources — **Music Assistant Queue** plus **AirPlay Receiver** — but I cannot switch sources from Home Assistant; the service call 500s and no UI elements show. I have to click through several layers into MA and into deep menus to do this routine switch every time I change music source, which is super annoying.

This fixes the omission: if there are sources to pick for players in MA, they can be picked in HA and triggered by scripts and voice.

My own home setup uses Music Assistant installed as an App alongside Home Assistant, and I have not yet figured out how to build and deploy MA to seamlessly swap that in so I can test. I thought it would still be worth putting up a PR to get opinions, as the change is relatively small and is covered by tests.

## Details

`Player.__final_source_list` injects `Music Assistant Queue` plus every enabled `PluginSource` into the source list shipped on `PlayerState` for any non-`PROTOCOL` player, and `PlayerController.select_source` accepts plugin/queue source IDs **before** ever checking `PlayerFeature.SELECT_SOURCE`. The flag is only required for the native
hardware-input fallback path.

Today, only six providers declare `PlayerFeature.SELECT_SOURCE` (`bluesound`, `heos`, `musiccast`, `sonos`, `sonos_s1`, `wiim`). For everything else (`hass_players`, `squeezelite`, `dlna`, `cast`, etc.) the flag stays clear even though the FINAL source list contains a fully-usable list of selectable sources. Home Assistant's `MediaPlayerEntity` base class then hides `source_list` and rejects the `select_source` service call because its own gating keys on `MediaPlayerEntityFeature.SELECT_SOURCE`, which the HA integration ties directly to `PlayerFeature.SELECT_SOURCE`.

The consequence is that any MA player not coming from one of the six hardware-input providers can't be source-switched from a HA dashboard tile, voice assistant, or `media_player.select_source` action — even though the MA web UI shows the picker, and even though `players/cmd/select_source` would happily accept the command.

## Where to put the fix

The mismatch is between two pieces of the model layer that should already agree: `__final_source_list` decides what source list ships, and `__final_supported_features` decides which capability flags ship. Today they disagree: the source list contains 2+ selectable entries while the `SELECT_SOURCE` flag is unset. Putting the derivation right next to its
dependency keeps them in sync.

## Changed behavior

- Non-`PROTOCOL` players with at least one plugin source enabled (e.g., AirPlay Receiver) → flag set. Their FINAL source list reaches the user as `[Music Assistant Queue, AirPlay Receiver, …]` and `media_player.select_source` from any client just works.

## Unchanged behavior
- Non-`PROTOCOL` players with no plugin sources and no native sources → flag stays clear. Final list is `[Music Assistant Queue]` only — one entry — so there's nothing to switch between and the picker is correctly suppressed.
- `PROTOCOL` players → behavior unchanged. `__final_source_list` short-circuits for them, so they only get the flag if their native list itself contains 2+ non-passive entries (or the provider declared the flag explicitly).
- Hardware-input providers that already declare `PlayerFeature.SELECT_SOURCE` → unchanged; the flag survives via `.copy()`.
- Players whose only "extra" sources are `passive=True` (e.g., the `External Source` placeholder in `hass_players`) → flag stays clear. Passive sources don't count toward the selectable threshold.

## Tests

New file `tests/core/test_player_state_select_source.py` covers:

1. Non-`PROTOCOL` player + 1 plugin source → SELECT_SOURCE set, FINAL source list reaches the user with both entries.
2. Non-`PROTOCOL` player, no plugins, no native sources → SELECT_SOURCE stays clear (FINAL list = `[MA Queue]`).
3. `PROTOCOL` player without native SELECT_SOURCE declaration → stays clear.
4. Provider-declared SELECT_SOURCE on a `PROTOCOL` player → preserved.
5. Non-`PROTOCOL` player whose extras are all `passive=True` (mirrors the `hass_players` "External Source" entry) → stays clear.

Test suite and ruff pass.

## User-visible impact

Every non-`PROTOCOL` player gains a working source picker in any client that respects the `SELECT_SOURCE` capability — Home Assistant included. No client changes required. 

My own example is a FutureProofHomes Satellite, which currently shows `supported_features = 8320575` (bit 11 / `SELECT_SOURCE = 2048` clear) and no `source_list` attribute in HA; with this change it'll get bit 11 set and the same source list MA's web UI already shows.

## Not changed

- `_demo_player_provider` example update. Its docstrings still describe the previous "set SELECT_SOURCE only when implementing native `select_source`" rule, which is correct guidance for *providers* — the auto-set added here is at the model layer for the auto-injected MA Queue + plugin source case, not a substitute for native input handling.