### PR TITLE
Compute the artwork-derived color palette in the backend

### DIFF
--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -67,7 +67,6 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.helpers.api import api_command
-from music_assistant.helpers.colors import cleanup_palette_cache
 from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.datetime import local_clock_time_to_utc
 from music_assistant.helpers.images import (
@@ -158,12 +157,10 @@ CONF_ENABLE_RADIO_METADATA_LOOKUP = "enable_radio_metadata_lookup"
 MISSING_ARTIST_METADATA_SCAN_TASK_ID = "metadata_missing_artist_metadata_scan"
 PLAYLIST_METADATA_SCAN_TASK_ID = "metadata_playlist_metadata_scan"
 THUMB_CACHE_CLEANUP_TASK_ID = "metadata_thumb_cache_cleanup"
-PALETTE_CACHE_CLEANUP_TASK_ID = "metadata_palette_cache_cleanup"
 METADATA_LOOKUP_TASK_ID_PREFIX = "metadata_lookup"
 METADATA_SCAN_BATCH_SIZE = 5
 CONF_THUMB_CACHE_MAX_SIZE = "thumb_cache_max_size"
 DEFAULT_THUMB_CACHE_MAX_SIZE_MB = 500
-PALETTE_CACHE_MAX_SIZE_MB = 10
 
 
 class MetaDataController(CoreController):
@@ -1660,15 +1657,6 @@ class MetaDataController(CoreController):
             metadata={"task_domain": "metadata_thumb_cache_cleanup"},
             allow_retry=True,
         )
-        self.mass.tasks.register_scheduled_task(
-            task_id=PALETTE_CACHE_CLEANUP_TASK_ID,
-            name="Cleanup color palette cache",
-            handler=self._cleanup_palette_cache,
-            schedule=desired_schedule,
-            translation_key="background_task.cleanup_palette_cache",
-            metadata={"task_domain": "metadata_palette_cache_cleanup"},
-            allow_retry=True,
-        )
 
     @staticmethod
     def _get_metadata_lookup_task_id(uri: str) -> str:
@@ -1756,11 +1744,3 @@ class MetaDataController(CoreController):
         removed = await cleanup_thumb_cache(self.mass.cache_path, max_size_mb * 1024 * 1024)
         if removed:
             self.logger.debug("Thumbnail cache cleanup: removed %s file(s)", removed)
-
-    async def _cleanup_palette_cache(self) -> None:
-        """Remove oldest palettes when the cache folder exceeds the hardcoded limit."""
-        removed = await cleanup_palette_cache(
-            self.mass.cache_path, PALETTE_CACHE_MAX_SIZE_MB * 1024 * 1024
-        )
-        if removed:
-            self.logger.debug("Palette cache cleanup: removed %s file(s)", removed)

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -69,6 +69,7 @@ from music_assistant.controllers.tasks.context import (
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.datetime import local_clock_time_to_utc
+from music_assistant.helpers.colors import cleanup_palette_cache
 from music_assistant.helpers.images import (
     cleanup_thumb_cache,
     create_collage,
@@ -157,10 +158,12 @@ CONF_ENABLE_RADIO_METADATA_LOOKUP = "enable_radio_metadata_lookup"
 MISSING_ARTIST_METADATA_SCAN_TASK_ID = "metadata_missing_artist_metadata_scan"
 PLAYLIST_METADATA_SCAN_TASK_ID = "metadata_playlist_metadata_scan"
 THUMB_CACHE_CLEANUP_TASK_ID = "metadata_thumb_cache_cleanup"
+PALETTE_CACHE_CLEANUP_TASK_ID = "metadata_palette_cache_cleanup"
 METADATA_LOOKUP_TASK_ID_PREFIX = "metadata_lookup"
 METADATA_SCAN_BATCH_SIZE = 5
 CONF_THUMB_CACHE_MAX_SIZE = "thumb_cache_max_size"
 DEFAULT_THUMB_CACHE_MAX_SIZE_MB = 500
+PALETTE_CACHE_MAX_SIZE_MB = 10
 
 
 class MetaDataController(CoreController):
@@ -1657,6 +1660,15 @@ class MetaDataController(CoreController):
             metadata={"task_domain": "metadata_thumb_cache_cleanup"},
             allow_retry=True,
         )
+        self.mass.tasks.register_scheduled_task(
+            task_id=PALETTE_CACHE_CLEANUP_TASK_ID,
+            name="Cleanup color palette cache",
+            handler=self._cleanup_palette_cache,
+            schedule=desired_schedule,
+            translation_key="background_task.cleanup_palette_cache",
+            metadata={"task_domain": "metadata_palette_cache_cleanup"},
+            allow_retry=True,
+        )
 
     @staticmethod
     def _get_metadata_lookup_task_id(uri: str) -> str:
@@ -1744,3 +1756,11 @@ class MetaDataController(CoreController):
         removed = await cleanup_thumb_cache(self.mass.cache_path, max_size_mb * 1024 * 1024)
         if removed:
             self.logger.debug("Thumbnail cache cleanup: removed %s file(s)", removed)
+
+    async def _cleanup_palette_cache(self) -> None:
+        """Remove oldest palettes when the cache folder exceeds the hardcoded limit."""
+        removed = await cleanup_palette_cache(
+            self.mass.cache_path, PALETTE_CACHE_MAX_SIZE_MB * 1024 * 1024
+        )
+        if removed:
+            self.logger.debug("Palette cache cleanup: removed %s file(s)", removed)

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -67,9 +67,9 @@ from music_assistant.controllers.tasks.context import (
     update_current_task_progress_text,
 )
 from music_assistant.helpers.api import api_command
+from music_assistant.helpers.colors import cleanup_palette_cache
 from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.datetime import local_clock_time_to_utc
-from music_assistant.helpers.colors import cleanup_palette_cache
 from music_assistant.helpers.images import (
     cleanup_thumb_cache,
     create_collage,

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1550,7 +1550,14 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         current = player.state.current_media if player else None
         if not current or current.image_url != image_url:
             return  # media changed while fetching
-        self.trigger_player_update(player_id, force_update=True)
+        # Avoid trigger_player_update so a concurrent state-change debounce
+        # doesn't cancel our timer via the shared player_update_state task_id.
+        self.mass.call_later(
+            0,
+            player.update_state,
+            force_update=True,
+            task_id=f"palette_player_update_{player_id}",
+        )
 
     def _schedule_next_queue_item_palette_prefetch(
         self, player_id: str, current_media: PlayerMedia

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -96,6 +96,7 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_sendspin_player_id,
 )
 from music_assistant.helpers.api import api_command
+from music_assistant.helpers.colors import get_palette_for_url, peek_palette_for_url
 from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.throttle_retry import Throttler
 from music_assistant.helpers.util import (
@@ -1522,6 +1523,50 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             task_id=task_id,
         )
 
+    def _schedule_palette_fetch(
+        self, player_id: str, image_url: str | None, *, trigger_update: bool = True
+    ) -> None:
+        """Kick off an async palette extraction for an image URL.
+
+        :param player_id: Player the palette is scoped to (used for task dedup).
+        :param image_url: Image URL to extract from. No-op when empty or already cached.
+        :param trigger_update: When True, re-emit player state once palette is ready
+                               (current track). When False, only warm the cache (prefetch).
+        """
+        if not image_url or peek_palette_for_url(image_url) is not None:
+            return
+        slot = "current" if trigger_update else "next"
+        self.mass.create_task(
+            self._fetch_palette(player_id, image_url, trigger_update=trigger_update),
+            task_id=f"palette_fetch_{player_id}_{slot}",
+            abort_existing=False,
+        )
+
+    async def _fetch_palette(self, player_id: str, image_url: str, *, trigger_update: bool) -> None:
+        palette = await get_palette_for_url(self.mass, image_url)
+        if palette is None or not trigger_update:
+            return
+        player = self.get_player(player_id)
+        current = player.state.current_media if player else None
+        if not current or current.image_url != image_url:
+            return  # media changed while fetching
+        self.trigger_player_update(player_id, force_update=True)
+
+    def _schedule_next_queue_item_palette_prefetch(
+        self, player_id: str, current_media: PlayerMedia
+    ) -> None:
+        """Warm the palette cache for the next queue item so it's hot at transition."""
+        queue_id, item_id = current_media.source_id, current_media.queue_item_id
+        if not queue_id or not item_id:
+            return
+        next_item = self.mass.player_queues.get_next_item(queue_id, item_id)
+        if next_item is None or not next_item.image:
+            return
+        next_url = self.mass.metadata.get_image_url(
+            next_item.image, size=500, prefer_stream_server=True
+        )
+        self._schedule_palette_fetch(player_id, next_url, trigger_update=False)
+
     async def unregister(self, player_id: str, permanent: bool = False) -> None:
         """
         Unregister a player from the player controller.
@@ -1731,6 +1776,14 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 changed_values,
                 task_id=f"queue_on_player_update_{player.player_id}",
             )
+
+        # Kick async palette extraction on cold cache. On transition prefetch
+        # the next queue item too.
+        if (current_media := player.state.current_media) and current_media.image_url:
+            if current_media.palette is None:
+                self._schedule_palette_fetch(player_id, current_media.image_url)
+            if "current_media.image_url" in changed_values or "current_media" in changed_values:
+                self._schedule_next_queue_item_palette_prefetch(player_id, current_media)
 
         # handle DSP reload of the leader when grouping/ungrouping
         if ATTR_GROUP_MEMBERS in changed_values:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1547,8 +1547,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if palette is None or not trigger_update:
             return
         player = self.get_player(player_id)
-        current = player.state.current_media if player else None
-        if not current or current.image_url != image_url:
+        if player is None:
+            return
+        current = player.state.current_media
+        if current is None or current.image_url != image_url:
             return  # media changed while fetching
         # Avoid trigger_player_update so a concurrent state-change debounce
         # doesn't cancel our timer via the shared player_update_state task_id.

--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -6,21 +6,17 @@ image: a `colorthief` MMCQ quantizer produces image candidates, then `primary`,
 chosen (and adjusted where needed) so that every spec-mandated contrast pair
 clears the WCAG AA 4.5:1 threshold.
 
-A two-tier cache (in-memory FIFO + on-disk JSON) keyed on a hash of provider
-and image path avoids redundant extraction across consumers.
+A process-wide in-memory cache keyed on a hash of provider and image path
+avoids redundant extraction while the server is running.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
-import os
 from collections import OrderedDict
 from io import BytesIO
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-import aiofiles
 from colorthief import ColorThief
 from music_assistant_models.media_items import MediaItemPalette
 from PIL import UnidentifiedImageError
@@ -35,7 +31,6 @@ if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
 
 
-_PALETTE_CACHE_DIR = "palettes"
 _PALETTE_MEMORY_CACHE_MAX = 256
 _PALETTE_QUANTIZE_COLORS = 5
 _COLORTHIEF_QUALITY = 10
@@ -229,42 +224,19 @@ def extract_palette(image_bytes: bytes) -> MediaItemPalette:
     return _derive_palette(candidates)
 
 
-async def _load_from_disk(cache_filepath: str) -> MediaItemPalette | None:
-    if not await asyncio.to_thread(os.path.isfile, cache_filepath):
-        return None
-    try:
-        async with aiofiles.open(cache_filepath, "rb") as f:
-            data = await f.read()
-        return MediaItemPalette.from_dict(json.loads(data))
-    except (OSError, ValueError):
-        return None
-
-
-async def _save_to_disk(cache_filepath: str, palette: MediaItemPalette) -> None:
-    try:
-        await asyncio.to_thread(os.makedirs, os.path.dirname(cache_filepath), exist_ok=True)
-        async with aiofiles.open(cache_filepath, "wb") as f:
-            await f.write(json.dumps(palette.to_dict()).encode())
-    except OSError:
-        pass
-
-
 async def _extract_and_cache(
-    mass: MusicAssistant,
-    path_or_url: str,
-    provider: str,
-    cache_filepath: str,
+    mass: MusicAssistant, path_or_url: str, provider: str, key: str
 ) -> MediaItemPalette:
     img_data = await get_image_data(mass, path_or_url, provider)
     palette = await asyncio.to_thread(extract_palette, img_data)
-    await _save_to_disk(cache_filepath, palette)
+    _put_in_memory_cache(key, palette)
     return palette
 
 
 async def get_palette(
     mass: MusicAssistant, path_or_url: str, provider: str
 ) -> MediaItemPalette | None:
-    """Get the color palette for an image, using a two-tier cache.
+    """Get the color palette for an image, using a process-wide memory cache.
 
     :param mass: The MusicAssistant instance.
     :param path_or_url: Image path or URL (same format as get_image_data).
@@ -277,35 +249,23 @@ async def get_palette(
     if cached := _get_from_memory_cache(key):
         return cached
 
-    cache_dir = os.path.join(mass.cache_path, _PALETTE_CACHE_DIR)
-    cache_filepath = os.path.join(cache_dir, f"{key}.json")
-    resolved = os.path.realpath(cache_filepath)
-    if not resolved.startswith(os.path.realpath(cache_dir) + os.sep):
-        return None
-    if cached := await _load_from_disk(cache_filepath):
-        _put_in_memory_cache(key, cached)
-        return cached
-
     task: asyncio.Task[MediaItemPalette] = mass.create_task(
         _extract_and_cache,
         mass,
         path_or_url,
         provider,
-        cache_filepath,
+        key,
         task_id=f"palette.{key}",
         abort_existing=False,
     )
-    palette = await asyncio.shield(task)
-    _put_in_memory_cache(key, palette)
-    return palette
+    return await asyncio.shield(task)
 
 
 def peek_palette_for_url(image_url: str | None) -> MediaItemPalette | None:
     """Return the cached palette for an image URL, or None.
 
-    Memory-cache only, does not fetch or read from disk. Use to attach a
-    palette to a PlayerMedia without blocking when a prior async fetch has
-    already populated the cache.
+    Memory-only sync lookup. Use to attach a palette to a PlayerMedia without
+    blocking when a prior async fetch has already populated the cache.
     """
     if not image_url:
         return None
@@ -331,37 +291,3 @@ async def get_palette_for_url(
         return await get_palette(mass, path, provider)
     except (FileNotFoundError, OSError):
         return None
-
-
-async def cleanup_palette_cache(cache_path: str, max_size_bytes: int) -> int:
-    """Remove oldest cached palettes when total size exceeds the limit.
-
-    :param cache_path: The base cache directory (mass.cache_path).
-    :param max_size_bytes: Maximum allowed total size in bytes.
-    :returns: Number of files removed.
-    """
-    palette_dir = os.path.join(cache_path, _PALETTE_CACHE_DIR)
-
-    def _cleanup() -> int:
-        if not os.path.isdir(palette_dir):
-            return 0
-        entries: list[tuple[str, int, float]] = []
-        for entry in os.scandir(palette_dir):
-            if entry.is_file():
-                stat = entry.stat()
-                entries.append((entry.path, stat.st_size, stat.st_mtime))
-        entries.sort(key=lambda e: e[2])
-        total_size = sum(e[1] for e in entries)
-        removed = 0
-        for filepath, file_size, _ in entries:
-            if total_size <= max_size_bytes:
-                break
-            try:
-                Path(filepath).unlink()
-                total_size -= file_size
-                removed += 1
-            except OSError:
-                pass
-        return removed
-
-    return await asyncio.to_thread(_cleanup)

--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -1,0 +1,367 @@
+"""Color palette extraction from artwork.
+
+Derives a 6-field MediaItemPalette per the Sendspin color@v1 spec from an
+image: a `colorthief` MMCQ quantizer produces image candidates, then `primary`,
+`accent`, `on_dark`, `on_light`, `background_dark`, and `background_light` are
+chosen (and adjusted where needed) so that every spec-mandated contrast pair
+clears the WCAG AA 4.5:1 threshold.
+
+A two-tier cache (in-memory FIFO + on-disk JSON) keyed on a hash of provider
+and image path avoids redundant extraction across consumers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections import OrderedDict
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import aiofiles
+from colorthief import ColorThief
+from music_assistant_models.media_items.metadata import MediaItemPalette
+from PIL import UnidentifiedImageError
+
+from music_assistant.helpers.images import (
+    _create_thumb_hash,
+    _extract_imageproxy_params,
+    get_image_data,
+)
+
+if TYPE_CHECKING:
+    from music_assistant.mass import MusicAssistant
+
+
+_PALETTE_CACHE_DIR = "palettes"
+_PALETTE_MEMORY_CACHE_MAX = 256
+_PALETTE_QUANTIZE_COLORS = 5
+_COLORTHIEF_QUALITY = 10
+# Minimum contrast ratio between colors (Sendspin color@v1 requires WCAG AA ≥ 4.5:1).
+_MIN_CONTRAST = 4.5
+# Preferred contrast (we try this first for richer, more vivid picks)
+_PREFERRED_CONTRAST = 7.0
+# Upper cap when picking the dark on-light color. Without this, near-black
+# image regions (e.g. text outlines) win and the picked color looks like pure
+# black instead of a vibrant darker shade from the artwork.
+_MAX_DARK_PICK_CONTRAST = 17.35
+_BACKGROUND_ADJUST_STEPS = 20
+_SIMILARITY_THRESHOLD = 60  # squared euclidean RGB distance for accent picking
+
+_RGB = tuple[int, int, int]
+
+_palette_memory_cache: OrderedDict[str, MediaItemPalette] = OrderedDict()
+
+
+def _get_from_memory_cache(key: str) -> MediaItemPalette | None:
+    if key in _palette_memory_cache:
+        _palette_memory_cache.move_to_end(key)
+        return _palette_memory_cache[key]
+    return None
+
+
+def _put_in_memory_cache(key: str, palette: MediaItemPalette) -> None:
+    _palette_memory_cache[key] = palette
+    _palette_memory_cache.move_to_end(key)
+    while len(_palette_memory_cache) > _PALETTE_MEMORY_CACHE_MAX:
+        _palette_memory_cache.popitem(last=False)
+
+
+def _relative_luminance(rgb: _RGB) -> float:
+    """Compute WCAG relative luminance for an sRGB color."""
+
+    def channel(c: int) -> float:
+        s = c / 255.0
+        return s / 12.92 if s <= 0.03928 else ((s + 0.055) / 1.055) ** 2.4
+
+    r, g, b = rgb
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+
+
+def _contrast_ratio(a: _RGB, b: _RGB) -> float:
+    """Compute WCAG contrast ratio between two RGB colors."""
+    la = _relative_luminance(a)
+    lb = _relative_luminance(b)
+    lighter, darker = (la, lb) if la >= lb else (lb, la)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _color_distance_sq(a: _RGB, b: _RGB) -> int:
+    return (a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2
+
+
+def _mix(rgb: _RGB, target: _RGB, factor: float) -> _RGB:
+    """Blend rgb toward target. factor=0 returns rgb, factor=1 returns target."""
+    return (
+        round(rgb[0] + (target[0] - rgb[0]) * factor),
+        round(rgb[1] + (target[1] - rgb[1]) * factor),
+        round(rgb[2] + (target[2] - rgb[2]) * factor),
+    )
+
+
+def _adjust_until_contrast(
+    color: _RGB,
+    mix_toward: _RGB,
+    refs: tuple[_RGB, ...],
+    min_contrast: float = _MIN_CONTRAST,
+) -> _RGB | None:
+    """Mix color toward mix_toward until contrast >= min_contrast vs all refs.
+
+    :param color: Starting color.
+    :param mix_toward: Direction to blend (e.g. black to darken, white to lighten).
+    :param refs: Colors that the result must contrast against.
+    :param min_contrast: Required minimum contrast ratio against every ref.
+    """
+    for step in range(_BACKGROUND_ADJUST_STEPS + 1):
+        factor = step / _BACKGROUND_ADJUST_STEPS
+        candidate = _mix(color, mix_toward, factor)
+        if all(_contrast_ratio(candidate, ref) >= min_contrast for ref in refs):
+            return candidate
+    return None
+
+
+def _adjust_with_fallback(color: _RGB, mix_toward: _RGB, refs: tuple[_RGB, ...]) -> _RGB | None:
+    """Try _PREFERRED_CONTRAST first, fall back to _MIN_CONTRAST if needed."""
+    return _adjust_until_contrast(
+        color, mix_toward, refs, _PREFERRED_CONTRAST
+    ) or _adjust_until_contrast(color, mix_toward, refs, _MIN_CONTRAST)
+
+
+def _extract_candidates(image_bytes: bytes) -> list[_RGB]:
+    """Extract a dominant-color palette via MMCQ (matches the colorthief JS lib)."""
+    thief = ColorThief(BytesIO(image_bytes))
+    palette = thief.get_palette(color_count=_PALETTE_QUANTIZE_COLORS, quality=_COLORTHIEF_QUALITY)
+    return [(r, g, b) for r, g, b in palette]
+
+
+def _pick_on_color(
+    candidates: list[_RGB],
+    target: _RGB,
+    min_contrast: float = _MIN_CONTRAST,
+    max_contrast: float = float("inf"),
+) -> _RGB | None:
+    """Pick the candidate with highest contrast vs target in [min, max]."""
+    best: _RGB | None = None
+    best_ratio = 0.0
+    for rgb in candidates:
+        ratio = _contrast_ratio(rgb, target)
+        if min_contrast <= ratio <= max_contrast and ratio > best_ratio:
+            best = rgb
+            best_ratio = ratio
+    return best
+
+
+def _pick_on_color_with_fallback(
+    candidates: list[_RGB], target: _RGB, max_contrast: float = float("inf")
+) -> _RGB | None:
+    """Try _PREFERRED_CONTRAST first, fall back to _MIN_CONTRAST if needed."""
+    return _pick_on_color(candidates, target, _PREFERRED_CONTRAST, max_contrast) or _pick_on_color(
+        candidates, target, _MIN_CONTRAST, max_contrast
+    )
+
+
+def _pick_accent(primary: _RGB, candidates: list[_RGB]) -> _RGB | None:
+    """Return the first candidate that is hue-distant from primary, or None."""
+    for rgb in candidates:
+        if rgb == primary:
+            continue
+        if _color_distance_sq(rgb, primary) >= _SIMILARITY_THRESHOLD**2:
+            return rgb
+    return None
+
+
+def _derive_palette(candidates: list[_RGB]) -> MediaItemPalette:
+    if not candidates:
+        return MediaItemPalette()
+    primary = candidates[0]
+
+    # On-colors are picked from image candidates against pure black/white (the
+    # natural reference for a "light color" or "dark color"), this matches the previous algorithm from the frontend.
+    # on_light caps at _MAX_DARK_PICK_CONTRAST to avoid near-black picks (e.g. text outlines) winning over genuinely dark
+    # image colors.
+    on_dark = _pick_on_color_with_fallback(candidates, (0, 0, 0))
+    on_light = _pick_on_color_with_fallback(candidates, (255, 255, 255), _MAX_DARK_PICK_CONTRAST)
+
+    # Synthesize a fallback when no candidate cleared the contrast bar so the
+    # field is always emitted. Spec dual-use: on_dark must clear 4.5:1 vs black
+    # text (so it can also act as a light bg), on_light must clear vs white.
+    if on_dark is None:
+        on_dark = _adjust_until_contrast(primary, (255, 255, 255), ((0, 0, 0),))
+    if on_light is None:
+        on_light = _adjust_until_contrast(primary, (0, 0, 0), ((255, 255, 255),))
+
+    # Adjust backgrounds so they clear MIN_CONTRAST vs both the matching text
+    # color (white/black) and the chosen on-color, per spec.
+    bg_dark_refs: tuple[_RGB, ...] = ((255, 255, 255),)
+    if on_dark is not None:
+        bg_dark_refs = ((255, 255, 255), on_dark)
+    background_dark = _adjust_with_fallback(primary, (0, 0, 0), bg_dark_refs)
+
+    bg_light_refs: tuple[_RGB, ...] = ((0, 0, 0),)
+    if on_light is not None:
+        bg_light_refs = ((0, 0, 0), on_light)
+    background_light = _adjust_with_fallback(primary, (255, 255, 255), bg_light_refs)
+
+    # Accent: a hue-distant secondary from the image. This is not adjusted for contrast.
+    accent = _pick_accent(primary, candidates)
+
+    return MediaItemPalette(
+        background_dark=background_dark,
+        background_light=background_light,
+        primary=primary,
+        accent=accent,
+        on_dark=on_dark,
+        on_light=on_light,
+    )
+
+
+def extract_palette(image_bytes: bytes) -> MediaItemPalette:
+    """Extract a MediaItemPalette from raw image bytes.
+
+    :param image_bytes: Raw image data (PNG, JPEG, etc.).
+    """
+    try:
+        candidates = _extract_candidates(image_bytes)
+    except (UnidentifiedImageError, OSError):
+        return MediaItemPalette()
+    return _derive_palette(candidates)
+
+
+async def _load_from_disk(cache_filepath: str) -> MediaItemPalette | None:
+    if not await asyncio.to_thread(os.path.isfile, cache_filepath):
+        return None
+    try:
+        async with aiofiles.open(cache_filepath, "rb") as f:
+            data = await f.read()
+        return MediaItemPalette.from_dict(json.loads(data))
+    except (OSError, ValueError):
+        return None
+
+
+async def _save_to_disk(cache_filepath: str, palette: MediaItemPalette) -> None:
+    try:
+        await asyncio.to_thread(os.makedirs, os.path.dirname(cache_filepath), exist_ok=True)
+        async with aiofiles.open(cache_filepath, "wb") as f:
+            await f.write(json.dumps(palette.to_dict()).encode())
+    except OSError:
+        pass
+
+
+async def _extract_and_cache(
+    mass: MusicAssistant,
+    path_or_url: str,
+    provider: str,
+    cache_filepath: str,
+) -> MediaItemPalette:
+    img_data = await get_image_data(mass, path_or_url, provider)
+    palette = await asyncio.to_thread(extract_palette, img_data)
+    await _save_to_disk(cache_filepath, palette)
+    return palette
+
+
+async def get_palette(
+    mass: MusicAssistant, path_or_url: str, provider: str
+) -> MediaItemPalette | None:
+    """Get the color palette for an image, using a two-tier cache.
+
+    :param mass: The MusicAssistant instance.
+    :param path_or_url: Image path or URL (same format as get_image_data).
+    :param provider: Provider identifier for the image source.
+    """
+    if not path_or_url:
+        return None
+    key = _create_thumb_hash(provider, path_or_url)
+
+    if cached := _get_from_memory_cache(key):
+        return cached
+
+    cache_dir = os.path.join(mass.cache_path, _PALETTE_CACHE_DIR)
+    cache_filepath = os.path.join(cache_dir, f"{key}.json")
+    resolved = os.path.realpath(cache_filepath)
+    if not resolved.startswith(os.path.realpath(cache_dir) + os.sep):
+        return None
+    if cached := await _load_from_disk(cache_filepath):
+        _put_in_memory_cache(key, cached)
+        return cached
+
+    task: asyncio.Task[MediaItemPalette] = mass.create_task(
+        _extract_and_cache,
+        mass,
+        path_or_url,
+        provider,
+        cache_filepath,
+        task_id=f"palette.{key}",
+        abort_existing=False,
+    )
+    palette = await asyncio.shield(task)
+    _put_in_memory_cache(key, palette)
+    return palette
+
+
+def peek_palette_for_url(image_url: str | None) -> MediaItemPalette | None:
+    """Return the cached palette for an image URL, or None.
+
+    Memory-cache only, does not fetch or read from disk. Use to attach a
+    palette to a PlayerMedia without blocking when a prior async fetch has
+    already populated the cache.
+    """
+    if not image_url:
+        return None
+    if extracted := _extract_imageproxy_params(image_url):
+        path, provider = extracted
+    else:
+        path, provider = image_url, "builtin"
+    key = _create_thumb_hash(provider, path)
+    return _get_from_memory_cache(key)
+
+
+async def get_palette_for_url(
+    mass: MusicAssistant, image_url: str | None
+) -> MediaItemPalette | None:
+    """Resolve an imageproxy URL to (path, provider) and return its palette."""
+    if not image_url:
+        return None
+    if extracted := _extract_imageproxy_params(image_url):
+        path, provider = extracted
+    else:
+        path, provider = image_url, "builtin"
+    try:
+        return await get_palette(mass, path, provider)
+    except (FileNotFoundError, OSError):
+        return None
+
+
+async def cleanup_palette_cache(cache_path: str, max_size_bytes: int) -> int:
+    """Remove oldest cached palettes when total size exceeds the limit.
+
+    :param cache_path: The base cache directory (mass.cache_path).
+    :param max_size_bytes: Maximum allowed total size in bytes.
+    :returns: Number of files removed.
+    """
+    palette_dir = os.path.join(cache_path, _PALETTE_CACHE_DIR)
+
+    def _cleanup() -> int:
+        if not os.path.isdir(palette_dir):
+            return 0
+        entries: list[tuple[str, int, float]] = []
+        for entry in os.scandir(palette_dir):
+            if entry.is_file():
+                stat = entry.stat()
+                entries.append((entry.path, stat.st_size, stat.st_mtime))
+        entries.sort(key=lambda e: e[2])
+        total_size = sum(e[1] for e in entries)
+        removed = 0
+        for filepath, file_size, _ in entries:
+            if total_size <= max_size_bytes:
+                break
+            try:
+                Path(filepath).unlink()
+                total_size -= file_size
+                removed += 1
+            except OSError:
+                pass
+        return removed
+
+    return await asyncio.to_thread(_cleanup)

--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 
 import aiofiles
 from colorthief import ColorThief
-from music_assistant_models.media_items.metadata import MediaItemPalette
+from music_assistant_models.media_items import MediaItemPalette
 from PIL import UnidentifiedImageError
 
 from music_assistant.helpers.images import (

--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -1,7 +1,7 @@
 """Color palette extraction from artwork.
 
 Derives a 6-field MediaItemPalette per the Sendspin color@v1 spec from an
-image: a `colorthief` MMCQ quantizer produces image candidates, then `primary`,
+image: a `modern_colorthief` MMCQ quantizer produces image candidates, then `primary`,
 `accent`, `on_dark`, `on_light`, `background_dark`, and `background_light` are
 chosen (and adjusted where needed) so that every spec-mandated contrast pair
 clears the WCAG AA 4.5:1 threshold.
@@ -14,12 +14,10 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
-from io import BytesIO
 from typing import TYPE_CHECKING
 
-from colorthief import ColorThief
+from modern_colorthief import get_palette as _mmcq_palette
 from music_assistant_models.media_items import MediaItemPalette
-from PIL import UnidentifiedImageError
 
 from music_assistant.helpers.images import (
     _create_thumb_hash,
@@ -126,8 +124,9 @@ def _adjust_with_fallback(color: _RGB, mix_toward: _RGB, refs: tuple[_RGB, ...])
 
 def _extract_candidates(image_bytes: bytes) -> list[_RGB]:
     """Extract a dominant-color palette via MMCQ (matches the colorthief JS lib)."""
-    thief = ColorThief(BytesIO(image_bytes))
-    palette = thief.get_palette(color_count=_PALETTE_QUANTIZE_COLORS, quality=_COLORTHIEF_QUALITY)
+    palette = _mmcq_palette(
+        image_bytes, color_count=_PALETTE_QUANTIZE_COLORS, quality=_COLORTHIEF_QUALITY
+    )
     return [(r, g, b) for r, g, b in palette]
 
 
@@ -219,7 +218,7 @@ def extract_palette(image_bytes: bytes) -> MediaItemPalette:
     """
     try:
         candidates = _extract_candidates(image_bytes)
-    except (UnidentifiedImageError, OSError):
+    except (ValueError, OSError):
         return MediaItemPalette()
     return _derive_palette(candidates)
 

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1473,14 +1473,6 @@ class Player(ABC):
             needs_setup=self.needs_setup,
         )
 
-        # Peek the cached palette so the media checksum below sees palette
-        # transitions. Lazy import to avoid the helpers.colors -> helpers.images
-        # -> models.plugin cycle.
-        if (cm := self._state.current_media) and cm.image_url:
-            from music_assistant.helpers.colors import peek_palette_for_url  # noqa: PLC0415
-
-            cm.palette = peek_palette_for_url(cm.image_url)
-
         # track stop called state
         if (
             prev_state.playback_state == PlaybackState.IDLE
@@ -1666,6 +1658,9 @@ class Player(ABC):
     @final
     def __final_current_media(self) -> PlayerMedia | None:
         """Return the FINAL current media for the player."""
+        # Lazy import to avoid helpers.colors -> helpers.images -> models.plugin cycle.
+        from music_assistant.helpers.colors import peek_palette_for_url  # noqa: PLC0415
+
         # if the player is grouped/synced, use the current_media of the group/parent player
         if parent_player_id := (self.__final_active_group or self.__final_synced_to):
             if parent_player_id != self.player_id and (
@@ -1684,13 +1679,15 @@ class Player(ABC):
             and (source := self.mass.players.get_plugin_source(active_source))
             and source.metadata
         ):
+            image_url = source.metadata.image_url
             return PlayerMedia(
                 uri=source.metadata.uri or source.id,
                 media_type=MediaType.PLUGIN_SOURCE,
                 title=source.metadata.title,
                 artist=source.metadata.artist,
                 album=source.metadata.album,
-                image_url=source.metadata.image_url,
+                image_url=image_url,
+                palette=peek_palette_for_url(image_url),
                 duration=source.metadata.duration,
                 source_id=source.id,
                 elapsed_time=source.metadata.elapsed_time,
@@ -1713,13 +1710,15 @@ class Player(ABC):
                 stream_metadata := current_item.streamdetails.stream_metadata
             ):
                 # handle stream metadata in streamdetails (e.g. for radio stream)
+                image_url = stream_metadata.image_url or item_image_url
                 return PlayerMedia(
                     uri=current_item.uri,
                     media_type=current_item.media_type,
                     title=stream_metadata.title or current_item.name,
                     artist=stream_metadata.artist,
                     album=stream_metadata.album or stream_metadata.description or current_item.name,
-                    image_url=(stream_metadata.image_url or item_image_url),
+                    image_url=image_url,
+                    palette=peek_palette_for_url(image_url),
                     duration=stream_metadata.duration or current_item.duration,
                     source_id=active_queue.queue_id,
                     queue_item_id=current_item.queue_item_id,
@@ -1735,19 +1734,23 @@ class Player(ABC):
                 podcast = getattr(media_item, "podcast", None)
                 metadata = getattr(media_item, "metadata", None)
                 description = getattr(metadata, "description", None) if metadata else None
+                # the image format needs to be 500x500 jpeg for maximum player compatibility
+                image_url = (
+                    self.mass.metadata.get_image_url(
+                        current_item.media_item.image, size=500, image_format="jpeg"
+                    )
+                    or item_image_url
+                    if current_item.media_item.image
+                    else item_image_url
+                )
                 return PlayerMedia(
                     uri=str(media_item.uri),
                     media_type=media_item.media_type,
                     title=f"{media_item.name} ({version})" if version else media_item.name,
                     artist=getattr(media_item, "artist_str", None),
                     album=album.name if album else podcast.name if podcast else description,
-                    # the image format needs to be 500x500 jpeg for maximum player compatibility
-                    image_url=self.mass.metadata.get_image_url(
-                        current_item.media_item.image, size=500, image_format="jpeg"
-                    )
-                    or item_image_url
-                    if current_item.media_item.image
-                    else item_image_url,
+                    image_url=image_url,
+                    palette=peek_palette_for_url(image_url),
                     duration=media_item.duration,
                     source_id=active_queue.queue_id,
                     queue_item_id=current_item.queue_item_id,
@@ -1761,6 +1764,7 @@ class Player(ABC):
                 media_type=current_item.media_type,
                 title=current_item.name,
                 image_url=item_image_url,
+                palette=peek_palette_for_url(item_image_url),
                 duration=current_item.duration,
                 source_id=active_queue.queue_id,
                 queue_item_id=current_item.queue_item_id,
@@ -1772,13 +1776,15 @@ class Player(ABC):
             return None
         # return native current media if no group/queue is active
         if self.current_media:
+            image_url = self.current_media.image_url
             return PlayerMedia(
                 uri=self.current_media.uri,
                 media_type=self.current_media.media_type,
                 title=self.current_media.title,
                 artist=self.current_media.artist,
                 album=self.current_media.album,
-                image_url=self.current_media.image_url,
+                image_url=image_url,
+                palette=peek_palette_for_url(image_url),
                 duration=self.current_media.duration,
                 source_id=self.current_media.source_id or active_source,
                 queue_item_id=self.current_media.queue_item_id,

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1335,7 +1335,7 @@ class Player(ABC):
             return ""
         return (
             f"{media.uri}|{media.title}|{media.source_id}|{media.queue_item_id}|"
-            f"{media.image_url}|{media.duration}|{media.elapsed_time}"
+            f"{media.image_url}|{media.duration}|{media.elapsed_time}|{media.palette}"
         )
 
     @final
@@ -1472,6 +1472,14 @@ class Player(ABC):
             active_output_protocol=self.__attr_active_output_protocol,
             needs_setup=self.needs_setup,
         )
+
+        # Peek the cached palette so the media checksum below sees palette
+        # transitions. Lazy import to avoid the helpers.colors -> helpers.images
+        # -> models.plugin cycle.
+        if (cm := self._state.current_media) and cm.image_url:
+            from music_assistant.helpers.colors import peek_palette_for_url  # noqa: PLC0415
+
+            cm.palette = peek_palette_for_url(cm.image_url)
 
         # track stop called state
         if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "awesomeversion>=24.6.0",
   "certifi==2025.11.12",
   "colorlog==6.10.1",
-  "colorthief==0.2.1",
+  "modern_colorthief==0.2.0",
   "cryptography==46.0.7",
   "chardet>=5.2.0",
   "ifaddr==0.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "awesomeversion>=24.6.0",
   "certifi==2025.11.12",
   "colorlog==6.10.1",
+  "colorthief==0.2.1",
   "cryptography==46.0.7",
   "chardet>=5.2.0",
   "ifaddr==0.2.0",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -30,7 +30,6 @@ bidict==0.23.1
 certifi==2025.11.12
 chardet>=5.2.0
 colorlog==6.10.1
-colorthief==0.2.1
 cryptography==46.0.7
 deezer-python-async==0.3.0
 defusedxml==0.7.1
@@ -46,6 +45,7 @@ liblistenbrainz==0.7.0
 librosa==0.11.0
 lyricsgenius==3.11.0
 mashumaro==3.20
+modern_colorthief==0.2.0
 music-assistant-frontend==2.17.158
 music-assistant-models==1.1.119
 mutagen==1.47.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -30,6 +30,7 @@ bidict==0.23.1
 certifi==2025.11.12
 chardet>=5.2.0
 colorlog==6.10.1
+colorthief==0.2.1
 cryptography==46.0.7
 deezer-python-async==0.3.0
 defusedxml==0.7.1

--- a/tests/core/test_colors.py
+++ b/tests/core/test_colors.py
@@ -1,0 +1,128 @@
+"""Tests for the color palette helper."""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image, ImageDraw
+
+from music_assistant.helpers.colors import (
+    _adjust_until_contrast,
+    _contrast_ratio,
+    _derive_palette,
+    _pick_accent,
+    _pick_on_color,
+    _relative_luminance,
+    extract_palette,
+)
+
+_MIN_CONTRAST = 4.5
+
+
+def _make_image_bytes(colors: list[tuple[int, int, int]]) -> bytes:
+    """Build a PNG composed of rectangles for each input color."""
+    width = 60
+    height = 60
+    img = Image.new("RGB", (width * len(colors), height), colors[0])
+    draw = ImageDraw.Draw(img)
+    for idx, color in enumerate(colors):
+        draw.rectangle([idx * width, 0, (idx + 1) * width, height], fill=color)
+    buf = io.BytesIO()
+    img.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def test_relative_luminance_extremes() -> None:
+    """Black is 0, white is 1."""
+    assert _relative_luminance((0, 0, 0)) == 0.0
+    assert abs(_relative_luminance((255, 255, 255)) - 1.0) < 1e-9
+
+
+def test_contrast_ratio_black_vs_white() -> None:
+    """Black vs white is the maximum 21:1 ratio."""
+    assert abs(_contrast_ratio((0, 0, 0), (255, 255, 255)) - 21.0) < 1e-9
+
+
+def test_adjust_until_contrast_darkens_when_needed() -> None:
+    """Mixing a mid-gray toward black yields a darker color that clears MIN vs white."""
+    result = _adjust_until_contrast((180, 180, 180), (0, 0, 0), ((255, 255, 255),))
+    assert result is not None
+    assert _contrast_ratio(result, (255, 255, 255)) >= _MIN_CONTRAST
+
+
+def test_adjust_until_contrast_returns_none_for_unsolvable() -> None:
+    """Mixing toward white can never satisfy contrast vs white."""
+    assert _adjust_until_contrast((128, 128, 128), (255, 255, 255), ((255, 255, 255),)) is None
+
+
+def test_pick_accent_skips_similar_to_primary() -> None:
+    """_pick_accent returns the first candidate far enough from primary."""
+    primary = (200, 30, 30)
+    assert _pick_accent(primary, [primary, (205, 35, 35), (10, 50, 200)]) == (10, 50, 200)
+    assert _pick_accent(primary, [primary, (205, 35, 35)]) is None
+
+
+def test_pick_on_color_requires_min_contrast() -> None:
+    """Only candidates clearing MIN_CONTRAST vs the target are considered."""
+    candidates = [(255, 255, 255), (128, 128, 128), (20, 20, 20)]
+    # vs near-black target, white wins, gray fails MIN_CONTRAST
+    assert _pick_on_color(candidates, (20, 20, 20)) == (255, 255, 255)
+
+
+def test_derive_palette_synthesizes_on_colors_when_no_candidate() -> None:
+    """When no image candidate clears contrast, on_dark/on_light are synthesized."""
+    # All candidates near mid-gray — none can clear 4.5 vs pure black or pure white.
+    candidates = [(120, 120, 120), (130, 125, 128), (115, 118, 122)]
+    palette = _derive_palette(candidates)
+    assert palette.on_dark is not None
+    assert palette.on_light is not None
+    assert _contrast_ratio(palette.on_dark, (0, 0, 0)) >= _MIN_CONTRAST
+    assert _contrast_ratio(palette.on_light, (255, 255, 255)) >= _MIN_CONTRAST
+
+
+def test_derive_palette_empty() -> None:
+    """Empty candidates yield a fully-empty palette, not an exception."""
+    palette = _derive_palette([])
+    assert palette.primary is None
+    assert palette.background_dark is None
+
+
+def test_palette_invariants_over_random_candidates() -> None:
+    """Across many synthetic candidate sets, every emitted contrast pair holds.
+
+    Sweeps a fixed-seed RNG over candidate counts and RGB values to catch
+    regressions in the contrast invariants. Calibrate the iteration count so
+    the test stays cheap in CI.
+    """
+    import random  # noqa: PLC0415
+
+    rng = random.Random(42)
+    # Calibrated for CI: 50 iterations runs in a few ms. Bump if invariants
+    # regress and we need denser coverage.
+    for _ in range(50):
+        n = rng.randint(1, 8)
+        cands = [(rng.randrange(256), rng.randrange(256), rng.randrange(256)) for _ in range(n)]
+        p = _derive_palette(cands)
+        if p.background_dark is not None:
+            assert _contrast_ratio(p.background_dark, (255, 255, 255)) >= _MIN_CONTRAST
+        if p.background_light is not None:
+            assert _contrast_ratio(p.background_light, (0, 0, 0)) >= _MIN_CONTRAST
+        if p.on_dark is not None:
+            assert _contrast_ratio(p.on_dark, (0, 0, 0)) >= _MIN_CONTRAST
+        if p.on_light is not None:
+            assert _contrast_ratio(p.on_light, (255, 255, 255)) >= _MIN_CONTRAST
+
+
+def test_extract_palette_handles_invalid_bytes() -> None:
+    """Invalid image bytes return an empty palette."""
+    palette = extract_palette(b"not an image")
+    assert palette.primary is None
+
+
+def test_extract_palette_end_to_end() -> None:
+    """An image with multiple distinct colors yields a palette that meets WCAG."""
+    image_bytes = _make_image_bytes([(60, 30, 90), (220, 200, 150), (250, 250, 245)])
+    palette = extract_palette(image_bytes)
+    assert palette.primary is not None
+    if palette.background_dark is not None:
+        assert _contrast_ratio(palette.background_dark, (255, 255, 255)) >= _MIN_CONTRAST

--- a/tests/core/test_protocol_linking.py
+++ b/tests/core/test_protocol_linking.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Awaitable
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -4723,7 +4723,7 @@ class TestUniversalPlayerMerging:
         # up1 should have no more links
         assert len(up1.linked_output_protocols) == 0
 
-    async def test_merge_preserves_moved_protocols_during_parent_cleanup(
+    async def test_merge_preserves_moved_protocols_during_parent_cleanup(  # noqa: PLR0915
         self, mock_mass: MagicMock
     ) -> None:
         """Moved protocol ownership must survive the removed parent's permanent cleanup."""
@@ -4754,7 +4754,7 @@ class TestUniversalPlayerMerging:
 
         scheduled_tasks: list[Awaitable[object]] = []
 
-        def capture_task(task: Awaitable[object]) -> None:
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
             scheduled_tasks.append(task)
 
         mock_mass.config.get = MagicMock(side_effect=config_get)
@@ -4826,9 +4826,10 @@ class TestUniversalPlayerMerging:
 
         assert dlna_live.protocol_parent_id == "up_keep"
         assert config_store["players/dlna_cached/values/protocol_parent_id"] == "up_keep"
-        assert len(scheduled_tasks) == 1
+        unregister_tasks = [t for t in scheduled_tasks if "unregister" in repr(t)]
+        assert len(unregister_tasks) == 1
 
-        await scheduled_tasks[0]
+        await unregister_tasks[0]
 
         assert "up_remove" not in controller._players
         assert dlna_live.protocol_parent_id == "up_keep"
@@ -4945,7 +4946,7 @@ class TestUniversalPlayerReplacement:
 
         scheduled_tasks: list[Awaitable[object]] = []
 
-        def capture_task(task: Awaitable[object]) -> None:
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
             scheduled_tasks.append(task)
 
         mock_mass.config.get = MagicMock(side_effect=config_get)
@@ -5006,9 +5007,10 @@ class TestUniversalPlayerReplacement:
             "dlna_cached",
         }
         assert config_store["players/dlna_cached/values/protocol_parent_id"] == "sonos_1"
-        assert len(scheduled_tasks) == 1
+        unregister_tasks = [t for t in scheduled_tasks if "unregister" in repr(t)]
+        assert len(unregister_tasks) == 1
 
-        await scheduled_tasks[0]
+        await unregister_tasks[0]
 
         assert "up_old" not in controller._players
         assert ap_live.protocol_parent_id == "sonos_1"


### PR DESCRIPTION
This PR moves the color palette extraction from the frontend to the backend to prepare for the `color@v1` Sendspin role.

Extract a color palette from cover art with WCAG-AA contrast guarantees. The players controller attaches the palette to `PlayerMedia.palette`.

The next queue item's palette is also prefetched so clients see colors without flickering at track transitions.

Adds a python port of `colorthief` as a dependency. I also tried out `Image.quantize` but that looked more washed-out from some testing.

Depends on:
- https://github.com/music-assistant/models/pull/228