### PR TITLE
Fully implement hide in the UI

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -114,7 +114,7 @@ from .helpers import AnnounceData, handle_player_command, wait_for_power_on
 from .protocol_linking import ProtocolLinkingMixin
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable, Iterable, Iterator
 
     from music_assistant_models.config_entries import (
         ConfigEntry,
@@ -249,6 +249,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         return_disabled: bool = False,
         provider_filter: str | None = None,
         return_protocol_players: bool = False,
+        *,
+        exclude_hidden: bool = False,
+        keep_player_ids: str | Iterable[str] | None = None,
     ) -> list[Player]:
         """
         Return all registered players.
@@ -259,6 +262,12 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         :param return_disabled [bool]: Include disabled players.
         :param provider_filter [str]: Optional filter by provider lookup key.
         :param return_protocol_players [bool]: Include protocol players (hidden by default).
+        :param exclude_hidden [bool]: When True, exclude players with hide_in_ui=True
+            from the result. Use this for UI candidate pickers.
+        :param keep_player_ids: Player id(s) that must always be returned even when
+            hidden. Accepts a single id, an iterable of ids, or None. Use this to
+            preserve already-saved selections in pickers so the dropdown can render
+            and the user can change them.
 
         :return: List of Player objects.
         """
@@ -269,6 +278,12 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             else None
         )
         current_sendspin_player = get_sendspin_player_id()
+        if keep_player_ids is None:
+            keep_set: set[str] = set()
+        elif isinstance(keep_player_ids, str):
+            keep_set = {keep_player_ids}
+        else:
+            keep_set = set(keep_player_ids)
         return [
             player
             for player in list(self._players.values())
@@ -282,6 +297,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 or player.player_id == current_sendspin_player
             )
             and (return_protocol_players or player.state.type != PlayerType.PROTOCOL)
+            and (not exclude_hidden or not player.hide_in_ui or player.player_id in keep_set)
         ]
 
     @api_command("players/all")

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -64,7 +64,7 @@ async def setup(
 
 async def get_config_entries(
     mass: MusicAssistant,
-    instance_id: str | None = None,  # noqa: ARG001
+    instance_id: str | None = None,
     action: str | None = None,  # noqa: ARG001
     values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
@@ -75,6 +75,11 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
+    saved_player_id = (
+        mass.config.get_raw_provider_config_value(instance_id, CONF_MASS_PLAYER_ID)
+        if instance_id
+        else None
+    )
     return (
         CONF_ENTRY_WARN_PREVIEW,
         ConfigEntry(
@@ -93,7 +98,13 @@ async def get_config_entries(
                 *(
                     ConfigValueOption(x.display_name, x.player_id)
                     for x in sorted(
-                        mass.players.all_players(False, False), key=lambda p: p.display_name.lower()
+                        mass.players.all_players(
+                            False,
+                            False,
+                            exclude_hidden=True,
+                            keep_player_ids=cast("str | None", saved_player_id),
+                        ),
+                        key=lambda p: p.display_name.lower(),
                     )
                 ),
             ],

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -8,7 +8,7 @@ import time
 from collections import deque
 from collections.abc import AsyncGenerator
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
 from aiohttp import ClientTimeout
@@ -54,11 +54,16 @@ async def setup(
 
 async def get_config_entries(
     mass: MusicAssistant,
-    instance_id: str | None = None,  # noqa: ARG001
+    instance_id: str | None = None,
     action: str | None = None,  # noqa: ARG001
     values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
+    saved_player_id = (
+        mass.config.get_raw_provider_config_value(instance_id, CONF_MASS_PLAYER_ID)
+        if instance_id
+        else None
+    )
     return (
         CONF_ENTRY_WARN_PREVIEW,
         ConfigEntry(
@@ -72,7 +77,13 @@ async def get_config_entries(
                 *(
                     ConfigValueOption(x.display_name, x.player_id)
                     for x in sorted(
-                        mass.players.all_players(False, False), key=lambda p: p.display_name.lower()
+                        mass.players.all_players(
+                            False,
+                            False,
+                            exclude_hidden=True,
+                            keep_player_ids=cast("str | None", saved_player_id),
+                        ),
+                        key=lambda p: p.display_name.lower(),
                     )
                 ),
             ],

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -141,7 +141,7 @@ async def setup(
 
 async def get_config_entries(
     mass: MusicAssistant,
-    instance_id: str | None = None,  # noqa: ARG001
+    instance_id: str | None = None,
     action: str | None = None,
     values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
@@ -163,6 +163,12 @@ async def get_config_entries(
 
     guest_access_enabled = bool(values.get(CONF_ENABLE_GUEST_ACCESS, False))
 
+    saved_player_id = (
+        mass.config.get_raw_provider_config_value(instance_id, CONF_PARTY_PLAYER)
+        if instance_id
+        else None
+    )
+
     return (
         ConfigEntry(
             key=CONF_PARTY_PLAYER,
@@ -177,7 +183,12 @@ async def get_config_entries(
                 *[
                     ConfigValueOption(player.display_name, player.player_id)
                     for player in sorted(
-                        mass.players.all_players(False, False),
+                        mass.players.all_players(
+                            False,
+                            False,
+                            exclude_hidden=True,
+                            keep_player_ids=cast("str | None", saved_player_id),
+                        ),
                         key=lambda p: p.display_name.lower(),
                     )
                 ],

--- a/music_assistant/providers/plex_connect/__init__.py
+++ b/music_assistant/providers/plex_connect/__init__.py
@@ -49,7 +49,7 @@ async def setup(
 
 async def get_config_entries(
     mass: MusicAssistant,
-    instance_id: str | None = None,  # noqa: ARG001
+    instance_id: str | None = None,
     action: str | None = None,  # noqa: ARG001
     values: dict[str, ConfigValueType] | None = None,
 ) -> tuple[ConfigEntry, ...]:
@@ -75,6 +75,12 @@ async def get_config_entries(
         if player := mass.players.get_player(player_id):
             player_name_default = player.display_name
 
+    saved_player_id = (
+        mass.config.get_raw_provider_config_value(instance_id, CONF_MASS_PLAYER_ID)
+        if instance_id
+        else None
+    )
+
     return (
         ConfigEntry(
             key=CONF_PLEX_PROVIDER_ID,
@@ -96,7 +102,13 @@ async def get_config_entries(
             options=[
                 ConfigValueOption(x.display_name, x.player_id)
                 for x in sorted(
-                    mass.players.all_players(False, False), key=lambda p: p.display_name.lower()
+                    mass.players.all_players(
+                        False,
+                        False,
+                        exclude_hidden=True,
+                        keep_player_ids=cast("str | None", saved_player_id),
+                    ),
+                    key=lambda p: p.display_name.lower(),
                 )
             ],
         ),

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -69,7 +69,7 @@ async def setup(
 
 async def get_config_entries(
     mass: MusicAssistant,
-    instance_id: str | None = None,  # noqa: ARG001
+    instance_id: str | None = None,
     action: str | None = None,  # noqa: ARG001
     values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
@@ -80,6 +80,11 @@ async def get_config_entries(
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
+    saved_player_id = (
+        mass.config.get_raw_provider_config_value(instance_id, CONF_MASS_PLAYER_ID)
+        if instance_id
+        else None
+    )
     return (
         CONF_ENTRY_WARN_PREVIEW,
         ConfigEntry(
@@ -98,7 +103,13 @@ async def get_config_entries(
                 *(
                     ConfigValueOption(x.display_name, x.player_id)
                     for x in sorted(
-                        mass.players.all_players(False, False), key=lambda p: p.display_name.lower()
+                        mass.players.all_players(
+                            False,
+                            False,
+                            exclude_hidden=True,
+                            keep_player_ids=cast("str | None", saved_player_id),
+                        ),
+                        key=lambda p: p.display_name.lower(),
                     )
                 ),
             ],

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -226,16 +226,23 @@ class SyncGroupPlayer(Player):
         values: dict[str, ConfigValueType] | None = None,
     ) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the given player (if any)."""
-        possible_players = sorted(
-            [
-                ConfigValueOption(x.display_name, x.player_id)
-                for x in self.mass.players.all_players(True, False)
-                if x.type != PlayerType.GROUP
-                and PlayerFeature.SET_MEMBERS in x.state.supported_features
-                and x.state.can_group_with
-            ],
-            key=lambda x: x.title,
-        )
+        saved_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, [])) or []
+        saved_filter = cast("list[str]", self.config.get_value(CONF_MEMBERS_FILTER, [])) or []
+
+        def _options(saved_ids: list[str]) -> list[ConfigValueOption]:
+            return sorted(
+                [
+                    ConfigValueOption(x.display_name, x.player_id)
+                    for x in self.mass.players.all_players(
+                        True, False, exclude_hidden=True, keep_player_ids=saved_ids
+                    )
+                    if x.type != PlayerType.GROUP
+                    and PlayerFeature.SET_MEMBERS in x.state.supported_features
+                    and x.state.can_group_with
+                ],
+                key=lambda x: x.title,
+            )
+
         entries: list[ConfigEntry] = [
             # syncgroup specific entries
             CONF_ENTRY_SGP_NOTE,
@@ -249,7 +256,7 @@ class SyncGroupPlayer(Player):
                 "These members will always be part of the group and can never be unjoined "
                 "from the group. ",
                 required=False,  # needed for dynamic members (which allows empty members list)
-                options=possible_players,
+                options=_options(saved_members),
             ),
             ConfigEntry(
                 key=CONF_DYNAMIC_GROUP_MEMBERS,
@@ -275,7 +282,7 @@ class SyncGroupPlayer(Player):
                 "is in this list to the group will be prevented.",
                 default_value=[],
                 required=False,
-                options=possible_players,
+                options=_options(saved_filter),
                 depends_on=CONF_DYNAMIC_GROUP_MEMBERS,
             ),
         ]

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -132,6 +132,7 @@ class UniversalGroupPlayer(Player):
         values: dict[str, ConfigValueType] | None = None,
     ) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the given player (if any)."""
+        saved_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, [])) or []
         return [
             # add universal group specific entries
             CONFIG_ENTRY_UGP_NOTE,
@@ -145,7 +146,9 @@ class UniversalGroupPlayer(Player):
                 required=False,  # needed for dynamic members (which allows empty members list)
                 options=[
                     ConfigValueOption(x.display_name, x.player_id)
-                    for x in self.mass.players.all_players(True, False)
+                    for x in self.mass.players.all_players(
+                        True, False, exclude_hidden=True, keep_player_ids=saved_members
+                    )
                     if x.type != PlayerType.GROUP
                 ],
             ),

--- a/music_assistant/providers/yandex_smarthome/__init__.py
+++ b/music_assistant/providers/yandex_smarthome/__init__.py
@@ -218,10 +218,16 @@ async def get_config_entries(
         direct_auth_url = f"{ma_base_url}{DIRECT_AUTH_BASE_PATH}/authorize"
         direct_token_url = f"{ma_base_url}{DIRECT_AUTH_BASE_PATH}/token"
 
-    # Build player options for exposed players filter
+    # Build player options for exposed players filter.
+    raw_saved = (
+        mass.config.get_raw_provider_config_value(instance_id, CONF_EXPOSED_PLAYERS)
+        if instance_id
+        else None
+    )
+    keep_ids = [str(v) for v in raw_saved] if isinstance(raw_saved, list) else []
     player_options: list[ConfigValueOption] = []
     try:
-        for player in mass.players.all_players():
+        for player in mass.players.all_players(exclude_hidden=True, keep_player_ids=keep_ids):
             state = player.state
             player_options.append(
                 ConfigValueOption(title=state.name or state.player_id, value=state.player_id)


### PR DESCRIPTION
Following on from this https://github.com/music-assistant/frontend/pull/1711

The "Hide in UI" setting was only loosely applied: a few server-rendered config pickers (sync-group / universal-group members, members filter, plus several provider connectors) still listed hidden players as candidates. This PR finishes the coverage so hidden players are filtered from every player picker, while still appearing if they're already the saved selection (so existing group members / connector targets remain visible and changeable). The filter is centralized as two new kwargs on `PlayerController.all_players` (`exclude_hidden, keep_player_ids`) so each call site is just one line.