### PR TITLE
Detect Sendspin Cast Receiver failures and show them in the frontend

### DIFF
--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
@@ -77,6 +78,7 @@ class ChromecastPlayer(Player):
         self.status_listener: CastStatusListener | None
         self.cast_info = cast_info
         self.mz_controller: MultizoneController | None = None
+        self.on_app_status_changed: Callable[[str | None], None] | None = None
         self.last_poll = 0.0
         self.flow_meta_checksum: str | None = None
         # set static variables
@@ -450,6 +452,11 @@ class ChromecastPlayer(Player):
         self._attr_volume_level = round(status.volume_level * 100)
         self._attr_volume_muted = status.volume_muted
         self.update_state()
+        if self.on_app_status_changed is not None:
+            try:
+                self.on_app_status_changed(status.app_id)
+            except Exception:
+                self.logger.exception("Error in app status callback for %s", self.display_name)
 
     def on_new_media_status(self, status: MediaStatus) -> None:
         """Handle updated MediaStatus (called from pychromecast socket thread)."""
@@ -572,6 +579,11 @@ class ChromecastPlayer(Player):
         if status.status == CONNECTION_STATUS_DISCONNECTED:
             self._attr_available = False
             self.update_state()
+            if self.on_app_status_changed is not None:
+                try:
+                    self.on_app_status_changed(None)
+                except Exception:
+                    self.logger.exception("Error in app status callback for %s", self.display_name)
             return
 
         new_available = status.status == CONNECTION_STATUS_CONNECTED

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -826,6 +826,16 @@ class SendspinBridgeManager:
         """
         return self._bridges.get(cast_player_id)
 
+    def get_bridge_by_client_id(self, bridge_client_id: str) -> SendspinChromecastBridge | None:
+        """Return the bridge whose `bridge_client_id` matches, if any.
+
+        :param bridge_client_id: The Sendspin client_id used by a bridged Cast device.
+        """
+        for bridge in self._bridges.values():
+            if bridge.bridge_client_id == bridge_client_id:
+                return bridge
+        return None
+
     async def _on_player_config_updated(self, event: MassEvent) -> None:
         """Handle player config updates for bridged Sendspin Chromecast players."""
         if not event.object_id:

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, cast
 from aiosendspin.models.core import ClientHelloPayload
 from aiosendspin.models.core import DeviceInfo as SendspinDeviceInfo
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
-from aiosendspin.models.types import AudioCodec
+from aiosendspin.models.types import AudioCodec, GoodbyeReason
 from aiosendspin.server import ClientRemovedEvent
 from music_assistant_models.enums import EventType, IdentifierType
 from pychromecast.controllers import BaseController
@@ -241,6 +241,7 @@ class SendspinChromecastBridge:
         self._bridge_role: BridgePlayerRole | None = None
         self._launch_task: asyncio.Task[None] | None = None
         self._log_controller: SendspinCastController | None = None
+        self._cast_app_was_active: bool = False
 
     @property
     def bridge_client_id(self) -> str:
@@ -282,6 +283,9 @@ class SendspinChromecastBridge:
         )
         self.cast_player.cc.register_handler(self._log_controller)
 
+        self._cast_app_was_active = self.cast_player.cc.app_id == SENDSPIN_CAST_APP_ID
+        self.cast_player.on_app_status_changed = self.on_cast_status_changed
+
         self.logger.info(
             "Sendspin bridge registered for %s (client_id=%s)",
             self.cast_player.display_name,
@@ -290,6 +294,8 @@ class SendspinChromecastBridge:
 
     async def stop(self) -> None:
         """Stop and unregister the Sendspin bridge."""
+        self.cast_player.on_app_status_changed = None
+
         if self._log_controller is not None:
             self.cast_player.cc.unregister_handler(self._log_controller)
             self._log_controller = None
@@ -323,6 +329,25 @@ class SendspinChromecastBridge:
         self.mass.config.set_raw_player_config_value(
             self._bridge_client_id, CONF_CAST_AUDIO_UNSUPPORTED, True
         )
+
+    def on_cast_status_changed(self, app_id: str | None) -> None:
+        """Handle Cast app id change / connection loss.
+
+        :param app_id: The current Cast app id, or None if the device disconnected.
+        """
+        if app_id == SENDSPIN_CAST_APP_ID:
+            return
+        if not self._cast_app_was_active:
+            return
+        self._cast_app_was_active = False
+        self.logger.info(
+            "Sendspin Cast app no longer active on %s (app_id=%s) — detaching client",
+            self.cast_player.display_name,
+            app_id,
+        )
+        client = self._sendspin_client
+        if client is not None and client.is_connected:
+            client.detach_connection(GoodbyeReason.SHUTDOWN)
 
     def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
         """Handle stream start request from Sendspin server.
@@ -375,6 +400,7 @@ class SendspinChromecastBridge:
             # Send config with retry — the Cast app's message listener
             # may not be ready immediately after the launch callback fires.
             await self._send_sendspin_config_with_retry()
+            self._cast_app_was_active = True
 
             self.logger.info(
                 "Sendspin Cast App launched on %s (client_id=%s)",

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -874,10 +874,8 @@ class SendspinBridgeManager:
 
         cast_app_was_active = cast_player.cc.app_id == SENDSPIN_CAST_APP_ID
 
-        def _on_cast_status_changed(app_id: str | None) -> None:
+        def _handle_app_gone(app_id: str | None) -> None:
             nonlocal cast_app_was_active
-            if app_id == SENDSPIN_CAST_APP_ID:
-                return
             if not cast_app_was_active:
                 return
             cast_app_was_active = False
@@ -893,6 +891,13 @@ class SendspinBridgeManager:
                 self.mass.create_task(_apply_fatal_disconnect(client, self.logger))
             if cast_player.on_app_status_changed is _on_cast_status_changed:
                 cast_player.on_app_status_changed = None
+
+        def _on_cast_status_changed(app_id: str | None) -> None:
+            if app_id == SENDSPIN_CAST_APP_ID:
+                return
+            if not cast_app_was_active:
+                return
+            self.mass.loop.call_soon_threadsafe(_handle_app_gone, app_id)
 
         cast_player.on_app_status_changed = _on_cast_status_changed
 

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -817,7 +817,37 @@ class SendspinBridgeManager:
                 return
             self.mass.create_task(self.setup_bridge(cast_player))
 
-        self._rebridge_unsubs[client_id] = server_api.add_event_listener(_listener)
+        event_unsub = server_api.add_event_listener(_listener)
+
+        cast_app_was_active = cast_player.cc.app_id == SENDSPIN_CAST_APP_ID
+
+        def _on_cast_status_changed(app_id: str | None) -> None:
+            nonlocal cast_app_was_active
+            if app_id == SENDSPIN_CAST_APP_ID:
+                return
+            if not cast_app_was_active:
+                return
+            cast_app_was_active = False
+            self.logger.info(
+                "Claimed Sendspin Cast client lost on %s (app_id=%s) — detaching",
+                cast_player.display_name,
+                app_id,
+            )
+            client = server_api.get_client(client_id)
+            if client is not None and client.is_connected:
+                client.detach_connection(GoodbyeReason.SHUTDOWN)
+            if cast_player.on_app_status_changed is _on_cast_status_changed:
+                cast_player.on_app_status_changed = None
+
+        cast_player.on_app_status_changed = _on_cast_status_changed
+
+        def _combined_unsub() -> None:
+            with suppress(Exception):
+                event_unsub()
+            if cast_player.on_app_status_changed is _on_cast_status_changed:
+                cast_player.on_app_status_changed = None
+
+        self._rebridge_unsubs[client_id] = _combined_unsub
 
     def get_bridge(self, cast_player_id: str) -> SendspinChromecastBridge | None:
         """Get the bridge for a Chromecast player.

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -293,9 +293,14 @@ class SendspinChromecastBridge:
         return fut
 
     def ensure_cast_ready_future(self) -> asyncio.Future[None]:
-        """Return the current pending future, creating one if missing or done."""
+        """Return the current future, creating one only if missing.
+
+        Leaves a resolved future intact so a stream-start fired after a
+        successful connect doesn't replace it with a pending one that
+        nothing will resolve.
+        """
         fut = self._cast_ready_future
-        if fut is None or fut.done():
+        if fut is None:
             fut = self.mass.loop.create_future()
             self._cast_ready_future = fut
         return fut

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -41,6 +41,7 @@ from music_assistant.providers.sendspin.bridge_role import (
 )
 from music_assistant.providers.sendspin.constants import (
     BRIDGE_PREFIX,
+    CONF_CAST_AUDIO_UNSUPPORTED,
     CONF_SENDSPIN_STATIC_DELAY,
 )
 from music_assistant.providers.sendspin.helpers import (
@@ -81,13 +82,19 @@ class SendspinCastController(BaseController):
     status messages (connection state, errors) from the Cast app.
     """
 
-    def __init__(self, logger: logging.Logger) -> None:
+    def __init__(
+        self,
+        logger: logging.Logger,
+        on_fatal_audio_error: Callable[[], None] | None = None,
+    ) -> None:
         """Initialize the controller.
 
         :param logger: Logger to forward Cast receiver messages to.
+        :param on_fatal_audio_error: Callback when Cast app reports audio is unsupported.
         """
         super().__init__(SENDSPIN_CAST_NAMESPACE)
         self._log = logger
+        self._on_fatal_audio_error = on_fatal_audio_error
 
     def receive_message(self, _message: CastMessage, data: dict[str, Any]) -> bool:
         """Handle incoming messages on the Sendspin namespace.
@@ -119,6 +126,8 @@ class SendspinCastController(BaseController):
         message = data.get("message", "")
         if state == "error":
             self._log.error("[CastApp] Error: %s", message)
+            if "Audio output is not supported" in message and self._on_fatal_audio_error:
+                self._on_fatal_audio_error()
         return True
 
 
@@ -267,7 +276,10 @@ class SendspinChromecastBridge:
             self._bridge_role.setup_audio_requirements()
 
         # Register log controller to receive receiver_log messages from the Cast app
-        self._log_controller = SendspinCastController(self.logger)
+        self._log_controller = SendspinCastController(
+            self.logger,
+            on_fatal_audio_error=self._on_cast_fatal_audio_error,
+        )
         self.cast_player.cc.register_handler(self._log_controller)
 
         self.logger.info(
@@ -294,6 +306,23 @@ class SendspinChromecastBridge:
             self._bridge_role = None
 
         self.logger.debug("Sendspin bridge stopped for %s", self.cast_player.display_name)
+
+    def _on_cast_fatal_audio_error(self) -> None:
+        """Handle fatal audio error from Cast receiver (called from socket thread)."""
+        self.mass.loop.call_soon_threadsafe(self.mass.create_task, self._handle_fatal_audio_error())
+
+    async def _handle_fatal_audio_error(self) -> None:
+        """Process fatal audio error on the event loop.
+
+        Sets persistent config flag so the Sendspin player shows an alert.
+        """
+        self.logger.error(
+            "Cast device %s does not support AudioContext — audio playback unavailable",
+            self.cast_player.display_name,
+        )
+        self.mass.config.set_raw_player_config_value(
+            self._bridge_client_id, CONF_CAST_AUDIO_UNSUPPORTED, True
+        )
 
     def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
         """Handle stream start request from Sendspin server.

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -211,17 +211,7 @@ def _build_bridge_hello(cast_player: ChromecastPlayer, bridge_client_id: str) ->
 
 
 async def _apply_fatal_disconnect(client: SendspinClient, logger: logging.Logger) -> None:
-    """Tear down playback for a Cast device that has died unrecoverably.
-
-    aiosendspin's `detach_connection` does not auto-apply DisconnectBehaviour
-    for SHUTDOWN. The behaviour pref (auto-computed in `SendspinPlayer`) maps
-    UNGROUP to a no-op when the client is already solo, leaving the queue
-    running on a dead device. For fatal Cast errors we want a deterministic
-    outcome: solo → stop the queue, grouped → remove only the dead member.
-
-    :param client: The Sendspin client representing the dead Cast device.
-    :param logger: Logger for recording failures.
-    """
+    """Tear down playback for a dead Cast client: solo → stop, grouped → ungroup."""
     try:
         if len(client.group.clients) > 1:
             await client.ungroup()
@@ -270,9 +260,9 @@ class SendspinChromecastBridge:
         self._log_controller: SendspinCastController | None = None
         self._cast_app_was_active: bool = False
         self._cast_app_connected: bool = False
-        self._cast_ready_future: asyncio.Future[None] | None = None
+        self._cast_app_ready: asyncio.Future[None] | None = None
 
-    def reset_cast_ready_future(self) -> asyncio.Future[None]:
+    def reset_cast_app_ready(self) -> asyncio.Future[None]:
         """Return a fresh cast-ready future, cancelling any prior pending one.
 
         If the Sendspin Cast app is already running (either previously
@@ -280,29 +270,29 @@ class SendspinChromecastBridge:
         future that's already resolved so callers don't wait 30s for a
         "connected" status that won't fire again.
         """
-        prior = self._cast_ready_future
+        prior = self._cast_app_ready
         if prior is not None and not prior.done():
             prior.cancel()
         fut: asyncio.Future[None] = self.mass.loop.create_future()
         already_running = self.cast_player.cc.app_id == SENDSPIN_CAST_APP_ID
         if self._cast_app_connected or already_running:
             fut.set_result(None)
-            self._cast_ready_future = fut
+            self._cast_app_ready = fut
             return fut
-        self._cast_ready_future = fut
+        self._cast_app_ready = fut
         return fut
 
-    def ensure_cast_ready_future(self) -> asyncio.Future[None]:
+    def ensure_cast_app_ready(self) -> asyncio.Future[None]:
         """Return the current future, creating one only if missing.
 
         Leaves a resolved future intact so a stream-start fired after a
         successful connect doesn't replace it with a pending one that
         nothing will resolve.
         """
-        fut = self._cast_ready_future
+        fut = self._cast_app_ready
         if fut is None:
             fut = self.mass.loop.create_future()
-            self._cast_ready_future = fut
+            self._cast_app_ready = fut
         return fut
 
     @property
@@ -360,9 +350,9 @@ class SendspinChromecastBridge:
         self.cast_player.on_app_status_changed = None
         self._cast_app_connected = False
 
-        if self._cast_ready_future is not None and not self._cast_ready_future.done():
-            self._cast_ready_future.cancel()
-        self._cast_ready_future = None
+        if self._cast_app_ready is not None and not self._cast_app_ready.done():
+            self._cast_app_ready.cancel()
+        self._cast_app_ready = None
 
         if self._log_controller is not None:
             self.cast_player.cc.unregister_handler(self._log_controller)
@@ -397,10 +387,11 @@ class SendspinChromecastBridge:
         self.mass.config.set_raw_player_config_value(
             self._bridge_client_id, CONF_CAST_AUDIO_UNSUPPORTED, True
         )
-        self._resolve_cast_ready_future(
+        # Bubbles up to the frontend toast via play_media / set_members awaiting this future.
+        self._resolve_cast_app_ready(
             PlayerCommandFailed(
-                f"{self.cast_player.display_name} has incompatible Cast firmware that "
-                "doesn't support Sendspin. Use the Native Cast protocol for this device."
+                f"Sendspin isn't supported on {self.cast_player.display_name}. "
+                "Use the standard Cast protocol instead."
             )
         )
 
@@ -411,14 +402,14 @@ class SendspinChromecastBridge:
     def _mark_cast_app_connected(self) -> None:
         """Mark the Cast app as connected and resolve any pending future."""
         self._cast_app_connected = True
-        self._resolve_cast_ready_future(None)
+        self._resolve_cast_app_ready(None)
 
-    def _resolve_cast_ready_future(self, error: BaseException | None) -> None:
+    def _resolve_cast_app_ready(self, error: BaseException | None) -> None:
         """Resolve the cast-ready future if still pending.
 
         :param error: Exception to set on the future, or None for success.
         """
-        fut = self._cast_ready_future
+        fut = self._cast_app_ready
         if fut is None or fut.done():
             return
         if error is None:
@@ -453,7 +444,8 @@ class SendspinChromecastBridge:
             if client.is_connected:
                 client.detach_connection(GoodbyeReason.SHUTDOWN)
             self.mass.create_task(_apply_fatal_disconnect(client, self.logger))
-        self._resolve_cast_ready_future(
+        # Bubbles up to the frontend toast via play_media / set_members awaiting this future.
+        self._resolve_cast_app_ready(
             PlayerCommandFailed(
                 f"Cast app on {self.cast_player.display_name} stopped before reporting ready."
             )
@@ -472,7 +464,7 @@ class SendspinChromecastBridge:
             self.cast_player.display_name,
             request.connection_reason,
         )
-        self.ensure_cast_ready_future()
+        self.ensure_cast_app_ready()
         if not self.cast_player.available:
             self.logger.warning("Cannot start Sendspin stream for %s: player not available")
             return

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -28,6 +28,7 @@ from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFo
 from aiosendspin.models.types import AudioCodec, GoodbyeReason
 from aiosendspin.server import ClientRemovedEvent
 from music_assistant_models.enums import EventType, IdentifierType
+from music_assistant_models.errors import PlayerCommandFailed
 from pychromecast.controllers import BaseController
 
 from music_assistant.helpers.util import format_ip_for_url, is_valid_mac_address
@@ -86,15 +87,18 @@ class SendspinCastController(BaseController):
         self,
         logger: logging.Logger,
         on_fatal_audio_error: Callable[[], None] | None = None,
+        on_cast_connected: Callable[[], None] | None = None,
     ) -> None:
         """Initialize the controller.
 
         :param logger: Logger to forward Cast receiver messages to.
         :param on_fatal_audio_error: Callback when Cast app reports audio is unsupported.
+        :param on_cast_connected: Callback when Cast app reports it connected to Sendspin.
         """
         super().__init__(SENDSPIN_CAST_NAMESPACE)
         self._log = logger
         self._on_fatal_audio_error = on_fatal_audio_error
+        self._on_cast_connected = on_cast_connected
 
     def receive_message(self, _message: CastMessage, data: dict[str, Any]) -> bool:
         """Handle incoming messages on the Sendspin namespace.
@@ -128,6 +132,8 @@ class SendspinCastController(BaseController):
             self._log.error("[CastApp] Error: %s", message)
             if "Audio output is not supported" in message and self._on_fatal_audio_error:
                 self._on_fatal_audio_error()
+        elif state == "connected" and self._on_cast_connected:
+            self._on_cast_connected()
         return True
 
 
@@ -242,6 +248,24 @@ class SendspinChromecastBridge:
         self._launch_task: asyncio.Task[None] | None = None
         self._log_controller: SendspinCastController | None = None
         self._cast_app_was_active: bool = False
+        self._cast_ready_future: asyncio.Future[None] | None = None
+
+    def reset_cast_ready_future(self) -> asyncio.Future[None]:
+        """Return a fresh cast-ready future, cancelling any prior pending one."""
+        prior = self._cast_ready_future
+        if prior is not None and not prior.done():
+            prior.cancel()
+        fut: asyncio.Future[None] = self.mass.loop.create_future()
+        self._cast_ready_future = fut
+        return fut
+
+    def ensure_cast_ready_future(self) -> asyncio.Future[None]:
+        """Return the current pending future, creating one if missing or done."""
+        fut = self._cast_ready_future
+        if fut is None or fut.done():
+            fut = self.mass.loop.create_future()
+            self._cast_ready_future = fut
+        return fut
 
     @property
     def bridge_client_id(self) -> str:
@@ -280,6 +304,7 @@ class SendspinChromecastBridge:
         self._log_controller = SendspinCastController(
             self.logger,
             on_fatal_audio_error=self._on_cast_fatal_audio_error,
+            on_cast_connected=self._on_cast_connected,
         )
         self.cast_player.cc.register_handler(self._log_controller)
 
@@ -295,6 +320,10 @@ class SendspinChromecastBridge:
     async def stop(self) -> None:
         """Stop and unregister the Sendspin bridge."""
         self.cast_player.on_app_status_changed = None
+
+        if self._cast_ready_future is not None and not self._cast_ready_future.done():
+            self._cast_ready_future.cancel()
+        self._cast_ready_future = None
 
         if self._log_controller is not None:
             self.cast_player.cc.unregister_handler(self._log_controller)
@@ -329,6 +358,28 @@ class SendspinChromecastBridge:
         self.mass.config.set_raw_player_config_value(
             self._bridge_client_id, CONF_CAST_AUDIO_UNSUPPORTED, True
         )
+        self._resolve_cast_ready_future(
+            PlayerCommandFailed(
+                "This Cast device does not support audio playback (AudioContext unavailable)."
+            )
+        )
+
+    def _on_cast_connected(self) -> None:
+        """Handle Cast app "connected" status (called from socket thread)."""
+        self.mass.loop.call_soon_threadsafe(self._resolve_cast_ready_future, None)
+
+    def _resolve_cast_ready_future(self, error: BaseException | None) -> None:
+        """Resolve the cast-ready future if still pending.
+
+        :param error: Exception to set on the future, or None for success.
+        """
+        fut = self._cast_ready_future
+        if fut is None or fut.done():
+            return
+        if error is None:
+            fut.set_result(None)
+        else:
+            fut.set_exception(error)
 
     def on_cast_status_changed(self, app_id: str | None) -> None:
         """Handle Cast app id change / connection loss.
@@ -348,6 +399,9 @@ class SendspinChromecastBridge:
         client = self._sendspin_client
         if client is not None and client.is_connected:
             client.detach_connection(GoodbyeReason.SHUTDOWN)
+        self._resolve_cast_ready_future(
+            PlayerCommandFailed("Cast app stopped before reporting ready.")
+        )
 
     def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
         """Handle stream start request from Sendspin server.
@@ -362,6 +416,7 @@ class SendspinChromecastBridge:
             self.cast_player.display_name,
             request.connection_reason,
         )
+        self.ensure_cast_ready_future()
         if not self.cast_player.available:
             self.logger.warning("Cannot start Sendspin stream for %s: player not available")
             return

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -210,6 +210,27 @@ def _build_bridge_hello(cast_player: ChromecastPlayer, bridge_client_id: str) ->
     )
 
 
+async def _apply_fatal_disconnect(client: SendspinClient, logger: logging.Logger) -> None:
+    """Tear down playback for a Cast device that has died unrecoverably.
+
+    aiosendspin's `detach_connection` does not auto-apply DisconnectBehaviour
+    for SHUTDOWN. The behaviour pref (auto-computed in `SendspinPlayer`) maps
+    UNGROUP to a no-op when the client is already solo, leaving the queue
+    running on a dead device. For fatal Cast errors we want a deterministic
+    outcome: solo → stop the queue, grouped → remove only the dead member.
+
+    :param client: The Sendspin client representing the dead Cast device.
+    :param logger: Logger for recording failures.
+    """
+    try:
+        if len(client.group.clients) > 1:
+            await client.ungroup()
+        else:
+            await client.group.stop()
+    except Exception:
+        logger.exception("Failed to tear down dead Cast client %s", client.client_id)
+
+
 class SendspinChromecastBridge:
     """Manages the Sendspin to Chromecast bridge for a single player.
 
@@ -248,14 +269,26 @@ class SendspinChromecastBridge:
         self._launch_task: asyncio.Task[None] | None = None
         self._log_controller: SendspinCastController | None = None
         self._cast_app_was_active: bool = False
+        self._cast_app_connected: bool = False
         self._cast_ready_future: asyncio.Future[None] | None = None
 
     def reset_cast_ready_future(self) -> asyncio.Future[None]:
-        """Return a fresh cast-ready future, cancelling any prior pending one."""
+        """Return a fresh cast-ready future, cancelling any prior pending one.
+
+        If the Sendspin Cast app is already running (either previously
+        connected this session, or running from before MA restart), return a
+        future that's already resolved so callers don't wait 30s for a
+        "connected" status that won't fire again.
+        """
         prior = self._cast_ready_future
         if prior is not None and not prior.done():
             prior.cancel()
         fut: asyncio.Future[None] = self.mass.loop.create_future()
+        already_running = self.cast_player.cc.app_id == SENDSPIN_CAST_APP_ID
+        if self._cast_app_connected or already_running:
+            fut.set_result(None)
+            self._cast_ready_future = fut
+            return fut
         self._cast_ready_future = fut
         return fut
 
@@ -320,6 +353,7 @@ class SendspinChromecastBridge:
     async def stop(self) -> None:
         """Stop and unregister the Sendspin bridge."""
         self.cast_player.on_app_status_changed = None
+        self._cast_app_connected = False
 
         if self._cast_ready_future is not None and not self._cast_ready_future.done():
             self._cast_ready_future.cancel()
@@ -360,13 +394,19 @@ class SendspinChromecastBridge:
         )
         self._resolve_cast_ready_future(
             PlayerCommandFailed(
-                "This Cast device does not support audio playback (AudioContext unavailable)."
+                f"{self.cast_player.display_name} has incompatible Cast firmware that "
+                "doesn't support Sendspin. Use the Native Cast protocol for this device."
             )
         )
 
     def _on_cast_connected(self) -> None:
         """Handle Cast app "connected" status (called from socket thread)."""
-        self.mass.loop.call_soon_threadsafe(self._resolve_cast_ready_future, None)
+        self.mass.loop.call_soon_threadsafe(self._mark_cast_app_connected)
+
+    def _mark_cast_app_connected(self) -> None:
+        """Mark the Cast app as connected and resolve any pending future."""
+        self._cast_app_connected = True
+        self._resolve_cast_ready_future(None)
 
     def _resolve_cast_ready_future(self, error: BaseException | None) -> None:
         """Resolve the cast-ready future if still pending.
@@ -391,16 +431,21 @@ class SendspinChromecastBridge:
         if not self._cast_app_was_active:
             return
         self._cast_app_was_active = False
+        self._cast_app_connected = False
         self.logger.info(
             "Sendspin Cast app no longer active on %s (app_id=%s) — detaching client",
             self.cast_player.display_name,
             app_id,
         )
         client = self._sendspin_client
-        if client is not None and client.is_connected:
-            client.detach_connection(GoodbyeReason.SHUTDOWN)
+        if client is not None:
+            if client.is_connected:
+                client.detach_connection(GoodbyeReason.SHUTDOWN)
+            self.mass.create_task(_apply_fatal_disconnect(client, self.logger))
         self._resolve_cast_ready_future(
-            PlayerCommandFailed("Cast app stopped before reporting ready.")
+            PlayerCommandFailed(
+                f"Cast app on {self.cast_player.display_name} stopped before reporting ready."
+            )
         )
 
     def _on_stream_start(self, request: ExternalStreamStartRequest) -> None:
@@ -530,7 +575,9 @@ class SendspinChromecastBridge:
         # The Sendspin server runs on its own port (8927), NOT through
         # the MA webserver or streams server. Use publish_ip directly.
         publish_ip = cast("str", self.mass.streams.publish_ip)
-        server_url = f"ws://{format_ip_for_url(publish_ip)}:8927/sendspin"
+        # sendspin-js's SendspinCore appends `/sendspin` to baseUrl when constructing
+        # the WebSocket URL. Send the bare server URL here so it ends up correct.
+        server_url = f"ws://{format_ip_for_url(publish_ip)}:8927"
         raw_delay = self.mass.config.get_raw_player_config_value(
             self._bridge_client_id, CONF_SENDSPIN_STATIC_DELAY
         )
@@ -834,8 +881,10 @@ class SendspinBridgeManager:
                 app_id,
             )
             client = server_api.get_client(client_id)
-            if client is not None and client.is_connected:
-                client.detach_connection(GoodbyeReason.SHUTDOWN)
+            if client is not None:
+                if client.is_connected:
+                    client.detach_connection(GoodbyeReason.SHUTDOWN)
+                self.mass.create_task(_apply_fatal_disconnect(client, self.logger))
             if cast_player.on_app_status_changed is _on_cast_status_changed:
                 cast_player.on_app_status_changed = None
 

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -422,12 +422,18 @@ class SendspinChromecastBridge:
             fut.set_exception(error)
 
     def on_cast_status_changed(self, app_id: str | None) -> None:
-        """Handle Cast app id change / connection loss.
+        """Handle Cast app id change / connection loss (called from socket thread).
 
         :param app_id: The current Cast app id, or None if the device disconnected.
         """
         if app_id == SENDSPIN_CAST_APP_ID:
             return
+        if not self._cast_app_was_active:
+            return
+        self.mass.loop.call_soon_threadsafe(self._handle_cast_app_gone, app_id)
+
+    def _handle_cast_app_gone(self, app_id: str | None) -> None:
+        """Process Cast app disappearance on the event loop."""
         if not self._cast_app_was_active:
             return
         self._cast_app_was_active = False

--- a/music_assistant/providers/sendspin/constants.py
+++ b/music_assistant/providers/sendspin/constants.py
@@ -4,5 +4,6 @@ from __future__ import annotations
 
 BRIDGE_PREFIX = "spb_"
 
+CONF_CAST_AUDIO_UNSUPPORTED = "cast_audio_unsupported"
 CONF_SENDSPIN_STATIC_DELAY = "sendspin_static_delay"
 DEFAULT_SENDSPIN_STATIC_DELAY = 0

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -747,15 +747,16 @@ class SendspinPlayer(SendspinBasePlayer):
                         self.playback_session = SendspinPlaybackSession(self)
 
             await self.api.group.remove_client(member_player.api)
+        # Reset the cast-ready future *before* group add so a fatal error
+        # on a Cast-bridged member (e.g. AudioContext unsupported) raises
+        # PlayerCommandFailed out of set_members → frontend toast.
+        bridge_manager = self._get_cast_bridge_manager()
+        pending_cast: list[tuple[SendspinPlayer, asyncio.Future[None]]] = []
         for player_id in player_ids_to_add or []:
             member_player = self.mass.players.get_player(player_id, True)
             member_player = cast("SendspinPlayer", member_player)
 
-            # Reset the cast-ready future *before* group add so a fatal error
-            # on a Cast-bridged member (e.g. AudioContext unsupported) raises
-            # PlayerCommandFailed out of set_members → frontend toast.
             cast_ready_future: asyncio.Future[None] | None = None
-            bridge_manager = self._get_cast_bridge_manager()
             if bridge_manager is not None:
                 bridge = bridge_manager.get_bridge_by_client_id(player_id)
                 if bridge is not None:
@@ -763,16 +764,28 @@ class SendspinPlayer(SendspinBasePlayer):
 
             await self.api.group.add_client(member_player.api)
 
-            if cast_ready_future is None:
-                continue
+            if cast_ready_future is not None:
+                pending_cast.append((member_player, cast_ready_future))
+
+        if pending_cast:
             try:
-                await asyncio.wait_for(asyncio.shield(cast_ready_future), timeout=30.0)
+                await asyncio.wait_for(
+                    asyncio.gather(*(asyncio.shield(f) for _, f in pending_cast)),
+                    timeout=30.0,
+                )
             except TimeoutError:
-                if not cast_ready_future.done():
-                    cast_ready_future.cancel()
+                stuck = [m.display_name for m, f in pending_cast if not f.done()]
+                for _, f in pending_cast:
+                    if not f.done():
+                        f.cancel()
                 raise PlayerCommandFailed(
-                    f"Cast app on {member_player.display_name} did not report ready within 30s"
+                    f"Cast app on {', '.join(stuck)} did not report ready within 30s"
                 ) from None
+            except BaseException:
+                for _, f in pending_cast:
+                    if not f.done():
+                        f.cancel()
+                raise
         # self.group_members will be updated by the group event callback
 
     async def _send_album_artwork(self, current_item: QueueItem) -> str | None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -49,6 +49,7 @@ from music_assistant_models.enums import (
     PlayerType,
     RepeatMode,
 )
+from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
@@ -658,12 +659,11 @@ class SendspinPlayer(SendspinBasePlayer):
         try:
             await asyncio.wait_for(asyncio.shield(cast_ready_future), timeout=30.0)
         except TimeoutError:
-            self.logger.warning(
-                "Timed out waiting for Cast app on %s to report ready",
-                self.display_name,
-            )
             if not cast_ready_future.done():
                 cast_ready_future.cancel()
+            raise PlayerCommandFailed(
+                f"Cast app on {self.display_name} did not report ready within 30s"
+            ) from None
 
     async def on_config_updated(self) -> None:
         """Handle logic when the PlayerConfig is first loaded or updated."""
@@ -768,12 +768,11 @@ class SendspinPlayer(SendspinBasePlayer):
             try:
                 await asyncio.wait_for(asyncio.shield(cast_ready_future), timeout=30.0)
             except TimeoutError:
-                self.logger.warning(
-                    "Timed out waiting for Cast app on %s to report ready",
-                    member_player.display_name,
-                )
                 if not cast_ready_future.done():
                     cast_ready_future.cancel()
+                raise PlayerCommandFailed(
+                    f"Cast app on {member_player.display_name} did not report ready within 30s"
+                ) from None
         # self.group_members will be updated by the group event callback
 
     async def _send_album_artwork(self, current_item: QueueItem) -> str | None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -640,27 +640,24 @@ class SendspinPlayer(SendspinBasePlayer):
 
         await self.playback_session.cancel("new media requested")
 
-        # Reset the cast-ready future *before* starting playback so it cannot
-        # race with `_on_stream_start`, and so a stale pending future from a
-        # previous timed-out attempt is cancelled and replaced. Non-Cast
-        # Sendspin players have no bridge and skip this entirely.
-        cast_ready_future: asyncio.Future[None] | None = None
-        bridge_manager = self._get_cast_bridge_manager()
-        if bridge_manager is not None:
-            bridge = bridge_manager.get_bridge_by_client_id(self.player_id)
-            if bridge is not None:
-                cast_ready_future = bridge.reset_cast_ready_future()
+        # Cast-only: reset future before start() to avoid racing _on_stream_start
+        # and to cancel any stale pending future from a previous timed-out attempt.
+        cast_app_ready: asyncio.Future[None] | None = None
+        if (mgr := self._get_cast_bridge_manager()) and (
+            bridge := mgr.get_bridge_by_client_id(self.player_id)
+        ):
+            cast_app_ready = bridge.reset_cast_app_ready()
 
         await self.playback_session.start(media)
         self.update_state()
 
-        if cast_ready_future is None:
+        if cast_app_ready is None:
             return
         try:
-            await asyncio.wait_for(asyncio.shield(cast_ready_future), timeout=30.0)
+            await asyncio.wait_for(asyncio.shield(cast_app_ready), timeout=30.0)
         except TimeoutError:
-            if not cast_ready_future.done():
-                cast_ready_future.cancel()
+            if not cast_app_ready.done():
+                cast_app_ready.cancel()
             raise PlayerCommandFailed(
                 f"Cast app on {self.display_name} did not report ready within 30s"
             ) from None
@@ -747,26 +744,18 @@ class SendspinPlayer(SendspinBasePlayer):
                         self.playback_session = SendspinPlaybackSession(self)
 
             await self.api.group.remove_client(member_player.api)
-        # Reset the cast-ready future *before* group add so a fatal error
-        # on a Cast-bridged member (e.g. AudioContext unsupported) raises
-        # PlayerCommandFailed out of set_members → frontend toast.
+        # Cast-only: reset futures before add so a fatal error on a Cast-bridged
+        # member (e.g. AudioContext unsupported) raises PlayerCommandFailed.
         bridge_manager = self._get_cast_bridge_manager()
         pending_cast: list[tuple[SendspinPlayer, asyncio.Future[None]]] = []
         try:
             for player_id in player_ids_to_add or []:
-                member_player = self.mass.players.get_player(player_id, True)
-                member_player = cast("SendspinPlayer", member_player)
-
-                cast_ready_future: asyncio.Future[None] | None = None
-                if bridge_manager is not None:
-                    bridge = bridge_manager.get_bridge_by_client_id(player_id)
-                    if bridge is not None:
-                        cast_ready_future = bridge.reset_cast_ready_future()
-
+                member_player = cast(
+                    "SendspinPlayer", self.mass.players.get_player(player_id, True)
+                )
+                if bridge_manager and (bridge := bridge_manager.get_bridge_by_client_id(player_id)):
+                    pending_cast.append((member_player, bridge.reset_cast_app_ready()))
                 await self.api.group.add_client(member_player.api)
-
-                if cast_ready_future is not None:
-                    pending_cast.append((member_player, cast_ready_future))
 
             if pending_cast:
                 try:
@@ -964,8 +953,8 @@ class SendspinPlayer(SendspinBasePlayer):
                 ConfigEntry(
                     key="cast_audio_unsupported",
                     type=ConfigEntryType.ALERT,
-                    label="This device has incompatible Cast firmware that doesn't "
-                    "support Sendspin. Use the Native Cast protocol for this device.",
+                    label="Sendspin isn't supported on this Cast device. "
+                    "Use the standard Cast protocol instead.",
                     required=False,
                 )
             )

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -655,12 +655,18 @@ class SendspinPlayer(SendspinBasePlayer):
             return
         try:
             await asyncio.wait_for(asyncio.shield(cast_app_ready), timeout=30.0)
-        except TimeoutError:
+        except BaseException as exc:
             if not cast_app_ready.done():
                 cast_app_ready.cancel()
-            raise PlayerCommandFailed(
-                f"Cast app on {self.display_name} did not report ready within 30s"
-            ) from None
+            # Cancel the playback session so we don't keep streaming to a
+            # device that never reported ready.
+            with suppress(Exception):
+                await self.playback_session.cancel("cast app readiness failed")
+            if isinstance(exc, TimeoutError):
+                raise PlayerCommandFailed(
+                    f"Cast app on {self.display_name} did not report ready within 30s"
+                ) from None
+            raise
 
     async def on_config_updated(self) -> None:
         """Handle logic when the PlayerConfig is first loaded or updated."""
@@ -768,6 +774,13 @@ class SendspinPlayer(SendspinBasePlayer):
                     raise PlayerCommandFailed(
                         f"Cast app on {', '.join(stuck)} did not report ready within 30s"
                     ) from None
+        except BaseException:
+            # Roll back Cast members we just added so a failed group operation
+            # doesn't leave dead members in the Sendspin group.
+            for member, _ in pending_cast:
+                with suppress(Exception):
+                    await self.api.group.remove_client(member.api)
+            raise
         finally:
             for _, f in pending_cast:
                 if not f.done():

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -750,7 +750,30 @@ class SendspinPlayer(SendspinBasePlayer):
         for player_id in player_ids_to_add or []:
             member_player = self.mass.players.get_player(player_id, True)
             member_player = cast("SendspinPlayer", member_player)
+
+            # Reset the cast-ready future *before* group add so a fatal error
+            # on a Cast-bridged member (e.g. AudioContext unsupported) raises
+            # PlayerCommandFailed out of set_members → frontend toast.
+            cast_ready_future: asyncio.Future[None] | None = None
+            bridge_manager = self._get_cast_bridge_manager()
+            if bridge_manager is not None:
+                bridge = bridge_manager.get_bridge_by_client_id(player_id)
+                if bridge is not None:
+                    cast_ready_future = bridge.reset_cast_ready_future()
+
             await self.api.group.add_client(member_player.api)
+
+            if cast_ready_future is None:
+                continue
+            try:
+                await asyncio.wait_for(asyncio.shield(cast_ready_future), timeout=30.0)
+            except TimeoutError:
+                self.logger.warning(
+                    "Timed out waiting for Cast app on %s to report ready",
+                    member_player.display_name,
+                )
+                if not cast_ready_future.done():
+                    cast_ready_future.cancel()
         # self.group_members will be updated by the group event callback
 
     async def _send_album_artwork(self, current_item: QueueItem) -> str | None:
@@ -932,9 +955,8 @@ class SendspinPlayer(SendspinBasePlayer):
                 ConfigEntry(
                     key="cast_audio_unsupported",
                     type=ConfigEntryType.ALERT,
-                    label="This Cast device does not support audio playback. "
-                    "The Sendspin Cast bridge requires AudioContext support, "
-                    "which is not available on this device.",
+                    label="This device has incompatible Cast firmware that doesn't "
+                    "support Sendspin. Use the Native Cast protocol for this device.",
                     required=False,
                 )
             )

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -57,6 +57,7 @@ from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player, PlayerMedia
 
 from .constants import (
+    CONF_CAST_AUDIO_UNSUPPORTED,
     CONF_SENDSPIN_STATIC_DELAY,
     DEFAULT_SENDSPIN_STATIC_DELAY,
 )
@@ -891,6 +892,20 @@ class SendspinPlayer(SendspinBasePlayer):
     ) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the player."""
         entries: list[ConfigEntry] = []
+        # Show alert if this Cast device is known to lack AudioContext support
+        if self.mass.config.get_raw_player_config_value(
+            self.player_id, CONF_CAST_AUDIO_UNSUPPORTED
+        ):
+            entries.append(
+                ConfigEntry(
+                    key="cast_audio_unsupported",
+                    type=ConfigEntryType.ALERT,
+                    label="This Cast device does not support audio playback. "
+                    "The Sendspin Cast bridge requires AudioContext support, "
+                    "which is not available on this device.",
+                    required=False,
+                )
+            )
         # Build dynamic format options from player's supported formats
         player_role = self._player_role
         if player_role is not None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -752,40 +752,37 @@ class SendspinPlayer(SendspinBasePlayer):
         # PlayerCommandFailed out of set_members → frontend toast.
         bridge_manager = self._get_cast_bridge_manager()
         pending_cast: list[tuple[SendspinPlayer, asyncio.Future[None]]] = []
-        for player_id in player_ids_to_add or []:
-            member_player = self.mass.players.get_player(player_id, True)
-            member_player = cast("SendspinPlayer", member_player)
+        try:
+            for player_id in player_ids_to_add or []:
+                member_player = self.mass.players.get_player(player_id, True)
+                member_player = cast("SendspinPlayer", member_player)
 
-            cast_ready_future: asyncio.Future[None] | None = None
-            if bridge_manager is not None:
-                bridge = bridge_manager.get_bridge_by_client_id(player_id)
-                if bridge is not None:
-                    cast_ready_future = bridge.reset_cast_ready_future()
+                cast_ready_future: asyncio.Future[None] | None = None
+                if bridge_manager is not None:
+                    bridge = bridge_manager.get_bridge_by_client_id(player_id)
+                    if bridge is not None:
+                        cast_ready_future = bridge.reset_cast_ready_future()
 
-            await self.api.group.add_client(member_player.api)
+                await self.api.group.add_client(member_player.api)
 
-            if cast_ready_future is not None:
-                pending_cast.append((member_player, cast_ready_future))
+                if cast_ready_future is not None:
+                    pending_cast.append((member_player, cast_ready_future))
 
-        if pending_cast:
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*(asyncio.shield(f) for _, f in pending_cast)),
-                    timeout=30.0,
-                )
-            except TimeoutError:
-                stuck = [m.display_name for m, f in pending_cast if not f.done()]
-                for _, f in pending_cast:
-                    if not f.done():
-                        f.cancel()
-                raise PlayerCommandFailed(
-                    f"Cast app on {', '.join(stuck)} did not report ready within 30s"
-                ) from None
-            except BaseException:
-                for _, f in pending_cast:
-                    if not f.done():
-                        f.cancel()
-                raise
+            if pending_cast:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*(asyncio.shield(f) for _, f in pending_cast)),
+                        timeout=30.0,
+                    )
+                except TimeoutError:
+                    stuck = [m.display_name for m, f in pending_cast if not f.done()]
+                    raise PlayerCommandFailed(
+                        f"Cast app on {', '.join(stuck)} did not report ready within 30s"
+                    ) from None
+        finally:
+            for _, f in pending_cast:
+                if not f.done():
+                    f.cancel()
         # self.group_members will be updated by the group event callback
 
     async def _send_album_artwork(self, current_item: QueueItem) -> str | None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -133,6 +133,8 @@ if TYPE_CHECKING:
     from music_assistant_models.player_queue import PlayerQueue
     from music_assistant_models.queue_item import QueueItem
 
+    from music_assistant.providers.chromecast.sendspin_bridge import SendspinBridgeManager
+
     from .provider import SendspinProvider
 
 
@@ -615,23 +617,53 @@ class SendspinPlayer(SendspinBasePlayer):
         await self.playback_session.cancel("stop command")
         await self.api.group.stop()
 
+    def _get_cast_bridge_manager(self) -> SendspinBridgeManager | None:
+        """Return the Chromecast provider's Sendspin bridge manager, if loaded."""
+        chromecast_provider = self.mass.get_provider("chromecast")
+        if chromecast_provider is None:
+            return None
+        manager = getattr(chromecast_provider, "bridge_manager", None)
+        if manager is None:
+            return None
+        return cast("SendspinBridgeManager", manager)
+
     async def play_media(self, media: PlayerMedia) -> None:
         """Play media command."""
         self.logger.debug(
             "Received PLAY_MEDIA command on player %s with uri %s", self.display_name, media.uri
         )
 
-        # Set current media; elapsed_time will be updated once audio actually commits.
         self._attr_current_media = media
         self._attr_elapsed_time = None
         self._attr_elapsed_time_last_updated = None
-        # playback_state will be set by the group state change event
 
-        # Stop previous stream in case we were already playing something.
-        # Do not call group.stop() here to avoid STOPPED-event races with next-track transitions.
         await self.playback_session.cancel("new media requested")
+
+        # Reset the cast-ready future *before* starting playback so it cannot
+        # race with `_on_stream_start`, and so a stale pending future from a
+        # previous timed-out attempt is cancelled and replaced. Non-Cast
+        # Sendspin players have no bridge and skip this entirely.
+        cast_ready_future: asyncio.Future[None] | None = None
+        bridge_manager = self._get_cast_bridge_manager()
+        if bridge_manager is not None:
+            bridge = bridge_manager.get_bridge_by_client_id(self.player_id)
+            if bridge is not None:
+                cast_ready_future = bridge.reset_cast_ready_future()
+
         await self.playback_session.start(media)
         self.update_state()
+
+        if cast_ready_future is None:
+            return
+        try:
+            await asyncio.wait_for(asyncio.shield(cast_ready_future), timeout=30.0)
+        except TimeoutError:
+            self.logger.warning(
+                "Timed out waiting for Cast app on %s to report ready",
+                self.display_name,
+            )
+            if not cast_ready_future.done():
+                cast_ready_future.cancel()
 
     async def on_config_updated(self) -> None:
         """Handle logic when the PlayerConfig is first loaded or updated."""


### PR DESCRIPTION
Sendspin Cast players previously had no mechanism to signal failures to users. So, in case the Cast App immediately crashes, there was no feedback indicating that. Specifically newer Cast devices that are built on GC4A 2.0 that can't run Sendspin due to missing APIs would similarly show no feedback to the user.

This PR addresses this by:
- Wiring the Sendspin provider to wait for Cast devices when playing media or grouping speakers, raising an exception that surfaces to the frontend in case anything fails.
- Showing a "Sendspin isn't supported on <device>. Use the standard Cast protocol instead." if a missing `AudioContext` API is detected (on GC4A 2.0 devices). this is shown when starting playback or grouping the speaker.
- Showing a persistent alert in the Sendspin protocol settings of GC4A 2.0 devices: "Sendspin isn't supported on this Cast device. Use the standard Cast protocol instead."
- Detecting if the Sendspin Cast App stopped (e.g. the user casts through their phone to the speaker mid-playback), stopping/ungrouping the player from the Sendspin provider

Notes:
- In addition to this frontend error, a TTS announcement will also play on the speaker.
- The Cast protocol for this speaker is not auto-disabled. Auto-disabling would leave users wondering why their speaker stopped appearing in the grouping list if they missed the initial error message and announcement.