### PR TITLE
Revert "Remaintain jellyfin (#3528)"

### DIFF
--- a/music_assistant/providers/jellyfin/manifest.json
+++ b/music_assistant/providers/jellyfin/manifest.json
@@ -1,10 +1,10 @@
 {
   "type": "music",
   "domain": "jellyfin",
-  "stage": "stable",
+  "stage": "unmaintained",
   "name": "Jellyfin Media Server Library",
   "description": "Stream music from your self-hosted Jellyfin server.",
-  "codeowners": ["@lokiberra", "@Jc2k", "@staticdev"],
+  "codeowners": ["@lokiberra", "@Jc2k"],
   "credits": ["[aiojellyfin](https://github.com/Jc2k/aiojellyfin)"],
   "requirements": ["aiojellyfin==0.14.1"],
   "documentation": "https://music-assistant.io/music-providers/jellyfin/",


### PR DESCRIPTION
Reverts music-assistant/server#3528

After trying a month I had little to no progress improving the flaky behavior of Jellyfin with Music Assistant and decided to switch to Subsonic Media Server Library. Then I would like to step down from the maintenance of Jellyfin.

I underestimated the amount of work just to make it work properly, adding to the facts discussed in https://github.com/Jc2k/aiojellyfin/issues/8