### PR TITLE
Fix output bit depth ignoring supported sample-rate/bit-depth pairs in player settings

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1097,14 +1097,17 @@ class StreamsAudio:
             player.player_id, CONF_OUTPUT_CHANNELS, "stereo"
         )
         supported_sample_rates = tuple(int(x[0]) for x in supported_rates_conf)
-        supported_bit_depths = tuple(int(x[1]) for x in supported_rates_conf)
 
-        player_max_bit_depth = max(supported_bit_depths)
-        output_bit_depth = min(content_bit_depth, player_max_bit_depth)
         if content_sample_rate in supported_sample_rates:
             output_sample_rate = content_sample_rate
         else:
             output_sample_rate = max(supported_sample_rates)
+
+        # only consider bit depths that are actually paired with the chosen sample rate
+        bit_depths_for_rate = [
+            int(bd) for (sr, bd) in supported_rates_conf if int(sr) == output_sample_rate
+        ]
+        output_bit_depth = min(content_bit_depth, max(bit_depths_for_rate, default=16))
 
         if not content_type.is_lossless():
             # no point in having a higher bit depth for lossy formats


### PR DESCRIPTION
## Summary

- `get_output_format()` was selecting `output_bit_depth` from `max(supported_bit_depths)` across the entire supported list, independent of the chosen sample rate. With a mixed list like `[(44.1, 16), (96, 24)]`, a 44.1/16 source would be encoded as 44.1/24 which was a combination the player never advertised because 24 was the max bit depth anywhere in the list.
- Now picks the bit depth only from entries paired with the chosen output sample rate, guaranteeing the output is always a (rate, depth) pair the player actually advertised.

## Background

Reported in music-assistant/support#5364. The user noticed that adding any hi-res sample rate to a DLNA player's supported list caused lo-res tracks to play distorted on their Naim NDX, and that the audio pipeline UI was showing 44.1/24 as the chosen output even though only 44.1/16 and 96/24 were in the supported list.

The distortion symptom is a separate device-specific FLAC issue on the NDX ), but the format-pick bug itself is real and reproduces on every player with a mixed-bit-depth supported list. A Yamaha amplifier was used to isolate it cleanly using DLNA as the putput protocol.

## Test plan

Tested on Yamaha (DLNA), Nest Mini (Chromecast), Yamaha (MusicCast), Sonos S2.

- [x] Yamaha DLNA, supported `[(44.1,16),(96,24)]`, source 44.1/16 FLAC, Gapless OFF → output 44.1/16 (was 44.1/24)
- [x] Yamaha DLNA, same setup, Gapless ON → output 96/24 (flow mode unchanged)
- [x] Yamaha DLNA, source 96/24, Gapless OFF/ON → 96/24 (unchanged)
- [x] Yamaha DLNA, supported `[(44.1,16),(48,16),(96,24),(192,24)]`, 44.1/16 source → 44.1/16; 48/24 source → 48/16; 96/24 → 96/24; 192/24 → 192/24
- [x] Yamaha DLNA, supported `[(44.1,16),(48,16)]` (lo-res only) — no regression
- [x] Yamaha DLNA, supported `[(44.1,16),(96,24),(192,24)]`, sub-rate 24-bit sources cleanly downconverted to nearest valid pair
- [x] Nest Mini (Chromecast), repeated tests 1–4 — bug fixed, no regression
- [x] Yamaha MusicCast — bug fixed
- [x] Sonos S2 — no regression