### PR TITLE
Fix double sendspin bridges for devices with both Airplay and Cast

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1007,6 +1007,9 @@ class ProtocolLinkingMixin:
 
     def _save_protocol_parent_id(self, protocol_player_id: str, parent_id: str) -> None:
         """Save the parent ID for a protocol player for persistence across restarts."""
+        # Only save if the player config still exists to avoid creating partial entries
+        if not self.mass.config.get(f"{CONF_PLAYERS}/{protocol_player_id}"):
+            return
         conf_key = f"{CONF_PLAYERS}/{protocol_player_id}/values/{CONF_PROTOCOL_PARENT_ID}"
         self.mass.config.set(conf_key, parent_id)
 
@@ -1134,6 +1137,9 @@ class ProtocolLinkingMixin:
                         )
                     else:
                         parent_player.update_state()
+                else:
+                    # Parent not registered yet — still purge the cached id
+                    self._remove_protocol_id_from_cache(parent_id, player.player_id)
         else:
             # Native/universal player being removed: handle all linked protocol players.
             # Collect all known protocol IDs from both active links and cached state,

--- a/music_assistant/providers/alexa/__init__.py
+++ b/music_assistant/providers/alexa/__init__.py
@@ -51,6 +51,7 @@ CONF_API_URL = "api_url"
 CONF_ALEXA_LANGUAGE = "alexa_language"
 
 ALEXA_LANGUAGE_COMMANDS = {
+    "play_audio_fr-FR": "demande à music assistant de lire l'audio",
     "play_audio_de-DE": "sag music assistant spiele audio",
     "play_audio_en-US": "ask music assistant to play audio",
     "play_audio_default": "ask music assistant to play audio",

--- a/music_assistant/providers/alexa/__init__.py
+++ b/music_assistant/providers/alexa/__init__.py
@@ -49,7 +49,6 @@ CONF_API_URL = "api_url"
 CONF_ALEXA_LANGUAGE = "alexa_language"
 
 ALEXA_LANGUAGE_COMMANDS = {
-    "play_audio_fr-FR": "demande à music assistant de lire l'audio",
     "play_audio_de-DE": "sag music assistant spiele audio",
     "play_audio_en-CA": "ask music assistant to play audio",
     "play_audio_en-US": "ask music assistant to play audio",

--- a/music_assistant/providers/chromecast/provider.py
+++ b/music_assistant/providers/chromecast/provider.py
@@ -189,7 +189,7 @@ class ChromecastProvider(PlayerProvider):
             await castplayer.async_setup()
             await self.mass.players.register_or_update(castplayer)
             # Set up Sendspin bridge
-            await self.bridge_manager.setup_bridge(castplayer)
+            await self.bridge_manager.evaluate_bridge(castplayer)
         finally:
             self._pending_discoveries.discard(player_id)
 

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -589,11 +589,15 @@ class SendspinBridgeManager:
                 return
 
             bridge_client_id = get_bridge_client_id(cast_player)
-            assert bridge_client_id is not None  # validated by _should_have_bridge
+            sendspin_server = self.sendspin_server
+            if bridge_client_id is None or sendspin_server is None:
+                self.logger.debug(
+                    "Skipping bridge setup for %s — preconditions changed since evaluation",
+                    cast_player.display_name,
+                )
+                return
             manufacturer = cast_player.device_info.manufacturer or ""
             model = cast_player.device_info.model or ""
-            sendspin_server = self.sendspin_server
-            assert sendspin_server is not None  # validated by _should_have_bridge
 
             existing_client_id = self._find_existing_sendspin_client(
                 sendspin_server, bridge_client_id, cast_player
@@ -668,7 +672,10 @@ class SendspinBridgeManager:
                     unsub()
             target_id = client_id or claimed_client_id
             if target_id:
-                await self.mass.players.unregister(target_id, permanent=True)
+                if self.mass.players.get_player(target_id):
+                    await self.mass.players.unregister(target_id, permanent=True)
+                else:
+                    self.mass.players.delete_player_config(target_id)
             if bridge:
                 await bridge.stop()
             elif claimed_client_id and (sendspin_server := self.sendspin_server):

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -475,6 +475,13 @@ class SendspinBridgeManager:
         self._unsub_config_updated = self.mass.subscribe(
             self._on_player_config_updated, EventType.PLAYER_CONFIG_UPDATED
         )
+        self._unsub_player_updated = self.mass.subscribe(
+            self._on_player_updated, EventType.PLAYER_UPDATED
+        )
+        self._airplay_was_available = self.mass.get_provider("airplay") is not None
+        self._unsub_providers_updated = self.mass.subscribe(
+            self._on_providers_updated, EventType.PROVIDERS_UPDATED
+        )
 
     @property
     def sendspin_provider(self) -> SendspinProvider | None:
@@ -490,6 +497,73 @@ class SendspinBridgeManager:
         if provider := self.sendspin_provider:
             return provider.server_api
         return None
+
+    def _should_have_bridge(self, cast_player: ChromecastPlayer) -> bool:
+        """
+        Return whether this cast player should have a Sendspin bridge.
+
+        :param cast_player: The Chromecast player to evaluate.
+        """
+        # Audio groups (non-stereo-pair) have their own playback mechanism
+        if cast_player.cast_info.is_audio_group and not cast_player.cast_info.is_multichannel_group:
+            return False
+
+        if not get_bridge_client_id(cast_player):
+            return False
+
+        manufacturer = cast_player.device_info.manufacturer or ""
+        model = cast_player.device_info.model or ""
+        if is_sendspin_cast_blocked(manufacturer, model):
+            self.logger.debug(
+                "Skipping Sendspin Cast bridge for %s (%s / %s) — device is blocklisted",
+                cast_player.display_name,
+                manufacturer,
+                model,
+            )
+            return False
+
+        if not self.sendspin_server:
+            self.logger.debug(
+                "Sendspin provider not available, skipping bridge for %s",
+                cast_player.display_name,
+            )
+            return False
+
+        # Prefer the airplay bridge over the cast bridge (better sync performance)
+        # when the cast player shares a parent with an airplay protocol player.
+        if cast_player.protocol_parent_id:
+            parent_player = self.mass.players.get_player(cast_player.protocol_parent_id)
+            if parent_player:
+                for protocol in parent_player.linked_output_protocols:
+                    if protocol.protocol_domain != "airplay":
+                        continue
+                    airplay_player = self.mass.players.get_player(protocol.output_protocol_id)
+                    if airplay_player and airplay_player.available:
+                        return False
+
+        return True
+
+    async def evaluate_bridge(self, cast_player: ChromecastPlayer) -> None:
+        """
+        Reconcile the Sendspin bridge state for this cast player.
+
+        Creates or removes the bridge to match the desired state derived from
+        the current player graph. Idempotent and safe to call repeatedly.
+
+        :param cast_player: The Chromecast player to evaluate.
+        """
+        player_id = cast_player.player_id
+        desired = self._should_have_bridge(cast_player)
+        has_bridge = player_id in self._bridges or player_id in self._claimed_clients
+
+        if desired and not has_bridge:
+            await self.setup_bridge(cast_player)
+        elif not desired and has_bridge:
+            self.logger.info(
+                "Removing redundant Sendspin Cast bridge for %s",
+                cast_player.display_name,
+            )
+            await self.remove_bridge(player_id)
 
     async def setup_bridge(self, cast_player: ChromecastPlayer) -> None:
         """
@@ -511,45 +585,15 @@ class SendspinBridgeManager:
                 )
                 return
 
-            # Skip audio groups (non-stereo-pair) — they have their own playback mechanism
-            if (
-                cast_player.cast_info.is_audio_group
-                and not cast_player.cast_info.is_multichannel_group
-            ):
+            if not self._should_have_bridge(cast_player):
                 return
-
-            # skip if the cast player's parent also has airplay linked
-            # (we prefer the airplay bridge due to better sync performance)
-            if cast_player.protocol_parent_id:
-                parent_player = self.mass.players.get_player(cast_player.protocol_parent_id)
-                if parent_player:
-                    for protocol in parent_player.linked_output_protocols:
-                        if protocol.protocol_domain == "airplay":
-                            return
 
             bridge_client_id = get_bridge_client_id(cast_player)
-            if not bridge_client_id:
-                return
-
-            # Skip devices on the blocklist
+            assert bridge_client_id is not None  # validated by _should_have_bridge
             manufacturer = cast_player.device_info.manufacturer or ""
             model = cast_player.device_info.model or ""
-            if is_sendspin_cast_blocked(manufacturer, model):
-                self.logger.debug(
-                    "Skipping Sendspin Cast bridge for %s (%s / %s) — device is blocklisted",
-                    cast_player.display_name,
-                    manufacturer,
-                    model,
-                )
-                return
-
             sendspin_server = self.sendspin_server
-            if not sendspin_server:
-                self.logger.debug(
-                    "Sendspin provider not available, skipping bridge for %s",
-                    cast_player.display_name,
-                )
-                return
+            assert sendspin_server is not None  # validated by _should_have_bridge
 
             existing_client_id = self._find_existing_sendspin_client(
                 sendspin_server, bridge_client_id, cast_player
@@ -616,12 +660,17 @@ class SendspinBridgeManager:
         :param cast_player_id: The player ID to remove the bridge for.
         """
         async with self._lock:
-            if bridge := self._bridges.pop(cast_player_id, None):
-                await bridge.stop()
+            bridge = self._bridges.pop(cast_player_id, None)
+            client_id = bridge.bridge_client_id if bridge else None
             claimed_client_id = self._claimed_clients.pop(cast_player_id, None)
             if claimed_client_id and (unsub := self._rebridge_unsubs.pop(claimed_client_id, None)):
                 with suppress(Exception):
                     unsub()
+            target_id = client_id or claimed_client_id
+            if target_id:
+                await self.mass.players.unregister(target_id, permanent=True)
+            if bridge:
+                await bridge.stop()
 
             self.logger.debug("Sendspin bridge removed for Chromecast player %s", cast_player_id)
 
@@ -638,6 +687,8 @@ class SendspinBridgeManager:
     async def close(self) -> None:
         """Stop all bridges and unsubscribe event listeners."""
         self._unsub_config_updated()
+        self._unsub_player_updated()
+        self._unsub_providers_updated()
         for unsub in list(self._rebridge_unsubs.values()):
             with suppress(Exception):
                 unsub()
@@ -715,6 +766,27 @@ class SendspinBridgeManager:
         :param cast_player_id: The player ID to look up.
         """
         return self._bridges.get(cast_player_id)
+
+    async def _on_player_updated(self, event: MassEvent) -> None:
+        """Re-evaluate bridge state for cast players affected by a player update."""
+        if not event.object_id:
+            return
+        affected: list[ChromecastPlayer] = []
+        for player in self.provider.players:
+            cast_player = cast("ChromecastPlayer", player)
+            if event.object_id in {cast_player.player_id, cast_player.protocol_parent_id}:
+                affected.append(cast_player)
+        for cast_player in affected:
+            await self.evaluate_bridge(cast_player)
+
+    async def _on_providers_updated(self, event: MassEvent) -> None:
+        """Re-evaluate cast bridges when the airplay provider availability flips."""
+        airplay_available = self.mass.get_provider("airplay") is not None
+        if airplay_available == self._airplay_was_available:
+            return
+        self._airplay_was_available = airplay_available
+        for player in self.provider.players:
+            await self.evaluate_bridge(cast("ChromecastPlayer", player))
 
     async def _on_player_config_updated(self, event: MassEvent) -> None:
         """Handle player config updates for bridged Sendspin Chromecast players."""

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -978,13 +978,16 @@ class SendspinBridgeManager:
         """Re-evaluate bridge state for cast players affected by a player update."""
         if not event.object_id:
             return
-        affected: list[ChromecastPlayer] = []
+        updated_player = self.mass.players.get_player(event.object_id)
+        match_ids = {event.object_id}
+        if updated_player and updated_player.protocol_parent_id:
+            match_ids.add(updated_player.protocol_parent_id)
         for player in self.provider.players:
             cast_player = cast("ChromecastPlayer", player)
-            if event.object_id in {cast_player.player_id, cast_player.protocol_parent_id}:
-                affected.append(cast_player)
-        for cast_player in affected:
-            await self.evaluate_bridge(cast_player)
+            if cast_player.player_id in match_ids or (
+                cast_player.protocol_parent_id and cast_player.protocol_parent_id in match_ids
+            ):
+                await self.evaluate_bridge(cast_player)
 
     async def _on_providers_updated(self, event: MassEvent) -> None:
         """Re-evaluate cast bridges when the airplay provider availability flips."""

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -671,6 +671,9 @@ class SendspinBridgeManager:
                 await self.mass.players.unregister(target_id, permanent=True)
             if bridge:
                 await bridge.stop()
+            elif claimed_client_id and (sendspin_server := self.sendspin_server):
+                with suppress(Exception):
+                    await sendspin_server.remove_client(claimed_client_id)
 
             self.logger.debug("Sendspin bridge removed for Chromecast player %s", cast_player_id)
 

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -102,7 +102,10 @@ class UniversalPlayerProvider(PlayerProvider):
                     protocol_id,
                     player_id,
                 )
-                await self.mass.config.remove_player_config(protocol_id)
+                if self.mass.players.get_player(protocol_id):
+                    await self.mass.players.unregister(protocol_id, permanent=True)
+                else:
+                    self.mass.players.delete_player_config(protocol_id)
                 continue
             valid_protocol_ids.append(protocol_id)
 

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -59,7 +59,7 @@ class UniversalPlayerProvider(PlayerProvider):
                 # The stored protocol IDs enable fast matching when protocols register
                 await self._restore_player(player_conf.player_id)
 
-    async def _restore_player(self, player_id: str) -> None:
+    async def _restore_player(self, player_id: str) -> None:  # noqa: PLR0915
         """
         Restore a universal player from config.
 
@@ -78,7 +78,7 @@ class UniversalPlayerProvider(PlayerProvider):
         stored_identifiers = values.get(CONF_DEVICE_IDENTIFIERS, {})
         stored_device_info = values.get(CONF_DEVICE_INFO, {})
 
-        # Filter out protocol IDs that are no longer PROTOCOL type players
+        # Filter out protocol IDs that are no longer valid for this universal
         valid_protocol_ids = []
         for protocol_id in stored_protocol_ids:
             protocol_config = self.mass.config.get(f"{CONF_PLAYERS}/{protocol_id}")
@@ -87,15 +87,24 @@ class UniversalPlayerProvider(PlayerProvider):
                 valid_protocol_ids.append(protocol_id)
                 continue
             protocol_player_type = protocol_config.get("player_type")
-            if protocol_player_type == "protocol":
-                valid_protocol_ids.append(protocol_id)
-            else:
+            if protocol_player_type != "protocol":
                 self.logger.info(
                     "Removing %s from universal player %s - player type changed to %s",
                     protocol_id,
                     player_id,
                     protocol_player_type,
                 )
+                continue
+            protocol_values = protocol_config.get("values") or {}
+            if not protocol_values.get("protocol_parent_id"):
+                self.logger.info(
+                    "Deleting orphaned protocol player config %s (was linked to %s)",
+                    protocol_id,
+                    player_id,
+                )
+                await self.mass.config.remove_player_config(protocol_id)
+                continue
+            valid_protocol_ids.append(protocol_id)
 
         # If no valid protocol IDs remain, delete this stale universal player
         if not valid_protocol_ids:

--- a/tests/core/test_protocol_linking.py
+++ b/tests/core/test_protocol_linking.py
@@ -6456,3 +6456,131 @@ class TestStaleConfigMigration:
         # Verify no set calls were made to clear the parent_id
         for call in mock_mass.config.set.call_args_list:
             assert "protocol_parent_id" not in str(call), "Valid parent_id should not be cleared"
+
+
+class TestUniversalPlayerRestoreOrphanCleanup:
+    """Tests for UniversalPlayerProvider._restore_player orphan cleanup behavior."""
+
+    @staticmethod
+    def _setup_config_get(
+        mock_mass: MagicMock,
+        universal_id: str,
+        linked_protocol_ids: list[str],
+        protocol_configs: dict[str, dict[str, object]],
+    ) -> None:
+        """Wire mass.config.get to return universal/protocol configs by key."""
+        universal_conf = {
+            "values": {
+                "linked_protocol_ids": list(linked_protocol_ids),
+                "device_identifiers": {},
+                "device_info": {},
+            },
+            "name": "Test Universal",
+        }
+
+        def _get(key: str, default: object = None) -> object:
+            if key == f"players/{universal_id}":
+                return universal_conf
+            for pid, conf in protocol_configs.items():
+                if key == f"players/{pid}":
+                    return conf
+            return default
+
+        mock_mass.config.get.side_effect = _get
+
+    @pytest.mark.asyncio
+    async def test_orphan_protocol_deleted_when_not_registered(self, mock_mass: MagicMock) -> None:
+        """Orphan protocol with no live registration → delete_player_config path."""
+        provider = create_mock_universal_provider(mock_mass)
+        universal_id = "up_test"
+        orphan_id = "spb_orphan"
+
+        self._setup_config_get(
+            mock_mass,
+            universal_id,
+            [orphan_id],
+            {
+                orphan_id: {
+                    "player_type": "protocol",
+                    "values": {"protocol_parent_id": None},
+                },
+            },
+        )
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(return_value=None)
+        mock_mass.players.delete_player_config = MagicMock()
+        mock_mass.players.unregister = AsyncMock()
+        mock_mass.config.remove_player_config = AsyncMock()
+
+        await provider._restore_player(universal_id)
+
+        mock_mass.players.delete_player_config.assert_called_once_with(orphan_id)
+        mock_mass.players.unregister.assert_not_called()
+        # With no valid protocols left, the universal is also removed
+        mock_mass.config.remove_player_config.assert_called_once_with(universal_id)
+
+    @pytest.mark.asyncio
+    async def test_orphan_protocol_unregistered_when_active(self, mock_mass: MagicMock) -> None:
+        """Orphan protocol that is currently registered → unregister(permanent=True) path."""
+        provider = create_mock_universal_provider(mock_mass)
+        universal_id = "up_test"
+        orphan_id = "spb_orphan"
+
+        self._setup_config_get(
+            mock_mass,
+            universal_id,
+            [orphan_id],
+            {
+                orphan_id: {
+                    "player_type": "protocol",
+                    "values": {"protocol_parent_id": None},
+                },
+            },
+        )
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(return_value=MagicMock())
+        mock_mass.players.delete_player_config = MagicMock()
+        mock_mass.players.unregister = AsyncMock()
+        mock_mass.config.remove_player_config = AsyncMock()
+
+        await provider._restore_player(universal_id)
+
+        mock_mass.players.unregister.assert_awaited_once_with(orphan_id, permanent=True)
+        mock_mass.players.delete_player_config.assert_not_called()
+        mock_mass.config.remove_player_config.assert_called_once_with(universal_id)
+
+    @pytest.mark.asyncio
+    async def test_valid_protocol_kept_and_no_cleanup(self, mock_mass: MagicMock) -> None:
+        """Protocol with a valid protocol_parent_id is kept and no cleanup runs."""
+        provider = create_mock_universal_provider(mock_mass)
+        universal_id = "up_test"
+        protocol_id = "spb_valid"
+
+        self._setup_config_get(
+            mock_mass,
+            universal_id,
+            [protocol_id],
+            {
+                protocol_id: {
+                    "player_type": "protocol",
+                    "values": {"protocol_parent_id": universal_id},
+                },
+            },
+        )
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(return_value=None)
+        mock_mass.players.delete_player_config = MagicMock()
+        mock_mass.players.unregister = AsyncMock()
+        mock_mass.players.register_or_update = AsyncMock()
+        mock_mass.config.remove_player_config = AsyncMock()
+        mock_mass.config.get_base_player_config.return_value = create_mock_config("Test Universal")
+
+        await provider._restore_player(universal_id)
+
+        mock_mass.players.delete_player_config.assert_not_called()
+        mock_mass.players.unregister.assert_not_called()
+        mock_mass.config.remove_player_config.assert_not_called()
+        # Universal is constructed and registered with the valid protocol kept
+        mock_mass.players.register_or_update.assert_awaited_once()
+        registered = mock_mass.players.register_or_update.call_args.args[0]
+        assert protocol_id in registered._protocol_player_ids

--- a/tests/core/test_protocol_linking.py
+++ b/tests/core/test_protocol_linking.py
@@ -6180,7 +6180,14 @@ class TestProtocolParentIdPersistence:
     def test_parent_id_saved_for_universal_parent(self, mock_mass: MagicMock) -> None:
         """protocol_parent_id should be saved when linking to a universal player."""
         controller = PlayerController(mock_mass)
-        mock_mass.config.get = MagicMock(return_value=[])
+
+        def _config_get(key: str, default: object = None) -> object:
+            # Protocol player config must exist for _save_protocol_parent_id to write
+            if key == "players/airplay_test":
+                return {"enabled": True}
+            return default if default is not None else []
+
+        mock_mass.config.get = MagicMock(side_effect=_config_get)
 
         universal_provider = create_mock_universal_provider(mock_mass)
         parent = UniversalPlayer(


### PR DESCRIPTION
This PR makes the bridge evaluation idempotent for devices that both have Airplay and Cast protocols:
- Airplay is always preferred
- Chromecast bridges now subscribe to player and provider events to evaluate whether the cast bridge is still needed

So MA can now:
- Tear down the cast bridge and add an Airplay one when Airplay is detected (and vice versa). This also fixes the race condition where Cast registered before Airplay and left an orphaned (2nd grayed out) sendspin protocol on the universal player
- Auto clean up orphaned sendspin bridges.

This PR also surfaced the `KeyError: 'player_id'` bug which turned out to be a missing guard in the `save_protocol_parent_id` function.