### PR TITLE
Stabilize group players: session-lifecycle instead of mandatory power

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -94,6 +94,7 @@ CONF_BIND_IP: Final[str] = "bind_ip"
 CONF_BIND_PORT: Final[str] = "bind_port"
 CONF_PUBLISH_IP: Final[str] = "publish_ip"
 CONF_AUTO_PLAY: Final[str] = "auto_play"
+CONF_PLAY_MEDIA_OVERRIDES_GROUP: Final[str] = "play_media_overrides_group"
 CONF_GROUP_MEMBERS: Final[str] = "group_members"
 CONF_DYNAMIC_GROUP_MEMBERS: Final[str] = "dynamic_members"
 CONF_HIDE_IN_UI: Final[str] = "hide_in_ui"
@@ -289,6 +290,21 @@ CONF_ENTRY_AUTO_PLAY = ConfigEntry(
     depends_on=CONF_POWER_CONTROL,
     depends_on_value_not="none",
     category="player_controls",
+)
+
+CONF_ENTRY_PLAY_MEDIA_OVERRIDES_GROUP = ConfigEntry(
+    key=CONF_PLAY_MEDIA_OVERRIDES_GROUP,
+    type=ConfigEntryType.BOOLEAN,
+    label="Play Media overrides active group",
+    description="When this player is currently captured by an active group or sync session, "
+    "an explicit Play Media command (e.g. starting a new playlist or track from Home "
+    "Assistant) will release this player from the group/sync and play the new media "
+    "directly on this player. Disable this to keep the legacy behavior where Play "
+    "Media is redirected to the group leader. Other commands (next/prev/pause/resume) "
+    "are always forwarded to the group leader as they act on the existing playback.",
+    default_value=True,
+    category="generic",
+    advanced=False,
 )
 
 CONF_ENTRY_MIN_VOLUME = ConfigEntry(

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -73,6 +73,7 @@ from music_assistant.constants import (
     CONF_ENTRY_OUTPUT_CHANNELS,
     CONF_ENTRY_OUTPUT_CODEC,
     CONF_ENTRY_OUTPUT_LIMITER,
+    CONF_ENTRY_PLAY_MEDIA_OVERRIDES_GROUP,
     CONF_ENTRY_PLAYER_ICON,
     CONF_ENTRY_PLAYER_ICON_GROUP,
     CONF_ENTRY_SAMPLE_RATES,
@@ -1689,11 +1690,14 @@ class ConfigController:
             CONF_ENTRY_ANNOUNCE_VOLUME,
             CONF_ENTRY_ANNOUNCE_VOLUME_MIN,
             CONF_ENTRY_ANNOUNCE_VOLUME_MAX,
+            # play_media-on-self preference (only relevant to non-group players)
+            CONF_ENTRY_PLAY_MEDIA_OVERRIDES_GROUP,
         ]
         return entries
 
     def _create_player_control_config_entries(self, player: Player) -> list[ConfigEntry]:
         """Create config entries for player controls."""
+        is_group = player.state.type == PlayerType.GROUP
         all_controls = self.mass.players.player_controls()
         power_controls = [x for x in all_controls if x.supports_power]
         volume_controls = [x for x in all_controls if x.supports_volume]
@@ -1809,8 +1813,11 @@ class ConfigController:
             # Volume limit entries
             CONF_ENTRY_MIN_VOLUME,
             CONF_ENTRY_MAX_VOLUME,
-            # auto-play on power on control config entry
-            CONF_ENTRY_AUTO_PLAY,
+            # auto-play on power on — only meaningful for individual players.
+            # For group players, power on/off is purely a "capture members"
+            # toggle (Fake control) and auto-starting playback there causes
+            # surprise playback when the user just wanted to pin the group.
+            *([] if is_group else [CONF_ENTRY_AUTO_PLAY]),
         ]
 
     async def _create_output_protocol_config_entries(  # noqa: PLR0915

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1008,11 +1008,19 @@ class PlayerQueuesController(CoreController):
         if target_player.state.active_group or target_player.state.synced_to:
             # edge case: the user wants to move playback from the group as a whole, to a single
             # player in the group or it is grouped and the command targeted at the single player.
-            # We need to dissolve the group first.
+            # We need to dissolve the group/sync first, and wait for the state to actually
+            # propagate before we hand the queue over to the target player.
             group_id = target_player.state.active_group or target_player.state.synced_to
             assert group_id is not None  # checked in if condition above
-            await self.mass.players.cmd_ungroup(group_id)
-            await asyncio.sleep(3)
+            async with self.mass.players.wait_for_player_update(
+                target_queue_id,
+                attribute_name=(
+                    "active_group" if target_player.state.active_group else "synced_to"
+                ),
+                attribute_value=None,
+                timeout=5,
+            ):
+                await self.mass.players.cmd_ungroup(group_id)
 
         # capture source state before stopping (stop resets these)
         source_items = self._queue_items[source_queue_id]

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -84,6 +84,7 @@ from music_assistant.constants import (
     CONF_GROUP_MEMBERS,
     CONF_MAX_VOLUME,
     CONF_MIN_VOLUME,
+    CONF_PLAY_MEDIA_OVERRIDES_GROUP,
     CONF_PLAYER_DSP,
     CONF_PLAYERS,
     CONF_PRE_ANNOUNCE_CHIME_URL,
@@ -996,14 +997,88 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def play_media(self, player_id: str, media: PlayerMedia) -> None:
-        """Handle PLAY MEDIA on given player.
+        """
+        Handle PLAY MEDIA on given player.
 
         :param player_id: player_id of the player to handle the command.
         :param media: The Media that needs to be played on the player.
         """
+        # An explicit play_media on a captured player honors the player's
+        # CONF_PLAY_MEDIA_OVERRIDES_GROUP preference (default: True) — the
+        # player is released from its group/sync first, then plays the media
+        # standalone. With the preference off, behavior falls back to the
+        # legacy "redirect to group leader" path below.
+        target_player = self.get_player(player_id, True)
+        if target_player is not None and (
+            target_player.state.synced_to or target_player.state.active_group
+        ):
+            override = bool(
+                self.mass.config.get_raw_player_config_value(
+                    target_player.player_id,
+                    CONF_PLAY_MEDIA_OVERRIDES_GROUP,
+                    True,
+                )
+            )
+            if override:
+                await self._release_player_for_play_media(target_player)
+                await self._handle_play_media(target_player.player_id, media)
+                return
         player = self._get_player_with_redirect(player_id)
-        # Delegate to internal handler for actual implementation
         await self._handle_play_media(player.player_id, media)
+
+    async def _release_player_for_play_media(self, player: Player) -> None:
+        """
+        Release a captured player so a play_media command can target it directly.
+
+        :param player: The captured player to release.
+        """
+        # Strategy is picked from how the player is currently captured:
+        #   synced_to            → unsync this player (cmd_ungroup)
+        #   dynamic group member → remove from group via cmd_set_members
+        #   static group member  → dissolve the whole group (power off if it
+        #                          has a real power control, otherwise stop)
+        if player.state.synced_to:
+            self.logger.debug(
+                "Unsyncing %s from %s to honor explicit play_media target",
+                player.state.name,
+                player.state.synced_to,
+            )
+            await self.cmd_ungroup(player.player_id)
+            return
+        if not player.state.active_group:
+            return
+        group = self.get_player(player.state.active_group)
+        if group is None:
+            return
+        is_dynamic_member = (
+            PlayerFeature.SET_MEMBERS in group.state.supported_features
+            and player.player_id not in group.state.static_group_members
+        )
+        if is_dynamic_member:
+            self.logger.debug(
+                "Removing %s from dynamic group %s to honor explicit play_media target",
+                player.state.name,
+                group.state.name,
+            )
+            await self.cmd_set_members(group.player_id, player_ids_to_remove=[player.player_id])
+            return
+        # static member: a single member can't be released, so the whole
+        # group must dissolve. Prefer cmd_power when an explicit power
+        # control is set so the user-visible state stays consistent.
+        if group.state.power_control != PLAYER_CONTROL_NONE and group.state.powered:
+            self.logger.debug(
+                "Powering off %s to honor explicit play_media target on %s",
+                group.state.name,
+                player.state.name,
+            )
+            await self._handle_cmd_power(group.player_id, False)
+        else:
+            self.logger.debug(
+                "Stopping %s to honor explicit play_media target on %s",
+                group.state.name,
+                player.state.name,
+            )
+            await self._handle_cmd_stop(group.player_id)
 
     @api_command("players/cmd/select_sound_mode")
     @handle_player_command
@@ -1228,8 +1303,27 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             self.logger.warning("Player %s is not available", player_id)
             return
 
+        # Ungroup on a group player is interpreted as 'release the captured
+        # session entirely'. This avoids the "Cannot remove static member"
+        # error path when transfer_queue or HA's unjoin asks us to release a
+        # group that has static members.
+        if player.state.type == PlayerType.GROUP:
+            if player.state.power_control != PLAYER_CONTROL_NONE:
+                await self._handle_cmd_power(player.player_id, False)
+            else:
+                await self._handle_cmd_stop(player.player_id)
+            return
+
         if player.state.active_group:
-            # the player is part of a (permanent) groupplayer and the user tries to ungroup
+            group = self.get_player(player.state.active_group)
+            is_static_member = group is not None and player_id in group.state.static_group_members
+            if is_static_member:
+                # Static members can't be released individually — recurse so
+                # the group-player branch above stops/dissolves the session.
+                if group is not None:
+                    await self.cmd_ungroup(group.player_id)
+                return
+            # dynamic or non-static member — remove just this player
             await self.cmd_set_members(player.state.active_group, player_ids_to_remove=[player_id])
             return
 
@@ -1239,7 +1333,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             return
 
         if player.state.group_members:
-            # player is a sync leader (or syncgroup), so we ungroup all members from it
+            # player is a sync leader (a non-group player with synced followers).
+            # Ungroup all followers from it.
             await self.cmd_set_members(
                 player.player_id, player_ids_to_remove=player.state.group_members
             )
@@ -1436,15 +1531,23 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             # register throttler for this player
             self._player_throttlers[player_id] = Throttler(1, 0.05)
 
-            # restore 'fake' power state from cache if available
-            cached_value = await self.mass.cache.get(
-                key=player.player_id,
-                provider=self.domain,
-                category=CACHE_CATEGORY_PLAYER_POWER,
-                default=False,
-            )
-            if cached_value is not None:
-                player.extra_data[ATTR_FAKE_POWER] = cached_value
+            # restore 'fake' power state from cache if available.
+            # Group players intentionally do NOT restore their fake-power
+            # state across restarts: at boot there is no sync session yet, so
+            # a restored 'powered=True' would put the group in an inconsistent
+            # 'active without captured session' state where children appear
+            # owned by a group that has no leader. Users who want their
+            # 'group captured' state preserved across restarts would need
+            # explicit session restoration which is out of scope here.
+            if player.type != PlayerType.GROUP:
+                cached_value = await self.mass.cache.get(
+                    key=player.player_id,
+                    provider=self.domain,
+                    category=CACHE_CATEGORY_PLAYER_POWER,
+                    default=False,
+                )
+                if cached_value is not None:
+                    player.extra_data[ATTR_FAKE_POWER] = cached_value
 
             # finally actually register it
 
@@ -3250,13 +3353,21 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             # user wants to use fake power control - so we (optimistically) update the state
             # and store the state in the cache
             player.extra_data[ATTR_FAKE_POWER] = powered
+            # Group players need to actively form/dissolve their session when the
+            # user toggles fake power — otherwise the toggle would only update the
+            # cosmetic state without ever capturing or releasing the members.
+            if player_state.type == PlayerType.GROUP:
+                await player.power(powered)
             player.update_state()  # trigger update of the player state
-            await self.mass.cache.set(
-                key=player_id,
-                data=powered,
-                provider=self.domain,
-                category=CACHE_CATEGORY_PLAYER_POWER,
-            )
+            if player_state.type != PlayerType.GROUP:
+                # see register(): group fake-power is intentionally not persisted
+                # because there is no session to restore at boot.
+                await self.mass.cache.set(
+                    key=player_id,
+                    data=powered,
+                    provider=self.domain,
+                    category=CACHE_CATEGORY_PLAYER_POWER,
+                )
         # handle external player control
         elif player_control := self._controls.get(player.state.power_control):
             control_name = player_control.name if player_control else player.state.power_control

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1037,13 +1037,23 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         #   dynamic group member → remove from group via cmd_set_members
         #   static group member  → dissolve the whole group (power off if it
         #                          has a real power control, otherwise stop)
+        # In every branch we wait for the relevant state attribute to actually
+        # clear before returning. Providers (Sonos in particular) reject a
+        # play_media on a player whose synced_to/active_group is still set
+        # locally even though the release command has been acknowledged.
         if player.state.synced_to:
             self.logger.debug(
                 "Unsyncing %s from %s to honor explicit play_media target",
                 player.state.name,
                 player.state.synced_to,
             )
-            await self.cmd_ungroup(player.player_id)
+            async with self.wait_for_player_update(
+                player.player_id,
+                attribute_name="synced_to",
+                attribute_value=None,
+                timeout=5,
+            ):
+                await self.cmd_ungroup(player.player_id)
             return
         if not player.state.active_group:
             return
@@ -1060,25 +1070,37 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 player.state.name,
                 group.state.name,
             )
-            await self.cmd_set_members(group.player_id, player_ids_to_remove=[player.player_id])
+            async with self.wait_for_player_update(
+                player.player_id,
+                attribute_name="active_group",
+                attribute_value=None,
+                timeout=5,
+            ):
+                await self.cmd_set_members(group.player_id, player_ids_to_remove=[player.player_id])
             return
         # static member: a single member can't be released, so the whole
         # group must dissolve. Prefer cmd_power when an explicit power
         # control is set so the user-visible state stays consistent.
-        if group.state.power_control != PLAYER_CONTROL_NONE and group.state.powered:
-            self.logger.debug(
-                "Powering off %s to honor explicit play_media target on %s",
-                group.state.name,
-                player.state.name,
-            )
-            await self._handle_cmd_power(group.player_id, False)
-        else:
-            self.logger.debug(
-                "Stopping %s to honor explicit play_media target on %s",
-                group.state.name,
-                player.state.name,
-            )
-            await self._handle_cmd_stop(group.player_id)
+        async with self.wait_for_player_update(
+            player.player_id,
+            attribute_name="active_group",
+            attribute_value=None,
+            timeout=5,
+        ):
+            if group.state.power_control != PLAYER_CONTROL_NONE and group.state.powered:
+                self.logger.debug(
+                    "Powering off %s to honor explicit play_media target on %s",
+                    group.state.name,
+                    player.state.name,
+                )
+                await self._handle_cmd_power(group.player_id, False)
+            else:
+                self.logger.debug(
+                    "Stopping %s to honor explicit play_media target on %s",
+                    group.state.name,
+                    player.state.name,
+                )
+                await self._handle_cmd_stop(group.player_id)
 
     @api_command("players/cmd/select_sound_mode")
     @handle_player_command

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -315,6 +315,19 @@ class Player(ABC):
         return self._attr_can_group_with
 
     @property
+    def is_active_session(self) -> bool:
+        """
+        Return whether this group player is currently holding (capturing) its members.
+
+        Used by :meth:`__final_active_group` to decide whether children should be
+        considered "owned" by this group at this moment. Non-group players should
+        always return ``False``. Group implementations should return ``True`` while
+        a session is being formed, while it is actively playing/paused, and during
+        any idle grace period; and ``False`` once the group is fully dormant.
+        """
+        return False
+
+    @property
     def synced_to(self) -> str | None:
         """Return the id of the player this player is synced to (sync leader)."""
         # default implementation, feel free to override if your
@@ -803,7 +816,11 @@ class Player(ABC):
         """Return the power control type."""
         conf = self.mass.config.get_raw_player_config_value(self.player_id, CONF_POWER_CONTROL)
         if conf and conf in (PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE):
-            # the control type is explicitly set in the config, use that
+            # validate that NATIVE is still backed by an actual POWER feature.
+            # this handles graceful degradation for players (e.g. group players)
+            # that previously advertised POWER but no longer do.
+            if conf == PLAYER_CONTROL_NATIVE and PlayerFeature.POWER not in self.supported_features:
+                return PLAYER_CONTROL_NONE
             return str(conf)
         if conf and (_control := self.mass.players.get_player_control(str(conf))):
             # the control type is explicitly set to a player control,
@@ -1659,11 +1676,19 @@ class Player(ABC):
                 continue
             if group_player.player_id == self.player_id:
                 continue
-            if group_player.powered is False or (
-                group_player.powered is None and group_player.playback_state == PlaybackState.IDLE
-            ):
-                # a group is only considered active if it supports power and is powered on,
-                # or if it doesn't support power but is not idle
+            # Use the raw `powered` attribute (not `state.powered`) so the
+            # check reflects what the group player itself believes — for
+            # native/fake control the group's `power()` method sets
+            # `_attr_powered` directly. `state.powered` routes through
+            # `__final_power_state` which may return None for power_control
+            # == NONE even though the group is actively capturing members.
+            powered = group_player.powered
+            if powered is False:
+                # explicit power-off (fake or native) - never captures members
+                continue
+            if powered is not True and not group_player.is_active_session:
+                # no explicit power-on and no captured session - group is dormant,
+                # configured members are free to be controlled individually
                 continue
             if self.player_id in group_player.state.group_members:
                 return group_player.player_id

--- a/music_assistant/providers/sync_group/constants.py
+++ b/music_assistant/providers/sync_group/constants.py
@@ -9,6 +9,12 @@ from music_assistant_models.enums import ConfigEntryType, PlayerFeature
 
 SGP_PREFIX: Final[str] = "syncgroup_"
 
+# Grace period (seconds) before a sync group dissolves itself after the queue
+# naturally finishes (playback_state transitions to IDLE without an explicit
+# stop). A short grace window absorbs end-of-track gaps and a quick "play next"
+# from the user without disrupting the live sync session.
+IDLE_GRACE_SECONDS: Final[float] = 10.0
+
 CONF_ENTRY_SGP_NOTE = ConfigEntry(
     key="sgp_note",
     type=ConfigEntryType.ALERT,

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
+from music_assistant_models.constants import PLAYER_CONTROL_FAKE
 from music_assistant_models.enums import ConfigEntryType, PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.errors import PlayerCommandFailed, UnsupportedFeaturedException
 from propcache import under_cached_property as cached_property
@@ -14,6 +15,7 @@ from music_assistant.constants import (
     APPLICATION_NAME,
     CONF_DYNAMIC_GROUP_MEMBERS,
     CONF_GROUP_MEMBERS,
+    CONF_POWER_CONTROL,
 )
 from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
@@ -22,6 +24,7 @@ from .constants import (
     CONF_ALLOWED_MEMBERS,
     CONF_ENTRY_SGP_NOTE,
     EXTRA_FEATURES_FROM_MEMBERS,
+    IDLE_GRACE_SECONDS,
     PROVIDERS_WITH_DYNAMIC_LEADER_SWITCH,
 )
 
@@ -48,8 +51,14 @@ class SyncGroupPlayer(Player):
         self._attr_name = self.config.name or self.config.default_name or f"SyncGroup {player_id}"
         self._attr_available = True
         self._attr_device_info = DeviceInfo(model=provider.name, manufacturer=APPLICATION_NAME)
-        self._attr_powered = False  # group players are always powered off by default
+        # Group players default to "no opinion" on power. The session lifecycle
+        # (form on play, dissolve on stop, debounced idle deform) governs whether
+        # the group is considered active. Users who want an explicit on/off button
+        # can assign 'Fake power control' which is then reflected via extra_data.
+        self._attr_powered = None
         self._attr_needs_poll = True
+        # task that dissolves the group after the idle grace window expires
+        self._idle_grace_task: asyncio.Task[None] | None = None
         self._update_attributes()
 
     @cached_property
@@ -62,6 +71,18 @@ class SyncGroupPlayer(Player):
         """Return the id of the player this player is synced to (sync leader)."""
         # groups can't be synced
         return None
+
+    @property
+    def is_active_session(self) -> bool:
+        """
+        Return whether this sync group is currently holding its members.
+
+        The session is considered active while a sync leader is set (formed and
+        potentially playing/paused) or while the idle grace timer is still
+        pending. ``__final_active_group`` reads this to decide whether the
+        configured members should be marked as ``active_group`` for this group.
+        """
+        return self.sync_leader is not None or self._idle_grace_task is not None
 
     async def on_config_updated(self) -> None:
         """Handle logic when the PlayerConfig is first loaded or updated."""
@@ -76,16 +97,31 @@ class SyncGroupPlayer(Player):
         else:
             self._attr_static_group_members = list(preset_members)
             self._attr_supported_features.discard(PlayerFeature.SET_MEMBERS)
-        self._attr_group_members = list(preset_members)
+        # Only realign the effective member list to the preset when we are
+        # dormant. Otherwise a config save (e.g. user toggling an unrelated
+        # field) would wipe any dynamic joins that happened during this session.
+        if not self.is_active_session:
+            self._attr_group_members = list(preset_members)
 
     @property
     def supported_features(self) -> set[PlayerFeature]:
         """Return the supported features of the player."""
-        # by default we don't have any features, except play_media and power
-        # but we can gain some features based on the capabilities of the members
-        # NOTE: set_members is only supported if it's a dynamic group
-        # we use the power feature as a proxy for "is group active/formed"
-        base_features: set[PlayerFeature] = {PlayerFeature.PLAY_MEDIA, PlayerFeature.POWER}
+        # PlayerFeature.POWER is intentionally NOT advertised by default: it forces
+        # users to remember to power the group off to release its members, which
+        # makes "play X on a single member from HA" silently redirect to the whole
+        # group long after playback ended. The new lifecycle forms the group on
+        # play and dissolves it on stop (with a short idle grace), so explicit
+        # power control is no longer required.
+        # Users who DO want an explicit on/off button can assign 'Fake power
+        # control' in the player config; we then advertise POWER so the UI shows
+        # the toggle. The raw config value is read here to avoid recursion via
+        # the power_control property (which itself may inspect supported features).
+        base_features: set[PlayerFeature] = {PlayerFeature.PLAY_MEDIA}
+        raw_power_conf = self.mass.config.get_raw_player_config_value(
+            self.player_id, CONF_POWER_CONTROL
+        )
+        if raw_power_conf == PLAYER_CONTROL_FAKE:
+            base_features.add(PlayerFeature.POWER)
         if self.is_dynamic:
             base_features.add(PlayerFeature.SET_MEMBERS)
         if self.sync_leader:
@@ -283,13 +319,27 @@ class SyncGroupPlayer(Player):
         return entries
 
     async def power(self, powered: bool) -> None:
-        """Handle POWER command to group player."""
-        # always stop at power off
+        """
+        Handle POWER command to group player.
+
+        Only called when the user has assigned a power control (native or fake)
+        to the group. Powering ON pre-forms the group so its members are
+        captured immediately (matching the legacy behaviour for users who opt
+        in). Powering OFF stops any playback and dissolves the group.
+
+        :param powered: True to power on (form/capture), False to power off (dissolve).
+        """
+        # always cancel any pending idle-grace timer on explicit power transitions
+        self._cancel_idle_grace_timer()
+
         if not powered and self.playback_state in (
             PlaybackState.PLAYING,
             PlaybackState.PAUSED,
         ):
-            await self.stop()
+            # stop directly via the leader to avoid re-entering our own stop()
+            # logic (which would dissolve before we re-dissolve below).
+            if sync_leader := self.sync_leader:
+                await self.mass.players._handle_cmd_stop(sync_leader.player_id)
 
         if powered:
             # apply the configured preset members on power-on so unjoins
@@ -311,12 +361,28 @@ class SyncGroupPlayer(Player):
             self.update_state()
 
     async def stop(self) -> None:
-        """Send STOP command to given player."""
+        """
+        Send STOP command to given player.
+
+        An explicit stop on the group dissolves the syncgroup immediately so the
+        members are released back to individual control. The idle grace timer is
+        intentionally only used when the queue ends naturally (playback_state
+        transitions to IDLE without a stop command). Users who want the group
+        to stay formed across stops can assign Fake power control and use that
+        to pin the group as 'active'.
+        """
+        self._cancel_idle_grace_timer()
         self._attr_current_media = None
         if sync_leader := self.sync_leader:
             # Use internal handler to target the sync leader directly,
             # bypassing group/sync redirect that would loop back to this player.
             await self.mass.players._handle_cmd_stop(sync_leader.player_id)
+        # Skip the dissolve when the user has explicitly powered the group on
+        # via Fake power control — they expect the group to stay 'active' until
+        # they power it off, even after a stop.
+        if self._attr_powered is True:
+            return
+        await self._dissolve_syncgroup()
 
     async def play(self) -> None:
         """Send PLAY (unpause) command to given player."""
@@ -487,8 +553,19 @@ class SyncGroupPlayer(Player):
         self._update_attributes()
         super().on_group_member_updated(member_player, changed_values)
 
+    async def on_unload(self) -> None:
+        """Handle logic when the player is unloaded from the Player controller."""
+        self._cancel_idle_grace_timer()
+        await super().on_unload()
+        # the player is going away; make sure we don't leave the protocol-level
+        # sync group standing with a now-nonexistent leader behind it.
+        if self.sync_leader is not None:
+            await self._dissolve_syncgroup()
+
     async def _form_syncgroup(self) -> None:
         """Form syncgroup by syncing all (possible) members."""
+        # any in-flight grace timer is moot now — we're (re)forming the group
+        self._cancel_idle_grace_timer()
         self.logger.debug(
             "Forming syncgroup %s, _attr_group_members=%s, sync_leader=%s",
             self.display_name,
@@ -508,6 +585,29 @@ class SyncGroupPlayer(Player):
             self.sync_leader.player_id,
             *[x for x in self._attr_group_members if x != self.sync_leader.player_id],
         ]
+        # If the leader still believes it's synced to a previous leader (e.g. we
+        # just picked a new leader after dissolving the old session and the
+        # protocol-level state hasn't propagated yet), wait for it to settle.
+        # Without this, the subsequent play_media call hits the provider's
+        # "I'm synced to another player" guard and gets rejected.
+        if self.sync_leader.state.synced_to is not None:
+            self.logger.debug(
+                "Waiting for new leader %s to report synced_to=None before forming",
+                self.sync_leader.display_name,
+            )
+            if not await self._wait_member_unsynced(self.sync_leader.player_id):
+                # Leader is genuinely stuck — bail out before issuing play_media
+                # so we don't trigger the provider's "synced to another player"
+                # rejection. The caller (play / play_media) will surface this as
+                # a no-op form; the next user action can retry once the
+                # protocol layer has caught up.
+                self.logger.error(
+                    "Aborting syncgroup form for %s: leader %s is stuck synced",
+                    self.display_name,
+                    self.sync_leader.display_name,
+                )
+                self.sync_leader = None
+                return
         # Translate the leader's group_members (may be protocol IDs) to parent IDs
         # so we can compare against our _attr_group_members (always parent IDs)
         already_synced = set(self._translate_to_parent_ids(self.sync_leader.state.group_members))
@@ -541,6 +641,8 @@ class SyncGroupPlayer(Player):
 
     async def _dissolve_syncgroup(self) -> None:
         """Dissolve the current syncgroup by ungrouping all members."""
+        # a dissolve is happening now — any pending grace timer is no longer needed
+        self._cancel_idle_grace_timer()
         if sync_leader := self.sync_leader:
             # dissolve the temporary syncgroup from the sync leader
             sync_children = [
@@ -620,6 +722,25 @@ class SyncGroupPlayer(Player):
                 )
                 return member_player
         return None
+
+    # -----------------------------------------------------------------------
+    # Protocol awareness
+    # -----------------------------------------------------------------------
+    # A sync group can contain members from multiple protocol domains (e.g. a
+    # Sonos that can play via either its native protocol or via AirPlay). The
+    # group needs to:
+    #   - track which protocol the live session is using (active_protocol_domain)
+    #   - resolve which player actually owns the protocol-level session
+    #     (_active_session_player) so leader/handoff bookkeeping is done on
+    #     the right object
+    #   - choose new leaders that keep protocol continuity
+    #     (_member_supports_protocol_domain / _select_sync_leader)
+    #   - downshift to the native protocol when the last protocol-requiring
+    #     member is gone (_any_member_requires_protocol_domain)
+    # The helpers below cover those needs. Composition decisions (which protocol
+    # to use given the current member mix) intentionally live in the group:
+    # individual protocol providers don't have visibility into the rest of the
+    # group's members.
 
     def _translate_to_parent_ids(self, player_ids: list[str]) -> list[str]:
         """Translate a list of (possibly protocol) player IDs to parent player IDs.
@@ -727,10 +848,14 @@ class SyncGroupPlayer(Player):
 
     def _update_attributes(self) -> None:
         """Update dynamic attributes."""
-        # NOTE: Always read the *raw* attributes (not `.state.*`) from the sync leader.
-        # The leader's `state.playback_state` is derived through __final_playback_state which,
-        # when this group is powered, treats us as the leader's active_group and routes its
-        # state back to ours - creating a circular dependency that strands both at IDLE.
+        # NOTE on what reads from `.state.*` vs the leader's raw attributes below:
+        # `__final_current_media` and `__final_active_source` on a player that has
+        # an ``active_group`` route through the active_group's state — so reading
+        # ``sync_leader.state.current_media`` from inside the group would loop
+        # back through our own state derivation (group → leader.state →
+        # active_group=group → group). For those two we MUST use the leader's
+        # raw attributes. ``playback_state`` / ``elapsed_time`` do not route via
+        # active_group and are safe to read from ``.state.*``.
         if (sync_leader := self.sync_leader) is None:
             # no sync leader, reset playback-related attributes to default values
             self._attr_playback_state = PlaybackState.IDLE
@@ -740,7 +865,9 @@ class SyncGroupPlayer(Player):
             self._attr_active_source = None
             self._attr_poll_interval = 30
             return
-        self._attr_playback_state = sync_leader.state.playback_state
+        prev_state = self._attr_playback_state
+        new_state = sync_leader.state.playback_state
+        self._attr_playback_state = new_state
         self._attr_elapsed_time = sync_leader.state.elapsed_time
         self._attr_elapsed_time_last_updated = sync_leader.state.elapsed_time_last_updated
         # don't use 'state' for current_media here since that points back to this group
@@ -749,7 +876,19 @@ class SyncGroupPlayer(Player):
         # on the leader rather than the group.
         self._attr_current_media = sync_leader.current_media
         self._attr_active_source = sync_leader.active_source
-        self._attr_poll_interval = 1 if self._attr_playback_state == PlaybackState.PLAYING else 30
+        self._attr_poll_interval = 1 if new_state == PlaybackState.PLAYING else 30
+        # idle grace handling: schedule a debounced dissolve when the leader
+        # naturally transitions from PLAYING/PAUSED to IDLE. The dissolve is
+        # skipped if the user has pinned the group with Fake power control.
+        if new_state == PlaybackState.IDLE and prev_state in (
+            PlaybackState.PLAYING,
+            PlaybackState.PAUSED,
+        ):
+            if self._attr_powered is not True:
+                self._schedule_idle_grace_timer()
+        elif new_state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+            # leader resumed playing, cancel any pending grace
+            self._cancel_idle_grace_timer()
 
     def _is_player_in_session(self, player: Player, session_player: Player | None) -> bool:
         """Return True if ``player`` is already a sync_client of the live session.
@@ -790,6 +929,7 @@ class SyncGroupPlayer(Player):
         old_leader_id: str,
         leader_to_stop: Player | None = None,
         resume_playback: bool = True,
+        preferred_protocol_domain: str | None = None,
     ) -> None:
         """Stop the current sync session, dissolve the syncgroup, and optionally re-form.
 
@@ -804,6 +944,10 @@ class SyncGroupPlayer(Player):
         :param resume_playback: If True, call ``play()`` after dissolving to
             restart playback on the new leader. Pass False when the group was
             not actively playing (e.g. paused or idle).
+        :param preferred_protocol_domain: Optional snapshot of the active
+            protocol domain taken before the old leader was cleared, passed to
+            :meth:`_select_sync_leader` so the new leader is chosen to keep the
+            protocol session continuous where possible.
         """
         leader_to_stop = leader_to_stop or self.sync_leader
         if leader_to_stop:
@@ -824,14 +968,45 @@ class SyncGroupPlayer(Player):
             # re-forming. Providers like Sonos propagate group state
             # asynchronously — the children can still report synced_to for
             # a few seconds after the leader's ungroup command returns.
-            await asyncio.gather(
+            unsync_results = await asyncio.gather(
                 *(self._wait_member_unsynced(m) for m in self._attr_group_members),
                 return_exceptions=True,
             )
+            stuck_members = [
+                self._attr_group_members[i]
+                for i, result in enumerate(unsync_results)
+                if result is False
+            ]
+            if stuck_members:
+                self.logger.error(
+                    "Members of group %s still report synced_to after recovery attempts: %s; "
+                    "aborting reform (no playback will resume on this call)",
+                    self.display_name,
+                    stuck_members,
+                )
+                return
+            # Preselect the new leader with the protocol hint so the form
+            # picks a member compatible with the previous session's protocol
+            # (e.g. keep AirPlay if the session was AirPlay).
+            if preferred_protocol_domain is not None:
+                self.sync_leader = self._select_sync_leader(
+                    preferred_protocol_domain=preferred_protocol_domain
+                )
             await self.play()
 
-    async def _wait_member_unsynced(self, member_id: str, timeout: float = 5.0) -> None:
-        """Wait until the given member reports as unsynced (synced_to is None)."""
+    async def _wait_member_unsynced(self, member_id: str, timeout: float = 5.0) -> bool:
+        """
+        Wait until the given member reports as unsynced (synced_to is None).
+
+        Returns ``True`` when the member is verified unsynced (downstream flows
+        like leader selection / play_media on the leader are safe to proceed),
+        or ``False`` when the player is genuinely stuck (the caller should
+        abort rather than issue a play_media that will be rejected by the
+        provider's "I'm synced to another player" guard).
+
+        :param member_id: The player to wait on.
+        :param timeout: Seconds to wait for the first state propagation.
+        """
         async with self.mass.players.wait_for_player_update(
             member_id,
             attribute_name="synced_to",
@@ -839,6 +1014,39 @@ class SyncGroupPlayer(Player):
             timeout=timeout,
         ):
             pass
+        member = self.mass.players.get_player(member_id)
+        if member is None or member.synced_to is None:
+            return True
+        # The provider didn't propagate within the timeout. Try an explicit
+        # ungroup to push the protocol layer, then wait again with a tighter
+        # budget. This rescues the common "Sonos UPnP event lag" case.
+        self.logger.warning(
+            "Player %s still reports synced_to=%s after %ss; "
+            "issuing explicit ungroup and re-waiting",
+            member.display_name,
+            member.synced_to,
+            timeout,
+        )
+        try:
+            await self.mass.players.cmd_ungroup(member_id)
+        except Exception as err:
+            self.logger.debug("ungroup recovery for %s raised: %s", member.display_name, err)
+        async with self.mass.players.wait_for_player_update(
+            member_id,
+            attribute_name="synced_to",
+            attribute_value=None,
+            timeout=2.0,
+        ):
+            pass
+        member = self.mass.players.get_player(member_id)
+        if member is None or member.synced_to is None:
+            return True
+        self.logger.error(
+            "Player %s is stuck synced_to=%s; aborting dissolve+reform path",
+            member.display_name,
+            member.synced_to,
+        )
+        return False
 
     async def _dynamic_leader_switch(self, old_leader_id: str) -> None:
         """Switch the sync leader without tearing down the stream session.
@@ -902,9 +1110,14 @@ class SyncGroupPlayer(Player):
                 self.display_name,
             )
             # Restore sync_leader so _dissolve_and_reform -> _dissolve_syncgroup
-            # can properly ungroup protocol-level members.
+            # can properly ungroup protocol-level members. Forward the protocol
+            # hint so the new form keeps protocol continuity when possible.
             self.sync_leader = old_leader
-            await self._dissolve_and_reform(old_leader_id, leader_to_stop=old_leader)
+            await self._dissolve_and_reform(
+                old_leader_id,
+                leader_to_stop=old_leader,
+                preferred_protocol_domain=preferred_domain,
+            )
             return
 
         self.sync_leader = new_leader
@@ -950,6 +1163,47 @@ class SyncGroupPlayer(Player):
             await new_target.set_members(player_ids_to_add=remaining_protocol_ids)
 
         self.update_state()
+
+    def _schedule_idle_grace_timer(self) -> None:
+        """Schedule a debounced dissolve after the leader becomes idle."""
+        # any previously scheduled task is replaced so we don't end up with
+        # two dissolves racing each other when the leader oscillates quickly
+        self._cancel_idle_grace_timer()
+        self.logger.debug(
+            "Scheduling idle-grace dissolve for syncgroup %s in %ss",
+            self.display_name,
+            IDLE_GRACE_SECONDS,
+        )
+        self._idle_grace_task = self.mass.create_task(self._idle_grace_runner())
+
+    def _cancel_idle_grace_timer(self) -> None:
+        """Cancel any pending idle-grace dissolve task."""
+        if self._idle_grace_task is not None:
+            if not self._idle_grace_task.done():
+                self._idle_grace_task.cancel()
+            self._idle_grace_task = None
+
+    async def _idle_grace_runner(self) -> None:
+        """Wait the grace window, then dissolve if the group is still idle."""
+        try:
+            await asyncio.sleep(IDLE_GRACE_SECONDS)
+        except asyncio.CancelledError:
+            return
+        # re-check state at fire time — playback may have resumed, the user
+        # may have powered the group on, or another path may have dissolved
+        # us already. Any of these means we should not dissolve here.
+        self._idle_grace_task = None
+        if self.sync_leader is None:
+            return
+        if self._attr_powered is True:
+            return
+        if self.sync_leader.state.playback_state != PlaybackState.IDLE:
+            return
+        self.logger.info(
+            "Idle-grace expired for syncgroup %s, dissolving",
+            self.display_name,
+        )
+        await self._dissolve_syncgroup()
 
     def _resolve_session_target(self, player: Player, domain: str | None) -> Player | None:
         """Resolve the player that participates in the live session for ``domain``.

--- a/music_assistant/providers/universal_group/constants.py
+++ b/music_assistant/providers/universal_group/constants.py
@@ -12,6 +12,11 @@ from music_assistant.constants import INTERNAL_PCM_FORMAT, create_sample_rates_c
 
 UGP_PREFIX: Final[str] = "ugp_"
 
+# Grace period (seconds) before a universal group releases its members after
+# the active stream naturally ends (playback_state transitions to IDLE without
+# an explicit stop). Matches the SyncGroup grace window.
+IDLE_GRACE_SECONDS: Final[float] = 10.0
+
 
 CONF_ENTRY_SAMPLE_RATES_UGP = create_sample_rates_config_entry(
     max_sample_rate=96000, max_bit_depth=24, hidden=True

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from copy import deepcopy
 from time import time
 from typing import TYPE_CHECKING, cast
 
 from aiohttp import web
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
-from music_assistant_models.constants import PLAYER_CONTROL_NONE
+from music_assistant_models.constants import PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
@@ -25,6 +26,7 @@ from music_assistant.constants import (
     CONF_DYNAMIC_GROUP_MEMBERS,
     CONF_GROUP_MEMBERS,
     CONF_HTTP_PROFILE,
+    CONF_POWER_CONTROL,
     DEFAULT_STREAM_HEADERS,
     DLNA_CONTENT_FEATURES_REALTIME,
 )
@@ -33,15 +35,18 @@ from music_assistant.helpers.util import TaskManager
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 from music_assistant.providers.universal_group.constants import UGP_FORMAT
 
-from .constants import CONF_ENTRY_SAMPLE_RATES_UGP, CONFIG_ENTRY_UGP_NOTE
+from .constants import CONF_ENTRY_SAMPLE_RATES_UGP, CONFIG_ENTRY_UGP_NOTE, IDLE_GRACE_SECONDS
 from .ugp_stream import UGPStream
 
 if TYPE_CHECKING:
     from .provider import UniversalGroupProvider
 
+# PlayerFeature.POWER is intentionally not in the base feature set anymore:
+# the lifecycle (form on play, dissolve on stop, debounced idle deform) governs
+# whether the group captures its members. POWER is added dynamically when the
+# user assigns 'Fake power control' to the group.
 BASE_FEATURES = {
     PlayerFeature.PLAY_MEDIA,
-    PlayerFeature.POWER,
     PlayerFeature.VOLUME_SET,
     PlayerFeature.MULTI_DEVICE_DSP,
 }
@@ -62,11 +67,16 @@ class UniversalGroupPlayer(Player):
         self.stream: UGPStream | None = None
         self._attr_name = self.config.name or f"Universal Group {player_id}"
         self._attr_available = True
-        self._attr_powered = False  # group players are always powered off by default
+        # See SyncGroupPlayer: groups have no opinion on power by default; the
+        # session lifecycle is what governs activity. Fake power control is the
+        # opt-in mechanism for explicit on/off semantics.
+        self._attr_powered = None
         self._attr_device_info = DeviceInfo(model="Universal Group", manufacturer=provider.name)
         self._attr_supported_features = {*BASE_FEATURES}
         self._attr_needs_poll = True
         self._attr_poll_interval = 30
+        # task that releases members after the idle grace window expires
+        self._idle_grace_task: asyncio.Task[None] | None = None
         # register dynamic route for the ugp stream
         self._on_unload_callbacks.append(
             self.mass.streams.register_dynamic_route(
@@ -97,6 +107,20 @@ class UniversalGroupPlayer(Player):
         return None
 
     @property
+    def is_active_session(self) -> bool:
+        """
+        Return whether this group currently has captured members.
+
+        The session is considered active while the multicast stream is live or
+        while the idle grace timer is still pending. ``__final_active_group``
+        reads this to decide whether the configured members should be marked
+        as ``active_group`` for this group.
+        """
+        if self.stream is not None and not self.stream.done:
+            return True
+        return self._idle_grace_task is not None
+
+    @property
     def can_group_with(self) -> set[str]:
         """Return the id's of players this player can group with."""
         if not self.is_dynamic:
@@ -114,12 +138,22 @@ class UniversalGroupPlayer(Player):
         """Handle logic when the PlayerConfig is first loaded or updated."""
         static_members = cast("list[str]", self.config.get_value(CONF_GROUP_MEMBERS, []))
         self._attr_static_group_members = static_members.copy()
-        if not self.powered:
+        if not self.is_active_session:
+            # only realign members to the configured static set when the group
+            # is dormant — otherwise we would lose any dynamic adds mid-session.
             self._attr_group_members = static_members.copy()
         if self.is_dynamic:
             self._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
         elif PlayerFeature.SET_MEMBERS in self._attr_supported_features:
             self._attr_supported_features.remove(PlayerFeature.SET_MEMBERS)
+        # advertise POWER feature only when the user has opted in via fake control
+        raw_power_conf = self.mass.config.get_raw_player_config_value(
+            self.player_id, CONF_POWER_CONTROL
+        )
+        if raw_power_conf == PLAYER_CONTROL_FAKE:
+            self._attr_supported_features.add(PlayerFeature.POWER)
+        else:
+            self._attr_supported_features.discard(PlayerFeature.POWER)
 
     @cached_property
     def is_dynamic(self) -> bool:
@@ -161,19 +195,48 @@ class UniversalGroupPlayer(Player):
         ]
 
     async def stop(self) -> None:
-        """Handle STOP command."""
+        """
+        Handle STOP command.
+
+        An explicit stop releases the captured members immediately so they
+        return to individual control. The idle grace timer is only used for
+        natural end-of-queue transitions (see :meth:`_set_attributes`). Users
+        who want the group to stay 'active' across stops can assign Fake
+        power control and use that to pin the group.
+        """
+        # an explicit stop overrides any pending idle-grace release
+        self._cancel_idle_grace_timer()
         async with TaskManager(self.mass) as tg:
             for member in self.mass.players.iter_group_members(self, active_only=True):
                 # Use internal handler to get protocol selection and avoid redirect
                 tg.create_task(self.mass.players._handle_cmd_stop(member.player_id))
-        # abort the stream session
+        # abort the stream session — this drops is_active_session to False so
+        # the (former) members will see active_group=None on their next state
+        # update and accept direct playback commands again.
         if self.stream and not self.stream.done:
             await self.stream.stop()
             self.stream = None
+        # snap group_members back to the configured static set so we don't
+        # keep stale dynamic adds around once the session has ended.
+        if self._attr_powered is not True:
+            self._attr_group_members = self._attr_static_group_members.copy()
         self._set_attributes()
 
     async def power(self, powered: bool) -> None:
-        """Handle POWER command to group player."""
+        """
+        Handle POWER command to group player.
+
+        Only called when the user has assigned a power control (native or fake)
+        to the group. Powering ON prepares the members so the group is
+        considered 'active' immediately (matching the legacy behaviour for
+        users who opt in). Powering OFF stops any playback and releases the
+        captured members.
+
+        :param powered: True to power on (capture members), False to power off (release).
+        """
+        # any pending idle-grace release is moot — we're on an explicit transition
+        self._cancel_idle_grace_timer()
+
         # always stop at power off
         if not powered and self._attr_playback_state in (
             PlaybackState.PLAYING,
@@ -181,67 +244,16 @@ class UniversalGroupPlayer(Player):
         ):
             await self.stop()
 
-        # optimistically set the group state
         prev_power = self._attr_powered
         self._attr_powered = powered
 
         if powered:
-            # reset the group members to the available static members when powering on
-            self._attr_group_members = []
-            for static_group_member in self._attr_static_group_members:
-                if (
-                    (member_player := self.mass.players.get_player(static_group_member))
-                    and member_player.available
-                    and member_player.enabled
-                ):
-                    self._attr_group_members.append(static_group_member)
-            # handle TURN_ON of the group player by turning on all members
-            for member in self.mass.players.iter_group_members(
-                self, only_powered=False, active_only=False
-            ):
-                if (
-                    member.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
-                    and member.active_source != self.active_source
-                ):
-                    # stop playing existing content on member if we start the group player
-                    # Use internal handler to get protocol selection and avoid redirect
-                    await self.mass.players._handle_cmd_stop(member.player_id)
-                if (
-                    member.state.active_group is not None
-                    and member.state.active_group != self.player_id
-                ):
-                    # collision: child player is part of multiple groups
-                    # and another group already active !
-                    # solve this by trying to leave the group first
-                    if other_group := self.mass.players.get_player(member.state.active_group):
-                        if (
-                            other_group.supports_feature(PlayerFeature.SET_MEMBERS)
-                            and member.player_id not in other_group.static_group_members
-                        ):
-                            async with self.mass.players.wait_for_player_update(
-                                member.player_id, timeout=5
-                            ):
-                                await other_group.set_members(
-                                    player_ids_to_remove=[member.player_id]
-                                )
-                        else:
-                            # if the other group does not support SET_MEMBERS or it is a static
-                            # member, we need to power it off to leave the group
-                            async with self.mass.players.wait_for_player_update(
-                                member.player_id, timeout=5
-                            ):
-                                await other_group.power(False)
-                if member.synced_to:
-                    # edge case: the member is part of a syncgroup - ungroup it first
-                    await member.ungroup()
-                if not member.powered and member.power_control != PLAYER_CONTROL_NONE:
-                    await self.mass.players.cmd_power(member.player_id, True)
+            await self._capture_members()
         elif prev_power:
             # handle TURN_OFF of the group player by turning off all members
             for member in self.mass.players.iter_group_members(
                 self, only_powered=True, active_only=True
             ):
-                # handle TURN_OFF of the group player by turning off all members
                 if member.powered and member.power_control != PLAYER_CONTROL_NONE:
                     await self.mass.players.cmd_power(member.player_id, False)
 
@@ -250,13 +262,78 @@ class UniversalGroupPlayer(Player):
             self._attr_group_members = self._attr_static_group_members.copy()
         self.update_state()
 
+    async def _capture_members(self) -> None:
+        """
+        Resolve collisions and prepare the configured members for grouping.
+
+        Rebuilds the effective member list from the configured static set,
+        powers on each member that has a power control, releases members
+        that are currently captured by another group / sync session, and
+        leaves the group ready for playback. Idempotent: safe to call on an
+        already-prepared group.
+        """
+        # rebuild the effective member list from the configured static set
+        self._attr_group_members = []
+        for static_group_member in self._attr_static_group_members:
+            if (
+                (member_player := self.mass.players.get_player(static_group_member))
+                and member_player.available
+                and member_player.enabled
+            ):
+                self._attr_group_members.append(static_group_member)
+        # ensure each member is free of any prior group/sync allegiance and ready to play
+        for member in self.mass.players.iter_group_members(
+            self, only_powered=False, active_only=False
+        ):
+            if (
+                member.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
+                and member.active_source != self.active_source
+            ):
+                # Use internal handler to get protocol selection and avoid redirect
+                await self.mass.players._handle_cmd_stop(member.player_id)
+            if (
+                member.state.active_group is not None
+                and member.state.active_group != self.player_id
+            ):
+                # collision: child is currently captured by a different group
+                if other_group := self.mass.players.get_player(member.state.active_group):
+                    if (
+                        other_group.supports_feature(PlayerFeature.SET_MEMBERS)
+                        and member.player_id not in other_group.static_group_members
+                    ):
+                        async with self.mass.players.wait_for_player_update(
+                            member.player_id, timeout=5
+                        ):
+                            await other_group.set_members(player_ids_to_remove=[member.player_id])
+                    # the other group can't release this member dynamically — stop it
+                    # entirely so the member is freed. Avoid calling power() on a group
+                    # that has no power control (would be a no-op + warning).
+                    elif other_group.state.power_control != PLAYER_CONTROL_NONE:
+                        async with self.mass.players.wait_for_player_update(
+                            member.player_id, timeout=5
+                        ):
+                            await other_group.power(False)
+                    else:
+                        async with self.mass.players.wait_for_player_update(
+                            member.player_id, timeout=5
+                        ):
+                            await other_group.stop()
+            if member.synced_to:
+                # member is part of a syncgroup — release it first
+                await member.ungroup()
+            if not member.powered and member.power_control != PLAYER_CONTROL_NONE:
+                await self.mass.players.cmd_power(member.player_id, True)
+
     async def volume_set(self, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""
         # group volume is already handled in the player manager
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Handle PLAY MEDIA on given player."""
-        await self.power(True)
+        # form on play: cancel any pending idle-grace release, then capture the
+        # configured members and free them of any conflicting prior allegiance.
+        self._cancel_idle_grace_timer()
+        await self._capture_members()
 
         if self.stream and not self.stream.done:
             # stop any existing stream first
@@ -357,11 +434,12 @@ class UniversalGroupPlayer(Player):
 
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
+        self._cancel_idle_grace_timer()
         await super().on_unload()
-        if self.powered:
-            # edge case: the group player is powered and being unloaded
-            # make sure to turn it off first (which will also ungroup a syncgroup)
-            await self.power(False)
+        if self.is_active_session or self._attr_powered is True:
+            # tear down any in-flight session before unloading
+            await self.stop()
+            self._attr_powered = False
 
     def _set_attributes(self) -> None:
         """Set attributes of the group player."""
@@ -371,6 +449,7 @@ class UniversalGroupPlayer(Player):
         elif not self.is_dynamic and PlayerFeature.SET_MEMBERS in self.supported_features:
             # static group players should not support SET_MEMBERS feature
             self._attr_supported_features.discard(PlayerFeature.SET_MEMBERS)
+        prev_state = self._attr_playback_state
         # grab current media and state from one of the active players
         # use state properties (not raw attributes) to account for protocol player propagation
         for child_player in self.mass.players.iter_group_members(self, active_only=True):
@@ -381,6 +460,62 @@ class UniversalGroupPlayer(Player):
             break
         else:
             self._attr_playback_state = PlaybackState.IDLE
+        # idle grace handling: schedule a debounced release when playback
+        # naturally transitions to IDLE (e.g. queue ended). Skipped if the
+        # user has pinned the group with Fake power control.
+        if (
+            self._attr_playback_state == PlaybackState.IDLE
+            and prev_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
+            and self._attr_powered is not True
+            and self.stream is not None
+            and not self.stream.done
+        ):
+            self._schedule_idle_grace_timer()
+        elif self._attr_playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
+            self._cancel_idle_grace_timer()
+        self.update_state()
+
+    def _schedule_idle_grace_timer(self) -> None:
+        """Schedule a debounced session release after the stream becomes idle."""
+        self._cancel_idle_grace_timer()
+        self.logger.debug(
+            "Scheduling idle-grace release for universal group %s in %ss",
+            self.display_name,
+            IDLE_GRACE_SECONDS,
+        )
+        self._idle_grace_task = self.mass.create_task(self._idle_grace_runner())
+
+    def _cancel_idle_grace_timer(self) -> None:
+        """Cancel any pending idle-grace release task."""
+        if self._idle_grace_task is not None:
+            if not self._idle_grace_task.done():
+                self._idle_grace_task.cancel()
+            self._idle_grace_task = None
+
+    async def _idle_grace_runner(self) -> None:
+        """Wait the grace window, then release members if still idle."""
+        try:
+            await asyncio.sleep(IDLE_GRACE_SECONDS)
+        except asyncio.CancelledError:
+            return
+        # re-check state at fire time — a new play may have arrived, the user
+        # may have powered the group on, or another path may have torn down
+        # the session already.
+        self._idle_grace_task = None
+        if self._attr_powered is True:
+            return
+        if self._attr_playback_state != PlaybackState.IDLE:
+            return
+        self.logger.info(
+            "Idle-grace expired for universal group %s, releasing members",
+            self.display_name,
+        )
+        if self.stream and not self.stream.done:
+            await self.stream.stop()
+            self.stream = None
+        # snap group_members back to the configured static set; this drops
+        # is_active_session to False so children see active_group=None.
+        self._attr_group_members = self._attr_static_group_members.copy()
         self.update_state()
 
     async def _serve_ugp_stream(self, request: web.Request) -> web.StreamResponse:

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -305,14 +305,16 @@ class UniversalGroupPlayer(Player):
                             member.player_id, timeout=5
                         ):
                             await other_group.set_members(player_ids_to_remove=[member.player_id])
-                    # the other group can't release this member dynamically — stop it
-                    # entirely so the member is freed. Avoid calling power() on a group
-                    # that has no power control (would be a no-op + warning).
+                    # the other group can't release this member dynamically — stop
+                    # it entirely so the member is freed. Route power-off through
+                    # the controller so a FAKE-power group also gets its extra_data
+                    # updated; calling other_group.power() directly would only set
+                    # _attr_powered and leave the cached fake state out of sync.
                     elif other_group.state.power_control != PLAYER_CONTROL_NONE:
                         async with self.mass.players.wait_for_player_update(
                             member.player_id, timeout=5
                         ):
-                            await other_group.power(False)
+                            await self.mass.players._handle_cmd_power(other_group.player_id, False)
                     else:
                         async with self.mass.players.wait_for_player_update(
                             member.player_id, timeout=5
@@ -395,8 +397,11 @@ class UniversalGroupPlayer(Player):
                 # This is player is part of a syncgroup - ungroup it first
                 await child_player.ungroup()
             self._attr_group_members.append(player_id)
-            # let the newly add member join the stream if we're playing
-            if self.stream and not self.stream.done and self.powered:
+            # let the newly added member join the stream if it's still live —
+            # the `self.powered` gate that used to guard this is gone with the
+            # session-lifecycle refactor (groups now have `_attr_powered=None`
+            # unless the user assigned Fake control).
+            if self.stream and not self.stream.done:
                 base_url = f"{self.mass.streams.base_url}/ugp/{self.player_id}.flac"
                 # Use internal handler to get protocol selection and avoid redirect
                 await self.mass.players._handle_play_media(

--- a/tests/core/test_player_controller.py
+++ b/tests/core/test_player_controller.py
@@ -422,5 +422,322 @@ class TestUnregisterCleanup:
         assert "set_members_other" in controller._player_command_locks
 
 
+def _set_play_media_override(mock_mass: MagicMock, value: bool) -> None:
+    """Configure get_raw_player_config_value to return ``value`` for the play-media override key.
+
+    Other keys keep the existing defaults from the shared fixture. Use this in
+    tests for ``play_media`` override behavior so the legacy/new branch is
+    selected deterministically.
+    """
+    original = mock_mass.config.get_raw_player_config_value.side_effect
+
+    def _side_effect(player_id: str, key: str, default: object = None) -> object:
+        if key == "play_media_overrides_group":
+            return value
+        if callable(original):
+            return original(player_id, key, default)
+        return default if default is not None else "auto"
+
+    mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_side_effect)
+
+
+class TestCmdUngroupNewBranches:
+    """Regression tests for the post-refactor cmd_ungroup flow.
+
+    The refactor changed two things:
+
+    - ``cmd_ungroup`` on a group player no longer calls ``cmd_set_members``
+      (which would hit the "Cannot remove static member" guard); instead it
+      stops or powers off the group entirely.
+    - ``cmd_ungroup`` on a static member of a group recurses to ungroup the
+      group, because static members cannot be released individually.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ungroup_group_player_with_power_uses_power_off(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Ungroup on a group with explicit power control routes through cmd_power(False)."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_group", instance_id="test_group", mass=mock_mass)
+        group = MockPlayer(provider, "g1", "Group", player_type=PlayerType.GROUP)
+        group._attr_powered = True
+        group._attr_group_members = ["member"]
+        group._attr_supported_features = {PlayerFeature.POWER}
+
+        # ensure power_control resolves to NATIVE so cmd_ungroup uses the power path
+        def _conf(_player_id: str, key: str, default: object = None) -> object:
+            if key == "power_control":
+                return "native"
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 100
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_conf)
+
+        controller._players = {"g1": group}
+        controller._player_throttlers = {"g1": Throttler(1, 0.05)}
+        mock_mass.players = controller
+
+        # populate state.type / state.power_control / state.group_members
+        group.set_initialized()
+        group._cache.clear()
+        group.update_state(signal_event=False)
+
+        called: dict[str, bool | str] = {}
+
+        async def _power(
+            player_id: str,
+            powered: bool,
+            skip_auto_play: bool = False,  # noqa: ARG001
+        ) -> None:
+            called["player_id"] = player_id
+            called["powered"] = powered
+
+        controller._handle_cmd_power = _power  # type: ignore[method-assign]
+
+        await controller.cmd_ungroup("g1")
+
+        assert called == {"player_id": "g1", "powered": False}
+
+    @pytest.mark.asyncio
+    async def test_ungroup_powerless_group_calls_stop(self, mock_mass: MagicMock) -> None:
+        """Ungroup on a powerless group falls through to _handle_cmd_stop."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_group", instance_id="test_group", mass=mock_mass)
+        group = MockPlayer(provider, "g1", "Group", player_type=PlayerType.GROUP)
+        group._attr_powered = None  # no power control
+        group._attr_group_members = ["member"]
+        # no POWER feature → power_control auto-selects to NONE
+
+        controller._players = {"g1": group}
+        controller._player_throttlers = {"g1": Throttler(1, 0.05)}
+        mock_mass.players = controller
+
+        group.set_initialized()
+        group._cache.clear()
+        group.update_state(signal_event=False)
+
+        stop_called: list[str] = []
+
+        async def _stop(player_id: str) -> None:
+            stop_called.append(player_id)
+
+        controller._handle_cmd_stop = _stop  # type: ignore[method-assign]
+        # also stub power to make sure we did NOT go down that branch
+        power_called: list[str] = []
+
+        async def _power(
+            player_id: str,
+            powered: bool,  # noqa: ARG001
+            skip_auto_play: bool = False,  # noqa: ARG001
+        ) -> None:
+            power_called.append(player_id)
+
+        controller._handle_cmd_power = _power  # type: ignore[method-assign]
+
+        await controller.cmd_ungroup("g1")
+
+        assert stop_called == ["g1"]
+        assert power_called == []  # powerless group → never goes through cmd_power
+
+
+class TestPlayMediaOverride:
+    """Tests for the new CONF_PLAY_MEDIA_OVERRIDES_GROUP behavior.
+
+    When a captured child player receives an explicit play_media command, the
+    default behavior is to *release* it from the active group/sync and play
+    directly on the targeted player. The legacy behavior (forward to the
+    leader) is preserved via the per-player config opt-out.
+    """
+
+    @pytest.mark.asyncio
+    async def test_override_disabled_redirects_to_group(self, mock_mass: MagicMock) -> None:
+        """With override disabled, play_media on a captured child redirects to the group."""
+        controller = PlayerController(mock_mass)
+        group_provider = MockProvider("test_group", instance_id="test_group", mass=mock_mass)
+        member_provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        class _SessionedGroup(MockPlayer):
+            @property
+            def is_active_session(self) -> bool:
+                return True
+
+        group = _SessionedGroup(group_provider, "g1", "Group", player_type=PlayerType.GROUP)
+        group._attr_powered = None
+        group._attr_group_members = ["member"]
+
+        member = MockPlayer(member_provider, "member", "Member")
+
+        controller._players = {"g1": group, "member": member}
+        controller._player_throttlers = {
+            "g1": Throttler(1, 0.05),
+            "member": Throttler(1, 0.05),
+        }
+        mock_mass.players = controller
+
+        group.set_initialized()
+        member.set_initialized()
+        group.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+        # sanity: the member is captured by the group
+        assert member.state.active_group == "g1"
+
+        _set_play_media_override(mock_mass, False)
+
+        played_on: list[str] = []
+
+        async def _handle_play_media(player_id: str, media: object) -> None:  # noqa: ARG001
+            played_on.append(player_id)
+
+        controller._handle_play_media = _handle_play_media  # type: ignore[method-assign]
+        # the play_media wrapper acquires a playback lock; stub it out
+        controller._player_command_locks = {}
+
+        media = MagicMock(uri="x", source_id="src")
+        await controller.play_media("member", media)
+
+        # legacy behavior: redirected to the group leader
+        assert played_on == ["g1"]
+
+    @pytest.mark.asyncio
+    async def test_override_releases_dynamic_member(self, mock_mass: MagicMock) -> None:
+        """With override enabled, play_media on a dynamic group member releases it first."""
+        controller = PlayerController(mock_mass)
+        group_provider = MockProvider("test_group", instance_id="test_group", mass=mock_mass)
+        member_provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        class _SessionedGroup(MockPlayer):
+            @property
+            def is_active_session(self) -> bool:
+                return True
+
+        group = _SessionedGroup(group_provider, "g1", "Group", player_type=PlayerType.GROUP)
+        group._attr_powered = None
+        group._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        group._attr_group_members = ["member"]
+        # NOT a static member ⇒ dynamic — can be removed via set_members
+        group._attr_static_group_members = []
+
+        member = MockPlayer(member_provider, "member", "Member")
+
+        controller._players = {"g1": group, "member": member}
+        controller._player_throttlers = {
+            "g1": Throttler(1, 0.05),
+            "member": Throttler(1, 0.05),
+        }
+        mock_mass.players = controller
+
+        group.set_initialized()
+        member.set_initialized()
+        group.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+        assert member.state.active_group == "g1"
+
+        # default: override enabled
+        _set_play_media_override(mock_mass, True)
+
+        set_members_calls: list[dict[str, object]] = []
+
+        async def _cmd_set_members(
+            target_player: str,
+            player_ids_to_add: list[str] | None = None,  # noqa: ARG001
+            player_ids_to_remove: list[str] | None = None,
+        ) -> None:
+            set_members_calls.append(
+                {"player_id": target_player, "remove": player_ids_to_remove or []}
+            )
+
+        controller.cmd_set_members = _cmd_set_members  # type: ignore[method-assign]
+
+        played_on: list[str] = []
+
+        async def _handle_play_media(player_id: str, media: object) -> None:  # noqa: ARG001
+            played_on.append(player_id)
+
+        controller._handle_play_media = _handle_play_media  # type: ignore[method-assign]
+        controller._player_command_locks = {}
+
+        media = MagicMock(uri="x", source_id="src")
+        await controller.play_media("member", media)
+
+        # the member was removed from the group ...
+        assert set_members_calls == [{"player_id": "g1", "remove": ["member"]}]
+        # ... and then play_media was issued directly on the member, NOT on the group
+        assert played_on == ["member"]
+
+    @pytest.mark.asyncio
+    async def test_override_stops_static_group(self, mock_mass: MagicMock) -> None:
+        """With override enabled, play_media on a STATIC group member stops the group."""
+        controller = PlayerController(mock_mass)
+        group_provider = MockProvider("test_group", instance_id="test_group", mass=mock_mass)
+        member_provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        class _SessionedGroup(MockPlayer):
+            @property
+            def is_active_session(self) -> bool:
+                return True
+
+        group = _SessionedGroup(group_provider, "g1", "Group", player_type=PlayerType.GROUP)
+        group._attr_powered = None  # no power control ⇒ stop, not power-off
+        group._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        group._attr_group_members = ["member"]
+        # static member - cannot be removed individually
+        group._attr_static_group_members = ["member"]
+
+        member = MockPlayer(member_provider, "member", "Member")
+
+        controller._players = {"g1": group, "member": member}
+        controller._player_throttlers = {
+            "g1": Throttler(1, 0.05),
+            "member": Throttler(1, 0.05),
+        }
+        mock_mass.players = controller
+
+        group.set_initialized()
+        member.set_initialized()
+        group.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+        assert member.state.active_group == "g1"
+
+        _set_play_media_override(mock_mass, True)
+
+        stop_calls: list[str] = []
+        power_calls: list[tuple[str, bool]] = []
+
+        async def _stop(player_id: str) -> None:
+            stop_calls.append(player_id)
+
+        async def _power(
+            player_id: str,
+            powered: bool,
+            skip_auto_play: bool = False,  # noqa: ARG001
+        ) -> None:
+            power_calls.append((player_id, powered))
+
+        controller._handle_cmd_stop = _stop  # type: ignore[method-assign]
+        controller._handle_cmd_power = _power  # type: ignore[method-assign]
+
+        played_on: list[str] = []
+
+        async def _handle_play_media(player_id: str, media: object) -> None:  # noqa: ARG001
+            played_on.append(player_id)
+
+        controller._handle_play_media = _handle_play_media  # type: ignore[method-assign]
+        controller._player_command_locks = {}
+
+        media = MagicMock(uri="x", source_id="src")
+        await controller.play_media("member", media)
+
+        # powerless group + static member: we should have stopped the group ...
+        assert stop_calls == ["g1"]
+        # ... not powered it off ...
+        assert power_calls == []
+        # ... and play_media was issued directly on the member
+        assert played_on == ["member"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/core/test_player_controls.py
+++ b/tests/core/test_player_controls.py
@@ -118,12 +118,25 @@ class TestPowerControlExplicitConfig:
     """Test power_control with explicit config values."""
 
     def test_explicit_native(self, mock_mass: MagicMock) -> None:
-        """Power control returns native when explicitly configured."""
+        """Power control returns native when explicitly configured and feature is supported."""
         mock_mass.config.get_raw_player_config_value = MagicMock(
             side_effect=_make_config_side_effect({CONF_POWER_CONTROL: PLAYER_CONTROL_NATIVE})
         )
-        player = _create_player(mock_mass)
+        # NATIVE control requires the player to actually advertise POWER —
+        # otherwise the getter degrades to NONE (e.g. when a group player
+        # drops POWER from its feature set on upgrade but its stale config
+        # still says NATIVE).
+        player = _create_player(mock_mass, features={PlayerFeature.POWER})
         assert player.power_control == PLAYER_CONTROL_NATIVE
+
+    def test_explicit_native_degrades_when_feature_missing(self, mock_mass: MagicMock) -> None:
+        """Stale NATIVE config falls back to NONE when the player no longer advertises POWER."""
+        mock_mass.config.get_raw_player_config_value = MagicMock(
+            side_effect=_make_config_side_effect({CONF_POWER_CONTROL: PLAYER_CONTROL_NATIVE})
+        )
+        # no POWER in features → the explicit NATIVE in config is invalid
+        player = _create_player(mock_mass)
+        assert player.power_control == PLAYER_CONTROL_NONE
 
     def test_explicit_fake(self, mock_mass: MagicMock) -> None:
         """Power control returns fake when explicitly configured."""

--- a/tests/core/test_player_grouping.py
+++ b/tests/core/test_player_grouping.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from music_assistant_models.enums import PlaybackState, PlayerFeature
+from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
 
 from music_assistant.controllers.players import PlayerController
 from tests.common import MockPlayer, MockProvider
@@ -334,6 +334,132 @@ class TestProviderInstanceIdExpansion:
         can_group = player_a.state.can_group_with
         assert "player_b" in can_group
         assert "player_c" in can_group
+
+
+class TestFinalActiveGroupNewModel:
+    """The active_group derivation respects is_active_session and the powered signal.
+
+    Verifies the post-refactor contract:
+
+    - A group whose ``powered`` attribute is ``False`` (e.g. user explicitly
+      pinned it off via Fake control) never captures its members.
+    - A group whose ``powered`` is ``True`` (fake-pinned on) captures members
+      even without a live session.
+    - A group with ``powered=None`` (no power control assigned) only captures
+      members while ``is_active_session`` is ``True`` — i.e. while it has a
+      sync_leader, an active stream, or a pending idle-grace task.
+    """
+
+    def test_dormant_group_does_not_capture_members(self, mock_mass: MagicMock) -> None:
+        """No power signal, no session → member's active_group is None."""
+        controller = PlayerController(mock_mass)
+        group_provider = MockProvider("test_group", instance_id="test_group", mass=mock_mass)
+        member_provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        group = MockPlayer(group_provider, "g1", "Group", player_type=PlayerType.GROUP)
+        # explicitly "no opinion" on power (matches new default for groups)
+        group._attr_powered = None
+        # listed as a configured member, but no active session
+        group._attr_group_members = ["member"]
+        # is_active_session base default is False → group is dormant
+        group._cache.clear()
+
+        member = MockPlayer(member_provider, "member", "Member")
+
+        controller._players = {"g1": group, "member": member}
+        mock_mass.players = controller
+
+        group.set_initialized()
+        member.set_initialized()
+        group.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+
+        assert member.state.active_group is None
+
+    def test_powered_true_group_captures_members(self, mock_mass: MagicMock) -> None:
+        """Group with _attr_powered=True (fake pin) captures members regardless of session."""
+        controller = PlayerController(mock_mass)
+        group_provider = MockProvider("test_group", instance_id="test_group", mass=mock_mass)
+        member_provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        group = MockPlayer(group_provider, "g1", "Group", player_type=PlayerType.GROUP)
+        group._attr_powered = True
+        group._attr_group_members = ["member"]
+        group._cache.clear()
+
+        member = MockPlayer(member_provider, "member", "Member")
+
+        controller._players = {"g1": group, "member": member}
+        mock_mass.players = controller
+
+        group.set_initialized()
+        member.set_initialized()
+        group.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+
+        assert member.state.active_group == "g1"
+
+    def test_powered_false_group_does_not_capture_members(self, mock_mass: MagicMock) -> None:
+        """Group with _attr_powered=False (explicit off) does not capture, even with a session."""
+        controller = PlayerController(mock_mass)
+        group_provider = MockProvider("test_group", instance_id="test_group", mass=mock_mass)
+        member_provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        group = MockPlayer(group_provider, "g1", "Group", player_type=PlayerType.GROUP)
+        group._attr_powered = False
+        group._attr_group_members = ["member"]
+        group._cache.clear()
+
+        member = MockPlayer(member_provider, "member", "Member")
+
+        controller._players = {"g1": group, "member": member}
+        mock_mass.players = controller
+
+        group.set_initialized()
+        member.set_initialized()
+        group.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+
+        assert member.state.active_group is None
+
+    def test_session_active_group_captures_members(self, mock_mass: MagicMock) -> None:
+        """Group with powered=None but is_active_session=True captures members."""
+        controller = PlayerController(mock_mass)
+        group_provider = MockProvider("test_group", instance_id="test_group", mass=mock_mass)
+        member_provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        # subclass MockPlayer to override is_active_session for this test
+        class _SessionedGroup(MockPlayer):
+            @property
+            def is_active_session(self) -> bool:
+                return True
+
+        group = _SessionedGroup(group_provider, "g1", "Group", player_type=PlayerType.GROUP)
+        group._attr_powered = None  # no opinion on power
+        group._attr_group_members = ["member"]
+        group._cache.clear()
+
+        member = MockPlayer(member_provider, "member", "Member")
+
+        controller._players = {"g1": group, "member": member}
+        mock_mass.players = controller
+
+        group.set_initialized()
+        member.set_initialized()
+        group.update_state(signal_event=False)
+        member.update_state(signal_event=False)
+
+        assert member.state.active_group == "g1"
+
+
+class TestPlayerBaseIsActiveSession:
+    """The Player base class defaults is_active_session to False; only groups override it."""
+
+    def test_base_player_is_not_an_active_session(self, mock_mass: MagicMock) -> None:
+        """A regular MockPlayer should never claim to hold a captured session."""
+        provider = MockProvider("test", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "p1", "P1")
+        assert player.is_active_session is False
 
 
 if __name__ == "__main__":

--- a/tests/providers/test_sync_group.py
+++ b/tests/providers/test_sync_group.py
@@ -89,6 +89,11 @@ def _make_mock_player(
     player.state.can_group_with = set()
     player.state.group_members = []
     player.state.supported_features = {PlayerFeature.SET_MEMBERS}
+    # default to "not synced" so the syncgroup form path doesn't enter the
+    # stale-state wait loop. Tests that want to assert on the stale-state
+    # behavior can override this explicitly.
+    player.state.synced_to = None
+    player.synced_to = None
     player.set_members = AsyncMock()
 
     return player
@@ -865,3 +870,299 @@ class TestMembersFilterMigration:
         # Universe = {a} (sg/ug/syncgroup_1 are group providers excluded).
         # Inversion removes a, so allowed_members is empty.
         assert sg["allowed_members"] == []
+
+
+class TestIsActiveSession:
+    """The is_active_session property gates whether children report active_group."""
+
+    def test_dormant_group_is_not_active(self) -> None:
+        """A freshly-initialized group has no leader and no grace timer."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        assert sgp.is_active_session is False
+
+    def test_group_with_sync_leader_is_active(self) -> None:
+        """A group with a sync leader is considered active even without playback."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        sgp.sync_leader = _make_mock_player("leader")
+        assert sgp.is_active_session is True
+
+    def test_group_in_grace_window_is_active(self) -> None:
+        """While the idle-grace task is pending, the group still claims captured members."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        # simulate a pending grace task without actually running asyncio
+        sgp._idle_grace_task = MagicMock()
+        assert sgp.is_active_session is True
+
+
+class TestPowerlessLifecycle:
+    """Form-on-play / deform-on-stop semantics when no power control is assigned."""
+
+    @pytest.mark.asyncio
+    async def test_play_media_forms_group_when_dormant(self) -> None:
+        """play_media on a dormant group should select a leader and forward to it."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader})
+        sgp._attr_group_members = ["leader"]
+        assert sgp.sync_leader is None
+
+        with patch.object(sgp, "update_state"):
+            await sgp.play_media(MagicMock(source_id="src", uri="x"))
+
+        assert sgp.sync_leader == leader
+        # mypy narrows sync_leader to None from the earlier assert; the
+        # play_media call is what re-populates it, but mypy can't track that
+        # mutation through the patch context — hence the ignore.
+        mass.players._handle_play_media.assert_awaited_once()  # type: ignore[unreachable]
+
+    @pytest.mark.asyncio
+    async def test_stop_dissolves_group_when_powerless(self) -> None:
+        """stop() on a group without power control should dissolve the session."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]
+        # _attr_powered is None by default (no power control) so stop dissolves
+        assert sgp._attr_powered is None
+
+        with patch.object(sgp, "update_state"):
+            await sgp.stop()
+
+        # leader was stopped via the internal handler ...
+        mass.players._handle_cmd_stop.assert_any_await("leader")
+        # ... and the session was dissolved (sync_leader cleared)
+        assert sgp.sync_leader is None
+
+    @pytest.mark.asyncio
+    async def test_stop_preserves_group_when_pinned_with_fake_power(self) -> None:
+        """stop() should NOT dissolve when the user has pinned the group on."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]
+        sgp._attr_powered = True  # user explicitly pinned via Fake control
+
+        await sgp.stop()
+
+        mass.players._handle_cmd_stop.assert_any_await("leader")
+        # session stays intact
+        assert sgp.sync_leader == leader
+
+
+class TestIdleGraceTimer:
+    """The idle-grace timer absorbs natural PLAYING→IDLE transitions."""
+
+    def test_grace_scheduled_on_playing_to_idle(self) -> None:
+        """_update_attributes schedules a grace task when the leader transitions to IDLE."""
+        mass = _make_mock_mass()
+        # create_task should return a sentinel we can inspect
+        sentinel = MagicMock()
+        mass.create_task = MagicMock(return_value=sentinel)
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader", playback_state=PlaybackState.IDLE)
+        sgp.sync_leader = leader
+        # previous state was PLAYING
+        sgp._attr_playback_state = PlaybackState.PLAYING
+        sgp._attr_powered = None  # no pin → debounce applies
+
+        sgp._update_attributes()
+
+        assert sgp._idle_grace_task is sentinel
+        mass.create_task.assert_called_once()
+
+    def test_grace_not_scheduled_when_pinned(self) -> None:
+        """No grace task when the user has pinned the group with Fake power."""
+        mass = _make_mock_mass()
+        mass.create_task = MagicMock()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader", playback_state=PlaybackState.IDLE)
+        sgp.sync_leader = leader
+        sgp._attr_playback_state = PlaybackState.PLAYING
+        sgp._attr_powered = True  # explicit pin
+
+        sgp._update_attributes()
+
+        assert sgp._idle_grace_task is None
+        mass.create_task.assert_not_called()
+
+    def test_grace_cancelled_on_resume(self) -> None:
+        """A pending grace task is cancelled when the leader resumes playback."""
+        mass = _make_mock_mass()
+        mass.create_task = MagicMock()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader", playback_state=PlaybackState.PLAYING)
+        sgp.sync_leader = leader
+        # pretend a grace task is pending
+        prior_task = MagicMock()
+        prior_task.done.return_value = False
+        sgp._idle_grace_task = prior_task
+        sgp._attr_playback_state = PlaybackState.IDLE
+
+        sgp._update_attributes()
+
+        prior_task.cancel.assert_called_once()
+        assert sgp._idle_grace_task is None
+
+    def test_grace_cancelled_on_explicit_stop(self) -> None:
+        """An explicit stop cancels the pending grace task immediately."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader")
+        mass.players.get_player = _player_lookup({"leader": leader})
+        sgp.sync_leader = leader
+        prior_task = MagicMock()
+        prior_task.done.return_value = False
+        sgp._idle_grace_task = prior_task
+
+        async def _run() -> None:
+            with patch.object(sgp, "update_state"):
+                await sgp.stop()
+
+        import asyncio  # noqa: PLC0415
+
+        asyncio.run(_run())
+
+        prior_task.cancel.assert_called_once()
+        assert sgp._idle_grace_task is None
+
+
+class TestFormWaitsForLeaderUnsynced:
+    """The form path must wait for a stale leader to report synced_to=None."""
+
+    @pytest.mark.asyncio
+    async def test_form_waits_when_leader_still_synced(self) -> None:
+        """If the new leader still reports synced_to, we wait before proceeding."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        # leader reports stale synced_to
+        leader.state.synced_to = "old_leader"
+        # but make _wait_member_unsynced succeed (clears state) so the form proceeds
+        mass.players.get_player = _player_lookup({"leader": leader})
+        sgp._attr_group_members = ["leader"]
+
+        async def fake_wait(
+            _member_id: str,
+            _timeout: float = 5.0,
+        ) -> bool:
+            leader.state.synced_to = None  # simulate provider catching up
+            return True
+
+        with (
+            patch.object(sgp, "update_state"),
+            patch.object(sgp, "_wait_member_unsynced", side_effect=fake_wait) as wait_mock,
+        ):
+            await sgp._form_syncgroup()
+
+        wait_mock.assert_awaited_once_with("leader")
+        assert sgp.sync_leader == leader
+
+    @pytest.mark.asyncio
+    async def test_form_aborts_when_leader_stuck(self) -> None:
+        """If the wait returns False (leader genuinely stuck), abort the form."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        leader.state.synced_to = "old_leader"
+        mass.players.get_player = _player_lookup({"leader": leader})
+        sgp._attr_group_members = ["leader"]
+
+        with (
+            patch.object(sgp, "update_state"),
+            patch.object(sgp, "_wait_member_unsynced", return_value=False),
+        ):
+            await sgp._form_syncgroup()
+
+        # form must NOT have left a sync_leader set, so the caller's play_media
+        # won't be issued against a stuck player (the original Poolhouse race).
+        assert sgp.sync_leader is None
+
+
+class TestWaitMemberUnsynced:
+    """The helper that waits for a member's synced_to to clear (with recovery)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_already_unsynced(self) -> None:
+        """Member already reports synced_to=None → return True without recovery."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        member = _make_mock_player("m1")
+        member.synced_to = None
+        mass.players.get_player = _player_lookup({"m1": member})
+        mass.players.cmd_ungroup = AsyncMock()
+
+        ok = await sgp._wait_member_unsynced("m1")
+
+        assert ok is True
+        mass.players.cmd_ungroup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_attempts_recovery_when_stuck(self) -> None:
+        """If the first wait doesn't clear it, issue a recovery ungroup and wait again."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        member = _make_mock_player("m1")
+        member.synced_to = "old_leader"  # still stale after first wait
+        mass.players.get_player = _player_lookup({"m1": member})
+
+        # cmd_ungroup is what should be called as the recovery action.
+        # We make it succeed by side-effect-clearing synced_to.
+        async def _ungroup(_player_id: str) -> None:
+            member.synced_to = None
+
+        mass.players.cmd_ungroup = AsyncMock(side_effect=_ungroup)
+
+        ok = await sgp._wait_member_unsynced("m1")
+
+        assert ok is True
+        mass.players.cmd_ungroup.assert_awaited_once_with("m1")
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_genuinely_stuck(self) -> None:
+        """If recovery doesn't help either, return False so callers can abort."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        member = _make_mock_player("m1")
+        member.synced_to = "old_leader"  # stays stuck even after recovery
+        mass.players.get_player = _player_lookup({"m1": member})
+        mass.players.cmd_ungroup = AsyncMock()  # no-op: state stays stale
+
+        ok = await sgp._wait_member_unsynced("m1")
+
+        assert ok is False
+        mass.players.cmd_ungroup.assert_awaited_once_with("m1")
+
+
+class TestSupportedFeaturesPower:
+    """POWER feature is only advertised when the user opts in via Fake control."""
+
+    def test_power_not_in_base_features_by_default(self) -> None:
+        """No power_control config → POWER feature not advertised."""
+        mass = _make_mock_mass()
+        # default config: no CONF_POWER_CONTROL
+        mass.config.get_raw_player_config_value = MagicMock(return_value=None)
+        sgp = _make_sync_group(mass)
+        assert PlayerFeature.POWER not in sgp.supported_features
+
+    def test_power_advertised_when_fake_control_assigned(self) -> None:
+        """User assigns Fake power control → POWER feature shows up."""
+        mass = _make_mock_mass()
+
+        # CONF_POWER_CONTROL is the only key we care about; for everything
+        # else return whatever the default config helper returns.
+        def _get_raw(_player_id: str, key: str, default: object = None) -> object:
+            if key == "power_control":
+                return "fake"
+            return default
+
+        mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
+        sgp = _make_sync_group(mass)
+        assert PlayerFeature.POWER in sgp.supported_features

--- a/tests/providers/test_universal_group.py
+++ b/tests/providers/test_universal_group.py
@@ -1,0 +1,364 @@
+"""Tests for the Universal Group Player lifecycle.
+
+Mirrors the structure of ``tests/providers/test_sync_group.py`` but covers the
+multicast-stream variant (Universal Group). The new lifecycle replaces the
+mandatory power control with form-on-play, dissolve-on-stop, and a debounced
+idle grace window; these tests pin that behavior in place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.constants import PLAYER_CONTROL_FAKE
+from music_assistant_models.enums import PlaybackState, PlayerFeature
+
+from music_assistant.providers.universal_group.player import UniversalGroupPlayer
+
+
+def _make_mock_mass() -> MagicMock:
+    """Create a minimal mock MusicAssistant for the UGP tests."""
+    mass = MagicMock()
+    mass.players = MagicMock()
+    mass.players.get_player = MagicMock(return_value=None)
+    mass.players._handle_cmd_stop = AsyncMock()
+    mass.players._handle_play_media = AsyncMock()
+    mass.players.cmd_power = AsyncMock()
+    mass.players.iter_group_members = MagicMock(return_value=[])
+
+    wait_ctx = AsyncMock()
+    wait_ctx.__aenter__.return_value = None
+    wait_ctx.__aexit__.return_value = False
+    mass.players.wait_for_player_update = MagicMock(return_value=wait_ctx)
+
+    mass.config = MagicMock()
+
+    def _config_value(key: str, default: object = None) -> object:
+        if key == "group_members":
+            return []
+        if key == "dynamic_members":
+            return False
+        return default
+
+    mass.config.get_base_player_config.return_value = MagicMock(
+        name=None, default_name="Test UGP", get_value=_config_value
+    )
+    mass.config.get_raw_player_config_value = MagicMock(return_value=None)
+
+    mass.streams = MagicMock()
+    mass.streams.base_url = "http://test"
+    mass.streams.register_dynamic_route = MagicMock(return_value=lambda: None)
+    mass.streams.get_stream = MagicMock(return_value=MagicMock())
+
+    # mass.create_task must return a real asyncio.Task so callers that do
+    # `await asyncio.wait([task])` (TaskManager.__aexit__) don't hang on a
+    # MagicMock that pretends to be a task. We wrap coroutines into real
+    # tasks; the underlying mocked methods (_handle_play_media, etc.)
+    # resolve immediately, so the tasks complete fast.
+    def _create_task(target: Any, *_args: Any, **_kwargs: Any) -> asyncio.Task[Any]:
+        if asyncio.iscoroutine(target):
+            return asyncio.ensure_future(target)
+
+        # not a coroutine - return a finished task so callers can still
+        # treat it as awaitable / cancellable.
+        async def _noop() -> None:
+            return None
+
+        return asyncio.ensure_future(_noop())
+
+    mass.create_task = MagicMock(side_effect=_create_task)
+    mass.cache = MagicMock()
+    return mass
+
+
+def _make_ugp(mass: MagicMock, player_id: str = "ugp_test") -> UniversalGroupPlayer:
+    """Create a UniversalGroupPlayer with a mock provider."""
+    provider = MagicMock()
+    provider.domain = "universal_group"
+    provider.instance_id = "universal_group_test"
+    provider.name = "Universal Group"
+    provider.mass = mass
+
+    return UniversalGroupPlayer(provider, player_id)
+
+
+def _make_mock_player(
+    player_id: str,
+    powered: bool = True,
+    available: bool = True,
+    enabled: bool = True,
+    active_group: str | None = None,
+    synced_to: str | None = None,
+    playback_state: PlaybackState = PlaybackState.IDLE,
+) -> MagicMock:
+    """Create a mock child player."""
+    player = MagicMock()
+    player.player_id = player_id
+    player.display_name = player_id
+    player.available = available
+    player.enabled = enabled
+    player.powered = powered
+    player.power_control = "native"
+    player.synced_to = synced_to
+    player.playback_state = playback_state
+    player.active_source = None
+    player.state = MagicMock()
+    player.state.available = available
+    player.state.enabled = enabled
+    player.state.powered = powered
+    player.state.power_control = "native"
+    player.state.active_group = active_group
+    player.state.synced_to = synced_to
+    player.state.playback_state = playback_state
+    player.state.supported_features = {PlayerFeature.PLAY_MEDIA}
+    player.state.elapsed_time = 0
+    player.state.elapsed_time_last_updated = None
+    player.ungroup = AsyncMock()
+    return player
+
+
+class TestIsActiveSession:
+    """is_active_session governs whether children report active_group to this UGP."""
+
+    def test_dormant_group_is_not_active(self) -> None:
+        """A freshly-initialized UGP has no stream and no grace task."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        assert ugp.is_active_session is False
+
+    def test_group_with_live_stream_is_active(self) -> None:
+        """A UGP with a live (not-done) stream is considered active."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        ugp.stream = MagicMock()
+        ugp.stream.done = False
+        assert ugp.is_active_session is True
+
+    def test_group_with_done_stream_is_not_active(self) -> None:
+        """If the stream has already ended, the session is not considered active."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        ugp.stream = MagicMock()
+        ugp.stream.done = True
+        assert ugp.is_active_session is False
+
+    def test_group_in_grace_window_is_active(self) -> None:
+        """While the idle-grace task is pending, the group still claims captured members."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        ugp.stream = None
+        ugp._idle_grace_task = MagicMock()
+        assert ugp.is_active_session is True
+
+
+class TestPowerlessLifecycle:
+    """Form-on-play / dissolve-on-stop without explicit power control."""
+
+    @pytest.mark.asyncio
+    async def test_play_media_captures_members(self) -> None:
+        """play_media should set up a stream and forward to members without a power command."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        ugp._attr_static_group_members = ["m1", "m2"]
+        member1 = _make_mock_player("m1")
+        member2 = _make_mock_player("m2")
+        mass.players.get_player = MagicMock(
+            side_effect=lambda pid, *_args, **_kwargs: {"m1": member1, "m2": member2}.get(pid)
+        )
+        # iter_group_members must yield the captured members after _capture_members runs
+        mass.players.iter_group_members.side_effect = lambda *_args, **_kwargs: iter(
+            [member1, member2]
+        )
+
+        with patch.object(ugp, "update_state"):
+            await ugp.play_media(MagicMock(uri="track://x", source_id="src"))
+
+        assert ugp.stream is not None
+        assert mass.players._handle_play_media.await_count == 2
+        # power command was NOT used to capture the members
+        mass.players.cmd_power.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stop_releases_members_when_powerless(self) -> None:
+        """stop() on a powerless UGP should tear down the stream and release members."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        stream = MagicMock()
+        stream.done = False
+        stream.stop = AsyncMock()
+        ugp.stream = stream
+        ugp._attr_group_members = ["m1"]
+        ugp._attr_static_group_members = ["m1"]
+        member = _make_mock_player("m1")
+        mass.players.iter_group_members.side_effect = lambda *_args, **_kwargs: iter([member])
+        # _attr_powered defaults to None (no power control)
+        assert ugp._attr_powered is None
+
+        with patch.object(ugp, "update_state"):
+            await ugp.stop()
+
+        stream.stop.assert_awaited()
+        # session is no longer active
+        assert ugp.stream is None
+        # mypy narrows ugp.stream to None above; the property check below is
+        # technically static after that narrowing, hence the ignore.
+        assert ugp.is_active_session is False  # type: ignore[unreachable]
+
+    @pytest.mark.asyncio
+    async def test_stop_preserves_session_when_pinned(self) -> None:
+        """stop() on a UGP pinned with Fake power should NOT reset _attr_group_members."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        stream = MagicMock()
+        stream.done = False
+        stream.stop = AsyncMock()
+        ugp.stream = stream
+        ugp._attr_group_members = ["m1", "extra"]
+        ugp._attr_static_group_members = ["m1"]
+        ugp._attr_powered = True  # user explicitly pinned via Fake control
+        member = _make_mock_player("m1")
+        mass.players.iter_group_members.side_effect = lambda *_args, **_kwargs: iter([member])
+
+        with patch.object(ugp, "update_state"):
+            await ugp.stop()
+
+        # we keep the dynamic adds because the user is pinning this group
+        assert "extra" in ugp._attr_group_members
+
+
+class TestIdleGraceTimer:
+    """The idle-grace timer absorbs natural PLAYING→IDLE transitions for UGP."""
+
+    def test_grace_scheduled_on_playing_to_idle(self) -> None:
+        """_set_attributes schedules a grace task on transition while stream is still live."""
+        mass = _make_mock_mass()
+        sentinel = MagicMock()
+        mass.create_task = MagicMock(return_value=sentinel)
+        ugp = _make_ugp(mass)
+        # simulate a live stream and a prior PLAYING state
+        ugp.stream = MagicMock()
+        ugp.stream.done = False
+        ugp._attr_playback_state = PlaybackState.PLAYING
+        # no active children → state derives IDLE
+        mass.players.iter_group_members.side_effect = lambda *_args, **_kwargs: iter([])
+
+        with patch.object(ugp, "update_state"):
+            ugp._set_attributes()
+
+        assert ugp._idle_grace_task is sentinel
+        mass.create_task.assert_called_once()
+
+    def test_grace_not_scheduled_when_pinned(self) -> None:
+        """No grace task when the user has pinned the UGP with Fake power on."""
+        mass = _make_mock_mass()
+        mass.create_task = MagicMock()
+        ugp = _make_ugp(mass)
+        ugp.stream = MagicMock()
+        ugp.stream.done = False
+        ugp._attr_playback_state = PlaybackState.PLAYING
+        ugp._attr_powered = True  # explicit pin
+        mass.players.iter_group_members.side_effect = lambda *_args, **_kwargs: iter([])
+
+        with patch.object(ugp, "update_state"):
+            ugp._set_attributes()
+
+        assert ugp._idle_grace_task is None
+        mass.create_task.assert_not_called()
+
+    def test_grace_cancelled_on_resume(self) -> None:
+        """A pending grace task is cancelled when a member resumes playback."""
+        mass = _make_mock_mass()
+        mass.create_task = MagicMock()
+        ugp = _make_ugp(mass)
+        ugp.stream = MagicMock()
+        ugp.stream.done = False
+        prior = MagicMock()
+        prior.done.return_value = False
+        ugp._idle_grace_task = prior
+        ugp._attr_playback_state = PlaybackState.IDLE
+        playing = _make_mock_player(
+            "m1", playback_state=PlaybackState.PLAYING, active_group="ugp_test"
+        )
+        mass.players.iter_group_members.side_effect = lambda *_args, **_kwargs: iter([playing])
+
+        with patch.object(ugp, "update_state"):
+            ugp._set_attributes()
+
+        prior.cancel.assert_called_once()
+        assert ugp._idle_grace_task is None
+
+
+class TestFakePowerLifecycle:
+    """When the user assigns Fake power control, power(True/False) drives form/dissolve."""
+
+    @pytest.mark.asyncio
+    async def test_power_on_captures_static_members(self) -> None:
+        """power(True) should populate the effective group_members from the configured static set."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        ugp._attr_static_group_members = ["m1", "m2"]
+        member1 = _make_mock_player("m1")
+        member2 = _make_mock_player("m2")
+        mass.players.get_player = MagicMock(
+            side_effect=lambda pid, *_args, **_kwargs: {"m1": member1, "m2": member2}.get(pid)
+        )
+        mass.players.iter_group_members.side_effect = lambda *_args, **_kwargs: iter(
+            [member1, member2]
+        )
+
+        with patch.object(ugp, "update_state"):
+            await ugp.power(True)
+
+        assert ugp._attr_group_members == ["m1", "m2"]
+        assert ugp._attr_powered is True
+
+    @pytest.mark.asyncio
+    async def test_power_off_releases_and_resets_members(self) -> None:
+        """power(False) should reset group_members to static and clear powered."""
+        mass = _make_mock_mass()
+        ugp = _make_ugp(mass)
+        ugp._attr_static_group_members = ["m1"]
+        ugp._attr_group_members = ["m1", "extra"]
+        ugp._attr_powered = True
+        # quietly powered-on member that should get cmd_power(False) on dissolve
+        member = _make_mock_player("m1", powered=True)
+        mass.players.iter_group_members.side_effect = lambda *_args, **_kwargs: iter([member])
+
+        with patch.object(ugp, "update_state"):
+            await ugp.power(False)
+
+        assert ugp._attr_group_members == ["m1"]
+        assert ugp._attr_powered is False
+
+
+class TestSupportedFeaturesPower:
+    """POWER feature is only advertised when the user opts in via Fake control."""
+
+    @pytest.mark.asyncio
+    async def test_power_not_in_features_by_default(self) -> None:
+        """No power_control config → no POWER feature."""
+        mass = _make_mock_mass()
+        # explicitly ensure power_control config is empty
+        mass.config.get_raw_player_config_value = MagicMock(return_value=None)
+        ugp = _make_ugp(mass)
+        # on_config_updated is what (re)evaluates the feature set
+        await ugp.on_config_updated()
+        assert PlayerFeature.POWER not in ugp.supported_features
+
+    @pytest.mark.asyncio
+    async def test_power_advertised_when_fake_control_assigned(self) -> None:
+        """User assigns Fake power control → POWER feature shows up."""
+        mass = _make_mock_mass()
+
+        def _get_raw(_player_id: str, key: str, default: object = None) -> object:
+            if key == "power_control":
+                return PLAYER_CONTROL_FAKE
+            return default
+
+        mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
+        ugp = _make_ugp(mass)
+        await ugp.on_config_updated()
+        assert PlayerFeature.POWER in ugp.supported_features


### PR DESCRIPTION
## Problem

Sync Group and Universal Group players currently require an explicit power-on to capture their members and a power-off to release them. Users find this unpopular because they have to remember to power the group off before playing on an individual member — otherwise the play command silently redirects to the group, e.g. starting a morning playlist on a single bedroom speaker from Home Assistant unexpectedly plays everywhere because the group is still powered from yesterday. See [music-assistant/support#5431](https://github.com/music-assistant/support/issues/5431).

The fix is to replace the mandatory power control with a session lifecycle: groups form when a `play_media` arrives, dissolve on `stop`, and use a short idle grace window to absorb natural end-of-queue gaps. Users who want explicit pin-on/off behavior can opt in by assigning Fake power control to the group.

## Changes

- **Form-on-play / dissolve-on-stop lifecycle** for Sync Group and Universal Group, with a 10s idle grace window before natural deform (cancelled on resume / explicit stop).
- **`PlayerFeature.POWER` is no longer advertised by default** on group players. Users who want explicit pin-on/off can assign "Fake power control" in the group's player settings.
- **Stale `power_control = native` config** on group players degrades to `none` so existing groups keep working after the upgrade.
- **New per-player `CONF_PLAY_MEDIA_OVERRIDES_GROUP`** (default on): an explicit `play_media` on a captured child releases it from the group/sync first and plays standalone. Other commands (next / prev / pause / resume) still redirect to the leader. The legacy redirect behavior is preserved as the opt-out.
- **`cmd_ungroup` on a group player** dissolves the session instead of erroring on static members. `cmd_ungroup` on a static member of a group recurses to dissolve the parent group (since a static member can't be released individually).
- **Leader-switch race fix**: the form path now waits for the new leader's `synced_to=None` before issuing `play_media`. On timeout, an explicit ungroup is tried as recovery, and the form aborts cleanly if the player is genuinely stuck — instead of proceeding with stale state and triggering the "Player X can not accept play_media command, it is synced to another player" warning.
- **`transfer_queue`** waits for `active_group` / `synced_to` to clear via `wait_for_player_update` instead of `asyncio.sleep(3)`.
- **FAKE-power cache** is intentionally not persisted across restarts for group players — at boot there's no session to restore, so a stale "powered=True" would leave the group in an inconsistent "active without captured session" state.
- **Auto-play-on-power** config entry is hidden for group players (toggling Fake power on a group is "capture members", not "start playback").
- **42 new test cases** across `tests/providers/test_sync_group.py`, the new `tests/providers/test_universal_group.py`, and the controller-level grouping/ungroup/play_media tests.