### PR TITLE
Fix Sendspin Cast bridge silently failing to set up

### DIFF
--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -42,7 +42,6 @@ from music_assistant.providers.sendspin.bridge_role import (
 from music_assistant.providers.sendspin.constants import (
     BRIDGE_PREFIX,
     CONF_SENDSPIN_STATIC_DELAY,
-    DEFAULT_SENDSPIN_STATIC_DELAY,
 )
 from music_assistant.providers.sendspin.helpers import (
     bridge_client_id_from_mac,
@@ -61,7 +60,6 @@ if TYPE_CHECKING:
     from music_assistant_models.event import MassEvent
     from pychromecast.generated.cast_channel_pb2 import CastMessage
 
-    from music_assistant.mass import MusicAssistant
     from music_assistant.providers.sendspin.provider import SendspinProvider
 
     from .player import ChromecastPlayer
@@ -195,22 +193,6 @@ def _build_bridge_hello(cast_player: ChromecastPlayer, bridge_client_id: str) ->
             supported_commands=[],
         ),
     )
-
-
-def _write_default_static_delay(
-    mass: MusicAssistant, bridge_client_id: str, manufacturer: str, model: str
-) -> None:
-    """Persist the model-specific default static delay if no user value exists."""
-    raw_delay = mass.config.get_raw_player_config_value(
-        bridge_client_id, CONF_SENDSPIN_STATIC_DELAY
-    )
-    if raw_delay is not None:
-        return
-    model_default = get_cast_model_static_delay(manufacturer, model)
-    if model_default != DEFAULT_SENDSPIN_STATIC_DELAY:
-        mass.config.set_raw_player_config_value(
-            bridge_client_id, CONF_SENDSPIN_STATIC_DELAY, model_default
-        )
 
 
 class SendspinChromecastBridge:
@@ -439,13 +421,16 @@ class SendspinChromecastBridge:
         # the MA webserver or streams server. Use publish_ip directly.
         publish_ip = cast("str", self.mass.streams.publish_ip)
         server_url = f"ws://{format_ip_for_url(publish_ip)}:8927/sendspin"
-        sync_delay = int(
-            self.mass.config.get_raw_player_config_value(
-                self._bridge_client_id,
-                CONF_SENDSPIN_STATIC_DELAY,
-                DEFAULT_SENDSPIN_STATIC_DELAY,
-            )
+        raw_delay = self.mass.config.get_raw_player_config_value(
+            self._bridge_client_id, CONF_SENDSPIN_STATIC_DELAY
         )
+        if raw_delay is None:
+            sync_delay = get_cast_model_static_delay(
+                self.cast_player.device_info.manufacturer or "",
+                self.cast_player.device_info.model or "",
+            )
+        else:
+            sync_delay = cast("int", raw_delay)
         # The Cast receiver JS reads playerId (not clientId) from the config.
         # It uses this as the client_id in its hello message to the Sendspin server,
         # allowing the server to match it to the bridge's pre-registered external client.
@@ -579,6 +564,9 @@ class SendspinBridgeManager:
                 if sendspin_provider is not None:
                     bridge_hello = _build_bridge_hello(cast_player, existing_client_id)
                     identifiers = {IdentifierType.CAST_UUID: str(cast_player.cast_info.uuid)}
+                    sendspin_provider.register_bridge_static_delay_default(
+                        existing_client_id, get_cast_model_static_delay(manufacturer, model)
+                    )
                     if not await sendspin_provider.apply_bridge_claim(
                         existing_client_id, identifiers, bridge_hello
                     ):
@@ -589,7 +577,6 @@ class SendspinBridgeManager:
                         sendspin_provider.register_bridge_identifiers(
                             existing_client_id, identifiers
                         )
-                    _write_default_static_delay(self.mass, existing_client_id, manufacturer, model)
                     self._claimed_clients[player_id] = existing_client_id
                     self._subscribe_rebridge_on_disconnect(cast_player, existing_client_id)
                 return
@@ -605,7 +592,9 @@ class SendspinBridgeManager:
                     bridge_client_id,
                     {IdentifierType.CAST_UUID: str(cast_player.cast_info.uuid)},
                 )
-                _write_default_static_delay(self.mass, bridge_client_id, manufacturer, model)
+                sendspin_provider.register_bridge_static_delay_default(
+                    bridge_client_id, get_cast_model_static_delay(manufacturer, model)
+                )
 
             try:
                 await bridge.start()

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -430,7 +430,7 @@ class SendspinChromecastBridge:
                 self.cast_player.device_info.model or "",
             )
         else:
-            sync_delay = cast("int", raw_delay)
+            sync_delay = int(cast("int", raw_delay))
         # The Cast receiver JS reads playerId (not clientId) from the config.
         # It uses this as the client_id in its hello message to the Sendspin server,
         # allowing the server to match it to the bridge's pre-registered external client.

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -396,6 +396,7 @@ class SendspinPlayer(SendspinBasePlayer):
     last_sent_artist_artwork_url: str | None = None
     playback_session: SendspinPlaybackSession
     is_web_player: bool = False
+    static_delay_default_ms: int = DEFAULT_SENDSPIN_STATIC_DELAY
 
     @property
     def requires_flow_mode(self) -> bool:
@@ -514,7 +515,7 @@ class SendspinPlayer(SendspinBasePlayer):
             case StaticDelayChangedEvent(static_delay_ms=delay_ms):
                 self.logger.debug("Static delay changed to %d ms", delay_ms)
                 current = self.config.get_value(
-                    CONF_SENDSPIN_STATIC_DELAY, DEFAULT_SENDSPIN_STATIC_DELAY
+                    CONF_SENDSPIN_STATIC_DELAY, self.static_delay_default_ms
                 )
                 if current != delay_ms:
                     self.mass.config.set_raw_player_config_value(
@@ -677,7 +678,7 @@ class SendspinPlayer(SendspinBasePlayer):
 
         config_value = cast(
             "int",
-            self.config.get_value(CONF_SENDSPIN_STATIC_DELAY, DEFAULT_SENDSPIN_STATIC_DELAY),
+            self.config.get_value(CONF_SENDSPIN_STATIC_DELAY, self.static_delay_default_ms),
         )
         player_role.set_static_delay(config_value)
 
@@ -936,7 +937,7 @@ class SendspinPlayer(SendspinBasePlayer):
                         "from an amp, active speakers, or the OS."
                     ),
                     required=False,
-                    default_value=DEFAULT_SENDSPIN_STATIC_DELAY,
+                    default_value=self.static_delay_default_ms,
                     range=(0, 5000),
                     immediate_apply=True,
                     # Not a advanced option since this will only show up for players where it is likely

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -27,6 +27,7 @@ from music_assistant.constants import CONF_ENABLED
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import Player
 from music_assistant.models.player_provider import PlayerProvider
+from music_assistant.providers.sendspin.constants import CONF_SENDSPIN_STATIC_DELAY
 from music_assistant.providers.sendspin.player import (
     SendspinBasePlayer,
     SendspinPlayer,
@@ -136,6 +137,13 @@ class SendspinProvider(PlayerProvider):
         existing = self.mass.players.get_player(client_id)
         if isinstance(existing, SendspinPlayer):
             existing.static_delay_default_ms = default_ms
+            # If no user-set value exists, push the new default to the device now
+            # so already-connected clients pick it up without a config edit.
+            if (
+                self.mass.config.get_raw_player_config_value(client_id, CONF_SENDSPIN_STATIC_DELAY)
+                is None
+            ):
+                self.mass.create_task(existing._apply_static_delay())
             return
         self._bridge_static_delay_defaults[client_id] = default_ms
 

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -49,6 +49,7 @@ class SendspinProvider(PlayerProvider):
     unregister_cbs: list[Callable[[], None]]
     _pending_unregisters: dict[str, asyncio.Event]
     _bridge_identifiers: dict[str, dict[IdentifierType, str]]
+    _bridge_static_delay_defaults: dict[str, int]
     _client_event_versions: dict[str, int]
     _client_event_task_counts: dict[str, int]
     _unloading: bool
@@ -63,6 +64,7 @@ class SendspinProvider(PlayerProvider):
         )
         self._pending_unregisters = {}
         self._bridge_identifiers = {}
+        self._bridge_static_delay_defaults = {}
         self._bridge_player_types: dict[str, PlayerType] = {}
         self._client_event_versions = {}
         self._client_event_task_counts = {}
@@ -121,6 +123,21 @@ class SendspinProvider(PlayerProvider):
         :param identifiers: Extra identifiers to attach to the SendspinPlayer.
         """
         self._bridge_identifiers[client_id] = identifiers
+
+    def register_bridge_static_delay_default(self, client_id: str, default_ms: int) -> None:
+        """Register a protocol-specific default static delay for a bridge client.
+
+        If the SendspinPlayer already exists, the default is applied immediately;
+        otherwise it is stashed and picked up when the player is created.
+
+        :param client_id: The bridge client_id for which the default applies.
+        :param default_ms: Model-specific default static delay in milliseconds.
+        """
+        existing = self.mass.players.get_player(client_id)
+        if isinstance(existing, SendspinPlayer):
+            existing.static_delay_default_ms = default_ms
+            return
+        self._bridge_static_delay_defaults[client_id] = default_ms
 
     def register_bridge_player_type(self, client_id: str, player_type: PlayerType) -> None:
         """
@@ -212,6 +229,9 @@ class SendspinProvider(PlayerProvider):
         """
         extra_ids = self._bridge_identifiers.pop(client_id, None)
         bridge_player_type = self._bridge_player_types.pop(client_id, None)
+        static_delay_default_ms = self._bridge_static_delay_defaults.pop(client_id, None)
+        if static_delay_default_ms is None and isinstance(existing_player, SendspinPlayer):
+            static_delay_default_ms = existing_player.static_delay_default_ms
 
         has_player_role = bool(sendspin_client.roles_by_family("player"))
         has_metadata_role = bool(sendspin_client.roles_by_family("metadata"))
@@ -236,6 +256,8 @@ class SendspinProvider(PlayerProvider):
         if extra_ids:
             for id_type, id_value in extra_ids.items():
                 player.device_info.add_identifier(id_type, id_value)
+        if static_delay_default_ms is not None and isinstance(player, SendspinPlayer):
+            player.static_delay_default_ms = static_delay_default_ms
         return player
 
     async def _handle_client_added(self, client_id: str, event_version: int) -> None:


### PR DESCRIPTION
The Cast bridge tried to write the model-specific static delay default into the player config DB on first connect. When the player config row did not yet exist the write and read raised, and the Sendspin Cast bridge silently failed to set up.