### PR TITLE
fix wrong base_url in reverse_proxy scenario to connect WSS

### DIFF
--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -98,7 +98,11 @@ class WebsocketClientHandler:
         self._writer_task = self.mass.create_task(self._writer())
 
         # send server(version) info when client connects
+        # Use proxy-aware base_url if available (set from X-Forwarded-Host in __init__),
+        # otherwise fall back to the configured base_url
         server_info = self.mass.get_server_info()
+        if self.base_url:
+            server_info.base_url = self.base_url
         await self._send_message(server_info)
 
         # Block until onboarding is complete


### PR DESCRIPTION
In reverse proxy scenario, like in Kubernetes, music-assistant cannot be reached through websocket, we got a 502 after setting the base_url parameter.

There is a dynamic configuration to handle base_url but in WebsocketClientHandler::handle_client we send the configured one and not the detected one