### PR TITLE
Fix AA Background Processing to not Monopolize CPU

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -143,10 +143,19 @@ CONF_DEFAULT_PROVIDERS_SETUP: Final[str] = "default_providers_setup"
 CONF_BACKGROUND_SCAN_CONCURRENCY: Final[str] = "background_scan_concurrency"
 
 
+def _default_background_scan_concurrency() -> int:
+    cpu_count = os.process_cpu_count() or os.cpu_count() or 4
+    if cpu_count >= 16:
+        return 4
+    if cpu_count >= 8:
+        return 2
+    return 1
+
+
 # config default values
 DEFAULT_HOST: Final[str] = "0.0.0.0"
 DEFAULT_PORT: Final[int] = 8095
-DEFAULT_BACKGROUND_SCAN_CONCURRENCY: Final[int] = 1
+DEFAULT_BACKGROUND_SCAN_CONCURRENCY: Final[int] = _default_background_scan_concurrency()
 
 
 # common db tables

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -35,7 +35,7 @@ BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
 # Per-chunk dispatch interval bounds. One PCM chunk = one audio-second of decoded data:
 # the floor is the fastest pace allowed; the ceiling is both the slowest pace and the
 # per-chunk processing timeout that evicts unresponsive providers.
-REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR = 0.5
+REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR = 0.250
 REAL_TIME_PACE_INTERVAL_SECONDS_CEILING = 1.0
 FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
     "filesystem_local",

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -142,7 +142,14 @@ class AudioAnalysisController:
 
         self._active_sessions[session_key] = provider_ids
         queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=10)
-        self._workers[session_key] = self.mass.create_task(self._chunk_worker(session_key, queue))
+        self._workers[session_key] = self.mass.create_task(
+            self._chunk_worker(
+                session_key,
+                queue,
+                min_interval=REAL_TIME_PACE_INTERVAL_SECONDS,
+                max_interval=REAL_TIME_PACE_INTERVAL_SECONDS,
+            )
+        )
 
         finalized = False
 
@@ -406,7 +413,12 @@ class AudioAnalysisController:
                 if not providers_for_track:
                     return
 
-                await self._run_background_streaming_for_track(streamdetails, providers_for_track)
+                await self._run_background_streaming_for_track(
+                    streamdetails,
+                    providers_for_track,
+                    min_interval=REAL_TIME_PACE_INTERVAL_SECONDS,
+                    max_interval=REAL_TIME_PACE_INTERVAL_SECONDS,
+                )
                 processed += 1
 
         await asyncio.gather(*(_run_one(c) for c in candidates))
@@ -431,8 +443,17 @@ class AudioAnalysisController:
         self,
         streamdetails: StreamDetails,
         providers: list[AudioAnalysisProvider],
+        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
+        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
     ) -> None:
-        """Run a single track through the streaming pipeline using ffmpeg as the source."""
+        """
+        Run a single track through the streaming pipeline using ffmpeg as the source.
+
+        :param streamdetails: Stream details for the track being analyzed.
+        :param providers: Audio analysis providers to dispatch chunks to.
+        :param min_interval: Floor on wall-seconds between consecutive chunk dispatches.
+        :param max_interval: Ceiling on wall-seconds between consecutive chunk dispatches.
+        """
         session_key = streamdetails.uri
         if session_key in self._active_sessions:
             self.logger.debug(
@@ -442,7 +463,13 @@ class AudioAnalysisController:
 
         try:
             await asyncio.wait_for(
-                self._run_background_streaming_inner(session_key, streamdetails, providers),
+                self._run_background_streaming_inner(
+                    session_key,
+                    streamdetails,
+                    providers,
+                    min_interval=min_interval,
+                    max_interval=max_interval,
+                ),
                 timeout=BACKGROUND_PER_TRACK_TIMEOUT_SECONDS,
             )
         except asyncio.CancelledError:
@@ -475,8 +502,18 @@ class AudioAnalysisController:
         session_key: str,
         streamdetails: StreamDetails,
         providers: list[AudioAnalysisProvider],
+        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
+        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
     ) -> None:
-        """Inner body of _run_background_streaming_for_track, wrapped by wait_for."""
+        """
+        Inner body of _run_background_streaming_for_track, wrapped by wait_for.
+
+        :param session_key: Active-session key for this track.
+        :param streamdetails: Stream details for the track being analyzed.
+        :param providers: Audio analysis providers to dispatch chunks to.
+        :param min_interval: Floor on wall-seconds between consecutive chunk dispatches.
+        :param max_interval: Ceiling on wall-seconds between consecutive chunk dispatches.
+        """
         if not isinstance(streamdetails.path, str) or not streamdetails.path:
             return
 
@@ -504,7 +541,7 @@ class AudioAnalysisController:
             if now < next_allowed:
                 await asyncio.sleep(next_allowed - now)
             await self._distribute_chunk(session_key, chunk)
-            next_allowed = time.monotonic() + REAL_TIME_PACE_INTERVAL_SECONDS
+            next_allowed = time.monotonic() + min_interval
         if session_key in self._active_sessions:
             self._finalize_providers(session_key)
 
@@ -653,8 +690,21 @@ class AudioAnalysisController:
             if not provider_ids:
                 self._active_sessions.pop(session_key, None)
 
-    async def _chunk_worker(self, session_key: str, queue: asyncio.Queue[bytes | None]) -> None:
-        """Background worker that processes queued PCM chunks via _distribute_chunk."""
+    async def _chunk_worker(
+        self,
+        session_key: str,
+        queue: asyncio.Queue[bytes | None],
+        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
+        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
+    ) -> None:
+        """
+        Background worker that processes queued PCM chunks via _distribute_chunk.
+
+        :param session_key: Active-session key for this worker.
+        :param queue: Queue receiving raw PCM chunks from the live producer.
+        :param min_interval: Floor on wall-seconds between consecutive chunk dispatches.
+        :param max_interval: Ceiling on wall-seconds between consecutive chunk dispatches.
+        """
         next_allowed = time.monotonic()
         while True:
             chunk = await queue.get()
@@ -666,7 +716,7 @@ class AudioAnalysisController:
             if now < next_allowed:
                 await asyncio.sleep(next_allowed - now)
             await self._distribute_chunk(session_key, chunk)
-            next_allowed = time.monotonic() + REAL_TIME_PACE_INTERVAL_SECONDS
+            next_allowed = time.monotonic() + min_interval
             if session_key not in self._active_sessions:
                 # all providers evicted by _distribute_chunk
                 self._workers.pop(session_key, None)

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -33,8 +33,9 @@ BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300
 # Per-run wall-clock cap; in-flight tracks finish, new ones defer to the next run.
 BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
-# One PCM chunk equals one audio-second of decoded data; 1.0s paces dispatch at real-time.
-REAL_TIME_PACE_INTERVAL_SECONDS = 1.0
+# One PCM chunk equals one audio-second of decoded data; 0.9s paces just above real-time
+# so the live buffer stays slightly ahead of playback rather than running dead-even.
+REAL_TIME_PACE_INTERVAL_SECONDS = 0.9
 FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
     "filesystem_local",
     "filesystem_smb",

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -33,6 +33,8 @@ BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300
 # Per-run wall-clock cap; in-flight tracks finish, new ones defer to the next run.
 BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
+# One PCM chunk equals one audio-second of decoded data; 1.0s paces dispatch at real-time.
+REAL_TIME_PACE_INTERVAL_SECONDS = 1.0
 FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
     "filesystem_local",
     "filesystem_smb",
@@ -493,11 +495,16 @@ class AudioAnalysisController:
         self._active_sessions[session_key] = accepted
 
         audio_source = self.mass.streams.audio.get_media_stream(streamdetails, pcm_format)
+        next_allowed = time.monotonic()
         async for chunk in audio_source:
             if session_key not in self._active_sessions:
                 # all providers evicted — bail early
                 break
+            now = time.monotonic()
+            if now < next_allowed:
+                await asyncio.sleep(next_allowed - now)
             await self._distribute_chunk(session_key, chunk)
+            next_allowed = time.monotonic() + REAL_TIME_PACE_INTERVAL_SECONDS
         if session_key in self._active_sessions:
             self._finalize_providers(session_key)
 
@@ -648,13 +655,18 @@ class AudioAnalysisController:
 
     async def _chunk_worker(self, session_key: str, queue: asyncio.Queue[bytes | None]) -> None:
         """Background worker that processes queued PCM chunks via _distribute_chunk."""
+        next_allowed = time.monotonic()
         while True:
             chunk = await queue.get()
             if chunk is None:
                 break
             if session_key not in self._active_sessions:
                 break
+            now = time.monotonic()
+            if now < next_allowed:
+                await asyncio.sleep(next_allowed - now)
             await self._distribute_chunk(session_key, chunk)
+            next_allowed = time.monotonic() + REAL_TIME_PACE_INTERVAL_SECONDS
             if session_key not in self._active_sessions:
                 # all providers evicted by _distribute_chunk
                 self._workers.pop(session_key, None)

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -27,15 +27,16 @@ from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
 from music_assistant.models.music_provider import MusicProvider
 
-CHUNK_PROCESS_TIMEOUT_SECONDS = 1.0
 LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
 BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300
 # Per-run wall-clock cap; in-flight tracks finish, new ones defer to the next run.
 BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
-# One PCM chunk equals one audio-second of decoded data; 0.9s paces just above real-time
-# so the live buffer stays slightly ahead of playback rather than running dead-even.
-REAL_TIME_PACE_INTERVAL_SECONDS = 0.9
+# Per-chunk dispatch interval bounds. One PCM chunk = one audio-second of decoded data:
+# the floor is the fastest pace allowed; the ceiling is both the slowest pace and the
+# per-chunk processing timeout that evicts unresponsive providers.
+REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR = 0.5
+REAL_TIME_PACE_INTERVAL_SECONDS_CEILING = 1.0
 FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
     "filesystem_local",
     "filesystem_smb",
@@ -147,8 +148,8 @@ class AudioAnalysisController:
             self._chunk_worker(
                 session_key,
                 queue,
-                min_interval=REAL_TIME_PACE_INTERVAL_SECONDS,
-                max_interval=REAL_TIME_PACE_INTERVAL_SECONDS,
+                min_interval=REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR,
+                max_interval=REAL_TIME_PACE_INTERVAL_SECONDS_CEILING,
             )
         )
 
@@ -164,7 +165,9 @@ class AudioAnalysisController:
                 self.mass.create_task(_finalize_session())
                 return
             try:
-                await asyncio.wait_for(queue.put(pcm_data), timeout=CHUNK_PROCESS_TIMEOUT_SECONDS)
+                await asyncio.wait_for(
+                    queue.put(pcm_data), timeout=REAL_TIME_PACE_INTERVAL_SECONDS_CEILING
+                )
             except (TimeoutError, asyncio.QueueFull):
                 return
 
@@ -417,8 +420,8 @@ class AudioAnalysisController:
                 await self._run_background_streaming_for_track(
                     streamdetails,
                     providers_for_track,
-                    min_interval=REAL_TIME_PACE_INTERVAL_SECONDS,
-                    max_interval=REAL_TIME_PACE_INTERVAL_SECONDS,
+                    min_interval=REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR,
+                    max_interval=REAL_TIME_PACE_INTERVAL_SECONDS_CEILING,
                 )
                 processed += 1
 
@@ -444,8 +447,8 @@ class AudioAnalysisController:
         self,
         streamdetails: StreamDetails,
         providers: list[AudioAnalysisProvider],
-        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
-        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
+        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR,
+        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_CEILING,
     ) -> None:
         """
         Run a single track through the streaming pipeline using ffmpeg as the source.
@@ -503,8 +506,8 @@ class AudioAnalysisController:
         session_key: str,
         streamdetails: StreamDetails,
         providers: list[AudioAnalysisProvider],
-        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
-        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
+        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR,
+        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_CEILING,
     ) -> None:
         """
         Inner body of _run_background_streaming_for_track, wrapped by wait_for.
@@ -541,7 +544,7 @@ class AudioAnalysisController:
             now = time.monotonic()
             if now < next_allowed:
                 await asyncio.sleep(next_allowed - now)
-            await self._distribute_chunk(session_key, chunk)
+            await self._distribute_chunk(session_key, chunk, max_interval=max_interval)
             next_allowed = time.monotonic() + min_interval
         if session_key in self._active_sessions:
             self._finalize_providers(session_key)
@@ -651,8 +654,19 @@ class AudioAnalysisController:
             if provider and isinstance(provider, AudioAnalysisProvider) and provider.available:
                 self.mass.create_task(provider.cancel(session_key))
 
-    async def _distribute_chunk(self, session_key: str, pcm_data: bytes) -> None:
-        """Fan a single PCM chunk to every provider in the session."""
+    async def _distribute_chunk(
+        self,
+        session_key: str,
+        pcm_data: bytes,
+        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_CEILING,
+    ) -> None:
+        """
+        Fan a single PCM chunk to every provider in the session.
+
+        :param session_key: Active-session key for the dispatch.
+        :param pcm_data: The 1-second PCM chunk to hand to each provider.
+        :param max_interval: Per-provider processing timeout; providers exceeding this are evicted.
+        """
         provider_ids = self._active_sessions.get(session_key)
         if not provider_ids:
             return
@@ -666,7 +680,7 @@ class AudioAnalysisController:
                     return None
                 await asyncio.wait_for(
                     provider.process_pcm_chunk(session_key, pcm_data),
-                    timeout=CHUNK_PROCESS_TIMEOUT_SECONDS,
+                    timeout=max_interval,
                 )
             except TimeoutError:
                 self.logger.warning(
@@ -695,8 +709,8 @@ class AudioAnalysisController:
         self,
         session_key: str,
         queue: asyncio.Queue[bytes | None],
-        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
-        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS,
+        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR,
+        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_CEILING,
     ) -> None:
         """
         Background worker that processes queued PCM chunks via _distribute_chunk.
@@ -716,7 +730,7 @@ class AudioAnalysisController:
             now = time.monotonic()
             if now < next_allowed:
                 await asyncio.sleep(next_allowed - now)
-            await self._distribute_chunk(session_key, chunk)
+            await self._distribute_chunk(session_key, chunk, max_interval=max_interval)
             next_allowed = time.monotonic() + min_interval
             if session_key not in self._active_sessions:
                 # all providers evicted by _distribute_chunk

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -263,7 +263,9 @@ async def test_run_background_scan_uses_union_candidate_query(
 
     streaming_calls: list[str] = []
 
-    async def _track_streaming(streamdetails: MagicMock, _providers: object) -> None:
+    async def _track_streaming(
+        streamdetails: MagicMock, _providers: object, **_kwargs: object
+    ) -> None:
         streaming_calls.append(streamdetails.item_id)
 
     monkeypatch.setattr(controller, "_run_background_streaming_for_track", _track_streaming)
@@ -371,7 +373,9 @@ async def test_run_background_scan_concurrency_semaphore(
     in_flight = 0
     max_in_flight = 0
 
-    async def _track_streaming(_streamdetails: MagicMock, _providers: object) -> None:
+    async def _track_streaming(
+        _streamdetails: MagicMock, _providers: object, **_kwargs: object
+    ) -> None:
         nonlocal in_flight, max_in_flight
         in_flight += 1
         max_in_flight = max(max_in_flight, in_flight)
@@ -397,7 +401,9 @@ async def test_background_streaming_cancellation_cleans_up(
 
     session_key = streamdetails.uri
 
-    async def _inner_cancelled(_session_key: str, _sd: object, _providers: object) -> None:
+    async def _inner_cancelled(
+        _session_key: str, _sd: object, _providers: object, **_kwargs: object
+    ) -> None:
         # Simulate the inner having registered the session before being cancelled.
         controller._active_sessions[session_key] = {"p1"}
         raise asyncio.CancelledError
@@ -444,7 +450,7 @@ async def test_run_background_scan_defers_past_run_budget(
 
     streaming_called = False
 
-    async def _track_streaming(_sd: object, _providers: object) -> None:
+    async def _track_streaming(_sd: object, _providers: object, **_kwargs: object) -> None:
         nonlocal streaming_called
         streaming_called = True
 

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import ContentType, StreamType
@@ -36,7 +36,7 @@ async def test_distribute_chunk_calls_all_providers() -> None:
 
 @pytest.mark.asyncio
 async def test_distribute_chunk_evicts_provider_on_timeout() -> None:
-    """A provider whose process_pcm_chunk exceeds CHUNK_PROCESS_TIMEOUT_SECONDS is evicted."""
+    """A provider whose process_pcm_chunk exceeds max_interval is evicted."""
     controller = _make_controller()
     session_key = "track://provider/abc"
     controller._active_sessions[session_key] = {"slow", "fast"}
@@ -49,8 +49,7 @@ async def test_distribute_chunk_evicts_provider_on_timeout() -> None:
     provider_map = {"slow": slow, "fast": fast}
     controller.mass.get_provider = MagicMock(side_effect=provider_map.get)  # type: ignore[method-assign]
 
-    with patch.object(audio_analysis_mod, "CHUNK_PROCESS_TIMEOUT_SECONDS", 0.05):
-        await controller._distribute_chunk(session_key, b"\x00" * 1024)
+    await controller._distribute_chunk(session_key, b"\x00" * 1024, max_interval=0.05)
 
     assert "slow" not in controller._active_sessions[session_key]
     assert "fast" in controller._active_sessions[session_key]

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -11,6 +11,7 @@ from music_assistant_models.enums import ContentType, StreamType
 from music_assistant_models.media_items import AudioFormat
 
 import music_assistant.controllers.streams.audio_analysis as audio_analysis_mod
+from music_assistant.constants import DEFAULT_BACKGROUND_SCAN_CONCURRENCY
 from music_assistant.controllers.streams.audio_analysis import AudioAnalysisController
 from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
 
@@ -82,7 +83,7 @@ async def test_get_scan_concurrency_returns_default_on_unset() -> None:
     """When the config value is unset/None, fall back to DEFAULT_BACKGROUND_SCAN_CONCURRENCY."""
     controller = _make_controller()
     controller.mass.config.get_raw_core_config_value = MagicMock(return_value=None)  # type: ignore[method-assign]
-    assert controller._get_scan_concurrency() == 1
+    assert controller._get_scan_concurrency() == DEFAULT_BACKGROUND_SCAN_CONCURRENCY
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_audio_analysis_controller.py
+++ b/tests/core/test_audio_analysis_controller.py
@@ -402,7 +402,8 @@ async def test_slow_provider_removed_after_timeout(
     mock_mass.get_provider = MagicMock(side_effect=_get_prov)
 
     with unittest.mock.patch(
-        "music_assistant.controllers.streams.audio_analysis.CHUNK_PROCESS_TIMEOUT_SECONDS", 0.1
+        "music_assistant.controllers.streams.audio_analysis.REAL_TIME_PACE_INTERVAL_SECONDS_CEILING",
+        0.1,
     ):
         await controller.start_analysis(audio_buffer, mock_stream_details)
         await _send_chunks(audio_buffer, 3)


### PR DESCRIPTION
Currently background processing goes As Fast As Possible, using as much CPU as it can while it's running (default midnight to 4 AM). This PR shifts the AFAP to be throttled to at MOST 4x real time, also enforcing that for real-time analysis during playback.  

The background process will run one song at a time unless 8+ cores of CPU are detected, then it will run 2 songs until 16+ are detected then it will run 4. 

