### PR TITLE
Nicovideo: fix get_user_history kwargs to match niconico API

### DIFF
--- a/music_assistant/providers/nicovideo/services/user.py
+++ b/music_assistant/providers/nicovideo/services/user.py
@@ -108,9 +108,11 @@ class NicovideoUserService(NicovideoBaseService):
 
     async def get_user_history(self, limit: int = 30) -> list[Track]:
         """Get user's history from nicovideo."""
+        page_size = min(limit, 100)  # API max is 100
         history = await self.service_manager._call_with_throttler(
             self.niconico_py_client.video.get_history,
-            limit=min(limit, 100),  # API max is 100
+            page_size=page_size,
+            page=1,
         )
         if not history or not history.items:
             return []


### PR DESCRIPTION
I noticed when opening https://github.com/music-assistant/server/pull/3826 that mypy wasn't passing. Tracked it down to this.

The niconico library's video.get_history takes (*, page_size, page) — not `limit`. The previous call passed `limit=...`, which would TypeError at runtime and was failing repo-wide mypy.

Mirror the page_size/page conversion that get_like_history above already uses (limit -> page_size capped at 100, page=1).