### PR TITLE
Decrease buffer warmup duration to 8s

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -112,6 +112,9 @@ if TYPE_CHECKING:
 
 # ruff: noqa: PLR0915
 
+# Seconds of PCM yielded directly to the player before the crossfade holdback starts buffering.
+WARMUP_DURATION = 8
+
 
 @dataclass
 class CrossfadeData:
@@ -1499,9 +1502,9 @@ class StreamsAudio:
             discard_seconds = streamdetails.seek_position
             discard_leftover = 0
 
-        # Yield the first crossfade_buffer_size worth of audio immediately
-        # so playback starts right away. Only after that, start accumulating
-        # the crossfade holdback buffer for the end-of-track crossfade.
+        # Yield the first WARMUP_DURATION worth of audio immediately so playback starts
+        # right away. After that, start accumulating the crossfade holdback buffer.
+        warmup_size = int(pcm_format.pcm_sample_size * WARMUP_DURATION)
         warmup_bytes = 0
         total_chunks_received = 0
         async for chunk in self.get_queue_item_stream(
@@ -1515,7 +1518,7 @@ class StreamsAudio:
                 chunk = chunk[discard_leftover:]  # noqa: PLW2901
                 discard_leftover = 0
 
-            if warmup_bytes < crossfade_buffer_size:
+            if warmup_bytes < warmup_size:
                 # warmup: yield directly, don't buffer
                 yield chunk
                 warmup_bytes += len(chunk)
@@ -1823,6 +1826,7 @@ class StreamsAudio:
             crossfade_buffer_size = int(pcm_format.pcm_sample_size * crossfade_buffer_duration)
             # Round down to nearest frame boundary
             crossfade_buffer_size = (crossfade_buffer_size // frame_size) * frame_size
+            warmup_size = int(pcm_format.pcm_sample_size * WARMUP_DURATION)
 
             bytes_written = 0
             crossfade_buffer = b""
@@ -1863,12 +1867,11 @@ class StreamsAudio:
                     del chunk
                     continue
 
-                # Warmup: yield chunks directly until we have streamed
-                # crossfade_buffer_size worth of audio, so playback starts
-                # immediately instead of waiting for the full buffer to fill.
-                # Skip warmup when crossfade data from the previous track
-                # is pending, as we need a full buffer for the mix.
-                if warmup_bytes < crossfade_buffer_size and not last_fadeout_part:
+                # Warmup: yield chunks directly until we have streamed WARMUP_DURATION
+                # worth of audio, so playback starts immediately. Skip warmup when
+                # crossfade data from the previous track is pending — we need a full
+                # buffer for the mix.
+                if warmup_bytes < warmup_size and not last_fadeout_part:
                     yield chunk
                     warmup_bytes += len(chunk)
                     bytes_written += len(chunk)


### PR DESCRIPTION
This PR decreases the warmup duration from 45s (crossfade duration) to 8s. This should be enough for slow sources to fill the crossfade buffer.

This prevents smart fades from being skipped when seeking towards the end of the song. Note, a smart fade is still cut short when seeking within 45s (crossfade buffer) + 8s (warmup duration) before the track ends.