### PR TITLE
Add Flow Mode sample-rate selection and per-player declared rates

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -294,15 +294,14 @@ CONF_ENTRY_FLOW_MODE_SAMPLE_RATE = ConfigEntry(
     options=[
         ConfigValueOption("Smart (upsample only)", FLOW_MODE_SAMPLE_RATE_SMART),
         ConfigValueOption("Bit-perfect (no resampling)", FLOW_MODE_SAMPLE_RATE_BIT_PERFECT),
-        ConfigValueOption(
-            "48 kHz / 24-bit (balanced quality and bandwidth)", FLOW_MODE_SAMPLE_RATE_48000
-        ),
-        ConfigValueOption("96 kHz / 24-bit (high quality)", FLOW_MODE_SAMPLE_RATE_96000),
+        ConfigValueOption("48 kHz (balanced quality and bandwidth)", FLOW_MODE_SAMPLE_RATE_48000),
+        ConfigValueOption("96 kHz (high quality)", FLOW_MODE_SAMPLE_RATE_96000),
         ConfigValueOption("Highest supported by player", FLOW_MODE_SAMPLE_RATE_HIGHEST),
     ],
     default_value=FLOW_MODE_SAMPLE_RATE_SMART,
     description="When streaming in Flow Mode, the entire queue is sent as one gapless stream "
-    "and must use a single sample rate/bit depth for the whole stream.\n\n"
+    "and must use a single sample rate for the whole stream. The bit depth follows the "
+    "source material (the player's preferred output bit depth still applies downstream).\n\n"
     "- 'Smart (upsample only)': Starts the flow stream at the sample rate of the first "
     "track. Subsequent tracks with an equal or lower sample rate are upsampled to match; "
     "if the next track has a higher sample rate, the flow stream is restarted at that "
@@ -310,9 +309,9 @@ CONF_ENTRY_FLOW_MODE_SAMPLE_RATE = ConfigEntry(
     "- 'Bit-perfect (no resampling)': Never resamples audio (unless the player does not "
     "support the track's sample rate). Playback is restarted between queue tracks when "
     "their sample rates differ, which disables gapless and crossfade between those tracks.\n"
-    "- '48 kHz / 24-bit': Resamples all audio to a fixed 48 kHz / 24-bit (if supported by "
+    "- '48 kHz': Resamples all audio to a fixed 48 kHz (or the closest rate supported by "
     "the player) using a high quality resampler. A good compromise of quality and bandwidth.\n"
-    "- '96 kHz / 24-bit': Resamples all audio to a fixed 96 kHz / 24-bit (if supported by "
+    "- '96 kHz': Resamples all audio to a fixed 96 kHz (or the closest rate supported by "
     "the player) using a high quality resampler.\n"
     "- 'Highest supported by player': Resamples all audio to the highest sample rate the "
     "player supports. Note that this can waste a lot of bandwidth.",

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -87,6 +87,7 @@ CONF_PLAYER_DSP: Final[str] = "player_dsp"
 CONF_PLAYER_DSP_PRESETS: Final[str] = "player_dsp_presets"
 CONF_OUTPUT_CHANNELS: Final[str] = "output_channels"
 CONF_FLOW_MODE: Final[str] = "flow_mode"
+CONF_FLOW_MODE_SAMPLE_RATE: Final[str] = "flow_mode_sample_rate"
 CONF_LOG_LEVEL: Final[str] = "log_level"
 CONF_HIDE_GROUP_CHILDS: Final[str] = "hide_group_childs"
 CONF_CROSSFADE_DURATION: Final[str] = "crossfade_duration"
@@ -274,6 +275,47 @@ CONF_ENTRY_FLOW_MODE = ConfigEntry(
     type=ConfigEntryType.BOOLEAN,
     label="Enforce Gapless playback with Queue Flow Mode streaming",
     default_value=False,
+    category="protocol_generic",
+    advanced=True,
+    requires_reload=True,
+)
+
+
+FLOW_MODE_SAMPLE_RATE_SMART: Final[str] = "smart"
+FLOW_MODE_SAMPLE_RATE_BIT_PERFECT: Final[str] = "bit_perfect"
+FLOW_MODE_SAMPLE_RATE_48000: Final[str] = "48000"
+FLOW_MODE_SAMPLE_RATE_96000: Final[str] = "96000"
+FLOW_MODE_SAMPLE_RATE_HIGHEST: Final[str] = "highest"
+
+CONF_ENTRY_FLOW_MODE_SAMPLE_RATE = ConfigEntry(
+    key=CONF_FLOW_MODE_SAMPLE_RATE,
+    type=ConfigEntryType.STRING,
+    label="Flow Mode sample rate",
+    options=[
+        ConfigValueOption("Smart (upsample only)", FLOW_MODE_SAMPLE_RATE_SMART),
+        ConfigValueOption("Bit-perfect (no resampling)", FLOW_MODE_SAMPLE_RATE_BIT_PERFECT),
+        ConfigValueOption(
+            "48 kHz / 24-bit (balanced quality and bandwidth)", FLOW_MODE_SAMPLE_RATE_48000
+        ),
+        ConfigValueOption("96 kHz / 24-bit (high quality)", FLOW_MODE_SAMPLE_RATE_96000),
+        ConfigValueOption("Highest supported by player", FLOW_MODE_SAMPLE_RATE_HIGHEST),
+    ],
+    default_value=FLOW_MODE_SAMPLE_RATE_SMART,
+    description="When streaming in Flow Mode, the entire queue is sent as one gapless stream "
+    "and must use a single sample rate/bit depth for the whole stream.\n\n"
+    "- 'Smart (upsample only)': Starts the flow stream at the sample rate of the first "
+    "track. Subsequent tracks with an equal or lower sample rate are upsampled to match; "
+    "if the next track has a higher sample rate, the flow stream is restarted at that "
+    "higher rate. This is the best balance between quality and seamless playback.\n"
+    "- 'Bit-perfect (no resampling)': Never resamples audio (unless the player does not "
+    "support the track's sample rate). Playback is restarted between queue tracks when "
+    "their sample rates differ, which disables gapless and crossfade between those tracks.\n"
+    "- '48 kHz / 24-bit': Resamples all audio to a fixed 48 kHz / 24-bit (if supported by "
+    "the player) using a high quality resampler. A good compromise of quality and bandwidth.\n"
+    "- '96 kHz / 24-bit': Resamples all audio to a fixed 96 kHz / 24-bit (if supported by "
+    "the player) using a high quality resampler.\n"
+    "- 'Highest supported by player': Resamples all audio to the highest sample rate the "
+    "player supports. Note that this can waste a lot of bandwidth.",
     category="protocol_generic",
     advanced=True,
     requires_reload=True,

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -300,8 +300,7 @@ CONF_ENTRY_FLOW_MODE_SAMPLE_RATE = ConfigEntry(
     ],
     default_value=FLOW_MODE_SAMPLE_RATE_SMART,
     description="When streaming in Flow Mode, the entire queue is sent as one gapless stream "
-    "and must use a single sample rate for the whole stream. The bit depth follows the "
-    "source material (the player's preferred output bit depth still applies downstream).\n\n"
+    "and must use a single sample rate for the whole stream.\n\n"
     "- 'Smart (upsample only)': Starts the flow stream at the sample rate of the first "
     "track. Subsequent tracks with an equal or lower sample rate are upsampled to match; "
     "if the next track has a higher sample rate, the flow stream is restarted at that "

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -56,6 +56,7 @@ from music_assistant.constants import (
     CONF_ENTRY_CROSSFADE_DURATION,
     CONF_ENTRY_ENABLE_ICY_METADATA,
     CONF_ENTRY_FLOW_MODE,
+    CONF_ENTRY_FLOW_MODE_SAMPLE_RATE,
     CONF_ENTRY_HTTP_PROFILE,
     CONF_ENTRY_LIBRARY_SYNC_ALBUM_TRACKS,
     CONF_ENTRY_LIBRARY_SYNC_ALBUMS,
@@ -1585,14 +1586,17 @@ class ConfigController:
             if is_http_based_player_protocol:
                 # for http based players we can add the http streaming related entries
                 default_entries += [
-                    CONF_ENTRY_SAMPLE_RATES,
                     CONF_ENTRY_OUTPUT_CODEC,
                     CONF_ENTRY_HTTP_PROFILE,
                     CONF_ENTRY_ENABLE_ICY_METADATA,
                 ]
+                # only inject the sample-rates config when the player can't declare its rates itself
+                if not player.declares_supported_sample_rates:
+                    default_entries.append(CONF_ENTRY_SAMPLE_RATES)
                 # add flow mode entry for http-based players that do not already enforce it
                 if not player.requires_flow_mode:
                     default_entries.append(CONF_ENTRY_FLOW_MODE)
+                default_entries.append(CONF_ENTRY_FLOW_MODE_SAMPLE_RATE)
         if PlayerFeature.GAPLESS_PLAYBACK in player.supported_features:
             default_entries.append(CONF_ENTRY_CROSSFADE_DIFFERENT_SAMPLE_RATES)
         # request player specific entries

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2227,10 +2227,13 @@ class StreamsAudio:
         """
         if streamdetails is None:
             return INTERNAL_PCM_FORMAT.content_type, INTERNAL_PCM_FORMAT.bit_depth
+        # mirror get_player_filter_params: when this player is a protocol wrapper,
+        # DSP is configured against its parent rather than itself
+        dsp_player_id = player.protocol_parent_id or player.player_id
         needs_headroom = (
             smartfades_enabled
             or streamdetails.volume_normalization_mode != VolumeNormalizationMode.DISABLED
-            or self.mass.config.get_player_dsp_config(player.player_id).enabled
+            or self.mass.config.get_player_dsp_config(dsp_player_id).enabled
         )
         if needs_headroom:
             return INTERNAL_PCM_FORMAT.content_type, INTERNAL_PCM_FORMAT.bit_depth

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1075,32 +1075,18 @@ class StreamsAudio:
         filter_params = []
 
         player = self.mass.players.get_player(player_id)
-        dsp_player_id = player_id
-        if player and player.protocol_parent_id:
-            dsp_player_id = player.protocol_parent_id
-        dsp = self.mass.config.get_player_dsp_config(dsp_player_id)
         limiter_enabled = True
 
         if player:
-            if is_grouping_preventing_dsp(player):
-                dsp.enabled = False
-            elif player.provider.domain == "player_group" and (
-                PlayerFeature.MULTI_DEVICE_DSP not in player.state.supported_features
-            ):
-                if player.state.group_members:
-                    child_player = self.mass.players.get_player(player.state.group_members[0])
-                    assert child_player is not None
-                    dsp = self.mass.config.get_player_dsp_config(child_player.player_id)
-                else:
-                    dsp.enabled = False
-
+            dsp = self._resolve_player_dsp_config(player)
             player.extra_data["output_format"] = output_format
             if player.protocol_parent_id:
                 parent_player = self.mass.players.get_player(player.protocol_parent_id)
                 if parent_player:
                     parent_player.extra_data["output_format"] = output_format
-
             limiter_enabled = self.is_output_limiter_enabled(player)
+        else:
+            dsp = self.mass.config.get_player_dsp_config(player_id)
 
         if dsp.enabled:
             if dsp.input_gain != 0:
@@ -2213,6 +2199,33 @@ class StreamsAudio:
 
     # --- Private methods ---
 
+    def _resolve_player_dsp_config(self, player: Player) -> DSPConfig:
+        """
+        Resolve the effective DSP config for a player.
+
+        Single source of truth shared by every code path that needs to know
+        whether DSP will run for this player. Protocol wrappers defer to their
+        parent player; single-leg ``player_group`` instances that don't expose
+        ``MULTI_DEVICE_DSP`` defer to their first member; players whose grouping
+        context prevents DSP get a disabled config back regardless.
+
+        :param player: The player to resolve DSP config for.
+        """
+        dsp_player_id = player.protocol_parent_id or player.player_id
+        dsp = self.mass.config.get_player_dsp_config(dsp_player_id)
+        if is_grouping_preventing_dsp(player):
+            dsp.enabled = False
+        elif player.provider.domain == "player_group" and (
+            PlayerFeature.MULTI_DEVICE_DSP not in player.state.supported_features
+        ):
+            if player.state.group_members:
+                child_player = self.mass.players.get_player(player.state.group_members[0])
+                assert child_player is not None
+                dsp = self.mass.config.get_player_dsp_config(child_player.player_id)
+            else:
+                dsp.enabled = False
+        return dsp
+
     def _pick_pcm_bit_depth(
         self,
         player: Player,
@@ -2231,13 +2244,10 @@ class StreamsAudio:
         """
         if streamdetails is None:
             return INTERNAL_PCM_FORMAT.content_type, INTERNAL_PCM_FORMAT.bit_depth
-        # mirror get_player_filter_params: when this player is a protocol wrapper,
-        # DSP is configured against its parent rather than itself
-        dsp_player_id = player.protocol_parent_id or player.player_id
         needs_headroom = (
             smartfades_enabled
             or streamdetails.volume_normalization_mode != VolumeNormalizationMode.DISABLED
-            or self.mass.config.get_player_dsp_config(dsp_player_id).enabled
+            or self._resolve_player_dsp_config(player).enabled
         )
         if needs_headroom:
             return INTERNAL_PCM_FORMAT.content_type, INTERNAL_PCM_FORMAT.bit_depth

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2251,15 +2251,15 @@ class StreamsAudio:
         Covers every case where the flow loop should break and hand control back to
         the queue controller for restart:
 
-        - Live media (radio, plugin/audio sources): cannot be played inside a flow,
+        - Live media (radio, audio sources): cannot be played inside a flow,
           the controller will fall back to a single-item stream.
         - Sample rate mismatch ('smart' / 'bit_perfect' modes only): the next
           track's sample rate (snapped up to the closest supported player rate,
-          mirroring select_flow_format's anchoring logic) is incompatible with the
-          current flow rate, so a new flow must be opened.
+          mirroring select_flow_pcm_format's anchoring logic) is incompatible with
+          the current flow rate, so a new flow must be opened.
 
         The first (anchor) track is always allowed to continue for the sample
-        rate check; select_flow_format has already snapped the flow rate to it.
+        rate check; select_flow_pcm_format has already snapped the flow rate to it.
 
         :param queue_track: The upcoming queue item.
         :param pcm_format: The current flow stream's PCM format.

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -51,12 +51,17 @@ from music_assistant.constants import (
     CONF_ENTRY_CROSSFADE_DIFFERENT_SAMPLE_RATES,
     CONF_ENTRY_OUTPUT_LIMITER,
     CONF_ENTRY_VOLUME_NORMALIZATION_TARGET,
+    CONF_FLOW_MODE_SAMPLE_RATE,
     CONF_OUTPUT_CHANNELS,
-    CONF_SAMPLE_RATES,
     CONF_SMART_FADES_MODE,
     CONF_VOLUME_NORMALIZATION_FIXED_GAIN_RADIO,
     CONF_VOLUME_NORMALIZATION_FIXED_GAIN_TRACKS,
     CONF_VOLUME_NORMALIZATION_TARGET,
+    FLOW_MODE_SAMPLE_RATE_48000,
+    FLOW_MODE_SAMPLE_RATE_96000,
+    FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
+    FLOW_MODE_SAMPLE_RATE_HIGHEST,
+    FLOW_MODE_SAMPLE_RATE_SMART,
     INTERNAL_PCM_FORMAT,
     MASS_LOGGER_NAME,
     VERBOSE_LOG_LEVEL,
@@ -127,6 +132,22 @@ class CrossfadeData:
     pcm_format: AudioFormat  # Format of the 'data' bytes (current/previous track's format)
     fade_in_pcm_format: AudioFormat  # Format for 'fade_in_size' (next track's format)
     queue_item_id: str
+
+
+def _snap_supported_rate_up(target: int, supported_sample_rates: list[int]) -> int:
+    """Snap target up to the lowest supported rate >= target, falling back to max."""
+    if target in supported_sample_rates:
+        return target
+    higher = [r for r in supported_sample_rates if r > target]
+    return min(higher) if higher else max(supported_sample_rates)
+
+
+def _snap_supported_rate_down(target: int, supported_sample_rates: list[int]) -> int:
+    """Snap target down to the highest supported rate <= target, falling back to min."""
+    if target in supported_sample_rates:
+        return target
+    lower = [r for r in supported_sample_rates if r < target]
+    return max(lower) if lower else min(supported_sample_rates)
 
 
 class StreamsAudio:
@@ -1117,25 +1138,15 @@ class StreamsAudio:
     ) -> AudioFormat:
         """Parse (player specific) output format details for given format string."""
         content_type: ContentType = ContentType.try_parse(output_format_str)
-        supported_rates_conf = cast(
-            "list[tuple[str, str]]",
-            await self.mass.config.get_player_config_value(
-                player.player_id, CONF_SAMPLE_RATES, unpack_splitted_values=True
-            ),
-        )
-        output_channels_str = self.mass.config.get_raw_player_config_value(
-            player.player_id, CONF_OUTPUT_CHANNELS, "stereo"
-        )
-        supported_sample_rates = tuple(int(x[0]) for x in supported_rates_conf)
-
-        if not supported_sample_rates or content_sample_rate in supported_sample_rates:
+        player_supported_rates = player.get_supported_sample_rates()
+        supported_sample_rates = [sr for sr, _ in player_supported_rates]
+        if content_sample_rate in supported_sample_rates:
             output_sample_rate = content_sample_rate
         else:
             output_sample_rate = max(supported_sample_rates)
-
         # only consider bit depths that are actually paired with the chosen sample rate
         bit_depths_for_rate = [
-            int(bd) for (sr, bd) in supported_rates_conf if int(sr) == output_sample_rate
+            bd for (sr, bd) in player_supported_rates if sr == output_sample_rate
         ]
         output_bit_depth = min(content_bit_depth, max(bit_depths_for_rate, default=16))
 
@@ -1148,6 +1159,10 @@ class StreamsAudio:
             output_bit_depth = min(output_bit_depth, 16)
         if output_format_str == "pcm":
             content_type = ContentType.from_bit_depth(output_bit_depth)
+
+        output_channels_str = self.mass.config.get_raw_player_config_value(
+            player.player_id, CONF_OUTPUT_CHANNELS, "stereo"
+        )
         fmt = AudioFormat(
             content_type=content_type,
             sample_rate=output_sample_rate,
@@ -1157,68 +1172,30 @@ class StreamsAudio:
         fmt.bit_rate = get_bit_rate(fmt)
         return fmt
 
-    async def select_flow_format(self, player: Player) -> AudioFormat:
-        """Parse (player specific) flow stream PCM format."""
-        supported_rates_conf = cast(
-            "list[tuple[str, str]]",
-            await self.mass.config.get_player_config_value(
-                player.player_id, CONF_SAMPLE_RATES, unpack_splitted_values=True
-            ),
-        )
-        supported_sample_rates = tuple(int(x[0]) for x in supported_rates_conf)
-        output_sample_rate = INTERNAL_PCM_FORMAT.sample_rate
-        for sample_rate in (192000, 96000, 48000, 44100):
-            if sample_rate in supported_sample_rates:
-                output_sample_rate = sample_rate
-                break
-        return AudioFormat(
-            content_type=INTERNAL_PCM_FORMAT.content_type,
-            sample_rate=output_sample_rate,
-            bit_depth=INTERNAL_PCM_FORMAT.bit_depth,
-            channels=2,
-        )
-
     async def select_pcm_format(
         self, player: Player, streamdetails: StreamDetails, smartfades_enabled: bool
     ) -> AudioFormat:
         """
-        Select the internal PCM format for streaming a queue item.
+        Select the internal PCM format for streaming a single queue item.
 
-        Uses F32 (float32) when audio processing is expected (volume normalization,
-        crossfade, DSP) for extra headroom. Falls back to the source material's
-        native bit depth when no processing is needed, avoiding unnecessary conversion.
+        Used by the per-item (non-flow) stream path. The sample rate is the highest
+        rate the player supports that is <= the source rate, so the source is never
+        upsampled. The bit depth follows the source unless audio processing
+        (crossfade, volume normalization, DSP) is active — those need F32 headroom
+        to avoid clipping/precision loss.
 
         :param player: The player requesting the stream.
         :param streamdetails: Stream details for the current item.
         :param smartfades_enabled: Whether crossfade is enabled for this stream.
         """
-        supported_rates_conf = cast(
-            "list[tuple[str, str]]",
-            await self.mass.config.get_player_config_value(
-                player.player_id, CONF_SAMPLE_RATES, unpack_splitted_values=True
-            ),
-        )
-        supported_sample_rates = tuple(int(x[0]) for x in supported_rates_conf)
+        supported_sample_rates = [sr for sr, _ in player.get_supported_sample_rates()]
         output_sample_rate = max(
             (r for r in supported_sample_rates if r <= streamdetails.audio_format.sample_rate),
             default=48000,
         )
-
-        # determine if audio processing will be applied
-        # if so, use F32 for headroom; otherwise use source bit depth
-        needs_processing = (
-            smartfades_enabled
-            or streamdetails.volume_normalization_mode != VolumeNormalizationMode.DISABLED
-            or self.mass.config.get_player_dsp_config(player.player_id).enabled
+        content_type, bit_depth = self._pick_pcm_bit_depth(
+            player, streamdetails, smartfades_enabled
         )
-
-        if needs_processing:
-            content_type = INTERNAL_PCM_FORMAT.content_type
-            bit_depth = INTERNAL_PCM_FORMAT.bit_depth
-        else:
-            bit_depth = streamdetails.audio_format.bit_depth
-            content_type = ContentType.from_bit_depth(bit_depth)
-
         pcm_format = AudioFormat(
             sample_rate=output_sample_rate,
             content_type=content_type,
@@ -1227,8 +1204,67 @@ class StreamsAudio:
         )
         if smartfades_enabled:
             pcm_format.channels = 2
-
         return pcm_format
+
+    async def select_flow_pcm_format(
+        self,
+        player: Player,
+        start_streamdetails: StreamDetails | None = None,
+        smartfades_enabled: bool = False,
+    ) -> AudioFormat:
+        """
+        Select the internal PCM format for a Queue Flow Mode stream.
+
+        Used by the gapless flow path that stitches multiple queue items into one
+        continuous PCM stream. The sample rate is driven by the player's
+        ``CONF_FLOW_MODE_SAMPLE_RATE`` setting (smart/bit_perfect/48k/96k/highest)
+        — for the anchored modes it follows the first track's rate, for the fixed
+        modes it snaps to the configured rate. The bit depth follows the first
+        track's source unless audio processing is active (then F32 for headroom),
+        avoiding an unnecessary up-convert to 32-bit when none of the consumers
+        will benefit from it.
+
+        :param player: The player the flow stream is being prepared for.
+        :param start_streamdetails: Stream details of the first track in the flow.
+            Required for the anchored modes ('smart' / 'bit_perfect') and for the
+            bit-depth optimization. May be omitted for the fixed-rate modes — when
+            omitted the bit depth defaults to F32.
+        :param smartfades_enabled: Whether the queue will use crossfade transitions.
+        """
+        supported_sample_rates = sorted({sr for sr, _ in player.get_supported_sample_rates()})
+        flow_mode_conf = cast(
+            "str",
+            player.config.get_value(CONF_FLOW_MODE_SAMPLE_RATE, FLOW_MODE_SAMPLE_RATE_SMART),
+        )
+
+        if flow_mode_conf == FLOW_MODE_SAMPLE_RATE_HIGHEST:
+            output_sample_rate = max(supported_sample_rates)
+        elif flow_mode_conf == FLOW_MODE_SAMPLE_RATE_48000:
+            # for the fixed-rate modes, the user picked a specific bandwidth/quality
+            # ceiling; prefer the highest supported rate <= target
+            output_sample_rate = _snap_supported_rate_down(48000, supported_sample_rates)
+        elif flow_mode_conf == FLOW_MODE_SAMPLE_RATE_96000:
+            output_sample_rate = _snap_supported_rate_down(96000, supported_sample_rates)
+        else:
+            # smart or bit_perfect (default): anchor the flow at the starting track's
+            # sample rate; if the player doesn't natively support it, upsample to the
+            # closest higher supported rate
+            target_rate = (
+                start_streamdetails.audio_format.sample_rate
+                if start_streamdetails
+                else max(supported_sample_rates)
+            )
+            output_sample_rate = _snap_supported_rate_up(target_rate, supported_sample_rates)
+
+        content_type, bit_depth = self._pick_pcm_bit_depth(
+            player, start_streamdetails, smartfades_enabled
+        )
+        return AudioFormat(
+            content_type=content_type,
+            sample_rate=output_sample_rate,
+            bit_depth=bit_depth,
+            channels=2,
+        )
 
     async def get_queue_item_stream(
         self,
@@ -1760,6 +1796,15 @@ class StreamsAudio:
             standard_crossfade_duration = self.mass.config.get_raw_player_config_value(
                 queue.queue_id, CONF_CROSSFADE_DURATION, 10
             )
+        flow_mode_sample_rate_conf = self.mass.config.get_raw_player_config_value(
+            queue.queue_id, CONF_FLOW_MODE_SAMPLE_RATE, FLOW_MODE_SAMPLE_RATE_SMART
+        )
+        flow_player = self.mass.players.get_player(queue.queue_id)
+        flow_supported_sample_rates = (
+            sorted({sr for sr, _ in flow_player.get_supported_sample_rates()})
+            if flow_player
+            else []
+        )
         # smart crossfade requires a large buffer for beat analysis
         if (
             smart_fades_mode == SmartFadesMode.SMART_CROSSFADE
@@ -1807,17 +1852,13 @@ class StreamsAudio:
                 except QueueEmpty:
                     break
 
-            if queue_track.media_type == MediaType.RADIO:
-                # radio streams should not be played in flow mode
-                # break out of the flow stream and let the queue controller
-                # restart playback using the single item stream
-                self.logger.info(
-                    "Radio item %s (%s) encountered in flow stream for queue %s "
-                    "- breaking out to single item stream",
-                    queue_track.queue_item_id,
-                    queue_track.name,
-                    queue.display_name,
-                )
+            if self._flow_stream_needs_restart(
+                queue_track,
+                pcm_format,
+                flow_supported_sample_rates,
+                flow_mode_sample_rate_conf,
+                is_first_track=queue_track is start_queue_item,
+            ):
                 break
 
             if queue_track.streamdetails is None:
@@ -2167,6 +2208,103 @@ class StreamsAudio:
             del self._crossfade_data[queue_id]
 
     # --- Private methods ---
+
+    def _pick_pcm_bit_depth(
+        self,
+        player: Player,
+        streamdetails: StreamDetails | None,
+        smartfades_enabled: bool,
+    ) -> tuple[ContentType, int]:
+        """
+        Return ``(content_type, bit_depth)`` for an internal PCM stream.
+
+        F32 is chosen when audio processing (crossfade, volume normalization, DSP)
+        will run on the stream — those need the extra headroom to avoid clipping
+        and precision loss. Otherwise the source's native bit depth is reused so
+        we don't waste memory upcasting a 16-bit stream to 32-bit just to pass it
+        through. When the source is unknown (no streamdetails) we fall back to
+        F32 conservatively.
+        """
+        if streamdetails is None:
+            return INTERNAL_PCM_FORMAT.content_type, INTERNAL_PCM_FORMAT.bit_depth
+        needs_headroom = (
+            smartfades_enabled
+            or streamdetails.volume_normalization_mode != VolumeNormalizationMode.DISABLED
+            or self.mass.config.get_player_dsp_config(player.player_id).enabled
+        )
+        if needs_headroom:
+            return INTERNAL_PCM_FORMAT.content_type, INTERNAL_PCM_FORMAT.bit_depth
+        bit_depth = streamdetails.audio_format.bit_depth
+        return ContentType.from_bit_depth(bit_depth), bit_depth
+
+    def _flow_stream_needs_restart(
+        self,
+        queue_track: QueueItem,
+        pcm_format: AudioFormat,
+        supported_sample_rates: list[int],
+        flow_mode_sample_rate_conf: str,
+        is_first_track: bool,
+    ) -> bool:
+        """
+        Return True if the upcoming queue track requires exiting the flow stream.
+
+        Covers every case where the flow loop should break and hand control back to
+        the queue controller for restart:
+
+        - Live media (radio, plugin/audio sources): cannot be played inside a flow,
+          the controller will fall back to a single-item stream.
+        - Sample rate mismatch ('smart' / 'bit_perfect' modes only): the next
+          track's sample rate (snapped up to the closest supported player rate,
+          mirroring select_flow_format's anchoring logic) is incompatible with the
+          current flow rate, so a new flow must be opened.
+
+        The first (anchor) track is always allowed to continue for the sample
+        rate check; select_flow_format has already snapped the flow rate to it.
+
+        :param queue_track: The upcoming queue item.
+        :param pcm_format: The current flow stream's PCM format.
+        :param supported_sample_rates: Sorted list of the player's supported rates.
+        :param flow_mode_sample_rate_conf: The flow mode sample rate config value.
+        :param is_first_track: Whether this is the first track of the flow stream.
+        """
+        # live audio (radio, plugin or audio source) cannot be flowed; let the
+        # queue controller fall back to single-item streaming for this item
+        if queue_track.media_type in (MediaType.RADIO, MediaType.AUDIO_SOURCE):
+            self.logger.info(
+                "Live media item %s (%s, %s) encountered in flow stream "
+                "- breaking out to single item stream",
+                queue_track.queue_item_id,
+                queue_track.name,
+                queue_track.media_type,
+            )
+            return True
+
+        if is_first_track or queue_track.streamdetails is None:
+            return False
+        raw_next_rate = queue_track.streamdetails.audio_format.sample_rate
+        if not raw_next_rate or not supported_sample_rates:
+            return False
+        effective_next_rate = _snap_supported_rate_up(raw_next_rate, supported_sample_rates)
+
+        if flow_mode_sample_rate_conf == FLOW_MODE_SAMPLE_RATE_BIT_PERFECT:
+            needs_restart = effective_next_rate != pcm_format.sample_rate
+        elif flow_mode_sample_rate_conf == FLOW_MODE_SAMPLE_RATE_SMART:
+            needs_restart = effective_next_rate > pcm_format.sample_rate
+        else:
+            needs_restart = False
+
+        if needs_restart:
+            self.logger.info(
+                "Track %s (%s) sample rate %s (snapped to %s) incompatible with flow rate %s "
+                "(mode: %s) - breaking out to restart flow stream",
+                queue_track.queue_item_id,
+                queue_track.name,
+                raw_next_rate,
+                effective_next_rate,
+                pcm_format.sample_rate,
+                flow_mode_sample_rate_conf,
+            )
+        return needs_restart
 
     @asynccontextmanager
     async def _connect_radio_stream(self, url: str, **kwargs: Any) -> AsyncGenerator[Any, None]:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2293,12 +2293,20 @@ class StreamsAudio:
             return False
         effective_next_rate = _snap_supported_rate_up(raw_next_rate, supported_sample_rates)
 
-        if flow_mode_sample_rate_conf == FLOW_MODE_SAMPLE_RATE_BIT_PERFECT:
-            needs_restart = effective_next_rate != pcm_format.sample_rate
-        elif flow_mode_sample_rate_conf == FLOW_MODE_SAMPLE_RATE_SMART:
-            needs_restart = effective_next_rate > pcm_format.sample_rate
-        else:
+        # branch order mirrors select_flow_pcm_format: fixed-rate modes resample
+        # everything to the chosen rate (no restart); bit_perfect restarts on any
+        # mismatch; anything else falls through to smart-anchor behavior so
+        # unknown/legacy config values don't silently pin the flow forever.
+        if flow_mode_sample_rate_conf in (
+            FLOW_MODE_SAMPLE_RATE_48000,
+            FLOW_MODE_SAMPLE_RATE_96000,
+            FLOW_MODE_SAMPLE_RATE_HIGHEST,
+        ):
             needs_restart = False
+        elif flow_mode_sample_rate_conf == FLOW_MODE_SAMPLE_RATE_BIT_PERFECT:
+            needs_restart = effective_next_rate != pcm_format.sample_rate
+        else:
+            needs_restart = effective_next_rate > pcm_format.sample_rate
 
         if needs_restart:
             self.logger.info(

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1189,9 +1189,13 @@ class StreamsAudio:
         :param smartfades_enabled: Whether crossfade is enabled for this stream.
         """
         supported_sample_rates = [sr for sr, _ in player.get_supported_sample_rates()]
+        # snap-down: pick the highest supported rate <= source. when the source rate
+        # is below every supported rate (e.g. 22 kHz content on a 44.1k-only player),
+        # fall back to the lowest supported rate instead of a hardcoded 48 kHz that
+        # the player may not actually support.
         output_sample_rate = max(
             (r for r in supported_sample_rates if r <= streamdetails.audio_format.sample_rate),
-            default=48000,
+            default=min(supported_sample_rates),
         )
         content_type, bit_depth = self._pick_pcm_bit_depth(
             player, streamdetails, smartfades_enabled

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -780,8 +780,19 @@ class StreamsController(CoreController):
         if not start_queue_item:
             raise web.HTTPNotFound(reason=f"Unknown Queue item: {start_queue_item_id}")
 
-        # select the highest possible PCM settings for this player
-        flow_pcm_format = await self.audio.select_flow_format(player)
+        # select the PCM format for the flow stream, anchored on the first track
+        smart_fades_mode = (
+            await self.mass.config.get_player_config_value(
+                queue_id, CONF_SMART_FADES_MODE, return_type=SmartFadesMode
+            )
+            if start_queue_item.media_type == MediaType.TRACK
+            else SmartFadesMode.DISABLED
+        )
+        flow_pcm_format = await self.audio.select_flow_pcm_format(
+            player,
+            start_streamdetails=start_queue_item.streamdetails,
+            smartfades_enabled=smart_fades_mode != SmartFadesMode.DISABLED,
+        )
 
         # work out output format/details
         output_format = await self.audio.get_output_format(

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -821,8 +821,17 @@ class Player(ABC):
         if conf := self.config.get_value(CONF_SAMPLE_RATES):
             conf = cast("list[str]", conf)
             for item in conf:
-                sample_rate_str, bit_depth_str = item.split(MULTI_VALUE_SPLITTER)
-                config_rates.append((int(sample_rate_str.strip()), int(bit_depth_str.strip())))
+                # tolerate legacy/malformed entries: anything that does not parse as
+                # `<rate><splitter><bit_depth>` is skipped and we fall back to defaults
+                try:
+                    sample_rate_str, bit_depth_str = item.split(MULTI_VALUE_SPLITTER, 1)
+                    config_rates.append((int(sample_rate_str.strip()), int(bit_depth_str.strip())))
+                except (ValueError, TypeError):
+                    self.logger.warning(
+                        "Ignoring malformed CONF_SAMPLE_RATES entry %r for player %s",
+                        item,
+                        self.player_id,
+                    )
         return config_rates or [(44100, 16)]
 
     @property

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, cast, final
 
+from music_assistant_models.config_entries import MULTI_VALUE_SPLITTER
 from music_assistant_models.constants import (
     EXTRA_ATTRIBUTES_TYPES,
     PLAYER_CONTROL_FAKE,
@@ -54,6 +55,7 @@ from music_assistant.constants import (
     CONF_PLAYERS,
     CONF_POWER_CONTROL,
     CONF_PREFERRED_OUTPUT_PROTOCOL,
+    CONF_SAMPLE_RATES,
     CONF_VOLUME_CONTROL,
     EXTERNAL_SOURCES,
     PLAYER_CONTROL_PROTOCOL,
@@ -102,6 +104,7 @@ class Player(ABC):
     _attr_expose_to_ha_by_default: bool = True
     _attr_enabled_by_default: bool = True
     _attr_needs_setup: bool = False
+    _attr_supported_sample_rates: list[tuple[int, int]] | None = None
 
     def __init__(self, provider: PlayerProvider, player_id: str) -> None:
         """Initialize the Player."""
@@ -369,6 +372,23 @@ class Player(ABC):
     def options(self) -> UniqueList[PlayerOption]:
         """Return all PlayerOptions for Player."""
         return UniqueList(self._attr_options)
+
+    @property
+    def supported_sample_rates(self) -> list[tuple[int, int]] | None:
+        """
+        Return the (sample_rate, bit_depth) pairs this player natively supports.
+
+        Example: [(44100, 16), (48000, 24)]
+
+        Players with a known static set should set ``_attr_supported_sample_rates``.
+        Players whose supported rates depend on runtime state (e.g. group players
+        whose members can change) should override this property.
+
+        Returning ``None`` defers to the user's per-player ``CONF_SAMPLE_RATES``
+        selection — callers should use ``get_supported_sample_rates()`` to get a
+        resolved, non-None list.
+        """
+        return self._attr_supported_sample_rates
 
     async def power(self, powered: bool) -> None:
         """
@@ -784,6 +804,37 @@ class Player(ABC):
     def enabled(self) -> bool:
         """Return if the player is enabled."""
         return self._config.enabled
+
+    @final
+    def get_supported_sample_rates(self) -> list[tuple[int, int]]:
+        """
+        Return the resolved (sample_rate, bit_depth) pairs the player can play.
+
+        Honors, in order:
+        1. The ``supported_sample_rates`` property (declarative or overridden)
+        2. The user's ``CONF_SAMPLE_RATES`` selection
+        3. A safe ``[(44100, 16)]`` fallback
+        """
+        if (declared := self.supported_sample_rates) is not None:
+            return declared
+        config_rates: list[tuple[int, int]] = []
+        if conf := self.config.get_value(CONF_SAMPLE_RATES):
+            conf = cast("list[str]", conf)
+            for item in conf:
+                sample_rate_str, bit_depth_str = item.split(MULTI_VALUE_SPLITTER)
+                config_rates.append((int(sample_rate_str.strip()), int(bit_depth_str.strip())))
+        return config_rates or [(44100, 16)]
+
+    @property
+    @final
+    def declares_supported_sample_rates(self) -> bool:
+        """
+        Return True when this player exposes its supported rates without user config.
+
+        Used by the config controller to decide whether to inject the generic
+        ``CONF_ENTRY_SAMPLE_RATES`` option in the player config UI.
+        """
+        return self.supported_sample_rates is not None
 
     @property
     @final

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -16,7 +16,7 @@ from music_assistant_models.enums import (
     PlayerType,
 )
 
-from music_assistant.constants import CONF_ENTRY_SYNC_ADJUST, create_sample_rates_config_entry
+from music_assistant.constants import CONF_ENTRY_SYNC_ADJUST
 from music_assistant.helpers.util import get_primary_ip_address_from_zeroconf, is_valid_mac_address
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 
@@ -25,6 +25,7 @@ from .constants import (
     AIRPLAY_DISCOVERY_TYPE,
     AIRPLAY_FLOW_PCM_FORMAT,
     AIRPLAY_OUTPUT_BUFFER_DEFAULT_DURATION_MS,
+    AIRPLAY_PCM_FORMAT,
     AIRPLAY_SESSION_ESTABLISHMENT_LATENCY_DEFAULT_MS,
     AIRPLAY_SESSION_ESTABLISHMENT_LATENCY_MAX_MS,
     AIRPLAY_SESSION_ESTABLISHMENT_LATENCY_MIN_MS,
@@ -112,6 +113,9 @@ class AirPlayPlayer(Player):
         self._attr_volume_level = initial_volume
         self._attr_can_group_with = {provider.instance_id}
         self._attr_enabled_by_default = not is_broken_airplay_model(manufacturer, model)
+        self._attr_supported_sample_rates = [
+            (AIRPLAY_PCM_FORMAT.sample_rate, AIRPLAY_PCM_FORMAT.bit_depth)
+        ]
 
         # Set player type based on manufacturer/model:
         # - Apple devices (HomePod, Apple TV) have native AirPlay support -> PLAYER
@@ -289,10 +293,6 @@ class AirPlayPlayer(Player):
                 hidden=not is_raop,
                 category="protocol_generic",
                 advanced=True,
-            ),
-            # airplay has fixed sample rate/bit depth so make this config entry static and hidden
-            create_sample_rates_config_entry(
-                supported_sample_rates=[44100], supported_bit_depths=[16], hidden=True
             ),
             ConfigEntry(
                 key=CONF_SESSION_ESTABLISHMENT_LATENCY,

--- a/music_assistant/providers/hass_players/player.py
+++ b/music_assistant/providers/hass_players/player.py
@@ -22,7 +22,6 @@ from music_assistant.constants import (
     CONF_ENTRY_OUTPUT_CODEC_DEFAULT_MP3,
     HIDDEN_ANNOUNCE_VOLUME_CONFIG_ENTRIES,
     create_output_codec_config_entry,
-    create_sample_rates_config_entry,
 )
 from music_assistant.helpers.datetime import from_iso_string
 from music_assistant.helpers.tags import async_parse_tags
@@ -119,6 +118,16 @@ class HomeAssistantPlayer(Player):
         # Set dynamic features (PAUSE, NEXT_PREVIOUS, SEEK) via shared helper
         self._update_hass_features(hass_supported_features)
 
+        # Derive supported sample rates from ESPHome's reported formats when available
+        esphome_formats: list[ESPHomeSupportedAudioFormat] | None = self.extra_data.get(
+            "esphome_supported_audio_formats"
+        )
+        if esphome_formats:
+            rates = sorted(
+                {(fmt["sample_rate"], (fmt["sample_bytes"] or 2) * 8) for fmt in esphome_formats}
+            )
+            self._attr_supported_sample_rates = rates or [(48000, 16)]
+
         self._update_attributes(hass_state["attributes"])
 
     @property
@@ -134,29 +143,15 @@ class HomeAssistantPlayer(Player):
     ) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the player."""
         base_entries = [*DEFAULT_PLAYER_CONFIG_ENTRIES]
-        if self.extra_data.get("esphome_supported_audio_formats"):
+        supported_formats: list[ESPHomeSupportedAudioFormat] | None = self.extra_data.get(
+            "esphome_supported_audio_formats"
+        )
+        if supported_formats:
             # optimized config for new ESPHome mediaplayer
-            supported_sample_rates: list[int] = []
-            supported_bit_depths: list[int] = []
-            codec: str | None = None
-            supported_formats: list[ESPHomeSupportedAudioFormat] = self.extra_data[
-                "esphome_supported_audio_formats"
-            ]
             # sort on purpose field, so we prefer the media pipeline
             # but allows fallback to announcements pipeline if no media pipeline is available
             supported_formats.sort(key=lambda x: x["purpose"])
-            for supported_format in supported_formats:
-                codec = supported_format["format"]
-                if supported_format["sample_rate"] not in supported_sample_rates:
-                    supported_sample_rates.append(supported_format["sample_rate"])
-                bit_depth = (supported_format["sample_bytes"] or 2) * 8
-                if bit_depth not in supported_bit_depths:
-                    supported_bit_depths.append(bit_depth)
-            if not supported_sample_rates or not supported_bit_depths:
-                # esphome device with no media pipeline configured
-                # simply use the default config of the media pipeline
-                supported_sample_rates = [48000]
-                supported_bit_depths = [16]
+            codec = supported_formats[0]["format"] if supported_formats else None
 
             config_entries = [
                 *base_entries,
@@ -170,11 +165,6 @@ class HomeAssistantPlayer(Player):
             config_entries.extend(
                 [
                     CONF_ENTRY_ENABLE_ICY_METADATA_HIDDEN,
-                    create_sample_rates_config_entry(
-                        supported_sample_rates=supported_sample_rates,
-                        supported_bit_depths=supported_bit_depths,
-                        hidden=True,
-                    ),
                     # although the Voice PE supports announcements,
                     # it does not support volume for announcements
                     *HIDDEN_ANNOUNCE_VOLUME_CONFIG_ENTRIES,

--- a/music_assistant/providers/heos/constants.py
+++ b/music_assistant/providers/heos/constants.py
@@ -36,3 +36,17 @@ DEFAULT_TIMEOUT: Final = 25.0
 CONNECT_MAX_ATTEMPTS: Final = 3
 CONNECT_INITIAL_RETRY_DELAY: Final = 5
 CONNECT_RETRY_BACKOFF_FACTOR: Final = 1.5
+
+# Gen 1 HEOS hardware (HS1) is limited to 48kHz/16-bit playback. Gen 2 (HS2)
+# and newer Denon/Marantz HEOS-enabled receivers support up to 192kHz/24-bit.
+# The "HS2" suffix is the canonical Gen 2 indicator; models in this allowlist
+# predate it and need to be capped.
+NON_HIRES_HEOS_MODELS: Final[tuple[str, ...]] = (
+    "HEOS 1",
+    "HEOS 3",
+    "HEOS 5",
+    "HEOS 7",
+    "HEOS Amp",
+    "HEOS Link",
+    "HEOS HomeCinema",
+)

--- a/music_assistant/providers/heos/player.py
+++ b/music_assistant/providers/heos/player.py
@@ -13,17 +13,17 @@ from music_assistant_models.player import DeviceInfo, PlayerSource
 from pyheos import Heos, HeosError, const
 from pyheos import PlayState as HeosPlayState
 
-from music_assistant.constants import (
-    VERBOSE_LOG_LEVEL,
-    create_sample_rates_config_entry,
-)
+from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.models.player import Player, PlayerMedia
 from music_assistant.providers.heos.helpers import media_uri_from_now_playing_media
 
-from .constants import HEOS_MEDIA_TYPE_TO_MEDIA_TYPE, HEOS_PLAY_STATE_TO_PLAYBACK_STATE
+from .constants import (
+    HEOS_MEDIA_TYPE_TO_MEDIA_TYPE,
+    HEOS_PLAY_STATE_TO_PLAYBACK_STATE,
+    NON_HIRES_HEOS_MODELS,
+)
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
     from pyheos import HeosPlayer as PyHeosPlayer
 
     from .provider import HeosPlayerProvider
@@ -105,6 +105,15 @@ class HeosPlayer(Player):
         self._attr_device_info = _device_info
         self._attr_available = self._device.available
         self._attr_name = self._device.name
+
+        # Gen 1 HEOS hardware is capped at 48kHz/16-bit; HS2 and newer models
+        # are hi-res capable up to 192kHz/24-bit
+        if model in NON_HIRES_HEOS_MODELS:
+            self._attr_supported_sample_rates = [(44100, 16), (48000, 16)]
+        else:
+            self._attr_supported_sample_rates = [
+                (sr, bd) for sr in (44100, 48000, 88200, 96000, 176400, 192000) for bd in (16, 24)
+            ]
 
     async def build_group_list(self) -> None:
         """Build group list based on group info from controller."""
@@ -435,19 +444,3 @@ class HeosPlayer(Player):
         self._ma_controls_playback = False
         self._queue_cleanup_pending = False
         await self._device.play_input_source(source)
-
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> list[ConfigEntry]:
-        """Return all (provider/player specific) Config Entries for the player."""
-        return [
-            # Gen 1 devices, like HEOS Link, only support up to 48kHz/16bit
-            create_sample_rates_config_entry(
-                max_sample_rate=192000,
-                safe_max_sample_rate=48000,
-                max_bit_depth=24,
-                safe_max_bit_depth=16,
-            ),
-        ]

--- a/music_assistant/providers/samsung_wam/consts.py
+++ b/music_assistant/providers/samsung_wam/consts.py
@@ -3,7 +3,7 @@
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import PlayerFeature
 
-from music_assistant.constants import CONF_ENTRY_HTTP_PROFILE, create_sample_rates_config_entry
+from music_assistant.constants import CONF_ENTRY_HTTP_PROFILE
 
 # --- Global Provider Settings ---
 
@@ -24,13 +24,6 @@ PLAYER_FEATURES_BASE = {
 }
 
 # --- Configuration Entries ---
-
-CONF_ENTRY_SAMPLE_RATES_WAM = create_sample_rates_config_entry(
-    supported_sample_rates=[44100, 48000, 88200, 96000, 176400, 192000],
-    supported_bit_depths=[16, 24],
-    safe_max_sample_rate=192000,
-    safe_max_bit_depth=24,
-)
 
 CONF_ENTRY_HTTP_PROFILE_WAM = ConfigEntry.from_dict(
     {**CONF_ENTRY_HTTP_PROFILE.to_dict(), "default_value": "forced_content_length"}

--- a/music_assistant/providers/samsung_wam/player.py
+++ b/music_assistant/providers/samsung_wam/player.py
@@ -16,7 +16,6 @@ from music_assistant.models.player import Player
 
 from .consts import (
     CONF_ENTRY_HTTP_PROFILE_WAM,
-    CONF_ENTRY_SAMPLE_RATES_WAM,
     MANUFACTURER_NAME,
     PLAYER_FEATURES_BASE,
 )
@@ -36,6 +35,10 @@ if TYPE_CHECKING:
 
 class WamPlayer(Player):
     """Representation of a Samsung WAM speaker."""
+
+    _attr_supported_sample_rates = [
+        (sr, bd) for sr in (44100, 48000, 88200, 96000, 176400, 192000) for bd in (16, 24)
+    ]
 
     def __init__(
         self,
@@ -125,7 +128,7 @@ class WamPlayer(Player):
         :param values: The current configuration values.
         :return: A list of ConfigEntry objects.
         """
-        return [CONF_ENTRY_SAMPLE_RATES_WAM, CONF_ENTRY_HTTP_PROFILE_WAM]
+        return [CONF_ENTRY_HTTP_PROFILE_WAM]
 
     async def on_config_updated(self) -> None:
         """Handle player config updates."""

--- a/music_assistant/providers/sendspin/playback.py
+++ b/music_assistant/providers/sendspin/playback.py
@@ -33,19 +33,22 @@ if TYPE_CHECKING:
     from .provider import SendspinProvider
 
 
-# Same sample format expressed in both MA and Sendspin type systems.
-_PCM_FORMAT = AudioFormat(
+# Default session PCM format (MA-side and wire) used until _run_playback picks a
+# leader-driven rate. Same sample format expressed in both MA and Sendspin types.
+_DEFAULT_PCM_FORMAT = AudioFormat(
     content_type=ContentType.PCM_F32LE,
     sample_rate=48000,
     bit_depth=32,
     channels=2,
 )
-_SENDSPIN_PCM_FORMAT = SendspinAudioFormat(
+_DEFAULT_SENDSPIN_PCM_FORMAT = SendspinAudioFormat(
     sample_rate=48000,
     bit_depth=32,
     channels=2,
     sample_type="float",
 )
+# Sample rate ceiling for lossy output codecs — anything above is wasted bandwidth.
+_LOSSY_MAX_SAMPLE_RATE = 48000
 # Max PCM slice fed to the producer per iteration.
 _PRODUCER_SLICE_US = 100_000
 # Max pending chunks between producer and committer before the producer blocks.
@@ -325,6 +328,12 @@ class SendspinPlaybackSession:
         self._preassigned_channels: dict[str, UUID] = {}
         self._mapping_dirty = True
         self._cancel_requested = False
+        # PCM formats are session-scoped and refreshed at the start of every
+        # _run_playback: the wire/MA-side rate is taken from the leader player's
+        # preferred format (capped at 48 kHz for lossy codecs), F32 is always used
+        # internally for DSP headroom.
+        self._pcm_format: AudioFormat = _DEFAULT_PCM_FORMAT
+        self._sendspin_pcm_format: SendspinAudioFormat = _DEFAULT_SENDSPIN_PCM_FORMAT
 
     # -- Helpers ---------------------------------------------------------------
 
@@ -502,7 +511,7 @@ class SendspinPlaybackSession:
         await self._stop_join_catchup(player_id)
 
         ffmpeg_obj = self._create_member_ffmpeg(pipeline.config.filter_params)
-        processor = _BufferedFfmpegProcessor(ffmpeg_obj, _PCM_FORMAT)
+        processor = _BufferedFfmpegProcessor(ffmpeg_obj, self._pcm_format)
         await processor.start()
         # Bounded queue sized to hold the full buffer duration with some headroom.
         queue_size = (_PRODUCER_BUFFER_LIMIT_US // _PRODUCER_SLICE_US) + _PRODUCER_BACKLOG_SIZE
@@ -681,6 +690,15 @@ class SendspinPlaybackSession:
         Sendspin push stream, and commits audio continuously. Supports dynamic group
         membership changes and late-join historical backfill while running.
         """
+        # refresh the session PCM format from the leader's preferred output before
+        # building any pipelines; member ffmpeg pipelines and pre-computed filter
+        # params depend on this rate so the cache must also be cleared
+        self._pcm_format, self._sendspin_pcm_format = self._select_session_pcm_formats()
+        self._pipeline_config_cache.clear()
+        self.player.logger.debug(
+            "Sendspin session PCM format: %d Hz / F32",
+            self._pcm_format.sample_rate,
+        )
         push_stream = self._create_push_stream()
         async with self._state_lock:
             self._push_stream = push_stream
@@ -703,7 +721,7 @@ class SendspinPlaybackSession:
         async def _produce_pending_chunks() -> None:
             nonlocal pending_duration_us
             audio_source = self.player.mass.streams.get_stream(
-                media, _PCM_FORMAT, self.player.player_id
+                media, self._pcm_format, self.player.player_id
             )
             completed = False
             try:
@@ -711,11 +729,11 @@ class SendspinPlaybackSession:
                     if not chunk:
                         continue
                     for slice_chunk in iter_pcm_slices(
-                        chunk, _PCM_FORMAT, target_duration_ms=_PRODUCER_SLICE_US // 1000
+                        chunk, self._pcm_format, target_duration_ms=_PRODUCER_SLICE_US // 1000
                     ):
                         if not slice_chunk:
                             continue
-                        duration_us = self._duration_us(slice_chunk, _PCM_FORMAT)
+                        duration_us = self._duration_us(slice_chunk, self._pcm_format)
                         if duration_us <= 0:
                             continue
                         await self._refresh_member_mappings()
@@ -765,7 +783,7 @@ class SendspinPlaybackSession:
                 pending_duration_us = max(0, pending_duration_us - pending.duration_us)
                 await self._inject_ready_join_historical(push_stream, pending_backlog, pending.pcm)
                 push_stream.prepare_audio(
-                    pending.pcm, _SENDSPIN_PCM_FORMAT, channel_id=MAIN_CHANNEL
+                    pending.pcm, self._sendspin_pcm_format, channel_id=MAIN_CHANNEL
                 )
                 join_pending_ids, pipelines = await self._snapshot_active_pipelines()
                 transform_pipelines: list[_MemberPipeline] = []
@@ -796,7 +814,7 @@ class SendspinPlaybackSession:
                         continue
                     push_stream.prepare_audio(
                         transformed_chunk,
-                        _SENDSPIN_PCM_FORMAT,
+                        self._sendspin_pcm_format,
                         channel_id=pipeline.channel_id,
                     )
                 try:
@@ -978,15 +996,17 @@ class SendspinPlaybackSession:
             )
             pipeline = await self._sync_member_pipeline(player_id)
             # Split the blob into slices so push_stream can yield between encodes.
-            frame_stride = (_SENDSPIN_PCM_FORMAT.bit_depth // 8) * _SENDSPIN_PCM_FORMAT.channels
+            frame_stride = (
+                self._sendspin_pcm_format.bit_depth // 8
+            ) * self._sendspin_pcm_format.channels
             slice_bytes = (
-                int(_SENDSPIN_PCM_FORMAT.sample_rate * _PRODUCER_SLICE_US / 1_000_000)
+                int(self._sendspin_pcm_format.sample_rate * _PRODUCER_SLICE_US / 1_000_000)
                 * frame_stride
             )
             for offset in range(0, len(transformed_history), slice_bytes):
                 push_stream.prepare_historical_audio(
                     transformed_history[offset : offset + slice_bytes],
-                    _SENDSPIN_PCM_FORMAT,
+                    self._sendspin_pcm_format,
                     channel_id=pipeline.channel_id,
                     start_time_us=first_history_start_us if offset == 0 else None,
                 )
@@ -1120,7 +1140,7 @@ class SendspinPlaybackSession:
             processor: _BufferedFfmpegProcessor | None = None
             if config.requires_transform:
                 ffmpeg_obj = self._create_member_ffmpeg(config.filter_params)
-                processor = _BufferedFfmpegProcessor(ffmpeg_obj, _PCM_FORMAT)
+                processor = _BufferedFfmpegProcessor(ffmpeg_obj, self._pcm_format)
                 start_processor = processor
             pipeline = _MemberPipeline(
                 player_id=player_id,
@@ -1176,7 +1196,7 @@ class SendspinPlaybackSession:
             filter_params = tuple(
                 self.player.mass.streams.audio.get_player_filter_params(
                     player_id,
-                    _PCM_FORMAT,
+                    self._pcm_format,
                     output_format,
                 )
             )
@@ -1191,6 +1211,34 @@ class SendspinPlaybackSession:
             output_channels=output_channels,
             filter_params=filter_params,
         )
+
+    def _select_session_pcm_formats(self) -> tuple[AudioFormat, SendspinAudioFormat]:
+        """
+        Pick the session PCM format (MA-side + wire) from the leader's preferred format.
+
+        F32 is always used for DSP headroom. The sample rate follows the leader's
+        preferred rate but is capped at 48 kHz when the leader's output codec is
+        lossy — higher rates yield no perceivable quality gain there. Member
+        clients with a different preferred rate up/down-sample in their own DSP
+        step on the receiving side.
+        """
+        leader_output = self._get_member_output_format(self.player.player_id)
+        sample_rate = int(leader_output.sample_rate) or _DEFAULT_PCM_FORMAT.sample_rate
+        if leader_output.content_type in (ContentType.OPUS, ContentType.MP3, ContentType.AAC):
+            sample_rate = min(sample_rate, _LOSSY_MAX_SAMPLE_RATE)
+        pcm_format = AudioFormat(
+            content_type=ContentType.PCM_F32LE,
+            sample_rate=sample_rate,
+            bit_depth=32,
+            channels=2,
+        )
+        sendspin_pcm_format = SendspinAudioFormat(
+            sample_rate=sample_rate,
+            bit_depth=32,
+            channels=2,
+            sample_type="float",
+        )
+        return pcm_format, sendspin_pcm_format
 
     def _get_member_output_format(self, player_id: str) -> AudioFormat:
         """
@@ -1226,7 +1274,7 @@ class SendspinPlaybackSession:
                         bit_depth=BRIDGE_BIT_DEPTH,
                         channels=BRIDGE_CHANNELS,
                     )
-        return _PCM_FORMAT
+        return self._pcm_format
 
     def _get_or_create_preassigned_channel(self, player_id: str) -> UUID:
         """Return stable dedicated channel id for transform-required player."""
@@ -1242,8 +1290,8 @@ class SendspinPlaybackSession:
         """Create per-member FFMpeg for DSP pipeline."""
         return FFMpeg(
             audio_input="-",
-            input_format=_PCM_FORMAT,
-            output_format=_PCM_FORMAT,
+            input_format=self._pcm_format,
+            output_format=self._pcm_format,
             filter_params=list(filter_params),
         )
 
@@ -1362,12 +1410,11 @@ class SendspinPlaybackSession:
             return 0
         return int((len(audio) / bytes_per_second) * 1_000_000)
 
-    @staticmethod
-    def _silence_for_duration_us(duration_us: int) -> bytes:
-        """Generate silent PCM with frame-aligned duration for the default format."""
+    def _silence_for_duration_us(self, duration_us: int) -> bytes:
+        """Generate silent PCM with frame-aligned duration for the current session format."""
         if duration_us <= 0:
             return b""
-        bytes_per_sample = max(1, int(_PCM_FORMAT.bit_depth // 8))
-        frame_size = bytes_per_sample * int(_PCM_FORMAT.channels)
-        samples = max(0, round((duration_us / 1_000_000) * int(_PCM_FORMAT.sample_rate)))
+        bytes_per_sample = max(1, int(self._pcm_format.bit_depth // 8))
+        frame_size = bytes_per_sample * int(self._pcm_format.channels)
+        samples = max(0, round((duration_us / 1_000_000) * int(self._pcm_format.sample_rate)))
         return b"\x00" * (samples * frame_size)

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -55,6 +55,7 @@ from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
+from propcache import under_cached_property as cached_property
 
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player, PlayerMedia
@@ -440,6 +441,16 @@ class SendspinPlayer(SendspinBasePlayer):
                 self._attr_supported_features.add(PlayerFeature.VOLUME_SET)
             if PlayerCommand.MUTE in _supported_commands:
                 self._attr_supported_features.add(PlayerFeature.VOLUME_MUTE)
+
+    @cached_property
+    def supported_sample_rates(self) -> list[tuple[int, int]] | None:
+        """Return supported (sample_rate, bit_depth) tuples derived from the player role."""
+        if (player_role := self._player_role) is not None:
+            formats = player_role.get_supported_formats() or []
+            rates = sorted({(fmt.sample_rate, fmt.bit_depth) for fmt in formats})
+            if rates:
+                return rates
+        return [(44100, 16)]
 
     def preserve_control_features_from(self, other: SendspinPlayer) -> None:
         """Keep the first registration's volume/mute features as a workaround for Cast."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -55,7 +55,6 @@ from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
-from propcache import under_cached_property as cached_property
 
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player, PlayerMedia
@@ -442,9 +441,11 @@ class SendspinPlayer(SendspinBasePlayer):
             if PlayerCommand.MUTE in _supported_commands:
                 self._attr_supported_features.add(PlayerFeature.VOLUME_MUTE)
 
-    @cached_property
+    @property
     def supported_sample_rates(self) -> list[tuple[int, int]] | None:
         """Return supported (sample_rate, bit_depth) tuples derived from the player role."""
+        # not cached: the player role / reported formats can change after the
+        # client (re)registers, so we always re-resolve from the live role state
         if (player_role := self._player_role) is not None:
             formats = player_role.get_supported_formats() or []
             rates = sorted({(fmt.sample_rate, fmt.bit_depth) for fmt in formats})

--- a/music_assistant/providers/snapcast/constants.py
+++ b/music_assistant/providers/snapcast/constants.py
@@ -5,8 +5,6 @@ import pathlib
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items.audio_format import AudioFormat
 
-from music_assistant.constants import create_sample_rates_config_entry
-
 CONF_SERVER_HOST = "snapcast_server_host"
 CONF_SERVER_CONTROL_PORT = "snapcast_server_control_port"
 CONF_USE_EXTERNAL_SERVER = "snapcast_use_external_server"
@@ -23,11 +21,6 @@ CONF_CATEGORY_BUILT_IN = "Built-in Snapserver Settings"
 
 CONF_HELP_LINK = (
     "https://raw.githubusercontent.com/badaix/snapcast/refs/heads/master/server/etc/snapserver.conf"
-)
-
-# snapcast has fixed sample rate/bit depth so make this config entry static and hidden
-CONF_ENTRY_SAMPLE_RATES_SNAPCAST = create_sample_rates_config_entry(
-    supported_sample_rates=[48000], supported_bit_depths=[16], hidden=True
 )
 
 DEFAULT_SNAPSERVER_IP = "127.0.0.1"

--- a/music_assistant/providers/snapcast/player.py
+++ b/music_assistant/providers/snapcast/player.py
@@ -14,7 +14,6 @@ from propcache import under_cached_property as cached_property
 from music_assistant.constants import ATTR_ANNOUNCEMENT_IN_PROGRESS, CONF_ENTRY_HTTP_PROFILE_HIDDEN
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player
-from music_assistant.providers.snapcast.constants import CONF_ENTRY_SAMPLE_RATES_SNAPCAST
 from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
 from music_assistant.providers.sync_group.constants import SGP_PREFIX
 
@@ -53,6 +52,9 @@ class TrackedPlayerState(TypedDict, total=False):
 
 class SnapCastPlayer(Player):
     """SnapCastPlayer."""
+
+    # snapcast has fixed sample rate/bit depth
+    _attr_supported_sample_rates = [(48000, 16)]
 
     def __init__(
         self,
@@ -362,7 +364,6 @@ class SnapCastPlayer(Player):
     ) -> list[ConfigEntry]:
         """Player config."""
         return [
-            CONF_ENTRY_SAMPLE_RATES_SNAPCAST,
             # we don't use the http server for streaming
             CONF_ENTRY_HTTP_PROFILE_HIDDEN,
         ]

--- a/music_assistant/providers/sonos/const.py
+++ b/music_assistant/providers/sonos/const.py
@@ -75,3 +75,20 @@ PLAYER_SOURCE_MAP = {
 }
 
 UNSUPPORTED_MODELS_NATIVE_ANNOUNCEMENTS = ("Play:1", "Play:3")
+NON_HIRES_MODELS = (
+    "Play:1",
+    "Play:3",
+    "Play:5 Gen2",
+    "One",
+    "One SL",
+    "Beam",
+    "Playbar",
+    "Playbase",
+    "Connect",
+    "Connect:Amp",
+    "Port",
+    "Amp",
+    "Move",
+    "Symfonisk Bookshelf",
+    "Symfonisk Table Lamp",
+)

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -33,12 +33,12 @@ from music_assistant_models.player import OutputProtocol, PlayerMedia
 from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE_DEFAULT_2,
     VERBOSE_LOG_LEVEL,
-    create_sample_rates_config_entry,
 )
 from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player
 from music_assistant.providers.sonos.const import (
+    NON_HIRES_MODELS,
     PLAYBACK_STATE_MAP,
     PLAYER_SOURCE_MAP,
     SOURCE_AIRPLAY,
@@ -147,6 +147,18 @@ class SonosPlayer(Player):
         self._attr_device_info.manufacturer = self._provider.manifest.name
         self._attr_can_group_with = {self._provider.instance_id}
 
+        # all current Sonos models accept up to 24-bit/48kHz; the older models in
+        # NON_HIRES_MODELS are limited to 16-bit playback
+        if self._attr_device_info.model in NON_HIRES_MODELS:
+            self._attr_supported_sample_rates = [(44100, 16), (48000, 16)]
+        else:
+            self._attr_supported_sample_rates = [
+                (44100, 16),
+                (48000, 16),
+                (44100, 24),
+                (48000, 24),
+            ]
+
         # Add identifiers for matching with other protocols (like AirPlay, DLNA)
         # The player_id is the Sonos UUID (e.g., RINCON_xxxxxxxxxxxx)
         self._attr_device_info.add_identifier(IdentifierType.UUID, self.player_id)
@@ -186,14 +198,6 @@ class SonosPlayer(Player):
         """Return all (provider/player specific) Config Entries for the player."""
         return [
             CONF_ENTRY_HTTP_PROFILE_DEFAULT_2,
-            create_sample_rates_config_entry(
-                # set safe max bit depth to 16 bits because the older Sonos players
-                # do not support 24 bit playback (e.g. Play:1)
-                max_sample_rate=48000,
-                max_bit_depth=24,
-                safe_max_bit_depth=16,
-                hidden=False,
-            ),
         ]
 
     async def volume_set(self, volume_level: int) -> None:

--- a/music_assistant/providers/sonos_s1/player.py
+++ b/music_assistant/providers/sonos_s1/player.py
@@ -20,7 +20,7 @@ from soco import SoCoException
 from soco.core import MUSIC_SRC_RADIO, SoCo
 from soco.data_structures import DidlAudioBroadcast
 
-from music_assistant.constants import VERBOSE_LOG_LEVEL, create_sample_rates_config_entry
+from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.upnp import create_didl_metadata
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
 
@@ -43,7 +43,6 @@ from .constants import (
 from .helpers import SonosUpdateError, soco_error
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
     from soco.events_base import Event as SonosEvent
     from soco.events_base import SubscriptionBase
 
@@ -59,6 +58,9 @@ class SonosSubscriptionsFailed(PlayerCommandFailed):
 
 class SonosPlayer(Player):
     """Sonos Player implementation for S1 speakers."""
+
+    # S1 hardware is fixed to 16-bit at 44.1/48 kHz
+    _attr_supported_sample_rates = [(44100, 16), (48000, 16)]
 
     def __init__(
         self,
@@ -151,20 +153,6 @@ class SonosPlayer(Player):
 
         self.update_state()
         await self.unsubscribe()
-
-    async def get_config_entries(
-        self,
-        action: str | None = None,
-        values: dict[str, ConfigValueType] | None = None,
-    ) -> list[ConfigEntry]:
-        """Return all (provider/player specific) Config Entries for the player."""
-        return [
-            create_sample_rates_config_entry(
-                supported_sample_rates=[44100, 48000],
-                supported_bit_depths=[16],
-                hidden=True,
-            ),
-        ]
 
     async def stop(self) -> None:
         """Send STOP command to the player."""

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -26,19 +26,18 @@ from music_assistant_models.enums import (
     RepeatMode,
 )
 from music_assistant_models.errors import InvalidCommand, MusicAssistantError
-from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.constants import (
     CONF_ENTRY_HTTP_PROFILE_FORCED_2,
     CONF_ENTRY_SYNC_ADJUST,
     CONF_OUTPUT_CODEC,
-    INTERNAL_PCM_FORMAT,
+    CONF_SMART_FADES_MODE,
     VERBOSE_LOG_LEVEL,
-    create_sample_rates_config_entry,
 )
 from music_assistant.helpers.audio import get_mime_type
 from music_assistant.helpers.util import TaskManager
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
+from music_assistant.models.smart_fades import SmartFadesMode
 
 from .constants import (
     CONF_ENTRY_DISPLAY,
@@ -99,6 +98,13 @@ class SqueezelitePlayer(Player):
             PlayerFeature.GAPLESS_PLAYBACK,
         }
         self._attr_can_group_with = {provider.instance_id}
+        max_sr = int(self.client.max_sample_rate)
+        self._attr_supported_sample_rates = [
+            (sr, bd)
+            for sr in (44100, 48000, 88200, 96000, 176400, 192000)
+            if sr <= max_sr
+            for bd in (16, 24)
+        ]
         self.multi_client_stream: MultiClientStream | None = None
         self._sync_playpoints: deque[SyncPlayPoint] = deque(maxlen=MIN_REQ_PLAYPOINTS)
         self._do_not_resync_before: float = 0.0
@@ -144,7 +150,6 @@ class SqueezelitePlayer(Player):
     ) -> list[ConfigEntry]:
         """Return all (provider/player specific) Config Entries for the player."""
         base_entries = await super().get_config_entries(action=action, values=values)
-        max_sample_rate = int(self.client.max_sample_rate)
         # create preset entries (for players that support it)
         presets = []
         async for playlist in self.mass.music.playlists.iter_library_items(True):
@@ -172,9 +177,6 @@ class SqueezelitePlayer(Player):
             CONF_ENTRY_DISPLAY,
             CONF_ENTRY_VISUALIZATION,
             CONF_ENTRY_HTTP_PROFILE_FORCED_2,
-            create_sample_rates_config_entry(
-                max_sample_rate=max_sample_rate, max_bit_depth=24, safe_max_bit_depth=24
-            ),
         ]
 
     async def volume_set(self, volume_level: int) -> None:
@@ -260,13 +262,26 @@ class SqueezelitePlayer(Player):
             )
             return
 
-        # this is a syncgroup, we need to handle this with a multi client stream
-        # Use a fixed 96kHz/24-bit format for syncgroup playback
-        master_audio_format = AudioFormat(
-            content_type=INTERNAL_PCM_FORMAT.content_type,
-            sample_rate=96000,
-            bit_depth=INTERNAL_PCM_FORMAT.bit_depth,
-            channels=2,
+        # this is a syncgroup; we need to handle this with a multi client stream.
+        # pick the master flow format honoring the leader's flow-mode-sample-rate
+        # setting and supported rates. anchor on the first track when its streamdetails
+        # are already resolved so smart/bit-perfect modes start at the right rate.
+        start_queue_item = (
+            self.mass.player_queues.get_item(media.source_id, media.queue_item_id)
+            if media.source_id and media.queue_item_id
+            else None
+        )
+        smart_fades_mode = (
+            await self.mass.config.get_player_config_value(
+                self.player_id, CONF_SMART_FADES_MODE, return_type=SmartFadesMode
+            )
+            if media.media_type == MediaType.TRACK
+            else SmartFadesMode.DISABLED
+        )
+        master_audio_format = await self.mass.streams.audio.select_flow_pcm_format(
+            self,
+            start_streamdetails=start_queue_item.streamdetails if start_queue_item else None,
+            smartfades_enabled=smart_fades_mode != SmartFadesMode.DISABLED,
         )
 
         # select audio source, we force flow mode

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -147,9 +147,11 @@ class SyncGroupPlayer(Player):
             return leader.flow_mode
         return False
 
-    @cached_property
+    @property
     def supported_sample_rates(self) -> list[tuple[int, int]] | None:
         """Return supported sample rates as defined by the sync leader."""
+        # not cached: sync_leader can change during dynamic group reforms,
+        # so we always re-resolve to stay in sync with the current leader
         if leader := self.sync_leader:
             return leader.get_supported_sample_rates()
         return [(44100, 16), (48000, 16)]

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -147,6 +147,13 @@ class SyncGroupPlayer(Player):
             return leader.flow_mode
         return False
 
+    @cached_property
+    def supported_sample_rates(self) -> list[tuple[int, int]] | None:
+        """Return supported sample rates as defined by the sync leader."""
+        if leader := self.sync_leader:
+            return leader.get_supported_sample_rates()
+        return [(44100, 16), (48000, 16)]
+
     @property
     def active_source(self) -> str | None:
         """Return the active source id of the current media (if any)."""

--- a/music_assistant/providers/universal_group/constants.py
+++ b/music_assistant/providers/universal_group/constants.py
@@ -60,9 +60,9 @@ CONF_ENTRY_UGP_OUTPUT_FORMAT = ConfigEntry(
     type=ConfigEntryType.STRING,
     label="Output format for Universal Group playback",
     options=[
-        ConfigValueOption("MP3 (320 kbps) — broadest compatibility", UGP_OUTPUT_MP3),
-        ConfigValueOption("FLAC 44.1 kHz / 16-bit — lossless CD-quality", UGP_OUTPUT_FLAC_44100_16),
-        ConfigValueOption("FLAC 48 kHz / 24-bit — hi-res", UGP_OUTPUT_FLAC_48000_24),
+        ConfigValueOption("MP3 (320 kbps)", UGP_OUTPUT_MP3),
+        ConfigValueOption("FLAC 44.1 kHz / 16-bit", UGP_OUTPUT_FLAC_44100_16),
+        ConfigValueOption("FLAC 48 kHz / 24-bit", UGP_OUTPUT_FLAC_48000_24),
     ],
     default_value=UGP_OUTPUT_MP3,
     description="Universal Groups deliver the exact same encoded stream to every "

--- a/music_assistant/providers/universal_group/constants.py
+++ b/music_assistant/providers/universal_group/constants.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from typing import Final
 
-from music_assistant_models.config_entries import ConfigEntry
-from music_assistant_models.enums import ConfigEntryType
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
+from music_assistant_models.enums import ConfigEntryType, ContentType
 from music_assistant_models.media_items import AudioFormat
-
-from music_assistant.constants import INTERNAL_PCM_FORMAT, create_sample_rates_config_entry
 
 UGP_PREFIX: Final[str] = "ugp_"
 
@@ -17,10 +15,35 @@ UGP_PREFIX: Final[str] = "ugp_"
 # an explicit stop). Matches the SyncGroup grace window.
 IDLE_GRACE_SECONDS: Final[float] = 10.0
 
+# Static output format options for the UGP stream. UGP is a heterogeneous-protocol
+# compatibility group, not a hi-res delivery path; every member receives the same
+# encoded stream, so the format is a single deliberate choice instead of a per-member
+# negotiation.
+CONF_UGP_OUTPUT_FORMAT: Final[str] = "ugp_output_format"
 
-CONF_ENTRY_SAMPLE_RATES_UGP = create_sample_rates_config_entry(
-    max_sample_rate=96000, max_bit_depth=24, hidden=True
-)
+UGP_OUTPUT_MP3: Final[str] = "mp3"
+UGP_OUTPUT_FLAC_44100_16: Final[str] = "flac_44100_16"
+UGP_OUTPUT_FLAC_48000_24: Final[str] = "flac_48000_24"
+
+# Map each option to (audio format the server will encode/serve, URL extension).
+# The audio format also drives the internal PCM pivot used by UGPStream so the
+# multiplexer runs at exactly the rate the encoder needs.
+UGP_OUTPUT_FORMATS: Final[dict[str, tuple[AudioFormat, str]]] = {
+    UGP_OUTPUT_MP3: (
+        AudioFormat(content_type=ContentType.MP3, sample_rate=44100, bit_depth=16),
+        "mp3",
+    ),
+    UGP_OUTPUT_FLAC_44100_16: (
+        AudioFormat(content_type=ContentType.FLAC, sample_rate=44100, bit_depth=16),
+        "flac",
+    ),
+    UGP_OUTPUT_FLAC_48000_24: (
+        AudioFormat(content_type=ContentType.FLAC, sample_rate=48000, bit_depth=24),
+        "flac",
+    ),
+}
+
+
 CONFIG_ENTRY_UGP_NOTE = ConfigEntry(
     key="ugp_note",
     type=ConfigEntryType.ALERT,
@@ -32,9 +55,25 @@ CONFIG_ENTRY_UGP_NOTE = ConfigEntry(
     required=False,
 )
 
-
-UGP_FORMAT = AudioFormat(
-    content_type=INTERNAL_PCM_FORMAT.content_type,
-    sample_rate=INTERNAL_PCM_FORMAT.sample_rate,
-    bit_depth=INTERNAL_PCM_FORMAT.bit_depth,
+CONF_ENTRY_UGP_OUTPUT_FORMAT = ConfigEntry(
+    key=CONF_UGP_OUTPUT_FORMAT,
+    type=ConfigEntryType.STRING,
+    label="Output format for Universal Group playback",
+    options=[
+        ConfigValueOption("MP3 (320 kbps) — broadest compatibility", UGP_OUTPUT_MP3),
+        ConfigValueOption("FLAC 44.1 kHz / 16-bit — lossless CD-quality", UGP_OUTPUT_FLAC_44100_16),
+        ConfigValueOption("FLAC 48 kHz / 24-bit — hi-res", UGP_OUTPUT_FLAC_48000_24),
+    ],
+    default_value=UGP_OUTPUT_MP3,
+    description="Universal Groups deliver the exact same encoded stream to every "
+    "member, regardless of each member's capabilities. Pick the format that all "
+    "members can play; MP3 is the safest default. Use the FLAC options only when "
+    "every member supports FLAC playback.",
+    category="generic",
+    requires_reload=True,
 )
+
+
+def resolve_ugp_output_format(option: str) -> tuple[AudioFormat, str]:
+    """Return the (output AudioFormat, URL extension) for a configured UGP option."""
+    return UGP_OUTPUT_FORMATS.get(option, UGP_OUTPUT_FORMATS[UGP_OUTPUT_MP3])

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -439,7 +439,7 @@ class UniversalGroupPlayer(Player):
                         uri=f"{base_url}?player_id={player_id}",
                         media_type=MediaType.FLOW_STREAM,
                         title=self.display_name,
-                        source_id=player_id,
+                        source_id=self.player_id,
                         custom_data={"ugp_player_id": self.player_id},
                     ),
                 )

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -25,7 +25,6 @@ from propcache import under_cached_property as cached_property
 from music_assistant.constants import (
     CONF_DYNAMIC_GROUP_MEMBERS,
     CONF_GROUP_MEMBERS,
-    CONF_HTTP_PROFILE,
     CONF_POWER_CONTROL,
     DEFAULT_STREAM_HEADERS,
     DLNA_CONTENT_FEATURES_REALTIME,
@@ -33,9 +32,15 @@ from music_assistant.constants import (
 from music_assistant.helpers.audio import get_mime_type
 from music_assistant.helpers.util import TaskManager
 from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
-from music_assistant.providers.universal_group.constants import UGP_FORMAT
 
-from .constants import CONF_ENTRY_SAMPLE_RATES_UGP, CONFIG_ENTRY_UGP_NOTE, IDLE_GRACE_SECONDS
+from .constants import (
+    CONF_ENTRY_UGP_OUTPUT_FORMAT,
+    CONF_UGP_OUTPUT_FORMAT,
+    CONFIG_ENTRY_UGP_NOTE,
+    IDLE_GRACE_SECONDS,
+    UGP_OUTPUT_MP3,
+    resolve_ugp_output_format,
+)
 from .ugp_stream import UGPStream
 
 if TYPE_CHECKING:
@@ -77,7 +82,9 @@ class UniversalGroupPlayer(Player):
         self._attr_poll_interval = 30
         # task that releases members after the idle grace window expires
         self._idle_grace_task: asyncio.Task[None] | None = None
-        # register dynamic route for the ugp stream
+        # register dynamic routes for the ugp stream (FLAC + MP3 cover the configured
+        # output formats; the actual codec served is decided by the UGP's own config,
+        # not by the request URL)
         self._on_unload_callbacks.append(
             self.mass.streams.register_dynamic_route(
                 f"/ugp/{self.player_id}.flac", self._serve_ugp_stream
@@ -86,11 +93,6 @@ class UniversalGroupPlayer(Player):
         self._on_unload_callbacks.append(
             self.mass.streams.register_dynamic_route(
                 f"/ugp/{self.player_id}.mp3", self._serve_ugp_stream
-            )
-        )
-        self._on_unload_callbacks.append(
-            self.mass.streams.register_dynamic_route(
-                f"/ugp/{self.player_id}.aac", self._serve_ugp_stream
             )
         )
         self._set_attributes()
@@ -133,6 +135,18 @@ class UniversalGroupPlayer(Player):
             for x in self.mass.players.providers
             if x.instance_id != self.provider.instance_id
         }
+
+    @cached_property
+    def supported_sample_rates(self) -> list[tuple[int, int]] | None:
+        """Return the (sample_rate, bit_depth) pair the UGP serves to its members."""
+        # UGP delivers the same encoded stream to every member, so its only natively
+        # supported rate is whatever the configured output format produces. Returning a
+        # single-rate list keeps the upstream MA flow stream pinned and prevents
+        # smart/bit-perfect modes from triggering needless restarts.
+        output_format, _ = resolve_ugp_output_format(
+            cast("str", self.config.get_value(CONF_UGP_OUTPUT_FORMAT, UGP_OUTPUT_MP3))
+        )
+        return [(output_format.sample_rate, output_format.bit_depth)]
 
     async def on_config_updated(self) -> None:
         """Handle logic when the PlayerConfig is first loaded or updated."""
@@ -191,7 +205,7 @@ class UniversalGroupPlayer(Player):
                 default_value=False,
                 required=False,
             ),
-            CONF_ENTRY_SAMPLE_RATES_UGP,
+            CONF_ENTRY_UGP_OUTPUT_FORMAT,
         ]
 
     async def stop(self) -> None:
@@ -341,14 +355,25 @@ class UniversalGroupPlayer(Player):
             # stop any existing stream first
             await self.stream.stop()
 
-        # select audio source
-        audio_source = self.mass.streams.get_stream(media, UGP_FORMAT, self.player_id)
-
-        # start the stream task
-        self.stream = UGPStream(
-            audio_source=audio_source, audio_format=UGP_FORMAT, base_pcm_format=UGP_FORMAT
+        # resolve the static output format the UGP serves to all members
+        output_format, fmt_str = resolve_ugp_output_format(
+            cast("str", self.config.get_value(CONF_UGP_OUTPUT_FORMAT, UGP_OUTPUT_MP3))
         )
-        base_url = f"{self.mass.streams.base_url}/ugp/{self.player_id}.flac"
+        # internal PCM pivot for the multiplexer: F32 at the configured output rate
+        # so the per-member encoder doesn't have to resample
+        pivot_format = AudioFormat(
+            content_type=ContentType.PCM_F32LE,
+            sample_rate=output_format.sample_rate,
+            bit_depth=32,
+            channels=2,
+        )
+        audio_source = self.mass.streams.get_stream(media, pivot_format, self.player_id)
+        self.stream = UGPStream(
+            audio_source=audio_source,
+            audio_format=pivot_format,
+            base_pcm_format=pivot_format,
+        )
+        base_url = f"{self.mass.streams.base_url}/ugp/{self.player_id}.{fmt_str}"
 
         # set the state optimistically
         self._attr_current_media = deepcopy(media)
@@ -369,6 +394,7 @@ class UniversalGroupPlayer(Player):
                             media_type=MediaType.FLOW_STREAM,
                             title=self.display_name,
                             source_id=self.player_id,
+                            custom_data={"ugp_player_id": self.player_id},
                         ),
                     )
                 )
@@ -402,7 +428,10 @@ class UniversalGroupPlayer(Player):
             # session-lifecycle refactor (groups now have `_attr_powered=None`
             # unless the user assigned Fake control).
             if self.stream and not self.stream.done:
-                base_url = f"{self.mass.streams.base_url}/ugp/{self.player_id}.flac"
+                _, fmt_str = resolve_ugp_output_format(
+                    cast("str", self.config.get_value(CONF_UGP_OUTPUT_FORMAT, UGP_OUTPUT_MP3))
+                )
+                base_url = f"{self.mass.streams.base_url}/ugp/{self.player_id}.{fmt_str}"
                 # Use internal handler to get protocol selection and avoid redirect
                 await self.mass.players._handle_play_media(
                     player_id,
@@ -411,6 +440,7 @@ class UniversalGroupPlayer(Player):
                         media_type=MediaType.FLOW_STREAM,
                         title=self.display_name,
                         source_id=player_id,
+                        custom_data={"ugp_player_id": self.player_id},
                     ),
                 )
         # handle removals
@@ -526,52 +556,33 @@ class UniversalGroupPlayer(Player):
     async def _serve_ugp_stream(self, request: web.Request) -> web.StreamResponse:
         """Serve the UGP (multi-client) flow stream audio to a player."""
         ugp_player_id = request.path.rsplit(".")[0].rsplit("/")[-1]
-        child_player_id = request.query.get("player_id")  # optional!
-        output_format_str = request.path.rsplit(".")[-1]
-
-        if child_player_id and (child_player := self.mass.players.get_player(child_player_id)):
-            # Use the preferred output format of the child player
-            output_format = await self.mass.streams.audio.get_output_format(
-                output_format_str=output_format_str,
-                player=child_player,
-                content_sample_rate=UGP_FORMAT.sample_rate,
-                content_bit_depth=UGP_FORMAT.bit_depth,
-                media_type=MediaType.FLOW_STREAM,
-            )
-            http_profile = await self.mass.config.get_player_config_value(
-                child_player_id, CONF_HTTP_PROFILE, return_type=str
-            )
-        elif output_format_str == "flac":
-            output_format = AudioFormat(content_type=ContentType.FLAC)
-        else:
-            output_format = AudioFormat(content_type=ContentType.MP3)
-            http_profile = "chunked"
+        # child_player_id is optional and only used for per-member DSP — never to
+        # decide the output codec/rate. The output format is dictated by the UGP
+        # player's own CONF_UGP_OUTPUT_FORMAT so every member receives an identical
+        # encoded stream.
+        child_player_id = request.query.get("player_id")
 
         if not (ugp_player := self.mass.players.get_player(ugp_player_id)):
             raise web.HTTPNotFound(reason=f"Unknown UGP player: {ugp_player_id}")
-
         if not self.stream or self.stream.done:
             raise web.HTTPNotFound(body=f"There is no active UGP stream for {ugp_player_id}!")
 
+        output_format, output_format_str = resolve_ugp_output_format(
+            cast("str", self.config.get_value(CONF_UGP_OUTPUT_FORMAT, UGP_OUTPUT_MP3))
+        )
         headers = {
             **DEFAULT_STREAM_HEADERS,
             "contentFeatures.dlna.org": DLNA_CONTENT_FEATURES_REALTIME,
             "Content-Type": get_mime_type(output_format_str),
         }
-
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
-        if http_profile == "forced_content_length":
-            resp.content_length = 4294967296
-        elif http_profile == "chunked":
-            resp.enable_chunked_encoding()
-
+        resp.enable_chunked_encoding()
         await resp.prepare(request)
 
         # return early if this is not a GET request
         if request.method != "GET":
             return resp
 
-        # all checks passed, start streaming!
         self.logger.debug(
             "Start serving UGP flow audio stream for UGP-player %s to %s",
             ugp_player.display_name,

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -24,7 +24,9 @@ from propcache import under_cached_property as cached_property
 
 from music_assistant.constants import (
     CONF_DYNAMIC_GROUP_MEMBERS,
+    CONF_ENTRY_HTTP_PROFILE_DEFAULT_1,
     CONF_GROUP_MEMBERS,
+    CONF_HTTP_PROFILE,
     CONF_POWER_CONTROL,
     DEFAULT_STREAM_HEADERS,
     DLNA_CONTENT_FEATURES_REALTIME,
@@ -206,6 +208,7 @@ class UniversalGroupPlayer(Player):
                 required=False,
             ),
             CONF_ENTRY_UGP_OUTPUT_FORMAT,
+            CONF_ENTRY_HTTP_PROFILE_DEFAULT_1,
         ]
 
     async def stop(self) -> None:
@@ -576,7 +579,13 @@ class UniversalGroupPlayer(Player):
             "Content-Type": get_mime_type(output_format_str),
         }
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
-        resp.enable_chunked_encoding()
+        http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
+        if http_profile == "forced_content_length":
+            # some clients (notably older Chromecast firmware) refuse to play unless
+            # they see a Content-Length header up front
+            resp.content_length = 4294967296
+        elif http_profile == "chunked":
+            resp.enable_chunked_encoding()
         await resp.prepare(request)
 
         # return early if this is not a GET request

--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -130,7 +130,7 @@ class WiimPlayer(Player):
         return [
             create_sample_rates_config_entry(
                 max_sample_rate=192000,
-                safe_max_sample_rate=96000,
+                safe_max_sample_rate=192000,
                 max_bit_depth=24,
                 safe_max_bit_depth=24,
             ),

--- a/tests/controllers/streams/test_flow_format.py
+++ b/tests/controllers/streams/test_flow_format.py
@@ -1,0 +1,443 @@
+"""Tests for the flow mode sample-rate selection and restart logic."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType, VolumeNormalizationMode
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.constants import (
+    CONF_FLOW_MODE_SAMPLE_RATE,
+    FLOW_MODE_SAMPLE_RATE_48000,
+    FLOW_MODE_SAMPLE_RATE_96000,
+    FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
+    FLOW_MODE_SAMPLE_RATE_HIGHEST,
+    FLOW_MODE_SAMPLE_RATE_SMART,
+)
+from music_assistant.controllers.streams.audio import (
+    StreamsAudio,
+    _snap_supported_rate_down,
+    _snap_supported_rate_up,
+)
+
+# --- snap helpers ---
+
+
+@pytest.mark.parametrize(
+    ("target", "supported", "expected"),
+    [
+        (48000, [44100, 48000, 96000], 48000),  # exact match
+        (50000, [44100, 48000, 96000], 96000),  # snap up to next higher
+        (200000, [44100, 48000, 96000], 96000),  # no higher; fall back to max
+        (40000, [44100, 48000], 44100),  # snap up to lowest higher
+    ],
+)
+def test_snap_supported_rate_up(target: int, supported: list[int], expected: int) -> None:
+    """_snap_supported_rate_up picks the lowest supported >= target, else max."""
+    assert _snap_supported_rate_up(target, supported) == expected
+
+
+@pytest.mark.parametrize(
+    ("target", "supported", "expected"),
+    [
+        (48000, [44100, 48000, 96000], 48000),  # exact match
+        (60000, [44100, 48000, 96000], 48000),  # snap down to highest lower
+        (40000, [48000, 96000], 48000),  # no lower; fall back to min
+        (200000, [44100, 48000], 48000),  # snap down (well above all)
+    ],
+)
+def test_snap_supported_rate_down(target: int, supported: list[int], expected: int) -> None:
+    """_snap_supported_rate_down picks the highest supported <= target, else min."""
+    assert _snap_supported_rate_down(target, supported) == expected
+
+
+# --- select_flow_pcm_format ---
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_highest() -> None:
+    """'highest' mode picks the player's max supported sample rate."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24), (96000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_HIGHEST,
+    )
+    fmt = await audio.select_flow_pcm_format(player)
+    assert fmt.sample_rate == 96000
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_48000_exact_match() -> None:
+    """'48000' mode picks 48 kHz when supported."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24), (96000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_48000,
+    )
+    fmt = await audio.select_flow_pcm_format(player)
+    assert fmt.sample_rate == 48000
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_48000_snaps_down_when_unsupported() -> None:
+    """'48000' mode falls back to 44.1 kHz when the player can't do 48 kHz."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_48000,
+    )
+    fmt = await audio.select_flow_pcm_format(player)
+    assert fmt.sample_rate == 44100
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_96000_falls_back_to_highest_below() -> None:
+    """'96000' mode snaps down to the highest supported rate <= 96000."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_96000,
+    )
+    fmt = await audio.select_flow_pcm_format(player)
+    assert fmt.sample_rate == 48000
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_96000_snaps_up_when_only_higher_supported() -> None:
+    """'96000' mode falls back to the lowest supported rate above 96 kHz when no lower exists."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(192000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_96000,
+    )
+    fmt = await audio.select_flow_pcm_format(player)
+    assert fmt.sample_rate == 192000
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_smart_anchors_on_start_track() -> None:
+    """'smart' mode anchors on the first track's sample rate when supported."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24), (96000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(sample_rate=44100, bit_depth=16)
+    fmt = await audio.select_flow_pcm_format(player, start_streamdetails=streamdetails)
+    assert fmt.sample_rate == 44100
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_smart_snaps_up_unsupported_rate() -> None:
+    """When the anchor rate isn't supported, smart snaps up to the next higher rate."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(48000, 24), (96000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(sample_rate=44100, bit_depth=16)
+    fmt = await audio.select_flow_pcm_format(player, start_streamdetails=streamdetails)
+    assert fmt.sample_rate == 48000
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_smart_without_start_format_uses_max() -> None:
+    """Smart mode with no start_streamdetails falls back to the player's highest rate."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (96000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    fmt = await audio.select_flow_pcm_format(player)
+    assert fmt.sample_rate == 96000
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_bit_perfect_matches_track() -> None:
+    """'bit_perfect' mode also anchors on the first track's sample rate."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24), (96000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
+    )
+    streamdetails = _make_streamdetails(sample_rate=96000, bit_depth=24)
+    fmt = await audio.select_flow_pcm_format(player, start_streamdetails=streamdetails)
+    assert fmt.sample_rate == 96000
+
+
+# --- bit-depth optimization ---
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_uses_source_bit_depth_without_processing() -> None:
+    """When no processing is active, the source's bit depth is reused (no F32 upcast)."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(sample_rate=44100, bit_depth=16)
+    fmt = await audio.select_flow_pcm_format(player, start_streamdetails=streamdetails)
+    assert fmt.bit_depth == 16
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_uses_f32_when_smartfades_enabled() -> None:
+    """Smartfades requires F32 headroom; bit depth must be 32 regardless of source."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(sample_rate=44100, bit_depth=16)
+    fmt = await audio.select_flow_pcm_format(
+        player, start_streamdetails=streamdetails, smartfades_enabled=True
+    )
+    assert fmt.bit_depth == 32
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_uses_f32_when_volume_normalization_active() -> None:
+    """Active volume normalization on the start track triggers F32 headroom."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(
+        sample_rate=44100,
+        bit_depth=16,
+        volume_normalization_mode=VolumeNormalizationMode.MEASUREMENT_ONLY,
+    )
+    fmt = await audio.select_flow_pcm_format(player, start_streamdetails=streamdetails)
+    assert fmt.bit_depth == 32
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_uses_f32_when_no_start_streamdetails() -> None:
+    """Without streamdetails we conservatively fall back to F32."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (96000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    fmt = await audio.select_flow_pcm_format(player)
+    assert fmt.bit_depth == 32
+
+
+# --- _flow_stream_needs_restart ---
+
+
+def test_needs_restart_first_track_never_breaks() -> None:
+    """The first (anchor) track is always allowed to continue."""
+    audio = _make_streams_audio()
+    track = _make_queue_track(rate=192000)
+    pcm = AudioFormat(sample_rate=48000, bit_depth=32, channels=2)
+    assert (
+        audio._flow_stream_needs_restart(
+            track,
+            pcm,
+            supported_sample_rates=[44100, 48000, 96000, 192000],
+            flow_mode_sample_rate_conf=FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
+            is_first_track=True,
+        )
+        is False
+    )
+
+
+def test_needs_restart_radio_always_breaks() -> None:
+    """Radio items always break out of flow, even on the first track."""
+    audio = _make_streams_audio()
+    track = _make_queue_track(rate=44100, media_type=MediaType.RADIO)
+    pcm = AudioFormat(sample_rate=44100, bit_depth=32, channels=2)
+    assert (
+        audio._flow_stream_needs_restart(
+            track,
+            pcm,
+            supported_sample_rates=[44100, 48000],
+            flow_mode_sample_rate_conf=FLOW_MODE_SAMPLE_RATE_SMART,
+            is_first_track=True,
+        )
+        is True
+    )
+
+
+def test_needs_restart_audio_source_breaks() -> None:
+    """Live AUDIO_SOURCE items break out so the controller can use single-item streaming."""
+    audio = _make_streams_audio()
+    track = _make_queue_track(rate=44100, media_type=MediaType.AUDIO_SOURCE)
+    pcm = AudioFormat(sample_rate=44100, bit_depth=32, channels=2)
+    assert (
+        audio._flow_stream_needs_restart(
+            track,
+            pcm,
+            supported_sample_rates=[44100, 48000],
+            flow_mode_sample_rate_conf=FLOW_MODE_SAMPLE_RATE_SMART,
+            is_first_track=False,
+        )
+        is True
+    )
+
+
+def test_needs_restart_smart_breaks_when_rate_increases() -> None:
+    """Smart mode breaks when the next track's effective rate is higher than the flow's."""
+    audio = _make_streams_audio()
+    track = _make_queue_track(rate=96000)
+    pcm = AudioFormat(sample_rate=48000, bit_depth=32, channels=2)
+    assert (
+        audio._flow_stream_needs_restart(
+            track,
+            pcm,
+            supported_sample_rates=[44100, 48000, 96000],
+            flow_mode_sample_rate_conf=FLOW_MODE_SAMPLE_RATE_SMART,
+            is_first_track=False,
+        )
+        is True
+    )
+
+
+def test_needs_restart_smart_no_break_on_lower_rate() -> None:
+    """Smart mode does not break when the next track's rate is equal or lower."""
+    audio = _make_streams_audio()
+    track = _make_queue_track(rate=44100)
+    pcm = AudioFormat(sample_rate=48000, bit_depth=32, channels=2)
+    assert (
+        audio._flow_stream_needs_restart(
+            track,
+            pcm,
+            supported_sample_rates=[44100, 48000, 96000],
+            flow_mode_sample_rate_conf=FLOW_MODE_SAMPLE_RATE_SMART,
+            is_first_track=False,
+        )
+        is False
+    )
+
+
+def test_needs_restart_bit_perfect_breaks_on_any_rate_change() -> None:
+    """Bit-perfect mode breaks on any rate change (including downsampling)."""
+    audio = _make_streams_audio()
+    track = _make_queue_track(rate=44100)
+    pcm = AudioFormat(sample_rate=48000, bit_depth=32, channels=2)
+    assert (
+        audio._flow_stream_needs_restart(
+            track,
+            pcm,
+            supported_sample_rates=[44100, 48000, 96000],
+            flow_mode_sample_rate_conf=FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
+            is_first_track=False,
+        )
+        is True
+    )
+
+
+def test_needs_restart_snaps_up_unsupported_next_rate_before_compare() -> None:
+    """An unsupported raw rate is snapped up before being compared to the flow rate."""
+    # raw 44100 isn't supported; the player snaps it up to 48000 — which equals the
+    # current flow rate, so no restart is needed even under bit-perfect.
+    audio = _make_streams_audio()
+    track = _make_queue_track(rate=44100)
+    pcm = AudioFormat(sample_rate=48000, bit_depth=32, channels=2)
+    assert (
+        audio._flow_stream_needs_restart(
+            track,
+            pcm,
+            supported_sample_rates=[48000, 96000],
+            flow_mode_sample_rate_conf=FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
+            is_first_track=False,
+        )
+        is False
+    )
+
+
+def test_needs_restart_fixed_rate_modes_never_break_on_rate() -> None:
+    """The fixed-rate modes always resample to the flow rate, so no restart."""
+    audio = _make_streams_audio()
+    track = _make_queue_track(rate=96000)
+    pcm = AudioFormat(sample_rate=48000, bit_depth=32, channels=2)
+    for mode in (
+        FLOW_MODE_SAMPLE_RATE_48000,
+        FLOW_MODE_SAMPLE_RATE_96000,
+        FLOW_MODE_SAMPLE_RATE_HIGHEST,
+    ):
+        assert (
+            audio._flow_stream_needs_restart(
+                track,
+                pcm,
+                supported_sample_rates=[44100, 48000, 96000, 192000],
+                flow_mode_sample_rate_conf=mode,
+                is_first_track=False,
+            )
+            is False
+        )
+
+
+def test_needs_restart_returns_false_when_streamdetails_missing() -> None:
+    """Without streamdetails the sample rate can't be evaluated; do not break the flow."""
+    audio = _make_streams_audio()
+    track = _make_queue_track(rate=44100)
+    track.streamdetails = None
+    pcm = AudioFormat(sample_rate=48000, bit_depth=32, channels=2)
+    assert (
+        audio._flow_stream_needs_restart(
+            track,
+            pcm,
+            supported_sample_rates=[44100, 48000],
+            flow_mode_sample_rate_conf=FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
+            is_first_track=False,
+        )
+        is False
+    )
+
+
+# --- helpers ---
+
+
+def _make_streams_audio() -> StreamsAudio:
+    """Return a StreamsAudio with everything mocked out except the logger."""
+    audio = StreamsAudio(MagicMock())
+    # DSP must be disabled in tests so the bit-depth optimization can engage;
+    # individual tests opt back in via smartfades or volume normalization.
+    audio.mass.config.get_player_dsp_config = MagicMock(  # type: ignore[method-assign]
+        return_value=MagicMock(enabled=False)
+    )
+    return audio
+
+
+def _make_player(*, supported: list[tuple[int, int]], flow_mode: str) -> MagicMock:
+    """Build a player double exposing only what select_flow_pcm_format needs."""
+    player = MagicMock()
+    player.get_supported_sample_rates = MagicMock(return_value=supported)
+    player.config.get_value = MagicMock(
+        side_effect=lambda key, default=None: (
+            flow_mode if key == CONF_FLOW_MODE_SAMPLE_RATE else default
+        )
+    )
+    return player
+
+
+def _make_streamdetails(
+    *,
+    sample_rate: int,
+    bit_depth: int,
+    volume_normalization_mode: VolumeNormalizationMode = VolumeNormalizationMode.DISABLED,
+) -> MagicMock:
+    """Build a StreamDetails double carrying just the fields the format selector reads."""
+    streamdetails = MagicMock()
+    streamdetails.audio_format = AudioFormat(
+        sample_rate=sample_rate, bit_depth=bit_depth, channels=2
+    )
+    streamdetails.volume_normalization_mode = volume_normalization_mode
+    return streamdetails
+
+
+def _make_queue_track(*, rate: int, media_type: MediaType = MediaType.TRACK) -> MagicMock:
+    """Build a queue_item double with the minimum fields the helper inspects."""
+    track = MagicMock()
+    track.queue_item_id = "item-1"
+    track.name = "Test Track"
+    track.media_type = media_type
+    track.streamdetails = MagicMock()
+    track.streamdetails.audio_format = AudioFormat(sample_rate=rate, bit_depth=16, channels=2)
+    return track

--- a/tests/models/test_player_supported_sample_rates.py
+++ b/tests/models/test_player_supported_sample_rates.py
@@ -1,0 +1,91 @@
+"""Tests for ``Player.supported_sample_rates`` and ``get_supported_sample_rates``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from music_assistant_models.config_entries import MULTI_VALUE_SPLITTER
+
+from music_assistant.constants import CONF_SAMPLE_RATES
+from music_assistant.models.player import Player
+
+
+def test_supported_sample_rates_property_reads_attr() -> None:
+    """The default property just exposes _attr_supported_sample_rates."""
+    player = _bare_player(attr_supported=[(96000, 24)])
+    assert player.supported_sample_rates == [(96000, 24)]
+
+
+def test_supported_sample_rates_property_returns_none_when_unset() -> None:
+    """A player that hasn't declared its rates returns None from the property."""
+    player = _bare_player(attr_supported=None)
+    assert player.supported_sample_rates is None
+
+
+def test_get_supported_sample_rates_uses_declared_value_when_set() -> None:
+    """``get_supported_sample_rates`` returns the declared list verbatim."""
+    player = _bare_player(attr_supported=[(96000, 24), (192000, 24)])
+    assert player.get_supported_sample_rates() == [(96000, 24), (192000, 24)]
+
+
+def test_get_supported_sample_rates_falls_back_to_config() -> None:
+    """When the property returns None, the user's CONF_SAMPLE_RATES selection is used."""
+    conf = [
+        f"44100{MULTI_VALUE_SPLITTER}16",
+        f"48000{MULTI_VALUE_SPLITTER}24",
+    ]
+    player = _bare_player(attr_supported=None, config_value=conf)
+    assert player.get_supported_sample_rates() == [(44100, 16), (48000, 24)]
+
+
+def test_get_supported_sample_rates_falls_back_to_default_when_no_config() -> None:
+    """Without any config value, the safe default [(44100, 16)] is returned."""
+    player = _bare_player(attr_supported=None, config_value=None)
+    assert player.get_supported_sample_rates() == [(44100, 16)]
+
+
+def test_declares_supported_sample_rates_true_when_attr_set() -> None:
+    """``declares_supported_sample_rates`` is True once _attr_* is populated."""
+    player = _bare_player(attr_supported=[(44100, 16)])
+    assert player.declares_supported_sample_rates is True
+
+
+def test_declares_supported_sample_rates_false_for_default_player() -> None:
+    """A player that hasn't set _attr_* and doesn't override the property returns False."""
+    player = _bare_player(attr_supported=None)
+    assert player.declares_supported_sample_rates is False
+
+
+def test_declares_supported_sample_rates_true_when_property_overridden() -> None:
+    """A subclass that overrides ``supported_sample_rates`` also counts as declared."""
+
+    class _OverridingPlayer(Player):
+        @property
+        def supported_sample_rates(self) -> list[tuple[int, int]] | None:
+            return [(48000, 24)]
+
+    player = object.__new__(_OverridingPlayer)
+    player._cache = {}
+    player._attr_supported_sample_rates = None
+    assert player.declares_supported_sample_rates is True
+    assert player.get_supported_sample_rates() == [(48000, 24)]
+
+
+def _bare_player(
+    *,
+    attr_supported: list[tuple[int, int]] | None,
+    config_value: list[str] | None = None,
+) -> Player:
+    """Construct a Player instance without invoking the real __init__."""
+    # the Player ABC's __init__ depends on a full provider/mass wiring;
+    # for these unit tests we only need the attributes that supported_sample_rates
+    # and get_supported_sample_rates actually read.
+    player = object.__new__(Player)
+    player._cache = {}
+    player._attr_supported_sample_rates = attr_supported
+    config = MagicMock()
+    config.get_value = MagicMock(
+        side_effect=lambda key, default=None: config_value if key == CONF_SAMPLE_RATES else default
+    )
+    player._config = config
+    return player


### PR DESCRIPTION
## Problem

Queue Flow Mode picked a single PCM format for the entire stitched stream with no user control over sample rate, and the format chain reached into player config in places it shouldn't (e.g. the UGP serve handler), causing `KeyError`s for `universal_player` wrappers and capping hi-res-capable players at 48 kHz. Players also had no way to declare their natively supported (sample_rate, bit_depth) pairs — everything went through the user-facing `CONF_SAMPLE_RATES` even when the player's capabilities are fixed/known.

## Changes

- **New `CONF_FLOW_MODE_SAMPLE_RATE`** with five modes: `smart` (default, anchor on first track, restart only on rate increase), `bit_perfect` (no resampling, restart on any rate change), fixed `48000`/`96000`, and `highest`.
- **`select_flow_pcm_format`** (renamed from `select_flow_format`) now honors that setting, takes the start track's `StreamDetails`, and only uses F32 when audio processing actually needs the headroom — source bit depth is preserved otherwise.
- **`Player.supported_sample_rates`** property + `@final get_supported_sample_rates()` resolver: implementers set `_attr_supported_sample_rates` (or override the property for dynamic cases like group players); the resolver falls back to `CONF_SAMPLE_RATES` and a `(44100, 16)` safe default. Config controller injects `CONF_ENTRY_SAMPLE_RATES` only when the player hasn't declared anything.
- **Provider updates** to declare static rates where applicable: AirPlay, Snapcast, Sonos (Gen 1 vs hi-res via `NON_HIRES_MODELS`), Sonos S1, HEOS (new `NON_HIRES_HEOS_MODELS` allowlist), Squeezelite, Samsung WAM, Sendspin (dynamic via player role), Home Assistant ESPHome players. WiiM/HEOS `safe_max_*` defaults raised to match hardware.
- **Sendspin**: session PCM format now follows the leader's preferred rate (capped at 48 kHz for lossy codecs), replacing the hardcoded 48 kHz F32.
- **Universal Group**: introduced `CONF_UGP_OUTPUT_FORMAT` (MP3 default, FLAC 44.1/16, FLAC 48/24 hi-res). UGP serves a single static output to all members so `_serve_ugp_stream` no longer peeks into child configs — fixes the `||protocol||` keysplitter `KeyError` that affected `universal_player`-wrapped DLNA/etc. members.
- **Squeezelite syncgroup** multi-client master format derived from `select_flow_pcm_format` instead of a hardcoded 96 kHz.
- **Flow loop** breaks out for `MediaType.AUDIO_SOURCE` (in addition to `RADIO`) and for sample-rate mismatches that the configured mode can't accommodate, letting the queue controller re-open a new flow at the next track's rate.
- Unit tests for `select_flow_pcm_format`, `_flow_stream_needs_restart`, the snap helpers, `Player.supported_sample_rates` / `get_supported_sample_rates`, and the bit-depth optimization.