### PR TITLE
Restore PlayerQueue.is_dynamic after loading queue from cache

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1076,9 +1076,12 @@ class PlayerQueuesController(CoreController):
                 # reset the play action in progress flag on restore
                 # this can happen if MA was killed while a play action was in progress
                 queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] = False
-                # from_cache reconstructs radio_source and enqueued_media_items,
-                # which mashumaro deserializes as plain dicts instead of MediaItemType objects.
+                # from_cache properly deserializes radio_source and enqueued_media_items
+                # back into MediaItemType objects (from_dict/mashumaro leaves them as plain dicts).
                 queue.from_cache(prev_state)
+                # recalculate is_dynamic after radio_source is restored from cache
+                # (old cache entries won't have is_dynamic set)
+                queue.is_dynamic = _is_radio_source_dynamic(queue.radio_source)
                 prev_items = await self.mass.cache.get(
                     key=queue_id,
                     provider=self.domain,


### PR DESCRIPTION
## Summary

Fixes a bug where `PlayerQueue.is_dynamic` was not correctly restored when a queue was loaded from cache on server startup.

## Problem

`PlayerQueue.from_cache()` (in `music-assistant-models`) reconstructs `radio_source` internally, but does not recalculate `is_dynamic`. After a server restart, any queue that had a dynamic playlist in its `radio_source` would have `is_dynamic = False` until the user replayed the playlist.

PR #3886 set `is_dynamic` at all direct `queue.radio_source =` assignments, but missed this indirect path via `from_cache()`.

## Fix

After calling `queue.from_cache(prev_state)`, recalculate `is_dynamic` from the restored `radio_source`.

## Related

- Follows on from #3886
- Frontend PR: music-assistant/frontend#1773