### PR TITLE
Fix podcast seek for RSS episodes without duration

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -618,7 +618,9 @@ class PlayerQueuesController(CoreController):
         queue.elapsed_time = 0
         queue.elapsed_time_last_updated = time.time()
         queue.index_in_buffer = None
-        self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
+        self.mass.create_task(
+            self._cleanup_queue_audio_data(queue_id, self._queue_items.get(queue_id, []).copy())
+        )
         self.update_items(queue_id, [])
 
     @api_command("player_queues/save_as_playlist")
@@ -839,13 +841,36 @@ class PlayerQueuesController(CoreController):
         if not queue.current_item:
             raise InvalidCommand(f"Queue {queue_player.state.name} has no item(s) loaded.")
         if not queue.current_item.duration:
+            await self._ensure_current_item_duration(queue_id, queue.current_item)
+        if not queue.current_item.duration:
             raise InvalidCommand("Can not seek items without duration.")
         position = max(0, int(position))
         if position > queue.current_item.duration:
             raise InvalidCommand("Can not seek outside of duration range.")
         if queue.current_index is None:
             raise InvalidCommand(f"Queue {queue_player.state.name} has no current index.")
+        if queue.current_item.streamdetails and queue.current_item.streamdetails.buffer:
+            await queue.current_item.streamdetails.buffer.clear()
+            queue.current_item.streamdetails.buffer = None
         await self.play_index(queue_id, queue.current_index, seek_position=position)
+
+    async def _ensure_current_item_duration(self, queue_id: str, queue_item: QueueItem) -> None:
+        """Try to populate a missing duration before rejecting queue seek."""
+        if queue_item.duration:
+            return
+        try:
+            queue_item.streamdetails = await self.mass.streams.audio.get_stream_details(
+                queue_item=queue_item,
+                seek_position=0,
+            )
+        except MusicAssistantError:
+            return
+        if queue_item.streamdetails.duration:
+            if not queue_item.duration:
+                queue_item.duration = queue_item.streamdetails.duration
+            if queue_item.media_item and not queue_item.media_item.duration:
+                queue_item.media_item.duration = queue_item.streamdetails.duration
+            self.signal_update(queue_id, items_changed=True)
 
     @api_command("player_queues/resume")
     @handle_play_action
@@ -1605,8 +1630,11 @@ class PlayerQueuesController(CoreController):
             prefer_album_loudness=bool(playing_album_tracks),
         )
         # update queue_item.duration from streamdetails if we got a better value
-        if queue_item.streamdetails.duration and not queue_item.duration:
-            queue_item.duration = queue_item.streamdetails.duration
+        if queue_item.streamdetails.duration:
+            if not queue_item.duration:
+                queue_item.duration = queue_item.streamdetails.duration
+            if queue_item.media_item and not queue_item.media_item.duration:
+                queue_item.media_item.duration = queue_item.streamdetails.duration
             self.signal_update(queue_id, items_changed=True)
 
         # pre-initialize the AudioBuffer so audio is ready
@@ -3257,7 +3285,9 @@ class PlayerQueuesController(CoreController):
                 cleanup_threshold + 1,
             )
 
-    async def _cleanup_queue_audio_data(self, queue_id: str) -> None:
+    async def _cleanup_queue_audio_data(
+        self, queue_id: str, queue_items: list[QueueItem] | None = None
+    ) -> None:
         """Clean up all audio-related data for a queue when it is stopped or cleared.
 
         This clears:
@@ -3268,7 +3298,8 @@ class PlayerQueuesController(CoreController):
         """
         self.mass.streams.audio.clear_crossfade_data(queue_id)
 
-        queue_items = self._queue_items.get(queue_id, [])
+        if queue_items is None:
+            queue_items = self._queue_items.get(queue_id, [])
         buffers_cleared = 0
 
         for item in queue_items:

--- a/music_assistant/providers/podcastfeed/__init__.py
+++ b/music_assistant/providers/podcastfeed/__init__.py
@@ -9,10 +9,12 @@ multiple instances with each one feed must exist.
 
 from __future__ import annotations
 
+import socket
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
 import podcastparser
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
 from aiohttp.client_exceptions import ClientError
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
@@ -22,7 +24,7 @@ from music_assistant_models.enums import (
     ProviderFeature,
     StreamType,
 )
-from music_assistant_models.errors import InvalidProviderURI, MediaNotFoundError
+from music_assistant_models.errors import InvalidDataError, InvalidProviderURI, MediaNotFoundError
 from music_assistant_models.media_items import (
     AudioFormat,
     MediaItemImage,
@@ -39,6 +41,7 @@ from music_assistant.helpers.podcast_parsers import (
     parse_podcast,
     parse_podcast_episode,
 )
+from music_assistant.helpers.tags import AudioTags, async_parse_tags
 from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
@@ -51,6 +54,11 @@ if TYPE_CHECKING:
 CONF_FEED_URL = "feed_url"
 
 CACHE_CATEGORY_PODCASTS = 0
+CACHE_CATEGORY_MEDIA_INFO = 1
+PODCAST_HTTP_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    "Connection": "close",
+}
 
 SUPPORTED_FEATURES = {
     ProviderFeature.BROWSE,
@@ -175,23 +183,259 @@ class PodcastMusicprovider(MusicProvider):
         for episode in self.parsed_podcast["episodes"]:
             if item_id == episode["guid"]:
                 stream_url = episode["enclosures"][0]["url"]
+                media_info = None
+                duration = int(episode.get("total_time") or 0) or None
+                if duration is None:
+                    media_info = await self._get_stream_media_info(stream_url)
+                if duration is None and media_info and media_info.duration:
+                    duration = int(media_info.duration)
+                    episode["total_time"] = duration
+                    await self._cache_set_podcast()
+                size = self._get_media_info_size(media_info)
+
                 return StreamDetails(
                     provider=self.instance_id,
                     item_id=item_id,
                     audio_format=AudioFormat(
-                        content_type=ContentType.try_parse(stream_url),
+                        content_type=ContentType.try_parse(
+                            media_info.format if media_info else stream_url.split("?", 1)[0]
+                        ),
                     ),
                     media_type=MediaType.PODCAST_EPISODE,
-                    stream_type=StreamType.HTTP,
+                    stream_type=StreamType.CUSTOM,
                     path=stream_url,
+                    duration=duration,
+                    size=size,
+                    data={"duration": duration, "size": size},
                     can_seek=True,
                     allow_seek=True,
-                    extra_input_args=[
-                        "-user_agent",
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-                    ],
                 )
         raise MediaNotFoundError("Stream not found")
+
+    async def get_audio_stream(
+        self, streamdetails: StreamDetails, seek_position: int = 0
+    ) -> AsyncGenerator[bytes, None]:
+        """Return podcast audio using HTTP range requests."""
+        assert isinstance(streamdetails.path, str)
+        if seek_position:
+            assert streamdetails.duration, "Duration required for seek requests"
+
+        headers = {**PODCAST_HTTP_HEADERS}
+        timeout = ClientTimeout(total=None, connect=5, sock_connect=5, sock_read=4)
+        stream_data = streamdetails.data if isinstance(streamdetails.data, dict) else {}
+        original_duration = await self._update_stream_original_metadata(
+            streamdetails,
+            stream_data,
+            seek_position,
+        )
+        seek_supported = await self._update_stream_size_from_head(
+            streamdetails,
+            stream_data,
+            headers,
+            timeout,
+            seek_position,
+        )
+        seek_position = self._prepare_seek_headers(
+            streamdetails,
+            headers,
+            original_duration,
+            seek_position,
+            seek_supported,
+        )
+
+        bytes_received = 0
+        async for chunk in self._iter_podcast_http_stream(
+            streamdetails,
+            headers,
+            timeout,
+            seek_position,
+        ):
+            bytes_received += len(chunk)
+            yield chunk
+
+        if not streamdetails.size:
+            streamdetails.size = bytes_received
+
+    async def _update_stream_original_metadata(
+        self,
+        streamdetails: StreamDetails,
+        stream_data: dict[str, Any],
+        seek_position: int,
+    ) -> int | None:
+        """Restore original duration and size before a new podcast seek."""
+        assert isinstance(streamdetails.path, str)
+        original_duration = stream_data.get("duration") or streamdetails.duration
+        original_size = stream_data.get("size") or streamdetails.size
+
+        if seek_position and (
+            not original_duration or int(original_duration) < seek_position
+        ):
+            media_info = await self._get_stream_media_info(streamdetails.path)
+            if media_info and media_info.duration:
+                original_duration = int(media_info.duration)
+                stream_data["duration"] = original_duration
+            if media_info and (media_size := self._get_media_info_size(media_info)):
+                original_size = media_size
+                stream_data["size"] = original_size
+        if original_duration:
+            streamdetails.duration = int(original_duration)
+        if original_size:
+            streamdetails.size = int(original_size)
+        streamdetails.data = stream_data
+        return int(original_duration) if original_duration else None
+
+    async def _update_stream_size_from_head(
+        self,
+        streamdetails: StreamDetails,
+        stream_data: dict[str, Any],
+        headers: dict[str, str],
+        timeout: ClientTimeout,
+        seek_position: int,
+    ) -> bool:
+        """Update podcast stream size and check byte range support."""
+        seek_supported = streamdetails.can_seek
+        if seek_position or not streamdetails.size:
+            assert isinstance(streamdetails.path, str)
+            try:
+                async with ClientSession(
+                    timeout=timeout,
+                    connector=TCPConnector(
+                        force_close=True,
+                        enable_cleanup_closed=True,
+                    ),
+                ) as http_session, http_session.head(
+                    streamdetails.path,
+                    allow_redirects=True,
+                    headers=headers,
+                ) as resp:
+                    resp.raise_for_status()
+                    if size := resp.headers.get("Content-Length"):
+                        streamdetails.size = int(size)
+                        stream_data["size"] = streamdetails.size
+                        streamdetails.data = stream_data
+                    seek_supported = resp.headers.get("Accept-Ranges", "").lower() == "bytes"
+            except (ClientError, TimeoutError) as err:
+                self.logger.debug(
+                    "Failed to read podcast stream headers for %s: %s",
+                    streamdetails.uri,
+                    err,
+                )
+                return bool(streamdetails.size and seek_supported)
+        return seek_supported
+
+    def _prepare_seek_headers(
+        self,
+        streamdetails: StreamDetails,
+        headers: dict[str, str],
+        original_duration: int | None,
+        seek_position: int,
+        seek_supported: bool,
+    ) -> int:
+        """Prepare byte range headers for podcast seek when possible."""
+        if seek_position and (
+            not seek_supported
+            or not streamdetails.size
+            or not original_duration
+            or streamdetails.audio_format.content_type
+            in (ContentType.UNKNOWN, ContentType.M4A, ContentType.M4B)
+        ):
+            self.logger.warning(
+                "Seeking in %s (%s) not possible.",
+                streamdetails.uri,
+                streamdetails.audio_format.output_format_str,
+            )
+            seek_position = 0
+            streamdetails.seek_position = 0
+
+        if seek_position:
+            assert streamdetails.size is not None
+            assert original_duration is not None
+            skip_bytes = min(
+                int(streamdetails.size / original_duration * seek_position),
+                streamdetails.size - 1,
+            )
+            end_byte = streamdetails.size - 1
+            headers["Range"] = f"bytes={skip_bytes}-{end_byte}"
+        return seek_position
+
+    async def _iter_podcast_http_stream(
+        self,
+        streamdetails: StreamDetails,
+        headers: dict[str, str],
+        timeout: ClientTimeout,
+        seek_position: int,
+    ) -> AsyncGenerator[bytes, None]:
+        """Read the podcast HTTP stream with one normal attempt and IPv4 fallback."""
+        assert isinstance(streamdetails.path, str)
+        bytes_sent = False
+        for attempt, ipv4_only in enumerate((False, True, True), start=1):
+            try:
+                async with ClientSession(
+                    timeout=timeout,
+                    connector=TCPConnector(
+                        force_close=True,
+                        enable_cleanup_closed=True,
+                        family=socket.AF_INET if ipv4_only else socket.AF_UNSPEC,
+                    ),
+                ) as http_session, http_session.get(
+                    streamdetails.path,
+                    allow_redirects=True,
+                    headers=headers,
+                ) as resp:
+                    is_partial = resp.status == 206
+                    if seek_position and not is_partial:
+                        raise InvalidDataError("HTTP source does not support seeking")
+                    resp.raise_for_status()
+                    async for chunk in resp.content.iter_any():
+                        bytes_sent = True
+                        yield chunk
+                break
+            except (ClientError, TimeoutError) as err:
+                if bytes_sent:
+                    raise
+                log = self.logger.warning if attempt == 3 else self.logger.debug
+                log(
+                    "Podcast range stream GET failed before first chunk: attempt=%s error=%s",
+                    attempt,
+                    err,
+                )
+                if attempt == 3:
+                    raise InvalidProviderURI("Podcast stream did not return audio data") from err
+
+    async def _get_stream_media_info(self, stream_url: str) -> AudioTags | None:
+        """Retrieve and cache media info for podcast streams without RSS duration."""
+        cached_info = await self.mass.cache.get(
+            key=stream_url,
+            provider=self.instance_id,
+            category=CACHE_CATEGORY_MEDIA_INFO,
+        )
+        if cached_info:
+            return AudioTags.parse(cached_info)
+
+        try:
+            media_info = await async_parse_tags(stream_url, require_duration=True)
+        except Exception as err:
+            self.logger.debug("Failed to probe podcast stream %s: %s", stream_url, err)
+            return None
+
+        await self.mass.cache.set(
+            key=stream_url,
+            provider=self.instance_id,
+            category=CACHE_CATEGORY_MEDIA_INFO,
+            data=media_info.raw,
+            expiration=60 * 60 * 24 * 30,
+        )
+        return media_info
+
+    @staticmethod
+    def _get_media_info_size(media_info: AudioTags | None) -> int | None:
+        """Return stream size from ffprobe media info when present."""
+        if not media_info:
+            return None
+        try:
+            return int(media_info.raw.get("format", {}).get("size") or 0) or None
+        except (TypeError, ValueError):
+            return None
 
     async def _parse_podcast(self) -> Podcast:
         """Parse podcast information from podcast feed."""

--- a/tests/providers/test_podcastfeed.py
+++ b/tests/providers/test_podcastfeed.py
@@ -1,0 +1,91 @@
+"""Tests for the podcast feed provider."""
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import Mock
+
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.helpers.tags import AudioTags
+from music_assistant.providers.podcastfeed import PodcastMusicprovider
+
+
+def _podcast_stream(content_type: ContentType = ContentType.MP3) -> StreamDetails:
+    return StreamDetails(
+        provider="podcastfeed",
+        item_id="episode",
+        audio_format=AudioFormat(content_type=content_type),
+        media_type=MediaType.PODCAST_EPISODE,
+        stream_type=StreamType.CUSTOM,
+        path="https://example.com/podcast.mp3",
+        duration=120,
+        size=1200,
+        can_seek=True,
+        allow_seek=True,
+    )
+
+
+def test_podcast_seek_headers_use_original_duration_for_byte_range() -> None:
+    """Test that podcast seek uses the original duration to calculate the byte range."""
+    streamdetails = _podcast_stream()
+    headers: dict[str, str] = {}
+    logger = Mock()
+    provider = cast("PodcastMusicprovider", SimpleNamespace(logger=logger))
+
+    seek_position = PodcastMusicprovider._prepare_seek_headers(
+        provider,
+        streamdetails,
+        headers,
+        original_duration=120,
+        seek_position=30,
+        seek_supported=True,
+    )
+
+    assert seek_position == 30
+    assert headers["Range"] == "bytes=300-1199"
+
+
+def test_podcast_seek_headers_disable_unsupported_seek() -> None:
+    """Test that unsupported podcast seeks fall back to a normal stream."""
+    streamdetails = _podcast_stream(ContentType.UNKNOWN)
+    headers: dict[str, str] = {}
+    logger = Mock()
+    provider = cast("PodcastMusicprovider", SimpleNamespace(logger=logger))
+
+    seek_position = PodcastMusicprovider._prepare_seek_headers(
+        provider,
+        streamdetails,
+        headers,
+        original_duration=120,
+        seek_position=30,
+        seek_supported=True,
+    )
+
+    assert seek_position == 0
+    assert "Range" not in headers
+    assert streamdetails.seek_position == 0
+    logger.warning.assert_called_once()
+
+
+def test_podcast_media_info_size_parsing() -> None:
+    """Test stream size extraction from ffprobe media info."""
+    assert (
+        PodcastMusicprovider._get_media_info_size(
+            cast("AudioTags", SimpleNamespace(raw={"format": {"size": "1234"}}))
+        )
+        == 1234
+    )
+    assert (
+        PodcastMusicprovider._get_media_info_size(
+            cast("AudioTags", SimpleNamespace(raw={"format": {}}))
+        )
+        is None
+    )
+    assert (
+        PodcastMusicprovider._get_media_info_size(
+            cast("AudioTags", SimpleNamespace(raw={"format": {"size": "invalid"}}))
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

- Lazily probe podcast stream metadata when the RSS episode duration is missing or zero.
- Cache probed duration and stream size for later playback and seek requests.
- Serve podcast feed playback through a custom HTTP range stream so byte-range seek works for MP3 podcast episodes.
- Preserve the original duration and size in `StreamDetails.data`, so repeated seeks keep using the full episode length instead of a remaining-duration value.
- Clear the current audio buffer before replaying the same queue item at a new seek position.
- Add focused unit coverage for podcast byte-range calculation and media size parsing.

## Root Cause

Some podcast feeds expose playable MP3 URLs but report `total_time` as `0`. In that case Music Assistant has no useful item duration, so the frontend cannot expose a usable timeline and `player_queues/seek` rejects the item.

For these streams, `ffprobe` can still read the actual duration and size from the remote MP3. Once that metadata is known, the provider can calculate a byte-range offset for the requested seek position and request `Range: bytes=start-end` from the podcast host.

## Validation

- `python -m py_compile music_assistant/providers/podcastfeed/__init__.py music_assistant/controllers/player_queues.py tests/providers/test_podcastfeed.py`
- `uv run --extra test ruff check music_assistant/providers/podcastfeed/__init__.py music_assistant/controllers/player_queues.py tests/providers/test_podcastfeed.py`
- `uv run --extra test --with hass-client mypy music_assistant/providers/podcastfeed/__init__.py music_assistant/controllers/player_queues.py tests/providers/test_podcastfeed.py`
- `uv run --extra test --with hass-client pytest tests/providers/test_podcastfeed.py tests/core/test_audio_buffer.py tests/core/test_player_controls.py`

Manual validation on a Music Assistant 2.8.7 instance with Radio24 podcast episodes that report missing RSS duration:

- `La Zanzara del 10 aprile 2026`: play, seek near quarter, middle, and near the end.
- `La Zanzara del 15 maggio 2026`: play, seek 10, 5, 3, and 1 minutes from the end.
- Playback continued from the requested position after each seek and the queue stopped cleanly afterward.
