### PR TITLE
Fix browse and recommendations not applying user filters

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -104,6 +104,7 @@ if TYPE_CHECKING:
     from music_assistant_models.media_items import Audiobook, PodcastEpisode
 
     from music_assistant import MusicAssistant
+    from music_assistant.models import ProviderInstanceType
     from music_assistant.models.metadata_provider import MetadataProvider
     from music_assistant.models.plugin import PluginProvider
     from music_assistant.models.provider import Provider
@@ -223,13 +224,25 @@ class MusicController(CoreController):
 
         Note that this applies user provider filters (for all user types).
         """
-        user = get_current_user()
-        user_provider_filter = user.provider_filter if user else None
         return [
             x
-            for x in self.mass.providers
+            for x in self._apply_user_provider_filter(self.mass.providers)
             if x.type == ProviderType.MUSIC
-            and (not user_provider_filter or x.instance_id in user_provider_filter)
+        ]
+
+    def _apply_user_provider_filter(
+        self,
+        providers: Iterable[ProviderInstanceType],
+    ) -> list[ProviderInstanceType]:
+        """Filter providers by the current user's music provider filter."""
+        user = get_current_user()
+        user_provider_filter = user.provider_filter if user else None
+        if not user_provider_filter:
+            return list(providers)
+        return [
+            p
+            for p in providers
+            if p.type != ProviderType.MUSIC or p.instance_id in user_provider_filter
         ]
 
     @api_command("music/sync")
@@ -557,7 +570,10 @@ class MusicController(CoreController):
         if not path or path == "root":
             # root level; folder per provider that declares BROWSE
             root_items: list[BrowseFolder] = []
-            for prov in self.mass.get_providers_supporting_feature(ProviderFeature.BROWSE):
+            providers_with_browse = self.mass.get_providers_supporting_feature(
+                ProviderFeature.BROWSE
+            )
+            for prov in self._apply_user_provider_filter(providers_with_browse):
                 root_items.append(
                     BrowseFolder(
                         item_id="root",
@@ -803,9 +819,10 @@ class MusicController(CoreController):
     @api_command("music/recommendations")
     async def recommendations(self) -> list[RecommendationFolder]:
         """Get all recommendations."""
-        recommendation_providers = self.mass.get_providers_supporting_feature(
+        providers_with_recommendations = self.mass.get_providers_supporting_feature(
             ProviderFeature.RECOMMENDATIONS,
         )
+        recommendation_providers = self._apply_user_provider_filter(providers_with_recommendations)
         results_per_provider: list[list[RecommendationFolder]] = await asyncio.gather(
             self._get_default_recommendations(),
             *[

--- a/tests/core/test_music_user_filters.py
+++ b/tests/core/test_music_user_filters.py
@@ -1,0 +1,89 @@
+"""Tests for user provider filter handling on MusicController."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from music_assistant_models.auth import UserRole
+from music_assistant_models.enums import ProviderFeature, ProviderType
+
+from music_assistant.controllers.music import MusicController
+
+
+def _make_prov(
+    instance_id: str,
+    prov_type: ProviderType,
+    features: set[ProviderFeature] | None = None,
+) -> Mock:
+    prov = Mock()
+    prov.instance_id = instance_id
+    prov.type = prov_type
+    prov.supported_features = features or set()
+    return prov
+
+
+@patch("music_assistant.controllers.music.get_current_user")
+def test_apply_user_provider_filter_filters_music_providers_for_admin(
+    mock_get_user: Mock,
+) -> None:
+    """Admin's provider_filter must still narrow music providers (issue #5509)."""
+    mock_get_user.return_value = Mock(role=UserRole.ADMIN, provider_filter=["m_a"])
+    music_a = _make_prov("m_a", ProviderType.MUSIC)
+    music_b = _make_prov("m_b", ProviderType.MUSIC)
+
+    controller = MusicController.__new__(MusicController)
+    result = controller._apply_user_provider_filter([music_a, music_b])
+
+    assert [p.instance_id for p in result] == ["m_a"]
+
+
+@patch("music_assistant.controllers.music.get_current_user")
+def test_apply_user_provider_filter_passes_non_music_providers(
+    mock_get_user: Mock,
+) -> None:
+    """Metadata and plugin providers bypass the user's music provider filter."""
+    mock_get_user.return_value = Mock(role=UserRole.ADMIN, provider_filter=["m_a"])
+    music_a = _make_prov("m_a", ProviderType.MUSIC)
+    metadata = _make_prov("meta_a", ProviderType.METADATA)
+    plugin = _make_prov("plug_a", ProviderType.PLUGIN)
+
+    controller = MusicController.__new__(MusicController)
+    result = controller._apply_user_provider_filter([music_a, metadata, plugin])
+
+    assert [p.instance_id for p in result] == ["m_a", "meta_a", "plug_a"]
+
+
+@patch("music_assistant.controllers.music.get_current_user")
+def test_apply_user_provider_filter_no_filter_returns_all(
+    mock_get_user: Mock,
+) -> None:
+    """An empty provider_filter passes every provider through."""
+    mock_get_user.return_value = Mock(role=UserRole.ADMIN, provider_filter=[])
+    music_a = _make_prov("m_a", ProviderType.MUSIC)
+    music_b = _make_prov("m_b", ProviderType.MUSIC)
+
+    controller = MusicController.__new__(MusicController)
+    result = controller._apply_user_provider_filter([music_a, music_b])
+
+    assert [p.instance_id for p in result] == ["m_a", "m_b"]
+
+
+@patch("music_assistant.controllers.music.get_current_user")
+async def test_browse_root_honors_admin_provider_filter(mock_get_user: Mock) -> None:
+    """Regression for issue #5509: browse must honor an admin's provider_filter."""
+    mock_get_user.return_value = Mock(role=UserRole.ADMIN, provider_filter=["m_a"])
+    mass = Mock()
+    music_a = _make_prov("m_a", ProviderType.MUSIC, {ProviderFeature.BROWSE})
+    music_a.domain = "music_a"
+    music_a.name = "Music A"
+    music_b = _make_prov("m_b", ProviderType.MUSIC, {ProviderFeature.BROWSE})
+    music_b.domain = "music_b"
+    music_b.name = "Music B"
+    mass.get_providers_supporting_feature.return_value = [music_a, music_b]
+
+    controller = MusicController.__new__(MusicController)
+    controller.mass = mass
+
+    result = await controller.browse(path=None)
+
+    assert [folder.path for folder in result] == ["m_a://"]  # type: ignore[union-attr]


### PR DESCRIPTION
The [PR](https://github.com/music-assistant/server/pull/3811/changes#diff-ea42010d87a2d75ab10cf20071ecf6d935eb1495da5a31e3d204d1138cd015ff) that opened up `browse` and `recommendations` for other type of providers introduced a regression on the browse and recommendation endpoints where no user filter was applied anymore. This PR fixes that