### PR TITLE
Fix issues with M4B audiobooks

### DIFF
--- a/music_assistant/helpers/tags.py
+++ b/music_assistant/helpers/tags.py
@@ -555,8 +555,8 @@ class AudioTags:
                 chapters.append(
                     AudioTagsChapter(
                         chapter_id=chapter_data["id"],
-                        position_start=chapter_data["start_time"],
-                        position_end=chapter_data["end_time"],
+                        position_start=float(chapter_data["start_time"]),
+                        position_end=float(chapter_data["end_time"]),
                         title=chapter_data.get("tags", {}).get("title"),
                     )
                 )

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -1257,14 +1257,17 @@ class LocalFileSystemProvider(MusicProvider):
         Audiobooks can be single files with embedded chapters or multiple files per folder.
         Only the first file (by track number or alphabetically) is processed as the audiobook.
         """
-        # Skip files that aren't the first chapter
+        # Skip files that aren't the first chapter.
+        # A file carrying its own embedded chapter markers is a standalone audiobook,
+        # so it should never be treated as a chapter file of another book.
         track_tag = tags.tags.get("track")
         if track_tag:
             track_num = try_parse_int(str(track_tag).split("/")[0], None)
-            if track_num and track_num > 1:
+            if track_num and track_num > 1 and not tags.chapters:
                 raise IsChapterFile
-        else:
-            # No track tag - only process the first file alphabetically
+        elif not tags.chapters:
+            # No track tag and no embedded chapters -
+            # assume part of a multi-file audiobook, only process the first file alphabetically
             items = await self._scandir(file_item.parent_path)
             # Sort by filename for alphabetical ordering
             items.sort(key=lambda x: x.filename.lower())


### PR DESCRIPTION
Two related issues affected single-file audiobooks (typically .m4b) in the local filesystem provider:

1. Embedded chapters were duplicated on every re-sync. ffprobe emits chapter start_time/end_time as JSON strings, which flowed unconverted into `MediaItemChapter.start/end`. After persistence and mashumaro deserialisation those fields came back as floats, so the dataclass __eq__ used by merge_lists in `MediaItemMetadata.update` considered the old and new chapter lists unequal and concatenated them.

2. Two standalone m4b files in the same folder caused the second one (alphabetically) to be dropped, because `_parse_audiobook` assumed any audiobook file without a track tag was part of a multi-file book and only kept the first file. A file carrying its own embedded chapter markers is by definition a complete audiobook, so skip the multi-file fallback in that case (and likewise don't treat a track>1 file with embedded chapters as a chapter file).