### PR TITLE
Snapcast: Adopt orphaned snapserver streams on name collision instead of misreporting as no-free-port

### DIFF
--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -467,7 +467,10 @@ class SnapcastMAStream:
         if self._socket_server:
             await self._stop_socket_server()
 
-        msg = "Unable to create stream - No free port found?"
+        msg = (
+            f"Unable to register snapserver stream {self.stream_name!r} "
+            f"after 50 attempts"
+        )
         raise RuntimeError(msg)
 
     async def _remove_snap_source(self) -> None:

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -421,6 +421,17 @@ class SnapcastMAStream:
             self._streamer_task = self._mass.create_task(self._streamer_task_impl())
             self._streamer_task.add_done_callback(self._on_streamer_done)
 
+    def _find_local_stream_by_name(self, name: str):
+        """Look up a snapserver stream by its name (not id) in the local cache.
+
+        :param name: Stream name to look up.
+        :return: The matching SnapstreamProto, or None if not found.
+        """
+        for s in self._provider._snapserver.streams:
+            if getattr(s, "name", None) == name:
+                return s
+        return None
+
     @staticmethod
     def _is_name_collision_error(result: object) -> bool:
         """Detect snapserver's 'Stream with name X already exists' error.
@@ -471,14 +482,26 @@ class SnapcastMAStream:
                 f"&idle_threshold={self._provider._snapcast_stream_idle_threshold}"
                 f"{extra_args}&name={self.stream_name}"
             )
-            if result is None or "id" not in result:
-                # if the port is already taken, the result will be an error
-                self._logger.warning(result)
-                continue
-            ## Do we need to synchronize the snapserver repr first?
-            self.snap_stream = self._provider._snapserver.stream(result["id"])
-            self.snap_stream.set_callback(self._snap_on_stream_update)
-            return
+            if isinstance(result, dict) and "id" in result:
+                self.snap_stream = self._provider._snapserver.stream(result["id"])
+                self.snap_stream.set_callback(self._snap_on_stream_update)
+                return
+
+            if self._is_name_collision_error(result):
+                adopted = self._find_local_stream_by_name(self.stream_name)
+                if adopted is not None:
+                    self._logger.info(
+                        "Adopted orphaned snapserver stream %s (name=%s)",
+                        adopted.identifier,
+                        self.stream_name,
+                    )
+                    self.snap_stream = adopted
+                    self.snap_stream.set_callback(self._snap_on_stream_update)
+                    return
+
+            # if the port is already taken, the result will be an error
+            self._logger.warning(result)
+            continue
 
         if self._socket_server:
             await self._stop_socket_server()

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -421,6 +421,22 @@ class SnapcastMAStream:
             self._streamer_task = self._mass.create_task(self._streamer_task_impl())
             self._streamer_task.add_done_callback(self._on_streamer_done)
 
+    @staticmethod
+    def _is_name_collision_error(result: object) -> bool:
+        """Detect snapserver's 'Stream with name X already exists' error.
+
+        :param result: Result returned by snapserver.stream_add_stream.
+        :return: True if the result indicates a stream-name collision.
+        """
+        if not isinstance(result, dict):
+            return False
+        data = result.get("data", "")
+        return (
+            isinstance(data, str)
+            and data.startswith("Stream with name")
+            and "already exists" in data
+        )
+
     async def _register_tcp_server_source(self) -> None:
         """Create a Snapcast TCP source for this stream (or reuse an existing one)."""
         # prefer to reuse existing stream if possible

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -421,7 +421,7 @@ class SnapcastMAStream:
             self._streamer_task = self._mass.create_task(self._streamer_task_impl())
             self._streamer_task.add_done_callback(self._on_streamer_done)
 
-    def _find_local_stream_by_name(self, name: str):
+    def _find_local_stream_by_name(self, name: str) -> SnapstreamProto | None:
         """Look up a snapserver stream by its name (not id) in the local cache.
 
         :param name: Stream name to look up.
@@ -449,8 +449,9 @@ class SnapcastMAStream:
         )
 
     def _pick_port_avoiding(self, used: set[int]) -> int | None:
-        """Pick a random TCP source port within the unchanged upstream range,
-        avoiding ports already tried in the current retry loop.
+        """Pick a random TCP source port within the unchanged upstream range.
+
+        Avoids ports already tried in the current retry loop.
 
         :param used: Set of ports that should not be returned again.
         :return: A port in [4953, 5153] not in `used`, or None if none could be
@@ -528,10 +529,7 @@ class SnapcastMAStream:
         if self._socket_server:
             await self._stop_socket_server()
 
-        msg = (
-            f"Unable to register snapserver stream {self.stream_name!r} "
-            f"after 50 attempts"
-        )
+        msg = f"Unable to register snapserver stream {self.stream_name!r} after 50 attempts"
         raise RuntimeError(msg)
 
     async def _remove_snap_source(self) -> None:

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -490,48 +490,55 @@ class SnapcastMAStream:
 
         tried_ports: set[int] = set()
         attempts = 50
-        while attempts:
-            attempts -= 1
-            port = self._pick_port_avoiding(tried_ports)
-            if port is None:
-                break
-            tried_ports.add(port)
-            result = await self._provider._snapserver.stream_add_stream(
-                # NOTE: setting the sampleformat to something else
-                # (like 24 bits bit depth) does not seem to work at all!
-                f"tcp://0.0.0.0:{port}?sampleformat=48000:16:2"
-                f"&idle_threshold={self._provider._snapcast_stream_idle_threshold}"
-                f"{extra_args}&name={self.stream_name}"
-            )
-            if isinstance(result, dict) and "id" in result:
-                self.snap_stream = self._provider._snapserver.stream(result["id"])
-                self.snap_stream.set_callback(self._snap_on_stream_update)
-                return
-
-            if self._is_name_collision_error(result):
-                adopted = self._find_local_stream_by_name(self.stream_name)
-                if adopted is None:
-                    # Local cache may be stale (e.g. after an MA restart). Resync.
-                    status, _ = await self._provider._snapserver.status()
-                    if isinstance(status, dict):
-                        self._provider._snapserver.synchronize(status)
-                    adopted = self._find_local_stream_by_name(self.stream_name)
-                if adopted is not None:
-                    self._logger.info(
-                        "Adopted orphaned snapserver stream %s (name=%s)",
-                        adopted.identifier,
-                        self.stream_name,
-                    )
-                    self.snap_stream = adopted
+        loop_succeeded = False
+        try:
+            while attempts:
+                attempts -= 1
+                port = self._pick_port_avoiding(tried_ports)
+                if port is None:
+                    break
+                tried_ports.add(port)
+                result = await self._provider._snapserver.stream_add_stream(
+                    # NOTE: setting the sampleformat to something else
+                    # (like 24 bits bit depth) does not seem to work at all!
+                    f"tcp://0.0.0.0:{port}?sampleformat=48000:16:2"
+                    f"&idle_threshold={self._provider._snapcast_stream_idle_threshold}"
+                    f"{extra_args}&name={self.stream_name}"
+                )
+                if isinstance(result, dict) and "id" in result:
+                    self.snap_stream = self._provider._snapserver.stream(result["id"])
                     self.snap_stream.set_callback(self._snap_on_stream_update)
+                    loop_succeeded = True
                     return
 
-            # if the port is already taken, the result will be an error
-            self._logger.warning(result)
-            continue
+                if self._is_name_collision_error(result):
+                    adopted = self._find_local_stream_by_name(self.stream_name)
+                    if adopted is None:
+                        # Local cache may be stale (e.g. after an MA restart). Resync.
+                        status, _ = await self._provider._snapserver.status()
+                        if isinstance(status, dict):
+                            self._provider._snapserver.synchronize(status)
+                        adopted = self._find_local_stream_by_name(self.stream_name)
+                    if adopted is not None:
+                        self._logger.info(
+                            "Adopted orphaned snapserver stream %s (name=%s)",
+                            adopted.identifier,
+                            self.stream_name,
+                        )
+                        self.snap_stream = adopted
+                        self.snap_stream.set_callback(self._snap_on_stream_update)
+                        loop_succeeded = True
+                        return
 
-        if self._socket_server:
-            await self._stop_socket_server()
+                # if the port is already taken, the result will be an error
+                self._logger.warning(result)
+                continue
+        finally:
+            # Invariant: if we leave _register_tcp_server_source without setting
+            # self.snap_stream (retries exhausted OR exception during a retry),
+            # any socket_server we started must be stopped.
+            if not loop_succeeded and self._socket_server:
+                await self._stop_socket_server()
 
         msg = f"Unable to register snapserver stream {self.stream_name!r} after 50 attempts"
         raise RuntimeError(msg)

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -539,7 +539,7 @@ class SnapcastMAStream:
                     )
 
                 # if the port is already taken, the result will be an error
-                self._logger.warning(result)
+                self._logger.warning("stream_add_stream failed: %s", result)
                 continue
         finally:
             # Invariant: if we leave _register_tcp_server_source without setting

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -489,6 +489,12 @@ class SnapcastMAStream:
 
             if self._is_name_collision_error(result):
                 adopted = self._find_local_stream_by_name(self.stream_name)
+                if adopted is None:
+                    # Local cache may be stale (e.g. after an MA restart). Resync.
+                    status, _ = await self._provider._snapserver.status()
+                    if isinstance(status, dict):
+                        self._provider._snapserver.synchronize(status)
+                    adopted = self._find_local_stream_by_name(self.stream_name)
                 if adopted is not None:
                     self._logger.info(
                         "Adopted orphaned snapserver stream %s (name=%s)",

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -529,6 +529,14 @@ class SnapcastMAStream:
                         self.snap_stream.set_callback(self._snap_on_stream_update)
                         loop_succeeded = True
                         return
+                elif isinstance(result, dict) and result.get("code") == -32603:
+                    # Forward-compat hint: snapserver may rephrase the name-collision
+                    # error in a future release; surface mismatches in debug logs.
+                    self._logger.debug(
+                        "snapserver returned internal error not matching "
+                        "name-collision pattern: %s",
+                        result,
+                    )
 
                 # if the port is already taken, the result will be an error
                 self._logger.warning(result)

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -448,6 +448,20 @@ class SnapcastMAStream:
             and "already exists" in data
         )
 
+    def _pick_port_avoiding(self, used: set[int]) -> int | None:
+        """Pick a random TCP source port within the unchanged upstream range,
+        avoiding ports already tried in the current retry loop.
+
+        :param used: Set of ports that should not be returned again.
+        :return: A port in [4953, 5153] not in `used`, or None if none could be
+            found within 20 attempts (extremely rare; the range has 201 values).
+        """
+        for _ in range(20):
+            port = random.randint(4953, 4953 + 200)
+            if port not in used:
+                return port
+        return None
+
     async def _register_tcp_server_source(self) -> None:
         """Create a Snapcast TCP source for this stream (or reuse an existing one)."""
         # prefer to reuse existing stream if possible
@@ -469,12 +483,14 @@ class SnapcastMAStream:
                 f"--streamserver-port={self._mass.streams.publish_port}"
             )
 
+        tried_ports: set[int] = set()
         attempts = 50
         while attempts:
             attempts -= 1
-            # pick a random port
-            port = random.randint(4953, 4953 + 200)
-            ## Do we need to add a time out here?
+            port = self._pick_port_avoiding(tried_ports)
+            if port is None:
+                break
+            tried_ports.add(port)
             result = await self._provider._snapserver.stream_add_stream(
                 # NOTE: setting the sampleformat to something else
                 # (like 24 bits bit depth) does not seem to work at all!

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -422,7 +422,8 @@ class SnapcastMAStream:
             self._streamer_task.add_done_callback(self._on_streamer_done)
 
     def _find_local_stream_by_name(self, name: str) -> SnapstreamProto | None:
-        """Look up a snapserver stream by its name (not id) in the local cache.
+        """
+        Look up a snapserver stream by its name (not id) in the local cache.
 
         :param name: Stream name to look up.
         :return: The matching SnapstreamProto, or None if not found.
@@ -434,7 +435,8 @@ class SnapcastMAStream:
 
     @staticmethod
     def _is_name_collision_error(result: object) -> bool:
-        """Detect snapserver's 'Stream with name X already exists' error.
+        """
+        Detect snapserver's 'Stream with name X already exists' error.
 
         :param result: Result returned by snapserver.stream_add_stream.
         :return: True if the result indicates a stream-name collision.
@@ -449,7 +451,8 @@ class SnapcastMAStream:
         )
 
     def _pick_port_avoiding(self, used: set[int]) -> int | None:
-        """Pick a random TCP source port within the unchanged upstream range.
+        """
+        Pick a random TCP source port within the unchanged upstream range.
 
         Avoids ports already tried in the current retry loop.
 

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -465,6 +465,10 @@ class SnapcastMAStream:
 
     async def _register_tcp_server_source(self) -> None:
         """Create a Snapcast TCP source for this stream (or reuse an existing one)."""
+        # This runs under the per-stream `_lifecycle_lock` (acquired in setup()), not the
+        # provider-wide `_snapcast_ma_streams_lock`. Adoption is safe because each MA-managed
+        # stream has at most one outstanding setup() call at a time.
+
         # prefer to reuse existing stream if possible
         if self.snap_stream:
             return

--- a/tests/providers/snapcast/__init__.py
+++ b/tests/providers/snapcast/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Snapcast provider."""

--- a/tests/providers/snapcast/conftest.py
+++ b/tests/providers/snapcast/conftest.py
@@ -61,8 +61,8 @@ class FakeSnapserver:
             if sid not in self._streams_by_id:
                 self._streams_by_id[sid] = FakeSnapstream(sid, name=s.get("name", sid))
 
-    def _status_impl(self) -> tuple[dict[str, Any] | None, None]:
-        # status() in the real Snapserver returns (result, error)
+    async def _status_impl(self) -> tuple[Any, Any]:
+        # status() in the real Snapserver is async and returns (result, error)
         return (self._status_payload, None)
 
     async def _add_stream_impl(self, stream_uri: str) -> dict[str, Any]:

--- a/tests/providers/snapcast/conftest.py
+++ b/tests/providers/snapcast/conftest.py
@@ -11,45 +11,48 @@ import pytest
 class FakeSnapstream:
     """Minimal Snapstream stand-in for testing ma_stream._register_tcp_server_source."""
 
-    def __init__(self, identifier: str, name: str, path: str = ""):
+    def __init__(self, identifier: str, name: str, path: str = "") -> None:
+        """Initialize with stream identifier, name, and optional path."""
         self.identifier = identifier
         self.name = name
         self.path = path
         self._stream: dict[str, Any] = {"uri": {"host": "127.0.0.1"}}
         self._callback = None
 
-    def set_callback(self, cb):
+    def set_callback(self, cb: Any) -> None:
+        """Register a callback for stream events."""
         self._callback = cb
 
 
 class FakeSnapserver:
     """Configurable mock implementing the subset of SnapserverProto used by ma_stream."""
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize with empty stream registry and response queues."""
         # streams added via stream_add_stream are kept here keyed by id
         self._streams_by_id: dict[str, FakeSnapstream] = {}
         # responses to return for each call to stream_add_stream, in order
         # Each entry is a dict that looks like the snapserver result OR error payload.
-        self._add_stream_responses: list[dict] = []
+        self._add_stream_responses: list[dict[str, Any]] = []
         # Calls captured for assertions
         self.add_stream_calls: list[str] = []
 
         self.stream_add_stream = AsyncMock(side_effect=self._add_stream_impl)
         self.stream_remove_stream = AsyncMock()
         self.status = AsyncMock(side_effect=self._status_impl)
-        self._status_payload: dict | None = None
+        self._status_payload: dict[str, Any] | None = None
 
     @property
     def streams(self) -> list[FakeSnapstream]:
+        """Return all registered streams."""
         return list(self._streams_by_id.values())
 
     def stream(self, identifier: str) -> FakeSnapstream:
+        """Return the stream with the given identifier."""
         return self._streams_by_id[identifier]
 
-    def synchronize(self, status: dict) -> None:
+    def synchronize(self, status: dict[str, Any]) -> None:
         """Populate _streams_by_id from a status payload, simulating real Snapserver."""
-        if not isinstance(status, dict):
-            return
         streams = status.get("server", {}).get("streams", [])
         for s in streams:
             sid = s.get("id")
@@ -58,16 +61,20 @@ class FakeSnapserver:
             if sid not in self._streams_by_id:
                 self._streams_by_id[sid] = FakeSnapstream(sid, name=s.get("name", sid))
 
-    def _status_impl(self):
+    def _status_impl(self) -> tuple[dict[str, Any] | None, None]:
         # status() in the real Snapserver returns (result, error)
         return (self._status_payload, None)
 
-    async def _add_stream_impl(self, stream_uri: str):
+    async def _add_stream_impl(self, stream_uri: str) -> dict[str, Any]:
         self.add_stream_calls.append(stream_uri)
         if self._add_stream_responses:
             response = self._add_stream_responses.pop(0)
         else:
-            response = {"code": -32603, "data": "Generic snapserver error", "message": "Internal error"}
+            response = {
+                "code": -32603,
+                "data": "Generic snapserver error",
+                "message": "Internal error",
+            }
         # On a successful add, also register the stream in our internal store
         if isinstance(response, dict) and "id" in response:
             stream_id = response["id"]
@@ -76,19 +83,26 @@ class FakeSnapserver:
             self._streams_by_id[stream_id] = FakeSnapstream(stream_id, name, path=stream_uri)
         return response
 
-    def queue_response(self, response: dict) -> None:
+    def queue_response(self, response: dict[str, Any]) -> None:
         """Queue a response that the next stream_add_stream call will return."""
         self._add_stream_responses.append(response)
 
     def queue_success(self, stream_id: str = "stream-1") -> None:
+        """Queue a successful stream_add_stream response with the given stream id."""
         self.queue_response({"id": stream_id})
 
     def queue_name_collision(self) -> None:
+        """Queue a name-already-exists error response."""
         self.queue_response(
-            {"code": -32603, "data": 'Stream with name "x" already exists', "message": "Internal error"}
+            {
+                "code": -32603,
+                "data": 'Stream with name "x" already exists',
+                "message": "Internal error",
+            }
         )
 
     def queue_other_error(self, data: str = "bind: Address already in use") -> None:
+        """Queue a generic (non-name-collision) error response."""
         self.queue_response({"code": -32603, "data": data, "message": "Internal error"})
 
     def cache_stream_directly(self, stream_id: str, name: str) -> FakeSnapstream:

--- a/tests/providers/snapcast/conftest.py
+++ b/tests/providers/snapcast/conftest.py
@@ -1,0 +1,133 @@
+"""Fixtures for Snapcast provider tests."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class FakeSnapstream:
+    """Minimal Snapstream stand-in for testing ma_stream._register_tcp_server_source."""
+
+    def __init__(self, identifier: str, name: str, path: str = ""):
+        self.identifier = identifier
+        self.name = name
+        self.path = path
+        self._stream: dict[str, Any] = {"uri": {"host": "127.0.0.1"}}
+        self._callback = None
+
+    def set_callback(self, cb):
+        self._callback = cb
+
+
+class FakeSnapserver:
+    """Configurable mock implementing the subset of SnapserverProto used by ma_stream."""
+
+    def __init__(self):
+        # streams added via stream_add_stream are kept here keyed by id
+        self._streams_by_id: dict[str, FakeSnapstream] = {}
+        # responses to return for each call to stream_add_stream, in order
+        # Each entry is a dict that looks like the snapserver result OR error payload.
+        self._add_stream_responses: list[dict] = []
+        # Calls captured for assertions
+        self.add_stream_calls: list[str] = []
+
+        self.stream_add_stream = AsyncMock(side_effect=self._add_stream_impl)
+        self.stream_remove_stream = AsyncMock()
+        self.status = AsyncMock(side_effect=self._status_impl)
+        self._status_payload: dict | None = None
+
+    @property
+    def streams(self) -> list[FakeSnapstream]:
+        return list(self._streams_by_id.values())
+
+    def stream(self, identifier: str) -> FakeSnapstream:
+        return self._streams_by_id[identifier]
+
+    def synchronize(self, status: dict) -> None:
+        """Populate _streams_by_id from a status payload, simulating real Snapserver."""
+        if not isinstance(status, dict):
+            return
+        streams = status.get("server", {}).get("streams", [])
+        for s in streams:
+            sid = s.get("id")
+            if not sid:
+                continue
+            if sid not in self._streams_by_id:
+                self._streams_by_id[sid] = FakeSnapstream(sid, name=s.get("name", sid))
+
+    def _status_impl(self):
+        # status() in the real Snapserver returns (result, error)
+        return (self._status_payload, None)
+
+    async def _add_stream_impl(self, stream_uri: str):
+        self.add_stream_calls.append(stream_uri)
+        if self._add_stream_responses:
+            response = self._add_stream_responses.pop(0)
+        else:
+            response = {"code": -32603, "data": "Generic snapserver error", "message": "Internal error"}
+        # On a successful add, also register the stream in our internal store
+        if isinstance(response, dict) and "id" in response:
+            stream_id = response["id"]
+            # parse name= from uri for realism
+            name = stream_uri.split("&name=", 1)[1] if "&name=" in stream_uri else stream_id
+            self._streams_by_id[stream_id] = FakeSnapstream(stream_id, name, path=stream_uri)
+        return response
+
+    def queue_response(self, response: dict) -> None:
+        """Queue a response that the next stream_add_stream call will return."""
+        self._add_stream_responses.append(response)
+
+    def queue_success(self, stream_id: str = "stream-1") -> None:
+        self.queue_response({"id": stream_id})
+
+    def queue_name_collision(self) -> None:
+        self.queue_response(
+            {"code": -32603, "data": 'Stream with name "x" already exists', "message": "Internal error"}
+        )
+
+    def queue_other_error(self, data: str = "bind: Address already in use") -> None:
+        self.queue_response({"code": -32603, "data": data, "message": "Internal error"})
+
+    def cache_stream_directly(self, stream_id: str, name: str) -> FakeSnapstream:
+        """Pre-register a stream in the local cache (skipping the status round-trip).
+
+        Use this when the test wants the orphan to be visible WITHOUT requiring
+        adopt() to call status() + synchronize() first.
+        """
+        s = FakeSnapstream(stream_id, name)
+        self._streams_by_id[stream_id] = s
+        return s
+
+    def stage_orphan_stream(self, stream_id: str, name: str) -> None:
+        """Stage an orphan stream that only appears after .synchronize(.status()).
+
+        Use this when the test wants to verify that adopt() falls back to a
+        status-driven resync (the actual Bug B post-MA-restart scenario).
+        The stream is NOT in _streams_by_id until synchronize() is called.
+        """
+        self._status_payload = {
+            "server": {
+                "streams": [{"id": stream_id, "name": name}],
+                "groups": [],
+            }
+        }
+
+
+@pytest.fixture
+def fake_snapserver() -> FakeSnapserver:
+    """Provide a fresh FakeSnapserver for each test."""
+    return FakeSnapserver()
+
+
+@pytest.fixture
+def fake_provider(fake_snapserver: FakeSnapserver) -> MagicMock:
+    """Provide a minimal SnapCastProvider mock wired to fake_snapserver."""
+    provider = MagicMock()
+    provider._snapserver = fake_snapserver
+    provider._snapcast_stream_idle_threshold = 60000
+    provider._use_builtin_server = False
+    provider.logger = MagicMock()
+    return provider

--- a/tests/providers/snapcast/conftest.py
+++ b/tests/providers/snapcast/conftest.py
@@ -106,7 +106,8 @@ class FakeSnapserver:
         self.queue_response({"code": -32603, "data": data, "message": "Internal error"})
 
     def cache_stream_directly(self, stream_id: str, name: str) -> FakeSnapstream:
-        """Pre-register a stream in the local cache (skipping the status round-trip).
+        """
+        Pre-register a stream in the local cache (skipping the status round-trip).
 
         Use this when the test wants the orphan to be visible WITHOUT requiring
         adopt() to call status() + synchronize() first.
@@ -116,7 +117,8 @@ class FakeSnapserver:
         return s
 
     def stage_orphan_stream(self, stream_id: str, name: str) -> None:
-        """Stage an orphan stream that only appears after .synchronize(.status()).
+        """
+        Stage an orphan stream that only appears after .synchronize(.status()).
 
         Use this when the test wants to verify that adopt() falls back to a
         status-driven resync (the actual Bug B post-MA-restart scenario).

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -123,3 +123,29 @@ async def test_name_collision_with_local_stream_cached_adopts_it(
     assert stream.snap_stream.identifier == "orphan-id"
     # Adoption must NOT spend further retries
     assert len(fake_snapserver.add_stream_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_orphan_stream_after_ma_restart_gets_adopted_via_resync(
+    fake_provider, fake_snapserver: "FakeSnapserver"
+):
+    """Bug B core scenario: MA restarted while a stream was registered.
+
+    The local snapserver cache is empty, but the server still holds the orphan.
+    MA must call status() + synchronize() to re-discover it before adopting.
+    """
+    target_name = "Music Assistant - 590b15 (announcement)"
+    # Stream visible only via status(), NOT in the local cache yet
+    fake_snapserver.stage_orphan_stream("orphan-id", target_name)
+    fake_snapserver.queue_name_collision()
+
+    # Sanity: the local cache is empty before
+    assert fake_snapserver._streams_by_id == {}
+
+    stream = _make_stream(fake_provider, name=target_name)
+    await stream._register_tcp_server_source()
+
+    assert stream.snap_stream is not None
+    assert stream.snap_stream.identifier == "orphan-id"
+    # The status() round-trip must have happened
+    assert fake_snapserver.status.await_count >= 1

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
 def _make_stream(
     provider: MagicMock, name: str = "Music Assistant - testhash (announcement)"
 ) -> SnapcastMAStream:
-    """Build a SnapcastMAStream instance directly.
+    """
+    Build a SnapcastMAStream instance directly.
 
     Bypasses the constructor's media handling (we only test the snapserver
     source registration).
@@ -70,7 +71,8 @@ async def test_real_port_conflict_retries_with_different_port(
 async def test_all_attempts_exhausted_raises_with_honest_message(
     fake_provider: MagicMock, fake_snapserver: FakeSnapserver
 ) -> None:
-    """When all 50 retries fail the error must reference 'after retries' or similar.
+    """
+    When all 50 retries fail the error must reference 'after retries' or similar.
 
     Must NOT say 'No free port found' which lies about the cause.
     """
@@ -139,7 +141,8 @@ def test_is_name_collision_error_matches_only_specific_pattern(
 async def test_name_collision_with_local_stream_cached_adopts_it(
     fake_provider: MagicMock, fake_snapserver: FakeSnapserver
 ) -> None:
-    """When snapserver reports the name as already-registered MA must adopt the orphan.
+    """
+    When snapserver reports the name as already-registered MA must adopt the orphan.
 
     The stream must be in the local snapserver cache; MA must adopt it instead of
     looping until retries exhaust.
@@ -161,7 +164,8 @@ async def test_name_collision_with_local_stream_cached_adopts_it(
 async def test_orphan_stream_after_ma_restart_gets_adopted_via_resync(
     fake_provider: MagicMock, fake_snapserver: FakeSnapserver
 ) -> None:
-    """Bug B core scenario: MA restarted while a stream was registered.
+    """
+    Bug B core scenario: MA restarted while a stream was registered.
 
     The local snapserver cache is empty, but the server still holds the orphan.
     MA must call status() + synchronize() to re-discover it before adopting.
@@ -187,7 +191,8 @@ async def test_orphan_stream_after_ma_restart_gets_adopted_via_resync(
 async def test_second_register_call_is_idempotent_when_stream_already_set(
     fake_provider: MagicMock, fake_snapserver: FakeSnapserver
 ) -> None:
-    """Calling _register_tcp_server_source after self.snap_stream is set is a no-op.
+    """
+    Calling _register_tcp_server_source after self.snap_stream is set is a no-op.
 
     This is the early-return guard at the top of the method. Real concurrency
     safety is provided by `_lifecycle_lock` in setup(); that path is exercised

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -174,3 +174,19 @@ async def test_concurrent_register_calls_dont_double_create(
     assert stream.snap_stream.identifier == "single-stream"
     # Only ONE add_stream call was issued
     assert len(fake_snapserver.add_stream_calls) == 1
+
+
+def test_pick_port_avoids_already_tried():
+    """Within a single retry loop, _pick_port_avoiding must not return a tried port."""
+    from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
+
+    # Build a stream stub that exposes only what _pick_port_avoiding needs
+    stream = SnapcastMAStream.__new__(SnapcastMAStream)
+
+    used = set()
+    for _ in range(100):
+        port = stream._pick_port_avoiding(used)
+        assert port is not None, "Helper unexpectedly returned None when ports remain"
+        assert 4953 <= port <= 4953 + 200
+        assert port not in used
+        used.add(port)

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -149,3 +149,28 @@ async def test_orphan_stream_after_ma_restart_gets_adopted_via_resync(
     assert stream.snap_stream.identifier == "orphan-id"
     # The status() round-trip must have happened
     assert fake_snapserver.status.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_register_calls_dont_double_create(
+    fake_provider, fake_snapserver: "FakeSnapserver"
+):
+    """Two coroutines calling _register_tcp_server_source() race-free.
+
+    The first one wins; the second sees self.snap_stream already set and returns early.
+    """
+    fake_snapserver.queue_success(stream_id="single-stream")
+    fake_snapserver.queue_success(stream_id="should-not-happen")
+
+    stream = _make_stream(fake_provider)
+
+    import asyncio
+    await asyncio.gather(
+        stream._register_tcp_server_source(),
+        stream._register_tcp_server_source(),
+    )
+
+    assert stream.snap_stream is not None
+    assert stream.snap_stream.identifier == "single-stream"
+    # Only ONE add_stream call was issued
+    assert len(fake_snapserver.add_stream_calls) == 1

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -13,22 +14,26 @@ if TYPE_CHECKING:
     from .conftest import FakeSnapserver
 
 
-def _make_stream(provider, name: str = "Music Assistant - testhash (announcement)") -> SnapcastMAStream:
-    """Build a SnapcastMAStream instance directly, bypassing the constructor's
-    media handling (we only test the snapserver source registration)."""
+def _make_stream(
+    provider: MagicMock, name: str = "Music Assistant - testhash (announcement)"
+) -> SnapcastMAStream:
+    """Build a SnapcastMAStream instance directly.
+
+    Bypasses the constructor's media handling (we only test the snapserver
+    source registration).
+    """
     media = MagicMock()
-    s = SnapcastMAStream(
+    return SnapcastMAStream(
         provider=provider,
         media=media,
         stream_name=name,
     )
-    return s
 
 
 @pytest.mark.asyncio
 async def test_happy_path_register_succeeds_first_attempt(
-    fake_provider, fake_snapserver: "FakeSnapserver"
-):
+    fake_provider: MagicMock, fake_snapserver: FakeSnapserver
+) -> None:
     """Regression: a clean snapserver returns id on first try, MA registers the stream."""
     fake_snapserver.queue_success(stream_id="ok-1")
     stream = _make_stream(fake_provider)
@@ -42,8 +47,8 @@ async def test_happy_path_register_succeeds_first_attempt(
 
 @pytest.mark.asyncio
 async def test_real_port_conflict_retries_with_different_port(
-    fake_provider, fake_snapserver: "FakeSnapserver"
-):
+    fake_provider: MagicMock, fake_snapserver: FakeSnapserver
+) -> None:
     """Regression: a non-name error (e.g. port already bound) keeps the loop going."""
     fake_snapserver.queue_other_error("bind: Address already in use")
     fake_snapserver.queue_success(stream_id="ok-after-retry")
@@ -63,10 +68,11 @@ async def test_real_port_conflict_retries_with_different_port(
 
 @pytest.mark.asyncio
 async def test_all_attempts_exhausted_raises_with_honest_message(
-    fake_provider, fake_snapserver: "FakeSnapserver"
-):
-    """When all 50 retries fail, the error must reference 'after retries' or
-    similar — not 'No free port found' which lies about the cause.
+    fake_provider: MagicMock, fake_snapserver: FakeSnapserver
+) -> None:
+    """When all 50 retries fail the error must reference 'after retries' or similar.
+
+    Must NOT say 'No free port found' which lies about the cause.
     """
     # Queue 51 errors so even after 50 attempts the loop hits the raise
     for _ in range(51):
@@ -87,31 +93,57 @@ async def test_all_attempts_exhausted_raises_with_honest_message(
 @pytest.mark.parametrize(
     ("result", "expected"),
     [
-        ({"code": -32603, "data": 'Stream with name "x" already exists', "message": "Internal error"}, True),
-        ({"code": -32603, "data": "Stream with name \"abc\" already exists in registry", "message": "Internal error"}, True),
+        (
+            {
+                "code": -32603,
+                "data": 'Stream with name "x" already exists',
+                "message": "Internal error",
+            },
+            True,
+        ),
+        (
+            {
+                "code": -32603,
+                "data": 'Stream with name "abc" already exists in registry',
+                "message": "Internal error",
+            },
+            True,
+        ),
         # negative cases — these must NOT match
-        ({"code": -32603, "data": "bind: Address already in use", "message": "Internal error"}, False),
-        ({"code": -32603, "data": "Some other error already exists somewhere", "message": "Internal error"}, False),
+        (
+            {"code": -32603, "data": "bind: Address already in use", "message": "Internal error"},
+            False,
+        ),
+        (
+            {
+                "code": -32603,
+                "data": "Some other error already exists somewhere",
+                "message": "Internal error",
+            },
+            False,
+        ),
         ({}, False),
         (None, False),
         ("plain string", False),
         ({"data": 12345}, False),
     ],
 )
-def test_is_name_collision_error_matches_only_specific_pattern(result, expected):
+def test_is_name_collision_error_matches_only_specific_pattern(
+    result: object, expected: bool
+) -> None:
     """_is_name_collision_error must NOT false-positive on unrelated errors."""
-    from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
-
     assert SnapcastMAStream._is_name_collision_error(result) is expected
 
 
 @pytest.mark.asyncio
 async def test_name_collision_with_local_stream_cached_adopts_it(
-    fake_provider, fake_snapserver: "FakeSnapserver"
-):
-    """When snapserver reports the name as already-registered AND the stream is
-    in the local snapserver cache, MA must adopt it instead of looping until
-    retries exhaust."""
+    fake_provider: MagicMock, fake_snapserver: FakeSnapserver
+) -> None:
+    """When snapserver reports the name as already-registered MA must adopt the orphan.
+
+    The stream must be in the local snapserver cache; MA must adopt it instead of
+    looping until retries exhaust.
+    """
     target_name = "Music Assistant - 590b15 (announcement)"
     fake_snapserver.cache_stream_directly("orphan-id", target_name)
     fake_snapserver.queue_name_collision()
@@ -127,8 +159,8 @@ async def test_name_collision_with_local_stream_cached_adopts_it(
 
 @pytest.mark.asyncio
 async def test_orphan_stream_after_ma_restart_gets_adopted_via_resync(
-    fake_provider, fake_snapserver: "FakeSnapserver"
-):
+    fake_provider: MagicMock, fake_snapserver: FakeSnapserver
+) -> None:
     """Bug B core scenario: MA restarted while a stream was registered.
 
     The local snapserver cache is empty, but the server still holds the orphan.
@@ -153,8 +185,8 @@ async def test_orphan_stream_after_ma_restart_gets_adopted_via_resync(
 
 @pytest.mark.asyncio
 async def test_concurrent_register_calls_dont_double_create(
-    fake_provider, fake_snapserver: "FakeSnapserver"
-):
+    fake_provider: MagicMock, fake_snapserver: FakeSnapserver
+) -> None:
     """Two coroutines calling _register_tcp_server_source() race-free.
 
     The first one wins; the second sees self.snap_stream already set and returns early.
@@ -164,7 +196,6 @@ async def test_concurrent_register_calls_dont_double_create(
 
     stream = _make_stream(fake_provider)
 
-    import asyncio
     await asyncio.gather(
         stream._register_tcp_server_source(),
         stream._register_tcp_server_source(),
@@ -176,14 +207,12 @@ async def test_concurrent_register_calls_dont_double_create(
     assert len(fake_snapserver.add_stream_calls) == 1
 
 
-def test_pick_port_avoids_already_tried():
+def test_pick_port_avoids_already_tried() -> None:
     """Within a single retry loop, _pick_port_avoiding must not return a tried port."""
-    from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
-
     # Build a stream stub that exposes only what _pick_port_avoiding needs
     stream = SnapcastMAStream.__new__(SnapcastMAStream)
 
-    used = set()
+    used: set[int] = set()
     for _ in range(100):
         port = stream._pick_port_avoiding(used)
         assert port is not None, "Helper unexpectedly returned None when ports remain"

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -38,3 +38,24 @@ async def test_happy_path_register_succeeds_first_attempt(
     assert stream.snap_stream is not None
     assert stream.snap_stream.identifier == "ok-1"
     assert len(fake_snapserver.add_stream_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_real_port_conflict_retries_with_different_port(
+    fake_provider, fake_snapserver: "FakeSnapserver"
+):
+    """Regression: a non-name error (e.g. port already bound) keeps the loop going."""
+    fake_snapserver.queue_other_error("bind: Address already in use")
+    fake_snapserver.queue_success(stream_id="ok-after-retry")
+
+    stream = _make_stream(fake_provider)
+    await stream._register_tcp_server_source()
+
+    assert stream.snap_stream is not None
+    assert stream.snap_stream.identifier == "ok-after-retry"
+    # Two add_stream calls were made — first failed, second succeeded
+    assert len(fake_snapserver.add_stream_calls) == 2
+    # The two URIs must use different ports
+    port_1 = fake_snapserver.add_stream_calls[0].split("0.0.0.0:")[1].split("?")[0]
+    port_2 = fake_snapserver.add_stream_calls[1].split("0.0.0.0:")[1].split("?")[0]
+    assert port_1 != port_2

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -103,3 +103,23 @@ def test_is_name_collision_error_matches_only_specific_pattern(result, expected)
     from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
 
     assert SnapcastMAStream._is_name_collision_error(result) is expected
+
+
+@pytest.mark.asyncio
+async def test_name_collision_with_local_stream_cached_adopts_it(
+    fake_provider, fake_snapserver: "FakeSnapserver"
+):
+    """When snapserver reports the name as already-registered AND the stream is
+    in the local snapserver cache, MA must adopt it instead of looping until
+    retries exhaust."""
+    target_name = "Music Assistant - 590b15 (announcement)"
+    fake_snapserver.cache_stream_directly("orphan-id", target_name)
+    fake_snapserver.queue_name_collision()
+
+    stream = _make_stream(fake_provider, name=target_name)
+    await stream._register_tcp_server_source()
+
+    assert stream.snap_stream is not None
+    assert stream.snap_stream.identifier == "orphan-id"
+    # Adoption must NOT spend further retries
+    assert len(fake_snapserver.add_stream_calls) == 1

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -1,0 +1,40 @@
+"""Tests for music_assistant.providers.snapcast.ma_stream._register_tcp_server_source."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
+
+if TYPE_CHECKING:
+    from .conftest import FakeSnapserver
+
+
+def _make_stream(provider, name: str = "Music Assistant - testhash (announcement)") -> SnapcastMAStream:
+    """Build a SnapcastMAStream instance directly, bypassing the constructor's
+    media handling (we only test the snapserver source registration)."""
+    media = MagicMock()
+    s = SnapcastMAStream(
+        provider=provider,
+        media=media,
+        stream_name=name,
+    )
+    return s
+
+
+@pytest.mark.asyncio
+async def test_happy_path_register_succeeds_first_attempt(
+    fake_provider, fake_snapserver: "FakeSnapserver"
+):
+    """Regression: a clean snapserver returns id on first try, MA registers the stream."""
+    fake_snapserver.queue_success(stream_id="ok-1")
+    stream = _make_stream(fake_provider)
+
+    await stream._register_tcp_server_source()
+
+    assert stream.snap_stream is not None
+    assert stream.snap_stream.identifier == "ok-1"
+    assert len(fake_snapserver.add_stream_calls) == 1

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -184,12 +184,14 @@ async def test_orphan_stream_after_ma_restart_gets_adopted_via_resync(
 
 
 @pytest.mark.asyncio
-async def test_concurrent_register_calls_dont_double_create(
+async def test_second_register_call_is_idempotent_when_stream_already_set(
     fake_provider: MagicMock, fake_snapserver: FakeSnapserver
 ) -> None:
-    """Two coroutines calling _register_tcp_server_source() race-free.
+    """Calling _register_tcp_server_source after self.snap_stream is set is a no-op.
 
-    The first one wins; the second sees self.snap_stream already set and returns early.
+    This is the early-return guard at the top of the method. Real concurrency
+    safety is provided by `_lifecycle_lock` in setup(); that path is exercised
+    by integration tests, not unit tests.
     """
     fake_snapserver.queue_success(stream_id="single-stream")
     fake_snapserver.queue_success(stream_id="should-not-happen")

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -82,3 +82,24 @@ async def test_all_attempts_exhausted_raises_with_honest_message(
         f"Error message still claims port shortage when the real cause may differ: {message}"
     )
     assert "attempts" in message.lower() or "register" in message.lower()
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ({"code": -32603, "data": 'Stream with name "x" already exists', "message": "Internal error"}, True),
+        ({"code": -32603, "data": "Stream with name \"abc\" already exists in registry", "message": "Internal error"}, True),
+        # negative cases — these must NOT match
+        ({"code": -32603, "data": "bind: Address already in use", "message": "Internal error"}, False),
+        ({"code": -32603, "data": "Some other error already exists somewhere", "message": "Internal error"}, False),
+        ({}, False),
+        (None, False),
+        ("plain string", False),
+        ({"data": 12345}, False),
+    ],
+)
+def test_is_name_collision_error_matches_only_specific_pattern(result, expected):
+    """_is_name_collision_error must NOT false-positive on unrelated errors."""
+    from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
+
+    assert SnapcastMAStream._is_name_collision_error(result) is expected

--- a/tests/providers/snapcast/test_ma_stream.py
+++ b/tests/providers/snapcast/test_ma_stream.py
@@ -59,3 +59,26 @@ async def test_real_port_conflict_retries_with_different_port(
     port_1 = fake_snapserver.add_stream_calls[0].split("0.0.0.0:")[1].split("?")[0]
     port_2 = fake_snapserver.add_stream_calls[1].split("0.0.0.0:")[1].split("?")[0]
     assert port_1 != port_2
+
+
+@pytest.mark.asyncio
+async def test_all_attempts_exhausted_raises_with_honest_message(
+    fake_provider, fake_snapserver: "FakeSnapserver"
+):
+    """When all 50 retries fail, the error must reference 'after retries' or
+    similar — not 'No free port found' which lies about the cause.
+    """
+    # Queue 51 errors so even after 50 attempts the loop hits the raise
+    for _ in range(51):
+        fake_snapserver.queue_other_error("Some persistent error")
+
+    stream = _make_stream(fake_provider)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await stream._register_tcp_server_source()
+
+    message = str(exc_info.value)
+    assert "No free port" not in message, (
+        f"Error message still claims port shortage when the real cause may differ: {message}"
+    )
+    assert "attempts" in message.lower() or "register" in message.lower()


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/4435

Hit this on my own setup (MA + external snapserver 0.35.0, lots of TTS
announcements via Home Assistant) and traced it to
`SnapcastMAStream._register_tcp_server_source()`.

## The bug

When MA registers a TCP source on snapserver, it generates a deterministic
stream name like `Music Assistant - <md5(stream_uri)[:6]> (announcement)`.
If snapserver already has a stream with that name (orphaned from a previous
MA crash, restart, or any path that bypassed cleanup), the register call
comes back with:

    {"code": -32603, "data": "Stream with name 'X' already exists", "message": "Internal error"}

The old code treated every snapserver error as a port-already-bound case,
so it picked a different random port and tried again. But the failure was
a name collision, not a port one, and re-rolling the port doesn't help.
After 50 retries the loop gave up and raised:

    RuntimeError("Unable to create stream - No free port found?")

which is the error users see in the support thread. Once you hit it, every
subsequent announcement on that stream name fails the same way until MA
restarts (the orphan stays).

## Fix

A new `_is_name_collision_error()` helper does a strict substring match on
snapserver's error data (`Stream with name '...' already exists`). I kept
it strict on purpose so we don't swallow unrelated -32603s; if snapserver
upstream ever rephrases the message, there's a `DEBUG` log on rejected
-32603s so the regression is visible without code changes.

On a confirmed name collision MA now looks up the orphan in its local
`_streams` cache. If it isn't cached (MA was restarted and never saw it),
we resync via `Server.GetStatus` + `synchronize()` and look again. If the
orphan turns up, MA adopts it (`self.snap_stream = ...`, re-registers the
update callback) and continues normally instead of retrying. One INFO line
in the log: `Adopted orphaned snapserver stream <id> (name=<name>)`.

For genuine non-name errors (port actually bound, snapserver overloaded,
etc.) the retry loop still works, but now with per-attempt port dedup via
`_pick_port_avoiding(used)` so we don't waste retries on a port we already
tried. The "I give up" message is now honest:
`Unable to register snapserver stream <name> after 50 attempts` instead of
pretending it's a port shortage. And socket-server cleanup happens in a
`try/finally` around the loop, so a network blip during the orphan resync
no longer leaks a socket server.

I didn't touch the port range (4953-5153). That's a separate question, and
bumping it has its own risk of colliding with mDNS / VNC / PostgreSQL on
the snapserver host. Adopting the orphan removes the pressure on the port
range in the first place.

No public API change; the change is internal to `SnapcastMAStream`. Happy
path with no orphan present behaves identically.

## Testing

Walked it through RED then GREEN against my running MA 2.8.6 with a
deterministic orphan.

Before fix (RED): staged `Music Assistant - 9b8f75 (announcement)` on
snapserver, triggered `players/cmd/play_announcement` for a player on
MA. Log shows 50 WARNING lines

    Stream with name 'Music Assistant - 9b8f75 (announcement)' already exists

within ~18ms, ending in the `Unable to create stream - No free port found?`
RuntimeError. WS reply: `error_code: 11`.

After fix (GREEN, same scenario): single INFO line

    Adopted orphaned snapserver stream Music Assistant - 9b8f75 (announcement)
    (name=Music Assistant - 9b8f75 (announcement))

followed by normal `Start streaming to tcp://<url>:5210` and clean
shutdown. WS reply: success. Snapserver state returns to baseline after the
announcement ends.

## Possibly also helps

- https://github.com/music-assistant/support/issues/4377 (announcement
  volume timing)
- https://github.com/music-assistant/support/issues/4672 (queue unavailable
  with external snapcast)

Stable orphan adoption should reduce racy stream churn in both cases. I
haven't reproduced either, so I'm not claiming `Fixes`.
