### PR TITLE
Detect source audio format from ffmpeg log output

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -521,7 +521,7 @@ class StreamsAudio:
                     # Some providers omit (or report 0 for) the item duration; ffmpeg can
                     # usually probe it from the source. Only apply when missing so we
                     # don't clobber an accurate provider value with a rounded one.
-                    if ffmpeg_proc.parsed_duration and not streamdetails.duration:
+                    if ffmpeg_proc.parsed_duration is not None and not streamdetails.duration:
                         streamdetails.duration = ffmpeg_proc.parsed_duration
                     logger.debug(
                         "First chunk received after %.2f seconds (codec detected: %s)",

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -513,8 +513,16 @@ class StreamsAudio:
                 if not first_chunk_received:
                     # At this point ffmpeg has started and should now know the codec used
                     # for encoding the audio.
+                    # Note: ffmpeg_proc.input_format is the same object as
+                    # streamdetails.audio_format, so sample_rate / bit_depth / bit_rate
+                    # parsed from the ffmpeg log already live on streamdetails too.
                     first_chunk_received = True
                     streamdetails.audio_format.codec_type = ffmpeg_proc.input_format.codec_type
+                    # Some providers omit (or report 0 for) the item duration; ffmpeg can
+                    # usually probe it from the source. Only apply when missing so we
+                    # don't clobber an accurate provider value with a rounded one.
+                    if ffmpeg_proc.parsed_duration and not streamdetails.duration:
+                        streamdetails.duration = ffmpeg_proc.parsed_duration
                     logger.debug(
                         "First chunk received after %.2f seconds (codec detected: %s)",
                         mass.loop.time() - stream_start,

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from collections import deque
 from collections.abc import AsyncGenerator
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
 
 from music_assistant_models.enums import ContentType
@@ -25,6 +27,48 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("ffmpeg")
 MINIMAL_FFMPEG_VERSION = 6
 CACHE_ATTR_LIBSOXR_PRESENT: Final[str] = "libsoxr_present"
+
+# Regex patterns to extract audio format details from ffmpeg's stderr output.
+# Examples of the lines we parse:
+#   Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 320 kb/s
+#   Stream #0:0(eng): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 254 kb/s
+#   Stream #0:0: Audio: flac, 96000 Hz, stereo, s32 (24 bit)
+#   Duration: 00:03:25.78, start: 0.000000, bitrate: 320 kb/s
+_FFMPEG_SAMPLE_RATE_RE: Final = re.compile(r"(\d+) Hz")
+_FFMPEG_BIT_RATE_RE: Final = re.compile(r"(\d+) kb/s")
+_FFMPEG_EXPLICIT_BIT_DEPTH_RE: Final = re.compile(r"\((\d+) bit\)")
+_FFMPEG_SAMPLE_FMT_RE: Final = re.compile(r"\b(u8p?|s16p?|s24p?|s32p?|fltp?|dblp?)\b")
+_FFMPEG_DURATION_RE: Final = re.compile(r"Duration: (\d+):(\d+):(\d+(?:\.\d+)?)")
+
+# Mapping from ffmpeg sample format token to bit depth.
+# Note: planar variants (suffix 'p') describe memory layout only.
+# Floating point formats (flt/fltp/dbl/dblp) are typically the decoder's internal
+# representation for lossy codecs and do not reflect source bit depth, so the
+# caller decides whether to apply them based on the codec.
+_SAMPLE_FMT_BIT_DEPTH: Final[dict[str, int]] = {
+    "u8": 8,
+    "u8p": 8,
+    "s16": 16,
+    "s16p": 16,
+    "s24": 24,
+    "s24p": 24,
+    "s32": 32,
+    "s32p": 32,
+    "flt": 32,
+    "fltp": 32,
+    "dbl": 64,
+    "dblp": 64,
+}
+
+
+@dataclass
+class FFMpegInputStreamInfo:
+    """Audio format details parsed from an ffmpeg input stream log line."""
+
+    codec: ContentType
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    bit_rate: int | None = None
 
 
 class FFMpeg(AsyncProcess):
@@ -60,9 +104,12 @@ class FFMpeg(AsyncProcess):
         self.collect_log_history = collect_log_history
         self.log_history: deque[str] = deque(maxlen=100)
         self.concat_error = False  # switch to True if concat demuxer fails on MultiPartFiles
+        # Source duration in (whole) seconds as detected from the ffmpeg input log line,
+        # or None if not yet parsed / not reported (e.g. live radio streams).
+        self.parsed_duration: int | None = None
         self._stdin_feeder_task: asyncio.Task[None] | None = None
         self._stderr_reader_task: asyncio.Task[None] | None = None
-        self._input_codec_parsed = False
+        self._input_stream_info_parsed = False
         stdin: bool | int
         if audio_input == "-" or isinstance(audio_input, AsyncGenerator):
             stdin = True
@@ -154,22 +201,19 @@ class FFMpeg(AsyncProcess):
                 # and should raise an exception to prevent false progress logging
                 self.concat_error = True
 
-            # if streamdetails contenttype is unknown, try parse it from the ffmpeg log
-            if line.startswith("Stream #") and ": Audio: " in line:
-                if not self._input_codec_parsed:
-                    content_type_raw = line.split(": Audio: ")[1].split(" ")[0]
-                    content_type_raw = content_type_raw.split(",")[0]
-                    content_type = ContentType.try_parse(content_type_raw)
-                    self.logger.log(
-                        VERBOSE_LOG_LEVEL,
-                        "Detected (input) content type: %s (%s)",
-                        content_type,
-                        content_type_raw,
-                    )
-                    if self.input_format.content_type == ContentType.UNKNOWN:
-                        self.input_format.content_type = content_type
-                    self.input_format.codec_type = content_type
-                    self._input_codec_parsed = True
+            # Provider-supplied audio format details are often incomplete (e.g. defaults
+            # to 44.1/16) or missing for lossy codecs; opportunistically parse the real
+            # values from ffmpeg's probe output and update the input_format in place.
+            if not self._input_stream_info_parsed:
+                if stream_info := parse_ffmpeg_stream_info(line):
+                    self._apply_input_stream_info(stream_info)
+                    self._input_stream_info_parsed = True
+            # Source duration is reported separately from the stream info. Useful when
+            # the provider didn't supply one (some podcast feeds report total_time=0).
+            if self.parsed_duration is None:
+                duration = parse_ffmpeg_duration(line)
+                if duration is not None:
+                    self.parsed_duration = duration
             del line
 
     async def _feed_stdin(self) -> None:
@@ -208,6 +252,76 @@ class FFMpeg(AsyncProcess):
             # if we get cancelled otherwise it keeps lingering forever
             if not generator_exhausted:
                 await close_async_generator(self.audio_input)
+
+    def _apply_input_stream_info(self, info: FFMpegInputStreamInfo) -> None:
+        """Mirror values from a parsed ffmpeg stream info line onto self.input_format."""
+        self.logger.log(
+            VERBOSE_LOG_LEVEL,
+            "Detected input stream info: codec=%s sample_rate=%s bit_depth=%s bit_rate=%s kb/s",
+            info.codec,
+            info.sample_rate,
+            info.bit_depth,
+            info.bit_rate,
+        )
+        # content_type is the container format; only fill it in if the provider didn't
+        # specify one. codec_type is always set to what ffmpeg actually detected.
+        if self.input_format.content_type == ContentType.UNKNOWN:
+            self.input_format.content_type = info.codec
+        self.input_format.codec_type = info.codec
+        if info.sample_rate:
+            self.input_format.sample_rate = info.sample_rate
+        if info.bit_depth:
+            self.input_format.bit_depth = info.bit_depth
+        if info.bit_rate:
+            self.input_format.bit_rate = info.bit_rate
+
+
+def parse_ffmpeg_stream_info(line: str) -> FFMpegInputStreamInfo | None:
+    """
+    Extract audio format details from an ffmpeg 'Stream #X: Audio: ...' log line.
+
+    :param line: A single ffmpeg stderr log line.
+    :returns: FFMpegInputStreamInfo when the line describes an audio stream,
+        otherwise None.
+    """
+    if not (line.startswith("Stream #") and ": Audio: " in line):
+        return None
+
+    # the codec name is the first token right after "Audio: ", stripping
+    # any trailing profile annotation like "(LC)" or container suffix
+    codec_part = line.split(": Audio: ", 1)[1].split(" ", 1)[0].split(",", maxsplit=1)[0]
+    codec = ContentType.try_parse(codec_part)
+
+    info = FFMpegInputStreamInfo(codec=codec)
+    if match := _FFMPEG_SAMPLE_RATE_RE.search(line):
+        info.sample_rate = int(match.group(1))
+    if match := _FFMPEG_BIT_RATE_RE.search(line):
+        info.bit_rate = int(match.group(1))
+    # Bit depth: an explicit "(N bit)" annotation wins (this is how ffmpeg reports
+    # 24-bit FLAC stored in an s32 sample format), otherwise infer from the sample
+    # format token. Lossy codecs report the decoder's internal precision (typically
+    # fltp), so we ignore the sample format token for those.
+    if match := _FFMPEG_EXPLICIT_BIT_DEPTH_RE.search(line):
+        info.bit_depth = int(match.group(1))
+    elif codec.is_lossless() and (match := _FFMPEG_SAMPLE_FMT_RE.search(line)):
+        info.bit_depth = _SAMPLE_FMT_BIT_DEPTH.get(match.group(1))
+
+    return info
+
+
+def parse_ffmpeg_duration(line: str) -> int | None:
+    """
+    Extract the source duration in seconds from an ffmpeg 'Duration: ...' log line.
+
+    :param line: A single ffmpeg stderr log line.
+    :returns: Duration in whole seconds, or None if the line does not contain
+        a parseable duration (e.g. 'Duration: N/A' on live streams).
+    """
+    match = _FFMPEG_DURATION_RE.search(line)
+    if not match:
+        return None
+    hours, minutes, seconds = match.groups()
+    return int(hours) * 3600 + int(minutes) * 60 + int(float(seconds))
 
 
 async def get_ffmpeg_stream(

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -279,10 +279,12 @@ class FFMpeg(AsyncProcess):
     def _apply_input_stream_info(self, info: FFMpegStreamInfo) -> None:
         """Mirror values from a parsed ffmpeg input stream line onto self.input_format."""
         # content_type is the container format; only fill it in if the provider didn't
-        # specify one. codec_type is always set to what ffmpeg actually detected.
-        if self.input_format.content_type == ContentType.UNKNOWN:
-            self.input_format.content_type = info.codec
-        self.input_format.codec_type = info.codec
+        # specify one. codec_type is the audio codec ffmpeg detected; only override
+        # if we actually parsed a known codec (don't clobber a provider value with UNKNOWN).
+        if info.codec != ContentType.UNKNOWN:
+            if self.input_format.content_type == ContentType.UNKNOWN:
+                self.input_format.content_type = info.codec
+            self.input_format.codec_type = info.codec
         if info.sample_rate:
             self.input_format.sample_rate = info.sample_rate
         if info.bit_depth:

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -255,8 +255,7 @@ class FFMpeg(AsyncProcess):
 
     def _apply_input_stream_info(self, info: FFMpegInputStreamInfo) -> None:
         """Mirror values from a parsed ffmpeg stream info line onto self.input_format."""
-        self.logger.log(
-            VERBOSE_LOG_LEVEL,
+        self.logger.debug(
             "Detected input stream info: codec=%s sample_rate=%s bit_depth=%s bit_rate=%s kb/s",
             info.codec,
             info.sample_rate,

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -62,8 +62,8 @@ _SAMPLE_FMT_BIT_DEPTH: Final[dict[str, int]] = {
 
 
 @dataclass
-class FFMpegInputStreamInfo:
-    """Audio format details parsed from an ffmpeg input stream log line."""
+class FFMpegStreamInfo:
+    """Audio format details parsed from an ffmpeg 'Stream #' log line."""
 
     codec: ContentType
     sample_rate: int | None = None
@@ -104,12 +104,21 @@ class FFMpeg(AsyncProcess):
         self.collect_log_history = collect_log_history
         self.log_history: deque[str] = deque(maxlen=100)
         self.concat_error = False  # switch to True if concat demuxer fails on MultiPartFiles
+        # Audio format details for the input and output stream as detected from ffmpeg's
+        # own stderr probe output. input_stream_info is also mirrored onto self.input_format
+        # so callers that share the AudioFormat (e.g. streamdetails) pick up the corrected
+        # values; output_stream_info is informational (useful for logging / future UI use).
+        self.input_stream_info: FFMpegStreamInfo | None = None
+        self.output_stream_info: FFMpegStreamInfo | None = None
         # Source duration in (whole) seconds as detected from the ffmpeg input log line,
         # or None if not yet parsed / not reported (e.g. live radio streams).
         self.parsed_duration: int | None = None
         self._stdin_feeder_task: asyncio.Task[None] | None = None
         self._stderr_reader_task: asyncio.Task[None] | None = None
-        self._input_stream_info_parsed = False
+        # ffmpeg emits 'Input #N, ...' and 'Output #N, ...' headers before each block of
+        # 'Stream #' lines; we track which block the next stream line belongs to.
+        # Defaults to "input" so a stray Stream # line before any header still routes there.
+        self._current_log_section: str = "input"
         stdin: bool | int
         if audio_input == "-" or isinstance(audio_input, AsyncGenerator):
             stdin = True
@@ -201,19 +210,33 @@ class FFMpeg(AsyncProcess):
                 # and should raise an exception to prevent false progress logging
                 self.concat_error = True
 
-            # Provider-supplied audio format details are often incomplete (e.g. defaults
-            # to 44.1/16) or missing for lossy codecs; opportunistically parse the real
-            # values from ffmpeg's probe output and update the input_format in place.
-            if not self._input_stream_info_parsed:
+            # Track which ffmpeg block we're currently parsing so the next 'Stream #'
+            # audio line is routed to the correct slot (input vs output).
+            if line.startswith("Input #"):
+                self._current_log_section = "input"
+            elif line.startswith("Output #"):
+                self._current_log_section = "output"
+
+            # Capture the first audio stream line per section. Provider-supplied input
+            # details are often incomplete (e.g. defaults to 44.1/16) or missing for
+            # lossy codecs, so we mirror the parsed input values onto input_format too.
+            if self._current_log_section == "input" and self.input_stream_info is None:
                 if stream_info := parse_ffmpeg_stream_info(line):
+                    self.input_stream_info = stream_info
+                    self._log_stream_info("input", stream_info)
                     self._apply_input_stream_info(stream_info)
-                    self._input_stream_info_parsed = True
+            elif self._current_log_section == "output" and self.output_stream_info is None:
+                if stream_info := parse_ffmpeg_stream_info(line):
+                    self.output_stream_info = stream_info
+                    self._log_stream_info("output", stream_info)
+
             # Source duration is reported separately from the stream info. Useful when
             # the provider didn't supply one (some podcast feeds report total_time=0).
             if self.parsed_duration is None:
                 duration = parse_ffmpeg_duration(line)
                 if duration is not None:
                     self.parsed_duration = duration
+                    self.logger.debug("Detected input duration: %s seconds", duration)
             del line
 
     async def _feed_stdin(self) -> None:
@@ -253,15 +276,8 @@ class FFMpeg(AsyncProcess):
             if not generator_exhausted:
                 await close_async_generator(self.audio_input)
 
-    def _apply_input_stream_info(self, info: FFMpegInputStreamInfo) -> None:
-        """Mirror values from a parsed ffmpeg stream info line onto self.input_format."""
-        self.logger.debug(
-            "Detected input stream info: codec=%s sample_rate=%s bit_depth=%s bit_rate=%s kb/s",
-            info.codec,
-            info.sample_rate,
-            info.bit_depth,
-            info.bit_rate,
-        )
+    def _apply_input_stream_info(self, info: FFMpegStreamInfo) -> None:
+        """Mirror values from a parsed ffmpeg input stream line onto self.input_format."""
         # content_type is the container format; only fill it in if the provider didn't
         # specify one. codec_type is always set to what ffmpeg actually detected.
         if self.input_format.content_type == ContentType.UNKNOWN:
@@ -274,13 +290,24 @@ class FFMpeg(AsyncProcess):
         if info.bit_rate:
             self.input_format.bit_rate = info.bit_rate
 
+    def _log_stream_info(self, label: str, info: FFMpegStreamInfo) -> None:
+        """Log a parsed FFMpegStreamInfo object at debug level."""
+        self.logger.debug(
+            "Detected %s stream info: codec=%s sample_rate=%s bit_depth=%s bit_rate=%s kb/s",
+            label,
+            info.codec,
+            info.sample_rate,
+            info.bit_depth,
+            info.bit_rate,
+        )
 
-def parse_ffmpeg_stream_info(line: str) -> FFMpegInputStreamInfo | None:
+
+def parse_ffmpeg_stream_info(line: str) -> FFMpegStreamInfo | None:
     """
     Extract audio format details from an ffmpeg 'Stream #X: Audio: ...' log line.
 
     :param line: A single ffmpeg stderr log line.
-    :returns: FFMpegInputStreamInfo when the line describes an audio stream,
+    :returns: FFMpegStreamInfo when the line describes an audio stream,
         otherwise None.
     """
     if not (line.startswith("Stream #") and ": Audio: " in line):
@@ -291,7 +318,7 @@ def parse_ffmpeg_stream_info(line: str) -> FFMpegInputStreamInfo | None:
     codec_part = line.split(": Audio: ", 1)[1].split(" ", 1)[0].split(",", maxsplit=1)[0]
     codec = ContentType.try_parse(codec_part)
 
-    info = FFMpegInputStreamInfo(codec=codec)
+    info = FFMpegStreamInfo(codec=codec)
     if match := _FFMPEG_SAMPLE_RATE_RE.search(line):
         info.sample_rate = int(match.group(1))
     if match := _FFMPEG_BIT_RATE_RE.search(line):

--- a/tests/core/test_ffmpeg.py
+++ b/tests/core/test_ffmpeg.py
@@ -119,6 +119,17 @@ def test_parse_stream_info_ignores_video_stream() -> None:
     assert parse_ffmpeg_stream_info(line) is None
 
 
+def test_parse_stream_info_unknown_codec_still_yields_other_fields() -> None:
+    """Unrecognised codec token returns UNKNOWN but sample rate / bit rate are still parsed."""
+    line = "Stream #0:0: Audio: somenewcodec, 48000 Hz, stereo, 192 kb/s"
+    info = parse_ffmpeg_stream_info(line)
+    assert info is not None
+    assert info.codec == ContentType.UNKNOWN
+    assert info.sample_rate == 48000
+    assert info.bit_rate == 192
+    assert info.bit_depth is None
+
+
 # -- parse_ffmpeg_duration --
 
 

--- a/tests/core/test_ffmpeg.py
+++ b/tests/core/test_ffmpeg.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from music_assistant_models.enums import ContentType
 
 from music_assistant.helpers.ffmpeg import (
-    FFMpegInputStreamInfo,
+    FFMpegStreamInfo,
     parse_ffmpeg_duration,
     parse_ffmpeg_stream_info,
 )
@@ -17,7 +17,7 @@ def test_parse_stream_info_mp3() -> None:
     """Lossy MP3 line yields codec/sample rate/bit rate, but no bit depth."""
     line = "Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 320 kb/s"
     info = parse_ffmpeg_stream_info(line)
-    assert info == FFMpegInputStreamInfo(
+    assert info == FFMpegStreamInfo(
         codec=ContentType.MP3,
         sample_rate=44100,
         bit_depth=None,
@@ -40,7 +40,7 @@ def test_parse_stream_info_flac_16bit() -> None:
     """16-bit FLAC: bit depth is inferred from the s16 sample format token."""
     line = "Stream #0:0: Audio: flac, 44100 Hz, stereo, s16, 1024 kb/s"
     info = parse_ffmpeg_stream_info(line)
-    assert info == FFMpegInputStreamInfo(
+    assert info == FFMpegStreamInfo(
         codec=ContentType.FLAC,
         sample_rate=44100,
         bit_depth=16,
@@ -52,7 +52,7 @@ def test_parse_stream_info_flac_24bit_in_s32() -> None:
     """24-bit FLAC is stored in s32; the explicit "(24 bit)" annotation wins."""
     line = "Stream #0:0: Audio: flac, 96000 Hz, stereo, s32 (24 bit)"
     info = parse_ffmpeg_stream_info(line)
-    assert info == FFMpegInputStreamInfo(
+    assert info == FFMpegStreamInfo(
         codec=ContentType.FLAC,
         sample_rate=96000,
         bit_depth=24,
@@ -64,7 +64,7 @@ def test_parse_stream_info_flac_24bit_hires_with_bitrate() -> None:
     """High-resolution 24-bit FLAC at 192k with reported bit rate."""
     line = "Stream #0:0: Audio: flac, 192000 Hz, stereo, s32 (24 bit), 5644 kb/s"
     info = parse_ffmpeg_stream_info(line)
-    assert info == FFMpegInputStreamInfo(
+    assert info == FFMpegStreamInfo(
         codec=ContentType.FLAC,
         sample_rate=192000,
         bit_depth=24,
@@ -76,7 +76,7 @@ def test_parse_stream_info_pcm_s16le() -> None:
     """PCM stream reports codec via try_parse, sample format gives bit depth."""
     line = "Stream #0:0: Audio: pcm_s16le, 44100 Hz, stereo, s16, 1411 kb/s"
     info = parse_ffmpeg_stream_info(line)
-    assert info == FFMpegInputStreamInfo(
+    assert info == FFMpegStreamInfo(
         codec=ContentType.PCM_S16LE,
         sample_rate=44100,
         bit_depth=16,
@@ -88,7 +88,7 @@ def test_parse_stream_info_opus_without_bitrate() -> None:
     """Opus often omits bit rate; we still get codec and sample rate."""
     line = "Stream #0:0: Audio: opus, 48000 Hz, stereo, fltp"
     info = parse_ffmpeg_stream_info(line)
-    assert info == FFMpegInputStreamInfo(
+    assert info == FFMpegStreamInfo(
         codec=ContentType.OPUS,
         sample_rate=48000,
         bit_depth=None,

--- a/tests/core/test_ffmpeg.py
+++ b/tests/core/test_ffmpeg.py
@@ -1,0 +1,149 @@
+"""Tests for the ffmpeg helper module."""
+
+from __future__ import annotations
+
+from music_assistant_models.enums import ContentType
+
+from music_assistant.helpers.ffmpeg import (
+    FFMpegInputStreamInfo,
+    parse_ffmpeg_duration,
+    parse_ffmpeg_stream_info,
+)
+
+# -- parse_ffmpeg_stream_info --
+
+
+def test_parse_stream_info_mp3() -> None:
+    """Lossy MP3 line yields codec/sample rate/bit rate, but no bit depth."""
+    line = "Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 320 kb/s"
+    info = parse_ffmpeg_stream_info(line)
+    assert info == FFMpegInputStreamInfo(
+        codec=ContentType.MP3,
+        sample_rate=44100,
+        bit_depth=None,
+        bit_rate=320,
+    )
+
+
+def test_parse_stream_info_aac_with_profile_and_language() -> None:
+    """AAC line with profile annotation and language tag is parsed correctly."""
+    line = "Stream #0:0(eng): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 254 kb/s"
+    info = parse_ffmpeg_stream_info(line)
+    assert info is not None
+    assert info.codec == ContentType.AAC
+    assert info.sample_rate == 44100
+    assert info.bit_rate == 254
+    assert info.bit_depth is None
+
+
+def test_parse_stream_info_flac_16bit() -> None:
+    """16-bit FLAC: bit depth is inferred from the s16 sample format token."""
+    line = "Stream #0:0: Audio: flac, 44100 Hz, stereo, s16, 1024 kb/s"
+    info = parse_ffmpeg_stream_info(line)
+    assert info == FFMpegInputStreamInfo(
+        codec=ContentType.FLAC,
+        sample_rate=44100,
+        bit_depth=16,
+        bit_rate=1024,
+    )
+
+
+def test_parse_stream_info_flac_24bit_in_s32() -> None:
+    """24-bit FLAC is stored in s32; the explicit "(24 bit)" annotation wins."""
+    line = "Stream #0:0: Audio: flac, 96000 Hz, stereo, s32 (24 bit)"
+    info = parse_ffmpeg_stream_info(line)
+    assert info == FFMpegInputStreamInfo(
+        codec=ContentType.FLAC,
+        sample_rate=96000,
+        bit_depth=24,
+        bit_rate=None,
+    )
+
+
+def test_parse_stream_info_flac_24bit_hires_with_bitrate() -> None:
+    """High-resolution 24-bit FLAC at 192k with reported bit rate."""
+    line = "Stream #0:0: Audio: flac, 192000 Hz, stereo, s32 (24 bit), 5644 kb/s"
+    info = parse_ffmpeg_stream_info(line)
+    assert info == FFMpegInputStreamInfo(
+        codec=ContentType.FLAC,
+        sample_rate=192000,
+        bit_depth=24,
+        bit_rate=5644,
+    )
+
+
+def test_parse_stream_info_pcm_s16le() -> None:
+    """PCM stream reports codec via try_parse, sample format gives bit depth."""
+    line = "Stream #0:0: Audio: pcm_s16le, 44100 Hz, stereo, s16, 1411 kb/s"
+    info = parse_ffmpeg_stream_info(line)
+    assert info == FFMpegInputStreamInfo(
+        codec=ContentType.PCM_S16LE,
+        sample_rate=44100,
+        bit_depth=16,
+        bit_rate=1411,
+    )
+
+
+def test_parse_stream_info_opus_without_bitrate() -> None:
+    """Opus often omits bit rate; we still get codec and sample rate."""
+    line = "Stream #0:0: Audio: opus, 48000 Hz, stereo, fltp"
+    info = parse_ffmpeg_stream_info(line)
+    assert info == FFMpegInputStreamInfo(
+        codec=ContentType.OPUS,
+        sample_rate=48000,
+        bit_depth=None,
+        bit_rate=None,
+    )
+
+
+def test_parse_stream_info_alac_planar() -> None:
+    """ALAC reported with s16p (planar) sample format still yields 16-bit depth."""
+    line = "Stream #0:0: Audio: alac (alac / 0x63616C61), 44100 Hz, stereo, s16p"
+    info = parse_ffmpeg_stream_info(line)
+    assert info is not None
+    assert info.codec == ContentType.ALAC
+    assert info.sample_rate == 44100
+    assert info.bit_depth == 16
+
+
+def test_parse_stream_info_returns_none_for_non_stream_line() -> None:
+    """Non-stream log lines must return None."""
+    assert parse_ffmpeg_stream_info("Duration: 00:03:25.78, start: 0.000000") is None
+    assert parse_ffmpeg_stream_info("[error] Invalid data found") is None
+    assert parse_ffmpeg_stream_info("") is None
+
+
+def test_parse_stream_info_ignores_video_stream() -> None:
+    """Video stream lines must not be misparsed as audio."""
+    line = "Stream #0:0: Video: h264 (High), yuv420p, 1920x1080, 5000 kb/s, 25 fps"
+    assert parse_ffmpeg_stream_info(line) is None
+
+
+# -- parse_ffmpeg_duration --
+
+
+def test_parse_duration_typical() -> None:
+    """Typical 'Duration: HH:MM:SS.ms' line yields total seconds (floor)."""
+    line = "Duration: 00:03:25.78, start: 0.000000, bitrate: 320 kb/s"
+    assert parse_ffmpeg_duration(line) == 3 * 60 + 25
+
+
+def test_parse_duration_one_hour() -> None:
+    """Hours component is honoured."""
+    assert parse_ffmpeg_duration("Duration: 01:00:00.00, bitrate: 128 kb/s") == 3600
+
+
+def test_parse_duration_under_one_second() -> None:
+    """Sub-second durations round down to 0."""
+    assert parse_ffmpeg_duration("Duration: 00:00:00.50, bitrate: 128 kb/s") == 0
+
+
+def test_parse_duration_na_returns_none() -> None:
+    """Live streams report 'Duration: N/A' — must not match."""
+    assert parse_ffmpeg_duration("Duration: N/A, start: 0.000000, bitrate: N/A") is None
+
+
+def test_parse_duration_unrelated_line_returns_none() -> None:
+    """Random log lines must return None."""
+    assert parse_ffmpeg_duration("Stream #0:0: Audio: mp3, 44100 Hz") is None
+    assert parse_ffmpeg_duration("") is None


### PR DESCRIPTION
## Problem

Some providers don't supply (accurate) audio format details when creating
`StreamDetails`: bit rate is often missing for lossy codecs, sample rate / bit
depth fall back to the 44.1/16 defaults, and duration is occasionally zero or
absent (e.g. some podcast RSS feeds).

FFmpeg already probes all of this when it opens the input — we just weren't
parsing it. The stderr parser at `helpers/ffmpeg.py` previously only extracted
the codec; this PR extends it to also read sample rate, bit depth and bit rate
from the `Stream # … Audio:` line, plus the source duration from the
`Duration:` line, and mirrors those onto the streamdetails so downstream
consumers see the real source format.

## Changes

- Add `parse_ffmpeg_stream_info` / `parse_ffmpeg_duration` helpers in
  `helpers/ffmpeg.py`.
- Extract sample rate, bit depth (incl. the `s32 (24 bit)` FLAC case),
  bit rate and duration from ffmpeg's stderr output.
- Update `input_format` in place from the parsed values; `streamdetails`
  already shares that object so providers get the corrected values for free.
- Fill `streamdetails.duration` from ffmpeg when the provider didn't set one.
- Unit tests covering MP3, AAC, FLAC (16-bit and 24-bit), PCM, ALAC, Opus
  and edge cases (N/A duration, video stream lines).