### PR TITLE
Fix protocol recovery with missing cached parent

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -183,9 +183,10 @@ class ProtocolLinkingMixin:
             # Link was refused (domain already active on parent) - fall through
             return False
 
-        # Parent not registered yet - set parent and skip evaluation
-        protocol_player.set_protocol_parent_id(cached_parent_id)
-        return True
+        # Parent is not registered yet. Leave the protocol player unparented
+        # so the caller schedules delayed evaluation, which can wait for the
+        # cached parent without stranding the protocol player on a dangling id.
+        return False
 
     def _try_link_to_existing_player(self, protocol_player: Player, protocol_domain: str) -> bool:
         """

--- a/tests/core/test_protocol_linking.py
+++ b/tests/core/test_protocol_linking.py
@@ -967,10 +967,10 @@ class TestCachedProtocolParentRestore:
             for link in native_player.linked_output_protocols
         )
 
-    def test_protocol_parent_id_prevents_universal_player_creation(
+    def test_missing_cached_parent_schedules_protocol_evaluation(
         self, mock_mass: MagicMock
     ) -> None:
-        """Test that cached protocol_parent_id prevents creating universal player."""
+        """Test that a missing cached parent does not block delayed protocol evaluation."""
         controller = PlayerController(mock_mass)
 
         # Mock config to return cached parent_id (parent not yet registered)
@@ -993,13 +993,72 @@ class TestCachedProtocolParentRestore:
         # No native player registered yet
         controller._players = {}
 
-        # Try to link protocol - should set parent_id and skip evaluation
+        with patch.object(controller, "_schedule_protocol_evaluation") as mock_schedule:
+            controller._try_link_protocol_to_native(protocol_player)
+
+        # A cached parent that is not registered yet should be handled by the
+        # delayed evaluation path, not by assigning a dangling in-memory parent.
+        assert protocol_player.protocol_parent_id is None
+        mock_schedule.assert_called_once_with(protocol_player)
+
+    @pytest.mark.asyncio
+    async def test_cached_parent_registers_before_delayed_eval_links_without_universal(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Test cached parent startup grace still links when native registers during delay."""
+        controller = PlayerController(mock_mass)
+
+        def mock_config_get(
+            key: str, default: str | list[str] | None = None
+        ) -> str | list[str] | None:
+            if "protocol_parent_id" in str(key):
+                return "native_player_id"
+            return default
+
+        mock_mass.config.get.side_effect = mock_config_get
+
+        dlna_provider = MockProvider("dlna", mass=mock_mass)
+        protocol_player = MockPlayer(
+            dlna_provider,
+            "uuid:RINCON_AABBCCDDEEFF_MR",
+            "Sonos DLNA",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        protocol_player.set_initialized()
+        controller._players = {protocol_player.player_id: protocol_player}
+        controller._player_throttlers = {
+            protocol_player.player_id: Throttler(1, 0.05),
+        }
+
         controller._try_link_protocol_to_native(protocol_player)
 
-        # Verify protocol_parent_id was set
-        assert protocol_player.protocol_parent_id == "native_player_id"
+        assert protocol_player.protocol_parent_id is None
+        assert mock_mass.loop.call_later.call_args.args[0] == 45.0
 
-        # Since parent_id is set, delayed evaluation won't create a universal player
+        native_provider = MockProvider("sonos", mass=mock_mass)
+        native_player = MockPlayer(
+            native_provider,
+            "native_player_id",
+            "Sonos Speaker",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        native_player.set_initialized()
+        controller._players[native_player.player_id] = native_player
+        controller._player_throttlers[native_player.player_id] = Throttler(1, 0.05)
+
+        controller._try_link_protocols_to_native(native_player)
+
+        assert protocol_player.protocol_parent_id == native_player.player_id
+        assert any(
+            link.output_protocol_id == protocol_player.player_id
+            for link in native_player.linked_output_protocols
+        )
+
+        with patch.object(controller, "_create_or_update_universal_player") as mock_create_up:
+            await controller._delayed_protocol_evaluation(protocol_player.player_id)
+
+        mock_create_up.assert_not_called()
 
 
 class TestSelectBestOutputProtocol:


### PR DESCRIPTION
## Summary

Fix protocol player recovery when a cached `protocol_parent_id` points to a parent player that exists in config but is not currently registered.

Previously, `_try_restore_cached_parent` treated a missing cached parent as handled by assigning the cached id directly to the protocol player:

```py
protocol_player.set_protocol_parent_id(cached_parent_id)
return True
```

That made the protocol player look linked even though the parent was not present. Because delayed protocol evaluation exits early when `protocol_parent_id` is set, the protocol player could become stranded on a dangling parent id and never recover into a Universal Player.

This changes that missing-parent path to return `False` without setting `protocol_parent_id`, allowing the existing delayed evaluation scheduler to handle the cached-parent grace period.

## Bug

The problematic state is:

1. A protocol player has persisted config with `values.protocol_parent_id`.
2. The cached parent still has a config row, so startup stale-config cleanup does not clear it.
3. The protocol player registers before, or without, that parent registering.
4. MA sets the protocol player's in-memory `protocol_parent_id` to the missing parent id.
5. Delayed evaluation is skipped.
6. If the parent never appears, no Universal Player is created and the endpoint remains invisible/unusable as a regular player.

This can break groups that depend on the expected visible parent because the protocol endpoint exists, but there is no available output protocol on the parent/group path.

## Fix

Keep `protocol_parent_id` as an in-memory indication of a live parent link.

When a cached parent is not registered yet, leave the protocol player unparented and fall through. `_try_link_protocol_to_native` then schedules delayed protocol evaluation. The scheduler already has special handling for this case and waits 45 seconds when a cached parent exists but is not registered.

That preserves the original startup intent: give native providers time to register and avoid premature duplicate Universal Players. It just avoids representing a missing parent as an active link.

## Regression Coverage

Added tests for:

- Missing cached parent does not assign a dangling `protocol_parent_id`.
- Missing cached parent schedules delayed protocol evaluation.
- If the cached native parent registers during the 45s grace window, the protocol links to that native parent and delayed evaluation does not create a Universal Player.

Existing coverage still verifies immediate restore when the cached parent is already registered.

## Black-box Reproduction

I also reproduced this with local MA containers using only runtime/public surfaces.

Setup:

1. Start MA with persisted config containing:
   - protocol player: `uuid:RINCON_AABBCCDDEEFF_MR`
   - `values.protocol_parent_id: native_player_id`
2. Include a config row for `native_player_id` so startup stale-config cleanup does not remove the parent id.
3. Use a disposable player provider that registers only the protocol player.
4. Do not register `native_player_id`.
5. Query `/api` with `players/all`.

Before this fix, after waiting longer than the 45s recovery window:

```text
players/all(return_protocol_players=true):
- uuid:RINCON_AABBCCDDEEFF_MR (type=protocol)

players/all(return_protocol_players=false):
- []
```

No log line appeared for waiting on the cached parent, and no Universal Player was created.

With this fix:

```text
Protocol player uuid:RINCON_AABBCCDDEEFF_MR waiting for cached parent native_player_id (45s delay)
Creating universal player upuuidrincon_aabbccddeeff_mr with protocol players: ['uuid:RINCON_AABBCCDDEEFF_MR']
Player (type player) registered: upuuidrincon_aabbccddeeff_mr/Blackbox Protocol Player
```

After the delay:

```text
players/all(return_protocol_players=false):
- upuuidrincon_aabbccddeeff_mr (type=player)
  output_protocols:
  - uuid:RINCON_AABBCCDDEEFF_MR
```