### PR TITLE
Plex: narrow session.verify type with bool() cast

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -447,7 +447,7 @@ class PlexProvider(MusicProvider):
             try:
                 session = requests.Session()
                 session.verify = (
-                    self.config.get_value(CONF_LOCAL_SERVER_VERIFY_CERT)
+                    bool(self.config.get_value(CONF_LOCAL_SERVER_VERIFY_CERT))
                     if self.config.get_value(CONF_LOCAL_SERVER_SSL)
                     else False
                 )


### PR DESCRIPTION
## Summary

Fixes a mypy `assignment` error on `music_assistant/providers/plex/__init__.py:450` where the ternary expression assigned to `requests.Session.verify` passes `self.config.get_value(...)` directly. `get_value()` returns the wide `ConfigValueType` union (`bool | float | int | str | list[...] | None`), while `requests.Session.verify` is typed as `bool | str` — so strict mypy runs (sensitive to which version of `requests` / `types-requests` gets installed transitively) reject the assignment.

Wrapping with `bool(...)` narrows the result to a single concrete `bool` that fits the destination type. The underlying config entry (`CONF_LOCAL_SERVER_VERIFY_CERT`) is a boolean — defaults assigned in the config flow are always `True`/`False` — so this preserves runtime semantics.

## Why this is surfacing now

The Plex code is unchanged. The lint regression appeared on a downstream PR after a transitive bump in the `requests`/typing stack tightened mypy's view of `session.verify`. dev's CI passes because dev's leaner dep tree happens to resolve a looser combination, but PRs that pull in heavier ML deps (e.g. transformers + huggingface-hub) reliably trip this.

## Test plan

- [x] mypy on `music_assistant/providers/plex/__init__.py` passes locally
- [x] Runtime semantics preserved: `bool(x)` for every value in the config's possible runtime type returns a `bool` matching truthiness of the original value
- [ ] CI green on this PR