### PR TITLE
Add similar_artists API endpoint and MusicProvider base method

### DIFF
--- a/music_assistant/controllers/media/artists.py
+++ b/music_assistant/controllers/media/artists.py
@@ -71,10 +71,9 @@ class ArtistsController(MediaControllerBase[Artist]):
             if ProviderFeature.SIMILAR_ARTISTS not in prov.supported_features:
                 continue
             try:
-                if result := await prov.get_similar_artists(
+                return await prov.get_similar_artists(
                     prov_artist_id=prov_mapping.item_id, limit=limit
-                ):
-                    return result
+                )
             except NotImplementedError:
                 continue
         return []

--- a/music_assistant/controllers/media/artists.py
+++ b/music_assistant/controllers/media/artists.py
@@ -25,10 +25,10 @@ from music_assistant.controllers.media.base import MediaControllerBase
 from music_assistant.helpers.compare import compare_artist, compare_strings, create_safe_string
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import serialize_to_json
+from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
     from music_assistant import MusicAssistant
-    from music_assistant.models.music_provider import MusicProvider
 
 
 class ArtistsController(MediaControllerBase[Artist]):
@@ -46,6 +46,38 @@ class ArtistsController(MediaControllerBase[Artist]):
         api_base = self.api_base
         self.mass.register_api_command(f"music/{api_base}/artist_albums", self.albums)
         self.mass.register_api_command(f"music/{api_base}/artist_tracks", self.tracks)
+        self.mass.register_api_command(f"music/{api_base}/similar_artists", self.similar_artists)
+
+    async def similar_artists(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+        limit: int = 25,
+    ) -> list[Artist]:
+        """
+        Get a list of similar artists for the given artist.
+
+        :param item_id: The item ID of the artist.
+        :param provider_instance_id_or_domain: The provider instance ID or domain.
+        :param limit: Maximum number of similar artists to return.
+        """
+        ref_item = await self.get(item_id, provider_instance_id_or_domain)
+        for prov_mapping in ref_item.provider_mappings:
+            prov = self.mass.get_provider(prov_mapping.provider_instance)
+            if prov is None or not prov.available:
+                continue
+            if not isinstance(prov, MusicProvider):
+                continue
+            if ProviderFeature.SIMILAR_ARTISTS not in prov.supported_features:
+                continue
+            try:
+                if result := await prov.get_similar_artists(
+                    prov_artist_id=prov_mapping.item_id, limit=limit
+                ):
+                    return result
+            except NotImplementedError:
+                continue
+        return []
 
     async def library_count(
         self, favorite_only: bool = False, album_artists_only: bool = False

--- a/music_assistant/controllers/media/artists.py
+++ b/music_assistant/controllers/media/artists.py
@@ -62,7 +62,17 @@ class ArtistsController(MediaControllerBase[Artist]):
         :param limit: Maximum number of similar artists to return.
         """
         ref_item = await self.get(item_id, provider_instance_id_or_domain)
-        for prov_mapping in ref_item.provider_mappings:
+        # Sort mappings so the requested provider comes first, then deterministically by instance/id.
+        sorted_mappings = sorted(
+            ref_item.provider_mappings,
+            key=lambda m: (
+                provider_instance_id_or_domain
+                not in {m.provider_instance, m.provider_domain},
+                m.provider_instance,
+                m.item_id,
+            ),
+        )
+        for prov_mapping in sorted_mappings:
             prov = self.mass.get_provider(prov_mapping.provider_instance)
             if prov is None or not prov.available:
                 continue

--- a/music_assistant/controllers/media/artists.py
+++ b/music_assistant/controllers/media/artists.py
@@ -66,8 +66,7 @@ class ArtistsController(MediaControllerBase[Artist]):
         sorted_mappings = sorted(
             ref_item.provider_mappings,
             key=lambda m: (
-                provider_instance_id_or_domain
-                not in {m.provider_instance, m.provider_domain},
+                provider_instance_id_or_domain not in {m.provider_instance, m.provider_domain},
                 m.provider_instance,
                 m.item_id,
             ),
@@ -80,12 +79,7 @@ class ArtistsController(MediaControllerBase[Artist]):
                 continue
             if ProviderFeature.SIMILAR_ARTISTS not in prov.supported_features:
                 continue
-            try:
-                return await prov.get_similar_artists(
-                    prov_artist_id=prov_mapping.item_id, limit=limit
-                )
-            except NotImplementedError:
-                continue
+            return await prov.get_similar_artists(prov_artist_id=prov_mapping.item_id, limit=limit)
         return []
 
     async def library_count(

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -398,6 +398,13 @@ class MusicProvider(Provider):
         """
         raise NotImplementedError
 
+    async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
+        """Retrieve a list of artists similar to the provided artist.
+
+        Only called if provider supports ProviderFeature.SIMILAR_ARTISTS.
+        """
+        raise NotImplementedError
+
     async def get_resume_position(
         self, item_id: str, media_type: MediaType
     ) -> tuple[bool, int, datetime | None]:

--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -402,9 +402,10 @@ class QobuzProvider(MusicProvider):
             )
         ]
 
-    async def get_similar_artists(self, prov_artist_id: str) -> None:
+    async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
         """Get similar artists for given artist."""
         # https://www.qobuz.com/api.json/0.2/artist/getSimilarArtists?artist_id=220020&offset=0&limit=3
+        raise NotImplementedError
 
     async def library_add(self, item: MediaItemType) -> bool:
         """Add item to library."""


### PR DESCRIPTION
## Summary

Adds infrastructure for providers to expose similar artists:

- **`ArtistsController.similar_artists()`** — new API endpoint (`music/artists/similar_artists`) that iterates a reference artist's provider mappings and returns similar artists from the first music provider that supports `ProviderFeature.SIMILAR_ARTISTS`
- **`MusicProvider.get_similar_artists()`** — base class stub (raises `NotImplementedError`) so providers can opt in by declaring `ProviderFeature.SIMILAR_ARTISTS` in `supported_features` and overriding this method
- **Qobuz** — fixed existing `get_similar_artists` stub: added missing `limit` parameter and correct return type to match the new base class signature (Qobuz does not declare `SIMILAR_ARTISTS` in `supported_features`, so the method remains a stub)

## Notes

- Pattern follows the existing `get_similar_tracks` / `TracksController.similar_tracks` approach
- A follow-up PR will add the Apple Music implementation (`views=similar-artists` API)
