### PR TITLE
Subsonic: Provide close implementation that cleans up

### DIFF
--- a/music_assistant/providers/opensubsonic/manifest.json
+++ b/music_assistant/providers/opensubsonic/manifest.json
@@ -6,7 +6,7 @@
   "description": "Stream music from your OpenSubsonic compatible server — your own cloud jukebox.",
   "codeowners": ["@khers"],
   "credits": ["[py-opensonic](https://github.com/khers/py-opensonic)"],
-  "requirements": ["py-opensonic==9.0.1"],
+  "requirements": ["py-opensonic==9.1.0"],
   "documentation": "https://music-assistant.io/music-providers/subsonic/",
   "multi_instance": true
 }

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -151,6 +151,11 @@ class OpenSonicProvider(MusicProvider):
         self._pagination_size = min(self._pagination_size, 500)
         self._raw_file = bool(self.config.get_value(CONF_RAW_FILE))
 
+    async def unload(self, is_removed: bool = False) -> None:
+        """Unload the provider."""
+        await super().unload(is_removed)
+        await self.conn.close()
+
     @property
     def is_streaming_provider(self) -> bool:
         """

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -57,7 +57,7 @@ pkce==1.0.3
 plexapi==4.18.1
 podcastparser==0.6.11
 propcache>=0.2.1
-py-opensonic==9.0.1
+py-opensonic==9.1.0
 pyblu==2.0.6
 pycares==4.11.0
 PyChromecast==14.0.9


### PR DESCRIPTION
The connection object from py-opensonic now provides and explicit way to cleanup the underlying async http session as it seems that the standard destructor does not handle this. Make sure we cleanly close the session when the proivder is unloaded.