### PR TITLE
Fix imageproxy URL encoding for paths containing only spaces

### DIFF
--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -482,7 +482,7 @@ class MetaDataController(CoreController):
         if not image.remotely_accessible or prefer_proxy or size:
             # return imageproxy url for images that need to be resolved
             # the original path is double encoded
-            encoded_url = urllib.parse.quote_plus(urllib.parse.quote_plus(image.path))
+            encoded_url = urllib.parse.quote(urllib.parse.quote(image.path))
             base_url = (
                 self.mass.streams.base_url if prefer_stream_server else self.mass.webserver.base_url
             )


### PR DESCRIPTION
Fixes music-assistant/support#5459

`quote_plus` encodes spaces as '+'. After a second quote_plus pass, that '+' becomes '%2B' in the URL. When the server reads it back, '%2B' becomes a plain '+' character rather than a space, and the existing recovery step is skipped because no '%' remains in the path. The image lookup then fails.

Switching to `quote()` encodes spaces as '%20' instead, which survives both encoding passes and decodes cleanly back to a space.
