### PR TITLE
Bump `aiosendspin` to 5.2.0 to fix slow desyncing at some player sample rates

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin[server]==5.1.2", "av==16.1.0"],
+  "requirements": ["aiosendspin[server]==5.2.0", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ aiohttp-socks==0.11.0
 aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
-aiosendspin[server]==5.1.2
+aiosendspin[server]==5.2.0
 aioslimproto==3.1.8
 aiosonos==0.1.12
 aiosqlite==0.22.1


### PR DESCRIPTION
Fixes a bug where spec-compliant Sendspin player implementations slowly drifted at certain sample rates.

At 44.1 kHz, this specifically caused a drift of 1.6 seconds per hour:
- https://github.com/Sendspin/aiosendspin/pull/236

Also prepares for a future option to connect to Sendspin players without mDNS:
- https://github.com/Sendspin/aiosendspin/pull/233