### PR TITLE
Apple Music: fix rotating IDs for recommendation folders and personal stations

### DIFF
--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -203,6 +203,11 @@ class AppleMusicMediaManager:
         )
         tracks = response.get("data", [])
         if not tracks:
+            self.logger.debug(
+                "No tracks returned for station_id=%s, raw response keys: %s",
+                station_id,
+                list(response.keys()),
+            )
             return []
         track_ids = [t["id"] for t in tracks if t and t.get("id")]
         rating_response = await self.api.get_ratings(track_ids, MediaType.TRACK)

--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -183,6 +183,21 @@ class AppleMusicMediaManager:
 
     async def _get_station_tracks(self, station_id: str) -> list[Track]:
         """Fetch the next batch of tracks for a radio station."""
+        tracks = await self._fetch_station_tracks(station_id)
+        if not tracks:
+            # Apple may rotate station IDs for personal stations; try to resolve the current one.
+            fresh_id = await self.provider.recommendation_manager.resolve_station_id(station_id)
+            if fresh_id and fresh_id != station_id:
+                self.logger.debug(
+                    "Station ID %s appears stale, retrying with refreshed ID %s",
+                    station_id,
+                    fresh_id,
+                )
+                tracks = await self._fetch_station_tracks(fresh_id)
+        return tracks
+
+    async def _fetch_station_tracks(self, station_id: str) -> list[Track]:
+        """Fetch tracks for a station ID from the Apple Music API."""
         response = await self.api.post_data(
             f"me/stations/next-tracks/{station_id}", include="artists"
         )

--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -204,9 +204,9 @@ class AppleMusicMediaManager:
         tracks = response.get("data", [])
         if not tracks:
             self.logger.debug(
-                "No tracks returned for station_id=%s, raw response keys: %s",
+                "No tracks returned for station_id=%s; errors=%s",
                 station_id,
-                list(response.keys()),
+                response.get("errors"),
             )
             return []
         track_ids = [t["id"] for t in tracks if t and t.get("id")]

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -119,8 +119,11 @@ class AppleMusicRecommendationManager:
                     if playlist.name == station_id:
                         continue
                 if title not in folders:
+                    stable_id = "".join(
+                        c for c in title.lower().replace(" ", "_") if c.isalnum() or c == "_"
+                    )
                     folders[title] = RecommendationFolder(
-                        item_id=rec_id,
+                        item_id=stable_id,
                         provider=self.provider.instance_id,
                         name=title,
                     )

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -15,7 +15,7 @@ from music_assistant_models.media_items import (
     Track,
 )
 
-from music_assistant.controllers.cache import use_cache
+from music_assistant.controllers.cache import BYPASS_CACHE, use_cache
 
 from .parsers import parse_artist, parse_station_as_playlist, parse_track
 
@@ -38,6 +38,8 @@ class AppleMusicRecommendationManager:
     def __init__(self, provider: AppleMusicProvider) -> None:
         """Initialize recommendation manager."""
         self.provider = provider
+        self._station_id_to_name: dict[str, str] = {}
+        self._station_name_to_id: dict[str, str] = {}
         self.mass = provider.mass
         self.instance_id = provider.instance_id
         self.domain = provider.domain
@@ -128,6 +130,9 @@ class AppleMusicRecommendationManager:
                     playlist = await self.provider.get_playlist(station_id)
                     if playlist.name == station_id:
                         continue
+                if playlist.name and playlist.name != station_id:
+                    self._station_id_to_name[station_id] = playlist.name
+                    self._station_name_to_id[playlist.name] = station_id
                 if title not in folders:
                     folders[title] = RecommendationFolder(
                         item_id=_slugify_title(title),
@@ -136,6 +141,22 @@ class AppleMusicRecommendationManager:
                     )
                 folders[title].items.append(playlist)
         return list(folders.values())
+
+    async def resolve_station_id(self, stale_id: str) -> str | None:
+        """
+        Return the current station ID for a stale one.
+
+        :param stale_id: The outdated station ID that may have been rotated by Apple.
+        """
+        station_name = self._station_id_to_name.get(stale_id)
+        if not station_name:
+            return None
+        token = BYPASS_CACHE.set(True)
+        try:
+            await self.get_personal_recommendations()
+        finally:
+            BYPASS_CACHE.reset(token)
+        return self._station_name_to_id.get(station_name)
 
     async def browse_stations(self) -> list[ItemMapping | Playlist]:
         """Return recommended radio stations from personal recommendations."""

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -15,7 +15,7 @@ from music_assistant_models.media_items import (
     Track,
 )
 
-from music_assistant.controllers.cache import BYPASS_CACHE, use_cache
+from music_assistant.controllers.cache import use_cache
 
 from .parsers import parse_artist, parse_station_as_playlist, parse_track
 
@@ -158,11 +158,8 @@ class AppleMusicRecommendationManager:
             station_name = self._station_id_to_name.get(stale_id)
             if not station_name:
                 return None
-        token = BYPASS_CACHE.set(True)
-        try:
+        async with self.mass.cache.handle_refresh(True):
             await self.get_personal_recommendations()
-        finally:
-            BYPASS_CACHE.reset(token)
         return self._station_name_to_id.get(station_name)
 
     async def browse_stations(self) -> list[ItemMapping | Playlist]:

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -105,6 +105,9 @@ class AppleMusicRecommendationManager:
         )
         seen: set[str] = set()
         folders: dict[str, RecommendationFolder] = {}
+        # Reset maps so stale entries from previous fetches are not kept.
+        self._station_id_to_name.clear()
+        self._station_name_to_id.clear()
         for recommendation in response.get("data", []):
             rec_id = recommendation.get("id", "")
             title = (
@@ -150,7 +153,11 @@ class AppleMusicRecommendationManager:
         """
         station_name = self._station_id_to_name.get(stale_id)
         if not station_name:
-            return None
+            # Map may be empty after a process restart; populate from the cache first.
+            await self.get_personal_recommendations()
+            station_name = self._station_id_to_name.get(stale_id)
+            if not station_name:
+                return None
         token = BYPASS_CACHE.set(True)
         try:
             await self.get_personal_recommendations()

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -28,7 +28,7 @@ def _slugify_title(title: str) -> str:
     slug = "".join(c for c in title.lower().replace(" ", "_") if c.isalnum() or c == "_")
     if not slug:
         # Fall back to a hash for titles that yield no alphanumeric characters.
-        slug = hashlib.md5(title.encode()).hexdigest()[:12]
+        slug = hashlib.md5(title.encode(), usedforsecurity=False).hexdigest()[:12]
     return slug
 
 

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import MediaType
@@ -20,6 +21,15 @@ from .parsers import parse_artist, parse_station_as_playlist, parse_track
 
 if TYPE_CHECKING:
     from .provider import AppleMusicProvider
+
+
+def _slugify_title(title: str) -> str:
+    """Return a stable, alphanumeric slug for a recommendation folder title."""
+    slug = "".join(c for c in title.lower().replace(" ", "_") if c.isalnum() or c == "_")
+    if not slug:
+        # Fall back to a hash for titles that yield no alphanumeric characters.
+        slug = hashlib.md5(title.encode()).hexdigest()[:12]
+    return slug
 
 
 class AppleMusicRecommendationManager:
@@ -119,11 +129,8 @@ class AppleMusicRecommendationManager:
                     if playlist.name == station_id:
                         continue
                 if title not in folders:
-                    stable_id = "".join(
-                        c for c in title.lower().replace(" ", "_") if c.isalnum() or c == "_"
-                    )
                     folders[title] = RecommendationFolder(
-                        item_id=stable_id,
+                        item_id=_slugify_title(title),
                         provider=self.provider.instance_id,
                         name=title,
                     )


### PR DESCRIPTION
## Problem

Apple Music rotates internal IDs on each API call, causing two related bugs:

**1. Home screen section preferences reset**
`get_personal_recommendations()` was using `rec_id` (e.g. `rp.1234567890`) as the `item_id` for `RecommendationFolder`. After a refresh, the section URI changes and stored home screen preferences (hide/sort position) no longer match — causing sections to reset to visible and back to the top position.

**2. Personal radio stations stop playing**
Station playlists from personal recommendations (e.g. "Stations for You") use Apple's station ID as their `item_id`. When Apple rotates this ID, `me/stations/next-tracks/{station_id}` returns empty — resulting in "No playable items found" when the station tries to refill its queue.

## Fix

**For the folder IDs:** Use a stable, title-derived slug as `item_id` instead (e.g. `"Stations for You"` → `"stations_for_you"`). Consistent with how YouTube Music and Tidal handle recommendation folder IDs.

**For the station IDs:** Maintain a `name ↔ station_id` mapping in the recommendation manager. When `_get_station_tracks` returns empty, bypass the cache, fetch fresh recommendations to get the current station ID, and retry.

## Testing

- Hide or reorder a section via Edit Home screen — preferences should persist across page refreshes.
- Start a personal radio station from the "Stations for You" section — it should continue playing after the recommendations cache expires (~1 hour).