### PR TITLE
TuneIn: store image URLs as HTTPS instead of HTTP

### DIFF
--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -310,7 +310,7 @@ class TuneInProvider(MusicProvider):
                 [
                     MediaItemImage(
                         type=ImageType.THUMB,
-                        path=img,
+                        path=img.replace("http://", "https://", 1),
                         provider=self.instance_id,
                         remotely_accessible=True,
                     )
@@ -388,7 +388,7 @@ class TuneInProvider(MusicProvider):
                 [
                     MediaItemImage(
                         type=ImageType.THUMB,
-                        path=img,
+                        path=img.replace("http://", "https://", 1),
                         provider=self.instance_id,
                         remotely_accessible=True,
                     )


### PR DESCRIPTION
TuneIn's OPML API returns image URLs over plain HTTP (e.g. `http://cdn-profiles.tunein.com/...`). TuneIn's CDN fully supports HTTPS — returning HTTP URLs is simply incorrect, and is already inconsistent: newer entries in the API return HTTPS, while older ones still return HTTP.

Storing HTTP image URLs has a real impact on clients that use the raw URL directly. When `remotely_accessible=True`, the server passes the URL as-is to clients, and any client that loads it directly (rather than proxying through the MA server) will encounter broken images on platforms where plain HTTP is blocked — such as iOS (App Transport Security).

This fix upgrades `http://` → `https://` at parse time in both `_parse_radio_lazy()` and `_parse_radio()`.

Tested: sampled URLs from both `cdn-profiles.tunein.com` and `cdn-radiotime-logos.tunein.com` over HTTPS — all return HTTP 200.

Related: music-assistant/mobile-app#272