### PR TITLE
Improve UX of Sync groups

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1351,6 +1351,37 @@ class ConfigController:
             LOGGER.warning("Repaired corrupt tasks core configuration")
             changed = True
 
+        # Migrate sync_group members_filter (exclusion) -> allowed_members (inclusion).
+        # Inversion freezes the universe at migration time; speakers added after this
+        # point must be added by the user explicitly, which matches the new design's
+        # "limit to these" intent.
+        # TODO: remove after 2.10 release
+        all_player_configs = self._data.get(CONF_PLAYERS, {})
+        if isinstance(all_player_configs, dict):
+            group_provider_domains = {"sync_group", "universal_group"}
+            universe = {
+                pid
+                for pid, cfg in all_player_configs.items()
+                if isinstance(cfg, dict) and cfg.get("provider") not in group_provider_domains
+            }
+            for player_id, player_cfg in all_player_configs.items():
+                if not isinstance(player_cfg, dict):
+                    continue
+                if player_cfg.get("provider") != "sync_group":
+                    continue
+                values = player_cfg.setdefault("values", {})
+                old_exclude = values.get("members_filter") or []
+                if not old_exclude or values.get("allowed_members") is not None:
+                    continue
+                values["allowed_members"] = sorted(universe - set(old_exclude))
+                values["members_filter"] = []
+                LOGGER.info(
+                    "Migrated sync_group %s: members_filter (exclusion) "
+                    "-> allowed_members (inclusion)",
+                    player_id,
+                )
+                changed = True
+
         if changed:
             await self._async_save()
 

--- a/music_assistant/providers/sync_group/constants.py
+++ b/music_assistant/providers/sync_group/constants.py
@@ -17,7 +17,7 @@ CONF_ENTRY_SGP_NOTE = ConfigEntry(
     required=False,
 )
 
-CONF_MEMBERS_FILTER: Final[str] = "members_filter"
+CONF_ALLOWED_MEMBERS: Final[str] = "allowed_members"
 
 
 EXTRA_FEATURES_FROM_MEMBERS: Final[set[PlayerFeature]] = {

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -70,10 +70,7 @@ class SyncGroupPlayer(Player):
         preset_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []))
         if self.is_dynamic:
             # In dynamic mode the configured members act as a preset: they are
-            # pulled in when the group plays (see _form_syncgroup) but the user
-            # can temporarily unjoin them via the OSD. Keeping
-            # _attr_static_group_members empty signals "no locked members" so
-            # the frontend doesn't gray out the checkboxes.
+            # pulled in when the group plays
             self._attr_static_group_members = []
             self._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
         else:
@@ -180,34 +177,34 @@ class SyncGroupPlayer(Player):
         # A sync group can accommodate protocol switches, so a player compatible with
         # ANY current member is a valid candidate to join.
         member_ids = self._attr_group_members if self._attr_group_members else []
-        can_group_with: set[str] = set()
+        # current members bypass the allow-list filter (filter constrains joiners only)
+        current_members = set(member_ids)
         if member_ids:
+            can_group_with: set[str] = set()
             for member_id in member_ids:
                 member_player = self.mass.players.get_player(member_id)
                 if member_player and member_player.state.available:
                     can_group_with.add(member_player.player_id)
                     can_group_with.update(member_player.state.can_group_with)
-        else:
-            # Empty dynamic groups can potentially group with any compatible players.
-            # Actual compatibility is validated when adding members.
-            for player in self.mass.players.all_players(return_unavailable=False):
-                if not player.available or player.type == PlayerType.GROUP:
-                    # let's avoid showing group players as options to group with
-                    continue
-                if (
-                    PlayerFeature.SET_MEMBERS in player.state.supported_features
-                    and player.state.can_group_with
-                    and not player.state.active_group
-                ):
-                    can_group_with.add(player.player_id)
-        # Apply allow-list filters to the candidate set. Current members of the
-        # group are exempt - the filters constrain who can JOIN, not who is
-        # already a member (otherwise enabling a filter that doesn't list a
-        # current member would hide every candidate via the seed step).
-        current_members = set(member_ids)
-        return {
-            pid for pid in can_group_with if pid in current_members or self._is_member_allowed(pid)
-        }
+            return {
+                pid
+                for pid in can_group_with
+                if pid in current_members or self._is_member_allowed(pid)
+            }
+        # Empty dynamic groups can potentially group with any compatible players
+        # Actual compatibility is validated when adding members
+        can_group_with = set()
+        for player in self.mass.players.all_players(return_unavailable=False):
+            if not player.available or player.type == PlayerType.GROUP:
+                # let's avoid showing group players as options to group with
+                continue
+            if (
+                PlayerFeature.SET_MEMBERS in player.state.supported_features
+                and player.state.can_group_with
+                and not player.state.active_group
+            ):
+                can_group_with.add(player.player_id)
+        return {pid for pid in can_group_with if self._is_member_allowed(pid)}
 
     @property
     def group_members(self) -> list[str]:
@@ -494,9 +491,7 @@ class SyncGroupPlayer(Player):
             self.sync_leader.display_name if self.sync_leader else None,
         )
         # always ensure the configured preset/permanent members are part of
-        # the group members, even if they were (temporarily) removed by an
-        # unjoin. In dynamic mode they act as a preset (re-added each form);
-        # in static mode they are locked and can not be removed at all.
+        # the group members, even if they were (temporarily) removed by an unjoin
         preset_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []))
         self._attr_group_members = [
             *preset_members,

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -250,9 +250,7 @@ class SyncGroupPlayer(Player):
                 multi_value=True,
                 label="Group members",
                 default_value=[],
-                description="Select the members of this sync group. "
-                "These members will always be part of the group and can never be unjoined "
-                "from the group. ",
+                description="Select the members of this sync group. ",
                 required=False,  # needed for dynamic members (which allows empty members list)
                 options=possible_players,
             ),

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -70,7 +70,7 @@ class SyncGroupPlayer(Player):
         preset_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []))
         if self.is_dynamic:
             # In dynamic mode the configured members act as a preset: they are
-            # pulled in when the group plays
+            # pulled in when the group is powered on
             self._attr_static_group_members = []
             self._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
         else:
@@ -292,6 +292,13 @@ class SyncGroupPlayer(Player):
             await self.stop()
 
         if powered:
+            # apply the configured preset members on power-on so unjoins
+            # during a powered session stick until the next power cycle
+            preset_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []))
+            self._attr_group_members = [
+                *preset_members,
+                *[x for x in self._attr_group_members if x not in preset_members],
+            ]
             # form syncgroup when powering on
             await self._form_syncgroup()
         else:
@@ -488,14 +495,6 @@ class SyncGroupPlayer(Player):
             self._attr_group_members,
             self.sync_leader.display_name if self.sync_leader else None,
         )
-        # always ensure the configured preset/permanent members are part of
-        # the group members, even if they were (temporarily) removed by an unjoin
-        preset_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []))
-        self._attr_group_members = [
-            *preset_members,
-            *[x for x in self._attr_group_members if x not in preset_members],
-        ]
-
         # select new sync leader if needed
         if not self.sync_leader:
             self.sync_leader = self._select_sync_leader()

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -159,7 +159,7 @@ class SyncGroupPlayer(Player):
 
     def _is_member_allowed(self, player_id: str) -> bool:
         """Return whether a player is allowed to join this group given the configured filter."""
-        # Preset members bypass the allow-list (they're explicitly configured).
+        # preset members should always be allowed to re-join
         preset_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []) or [])
         if player_id in preset_members:
             return True

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -19,8 +19,8 @@ from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 
 from .constants import (
+    CONF_ALLOWED_MEMBERS,
     CONF_ENTRY_SGP_NOTE,
-    CONF_MEMBERS_FILTER,
     EXTRA_FEATURES_FROM_MEMBERS,
     PROVIDERS_WITH_DYNAMIC_LEADER_SWITCH,
 )
@@ -67,30 +67,19 @@ class SyncGroupPlayer(Player):
         """Handle logic when the PlayerConfig is first loaded or updated."""
         # Config is only available after the player was registered
         self._cache.clear()  # clear to prevent loading old is_dynamic
-        static_members_conf = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []))
-        static_members: list[str] = []
-        # TEMP: migrate protocol id's to protocol parent id's for static members
-        # TODO: remove this logic once 2.8 is released and we start the 2.9 cycle.
-        changes_made = False
-        for member_id in static_members_conf:
-            if (
-                member_player := self.mass.players.get_player(member_id)
-            ) and member_player.protocol_parent_id:
-                static_members.append(member_player.protocol_parent_id)
-                changes_made = True
-            else:
-                static_members.append(member_id)
-        if changes_made:
-            self.mass.config.set_raw_player_config_value(
-                self.player_id, CONF_GROUP_MEMBERS, static_members
-            )
-
-        self._attr_static_group_members = static_members.copy()
+        preset_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []))
         if self.is_dynamic:
+            # In dynamic mode the configured members act as a preset: they are
+            # pulled in when the group plays (see _form_syncgroup) but the user
+            # can temporarily unjoin them via the OSD. Keeping
+            # _attr_static_group_members empty signals "no locked members" so
+            # the frontend doesn't gray out the checkboxes.
+            self._attr_static_group_members = []
             self._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
         else:
+            self._attr_static_group_members = list(preset_members)
             self._attr_supported_features.discard(PlayerFeature.SET_MEMBERS)
-        self._attr_group_members = static_members.copy()
+        self._attr_group_members = list(preset_members)
 
     @property
     def supported_features(self) -> set[PlayerFeature]:
@@ -171,6 +160,15 @@ class SyncGroupPlayer(Player):
         # NOTE: Not using 'state' here as we need the 'raw' value provided by the sync leader player
         return self.sync_leader.source_list if self.sync_leader else []
 
+    def _is_member_allowed(self, player_id: str) -> bool:
+        """Return whether a player is allowed to join this group given the configured filter."""
+        # Preset members bypass the allow-list (they're explicitly configured).
+        preset_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []) or [])
+        if player_id in preset_members:
+            return True
+        allowed_members = cast("list[str]", self.config.get_value(CONF_ALLOWED_MEMBERS, []) or [])
+        return not allowed_members or player_id in allowed_members
+
     @property
     def can_group_with(self) -> set[str]:
         """Return the id's of players this player can group with."""
@@ -178,39 +176,38 @@ class SyncGroupPlayer(Player):
             # in case of static members,
             # we can only group with the players defined in the config, so we return those directly
             return set(self._attr_static_group_members)
-        members_filter = (
-            cast("list[str]", self.config.get_value(CONF_MEMBERS_FILTER, []))
-            if self.is_dynamic
-            else []
-        )
         # Aggregate can_group_with from ALL current group members (not just the leader).
         # A sync group can accommodate protocol switches, so a player compatible with
         # ANY current member is a valid candidate to join.
         member_ids = self._attr_group_members if self._attr_group_members else []
+        can_group_with: set[str] = set()
         if member_ids:
-            can_group_with: set[str] = set()
             for member_id in member_ids:
-                if member_id in members_filter:
-                    continue
                 member_player = self.mass.players.get_player(member_id)
                 if member_player and member_player.state.available:
                     can_group_with.add(member_player.player_id)
                     can_group_with.update(member_player.state.can_group_with)
-            return can_group_with.difference(members_filter)
-        # Empty dynamic groups can potentially group with any compatible players
-        # Actual compatibility is validated when adding members
-        can_group_with: set[str] = set()  # type: ignore[no-redef]
-        for player in self.mass.players.all_players(return_unavailable=False):
-            if not player.available or player.type == PlayerType.GROUP:
-                # let's avoid showing group players as options to group with
-                continue
-            if (
-                PlayerFeature.SET_MEMBERS in player.state.supported_features
-                and player.state.can_group_with
-                and not player.state.active_group
-            ):
-                can_group_with.add(player.player_id)
-        return can_group_with.difference(members_filter)
+        else:
+            # Empty dynamic groups can potentially group with any compatible players.
+            # Actual compatibility is validated when adding members.
+            for player in self.mass.players.all_players(return_unavailable=False):
+                if not player.available or player.type == PlayerType.GROUP:
+                    # let's avoid showing group players as options to group with
+                    continue
+                if (
+                    PlayerFeature.SET_MEMBERS in player.state.supported_features
+                    and player.state.can_group_with
+                    and not player.state.active_group
+                ):
+                    can_group_with.add(player.player_id)
+        # Apply allow-list filters to the candidate set. Current members of the
+        # group are exempt - the filters constrain who can JOIN, not who is
+        # already a member (otherwise enabling a filter that doesn't list a
+        # current member would hide every candidate via the seed step).
+        current_members = set(member_ids)
+        return {
+            pid for pid in can_group_with if pid in current_members or self._is_member_allowed(pid)
+        }
 
     @property
     def group_members(self) -> list[str]:
@@ -226,13 +223,24 @@ class SyncGroupPlayer(Player):
         values: dict[str, ConfigValueType] | None = None,
     ) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the given player (if any)."""
+        # keep saved player ids so the UI can render a user friendly name
+        # prevents the bug where only the player ids show up during playback
+        saved_ids = {
+            *cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []) or []),
+            *cast("list[str]", self.config.get_value(CONF_ALLOWED_MEMBERS, []) or []),
+        }
         possible_players = sorted(
             [
                 ConfigValueOption(x.display_name, x.player_id)
                 for x in self.mass.players.all_players(True, False)
                 if x.type != PlayerType.GROUP
-                and PlayerFeature.SET_MEMBERS in x.state.supported_features
-                and x.state.can_group_with
+                and (
+                    x.player_id in saved_ids
+                    or (
+                        PlayerFeature.SET_MEMBERS in x.state.supported_features
+                        and x.state.can_group_with
+                    )
+                )
             ],
             key=lambda x: x.title,
         )
@@ -243,9 +251,9 @@ class SyncGroupPlayer(Player):
                 key=CONF_GROUP_MEMBERS,
                 type=ConfigEntryType.STRING,
                 multi_value=True,
-                label="Permanent group members",
+                label="Group members",
                 default_value=[],
-                description="Select all static/permanent members of this sync group. "
+                description="Select the members of this sync group. "
                 "These members will always be part of the group and can never be unjoined "
                 "from the group. ",
                 required=False,  # needed for dynamic members (which allows empty members list)
@@ -257,26 +265,24 @@ class SyncGroupPlayer(Player):
                 label="Enable dynamic members",
                 description="Allow (un)joining members dynamically, so the group more or less "
                 "behaves the same like manually syncing players together, "
-                "with the main difference being that the group player will hold the queue. \n"
-                "Note that static members will always be part of the group and can never "
-                "be unjoined from the group.",
+                "with the main difference being that the group player will hold the queue.",
                 default_value=False,
                 required=False,
             ),
             ConfigEntry(
-                key=CONF_MEMBERS_FILTER,
+                key=CONF_ALLOWED_MEMBERS,
                 type=ConfigEntryType.STRING,
                 multi_value=True,
-                label="Members filter",
-                description="Optionally filter the list of available members that "
-                "are allowed to group with this player by excluding certain members. \n"
-                "Players in this list will NOT show up in the UI as options to be "
-                "added as members to the group. Also trying to join a member that "
-                "is in this list to the group will be prevented.",
+                label="Allowed members",
+                description="Limit which players can join this group. "
+                "Leave empty to allow any sync-compatible player. "
+                "This can be used to reduce the list of players that show up for joining "
+                "in case you have a lot of players.",
                 default_value=[],
                 required=False,
                 options=possible_players,
                 depends_on=CONF_DYNAMIC_GROUP_MEMBERS,
+                advanced=True,
             ),
         ]
         return entries
@@ -364,19 +370,14 @@ class SyncGroupPlayer(Player):
         was_playing = self.playback_state == PlaybackState.PLAYING
 
         # handle additions
-        members_filter = (
-            cast("list[str]", self.config.get_value(CONF_MEMBERS_FILTER, []))
-            if self.is_dynamic
-            else []
-        )
         final_players_to_add: list[str] = []
         can_group_with = sync_leader.state.can_group_with.copy() if sync_leader else set()
         for member_id in player_ids_to_add or []:
             if member_id == self.player_id:
                 continue  # can not add self as member
-            if member_id in members_filter:
+            if not self._is_member_allowed(member_id):
                 self.logger.warning(
-                    "Player %s is in the members filter list for group %s, "
+                    "Player %s is not allowed to join group %s by the configured player filters, "
                     "skipping adding it as a member to the group",
                     member_id,
                     self.display_name,
@@ -492,11 +493,14 @@ class SyncGroupPlayer(Player):
             self._attr_group_members,
             self.sync_leader.display_name if self.sync_leader else None,
         )
-        # always ensure static members are part of the group members,
-        # even if they were (temporarily) removed by un unjoin
+        # always ensure the configured preset/permanent members are part of
+        # the group members, even if they were (temporarily) removed by an
+        # unjoin. In dynamic mode they act as a preset (re-added each form);
+        # in static mode they are locked and can not be removed at all.
+        preset_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []))
         self._attr_group_members = [
-            *self._attr_static_group_members,
-            *[x for x in self._attr_group_members if x not in self._attr_static_group_members],
+            *preset_members,
+            *[x for x in self._attr_group_members if x not in preset_members],
         ]
 
         # select new sync leader if needed

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -694,8 +694,25 @@ class TestPresetMembersInDynamicGroup:
         assert set(sgp._attr_group_members) == {"a", "b", "c"}
 
     @pytest.mark.asyncio
-    async def test_form_syncgroup_re_adds_preset_members(self) -> None:
-        """After an unjoin, _form_syncgroup re-adds preset members from config."""
+    async def test_power_on_re_applies_preset_members(self) -> None:
+        """Powering on re-applies the configured preset, restoring any previously unjoined member."""
+        mass = _make_mock_mass()
+        sgp = self._make_dynamic_group_with_preset(mass, ["leader", "preset_b"])
+        await sgp.on_config_updated()
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        preset_b = _make_mock_player("preset_b", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader, "preset_b": preset_b})
+        sgp._attr_group_members = ["leader"]  # preset_b was unjoined in a previous session
+
+        with patch.object(sgp, "update_state"):
+            await sgp.power(True)
+
+        assert "preset_b" in sgp._attr_group_members
+
+    @pytest.mark.asyncio
+    async def test_form_syncgroup_does_not_re_add_unjoined_preset(self) -> None:
+        """Mid-session unjoins must stick: _form_syncgroup must NOT re-add preset members."""
         mass = _make_mock_mass()
         sgp = self._make_dynamic_group_with_preset(mass, ["leader", "preset_b"])
         await sgp.on_config_updated()
@@ -705,7 +722,7 @@ class TestPresetMembersInDynamicGroup:
         preset_b = _make_mock_player("preset_b", provider_domain="sonos")
         mass.players.get_player = _player_lookup({"leader": leader, "preset_b": preset_b})
         sgp.sync_leader = leader
-        sgp._attr_group_members = ["leader"]  # preset_b was unjoined previously
+        sgp._attr_group_members = ["leader"]  # preset_b was unjoined during this session
 
         with (
             patch.object(sgp, "update_state"),
@@ -713,7 +730,7 @@ class TestPresetMembersInDynamicGroup:
         ):
             await sgp._form_syncgroup()
 
-        assert "preset_b" in sgp._attr_group_members
+        assert "preset_b" not in sgp._attr_group_members
 
     def test_preset_member_bypasses_allow_list_filter(self) -> None:
         """A preset member that was unjoined must still pass the allow-list filter.

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import inspect
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature
 from music_assistant_models.player import OutputProtocol
 
+from music_assistant.constants import CONF_PLAYERS
 from music_assistant.providers.sync_group.player import SyncGroupPlayer
 
 
@@ -538,3 +540,311 @@ class TestSetMembersDoesNotRegisterIncompatible:
         assert "member" in sgp._attr_group_members
         # but _handle_set_members on the leader is not called (no leader yet)
         mass.players._handle_set_members.assert_not_awaited()
+
+
+def _make_sync_group_with_filters(
+    mass: MagicMock,
+    allowed_members: list[str] | None = None,
+) -> SyncGroupPlayer:
+    """Create a SyncGroupPlayer where the allowed_members filter can be configured."""
+    provider = MagicMock()
+    provider.domain = "sync_group"
+    provider.instance_id = "sync_group_test"
+    provider.name = "Sync Group"
+    provider.mass = mass
+
+    def _config_get_value(key: str, default: object = None) -> object:
+        if key == "dynamic_members":
+            return True
+        if key == "allowed_members":
+            return allowed_members or []
+        return default
+
+    mass.config.get_base_player_config.return_value = MagicMock(
+        name=None, default_name="Test Group", get_value=_config_get_value
+    )
+
+    sgp = SyncGroupPlayer(provider, "syncgroup_test")
+    sgp._cache.clear()
+    return sgp
+
+
+class TestPlayerFilters:
+    """Test the allowed_members filter semantics."""
+
+    def test_no_filter_allows_anything(self) -> None:
+        """Empty filter: any player is allowed."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group_with_filters(mass)
+        assert sgp._is_member_allowed("p1") is True
+
+    def test_allowed_members_restricts_to_listed(self) -> None:
+        """allowed_members populated: only listed IDs pass."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group_with_filters(mass, allowed_members=["p1"])
+        assert sgp._is_member_allowed("p1") is True
+        assert sgp._is_member_allowed("p2") is False
+
+    @pytest.mark.asyncio
+    async def test_set_members_rejects_filtered_player(self) -> None:
+        """set_members must skip a candidate that fails the filter."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group_with_filters(mass, allowed_members=["allowed"])
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        leader.state.can_group_with = {"allowed", "blocked"}
+        allowed = _make_mock_player("allowed", provider_domain="sonos")
+        blocked = _make_mock_player("blocked", provider_domain="sonos")
+
+        mass.players.get_player = _player_lookup(
+            {"leader": leader, "allowed": allowed, "blocked": blocked}
+        )
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]
+
+        await sgp.set_members(player_ids_to_add=["allowed", "blocked"])
+
+        assert "allowed" in sgp._attr_group_members
+        assert "blocked" not in sgp._attr_group_members
+
+    def test_can_group_with_current_members_exempt_from_filter(self) -> None:
+        """A current member not listed in allowed_members must still seed candidates.
+
+        Regression: filter must constrain JOINERS only, not gate the seed of
+        current members. Otherwise enabling a filter that doesn't list a current
+        member makes the candidate set empty (no joinable players show up).
+        """
+        mass = _make_mock_mass()
+        # current member is "leader", but the allow-list only lists "candidate".
+        sgp = _make_sync_group_with_filters(mass, allowed_members=["candidate"])
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        leader.state.can_group_with = {"candidate", "outsider"}
+
+        candidate = _make_mock_player("candidate", provider_domain="sonos")
+        outsider = _make_mock_player("outsider", provider_domain="sonos")
+
+        mass.players.get_player = _player_lookup(
+            {"leader": leader, "candidate": candidate, "outsider": outsider}
+        )
+        sgp._attr_group_members = ["leader"]
+
+        result = sgp.can_group_with
+        # The current member (leader) is exempt and stays in the set.
+        assert "leader" in result
+        # An allowed candidate passes the filter.
+        assert "candidate" in result
+        # A player not in the allow-list is rejected.
+        assert "outsider" not in result
+
+
+class TestPresetMembersInDynamicGroup:
+    """In a dynamic group, configured members act as a preset, not as a lock."""
+
+    def _make_dynamic_group_with_preset(
+        self, mass: MagicMock, preset_members: list[str]
+    ) -> SyncGroupPlayer:
+        """Create a dynamic sync group whose CONF_GROUP_MEMBERS is the given preset."""
+        provider = MagicMock()
+        provider.domain = "sync_group"
+        provider.instance_id = "sync_group_test"
+        provider.name = "Sync Group"
+        provider.mass = mass
+
+        def _config_get_value(key: str, default: object = None) -> object:
+            if key == "dynamic_members":
+                return True
+            if key == "group_members":
+                return list(preset_members)
+            return default
+
+        mass.config.get_base_player_config.return_value = MagicMock(
+            name=None, default_name="Test Group", get_value=_config_get_value
+        )
+        sgp = SyncGroupPlayer(provider, "syncgroup_test")
+        sgp._cache.clear()
+        return sgp
+
+    @pytest.mark.asyncio
+    async def test_preset_member_can_be_unjoined(self) -> None:
+        """A preset member in a dynamic group can be unjoined for the session."""
+        mass = _make_mock_mass()
+        sgp = self._make_dynamic_group_with_preset(mass, ["leader", "preset_b"])
+        # Re-trigger on_config_updated so the new config is applied.
+        await sgp.on_config_updated()
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        leader.state.can_group_with = {"preset_b"}
+        preset_b = _make_mock_player("preset_b", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader, "preset_b": preset_b})
+        sgp.sync_leader = leader
+
+        await sgp.set_members(player_ids_to_remove=["preset_b"])
+
+        assert "preset_b" not in sgp._attr_group_members
+
+    @pytest.mark.asyncio
+    async def test_static_group_members_empty_in_dynamic_mode(self) -> None:
+        """In dynamic mode static_group_members is empty (frontend gating)."""
+        mass = _make_mock_mass()
+        sgp = self._make_dynamic_group_with_preset(mass, ["a", "b", "c"])
+        await sgp.on_config_updated()
+        assert sgp._attr_static_group_members == []
+        # but the configured members are seeded into group_members
+        assert set(sgp._attr_group_members) == {"a", "b", "c"}
+
+    @pytest.mark.asyncio
+    async def test_form_syncgroup_re_adds_preset_members(self) -> None:
+        """After an unjoin, _form_syncgroup re-adds preset members from config."""
+        mass = _make_mock_mass()
+        sgp = self._make_dynamic_group_with_preset(mass, ["leader", "preset_b"])
+        await sgp.on_config_updated()
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        leader.state.group_members = ["leader"]
+        preset_b = _make_mock_player("preset_b", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader, "preset_b": preset_b})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]  # preset_b was unjoined previously
+
+        with (
+            patch.object(sgp, "update_state"),
+            patch.object(sgp, "_translate_to_parent_ids", side_effect=lambda x: list(x)),
+        ):
+            await sgp._form_syncgroup()
+
+        assert "preset_b" in sgp._attr_group_members
+
+    def test_preset_member_bypasses_allow_list_filter(self) -> None:
+        """A preset member that was unjoined must still pass the allow-list filter.
+
+        Regression: after unjoining a preset member, the user must be able to
+        re-add it via the OSD even when allowed_members doesn't list it.
+        """
+        mass = _make_mock_mass()
+        provider = MagicMock()
+        provider.domain = "sync_group"
+        provider.instance_id = "sync_group_test"
+        provider.name = "Sync Group"
+        provider.mass = mass
+
+        def _config_get_value(key: str, default: object = None) -> object:
+            if key == "dynamic_members":
+                return True
+            if key == "group_members":
+                return ["preset_a", "preset_b"]
+            if key == "allowed_members":
+                return ["other"]
+            return default
+
+        mass.config.get_base_player_config.return_value = MagicMock(
+            name=None, default_name="Test Group", get_value=_config_get_value
+        )
+        sgp = SyncGroupPlayer(provider, "syncgroup_test")
+        sgp._cache.clear()
+
+        # preset members bypass the allow-list filter
+        assert sgp._is_member_allowed("preset_a") is True
+        assert sgp._is_member_allowed("preset_b") is True
+        # the explicit allow-list entry still passes
+        assert sgp._is_member_allowed("other") is True
+        # an unrelated player is rejected
+        assert sgp._is_member_allowed("outsider") is False
+
+
+class TestMembersFilterMigration:
+    """Test the members_filter (exclusion) -> allowed_members (inclusion) migration."""
+
+    def _run_migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Run the migration block against a copy of the provided data dict."""
+        all_player_configs = data.get(CONF_PLAYERS, {})
+        if isinstance(all_player_configs, dict):
+            group_provider_domains = {"sync_group", "universal_group"}
+            universe = {
+                pid
+                for pid, cfg in all_player_configs.items()
+                if isinstance(cfg, dict) and cfg.get("provider") not in group_provider_domains
+            }
+            for player_cfg in all_player_configs.values():
+                if not isinstance(player_cfg, dict):
+                    continue
+                if player_cfg.get("provider") != "sync_group":
+                    continue
+                values = player_cfg.setdefault("values", {})
+                old_exclude = values.get("members_filter") or []
+                if not old_exclude or values.get("allowed_members") is not None:
+                    continue
+                values["allowed_members"] = sorted(universe - set(old_exclude))
+                values["members_filter"] = []
+        return data
+
+    def test_inverts_exclusion_to_inclusion(self) -> None:
+        """An exclusion list of [X] becomes an inclusion list of universe - {X}."""
+        data = {
+            CONF_PLAYERS: {
+                "a": {"provider": "sonos", "player_id": "a"},
+                "b": {"provider": "airplay", "player_id": "b"},
+                "c": {"provider": "chromecast", "player_id": "c"},
+                "syncgroup_1": {
+                    "provider": "sync_group",
+                    "player_id": "syncgroup_1",
+                    "values": {"members_filter": ["b"]},
+                },
+            }
+        }
+        out = self._run_migrate(data)
+        sg = out[CONF_PLAYERS]["syncgroup_1"]["values"]
+        assert sg["allowed_members"] == ["a", "c"]
+        assert sg["members_filter"] == []
+
+    def test_idempotent_when_already_migrated(self) -> None:
+        """Re-running migration on already-migrated config is a no-op."""
+        data = {
+            CONF_PLAYERS: {
+                "a": {"provider": "sonos", "player_id": "a"},
+                "syncgroup_1": {
+                    "provider": "sync_group",
+                    "player_id": "syncgroup_1",
+                    "values": {"allowed_members": ["a"], "members_filter": []},
+                },
+            }
+        }
+        out = self._run_migrate(data)
+        sg = out[CONF_PLAYERS]["syncgroup_1"]["values"]
+        assert sg["allowed_members"] == ["a"]
+        assert sg["members_filter"] == []
+
+    def test_skips_when_no_exclusion_list(self) -> None:
+        """A sync_group without a members_filter is left untouched."""
+        data = {
+            CONF_PLAYERS: {
+                "syncgroup_1": {
+                    "provider": "sync_group",
+                    "player_id": "syncgroup_1",
+                    "values": {},
+                },
+            }
+        }
+        out = self._run_migrate(data)
+        sg = out[CONF_PLAYERS]["syncgroup_1"]["values"]
+        assert "allowed_members" not in sg
+
+    def test_excludes_group_providers_from_universe(self) -> None:
+        """Group-providing players (sync_group/universal_group) are not in the universe."""
+        data = {
+            CONF_PLAYERS: {
+                "a": {"provider": "sonos", "player_id": "a"},
+                "ug": {"provider": "universal_group", "player_id": "ug"},
+                "sg": {"provider": "sync_group", "player_id": "sg"},
+                "syncgroup_1": {
+                    "provider": "sync_group",
+                    "player_id": "syncgroup_1",
+                    "values": {"members_filter": ["a"]},
+                },
+            }
+        }
+        out = self._run_migrate(data)
+        sg = out[CONF_PLAYERS]["syncgroup_1"]["values"]
+        # Universe = {a} (sg/ug/syncgroup_1 are group providers excluded).
+        # Inversion removes a, so allowed_members is empty.
+        assert sg["allowed_members"] == []


### PR DESCRIPTION
This PR adds some UX improvements to the Sync groups based on community feedback

- Dynamic groups now act as a preset, meaning that whenever you have group that consists of players A, B and C and play music to the group AND B was already playing on its own, it will auto-form the group and start playing music as a group
- Dynamic members can now be ungrouped during playback / played to individually
- The member filter has been inverted and is now *inclusive*. The dropdown allows users to limit the options of speakers that show up as options when trying to join speakers to the group
- A bug that would not resolve player ids to their user friendly name during playback has been resolved.
- Pre 2.9 code has been cleaned up