### PR TITLE
Add Rainy Mood provider

### DIFF
--- a/music_assistant/providers/rain_mood/__init__.py
+++ b/music_assistant/providers/rain_mood/__init__.py
@@ -1,0 +1,108 @@
+"""
+Rainy Mood provider for Music Assistant.
+
+Serves a looping rain ambience from rainymood.com as a sound effect, suitable for
+direct playback or as the source for a queue's audio overlay. The remote stream is
+handed straight to the player pipeline - the audio overlay engine takes care of the
+looping, format conversion and volume mixing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from music_assistant_models.enums import ContentType, MediaType, ProviderFeature, StreamType
+from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.media_items import AudioFormat, ProviderMapping, SoundEffect
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.models.music_provider import MusicProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+    from music_assistant_models.provider import ProviderManifest
+
+    from music_assistant.mass import MusicAssistant
+    from music_assistant.models import ProviderInstanceType
+
+SUPPORTED_FEATURES = {
+    ProviderFeature.BROWSE,
+    ProviderFeature.SOUND_EFFECTS,
+}
+
+RAIN_ITEM_ID = "rain"
+RAIN_URL = "https://media.rainymood.com/0.mp3"
+
+
+async def setup(
+    mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
+) -> ProviderInstanceType:
+    """Initialize provider(instance) with given configuration."""
+    return RainyMoodProvider(mass, manifest, config, SUPPORTED_FEATURES)
+
+
+async def get_config_entries(
+    mass: MusicAssistant,  # noqa: ARG001
+    instance_id: str | None = None,  # noqa: ARG001
+    action: str | None = None,  # noqa: ARG001
+    values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
+) -> tuple[ConfigEntry, ...]:
+    """Return Config entries to setup this provider (none needed)."""
+    return ()
+
+
+class RainyMoodProvider(MusicProvider):
+    """Music provider serving a looping rain ambience from rainymood.com."""
+
+    @property
+    def is_streaming_provider(self) -> bool:
+        """Return True if the provider is a streaming provider."""
+        return True
+
+    async def get_sound_effect(self, prov_sound_effect_id: str) -> SoundEffect:
+        """Get full sound effect details by id."""
+        if prov_sound_effect_id != RAIN_ITEM_ID:
+            raise MediaNotFoundError(f"Unknown sound effect: {prov_sound_effect_id}")
+        return self._build_sound_effect()
+
+    async def get_sound_effects(self) -> AsyncGenerator[SoundEffect]:
+        """Get all sound effect items this provider offers."""
+        yield self._build_sound_effect()
+
+    async def get_stream_details(
+        self, item_id: str, media_type: MediaType = MediaType.TRACK
+    ) -> StreamDetails:
+        """Return the streamdetails to stream the rain sound effect."""
+        if item_id != RAIN_ITEM_ID:
+            raise MediaNotFoundError(f"Unknown sound effect: {item_id}")
+        return StreamDetails(
+            provider=self.instance_id,
+            item_id=item_id,
+            # remote source is a continuous ambience; let ffmpeg detect the codec
+            audio_format=AudioFormat(content_type=ContentType.UNKNOWN),
+            media_type=MediaType.SOUND_EFFECT,
+            stream_type=StreamType.HTTP,
+            path=RAIN_URL,
+            allow_seek=False,
+            can_seek=False,
+        )
+
+    def _build_sound_effect(self) -> SoundEffect:
+        """Create the SoundEffect item for the rain ambience."""
+        sound_effect = SoundEffect(
+            item_id=RAIN_ITEM_ID,
+            provider=self.instance_id,
+            name="Rain",
+            translation_key=RAIN_ITEM_ID,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=RAIN_ITEM_ID,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                )
+            },
+        )
+        sound_effect.metadata.description = "Looping rain ambience from rainymood.com."
+        return sound_effect

--- a/music_assistant/providers/rain_mood/manifest.json
+++ b/music_assistant/providers/rain_mood/manifest.json
@@ -1,0 +1,11 @@
+{
+  "type": "music",
+  "domain": "rain_mood",
+  "stage": "experimental",
+  "name": "Rainy Mood",
+  "description": "Looping rain ambience from rainymood.com to play directly or use as audio overlay on a queue.",
+  "codeowners": ["@jlpouffier"],
+  "requirements": [],
+  "multi_instance": false,
+  "icon": "weather-rainy"
+}

--- a/music_assistant/providers/rain_mood/strings.json
+++ b/music_assistant/providers/rain_mood/strings.json
@@ -1,0 +1,10 @@
+{
+  "media": {
+    "sound_effect": {
+      "rain": {
+        "name": "Rain",
+        "description": "Looping rain ambience from rainymood.com."
+      }
+    }
+  }
+}

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1712,6 +1712,8 @@
   "provider.radiobrowser.media.folder.radiobrowser_by_tag.name": "By tag",
   "provider.radiobrowser.media.folder.radiobrowser_by_votes.name": "By votes",
   "provider.radioparadise.manifest.description": "Stream an eclectic, human-curated radio mix (always ad-free) — listener supported and globally loved.",
+  "provider.rain_mood.media.sound_effect.rain.description": "Looping rain ambience from rainymood.com.",
+  "provider.rain_mood.media.sound_effect.rain.name": "Rain",
   "provider.roku_media_assistant.config_entries.auto_scan.description": "Enable automatic discovery of Roku players.",
   "provider.roku_media_assistant.config_entries.auto_scan.label": "Allow automatic Roku discovery",
   "provider.roku_media_assistant.config_entries.roku_app_id.description": "By default, Music Assistant will use the Roku Channel Store version of Media Assistant (ID: 782875). If you sideloaded the App on your Roku this will need to be set to (ID: dev).",

--- a/tests/providers/rain_mood/__init__.py
+++ b/tests/providers/rain_mood/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Rainy Mood provider."""

--- a/tests/providers/rain_mood/test_provider.py
+++ b/tests/providers/rain_mood/test_provider.py
@@ -1,0 +1,71 @@
+"""Tests for the Rainy Mood provider."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import MediaType, ProviderFeature, StreamType
+from music_assistant_models.errors import MediaNotFoundError
+
+from music_assistant.providers import rain_mood
+from music_assistant.providers.rain_mood import RAIN_ITEM_ID, RAIN_URL, RainyMoodProvider
+
+
+def _create_provider() -> RainyMoodProvider:
+    """Create a RainyMoodProvider with mocked dependencies."""
+    with patch.object(RainyMoodProvider, "__init__", lambda *_a, **_kw: None):
+        provider = RainyMoodProvider.__new__(RainyMoodProvider)
+
+    provider.config = MagicMock()
+    provider.config.instance_id = "rain_mood"
+    provider.manifest = MagicMock()
+    provider.manifest.domain = "rain_mood"
+    provider.mass = MagicMock()
+    provider.logger = MagicMock()
+
+    return provider
+
+
+async def test_sound_effects_enumeration() -> None:
+    """The provider offers a single rain sound effect item."""
+    provider = _create_provider()
+    items = [item async for item in provider.get_sound_effects()]
+    assert len(items) == 1
+    item = items[0]
+    assert item.item_id == RAIN_ITEM_ID
+    assert item.media_type == MediaType.SOUND_EFFECT
+    assert item.name == "Rain"
+    assert item.translation_key == RAIN_ITEM_ID
+    assert item.metadata.description
+
+
+async def test_get_sound_effect() -> None:
+    """The rain effect resolves by id; unknown ids raise MediaNotFoundError."""
+    provider = _create_provider()
+    item = await provider.get_sound_effect(RAIN_ITEM_ID)
+    assert item.name == "Rain"
+    assert item.provider_mappings
+    with pytest.raises(MediaNotFoundError):
+        await provider.get_sound_effect("unknown")
+
+
+async def test_supported_features() -> None:
+    """The provider advertises sound effects and browse, no library features."""
+    assert ProviderFeature.SOUND_EFFECTS in rain_mood.SUPPORTED_FEATURES
+    assert ProviderFeature.BROWSE in rain_mood.SUPPORTED_FEATURES
+    assert not any(x for x in rain_mood.SUPPORTED_FEATURES if x.value.startswith("library_"))
+
+
+async def test_stream_details() -> None:
+    """Streamdetails point at the remote rain stream over HTTP."""
+    provider = _create_provider()
+    stream_details = await provider.get_stream_details(RAIN_ITEM_ID)
+    assert stream_details.stream_type == StreamType.HTTP
+    assert stream_details.media_type == MediaType.SOUND_EFFECT
+    assert stream_details.path == RAIN_URL
+
+
+async def test_stream_details_unknown() -> None:
+    """Streamdetails for an unknown id raise MediaNotFoundError."""
+    provider = _create_provider()
+    with pytest.raises(MediaNotFoundError):
+        await provider.get_stream_details("unknown")


### PR DESCRIPTION
# What does this implement/fix?

Adds a **Rainy Mood** provider that offers a looping rain ambience from [rainymood.com](https://rainymood.com) as a sound effect. You can play it directly, or select it as the audio overlay on a queue to gently mix rain on top of your music.

This is now a small, isolated content provider that builds on the sound-effect and audio-overlay support already in `dev`. The provider only hands the rain stream to the player pipeline — the core overlay engine takes care of the looping, format conversion and volume mixing.

**What's in this PR:**

- New `rain_mood` music provider exposing a single "Rain" sound effect
- Streams the rain audio straight to the player over HTTP (no local caching)
- Translations for the sound effect name/description
- Tests for the provider

**Related issue (if applicable):**

- Frontend companion (queue overlay toggle): music-assistant/frontend#1753

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [x] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
