### PR TITLE
Fix Apple Music library_add errors

### DIFF
--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -120,6 +120,10 @@ class AppleMusicLibraryManager:
 
     async def library_add(self, item: MediaItemType) -> None:
         """Add item to library."""
+        if item.media_type == MediaType.ARTIST:
+            # The POST /v1/me/library endpoint does not support ids[artists];
+            # artists appear in the library implicitly via their albums/songs.
+            return
         item_type = translate_media_type_to_apple_type(item.media_type)
         kwargs = {f"ids[{item_type}]": item.item_id}
         await self.api.post_data("me/library", **kwargs)

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -122,7 +122,7 @@ class AppleMusicLibraryManager:
         """Add item to library."""
         item_type = translate_media_type_to_apple_type(item.media_type)
         kwargs = {f"ids[{item_type}]": item.item_id}
-        await self.api.post_data("me/library/", **kwargs)
+        await self.api.post_data("me/library", **kwargs)
 
     async def library_remove(self, prov_item_id: str, media_type: MediaType) -> None:
         """Remove item from library."""

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -123,6 +123,11 @@ class AppleMusicLibraryManager:
         if item.media_type == MediaType.ARTIST:
             # The POST /v1/me/library endpoint does not support ids[artists];
             # artists appear in the library implicitly via their albums/songs.
+            self.logger.debug(
+                "Skipping library_add for artist %s: Apple Music does not support "
+                "adding artists directly via the API.",
+                item.name,
+            )
             return
         item_type = translate_media_type_to_apple_type(item.media_type)
         kwargs = {f"ids[{item_type}]": item.item_id}


### PR DESCRIPTION
Two bugs in `library_add` caused 400 Bad Request errors when adding items to the Apple Music library:

1. **Trailing slash**: `POST /v1/me/library/` was called instead of `POST /v1/me/library`, which the Apple Music API rejects.
2. **Artists not supported**: `POST /v1/me/library` does not accept `ids[artists]` — only `albums`, `songs`, `playlists` and `music-videos` are valid types ([Apple Music API docs](https://developer.apple.com/documentation/applemusicapi/add-a-resource-to-a-library)). Artists appear in a user's library implicitly through their albums and songs, so the call is skipped for `MediaType.ARTIST`.