### PR TITLE
WiiM: Set the default max sample rate to 96kHz

### DIFF
--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -126,7 +126,7 @@ class WiimPlayer(Player):
         return [
             create_sample_rates_config_entry(
                 max_sample_rate=192000,
-                safe_max_sample_rate=192000,
+                safe_max_sample_rate=96000,
                 max_bit_depth=24,
                 safe_max_bit_depth=24,
             ),


### PR DESCRIPTION
I was seeing weird bugs with 192kHz where tracks would restart from the beginning every ~52 seconds. After doing a bunch of debugging, dropping the sample rate "fixed" it. By not dropping the max_sample_rate we allow for testing (presumably against a newer version of either the WiiM python library or against newer firmware versions of the players themselves) and for people to use if they want to. 96kHz is a reasonable default anyway, for the vast majority of people.