### PR TITLE
Improve lastfm recommendations

### DIFF
--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -32,7 +32,7 @@ TARGET_ITEM_COUNT = 10
 RESOLUTION_BUFFER_SMALL = 15
 
 # Number of items to fetch when we expect many resolution failures (large buffer)
-RESOLUTION_BUFFER_LARGE = 30
+RESOLUTION_BUFFER_LARGE = 40
 
 # Number of top items to always include when sampling (before random selection)
 TOP_ITEMS_TO_TAKE = 3

--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -41,7 +41,7 @@ TOP_ITEMS_TO_TAKE = 3
 SIMILAR_ITEMS_BUFFER = 12
 
 # Number of similar items to fetch for each seed artist/track
-SIMILAR_ITEMS_PER_SEED = 3
+SIMILAR_ITEMS_PER_SEED = 5
 
 # Number of top artists to use as seeds for personalized recommendations
 TOP_ARTISTS_LIMIT = 5

--- a/music_assistant/providers/lastfm_recommendations/parsers.py
+++ b/music_assistant/providers/lastfm_recommendations/parsers.py
@@ -264,6 +264,20 @@ async def _resolve_item(
     )
     if result is None:
         LOGGER.debug("Could not resolve %s: %s", item_mapping.media_type.value, item_mapping.name)
+        return None
+
+    # Streaming providers expose ISRCs (and sometimes MBIDs) that Last.fm doesn't always
+    # provide; re-check the library against the resolved item's external IDs so we prefer
+    # the user's own copy when it exists.
+    if result.external_ids:
+        if library_item := await ctrl.get_library_item_by_external_ids(result.external_ids):
+            LOGGER.debug(
+                "Found %s in library via resolved external IDs: %s",
+                item_mapping.media_type.value,
+                library_item.name,
+            )
+            return library_item
+
     return result
 
 

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -114,6 +114,7 @@ class LastFMRecommendationManager:
         :param item_data: Raw Last.fm item data (artist, album, or track dict).
         :param media_type: Type of media item to check.
         """
+        name = item_data.get("name", "")
         # MBID lookup is the most reliable; fall back to name search for items without MBID.
         mbid = item_data.get("mbid")
         if mbid:
@@ -121,42 +122,57 @@ class LastFMRecommendationManager:
                 if await self.mass.music.artists.get_library_item_by_external_id(
                     mbid, ExternalID.MB_ARTIST
                 ):
+                    self.logger.debug("Filtered artist '%s' (MBID match: %s)", name, mbid)
                     return True
             elif media_type == MediaType.ALBUM:
                 if await self.mass.music.albums.get_library_item_by_external_id(
                     mbid, ExternalID.MB_ALBUM
                 ):
+                    self.logger.debug("Filtered album '%s' (MBID match: %s)", name, mbid)
                     return True
             elif media_type == MediaType.TRACK:
                 if await self.mass.music.tracks.get_library_item_by_external_id(
                     mbid, ExternalID.MB_RECORDING
                 ):
+                    self.logger.debug("Filtered track '%s' (MBID match: %s)", name, mbid)
                     return True
 
         if media_type == MediaType.ARTIST:
-            name = item_data.get("name", "")
             if name:
                 artist_results = await self.mass.music.artists.library_items(search=name, limit=1)
-                return len(artist_results) > 0
+                if artist_results:
+                    self.logger.debug(
+                        "Filtered artist '%s' (name match: '%s')", name, artist_results[0].name
+                    )
+                    return True
 
         elif media_type == MediaType.ALBUM:
-            name = item_data.get("name", "")
             if name:
                 album_results = await self.mass.music.albums.library_items(search=name, limit=1)
-                return len(album_results) > 0
+                if album_results:
+                    self.logger.debug(
+                        "Filtered album '%s' (name match: '%s')", name, album_results[0].name
+                    )
+                    return True
 
         elif media_type == MediaType.TRACK:
             artist_info = item_data.get("artist", {})
             artist_name = (
                 artist_info if isinstance(artist_info, str) else artist_info.get("name", "")
             )
-            track_name = item_data.get("name", "")
-            if track_name and artist_name:
-                search_query = f"{artist_name} {track_name}"
+            if name and artist_name:
+                search_query = f"{artist_name} {name}"
                 track_results = await self.mass.music.tracks.library_items(
                     search=search_query, limit=1
                 )
-                return len(track_results) > 0
+                if track_results:
+                    self.logger.debug(
+                        "Filtered track '%s - %s' (name match: '%s')",
+                        artist_name,
+                        name,
+                        track_results[0].name,
+                    )
+                    return True
 
         return False
 


### PR DESCRIPTION
When using this against my full library I noticed that the "Discover Similar Tracks" and "Discover {Genre} Artists/Albums/Tracks" rows often returned only 9 items instead of the target 10. Digging into the debug logs showed two unrelated causes, plus a related issue where tracks I already owned were being linked to Spotify instead of my local copy.

Link resolved tracks back to the library when the streaming provider exposes a matching ISRC. Last.fm's similar-tracks API frequently omits MBIDs, so the upfront library check by external ID misses and we fall through to a streaming provider search. The Spotify result reliably carries an ISRC though, so after the streaming search returns, we now re-check the library against the resolved item's external IDs and prefer the library copy when one exists. No extra API calls — we just use the IDs we already have in hand.

Bump `SIMILAR_ITEMS_PER_SEED` from 3 to 5. With 5 seed tracks/artists and 3 items per seed, a single Last.fm "Track not found" error (which happens when Last.fm doesn't recognise an MBID it gave us) drops the ceiling below 10 before deduplication even runs.

Bump `RESOLUTION_BUFFER_LARGE` from 30 to 40. For the genre rows we filter out items already in the library before resolving (so users discover something new). In my case with mainly rock music, 21 of the 30 fetched items were already in the library, leaving only 9 survivors — not enough to fill the row. 40 gives roughly 12 survivors at a 30% novelty rate, which consistently hits the target of 10.

Add debug logging to `_is_in_library`. Each filter decision now logs which item was dropped and which check matched (MBID vs. name search), including the library item's name on a name match. This makes it easier to see which items are being filtered and why a row may come up short.