### PR TITLE
Squeezelite: Honor per-child output codec in sync group URL

### DIFF
--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -7,8 +7,8 @@ import statistics
 import struct
 import time
 from collections import deque
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, cast
+from collections.abc import Iterable, Iterator
+from typing import TYPE_CHECKING, Final, cast
 
 from aioslimproto.models import EventType as SlimEventType
 from aioslimproto.models import PlayerState as SlimPlayerState
@@ -31,6 +31,7 @@ from music_assistant_models.media_items import AudioFormat
 from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE_FORCED_2,
     CONF_ENTRY_SYNC_ADJUST,
+    CONF_OUTPUT_CODEC,
     INTERNAL_PCM_FORMAT,
     VERBOSE_LOG_LEVEL,
     create_sample_rates_config_entry,
@@ -72,6 +73,54 @@ PLAYER_DEVICE_TYPES = {
     "controller",
     "boom",
 }
+
+# Codec resolution for the multi-client sync URL `fmt=` query parameter.
+# Slimproto HELO advertises 3-letter codes; the URL/stream subsystem uses the
+# project-wide ContentType strings. Mapping is intentionally narrow — only
+# codecs that appear in practice on slimproto devices.
+_SLIM_HELO_TO_URL_CODEC: Final = {
+    "flc": "flac",
+    "mp3": "mp3",
+    "pcm": "wav",
+}
+
+# Preference order when picking from HELO capabilities: lossless first, then
+# the slimproto baseline mp3, then uncompressed wav (high bandwidth — last resort).
+_CODEC_PREFERENCE: Final = ("flac", "mp3", "wav")
+
+# Slimproto guaranteed baseline codec. Reached when no config is set and the
+# HELO list is empty (offline player) or contains no codecs we recognise.
+_BASELINE_CODEC: Final = "mp3"
+
+
+def _resolve_child_codec(
+    config_codec: str | None,
+    helo_codecs: Iterable[str],
+) -> str:
+    """
+    Pick the URL ``fmt=`` codec for a single sync-group child.
+
+    :param config_codec: The child's ``output_codec`` config value, or ``None``
+        when no per-player override is set. When provided, this wins
+        unconditionally — symmetric with the solo-path resolver, which treats
+        the per-player config as authoritative even if it disagrees with the
+        device's advertised capabilities.
+    :param helo_codecs: Slimproto codec codes from the child's HELO capability
+        list (e.g. ``("pcm", "mp3")`` for a classic Squeezebox Boom,
+        ``("pcm", "mp3", "flc")`` for a modern Squeezelite client).
+    :return: A URL-safe codec string accepted by the multi-client handler's
+        ``fmt`` query parameter — one of ``"flac"``, ``"mp3"``, ``"wav"``,
+        or whatever the config value is when set.
+    """
+    if config_codec:
+        return config_codec
+    translated = {
+        _SLIM_HELO_TO_URL_CODEC[code] for code in helo_codecs if code in _SLIM_HELO_TO_URL_CODEC
+    }
+    for codec in _CODEC_PREFERENCE:
+        if codec in translated:
+            return codec
+    return _BASELINE_CODEC
 
 
 class SqueezelitePlayer(Player):
@@ -278,9 +327,7 @@ class SqueezelitePlayer(Player):
         self.multi_client_stream = stream = MultiClientStream(
             audio_source=audio_source, audio_format=master_audio_format
         )
-        base_url = (
-            f"{self.mass.streams.base_url}/slimproto/multi?player_id={self.player_id}&fmt=flac"
-        )
+        base_url = f"{self.mass.streams.base_url}/slimproto/multi?player_id={self.player_id}"
 
         # Count how many clients will connect
         expected_clients = len(list(self._get_sync_clients()))
@@ -289,7 +336,20 @@ class SqueezelitePlayer(Player):
         # forward to downstream play_media commands
         async with TaskManager(self.mass) as tg:
             for slimplayer in self._get_sync_clients():
-                url = f"{base_url}&child_player_id={slimplayer.player_id}"
+                # Resolve the output codec per child rather than hardcoding one
+                # codec for the group: classic Squeezeboxes (Boom/Radio/Touch)
+                # advertise only `pcm, mp3` via HELO and silently emit no audio
+                # when handed a FLAC stream.
+                child_codec = _resolve_child_codec(
+                    cast(
+                        "str | None",
+                        self.mass.config.get_raw_player_config_value(
+                            slimplayer.player_id, CONF_OUTPUT_CODEC
+                        ),
+                    ),
+                    slimplayer.supported_codecs,
+                )
+                url = f"{base_url}&child_player_id={slimplayer.player_id}&fmt={child_codec}"
                 tg.create_task(
                     self._handle_play_url_for_slimplayer(
                         slimplayer,

--- a/tests/providers/squeezelite/__init__.py
+++ b/tests/providers/squeezelite/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the squeezelite player provider."""

--- a/tests/providers/squeezelite/test_player.py
+++ b/tests/providers/squeezelite/test_player.py
@@ -1,0 +1,35 @@
+"""Unit tests for the squeezelite per-child codec resolver."""
+
+import pytest
+
+from music_assistant.providers.squeezelite.player import _resolve_child_codec
+
+
+@pytest.mark.parametrize(
+    ("config_codec", "helo_codecs", "expected"),
+    [
+        # Config wins over HELO when set, even if it picks an unsupported codec.
+        # The user override is symmetric with the solo-path resolver:
+        # a deliberate "output_codec=flac" on a Boom is accepted (and will
+        # be silent — same trap as solo, by design).
+        ("mp3", ("pcm", "mp3", "flc"), "mp3"),
+        ("flac", ("pcm", "mp3"), "flac"),
+        # HELO-only path: pick the highest-preference codec the player supports.
+        # Modern Squeezelite / SqueezeESP32 announces FLAC support → FLAC.
+        (None, ("pcm", "mp3", "flc"), "flac"),
+        # Classic Squeezeboxes (Boom/Radio/Touch) advertise only "pcm, mp3" via
+        # HELO — picking MP3 here is the fix for the silent-audio bug.
+        (None, ("pcm", "mp3"), "mp3"),
+        # No HELO data and no config → slimproto baseline.
+        (None, (), "mp3"),
+        # Unrecognised HELO codes (e.g. ogg/wma) are ignored, baseline applies.
+        (None, ("ogg", "wma"), "mp3"),
+    ],
+)
+def test_resolve_child_codec(
+    config_codec: str | None,
+    helo_codecs: tuple[str, ...],
+    expected: str,
+) -> None:
+    """Per-child codec resolution covers config-override and HELO-fallback paths."""
+    assert _resolve_child_codec(config_codec, helo_codecs) == expected


### PR DESCRIPTION
# Squeezelite: Honor per-child output codec in sync group URL

## Summary

Fixes silent audio on classic Logitech Squeezebox devices (Boom / Radio /
Touch, MAC-OUI `00:04:20`) when grouped for synchronised playback. The
multi-client sync URL was hardcoded to `fmt=flac`, so every child got handed
a FLAC stream regardless of its slimproto-advertised codec capabilities.
Classic Squeezeboxes accept the FLAC stream syntactically (STAT frames
advance, MA shows "playing"), but the hardware decoder produces no audible
output.

Each child's URL now appends a per-child `fmt={resolved}` value computed
from the child's own `output_codec` config + slimproto HELO capabilities:

1. Explicit `output_codec` config wins (symmetric with the solo-path resolver
   in `StreamsController.resolve_stream_url`).
2. Otherwise pick the highest-preference codec from the child's HELO
   capabilities: `flac > mp3 > wav`.
3. Otherwise fall back to `mp3` (slimproto baseline).

`MultiClientStream` already transcodes per child via a separate ffmpeg
process per HTTP subscriber, so no shared-stream/encoder reorganisation was
required. Sample rate and bit depth continue to flow through the existing
`get_output_format` per-child path.

## Behaviour change

- Sync groups where every member supports FLAC: **no change** — each child
  still receives FLAC.
- Sync groups containing at least one non-FLAC-capable member (the bug
  scenario): that child receives MP3, FLAC-capable members keep FLAC. Each
  child gets its best-case codec individually — no group-wide downgrade.
- Solo playback: untouched.

## Fixes

`music-assistant/support#5506`

## Tests

`tests/providers/squeezelite/test_player.py` adds 6 parametrised unit tests
for `_resolve_child_codec`:

- Config override wins over HELO (both for sensible and explicitly-against-advice
  choices, symmetric with the solo path).
- HELO picks FLAC when the player advertises it.
- HELO picks MP3 when FLAC isn't advertised (the Boom case — this is the
  silent-audio fix).
- Empty HELO + no config → MP3 baseline.
- Unknown HELO codec codes are ignored, baseline applies.

## Hardware verification

Verified on a live MA 2.8.7 Docker container with the fix backported and
deployed via [`apply-fork-patch.sh`](https://github.com/digodigo/ma-flac-sync-patch/blob/main/apply-fork-patch.sh)
(companion workaround repo). All four scenarios audible on the speakers,
no anomalies observed:

- ✅ Classic Squeezebox sync group (2× Boom or more): audible synchronised
  playback — the bug scenario, was silent before the fix.
- ✅ Mixed group (classic Squeezebox + Touch / modern Squeezelite): Boom
  gets MP3, Touch keeps FLAC — confirms per-child resolution.
- ✅ Modern-only sync group (2× Muse Luxe): FLAC retained, no regression.
- ✅ Solo playback on each device model: no regression from the call-site
  refactor.

Hardware in the verification fleet:
- 4× Squeezebox Boom (original firmware)
- 5× Squeezebox Radio (original firmware)
- 1× Squeezebox Touch (original firmware)
- 2× Muse Luxe (SqueezeESP32, philippe44 firmware)

## Notes for reviewers

- The branch was based on `upstream/dev` @ `50283614`. On that tip, seven
  unrelated tests already fail (`tests/controllers/streams/test_audio_analysis.py`,
  `tests/core/test_discovery.py`, `tests/core/test_helpers.py`,
  `tests/core/test_tags.py`) — they pre-existed this change and are
  untouched by it.
- Diagnostic background and a DEBUG-level "before" log are linked from the
  upstream issue.
