### PR TITLE
Bump wiim SDK to 0.1.4 to fix track transition tracking

### DIFF
--- a/music_assistant/providers/wiim/manifest.json
+++ b/music_assistant/providers/wiim/manifest.json
@@ -5,7 +5,7 @@
   "name": "WiiM",
   "description": "Stream music to WiiM devices.",
   "codeowners": ["@davidanthoff", "@music-assistant"],
-  "requirements": ["wiim==0.1.1"],
+  "requirements": ["wiim==0.1.4"],
   "documentation": "https://music-assistant.io/player-support/wiim/",
   "mdns_discovery": ["_linkplay._tcp.local."]
 }

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -247,11 +247,13 @@ class WiimPlayer(Player):
         """Handle SET_MEMBERS command on the player."""
         try:
             if player_ids_to_add:
-                for member_id in player_ids_to_add:
-                    if member := self.mass.players.get_player(member_id):
-                        await self._wiim_controller.async_join_group(
-                            self.device.udn, cast("WiimPlayer", member).device.udn
-                        )
+                follower_udns = [
+                    cast("WiimPlayer", member).device.udn
+                    for member_id in player_ids_to_add
+                    if (member := self.mass.players.get_player(member_id))
+                ]
+                if follower_udns:
+                    await self._wiim_controller.async_join_group(self.device.udn, follower_udns)
 
             if player_ids_to_remove:
                 for member_id in player_ids_to_remove:
@@ -347,7 +349,8 @@ class WiimPlayer(Player):
         ]
 
         # Active source detection
-        device_uri = self.device.current_track_uri or ""
+        media = self.device.current_media
+        device_uri = media.uri if media and media.uri else ""
         play_mode = self.device.play_mode
         if play_mode and play_mode != SOURCE_NETWORK and play_mode in INPUT_MODE_SOURCES:
             self._attr_active_source = INPUT_MODE_SOURCES[play_mode].id
@@ -362,7 +365,7 @@ class WiimPlayer(Player):
             self._attr_active_source = None
 
         # Sync current_media from device state
-        if self._attr_active_source is not None and (media := self.device.current_media):
+        if self._attr_active_source is not None and media:
             self.set_current_media(
                 uri=media.uri or "",
                 title=media.title,
@@ -392,9 +395,8 @@ class WiimPlayer(Player):
         except (WiimDeviceException, WiimRequestException) as err:
             self.logger.debug("Failed to sync position for %s: %s", self._attr_name, err)
             return
-        device_pos = self.device.current_position
-        if device_pos is not None:
-            self._attr_elapsed_time = device_pos
+        if (media := self.device.current_media) is not None and media.position is not None:
+            self._attr_elapsed_time = media.position
             self._attr_elapsed_time_last_updated = time.time()
         self._update_ma_state_from_sdk_cache()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -86,7 +86,7 @@ torchaudio==2.11.0; sys_platform != 'linux' or platform_machine != 'x86_64'
 unidecode==1.4.0
 uv>=0.8.0
 websocket-client==1.9.0
-wiim==0.1.1
+wiim==0.1.4
 xmltodict==1.0.4
 ya-passport-auth==1.3.0
 yandex-music==2.2.0

--- a/tests/providers/wiim/test_player.py
+++ b/tests/providers/wiim/test_player.py
@@ -21,10 +21,7 @@ def mock_wiim_device() -> MagicMock:
     device.is_muted = False
     device.playing_status = None
     device.play_mode = None
-    device.current_track_uri = None
     device.current_media = None
-    device.current_position = 0
-    device.current_track_duration = 0
     device.model_name = "WiiM Pro"
     device.manufacturer = "Linkplay"
     device.firmware_version = "4.8.1"


### PR DESCRIPTION
The 0.1.1 SDK silently drops AVTransport metadata events whose payload is JSON rather than escaped XML DIDL — it logs "is raw XML in event", fails to parse, and writes current_track_info["uri"] = None. This makes device.current_media.uri stale after the WiiM auto-advances on SetNextAVTransportURI, which in turn prevents Music Assistant's queue tracker from advancing current_index past the first track.

0.1.4 includes 0bfa84c ("Add grouping support and fix metadata parsing"), which detects JSON payloads and adds a trackURIs[0] -> res fallback, so transitions populate current_track_info correctly.

0.1.4 also drops the public current_track_uri / current_position / current_track_duration / current_track_info attributes (12d058f) and changes async_join_group to take list[str] instead of a single UDN. This commit updates the provider for the new API:

- Read URI/position via device.current_media.uri / .position
- Batch follower UDNs into a single async_join_group call
- Drop the now-irrelevant attribute fixtures from the test mock