### PR TITLE
Fix Continue Listening / Recently Played shelves when MA is opened via HA ingress

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -69,6 +69,7 @@ from music_assistant.constants import (
     DB_TABLE_TRACK_ARTISTS,
     DB_TABLE_TRACKS,
     DEFAULT_GENRE_MAPPING,
+    HOMEASSISTANT_SYSTEM_USER,
     LOUDNESS_MEASUREMENT_MIN_LUFS,
     PROVIDERS_WITH_SHAREABLE_URLS,
 )
@@ -632,8 +633,20 @@ class MusicController(CoreController):
             query += "AND userid = :userid "
             params["userid"] = userid
         elif user := get_current_user():
-            query += "AND userid = :userid "
-            params["userid"] = user.user_id
+            # Also include rows owned by the HA system user: when the MA web UI
+            # is opened via HA ingress, playback initiated through HA-owned
+            # players scrobbles under that shared system identity rather than
+            # the viewing user.
+            system_user = await self.mass.webserver.auth.get_user_by_username(
+                HOMEASSISTANT_SYSTEM_USER
+            )
+            if system_user and system_user.user_id != user.user_id:
+                query += "AND userid IN (:userid, :system_userid) "
+                params["userid"] = user.user_id
+                params["system_userid"] = system_user.user_id
+            else:
+                query += "AND userid = :userid "
+                params["userid"] = user.user_id
         if queue_id:
             query += "AND queue_id = :queue_id "
             params["queue_id"] = queue_id
@@ -701,6 +714,17 @@ class MusicController(CoreController):
             filter_for_str = available_providers_str
             if user.provider_filter:
                 filter_for_str = "(" + ",".join(f'"{x}"' for x in user.provider_filter) + ")"
+            # Also include rows owned by the HA system user: when the MA web UI
+            # is opened via HA ingress, playback initiated through HA-owned
+            # players scrobbles under that shared system identity rather than
+            # the viewing user.
+            allowed_user_ids = [user.user_id]
+            system_user = await self.mass.webserver.auth.get_user_by_username(
+                HOMEASSISTANT_SYSTEM_USER
+            )
+            if system_user and system_user.user_id != user.user_id:
+                allowed_user_ids.append(system_user.user_id)
+            allowed_userids_str = "(" + ",".join(f"'{uid}'" for uid in allowed_user_ids) + ")"
             query += (
                 f"AND m.provider_instance IN {filter_for_str} "
                 f"AND m.provider_instance IN {available_providers_str} "
@@ -708,7 +732,7 @@ class MusicController(CoreController):
                 f"ELSE (p.provider IN {filter_for_str} AND p.provider IN {available_providers_str})"
                 "END "
                 ") "
-                f"AND p.userid = '{user.user_id}' "
+                f"AND p.userid IN {allowed_userids_str} "
             )
         else:
             # for a library item, we still have to verify via the provider mapping table


### PR DESCRIPTION
**Observed behaviour**
When I open the MA web UI through Home Assistant's sidebar (HA ingress) and start an audiobook or podcast playing on an mass_* player. The track plays fine and progress is tracked, but:

- The Continue Listening shelf on the home view does not show the audiobook/podcast that's currently playing, even mid-chapter.
- After it finishes (or you stop it), it does not appear in the Recently Played shelf either.
- I then have to navigate to the audiobook/podcast in the library each time to resume — there's no shortcut from the home view.
- Inspecting library.db confirms a row exists in playlog with correct seconds_played / fully_played data, but its userid is the homeassistant_system service-account id, not the human user logged in to the UI.

**Problem**
When the MA web UI is opened via Home Assistant ingress, the WebSocket session authenticates as the homeassistant_system service user. Playback initiated through HA-owned mass_* players writes playlog.userid = <homeassistant_system user id>. The playlog uniqueness key (item_id, provider, media_type, userid) pins the row to that identity. Both in_progress_items() and recently_played() filter strictly by the viewing user's id, so the playlog row never surfaces on the Continue Listening / Recently Played shelves.

**Fix**
Treat homeassistant_system as a shared household identity and OR it into the userid filter alongside the viewing user. The constant HOMEASSISTANT_SYSTEM_USER already exists and is already excluded from list_users() for the same conceptual reason; this aligns the shelf queries with that convention.

There is no schema change or attribution refactor. Per-user scoping for any non-system user remains intact (a different human user's rows are still hidden from the first).

**Notes / alternatives**
A deeper fix would thread the originating HA user through the play_media service call so attribution lands on the right human in the first place, but that's a cross-repo change (HA integration ↔ MA) with much larger scope.

**Code changes**
All edits are to [music_assistant/controllers/music.py](https://github.com/scootaash/MAserver/blob/claude/fix-continue-listening-shelf-8R6P4/music_assistant/controllers/music.py), plus one new import.

Import the existing constant. HOMEASSISTANT_SYSTEM_USER is already defined in /music_assistant/constants.py and used by the auth controller to identify the HA-ingress service user. Imported here so the music controller can look up that user by username.

**recently_played() (parameterised SQL path)**
Previously, when no explicit userid was passed in, the query scoped to the current user only:
```
elif user := get_current_user():
    query += "AND userid = :userid "
    params["userid"] = user.user_id
```
Now, if the current user is not the HA system user, the query expands to include rows owned by the HA system user as well:
```
elif user := get_current_user():
    system_user = await self.mass.webserver.auth.get_user_by_username(
        HOMEASSISTANT_SYSTEM_USER
    )
    if system_user and system_user.user_id != user.user_id:
        query += "AND userid IN (:userid, :system_userid) "
        params["userid"] = user.user_id
        params["system_userid"] = system_user.user_id
    else:
        query += "AND userid = :userid "
        params["userid"] = user.user_id
```
The else branch preserves the original behavior for standalone MA installs (no HA system user exists) and for the unlikely case that the viewer is the system user itself.
in_progress_items() (string-interpolated SQL path)
This function builds its SQL via f-strings rather than bound parameters, so the change matches that style: build a list of allowed user ids, format it as a SQL IN (…) clause, and replace the single-user equality check.
Before:
```
f"AND p.userid = '{user.user_id}' "
After:
allowed_user_ids = [user.user_id]
system_user = await self.mass.webserver.auth.get_user_by_username(
    HOMEASSISTANT_SYSTEM_USER
)
if system_user and system_user.user_id != user.user_id:
    allowed_user_ids.append(system_user.user_id)
allowed_userids_str = "(" + ",".join(f"'{uid}'" for uid in allowed_user_ids) + ")"
# …
f"AND p.userid IN {allowed_userids_str} "
```
User ids are MA-generated UUID-like strings (not user input), so this matches the existing interpolation pattern in this function without introducing new injection surface.

**What is intentionally not changed**
The userid argument-override path on recently_played() is untouched: explicit callers asking for a specific user still get strict per-user scoping.
The all_users=True path on in_progress_items() is untouched.
No changes to write paths (mark_item_played, scrobblers, queue ownership) — attribution still goes to whichever user owns the queue. This PR only widens the read filter on the two shelf queries.