### PR TITLE
Fix genre movements when genres are promoted or deleted

### DIFF
--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -1222,6 +1222,9 @@ class GenreController(MediaControllerBase[Genre]):
             "WHERE genre_id = :genre_id AND LOWER(alias) = LOWER(:alias)",
             {"genre_id": db_id, "alias": alias},
         )
+        # Rebuild propagated album/artist rows: the track rows we just removed may have
+        # fed them, so a derived row on this genre would otherwise linger past the alias.
+        await self._propagate_genre_mappings_to_parents()
         updated = await self.get_library_item(db_id)
         self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, updated.uri, updated)
         return updated
@@ -1383,25 +1386,33 @@ class GenreController(MediaControllerBase[Genre]):
         """
         Promote an alias to become a standalone genre.
 
-        Creates a new Genre with the alias's name, moves all media mappings
-        for that alias to the new genre, and removes the alias from the
-        original genre.
+        An alias can be claimed by multiple genres (n:n). Promotion moves every
+        direct mapping that was created via this alias to the new genre and strips
+        the alias from each genre that owned it, regardless of which one the user
+        invoked the action from. Derived album/artist mappings are rebuilt against
+        the moved track mappings so propagated genres follow.
 
-        :param genre_id: Database ID of the source genre.
+        :param genre_id: Database ID of the source genre the user invoked this on.
         :param alias: The alias string to promote.
         :return: The newly created Genre.
         """
         db_genre_id = int(genre_id)
         source_genre = await self.get_library_item(db_genre_id)
+        alias_norm = create_safe_string(alias, True, True)
 
-        if create_safe_string(alias, True, True) == create_safe_string(
-            source_genre.name, True, True
-        ):
+        if alias_norm == create_safe_string(source_genre.name, True, True):
             msg = (
                 f"Cannot promote self-alias '{alias}'. "
                 f"This alias is the primary name for genre '{source_genre.name}'."
             )
             raise ValueError(msg)
+
+        # Find every non-excluded genre that owns this alias (n:n). LOWER() catches the
+        # common case; create_safe_string() catches normalisation gaps like
+        # "Synth-Pop" vs "synthpop".
+        owning_ids = await self._find_genre_ids_for_alias(alias_norm)
+        if db_genre_id not in owning_ids:
+            owning_ids.append(db_genre_id)
 
         # Create new genre with the alias as its name
         new_genre = Genre(
@@ -1416,24 +1427,57 @@ class GenreController(MediaControllerBase[Genre]):
         created_genre = await self.add_item_to_library(new_genre)
         new_genre_id = int(created_genre.item_id)
 
-        # Move media mappings from source genre to new genre for this alias (case-insensitive)
+        # Move every direct mapping created via this alias to the new genre. UPDATE OR
+        # REPLACE resolves the rare case where the new genre already has a mapping for
+        # the same (media_id, media_type) by keeping the moved row.
+        placeholders = ", ".join(str(g) for g in owning_ids)
         await self.mass.music.database.execute(
-            f"UPDATE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
-            "SET genre_id = :new_id WHERE genre_id = :old_id AND LOWER(alias) = LOWER(:alias)",
-            {"new_id": new_genre_id, "old_id": db_genre_id, "alias": alias},
+            f"UPDATE OR REPLACE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            f"SET genre_id = :new_id "
+            f"WHERE genre_id IN ({placeholders}) AND LOWER(alias) = LOWER(:alias)",
+            {"new_id": new_genre_id, "alias": alias},
         )
 
-        # Remove alias from source genre (normalized comparison)
-        alias_norm = create_safe_string(alias, True, True)
-        aliases = list(source_genre.genre_aliases) if source_genre.genre_aliases else []
-        aliases = [a for a in aliases if create_safe_string(a, True, True) != alias_norm]
-        await self.mass.music.database.update(
-            self.db_table,
-            {"item_id": db_genre_id},
-            {"genre_aliases": serialize_to_json(list(aliases))},
-        )
+        # Strip the alias from every genre that claimed it (other than any genre whose
+        # own primary name happens to equal the alias — those would fail the self-alias
+        # invariant; in practice they shouldn't appear because primary-name match takes
+        # priority in the scanner, so an alias never co-exists with a same-named genre).
+        for owning_id in owning_ids:
+            owning = await self.get_library_item(owning_id)
+            if create_safe_string(owning.name, True, True) == alias_norm:
+                continue
+            owning_aliases = list(owning.genre_aliases) if owning.genre_aliases else []
+            filtered = [
+                a for a in owning_aliases if create_safe_string(a, True, True) != alias_norm
+            ]
+            if len(filtered) != len(owning_aliases):
+                await self.mass.music.database.update(
+                    self.db_table,
+                    {"item_id": owning_id},
+                    {"genre_aliases": serialize_to_json(filtered)},
+                )
+
+        # Rebuild derived album/artist rows so they follow the moved track mappings.
+        await self._propagate_genre_mappings_to_parents()
 
         return await self.get_library_item(new_genre_id)
+
+    async def _find_genre_ids_for_alias(self, alias_norm: str) -> list[int]:
+        """
+        Return every non-excluded genre id that claims the alias in its aliases list.
+
+        :param alias_norm: Normalised alias (via create_safe_string).
+        """
+        rows = await self.mass.music.database.get_rows_from_query(
+            f"SELECT item_id, genre_aliases FROM {DB_TABLE_GENRES} WHERE is_excluded = 0",
+            limit=0,
+        )
+        found: list[int] = []
+        for row in rows:
+            aliases = json.loads(row["genre_aliases"]) if row["genre_aliases"] else []
+            if any(create_safe_string(a.strip(), True, True) == alias_norm for a in aliases):
+                found.append(int(row["item_id"]))
+        return found
 
     async def merge_genres(self, genre_ids: list[str | int], target_genre_id: str | int) -> Genre:
         """
@@ -1488,6 +1532,9 @@ class GenreController(MediaControllerBase[Genre]):
         # not appear in the global exclusion list.
         for source_id in source_ids:
             await self.remove_item_from_library(source_id, exclude_globally=False)
+
+        # Rebuild derived album/artist rows so they reflect the merged track mappings.
+        await self._propagate_genre_mappings_to_parents()
 
         updated = await self.get_library_item(target_id)
         self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, updated.uri, updated)

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -1222,8 +1222,7 @@ class GenreController(MediaControllerBase[Genre]):
             "WHERE genre_id = :genre_id AND LOWER(alias) = LOWER(:alias)",
             {"genre_id": db_id, "alias": alias},
         )
-        # Rebuild propagated album/artist rows: the track rows we just removed may have
-        # fed them, so a derived row on this genre would otherwise linger past the alias.
+        # Derived album/artist rows can be left orphaned by the deleted track rows.
         await self._propagate_genre_mappings_to_parents()
         updated = await self.get_library_item(db_id)
         self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, updated.uri, updated)
@@ -1386,13 +1385,10 @@ class GenreController(MediaControllerBase[Genre]):
         """
         Promote an alias to become a standalone genre.
 
-        An alias can be claimed by multiple genres (n:n). Promotion moves every
-        direct mapping that was created via this alias to the new genre and strips
-        the alias from each genre that owned it, regardless of which one the user
-        invoked the action from. Derived album/artist mappings are rebuilt against
-        the moved track mappings so propagated genres follow.
+        Every genre that claimed the alias loses it, and all media mapped via
+        the alias is moved to the new genre.
 
-        :param genre_id: Database ID of the source genre the user invoked this on.
+        :param genre_id: Database ID of the source genre.
         :param alias: The alias string to promote.
         :return: The newly created Genre.
         """
@@ -1407,14 +1403,10 @@ class GenreController(MediaControllerBase[Genre]):
             )
             raise ValueError(msg)
 
-        # Find every non-excluded genre that owns this alias (n:n). LOWER() catches the
-        # common case; create_safe_string() catches normalisation gaps like
-        # "Synth-Pop" vs "synthpop".
         owning_ids = await self._find_genre_ids_for_alias(alias_norm)
         if db_genre_id not in owning_ids:
             owning_ids.append(db_genre_id)
 
-        # Create new genre with the alias as its name
         new_genre = Genre(
             item_id="0",
             provider="library",
@@ -1427,9 +1419,8 @@ class GenreController(MediaControllerBase[Genre]):
         created_genre = await self.add_item_to_library(new_genre)
         new_genre_id = int(created_genre.item_id)
 
-        # Move every direct mapping created via this alias to the new genre. UPDATE OR
-        # REPLACE resolves the rare case where the new genre already has a mapping for
-        # the same (media_id, media_type) by keeping the moved row.
+        # UPDATE OR REPLACE drops any pre-existing mapping on the new genre for
+        # the same (media_id, media_type) so the moved row wins.
         placeholders = ", ".join(str(g) for g in owning_ids)
         await self.mass.music.database.execute(
             f"UPDATE OR REPLACE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
@@ -1438,12 +1429,10 @@ class GenreController(MediaControllerBase[Genre]):
             {"new_id": new_genre_id, "alias": alias},
         )
 
-        # Strip the alias from every genre that claimed it (other than any genre whose
-        # own primary name happens to equal the alias — those would fail the self-alias
-        # invariant; in practice they shouldn't appear because primary-name match takes
-        # priority in the scanner, so an alias never co-exists with a same-named genre).
         for owning_id in owning_ids:
             owning = await self.get_library_item(owning_id)
+            # Defensive: a genre whose primary name equals the alias would hit
+            # the self-alias guard in remove_alias; skip rather than raise.
             if create_safe_string(owning.name, True, True) == alias_norm:
                 continue
             owning_aliases = list(owning.genre_aliases) if owning.genre_aliases else []
@@ -1457,16 +1446,17 @@ class GenreController(MediaControllerBase[Genre]):
                     {"genre_aliases": serialize_to_json(filtered)},
                 )
 
-        # Rebuild derived album/artist rows so they follow the moved track mappings.
+        # Derived album/artist rows still point at the old source genres; rebuild
+        # them from the moved track mappings.
         await self._propagate_genre_mappings_to_parents()
 
         return await self.get_library_item(new_genre_id)
 
     async def _find_genre_ids_for_alias(self, alias_norm: str) -> list[int]:
         """
-        Return every non-excluded genre id that claims the alias in its aliases list.
+        Return ids of non-excluded genres that claim the given alias.
 
-        :param alias_norm: Normalised alias (via create_safe_string).
+        :param alias_norm: Alias normalised via ``create_safe_string``.
         """
         rows = await self.mass.music.database.get_rows_from_query(
             f"SELECT item_id, genre_aliases FROM {DB_TABLE_GENRES} WHERE is_excluded = 0",
@@ -1533,7 +1523,7 @@ class GenreController(MediaControllerBase[Genre]):
         for source_id in source_ids:
             await self.remove_item_from_library(source_id, exclude_globally=False)
 
-        # Rebuild derived album/artist rows so they reflect the merged track mappings.
+        # Rebuild derived album/artist rows against the merged track mappings.
         await self._propagate_genre_mappings_to_parents()
 
         updated = await self.get_library_item(target_id)

--- a/tests/core/test_genres.py
+++ b/tests/core/test_genres.py
@@ -879,10 +879,12 @@ class TestPromoteAlias:
     async def test_promote_alias_shared_across_genres(
         self, mass: MusicAssistant, genre_ctrl: GenreController
     ) -> None:
-        """Promotion is global across genres that share the alias.
+        """
+        Promotion handles aliases shared across multiple genres.
 
-        When an alias is owned by multiple genres, promotion moves mappings and
-        strips the alias from every genre that claimed it, not just the one passed.
+        Every genre that claimed the alias loses it and all mappings made via
+        the alias are moved to the new genre, regardless of which source the
+        caller invoked the promotion from.
         """
         folk = await genre_ctrl.add_item_to_library(_make_genre("PromFolk"))
         pop = await genre_ctrl.add_item_to_library(_make_genre("PromPop"))
@@ -917,21 +919,22 @@ class TestPromoteAlias:
     async def test_promote_rebuilds_derived_album_mappings(
         self, mass: MusicAssistant, genre_ctrl: GenreController
     ) -> None:
-        """Derived album mappings follow the alias to the new genre.
+        """
+        Derived album rows are cleared from the source genre after promotion.
 
-        Reproduces the 'albums remained Hip Hop' case: a propagation-derived
-        album row (alias=NULL, is_derived=1) lingers on the source genre after
-        promotion unless we re-run propagation.
+        Without this, propagation-derived (alias=NULL, is_derived=1) rows would
+        still link the album to the source genre even though the underlying
+        tracks have moved to the new one.
         """
         parent = await genre_ctrl.add_item_to_library(_make_genre("PromHipHop"))
         await genre_ctrl.add_alias(parent.item_id, "PromRap")
         track = await _add_test_track(mass, "Rap Track")
         album = await _add_test_album(mass, "Rap Album")
-        # Track gets a direct mapping via the alias.
         await genre_ctrl.add_media_mapping(
             parent.item_id, MediaType.TRACK, track.item_id, "PromRap"
         )
-        # Simulate a propagation-derived album row (alias=NULL, is_derived=1).
+        # Seed a propagation-derived album row (alias=NULL, is_derived=1) as if
+        # it had been written by _propagate_genre_mappings_to_parents.
         await mass.music.database.execute(
             f"INSERT INTO {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
             "(genre_id, media_id, media_type, alias, is_derived) "
@@ -941,9 +944,6 @@ class TestPromoteAlias:
 
         await genre_ctrl.promote_alias_to_genre(parent.item_id, "PromRap")
 
-        # The stale derived row on the source genre must be gone — propagation
-        # wipes is_derived=1 rows. (Without an active filesystem provider with
-        # propagate_track_genres enabled, nothing re-derives, which is correct.)
         rows = await mass.music.database.get_rows_from_query(
             f"SELECT genre_id FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
             "WHERE media_id = :mid AND media_type = 'album'",

--- a/tests/core/test_genres.py
+++ b/tests/core/test_genres.py
@@ -876,6 +876,82 @@ class TestPromoteAlias:
         assert "PromAlias" not in updated_parent.genre_aliases
         assert "PromComplete" in updated_parent.genre_aliases
 
+    async def test_promote_alias_shared_across_genres(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """Promotion is global across genres that share the alias.
+
+        When an alias is owned by multiple genres, promotion moves mappings and
+        strips the alias from every genre that claimed it, not just the one passed.
+        """
+        folk = await genre_ctrl.add_item_to_library(_make_genre("PromFolk"))
+        pop = await genre_ctrl.add_item_to_library(_make_genre("PromPop"))
+        await genre_ctrl.add_alias(folk.item_id, "PromManele")
+        await genre_ctrl.add_alias(pop.item_id, "PromManele")
+        track = await _add_test_track(mass, "Manele Track")
+        # Track is mapped to both genres via the same alias (n:n).
+        await genre_ctrl.add_media_mapping(
+            folk.item_id, MediaType.TRACK, track.item_id, "PromManele"
+        )
+        await genre_ctrl.add_media_mapping(
+            pop.item_id, MediaType.TRACK, track.item_id, "PromManele"
+        )
+
+        # Invoke from one of the owning genres; both should be cleared.
+        new_genre = await genre_ctrl.promote_alias_to_genre(folk.item_id, "PromManele")
+
+        rows = await mass.music.database.get_rows_from_query(
+            f"SELECT genre_id FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "WHERE media_id = :mid AND media_type = 'track'",
+            {"mid": int(track.item_id)},
+            limit=0,
+        )
+        genre_ids = {int(r["genre_id"]) for r in rows}
+        assert genre_ids == {int(new_genre.item_id)}
+
+        updated_folk = await genre_ctrl.get_library_item(int(folk.item_id))
+        updated_pop = await genre_ctrl.get_library_item(int(pop.item_id))
+        assert "PromManele" not in (updated_folk.genre_aliases or [])
+        assert "PromManele" not in (updated_pop.genre_aliases or [])
+
+    async def test_promote_rebuilds_derived_album_mappings(
+        self, mass: MusicAssistant, genre_ctrl: GenreController
+    ) -> None:
+        """Derived album mappings follow the alias to the new genre.
+
+        Reproduces the 'albums remained Hip Hop' case: a propagation-derived
+        album row (alias=NULL, is_derived=1) lingers on the source genre after
+        promotion unless we re-run propagation.
+        """
+        parent = await genre_ctrl.add_item_to_library(_make_genre("PromHipHop"))
+        await genre_ctrl.add_alias(parent.item_id, "PromRap")
+        track = await _add_test_track(mass, "Rap Track")
+        album = await _add_test_album(mass, "Rap Album")
+        # Track gets a direct mapping via the alias.
+        await genre_ctrl.add_media_mapping(
+            parent.item_id, MediaType.TRACK, track.item_id, "PromRap"
+        )
+        # Simulate a propagation-derived album row (alias=NULL, is_derived=1).
+        await mass.music.database.execute(
+            f"INSERT INTO {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "(genre_id, media_id, media_type, alias, is_derived) "
+            "VALUES (:gid, :mid, 'album', NULL, 1)",
+            {"gid": int(parent.item_id), "mid": int(album.item_id)},
+        )
+
+        await genre_ctrl.promote_alias_to_genre(parent.item_id, "PromRap")
+
+        # The stale derived row on the source genre must be gone — propagation
+        # wipes is_derived=1 rows. (Without an active filesystem provider with
+        # propagate_track_genres enabled, nothing re-derives, which is correct.)
+        rows = await mass.music.database.get_rows_from_query(
+            f"SELECT genre_id FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "WHERE media_id = :mid AND media_type = 'album'",
+            {"mid": int(album.item_id)},
+            limit=0,
+        )
+        assert all(int(r["genre_id"]) != int(parent.item_id) for r in rows)
+
 
 # ===================================================================
 # Group F2: merge_genres (7 tests)


### PR DESCRIPTION
When a user promoted an alias to its own genre in the UI, the result was inconsistent. Two symptoms (reported [here](https://github.com/orgs/music-assistant/discussions/5507#discussioncomment-16983417)):

Albums and artists kept the old genre. A user with files tagged "Rap" (an alias of "Hip Hop") promoted "Rap" to its own genre. Their tracks moved to "Rap" as expected, but their albums and most artists were still listed under "Hip Hop".
Tracks ended up split across genres. A user with files tagged "Manele", which Music Assistant had assigned as an alias of both "Folk" and "Pop", promoted "Manele". Tracks ended up tagged as both "Folk" and "Manele" instead of just "Manele".

I believe this happens because `promote_alias_to_genre` was doing too little:

It only touched the one source genre the user clicked from, so if the alias was shared by multiple genres (n:n is supported elsewhere in the system), the other genres kept claiming the alias and kept their mappings.

It only moved rows in the mapping table whose alias column matched the promoted string. Rows produced by track-to-parent propagation have alias = NULL, so albums/artists derived from those tracks were never re-pointed at the new genre.
`remove_alias` and `merge_genres` had the same blind spot: they changed the track-level mappings without regenerating the derived album/artist rows that depended on them.

So this PR adjusts `promote_alias_to_genre` to now find every genre that claims the alias, moves all matching mappings to the new genre in one statement (UPDATE OR REPLACE handles the rare uniqueness collision), strips the alias from each owner, and re-runs propagation so derived album/artist rows follow the moved tracks.

`remove_alias` and `merge_genres` now also re-run propagation for the same reason.


The original report mentioned that album-artists moved with the promotion while featured artists did not. From the code, both go through the same propagation path, so I couldn't pin down what makes them behave differently without seeing the user's data. The fix corrects the broader stale-mapping issue; if the problem persists, the next step is to inspect the actual rows in `genre_media_item_mapping` for one of each kind of artist.