### PR TITLE
Fix HEOS queue cleanup slowing down other commands

### DIFF
--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -165,7 +165,6 @@ class HeosPlayer(Player):
             case const.EVENT_PLAYER_NOW_PLAYING_CHANGED:
                 self._update_player_current_media()
                 self._update_player_playing_progress()
-                self._schedule_queue_cleanup()
 
             case const.EVENT_PLAYER_QUEUE_CHANGED:
                 self._schedule_queue_cleanup()

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -358,6 +358,7 @@ class HeosPlayer(Player):
                 return
             try:
                 self.logger.debug("[%s] Queue cleanup started", self._device.name)
+                queue_items = await self._heos_queue.player_get_queue(self._device.player_id)
                 now_playing = await self._heos_queue.get_now_playing_media(self._device.player_id)
                 current_queue_id = now_playing.queue_id
                 if current_queue_id is None:
@@ -368,7 +369,6 @@ class HeosPlayer(Player):
                     self._schedule_queue_cleanup()
                     return
 
-                queue_items = await self._heos_queue.player_get_queue(self._device.player_id)
                 queue_ids_to_remove = [
                     item.queue_id for item in queue_items if item.queue_id != current_queue_id
                 ]

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -44,6 +44,7 @@ class HeosPlayer(Player):
     """HeosPlayer in Music Assistant."""
 
     _heos: Heos
+    _heos_queue: Heos
     _device: PyHeosPlayer
 
     @property
@@ -63,8 +64,12 @@ class HeosPlayer(Player):
         if self._device.heos is None:
             raise SetupFailedError("HEOS device has no controller assigned")
 
+        if provider._heos_queue is None:
+            raise SetupFailedError("HEOS queue controller is not set up")
+
         # Keep internal reference so we don't need to check None on each call
         self._heos = self._device.heos
+        self._heos_queue = provider._heos_queue
 
         self._attr_type = PlayerType.PLAYER
         self._attr_supported_features = PLAYER_FEATURES
@@ -365,7 +370,7 @@ class HeosPlayer(Player):
                 return
             try:
                 self.logger.debug("[%s] Queue cleanup started", self._device.name)
-                queue_items = await self._device.get_queue()
+                queue_items = await self._heos_queue.player_get_queue(self._device.player_id)
                 current_queue_id = self._device.now_playing_media.queue_id
                 if current_queue_id is None:
                     self.logger.debug(
@@ -385,7 +390,9 @@ class HeosPlayer(Player):
                     current_queue_id,
                 )
                 if queue_ids_to_remove:
-                    await self._device.remove_from_queue(queue_ids_to_remove)
+                    await self._heos_queue.player_remove_from_queue(
+                        self._device.player_id, queue_ids_to_remove
+                    )
                 self._queue_cleanup_pending = False
 
             except HeosError as err:

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -59,7 +59,6 @@ class HeosPlayer(Player):
         self._device: PyHeosPlayer = device
         self._ma_controls_playback = False
         self._queue_cleanup_lock = asyncio.Lock()
-        self._queue_cleanup_pending = False
 
         if self._device.heos is None:
             raise SetupFailedError("HEOS device has no controller assigned")
@@ -160,21 +159,16 @@ class HeosPlayer(Player):
                 if (
                     self._ma_controls_playback
                     and self._attr_playback_state == PlaybackState.PLAYING
-                    and self._queue_cleanup_pending
                 ):
-                    self._debounce_queue_cleanup()
+                    self._schedule_queue_cleanup()
 
             case const.EVENT_PLAYER_NOW_PLAYING_CHANGED:
                 self._update_player_current_media()
                 self._update_player_playing_progress()
+                self._schedule_queue_cleanup()
 
             case const.EVENT_PLAYER_QUEUE_CHANGED:
-                self._queue_cleanup_pending = self._ma_controls_playback
-                if (
-                    self._ma_controls_playback
-                    and self._attr_playback_state == PlaybackState.PLAYING
-                ):
-                    self._debounce_queue_cleanup()
+                self._schedule_queue_cleanup()
 
             case const.EVENT_PLAYER_NOW_PLAYING_PROGRESS:
                 self._update_player_playing_progress()
@@ -224,7 +218,6 @@ class HeosPlayer(Player):
             self._attr_active_source != self.player_id
         ):
             self._ma_controls_playback = False
-            self._queue_cleanup_pending = False
             self.logger.debug(
                 "[%s] Now playing changed externally: %s", self._device.name, now_playing
             )
@@ -324,7 +317,6 @@ class HeosPlayer(Player):
             await self._device.play_url(url)
         except HeosError as err:
             self._ma_controls_playback = False
-            self._queue_cleanup_pending = False
             raise PlayerCommandFailed("Failed to start playback.") from err
 
         self._attr_current_media = media
@@ -332,10 +324,11 @@ class HeosPlayer(Player):
 
         self.update_state()
 
-    def _debounce_queue_cleanup(self) -> None:
+    def _schedule_queue_cleanup(self) -> None:
         """Debounce queue cleanup so rapid queue changes only trigger one follow-up."""
         if not self._ma_controls_playback:
             return
+
         self.mass.call_later(
             1,
             self._start_queue_cleanup_task,
@@ -344,11 +337,7 @@ class HeosPlayer(Player):
 
     def _start_queue_cleanup_task(self) -> None:
         """Start the queue cleanup task if not already running."""
-        if (
-            not self._ma_controls_playback
-            or not self._queue_cleanup_pending
-            or self._queue_cleanup_lock.locked()
-        ):
+        if not self._ma_controls_playback or self._queue_cleanup_lock.locked():
             return
 
         self.mass.create_task(
@@ -359,7 +348,6 @@ class HeosPlayer(Player):
     async def _cleanup_heos_queue(self) -> None:
         async with self._queue_cleanup_lock:
             if not self._ma_controls_playback:
-                self._queue_cleanup_pending = False
                 return
             if self._attr_playback_state != PlaybackState.PLAYING:
                 self.logger.debug(
@@ -370,16 +358,17 @@ class HeosPlayer(Player):
                 return
             try:
                 self.logger.debug("[%s] Queue cleanup started", self._device.name)
-                queue_items = await self._heos_queue.player_get_queue(self._device.player_id)
-                current_queue_id = self._device.now_playing_media.queue_id
+                now_playing = await self._heos_queue.get_now_playing_media(self._device.player_id)
+                current_queue_id = now_playing.queue_id
                 if current_queue_id is None:
                     self.logger.debug(
                         "[%s] Queue cleanup postponed (no current qid yet)",
                         self._device.name,
                     )
-                    self._debounce_queue_cleanup()
+                    self._schedule_queue_cleanup()
                     return
 
+                queue_items = await self._heos_queue.player_get_queue(self._device.player_id)
                 queue_ids_to_remove = [
                     item.queue_id for item in queue_items if item.queue_id != current_queue_id
                 ]
@@ -393,7 +382,6 @@ class HeosPlayer(Player):
                     await self._heos_queue.player_remove_from_queue(
                         self._device.player_id, queue_ids_to_remove
                     )
-                self._queue_cleanup_pending = False
 
             except HeosError as err:
                 self.logger.warning(
@@ -433,7 +421,6 @@ class HeosPlayer(Player):
         """Handle SELECT SOURCE command on the player."""
         self.logger.debug("[%s] Selecting source %s", self._device.name, source)
         self._ma_controls_playback = False
-        self._queue_cleanup_pending = False
         await self._device.play_input_source(source)
 
     async def get_config_entries(

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -156,12 +156,7 @@ class HeosPlayer(Player):
             case const.EVENT_PLAYER_STATE_CHANGED:
                 self._update_player_state()
                 self._update_player_current_media()
-
-                if (
-                    self._ma_controls_playback
-                    and self._attr_playback_state == PlaybackState.PLAYING
-                ):
-                    self._schedule_queue_cleanup()
+                self._schedule_queue_cleanup()
 
             case const.EVENT_PLAYER_NOW_PLAYING_CHANGED:
                 self._update_player_current_media()
@@ -331,7 +326,11 @@ class HeosPlayer(Player):
 
     def _schedule_queue_cleanup(self) -> None:
         """Debounce queue cleanup so rapid queue changes only trigger one follow-up."""
-        if not self._ma_controls_playback or not self._queue_cleanup_pending:
+        if (
+            not self._ma_controls_playback
+            or not self._queue_cleanup_pending
+            or self._attr_playback_state != PlaybackState.PLAYING
+        ):
             return
 
         self.mass.call_later(

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -59,6 +59,7 @@ class HeosPlayer(Player):
         self._device: PyHeosPlayer = device
         self._ma_controls_playback = False
         self._queue_cleanup_lock = asyncio.Lock()
+        self._queue_cleanup_pending = False
 
         if self._device.heos is None:
             raise SetupFailedError("HEOS device has no controller assigned")
@@ -165,6 +166,7 @@ class HeosPlayer(Player):
             case const.EVENT_PLAYER_NOW_PLAYING_CHANGED:
                 self._update_player_current_media()
                 self._update_player_playing_progress()
+                self._schedule_queue_cleanup()
 
             case const.EVENT_PLAYER_QUEUE_CHANGED:
                 self._schedule_queue_cleanup()
@@ -179,6 +181,7 @@ class HeosPlayer(Player):
                 self.logger.error(
                     "[%s] Playback error: %s", self._device.name, self._device.playback_error
                 )
+                self._queue_cleanup_pending = False
                 self.set_dynamic_attributes()
 
             case _:
@@ -217,6 +220,7 @@ class HeosPlayer(Player):
             self._attr_active_source != self.player_id
         ):
             self._ma_controls_playback = False
+            self._queue_cleanup_pending = False
             self.logger.debug(
                 "[%s] Now playing changed externally: %s", self._device.name, now_playing
             )
@@ -316,16 +320,18 @@ class HeosPlayer(Player):
             await self._device.play_url(url)
         except HeosError as err:
             self._ma_controls_playback = False
+            self._queue_cleanup_pending = False
             raise PlayerCommandFailed("Failed to start playback.") from err
 
         self._attr_current_media = media
         self._attr_active_source = self.player_id
+        self._queue_cleanup_pending = True
 
         self.update_state()
 
     def _schedule_queue_cleanup(self) -> None:
         """Debounce queue cleanup so rapid queue changes only trigger one follow-up."""
-        if not self._ma_controls_playback:
+        if not self._ma_controls_playback or not self._queue_cleanup_pending:
             return
 
         self.mass.call_later(
@@ -336,7 +342,11 @@ class HeosPlayer(Player):
 
     def _start_queue_cleanup_task(self) -> None:
         """Start the queue cleanup task if not already running."""
-        if not self._ma_controls_playback or self._queue_cleanup_lock.locked():
+        if (
+            not self._ma_controls_playback
+            or not self._queue_cleanup_pending
+            or self._queue_cleanup_lock.locked()
+        ):
             return
 
         self.mass.create_task(
@@ -346,7 +356,7 @@ class HeosPlayer(Player):
 
     async def _cleanup_heos_queue(self) -> None:
         async with self._queue_cleanup_lock:
-            if not self._ma_controls_playback:
+            if not self._ma_controls_playback or not self._queue_cleanup_pending:
                 return
             if self._attr_playback_state != PlaybackState.PLAYING:
                 self.logger.debug(
@@ -381,6 +391,7 @@ class HeosPlayer(Player):
                     await self._heos_queue.player_remove_from_queue(
                         self._device.player_id, queue_ids_to_remove
                     )
+                self._queue_cleanup_pending = False
 
             except HeosError as err:
                 self.logger.warning(
@@ -420,6 +431,7 @@ class HeosPlayer(Player):
         """Handle SELECT SOURCE command on the player."""
         self.logger.debug("[%s] Selecting source %s", self._device.name, source)
         self._ma_controls_playback = False
+        self._queue_cleanup_pending = False
         await self._device.play_input_source(source)
 
     async def get_config_entries(

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -355,7 +355,10 @@ class HeosPlayer(Player):
 
     async def _cleanup_heos_queue(self) -> None:
         async with self._queue_cleanup_lock:
-            if not self._ma_controls_playback or not self._queue_cleanup_pending:
+            if not self._ma_controls_playback:
+                self._queue_cleanup_pending = False
+                return
+            if not self._queue_cleanup_pending:
                 return
             if self._attr_playback_state != PlaybackState.PLAYING:
                 self.logger.debug(

--- a/music_assistant/providers/heos/provider.py
+++ b/music_assistant/providers/heos/provider.py
@@ -49,12 +49,19 @@ class HeosPlayerProvider(PlayerProvider):
         if ip_address := self.config.get_value(CONF_IP_ADDRESS):
             # Manual IP path
             ip_address = cast("str", ip_address)
-            await self._setup_controller(ip_address)
+            try:
+                await self._setup_controllers(ip_address)
+            except SetupFailedError:
+                self.logger.error(
+                    "Failed to set up HEOS controller at configured IP %s", ip_address
+                )
+                await self._disconnect_controllers()
+                raise
 
             # Explicitly discover players now
             await self.discover_players()
 
-    async def _setup_controller(self, controller_ip: str, connect_preferred: bool = False) -> None:
+    async def _setup_controllers(self, controller_ip: str, connect_preferred: bool = False) -> None:
         """Set up the HEOS controller."""
         self.logger.debug("Attempting HEOS controller setup on IP %s", controller_ip)
 
@@ -82,7 +89,7 @@ class HeosPlayerProvider(PlayerProvider):
                     )
                     await self._heos.disconnect()
                     # Set up controller with preferred host instead
-                    return await self._setup_controller(preferred_ips[0], connect_preferred=False)
+                    return await self._setup_controllers(preferred_ips[0], connect_preferred=False)
 
                 # Just log a warning, it still works but might be less reliable
                 self.logger.warning("Configured IP %s is not a preferred HEOS host", controller_ip)
@@ -199,17 +206,25 @@ class HeosPlayerProvider(PlayerProvider):
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
-        if self._heos:
-            self._heos.dispatcher.disconnect_all()  # Remove all event connections
-            await self._heos.disconnect()
-
-        if self._heos_queue:
-            self._heos_queue.dispatcher.disconnect_all()  # Remove all event connections
-            await self._heos_queue.disconnect()
+        await self._disconnect_controllers()
 
         for player in self.players:
             self.logger.debug("Unloading player %s", player.name)
             await self.mass.players.unregister(player.player_id)
+
+    async def _disconnect_controllers(self) -> None:
+        """Disconnect HEOS controller connections."""
+        if self._heos:
+            self._heos.dispatcher.disconnect_all()  # Remove all event connections
+            with suppress(Exception):
+                await self._heos.disconnect()
+            self._heos = None
+
+        if self._heos_queue:
+            self._heos_queue.dispatcher.disconnect_all()  # Remove all event connections
+            with suppress(Exception):
+                await self._heos_queue.disconnect()
+            self._heos_queue = None
 
     async def discover_players(self) -> None:
         """Discover players for this provider."""
@@ -268,15 +283,12 @@ class HeosPlayerProvider(PlayerProvider):
 
         self._controller_discovery_running = True
         try:
-            await self._setup_controller(device_ip, True)
+            await self._setup_controllers(device_ip, True)
         except SetupFailedError:
             self.logger.error(
                 "Failed to set up HEOS controller at %s discovered via mDNS", device_ip
             )
-            if self._heos:
-                with suppress(Exception):
-                    await self._heos.disconnect()
-                self._heos = None
+            await self._disconnect_controllers()
         finally:
             self._controller_discovery_running = False
 

--- a/music_assistant/providers/heos/provider.py
+++ b/music_assistant/providers/heos/provider.py
@@ -33,6 +33,7 @@ class HeosPlayerProvider(PlayerProvider):
     """Player provided for Denon HEOS."""
 
     _heos: Heos | None = None
+    _heos_queue: Heos | None = None
     _music_source_list: list[PlayerSource] = []
     _input_source_list: list[MediaItem] = []
     _player_discovery_running: bool = False
@@ -95,6 +96,21 @@ class HeosPlayerProvider(PlayerProvider):
         except HeosError as err:
             self.logger.error("Unexpected error setting up HEOS controller: %s", err)
             raise SetupFailedError("Unexpected error setting up HEOS controller") from err
+
+        try:
+            self._heos_queue = Heos(
+                HeosOptions(
+                    controller_ip,
+                    timeout=cast("int", self.config.get_value(CONF_TIMEOUT)),
+                    auto_reconnect=True,
+                    auto_failover=True,
+                    events=False,
+                )
+            )
+            await self._heos_queue.connect()
+        except HeosError as err:
+            self.logger.error("Failed to set up HEOS queue: %s", err)
+            raise SetupFailedError("Failed to set up HEOS queue") from err
 
     async def _connect_controller(self, controller_ip: str) -> None:
         """Connect to the HEOS controller with a few retries for early mDNS announcements."""
@@ -185,6 +201,10 @@ class HeosPlayerProvider(PlayerProvider):
         if self._heos:
             self._heos.dispatcher.disconnect_all()  # Remove all event connections
             await self._heos.disconnect()
+
+        if self._heos_queue:
+            self._heos_queue.dispatcher.disconnect_all()  # Remove all event connections
+            await self._heos_queue.disconnect()
 
         for player in self.players:
             self.logger.debug("Unloading player %s", player.name)

--- a/music_assistant/providers/heos/provider.py
+++ b/music_assistant/providers/heos/provider.py
@@ -97,6 +97,7 @@ class HeosPlayerProvider(PlayerProvider):
             self.logger.error("Unexpected error setting up HEOS controller: %s", err)
             raise SetupFailedError("Unexpected error setting up HEOS controller") from err
 
+        # Set up up dedicated queue controller, queue commands can be slow and we don't want them to interfere with event processing on the main controller connection
         try:
             self._heos_queue = Heos(
                 HeosOptions(
@@ -109,8 +110,8 @@ class HeosPlayerProvider(PlayerProvider):
             )
             await self._heos_queue.connect()
         except HeosError as err:
-            self.logger.error("Failed to set up HEOS queue: %s", err)
-            raise SetupFailedError("Failed to set up HEOS queue") from err
+            self.logger.error("Failed to set up HEOS queue controller: %s", err)
+            raise SetupFailedError("Failed to set up HEOS queue controller") from err
 
     async def _connect_controller(self, controller_ip: str) -> None:
         """Connect to the HEOS controller with a few retries for early mDNS announcements."""


### PR DESCRIPTION
I've done a number of potential fixes in previous PR to the HEOS internal queuing logic, to fix the initial issue of 'ghost' items playing after MA's queue was finished.
Long story short, the latest fix works, but has the downside of, in some situations (mainly multiple wireless devices), blocking other commands, such as volume up/down while the queue operations are running.

This PR introduces a secondary connection to the main HEOS device (the HEOS specification also advises using 2 connections, 1 for event handling, 1 for sending commands) to operate all the queue commands. This secondary connection is only set up after the rest of the setup process for the HEOS provider is finished, so we know the default connection works for sure.
This secondary connection is only used for queue commands, all other commands and logic still flows through the main connection.
In the process I've also unified the scheduling checks, moved them all to the scheduling method where they belong.