### PR TITLE
Fix HEOS showing incorrect Now Playing

### DIFF
--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -11,6 +11,7 @@ from music_assistant_models.enums import MediaType, PlaybackState, PlayerFeature
 from music_assistant_models.errors import PlayerCommandFailed, SetupFailedError
 from music_assistant_models.player import DeviceInfo, PlayerSource
 from pyheos import Heos, HeosError, const
+from pyheos import PlayState as HeosPlayState
 
 from music_assistant.constants import (
     VERBOSE_LOG_LEVEL,
@@ -200,6 +201,13 @@ class HeosPlayer(Player):
     def _update_player_current_media(self) -> None:
         """Update current media properties."""
         now_playing = self._device.now_playing_media
+        if self._device.state == HeosPlayState.STOP:
+            self.logger.debug(
+                "[%s] Ignoring now playing change while stopped: %s",
+                self._device.name,
+                now_playing,
+            )
+            return
 
         # Only update if we're not playing from our queue
         # HEOS does not make a distinction on source ID when playing from a DLNA server, USB stick,

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -150,6 +150,8 @@ class HeosPlayer(Player):
         match event:
             case const.EVENT_PLAYER_STATE_CHANGED:
                 self._update_player_state()
+                self._update_player_current_media()
+
                 if (
                     self._ma_controls_playback
                     and self._attr_playback_state == PlaybackState.PLAYING


### PR DESCRIPTION
HEOS sends commands when it changes playing something. It looks like it also sends that command when the player state is changed (stopped, playing etc). 
When something is playing externally and we start playback from MA, there is an out of order sequence happening, causing the HEOS provider to think the player is playing something external (very limited check possible due to limited HEOS data available). This then marks the player as externally controller and we lose the internal MA metadata to be shown.

This PR makes sure we are not processing any of those commands when the player is not actually playing. We also update the now playing info when we change state, as the order of the events is not 100% guaranteed to be correct, causing the player is first signal it's now playing content has changed, and then signal it's playing.

Fixes https://github.com/music-assistant/support/issues/5311