### PR TITLE
Add multiroom transition debug logs to WiiM provider

### DIFF
--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -434,7 +434,7 @@ class WiimPlayer(Player):
 
     def _log_sdk_state_change(self) -> None:
         """Log a debug line whenever the SDK-reported URI or playing_status changes."""
-        new_sdk_uri = self._attr_current_media.uri if self._attr_current_media else None
+        new_sdk_uri = self.device.current_media.uri if self.device.current_media else None
         new_sdk_status = self.device.playing_status
         if (
             new_sdk_uri == self._last_logged_sdk_uri

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -87,6 +87,9 @@ class WiimPlayer(Player):
         device.av_transport_event_callback = self._handle_sdk_av_transport_event
         device.play_queue_event_callback = self._handle_sdk_play_queue_event
 
+        self._last_logged_sdk_uri: str | None = None
+        self._last_logged_sdk_status: PlayingStatus | None = None
+
     # --- Lifecycle ---
 
     async def setup(self) -> None:
@@ -160,6 +163,12 @@ class WiimPlayer(Player):
         """Handle enqueuing of the next queue item on the player."""
         stream_url = await self.mass.streams.resolve_stream_url(self.player_id, media)
         didl_metadata = create_didl_metadata(media, url=stream_url)
+        self.logger.debug(
+            "enqueue_next_media on %s: queue_item_id=%s, uri=%s",
+            self._attr_name,
+            media.queue_item_id,
+            stream_url,
+        )
         try:
             await self.device._invoke_upnp_action(
                 "AVTransport",
@@ -246,6 +255,22 @@ class WiimPlayer(Player):
         player_ids_to_remove: list[str] | None = None,
     ) -> None:
         """Handle SET_MEMBERS command on the player."""
+        queue = self.mass.player_queues.get(self.player_id)
+        entry_sdk_uri = self.device.current_media.uri if self.device.current_media else None
+        self.logger.debug(
+            "set_members entry on %s: add=%s, remove=%s | "
+            "queue.current_item_id=%s, queue.next_item_id=%s, "
+            "queue.next_item_id_enqueued=%s | "
+            "sdk.current_uri=%s, sdk.playing_status=%s",
+            self._attr_name,
+            player_ids_to_add,
+            player_ids_to_remove,
+            queue.current_item.queue_item_id if queue and queue.current_item else None,
+            queue.next_item.queue_item_id if queue and queue.next_item else None,
+            queue.next_item_id_enqueued if queue else None,
+            entry_sdk_uri,
+            self.device.playing_status,
+        )
         try:
             if player_ids_to_add:
                 follower_udns = [
@@ -264,6 +289,16 @@ class WiimPlayer(Player):
                         )
         except (WiimDeviceException, WiimRequestException) as err:
             self._handle_command_error("set_members", err)
+        finally:
+            exit_sdk_uri = self.device.current_media.uri if self.device.current_media else None
+            self.logger.debug(
+                "set_members exit on %s: sdk.current_uri=%s, sdk.playing_status=%s, "
+                "queue.current_item_id=%s",
+                self._attr_name,
+                exit_sdk_uri,
+                self.device.playing_status,
+                queue.current_item.queue_item_id if queue and queue.current_item else None,
+            )
 
     # --- SDK event handlers ---
 
@@ -394,7 +429,30 @@ class WiimPlayer(Player):
                 source_id=self._attr_active_source,
             )
 
+        self._log_sdk_state_change()
         self.update_state()
+
+    def _log_sdk_state_change(self) -> None:
+        """Log a debug line whenever the SDK-reported URI or playing_status changes."""
+        new_sdk_uri = self._attr_current_media.uri if self._attr_current_media else None
+        new_sdk_status = self.device.playing_status
+        if (
+            new_sdk_uri == self._last_logged_sdk_uri
+            and new_sdk_status == self._last_logged_sdk_status
+        ):
+            return
+        ma_queue = self.mass.player_queues.get(self.player_id)
+        self.logger.debug(
+            "WiiM state changed on %s: uri=%r->%r, status=%s->%s | queue.current_item_id=%s",
+            self._attr_name,
+            self._last_logged_sdk_uri,
+            new_sdk_uri,
+            self._last_logged_sdk_status,
+            new_sdk_status,
+            ma_queue.current_item.queue_item_id if ma_queue and ma_queue.current_item else None,
+        )
+        self._last_logged_sdk_uri = new_sdk_uri
+        self._last_logged_sdk_status = new_sdk_status
 
     async def _ensure_subscriptions_and_update(self) -> None:
         """Re-subscribe to UPnP events and update state."""


### PR DESCRIPTION
## Summary

Adds provider-scoped debug logs to trace cases where a WiiM multiroom leader/follower change disrupts MA's queue tracking, causing the device to stall after the current track ends.

**Context:** When a WiiM device becomes a multiroom leader mid-playback, it re-fetches its current stream URL (a hardware sync behavior). MA's queue controller responds by scheduling `_preload_streamdetails`, but the gating wait loop in that task can stall for the entire remaining track duration (~3 minutes in the observed log). By the time `SetNextAVTransportURI` finally fires, the WiiM has already finished the current track and gone idle — music stops.

These logs do not change behavior; they capture the data needed to confirm the root cause the next time the bug recurs.

## Logs added

| Log | Purpose |
|---|---|
| `set_members entry` | Snapshot of queue context (`current_item_id`, `next_item_id`, `next_item_id_enqueued`) and SDK state (`current_uri`, `playing_status`) at the moment grouping starts |
| `set_members exit` (finally) | Same SDK state, immediately after the join/ungroup SDK calls return |
| `enqueue_next_media entry` | Timestamp + `queue_item_id` of every `SetNextAVTransportURI` MA actually fires, to measure the lag between regroup and re-enqueue |
| `WiiM state changed` | Every transition of the SDK-reported URI or `playing_status`, paired with `queue.current_item_id` at that moment — change-detection only, so it's quiet during steady playback |

All logs at DEBUG level. One new instance attribute pair (`_last_logged_sdk_uri`, `_last_logged_sdk_status`) for the change detector. One new helper method `_log_sdk_state_change` extracted to keep `_update_ma_state_from_sdk_cache` under the statement limit.

## Test plan

- [x] `pre-commit run --files music_assistant/providers/wiim/player.py` passes (ruff, mypy)
- [x] `pytest tests/providers/wiim/` — 15 passed
- [ ] Manual: trigger a multiroom group change on a WiiM amp during playback, confirm the new debug logs appear in `musicassistant.log` and contain useful state info

🤖 Generated with [Claude Code](https://claude.com/claude-code)