### PR TITLE
Apple Music similar artists via views=similar-artists API

### DIFF
--- a/music_assistant/providers/apple_music/constants.py
+++ b/music_assistant/providers/apple_music/constants.py
@@ -15,6 +15,7 @@ SUPPORTED_FEATURES = {
     ProviderFeature.ARTIST_ALBUMS,
     ProviderFeature.ARTIST_TOPTRACKS,
     ProviderFeature.SIMILAR_TRACKS,
+    ProviderFeature.SIMILAR_ARTISTS,
     ProviderFeature.LIBRARY_ALBUMS_EDIT,
     ProviderFeature.LIBRARY_ARTISTS_EDIT,
     ProviderFeature.LIBRARY_PLAYLISTS_EDIT,

--- a/music_assistant/providers/apple_music/provider.py
+++ b/music_assistant/providers/apple_music/provider.py
@@ -153,6 +153,10 @@ class AppleMusicProvider(MusicProvider):
         """Retrieve a dynamic list of tracks based on the provided item."""
         return await self.recommendation_manager.get_similar_tracks(prov_track_id, limit)
 
+    async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
+        """Retrieve a list of artists similar to the provided artist."""
+        return await self.recommendation_manager.get_similar_artists(prov_artist_id, limit)
+
     # ------------------------------------------------------------------
     # Library generators
     # ------------------------------------------------------------------

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -6,11 +6,17 @@ from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MediaNotFoundError
-from music_assistant_models.media_items import ItemMapping, Playlist, RecommendationFolder, Track
+from music_assistant_models.media_items import (
+    Artist,
+    ItemMapping,
+    Playlist,
+    RecommendationFolder,
+    Track,
+)
 
 from music_assistant.controllers.cache import use_cache
 
-from .parsers import parse_station_as_playlist, parse_track
+from .parsers import parse_artist, parse_station_as_playlist, parse_track
 
 if TYPE_CHECKING:
     from .provider import AppleMusicProvider
@@ -47,6 +53,28 @@ class AppleMusicRecommendationManager:
                         parse_track(self.provider, track, rating_response.get(track["id"]))
                     )
         return found_tracks
+
+    @use_cache(3600 * 24)
+    async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
+        """Retrieve a list of artists similar to the provided artist via Apple Music similar-artists view."""
+        storefront = self.provider._storefront
+        try:
+            response = await self.api.get_data(
+                f"catalog/{storefront}/artists/{prov_artist_id}",
+                views="similar-artists",
+            )
+        except Exception:
+            return []
+        data = response.get("data", [])
+        if not data:
+            return []
+        similar = data[0].get("views", {}).get("similar-artists", {}).get("data", [])
+        artists: list[Artist] = []
+        for artist_obj in similar[:limit]:
+            parsed = parse_artist(self.provider, artist_obj)
+            if isinstance(parsed, Artist):
+                artists.append(parsed)
+        return artists
 
     async def get_station_playlist(self, station_id: str) -> Playlist:
         """Fetch name and artwork for a radio station and return it as a dynamic Playlist."""

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -58,13 +58,10 @@ class AppleMusicRecommendationManager:
     async def get_similar_artists(self, prov_artist_id: str, limit: int = 25) -> list[Artist]:
         """Retrieve a list of artists similar to the provided artist via Apple Music similar-artists view."""
         storefront = self.provider._storefront
-        try:
-            response = await self.api.get_data(
-                f"catalog/{storefront}/artists/{prov_artist_id}",
-                views="similar-artists",
-            )
-        except Exception:
-            return []
+        response = await self.api.get_data(
+            f"catalog/{storefront}/artists/{prov_artist_id}",
+            views="similar-artists",
+        )
         data = response.get("data", [])
         if not data:
             return []

--- a/tests/providers/apple_music/test_similar_artists.py
+++ b/tests/providers/apple_music/test_similar_artists.py
@@ -45,6 +45,7 @@ def mock_api() -> MagicMock:
 
 @pytest.fixture
 def manager(mock_api: MagicMock) -> AppleMusicRecommendationManager:
+    """Return an AppleMusicRecommendationManager wired to a mock API client."""
     provider = MagicMock()
     provider.instance_id = "apple_music_test"
     provider.domain = "apple_music"

--- a/tests/providers/apple_music/test_similar_artists.py
+++ b/tests/providers/apple_music/test_similar_artists.py
@@ -128,9 +128,8 @@ async def test_get_similar_artists_api_error(
     manager: AppleMusicRecommendationManager,
     mock_api: MagicMock,
 ) -> None:
-    """get_similar_artists returns empty list when the API call raises."""
+    """get_similar_artists propagates exceptions so they are not cached."""
     mock_api.get_data.side_effect = Exception("API error")
 
-    result = await manager.get_similar_artists("123")
-
-    assert result == []
+    with pytest.raises(Exception, match="API error"):
+        await manager.get_similar_artists("123")

--- a/tests/providers/apple_music/test_similar_artists.py
+++ b/tests/providers/apple_music/test_similar_artists.py
@@ -1,0 +1,118 @@
+"""Unit tests for Apple Music get_similar_artists."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.media_items import Artist
+
+from music_assistant.providers.apple_music.recommendations import AppleMusicRecommendationManager
+
+
+def _make_artist_obj(artist_id: str, name: str) -> dict[str, object]:
+    return {
+        "id": artist_id,
+        "type": "artists",
+        "attributes": {
+            "name": name,
+            "url": f"https://music.apple.com/artist/{artist_id}",
+        },
+        "relationships": {},
+    }
+
+
+def _make_api_response(artist_objects: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "data": [
+            {
+                "id": "123",
+                "views": {
+                    "similar-artists": {
+                        "data": artist_objects,
+                    }
+                },
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def manager() -> AppleMusicRecommendationManager:
+    api_client = MagicMock()
+    api_client.get_data = AsyncMock()
+
+    provider = MagicMock()
+    provider.instance_id = "apple_music_test"
+    provider.domain = "apple_music"
+    provider._storefront = "us"
+    provider.logger = MagicMock()
+    provider.mass.cache.get = AsyncMock(return_value=None)
+    provider.mass.cache.set = AsyncMock()
+    provider.api_client = api_client
+
+    return AppleMusicRecommendationManager(provider)
+
+
+@pytest.mark.asyncio
+async def test_get_similar_artists_returns_artists(manager: AppleMusicRecommendationManager) -> None:
+    """get_similar_artists parses artists from the views.similar-artists response."""
+    manager.api.get_data = AsyncMock(
+        return_value=_make_api_response(
+            [
+                _make_artist_obj("456", "Radiohead"),
+                _make_artist_obj("789", "Portishead"),
+            ]
+        )
+    )
+
+    result = await manager.get_similar_artists("123", limit=25)
+
+    manager.api.get_data.assert_called_once_with(
+        "catalog/us/artists/123",
+        views="similar-artists",
+    )
+    assert len(result) == 2
+    assert all(isinstance(a, Artist) for a in result)
+    names = {a.name for a in result}
+    assert "Radiohead" in names
+    assert "Portishead" in names
+
+
+@pytest.mark.asyncio
+async def test_get_similar_artists_respects_limit(manager: AppleMusicRecommendationManager) -> None:
+    """get_similar_artists truncates results to the requested limit."""
+    many_artists = [_make_artist_obj(str(i), f"Artist {i}") for i in range(10)]
+    manager.api.get_data = AsyncMock(return_value=_make_api_response(many_artists))
+
+    result = await manager.get_similar_artists("123", limit=3)
+
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_similar_artists_empty_data(manager: AppleMusicRecommendationManager) -> None:
+    """get_similar_artists returns empty list when API returns no data."""
+    manager.api.get_data = AsyncMock(return_value={"data": []})
+
+    result = await manager.get_similar_artists("123")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_similar_artists_missing_view(manager: AppleMusicRecommendationManager) -> None:
+    """get_similar_artists returns empty list when similar-artists view is absent."""
+    manager.api.get_data = AsyncMock(return_value={"data": [{"id": "123", "views": {}}]})
+
+    result = await manager.get_similar_artists("123")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_similar_artists_api_error(manager: AppleMusicRecommendationManager) -> None:
+    """get_similar_artists returns empty list when the API call raises."""
+    manager.api.get_data = AsyncMock(side_effect=Exception("API error"))
+
+    result = await manager.get_similar_artists("123")
+
+    assert result == []

--- a/tests/providers/apple_music/test_similar_artists.py
+++ b/tests/providers/apple_music/test_similar_artists.py
@@ -36,10 +36,15 @@ def _make_api_response(artist_objects: list[dict[str, object]]) -> dict[str, obj
 
 
 @pytest.fixture
-def manager() -> AppleMusicRecommendationManager:
+def mock_api() -> MagicMock:
+    """Return a MagicMock representing the Apple Music API client."""
     api_client = MagicMock()
     api_client.get_data = AsyncMock()
+    return api_client
 
+
+@pytest.fixture
+def manager(mock_api: MagicMock) -> AppleMusicRecommendationManager:
     provider = MagicMock()
     provider.instance_id = "apple_music_test"
     provider.domain = "apple_music"
@@ -47,26 +52,27 @@ def manager() -> AppleMusicRecommendationManager:
     provider.logger = MagicMock()
     provider.mass.cache.get = AsyncMock(return_value=None)
     provider.mass.cache.set = AsyncMock()
-    provider.api_client = api_client
+    provider.api_client = mock_api
 
     return AppleMusicRecommendationManager(provider)
 
 
 @pytest.mark.asyncio
-async def test_get_similar_artists_returns_artists(manager: AppleMusicRecommendationManager) -> None:
+async def test_get_similar_artists_returns_artists(
+    manager: AppleMusicRecommendationManager,
+    mock_api: MagicMock,
+) -> None:
     """get_similar_artists parses artists from the views.similar-artists response."""
-    manager.api.get_data = AsyncMock(
-        return_value=_make_api_response(
-            [
-                _make_artist_obj("456", "Radiohead"),
-                _make_artist_obj("789", "Portishead"),
-            ]
-        )
+    mock_api.get_data.return_value = _make_api_response(
+        [
+            _make_artist_obj("456", "Radiohead"),
+            _make_artist_obj("789", "Portishead"),
+        ]
     )
 
     result = await manager.get_similar_artists("123", limit=25)
 
-    manager.api.get_data.assert_called_once_with(
+    mock_api.get_data.assert_called_once_with(
         "catalog/us/artists/123",
         views="similar-artists",
     )
@@ -78,10 +84,13 @@ async def test_get_similar_artists_returns_artists(manager: AppleMusicRecommenda
 
 
 @pytest.mark.asyncio
-async def test_get_similar_artists_respects_limit(manager: AppleMusicRecommendationManager) -> None:
+async def test_get_similar_artists_respects_limit(
+    manager: AppleMusicRecommendationManager,
+    mock_api: MagicMock,
+) -> None:
     """get_similar_artists truncates results to the requested limit."""
     many_artists = [_make_artist_obj(str(i), f"Artist {i}") for i in range(10)]
-    manager.api.get_data = AsyncMock(return_value=_make_api_response(many_artists))
+    mock_api.get_data.return_value = _make_api_response(many_artists)
 
     result = await manager.get_similar_artists("123", limit=3)
 
@@ -89,9 +98,12 @@ async def test_get_similar_artists_respects_limit(manager: AppleMusicRecommendat
 
 
 @pytest.mark.asyncio
-async def test_get_similar_artists_empty_data(manager: AppleMusicRecommendationManager) -> None:
+async def test_get_similar_artists_empty_data(
+    manager: AppleMusicRecommendationManager,
+    mock_api: MagicMock,
+) -> None:
     """get_similar_artists returns empty list when API returns no data."""
-    manager.api.get_data = AsyncMock(return_value={"data": []})
+    mock_api.get_data.return_value = {"data": []}
 
     result = await manager.get_similar_artists("123")
 
@@ -99,9 +111,12 @@ async def test_get_similar_artists_empty_data(manager: AppleMusicRecommendationM
 
 
 @pytest.mark.asyncio
-async def test_get_similar_artists_missing_view(manager: AppleMusicRecommendationManager) -> None:
+async def test_get_similar_artists_missing_view(
+    manager: AppleMusicRecommendationManager,
+    mock_api: MagicMock,
+) -> None:
     """get_similar_artists returns empty list when similar-artists view is absent."""
-    manager.api.get_data = AsyncMock(return_value={"data": [{"id": "123", "views": {}}]})
+    mock_api.get_data.return_value = {"data": [{"id": "123", "views": {}}]}
 
     result = await manager.get_similar_artists("123")
 
@@ -109,9 +124,12 @@ async def test_get_similar_artists_missing_view(manager: AppleMusicRecommendatio
 
 
 @pytest.mark.asyncio
-async def test_get_similar_artists_api_error(manager: AppleMusicRecommendationManager) -> None:
+async def test_get_similar_artists_api_error(
+    manager: AppleMusicRecommendationManager,
+    mock_api: MagicMock,
+) -> None:
     """get_similar_artists returns empty list when the API call raises."""
-    manager.api.get_data = AsyncMock(side_effect=Exception("API error"))
+    mock_api.get_data.side_effect = Exception("API error")
 
     result = await manager.get_similar_artists("123")
 


### PR DESCRIPTION
## Summary

Implements `ProviderFeature.SIMILAR_ARTISTS` for the Apple Music provider using the correct `views=similar-artists` API endpoint.

### Changes

- **`constants.py`** — added `ProviderFeature.SIMILAR_ARTISTS` to `SUPPORTED_FEATURES`
- **`provider.py`** — added `get_similar_artists()` delegating to `recommendation_manager`
- **`recommendations.py`** — new `get_similar_artists()` method using `GET catalog/{storefront}/artists/{id}?views=similar-artists`; response parsed from `data[0].views.similar-artists.data`; cached for 24 h
- **`tests/providers/apple_music/test_similar_artists.py`** — 5 unit tests covering happy path, limit, empty data, missing view, and API errors

### Why `views=similar-artists` and not `include=related-artists`

The `include=related-artists` parameter on the artist endpoint is silently ignored by the Apple Music API — the response only contains `{albums}` in relationships. The direct endpoint `catalog/{storefront}/artists/{id}/related-artists` returns HTTP 400. The correct approach is `?views=similar-artists`, with the result at `data[0].views.similar-artists.data`.

### Note

The `ArtistsController.similar_artists()` endpoint and `MusicProvider.get_similar_artists()` base method (previously added by the now-closed #3860) are already part of `dev` via #3811.