### PR TITLE
Throttle torch to max 25% of CPU to prevent spikes during analysis

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -76,7 +76,7 @@ class AudioAnalysisController:
         with contextlib.suppress(RuntimeError):
             # set_num_interop_threads can only be called before the first torch op
             torch.set_num_interop_threads(1)
-        self.logger.debug(
+        self.logger.info(
             "AudioAnalysis thread caps: torch intra=%d, torch interop=%d",
             torch.get_num_threads(),
             torch.get_num_interop_threads(),
@@ -557,4 +557,4 @@ class AudioAnalysisController:
 
     def _aa_thread_budget(self) -> int:
         """Return the per-op PyTorch intra-op thread budget for inference (~25% of cpu_count)."""
-        return max(1, (os.cpu_count() or 4) // 2)
+        return max(1, (os.cpu_count() or 4) // 4)

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -70,7 +70,7 @@ class AudioAnalysisController:
         )
 
     def _configure_thread_caps(self) -> None:
-        """Cap PyTorch threading so Audio Analysis inference stays around half of cpu_count."""
+        """Cap PyTorch threading so Audio Analysis inference stays around a quarter of cpu_count."""
         budget = self._aa_thread_budget()
         torch.set_num_threads(budget)
         with contextlib.suppress(RuntimeError):

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -556,5 +556,5 @@ class AudioAnalysisController:
                     break
 
     def _aa_thread_budget(self) -> int:
-        """Return the per-op PyTorch intra-op thread budget for inference (~half of cpu_count)."""
+        """Return the per-op PyTorch intra-op thread budget for inference (~25% of cpu_count)."""
         return max(1, (os.cpu_count() or 4) // 2)

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 from math import inf
 from typing import TYPE_CHECKING
 
+import torch
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import MediaType, ProviderType, StreamType
 
@@ -56,7 +58,8 @@ class AudioAnalysisController:
         self._workers: dict[str, asyncio.Task[None]] = {}
 
     def setup(self) -> None:
-        """Register the nightly background scan task."""
+        """Register the nightly background scan task and apply CPU caps."""
+        self._configure_thread_caps()
         utc_hour, utc_minute = local_clock_time_to_utc(0, 0)
         self.mass.tasks.register_scheduled_task(
             task_id=BACKGROUND_SCAN_TASK_ID,
@@ -64,6 +67,19 @@ class AudioAnalysisController:
             handler=self._run_background_scan,
             schedule=TaskSchedule.daily(hour=utc_hour, minute=utc_minute),
             metadata={"task_domain": "audio_analysis"},
+        )
+
+    def _configure_thread_caps(self) -> None:
+        """Cap PyTorch threading so Audio Analysis inference stays around half of cpu_count."""
+        budget = self._aa_thread_budget()
+        torch.set_num_threads(budget)
+        with contextlib.suppress(RuntimeError):
+            # set_num_interop_threads can only be called before the first torch op
+            torch.set_num_interop_threads(1)
+        self.logger.debug(
+            "AudioAnalysis thread caps: torch intra=%d, torch interop=%d",
+            torch.get_num_threads(),
+            torch.get_num_interop_threads(),
         )
 
     @property
@@ -538,3 +554,7 @@ class AudioAnalysisController:
                     self._active_sessions.pop(session_key, None)
                     self._workers.pop(session_key, None)
                     break
+
+    def _aa_thread_budget(self) -> int:
+        """Return the per-op PyTorch intra-op thread budget for inference (~half of cpu_count)."""
+        return max(1, (os.cpu_count() or 4) // 2)

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -557,4 +557,4 @@ class AudioAnalysisController:
 
     def _aa_thread_budget(self) -> int:
         """Return the per-op PyTorch intra-op thread budget for inference (~25% of cpu_count)."""
-        return max(1, (os.cpu_count() or 4) // 4)
+        return max(1, (os.process_cpu_count() or os.cpu_count() or 4) // 4)

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import platform
 import time
 from dataclasses import dataclass, field
@@ -85,7 +84,6 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
     def _initialize_models(self) -> tuple[Any, ...]:
         """Initialize ML models (runs in a thread to avoid blocking the event loop)."""
-        torch.set_num_threads(max(1, (os.cpu_count() or 4) // 2))
         beat_this_model = Spect2Frames(checkpoint_path="small0", device=self._device)
         # torch aarch64 wheels advertise fbgemm in supported_engines but its kernels are x86-only.
         is_arm = platform.machine().lower() in ("arm64", "aarch64", "armv8l", "armv7l")

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -217,12 +217,11 @@ class SmartFadesProvider(AudioAnalysisProvider):
             data.musical_key_feature_blocks.clear()
 
         # Run beat and key inference sequentially to keep peak CPU bounded.
-        key, mode = await asyncio.to_thread(self._infer_musical_key, all_vqt)
         beats, downbeats = await asyncio.to_thread(self._infer_beat_timings, feats)
-
         if len(beats) < 2:
             self.logger.debug("Not enough beats detected, skipping storage")
             return
+        key, mode = await asyncio.to_thread(self._infer_musical_key, all_vqt)
 
         bpm = calculate_overall_bpm(beats)
 

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -216,10 +216,9 @@ class SmartFadesProvider(AudioAnalysisProvider):
             all_vqt = torch.cat(data.musical_key_feature_blocks, dim=-1)  # (1, 1, 84, T_total)
             data.musical_key_feature_blocks.clear()
 
-        # Run beat and key inference concurrently in separate threads
-        beat_task = asyncio.to_thread(self._infer_beat_timings, feats)
-        key_task = asyncio.to_thread(self._infer_musical_key, all_vqt)
-        (beats, downbeats), (key, mode) = await asyncio.gather(beat_task, key_task)
+        # Run beat and key inference sequentially to keep peak CPU bounded.
+        key, mode = await asyncio.to_thread(self._infer_musical_key, all_vqt)
+        beats, downbeats = await asyncio.to_thread(self._infer_beat_timings, feats)
 
         if len(beats) < 2:
             self.logger.debug("Not enough beats detected, skipping storage")


### PR DESCRIPTION
This PR throttles `torch` to only use max ~25% of available CPU to prevent huge CPU spikes during model inference. 

New load on a HA yellow during beat analysis:
<img width="680" height="402" alt="image" src="https://github.com/user-attachments/assets/e639bb75-de24-4712-bc3a-3eb231999d99" />
