### PR TITLE
Sonos S1: Implement select_source for line-in support

### DIFF
--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -285,9 +285,9 @@ class SonosPlayer(Player):
                     self.soco.switch_to_line_in()
 
             await asyncio.to_thread(_switch_to_linein)
+            self.mass.call_later(2, self.poll)
         else:
             await self.stop()
-        self.mass.call_later(2, self.poll)
 
     @soco_error()
     async def set_members(

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -274,6 +274,21 @@ class SonosPlayer(Player):
         await asyncio.to_thread(add_to_queue)
         self.mass.call_later(2, self.poll)
 
+    async def select_source(self, source: str) -> None:
+        """Handle SELECT SOURCE command on the player."""
+        if source in LINEIN_SOURCE_IDS:
+
+            def _switch_to_linein() -> None:
+                if source == "TV":
+                    self.soco.switch_to_tv()
+                else:
+                    self.soco.switch_to_line_in()
+
+            await asyncio.to_thread(_switch_to_linein)
+        else:
+            await self.stop()
+        self.mass.call_later(2, self.poll)
+
     @soco_error()
     async def set_members(
         self,

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -34,7 +34,9 @@ from .constants import (
     POSITION_SECONDS,
     RESUB_COOLDOWN_SECONDS,
     SONOS_STATE_TRANSITIONING,
+    SOURCE_LINEIN,
     SOURCE_MAPPING,
+    SOURCE_TV,
     SUBSCRIPTION_SERVICES,
     SUBSCRIPTION_TIMEOUT,
 )
@@ -279,9 +281,9 @@ class SonosPlayer(Player):
         if source in LINEIN_SOURCE_IDS:
 
             def _switch_to_linein() -> None:
-                if source == "TV":
+                if source == SOURCE_TV:
                     self.soco.switch_to_tv()
-                else:
+                elif source == SOURCE_LINEIN:
                     self.soco.switch_to_line_in()
 
             await asyncio.to_thread(_switch_to_linein)


### PR DESCRIPTION
## Summary

`PlayerFeature.SELECT_SOURCE` was advertised in `PLAYER_FEATURES` for the Sonos S1 provider, but no `select_source` method existed on `SonosPlayer`. Selecting Line-in (or TV) on a Play:5 / Connect / Playbar produced a hard error.

This adds the missing method: when a line-in source ID is selected, switch the SoCo speaker to line-in (or TV for the Playbar/Beam family); for any other source, stop playback. A short poll is scheduled to refresh state.

Fixes [#5483](https://github.com/music-assistant/support/issues/5483)

## Test plan

- [ ] Select "Line-in" on a Play:5 / Connect and confirm playback switches to the analog input
- [ ] Select "TV" on a Playbar / Beam and confirm TV audio plays
- [ ] Switch back to a regular source and confirm playback stops cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqzeCqV4Z16gdbmSrD71Bf)_