### PR TITLE
Enhance warning for Spotify top tracks fetch failure

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -666,7 +666,7 @@ class SpotifyProvider(MusicProvider):
                 if (item and item["id"])
             ]
         except MediaNotFoundError:
-            self.logger.info(
+            self.logger.warning(
                 "Top tracks search for artist %s appears to have been removed by Spotify for this account.",
                 prov_artist_id,
             )

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -666,7 +666,10 @@ class SpotifyProvider(MusicProvider):
                 if (item and item["id"])
             ]
         except MediaNotFoundError:
-            self.logger.info("Top tracks search for artist %s appears to have been removed by Spotify for this account.", prov_artist_id)
+            self.logger.info(
+                "Top tracks search for artist %s appears to have been removed by Spotify for this account.",
+                prov_artist_id,
+            )
             return []
 
     async def library_add(self, item: MediaItemType) -> bool:

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -666,7 +666,7 @@ class SpotifyProvider(MusicProvider):
                 if (item and item["id"])
             ]
         except MediaNotFoundError:
-            self.logger.warning("Unable to fetch top tracks for artist %s", prov_artist_id)
+            self.logger.info("Top tracks search for artist %s appears to have been removed by Spotify for this account.", prov_artist_id)
             return []
 
     async def library_add(self, item: MediaItemType) -> bool:


### PR DESCRIPTION
The user can’t do anything about this and it is expected behaviour for some accounts so a warning is not appropriate.