### PR TITLE
Squeezelite: Honor per-player output_codec in multi-client sync URL

### DIFF
--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -279,33 +279,20 @@ class SqueezelitePlayer(Player):
         self.multi_client_stream = stream = MultiClientStream(
             audio_source=audio_source, audio_format=master_audio_format
         )
-        # Honor each sync client's configured output_codec; use the most
-        # conservative one so classic firmware that can't decode FLAC gets audio.
-        sync_codec = self.mass.config.get_raw_player_config_value(
-            self.player_id, CONF_OUTPUT_CODEC, "flac"
-        )
-        if sync_codec == "flac":
-            for slimplayer in self._get_sync_clients():
-                if slimplayer.player_id == self.player_id:
-                    continue
-                player_codec = self.mass.config.get_raw_player_config_value(
-                    slimplayer.player_id, CONF_OUTPUT_CODEC, "flac"
-                )
-                if player_codec != "flac":
-                    sync_codec = player_codec
-                    break
-        base_url = (
-            f"{self.mass.streams.base_url}/slimproto/multi?player_id={self.player_id}&fmt={sync_codec}"
-        )
+        base_url = f"{self.mass.streams.base_url}/slimproto/multi?player_id={self.player_id}"
 
         # Count how many clients will connect
         expected_clients = len(list(self._get_sync_clients()))
         stream.expected_clients = expected_clients
 
         # forward to downstream play_media commands
+        # Per-member output_codec: classic Squeezeboxes silently fail on fixed flac in sync (#5506).
         async with TaskManager(self.mass) as tg:
             for slimplayer in self._get_sync_clients():
-                url = f"{base_url}&child_player_id={slimplayer.player_id}"
+                member_codec = self.mass.config.get_raw_player_config_value(
+                    slimplayer.player_id, CONF_OUTPUT_CODEC, "flac"
+                )
+                url = f"{base_url}&fmt={member_codec}&child_player_id={slimplayer.player_id}"
                 tg.create_task(
                     self._handle_play_url_for_slimplayer(
                         slimplayer,

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -31,6 +31,7 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE_FORCED_2,
     CONF_ENTRY_SYNC_ADJUST,
+    CONF_OUTPUT_CODEC,
     INTERNAL_PCM_FORMAT,
     VERBOSE_LOG_LEVEL,
     create_sample_rates_config_entry,
@@ -278,8 +279,23 @@ class SqueezelitePlayer(Player):
         self.multi_client_stream = stream = MultiClientStream(
             audio_source=audio_source, audio_format=master_audio_format
         )
+        # Honor each sync client's configured output_codec; use the most
+        # conservative one so classic firmware that can't decode FLAC gets audio.
+        sync_codec = self.mass.config.get_raw_player_config_value(
+            self.player_id, CONF_OUTPUT_CODEC, "flac"
+        )
+        if sync_codec == "flac":
+            for slimplayer in self._get_sync_clients():
+                if slimplayer.player_id == self.player_id:
+                    continue
+                player_codec = self.mass.config.get_raw_player_config_value(
+                    slimplayer.player_id, CONF_OUTPUT_CODEC, "flac"
+                )
+                if player_codec != "flac":
+                    sync_codec = player_codec
+                    break
         base_url = (
-            f"{self.mass.streams.base_url}/slimproto/multi?player_id={self.player_id}&fmt=flac"
+            f"{self.mass.streams.base_url}/slimproto/multi?player_id={self.player_id}&fmt={sync_codec}"
         )
 
         # Count how many clients will connect


### PR DESCRIPTION
## Summary

The multi-client sync URL in `SqueezelitePlayer.play_media` hardcoded `fmt=flac`, ignoring each player's configured `output_codec`. Classic Squeezebox firmware (Boom, Radio, Touch) can't decode FLAC in sync mode, so those devices played back silently when grouped.

This change reads the leader's `output_codec` and, when it is `flac`, walks the sync clients and downgrades to a non-FLAC codec if any member needs one — so classic hardware in a sync group gets audio it can actually decode.

Fixes [#5506](https://github.com/music-assistant/support/issues/5506)

## Test plan

- [ ] Group a classic Squeezebox (Boom / Radio / Touch) with a modern Squeezelite player and verify audio plays on both
- [ ] Group two FLAC-capable players and verify the URL still uses `fmt=flac`
- [ ] Single-player playback unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqzeCqV4Z16gdbmSrD71Bf)_