### PR TITLE
TuneIn: add translation_key to trending recommendations folder

### DIFF
--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -276,6 +276,7 @@ class TuneInProvider(MusicProvider):
                 item_id="trending",
                 provider=self.instance_id,
                 name="Trending",
+                translation_key="trending_stations",
                 items=UniqueList(stations),
             )
         ]


### PR DESCRIPTION
The "Trending" recommendations folder returned by the TuneIn provider had a hardcoded English name. This adds `translation_key="trending_stations"` so the frontend can display a localized label via the `recommendations.trending_stations` translation key.

The matching translation key (`trending_stations: "Trending stations"`) is added in the companion frontend PR.