### PR TITLE
Update MASS_LOGO_ONLINE URL to raw GitHub link

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -216,7 +216,7 @@ DEFAULT_GENRES: Final[tuple[str, ...]] = tuple(entry["genre"] for entry in DEFAU
 
 # all other
 MASS_LOGO_ONLINE: Final[str] = (
-    "https://github.com/music-assistant/server/blob/dev/music_assistant/logo.png"
+    "https://raw.githubusercontent.com/music-assistant/server/refs/heads/dev/music_assistant/logo.png"
 )
 ENCRYPT_SUFFIX = "_encrypted_"
 CONFIGURABLE_CORE_CONTROLLERS = (


### PR DESCRIPTION
Forwarding the github url as a fallback logo for music will result in an invalid preview image.

before:
<img width="1001" height="1257" alt="image" src="https://github.com/user-attachments/assets/7ac1c941-94a6-48d1-a2ea-a7f0644bf1ec" />

after:
<img width="991" height="903" alt="image" src="https://github.com/user-attachments/assets/e9e3b93b-da1a-45a1-8243-cb4af17f26cd" />
