### PR TITLE
Fix Spotify playlists failing when track count is a multiple of 50

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -606,20 +606,27 @@ class SpotifyProvider(MusicProvider):
         page_size = 50
         offset = page * page_size
 
-        # Get etag for caching
-        cache_checksum = await self._get_etag(uri, limit=1, offset=0, use_global_session=use_global)
+        meta = await self._get_paginated_meta(uri, limit=1, offset=0, use_global_session=use_global)
+        cache_checksum = meta["etag"]
+        total = meta["total"]
+
+        # Spotify has started returning 5xx for offset >= total on some
+        # playlists (notably algorithmic ones like Daily Mix). The retry
+        # storm that follows surfaces as "No playable items found".
+        if total and offset >= total:
+            return result
 
         spotify_result = await self._get_data_with_caching(
             uri, cache_checksum, limit=page_size, offset=offset, use_global_session=use_global
         )
-        total = spotify_result.get("total", 0)
+        page_total = spotify_result.get("total", total)
         items = spotify_result.get("items", [])
         # playlists/{id}/items is transitioning from item["track"] to item["item"]
         # during Spotify's Feb 2026 rollout, so accept either shape.
         for index, item in enumerate(items, 1):
             # Spotify wraps/recycles items for offsets beyond the playlist size,
             # so we need to break when we've reached the total.
-            if (offset + index) > total:
+            if page_total and (offset + index) > page_total:
                 break
             track_data = item and (item.get("item") or item.get("track"))
             if not (track_data and track_data.get("id")):
@@ -1126,9 +1133,15 @@ class SpotifyProvider(MusicProvider):
         """Get all items from a paged list."""
         limit = 50
         offset = 0
-        # do single request to get the etag (which we use as checksum for caching)
-        cache_checksum = await self._get_etag(endpoint, limit=1, offset=0, **kwargs)
+        # single request to fetch the etag (used as cache checksum) and total
+        meta = await self._get_paginated_meta(endpoint, limit=1, offset=0, **kwargs)
+        cache_checksum = meta["etag"]
+        total = meta["total"]
         while True:
+            # Avoid requesting beyond the known end. Spotify can return 5xx
+            # for offset >= total on some endpoints (e.g. algorithmic playlists).
+            if total and offset >= total:
+                break
             result = await self._get_data_with_caching(
                 endpoint, cache_checksum=cache_checksum, limit=limit, offset=offset, **kwargs
             )
@@ -1158,11 +1171,11 @@ class SpotifyProvider(MusicProvider):
         )
         return result
 
-    @use_cache(120, allow_bypass=False)  # short cache for etags (subsequent calls use cached data)
-    async def _get_etag(self, endpoint: str, **kwargs: Any) -> str | None:
-        """Get etag for api endpoint."""
+    @use_cache(120, allow_bypass=False)  # short cache: subsequent calls reuse cached data
+    async def _get_paginated_meta(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        """Get etag and total item count for a paginated api endpoint."""
         _res = await self._get_data(endpoint, **kwargs)
-        return _res.get("etag")
+        return {"etag": _res.get("etag"), "total": _res.get("total", 0)}
 
     @throttle_with_retries
     async def _get_data(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -606,9 +606,9 @@ class SpotifyProvider(MusicProvider):
         page_size = 50
         offset = page * page_size
 
-        meta = await self._get_etag(uri, limit=1, offset=0, use_global_session=use_global)
-        cache_checksum = meta["etag"]
-        total = meta["total"]
+        # Get etag for caching
+        cache_checksum = await self._get_etag(uri, limit=1, offset=0, use_global_session=use_global)
+        total = await self._get_total(uri, limit=1, offset=0, use_global_session=use_global)
 
         # Spotify has started returning 5xx for offset >= total on some
         # playlists (notably algorithmic ones like Daily Mix). The retry
@@ -619,7 +619,7 @@ class SpotifyProvider(MusicProvider):
         spotify_result = await self._get_data_with_caching(
             uri, cache_checksum, limit=page_size, offset=offset, use_global_session=use_global
         )
-        total = spotify_result.get("total", total)
+        total = spotify_result.get("total", 0)
         items = spotify_result.get("items", [])
         # playlists/{id}/items is transitioning from item["track"] to item["item"]
         # during Spotify's Feb 2026 rollout, so accept either shape.
@@ -1133,10 +1133,9 @@ class SpotifyProvider(MusicProvider):
         """Get all items from a paged list."""
         limit = 50
         offset = 0
-        # single request to fetch the etag (used as cache checksum) and total
-        meta = await self._get_etag(endpoint, limit=1, offset=0, **kwargs)
-        cache_checksum = meta["etag"]
-        total = meta["total"]
+        # do single request to get the etag (which we use as checksum for caching)
+        cache_checksum = await self._get_etag(endpoint, limit=1, offset=0, **kwargs)
+        total = await self._get_total(endpoint, limit=1, offset=0, **kwargs)
         while True:
             # Avoid requesting beyond the known end. Spotify can return 5xx
             # for offset >= total on some endpoints (e.g. algorithmic playlists).
@@ -1171,11 +1170,17 @@ class SpotifyProvider(MusicProvider):
         )
         return result
 
-    @use_cache(120, allow_bypass=False)  # short cache: subsequent calls reuse cached data
-    async def _get_etag(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
-        """Get etag and total item count for a paginated api endpoint."""
+    @use_cache(120, allow_bypass=False)  # short cache for etags (subsequent calls use cached data)
+    async def _get_etag(self, endpoint: str, **kwargs: Any) -> str | None:
+        """Get etag for api endpoint."""
         _res = await self._get_data(endpoint, **kwargs)
-        return {"etag": _res.get("etag"), "total": _res.get("total", 0)}
+        return _res.get("etag")
+
+    @use_cache(120, allow_bypass=False)  # short cache for totals (subsequent calls use cached data)
+    async def _get_total(self, endpoint: str, **kwargs: Any) -> int:
+        """Get total item count for paginated api endpoint."""
+        _res = await self._get_data(endpoint, **kwargs)
+        return _res.get("total", 0)
 
     @throttle_with_retries
     async def _get_data(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -619,14 +619,14 @@ class SpotifyProvider(MusicProvider):
         spotify_result = await self._get_data_with_caching(
             uri, cache_checksum, limit=page_size, offset=offset, use_global_session=use_global
         )
-        page_total = spotify_result.get("total", total)
+        total = spotify_result.get("total", total)
         items = spotify_result.get("items", [])
         # playlists/{id}/items is transitioning from item["track"] to item["item"]
         # during Spotify's Feb 2026 rollout, so accept either shape.
         for index, item in enumerate(items, 1):
             # Spotify wraps/recycles items for offsets beyond the playlist size,
             # so we need to break when we've reached the total.
-            if page_total and (offset + index) > page_total:
+            if (offset + index) > total:
                 break
             track_data = item and (item.get("item") or item.get("track"))
             if not (track_data and track_data.get("id")):

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -606,7 +606,7 @@ class SpotifyProvider(MusicProvider):
         page_size = 50
         offset = page * page_size
 
-        meta = await self._get_paginated_meta(uri, limit=1, offset=0, use_global_session=use_global)
+        meta = await self._get_etag(uri, limit=1, offset=0, use_global_session=use_global)
         cache_checksum = meta["etag"]
         total = meta["total"]
 
@@ -1134,7 +1134,7 @@ class SpotifyProvider(MusicProvider):
         limit = 50
         offset = 0
         # single request to fetch the etag (used as cache checksum) and total
-        meta = await self._get_paginated_meta(endpoint, limit=1, offset=0, **kwargs)
+        meta = await self._get_etag(endpoint, limit=1, offset=0, **kwargs)
         cache_checksum = meta["etag"]
         total = meta["total"]
         while True:
@@ -1172,7 +1172,7 @@ class SpotifyProvider(MusicProvider):
         return result
 
     @use_cache(120, allow_bypass=False)  # short cache: subsequent calls reuse cached data
-    async def _get_paginated_meta(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+    async def _get_etag(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """Get etag and total item count for a paginated api endpoint."""
         _res = await self._get_data(endpoint, **kwargs)
         return {"etag": _res.get("etag"), "total": _res.get("total", 0)}

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -607,9 +607,7 @@ class SpotifyProvider(MusicProvider):
         page_size = 50
         offset = page * page_size
 
-        meta = await self._get_paginated_meta(
-            uri, limit=1, offset=0, use_global_session=use_global
-        )
+        meta = await self._get_paginated_meta(uri, limit=1, offset=0, use_global_session=use_global)
         cache_checksum = meta["etag"]
         total = meta["total"]
 

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -606,9 +606,11 @@ class SpotifyProvider(MusicProvider):
         page_size = 50
         offset = page * page_size
 
-        # Get etag for caching
-        cache_checksum = await self._get_etag(uri, limit=1, offset=0, use_global_session=use_global)
-        total = await self._get_total(uri, limit=1, offset=0, use_global_session=use_global)
+        meta = await self._get_paginated_meta(
+            uri, limit=1, offset=0, use_global_session=use_global
+        )
+        cache_checksum = meta["etag"]
+        total = meta["total"]
 
         # Spotify has started returning 5xx for offset >= total on some
         # playlists (notably algorithmic ones like Daily Mix). The retry
@@ -1133,9 +1135,10 @@ class SpotifyProvider(MusicProvider):
         """Get all items from a paged list."""
         limit = 50
         offset = 0
-        # do single request to get the etag (which we use as checksum for caching)
-        cache_checksum = await self._get_etag(endpoint, limit=1, offset=0, **kwargs)
-        total = await self._get_total(endpoint, limit=1, offset=0, **kwargs)
+        # single request to fetch the etag (used as cache checksum) and total
+        meta = await self._get_paginated_meta(endpoint, limit=1, offset=0, **kwargs)
+        cache_checksum = meta["etag"]
+        total = meta["total"]
         while True:
             # Avoid requesting beyond the known end. Spotify can return 5xx
             # for offset >= total on some endpoints (e.g. algorithmic playlists).
@@ -1170,17 +1173,11 @@ class SpotifyProvider(MusicProvider):
         )
         return result
 
-    @use_cache(120, allow_bypass=False)  # short cache for etags (subsequent calls use cached data)
-    async def _get_etag(self, endpoint: str, **kwargs: Any) -> str | None:
-        """Get etag for api endpoint."""
+    @use_cache(120, allow_bypass=False)  # short cache: subsequent calls reuse cached data
+    async def _get_paginated_meta(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        """Get etag and total item count for a paginated api endpoint."""
         _res = await self._get_data(endpoint, **kwargs)
-        return _res.get("etag")
-
-    @use_cache(120, allow_bypass=False)  # short cache for totals (subsequent calls use cached data)
-    async def _get_total(self, endpoint: str, **kwargs: Any) -> int:
-        """Get total item count for paginated api endpoint."""
-        _res = await self._get_data(endpoint, **kwargs)
-        return _res.get("total", 0)
+        return {"etag": _res.get("etag"), "total": _res.get("total", 0)}
 
     @throttle_with_retries
     async def _get_data(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:


### PR DESCRIPTION
## What's broken

Playlists with exactly N*50 tracks (notably all Daily Mix variants at 50 tracks) fail to play, with "No playable items found" in the UI. Discover Weekly and Release Radar (30 tracks each) still work, which is what masked the bug for a while.

## Why

`PlaylistController._get_provider_playlist_tracks` pages through `provider.get_playlist_tracks(page=N)` until it gets an empty page back. For a 50-track playlist, page 0 returns a full 50 items, so the controller asks for page 1 (offset=50). Spotify's API has started responding 5xx for `offset == total` instead of returning the documented empty items list. `@throttle_with_retries` then sleeps 30s, 5 times, before raising `RetriesExhausted`, which surfaces as "No playable items found".

Smaller playlists don't trip this because page 0 already returns < 50 items, so the controller loop stops on its own.

The failing log looks like:

```
DEBUG handling get data .../playlists/.../items with kwargs {'limit': 50, 'offset': 50, ...}
INFO  Attempt 1/5 failed: 
INFO  Retrying in 30.0 seconds...
```

(empty error body because the 5xx path raises `ResourceTemporarilyUnavailable(backoff_time=30)` with no message.)

## What the PR does

A single `_get_paginated_meta` probe (`limit=1`) returns both the etag (cache checksum) and the playlist total in one cached request. `get_playlist_tracks` now returns `[]` early when `offset >= total`, avoiding the page request that triggers Spotify's 5xx. The same guard is applied in `_get_all_items` so other paginated endpoints (`me/tracks`, `me/albums`, …) are covered when their total is an exact multiple of 50.

## How this was tested

Verified live by bind-mounting the patched `provider.py` into a running Music Assistant container, restarting, and playing different playlists from the UI:

- Daily Mix (50 tracks): plays, queue populates with all 50 tracks, no retry storm in the log, no `offset=50` request made.
- Larger playlists (more than 50 tracks): play fully, all pages fetched correctly, no retry storm.
- Discover Weekly / Release Radar (30 tracks): still works as before.

Static checks pass locally:

```
ruff check  -> All checks passed!
ruff format -> 1 file already formatted
mypy        -> Success: no issues found in 1 source file
```

This bug is also present in `stable`, so it's a candidate for `backport-to-stable`.

## Result

Playlist is loading properly and songs are playing after applying the fix.

<img width="1423" height="1170" alt="image" src="https://github.com/user-attachments/assets/d884ad80-1506-4509-a3d3-e9c69bca613b" />

## Related

- Reproduces the symptom reported in https://github.com/orgs/music-assistant/discussions/5304.
- The 5xx-at-`offset==total` behaviour matches what other Spotify API users have observed: https://community.spotify.com/t5/Spotify-for-Developers/Web-API-502-Bad-Gateway-for-top-items-endpoints-when-offset-and/td-p/5897842

## Not the same as

To avoid confusion with other recent Spotify-provider fixes:

- music-assistant/support#5114 / #4978 — the Feb 2026 `/playlists/{id}/tracks` → `/items` endpoint rename. Already fixed by #3436 and merged in `dev`. This PR sits on top of that change; without #3436, the failing request would be a 403 instead of a 5xx.
- music-assistant/support#5360 — Spotify catalog endpoints (artist albums, top tracks, search) returning empty for dev apps without Extended Quota. Different code paths (`get_artist_albums`, `get_artist_toptracks`), addressed in PR #3762.
