### PR TITLE
Fix support for `Literal` handling in OpenAPI generation

### DIFF
--- a/music_assistant/controllers/webserver/api_docs.py
+++ b/music_assistant/controllers/webserver/api_docs.py
@@ -10,7 +10,7 @@ from dataclasses import MISSING
 from datetime import datetime
 from enum import Enum
 from types import NoneType, UnionType
-from typing import Any, Union, get_args, get_origin, get_type_hints
+from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
 
 from music_assistant_models.player import Player as PlayerState
 
@@ -317,6 +317,19 @@ def _get_type_schema(  # noqa: PLR0911, PLR0915
                 "description": f"Enum: {enum_name}. Possible values: {enum_values_str}",
             }
         return {"$ref": f"#/components/schemas/{enum_name}"}
+
+    # Handle Literal types
+    if origin is Literal:
+        args = get_args(type_hint)
+        values = [a.value if isinstance(a, Enum) else a for a in args]
+        literal_type = type(values[0]).__name__ if values else "string"
+        openapi_type = {
+            "str": "string",
+            "int": "integer",
+            "float": "number",
+            "bool": "boolean",
+        }.get(literal_type, "string")
+        return {"type": openapi_type, "enum": values}
 
     # Handle datetime
     if type_hint is datetime:


### PR DESCRIPTION
This PR fixes the OpenAPI json schema output for `Literal` types in models, such as those used in [`ParametricEQFilter.type`](https://github.com/music-assistant/models/blob/main/music_assistant_models/dsp.py#L91) and [`ToneControlFilter.type`](https://github.com/music-assistant/models/blob/main/music_assistant_models/dsp.py#L117).

Before this change, these fields would be marked as `object` types with a string default value, which breaks certain OpenAPI tooling, especially codegen related.

Here's a diff of the `openapi.json` before and after this change:

```diff
--- openapi.json.orig	2026-05-18 15:08:37
+++ openapi.json.fixed	2026-05-18 15:08:50
@@ -2439,7 +2439,8 @@
 						}
 					},
 					"type": {
-						"type": "object",
+						"type": "string",
+						"enum": ["parametric_eq"],
 						"default": "parametric_eq"
 					},
 					"bands": {
@@ -2458,7 +2459,8 @@
 						"type": "boolean"
 					},
 					"type": {
-						"type": "object",
+						"type": "string",
+						"enum": ["tone_control"],
 						"default": "tone_control"
 					},
 					"bass_level": {
```