### PR TITLE
Fix sync issues with Sendspin players

### DIFF
--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -285,8 +285,11 @@ class SendspinAirPlayBridge:
 
             # Derive start_ntp from _drop_until_us (set on first chunk arrival)
             # to give the CLI enough lead time to connect and fill the output buffer.
-            future_s = self._drop_until_us / 1_000_000 - time.monotonic()
-            start_ntp = unix_time_to_ntp(time.time() + future_s)
+            # _drop_until_us may use a different clock, convert to NTP
+            sendspin_clock_now_us = self.sendspin_server.clock.now_us()
+            unix_clock_now = time.time()
+            future_s = (self._drop_until_us - sendspin_clock_now_us) / 1_000_000
+            start_ntp = unix_time_to_ntp(unix_clock_now + future_s)
 
             # Always use RAOP for the bridge — AP2 (cliap2) doesn't respect
             # NTP start times correctly, breaking multi-device sync.
@@ -435,8 +438,8 @@ class SendspinAirPlayBridge:
         if self._airplay_stream_start_task is None:
             # Set the target start time (wait_start) in the future so the CLI
             # has enough time to connect and fill the device's output buffer.
-            wait_start_s = self.airplay_player.wait_start / 1000
-            self._drop_until_us = int((time.monotonic() + wait_start_s) * 1_000_000)
+            wait_start_us = int(self.airplay_player.wait_start * 1_000)
+            self._drop_until_us = self.sendspin_server.clock.now_us() + wait_start_us
             self._start_aligned = False
             self._airplay_stream_start_task = self.mass.create_task(
                 self._start_protocol_from_chunk()

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -310,10 +310,22 @@ class SendspinAirPlayBridge:
                     self.airplay_player.display_name,
                 )
                 return
-            self._airplay_stream = RaopStream(self.airplay_player)
-            self.airplay_player.stream = self._airplay_stream
-
-            await self._airplay_stream.start(start_ntp)
+            # On a rapid skip, _on_bridge_stream_start snapshots self._airplay_stream
+            # for cleanup. If we assigned it earlier, the new stream would be missed
+            # and leaked. Only publish once start() succeeds and this task is current.
+            new_stream = RaopStream(self.airplay_player)
+            try:
+                await new_stream.start(start_ntp)
+            except BaseException:
+                with suppress(Exception):
+                    await new_stream.stop(force=True)
+                raise
+            if asyncio.current_task() is not self._airplay_stream_start_task:
+                with suppress(Exception):
+                    await new_stream.stop(force=True)
+                return
+            self._airplay_stream = new_stream
+            self.airplay_player.stream = new_stream
             self._airplay_stream_ready.set()
             self.logger.info(
                 "Bridge protocol started for %s (NTP=%s, lookahead=%.0fms)",
@@ -328,12 +340,6 @@ class SendspinAirPlayBridge:
                 self.airplay_player.display_name,
                 err,
             )
-            # Clean up partially created protocol
-            if self._airplay_stream:
-                with suppress(Exception):
-                    await self._airplay_stream.stop(force=True)
-                self._airplay_stream = None
-                self.airplay_player.stream = None
             # Stop accepting chunks, unblock the writer, and schedule full cleanup
             self._is_streaming = False
             self._airplay_stream_ready.set()

--- a/music_assistant/providers/airplay/sendspin_bridge.py
+++ b/music_assistant/providers/airplay/sendspin_bridge.py
@@ -250,15 +250,25 @@ class SendspinAirPlayBridge:
         Called via the BridgePlayerRole.on_stream_start callback when the
         PushStream begins delivering audio chunks.
         """
-        # Cancel any existing writer task (leftover from previous stream)
-        if self._writer_task is not None and not self._writer_task.done():
-            self._writer_task.cancel()
-        # Re-assert streaming state and clear protocol references so the first
-        # audio chunk triggers a fresh protocol start. This is needed because
-        # the async cleanup scheduled by _on_stream_start may have cleared
-        # _is_streaming and _protocol_start_task between then and now.
-        self._is_streaming = True
+        # The stream might not yet be cleaned up completely (on rapid skips for example)
+        old_stream = self._airplay_stream
+        old_writer_task = self._writer_task
+        old_stream_start_task = self._airplay_stream_start_task
+
+        self._airplay_stream = None
+        self._writer_task = None
         self._airplay_stream_start_task = None
+        self.airplay_player.stream = None
+
+        if old_stream or old_writer_task or old_stream_start_task:
+            prev_cleanup = self._cleanup_task
+            self._cleanup_task = self.mass.create_task(
+                self._cleanup_old_stream(
+                    old_stream, old_writer_task, old_stream_start_task, prev_cleanup
+                )
+            )
+
+        self._is_streaming = True
         self._airplay_stream_ready.clear()
         self._next_expected_timestamp_us = None
         self._drop_until_us = 0

--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin[server]==5.1.1", "av==16.1.0"],
+  "requirements": ["aiosendspin[server]==5.1.2", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -191,7 +191,10 @@ class _BufferedFfmpegProcessor:
         target_bytes = self._target_bytes_for_duration_us(duration_us)
         if target_bytes <= 0:
             return b""
-        self._pending_skip_bytes += target_bytes
+        # Drop buffered output with stale source positions.
+        leftover = len(self._output_buffer)
+        self._output_buffer.clear()
+        self._pending_skip_bytes += max(0, target_bytes - leftover)
         return b"\x00" * target_bytes
 
     def _consume_pending_skip(self, chunk: bytes) -> bytes:

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -77,6 +77,7 @@ class _BufferedFfmpegProcessor:
         # ~25ms worth of audio per read syscall.
         self._read_quantum_bytes = max(1, int(self._bytes_per_second * 0.025))
         self._produced_output_us = 0
+        self._pending_skip_bytes = 0
 
     async def start(self) -> None:
         await self._ffmpeg.start()
@@ -108,7 +109,9 @@ class _BufferedFfmpegProcessor:
             chunk = await self._ffmpeg.readexactly(read_size)
             if not chunk:
                 break
-            self._output_buffer.extend(chunk)
+            chunk = self._consume_pending_skip(chunk)
+            if chunk:
+                self._output_buffer.extend(chunk)
 
         out = bytes(self._output_buffer[:target_bytes])
         del self._output_buffer[:target_bytes]
@@ -130,8 +133,10 @@ class _BufferedFfmpegProcessor:
                 break
             if not chunk:
                 break
-            self._output_buffer.extend(chunk)
             self._produced_output_us += self._duration_us_for_bytes(len(chunk))
+            chunk = self._consume_pending_skip(chunk)
+            if chunk:
+                self._output_buffer.extend(chunk)
             if len(chunk) < self._read_quantum_bytes:
                 break
         return self._produced_output_us
@@ -142,8 +147,10 @@ class _BufferedFfmpegProcessor:
             chunk = await self._ffmpeg.read(self._read_quantum_bytes)
             if not chunk:
                 break
-            self._output_buffer.extend(chunk)
             self._produced_output_us += self._duration_us_for_bytes(len(chunk))
+            chunk = self._consume_pending_skip(chunk)
+            if chunk:
+                self._output_buffer.extend(chunk)
 
     def pop_duration_us(self, duration_us: int) -> bytes | None:
         """Pop exactly `duration_us` from already buffered output, or None if insufficient."""
@@ -176,7 +183,16 @@ class _BufferedFfmpegProcessor:
             return None
         out = bytes(self._output_buffer)
         self._output_buffer.clear()
+        self._pending_skip_bytes += short_bytes
         return out + (b"\x00" * short_bytes)
+
+    def _consume_pending_skip(self, chunk: bytes) -> bytes:
+        # Drops bytes pop_duration_us_or_pad replaced with silence to keep timeline aligned.
+        if self._pending_skip_bytes <= 0 or not chunk:
+            return chunk
+        skip = min(self._pending_skip_bytes, len(chunk))
+        self._pending_skip_bytes -= skip
+        return chunk[skip:]
 
     def _duration_us_for_bytes(self, byte_count: int) -> int:
         if byte_count <= 0 or self._sample_rate <= 0 or self._frame_size <= 0:

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -186,6 +186,14 @@ class _BufferedFfmpegProcessor:
         self._pending_skip_bytes += short_bytes
         return out + (b"\x00" * short_bytes)
 
+    def pad_and_skip(self, duration_us: int) -> bytes:
+        """Return silence PCM and skip the equivalent from upcoming ffmpeg output."""
+        target_bytes = self._target_bytes_for_duration_us(duration_us)
+        if target_bytes <= 0:
+            return b""
+        self._pending_skip_bytes += target_bytes
+        return b"\x00" * target_bytes
+
     def _consume_pending_skip(self, chunk: bytes) -> bytes:
         # Drops bytes pop_duration_us_or_pad replaced with silence to keep timeline aligned.
         if self._pending_skip_bytes <= 0 or not chunk:
@@ -962,6 +970,9 @@ class SendspinPlaybackSession:
             )
             if transformed_history is None:
                 continue
+            transformed_history = await self._pad_history_to_live_tail(
+                state, target_end_us, transformed_history
+            )
             pipeline = await self._sync_member_pipeline(player_id)
             # Split the blob into slices so push_stream can yield between encodes.
             frame_stride = (_SENDSPIN_PCM_FORMAT.bit_depth // 8) * _SENDSPIN_PCM_FORMAT.channels
@@ -980,6 +991,25 @@ class SendspinPlaybackSession:
             await self._promote_join_catchup_processor(player_id, pipeline, target_end_us)
             injected_any = True
         return injected_any
+
+    async def _pad_history_to_live_tail(
+        self,
+        state: _JoinCatchupState,
+        target_end_us: int,
+        transformed_history: bytes,
+    ) -> bytes:
+        """Append silence so joiner's channel_timing aligns with the live tail at promotion."""
+        # target_end_us is locked from earlier and may lag the live tail by seconds.
+        async with self._state_lock:
+            live_tail_us = (
+                self._history[-1].start_time_us + self._history[-1].duration_us
+                if self._history
+                else target_end_us
+            )
+        promotion_lag_us = max(0, live_tail_us - target_end_us)
+        if promotion_lag_us <= 0:
+            return transformed_history
+        return transformed_history + state.processor.pad_and_skip(promotion_lag_us)
 
     async def _prefeed_pending_backlog_for_join(
         self,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ aiohttp-socks==0.11.0
 aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
-aiosendspin[server]==5.1.1
+aiosendspin[server]==5.1.2
 aioslimproto==3.1.8
 aiosonos==0.1.12
 aiosqlite==0.22.1


### PR DESCRIPTION
Fixes 3 issues in the Sendspin provider that could cause out of sync playback:
1. Use of a different clock than whats used in `aiosendspin` (monotonic instead of the internal raw monotonic clock)
2. A race condition that was triggered on rapid skips that could cause out of sync playback
3. Late joiners could have misaligned audio when using DSP.

Also bumps `aiosendspin` to 5.1.2 to resolve a few more syncing issues, notably:
- https://github.com/Sendspin/aiosendspin/pull/228
- https://github.com/Sendspin/aiosendspin/pull/229
- https://github.com/Sendspin/aiosendspin/pull/231
- https://github.com/Sendspin/aiosendspin/pull/227

It also fixes a non spec compliant `stream/end` messages:
- https://github.com/Sendspin/aiosendspin/pull/221