### PR TITLE
Fall back to protocol-scoped key in get_player_config_value

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -727,10 +727,33 @@ class ConfigController:
                 return raw_value
         conf = await self.get_player_config(player_id)
         if key not in conf.values:
-            if default is not None:
+            # Universal players that wrap a protocol player (DLNA, Sonos, etc.) store
+            # per-protocol settings such as ``sample_rates`` and ``http_profile`` under
+            # ``<protocol_id>||protocol||<key>`` rather than at the top level of the
+            # player config. When such a key is requested without the prefix (as the
+            # universal_group flow stream handler does), the bare lookup raises here
+            # and no audio is served to any DLNA-backed group member. Fall back to
+            # the active output protocol's namespaced key when present.
+            scoped_player = self.mass.players.get_player(player_id)
+            active_protocol = (
+                getattr(scoped_player, "active_output_protocol", None)
+                if scoped_player is not None
+                else None
+            )
+            if active_protocol:
+                scoped_key = f"{active_protocol}{CONF_PROTOCOL_KEY_SPLITTER}{key}"
+                if scoped_key in conf.values:
+                    key = scoped_key
+                elif default is not None:
+                    return default
+                else:
+                    msg = f"Config key {key} not found for player {player_id}"
+                    raise KeyError(msg)
+            elif default is not None:
                 return default
-            msg = f"Config key {key} not found for player {player_id}"
-            raise KeyError(msg)
+            else:
+                msg = f"Config key {key} not found for player {player_id}"
+                raise KeyError(msg)
         if unpack_splitted_values:
             return conf.values[key].get_splitted_values()
         return (


### PR DESCRIPTION
## Problem

Universal Group (UGP) streams produce **no audio** for any DLNA-backed member (Teufel/Raumfeld, generic UPnP) because every member's HTTP fetch from the UGP stream server raises `KeyError`. Reproducible against a Universal Group whose members are universal_players wrapping DLNA protocol players.

```
File "music_assistant/providers/universal_group/player.py", line 394, in _serve_ugp_stream
    output_format = await self.mass.streams.audio.get_output_format(
File "music_assistant/controllers/streams/audio.py", line 1151
    player.player_id, CONF_SAMPLE_RATES, unpack_splitted_values=True
File "music_assistant/controllers/config.py", line 733, in get_player_config_value
    raise KeyError(msg)
KeyError: 'Config key sample_rates not found for player up501e2d1d53ca'
```

The same KeyError fires for `CONF_HTTP_PROFILE` immediately afterwards in `_serve_ugp_stream` itself. Both lookups go through `ConfigController.get_player_config_value()`.

## Root cause

Since 2.8.0 (`CONF_PROTOCOL_KEY_SPLITTER = "||protocol||"`), universal_player wrappers store per-protocol settings (`sample_rates`, `http_profile`, etc.) under `<protocol_id>||protocol||<key>` rather than at the top level of the player config. Every caller still asks for the bare key, so the top-level lookup fails. The UGP stream handler is the most visible victim, but the latent shape is general.

Live config of an affected universal_player (Teufel One M wrapping DLNA):

```
uuid:640e08e3-…||protocol||sample_rates      = ['44100||16', '48000||16']
uuid:640e08e3-…||protocol||http_profile      = 'no_content_length'
```

No top-level `sample_rates` or `http_profile` exists, so `get_player_config_value(player_id, 'sample_rates')` raises.

## Fix

In `ConfigController.get_player_config_value`, when the bare key is missing and the player has an `active_output_protocol`, retry with `f"{active_protocol}{CONF_PROTOCOL_KEY_SPLITTER}{key}"`. Original `default` / `KeyError` semantics are preserved when no protocol is active.

A single-point fix at the config layer covers every caller (`get_output_format`, `select_flow_format`, `select_pcm_format`, `_serve_ugp_stream`'s `http_profile` lookup, and any future callers).

## Verification

Applied locally on 2.8.7, then created a UGP with two DLNA-wrapped members and played a Spotify playlist via `music_assistant.play_media`. Pre-patch: KeyError stack trace per member fetch, group reports `state=playing` but speakers silent. Post-patch: no errors in logs, both speakers audible. Same result for a single-member UGP.

Happy to add a test if maintainers want one — `get_player_config_value` doesn't currently have direct coverage, so I'd add a fixture rather than extending an existing test.