### PR TITLE
Tolerate non-UTF-8 metadata in DLNA SOAP/NOTIFY responses

### DIFF
--- a/music_assistant/providers/dlna/helpers.py
+++ b/music_assistant/providers/dlna/helpers.py
@@ -33,12 +33,18 @@ class DLNANotifyServer(UpnpNotifyServer):  # type: ignore[misc,unused-ignore]
         if request.method != "NOTIFY":
             return Response(status=405)
 
+        # Some DLNA devices (e.g. Denon HEOS) send NOTIFY bodies that are not
+        # valid UTF-8 when track metadata contains non-ASCII characters in the
+        # device's native encoding. Decode leniently so we don't drop the event.
+        body_bytes = await request.read()
+        body = body_bytes.decode("utf-8", errors="replace")
+
         # transform aiohttp request to async_upnp_client request
         http_request = HttpRequest(
             method=request.method,
             url=str(request.url),
             headers=request.headers,
-            body=await request.text(),
+            body=body,
         )
 
         try:

--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -560,6 +560,14 @@ class DLNAPlayer(Player):
                 await self.device.async_update(do_ping=do_ping)
             self.last_seen = now if do_ping else self.last_seen
         except UpnpError as err:
+            # Some devices (e.g. Denon HEOS) return SOAP responses containing
+            # non-UTF-8 bytes in track metadata, which the underlying library
+            # surfaces as a UpnpCommunicationError wrapping UnicodeDecodeError.
+            # Treat this as a transient metadata issue and keep the player
+            # connected; the next poll will likely succeed.
+            if isinstance(err.__cause__, UnicodeDecodeError):
+                self.logger.debug("Ignoring non-UTF-8 SOAP response from device: %r", err)
+                return
             self.logger.debug("Device unavailable: %r", err)
             await self._device_disconnect()
             raise PlayerUnavailableError from err


### PR DESCRIPTION
Fixes https://github.com/music-assistant/support/issues/5457

Some DLNA renderers (e.g. Denon HEOS AVRs) re-encode track metadata in their native (non-UTF-8) encoding when reporting their currently-playing status, producing SOAP/NOTIFY bodies that fail strict UTF-8 decoding. Previously this caused NOTIFY events to be dropped with a 500 and made the player unavailable on the next poll.

Decode NOTIFY bodies leniently and treat poll responses that fail UTF-8 decoding as a transient metadata glitch instead of disconnecting the player.