### PR TITLE
Streams: Handle empty supported_sample_rates in get_output_format

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1098,7 +1098,7 @@ class StreamsAudio:
         )
         supported_sample_rates = tuple(int(x[0]) for x in supported_rates_conf)
 
-        if content_sample_rate in supported_sample_rates:
+        if not supported_sample_rates or content_sample_rate in supported_sample_rates:
             output_sample_rate = content_sample_rate
         else:
             output_sample_rate = max(supported_sample_rates)


### PR DESCRIPTION
## Summary

`get_output_format` called `max(supported_sample_rates)` without a default. ESPHome devices (and any HA-bridged player that reports no supported audio formats) end up with an empty tuple, which raises `ValueError: max() arg is an empty sequence` and breaks playback.

When the tuple is empty, fall back to the content's own sample rate. This mirrors the prior fix in PR #3842, which handled the equivalent `supported_bit_depths` case but missed this adjacent call.

Fixes [#5451](https://github.com/music-assistant/support/issues/5451)

## Test plan

- [ ] Play to an ESPHome / HA player that reports no supported sample rates and confirm no crash
- [ ] Play to a player with explicit `supported_sample_rates` and confirm the chosen rate is unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqzeCqV4Z16gdbmSrD71Bf)_