### PR TITLE
Improve Listenbrainz multi-artist track scrobbles

### DIFF
--- a/music_assistant/controllers/media/tracks.py
+++ b/music_assistant/controllers/media/tracks.py
@@ -78,7 +78,8 @@ class TracksController(MediaControllerBase[Track]):
                 'provider', 'library',
                     'name', artists.name,
                     'sort_name', artists.sort_name,
-                    'media_type', 'artist'
+                    'media_type', 'artist',
+                    'external_ids', json(artists.external_ids)
                 )) FROM artists JOIN track_artists on track_artists.track_id = tracks.item_id  WHERE artists.item_id = track_artists.artist_id) AS artists,
             (SELECT
                 json_object(

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -99,9 +99,10 @@ class ListenBrainzEventHandler(ScrobblerHelper):
         # so they won't be scrobbled
 
         # https://pylistenbrainz.readthedocs.io/en/latest/api_ref.html#class-listen
+        artist_combined_name = ", ".join(a for a in report.artists)
         return Listen(
             track_name=self.get_name(report),
-            artist_name=report.artists[0] if report.artists else report.artist,
+            artist_name=artist_combined_name,
             artist_mbids=report.artist_mbids,
             release_name=report.album,
             release_mbid=report.album_mbid,

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -17,7 +17,7 @@ from music_assistant_models.errors import SetupFailedError
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 from music_assistant_models.provider import ProviderManifest
 
-from music_assistant.const import UNKNOWN_ARTIST
+from music_assistant.constants import UNKNOWN_ARTIST
 from music_assistant.helpers.scrobbler import ScrobblerConfig, ScrobblerHelper
 from music_assistant.mass import MusicAssistant
 from music_assistant.models import ProviderInstanceType

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -101,7 +101,7 @@ class ListenBrainzEventHandler(ScrobblerHelper):
         # https://pylistenbrainz.readthedocs.io/en/latest/api_ref.html#class-listen
         return Listen(
             track_name=self.get_name(report),
-            artist_name=report.artist,
+            artist_name=report.artists[0] if report.artists else report.artist,
             artist_mbids=report.artist_mbids,
             release_name=report.album,
             release_mbid=report.album_mbid,

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -100,7 +100,7 @@ class ListenBrainzEventHandler(ScrobblerHelper):
         if report.artists:
             return ", ".join(artist for artist in report.artists)
         return report.artist or UNKNOWN_ARTIST
-        
+
     def _make_listen(self, report: MediaItemPlaybackProgressReport) -> Listen:
         # album artist and track number are not available without an extra API call
         # so they won't be scrobbled

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -94,15 +94,20 @@ class ListenBrainzEventHandler(ScrobblerHelper):
         super().__init__(logger, ScrobblerConfig.create_from_config(config))
         self._client = client
 
+    def _get_artist_name(self, report: MediaItemPlaybackProgressReport) -> str:
+        """Return the best available artist name for the ListenBrainz payload."""
+        if report.artists:
+            return ", ".join(artist for artist in report.artists)
+        return report.artist
+        
     def _make_listen(self, report: MediaItemPlaybackProgressReport) -> Listen:
         # album artist and track number are not available without an extra API call
         # so they won't be scrobbled
 
         # https://pylistenbrainz.readthedocs.io/en/latest/api_ref.html#class-listen
-        artist_combined_name = ", ".join(a for a in report.artists)
         return Listen(
             track_name=self.get_name(report),
-            artist_name=artist_combined_name,
+            artist_name=self._get_artist_name(report),
             artist_mbids=report.artist_mbids,
             release_name=report.album,
             release_mbid=report.album_mbid,

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -17,6 +17,7 @@ from music_assistant_models.errors import SetupFailedError
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 from music_assistant_models.provider import ProviderManifest
 
+from music_assistant.const import UNKNOWN_ARTIST
 from music_assistant.helpers.scrobbler import ScrobblerConfig, ScrobblerHelper
 from music_assistant.mass import MusicAssistant
 from music_assistant.models import ProviderInstanceType
@@ -98,7 +99,7 @@ class ListenBrainzEventHandler(ScrobblerHelper):
         """Return the best available artist name for the ListenBrainz payload."""
         if report.artists:
             return ", ".join(artist for artist in report.artists)
-        return report.artist
+        return report.artist or UNKNOWN_ARTIST
         
     def _make_listen(self, report: MediaItemPlaybackProgressReport) -> Listen:
         # album artist and track number are not available without an extra API call


### PR DESCRIPTION
Currently we send artists as a single string to Listenbrainz, this works fine for tracks that only have 1 artist. 
However, when a track has multiple (feats or collabs), these are send as a single artists with `/` divider.
This result in Listenbrainz not being able to recognize these listens at all: 
<img width="328" height="83" alt="image" src="https://github.com/user-attachments/assets/3ae7b94d-45dc-4f4d-afa4-519d0450cd5f" />

Since we are already construct the `MediaItemPlaybackProgressReport` with the artist mbids (if they are populated), and we add those to the listen event of Listenbrainz, we can simply add them in the query to grab the track metadata.

This result in Listenbrainz somewhat linking the artists correctly:
<img width="335" height="83" alt="image" src="https://github.com/user-attachments/assets/d86164b3-2375-4a9d-b40d-e7ecdc00d432" />

The problem with that one is that the name is still incorrect, and it's assuming the full (concatenated) artists name belong to the first entry in the mbids list we've send. By sending the artists as a single string, separated with `,` instead, gives Listenbrainz a better chance at actually linking the track correctly.
<img width="362" height="83" alt="image" src="https://github.com/user-attachments/assets/16b46edc-f99e-42de-b2db-233f8410a764" />

**NOTE**: There still is an open issue with this, in the cases where the artist string is not in the correct order. As we don't have the concept of a 'main' performer, we don't always send the correct order of artists. 
Ideally we populate more data (like the track's mbid or album mbid), but I don't think these are fully implemented yet, at least not for online sources if I'm correct. The recording ID would be the main identifier to completely link the track correctly.
<img width="257" height="89" alt="image" src="https://github.com/user-attachments/assets/8d9f3e77-5c6c-4f28-9728-779e0fb451d3" />
