### PR TITLE
Maintenance: sort provider dirs in gen_requirements_all for deterministic output

### DIFF
--- a/scripts/gen_requirements_all.py
+++ b/scripts/gen_requirements_all.py
@@ -67,7 +67,7 @@ def gather_requirements_from_manifests() -> list[str]:
     """Gather all of the requirements from provider manifests."""
     dependencies: list[str] = []
     providers_path = "music_assistant/providers"
-    for dir_str in os.listdir(providers_path):  # noqa: PTH208, RUF100
+    for dir_str in sorted(os.listdir(providers_path)):  # noqa: PTH208, RUF100
         dir_path = os.path.join(providers_path, dir_str)
         if not os.path.isdir(dir_path):
             continue


### PR DESCRIPTION
## Summary

`scripts/gen_requirements_all.py` iterates `os.listdir("music_assistant/providers")` to gather provider manifest requirements. `os.listdir()` returns entries in filesystem-dependent order — inode order on Linux ext4, alphabetic on macOS APFS, etc.

This becomes observable when two providers declare different versions of the same package: the iteration order decides which version wins in `requirements_all.txt`, so the generated file differs across machines and even between successive CI runs on the same machine (inode order can shift after unrelated file changes).

We hit this on PRs that share a runtime dependency between two providers — the lint hook regenerated `requirements_all.txt` to a different shape than what was committed, with the "winning" version flipping between runs.

The fix is a one-line change: wrap the outer `os.listdir` in `sorted()`. Logic is unchanged; only the iteration order becomes stable.

## Notes

- The inner `os.listdir(dir_path)` is left as-is — it only looks for a single `manifest.json` per provider, so order has no effect.
- For repos without conflicting duplicates (the current state of `dev`), regenerating produces no diff to `requirements_all.txt`. This PR contains only the script change.
- For repos that do have conflicts, the alphabetically-first provider's version will consistently win after this change, instead of the inode-first provider.
- Closes the `# TODO: compare versions and only store most recent` partially (makes the choice deterministic; "pick the highest version" is still a separate, opinionated change).

## Test plan

- [x] Verified locally on macOS that `python -m scripts.gen_requirements_all` produces identical `requirements_all.txt` before/after the change on `dev` (no conflicting duplicates currently).
- [ ] CI lint job passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)