### PR TITLE
sonos: enable MULTI_DEVICE_DSP for grouped players

### DIFF
--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -63,6 +63,7 @@ SUPPORTED_FEATURES = {
     PlayerFeature.SELECT_SOURCE,
     PlayerFeature.SET_MEMBERS,
     PlayerFeature.GAPLESS_PLAYBACK,
+    PlayerFeature.MULTI_DEVICE_DSP,
 }
 
 


### PR DESCRIPTION
Adds PlayerFeature.MULTI_DEVICE_DSP to the Sonos SUPPORTED_FEATURES set.
MA applies DSP in the audio stream before sending to each Sonos speaker,
so per-device DSP works correctly even when multiple speakers are grouped.
Without this flag, DSP settings are ignored for all speakers in a group.
Validated on nightly build 2.9.0.dev2026052006.