### PR TITLE
fix(airplay_receiver): fix stuck album artwork on subsequent AirPlay sessions

### DIFF
--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -738,43 +738,38 @@ class AirPlayReceiverProvider(PluginProvider):
         :param metadata: Dictionary containing metadata updates.
         """
         if "cover_art_timestamp" in metadata:
-            # Use timestamp as query parameter to create a unique URL for each cover art update
-            # This prevents browser caching issues when switching between tracks
             timestamp = metadata["cover_art_timestamp"]
-            # Build image proxy URL for the cover art
-            # The actual image bytes are stored in the metadata reader
+            # Embed the timestamp in the path so each new artwork gets a unique server-side
+            # cache key.  The imageproxy caches by SHA256(provider+path), so a fixed path
+            # "cover_art" would return the first track's cached thumbnail forever.
             image = MediaItemImage(
                 type=ImageType.THUMB,
-                path="cover_art",
+                path=f"cover_art_{timestamp}",
                 provider=self.instance_id,
                 remotely_accessible=False,
             )
-            base_url = self.mass.metadata.get_image_url(image)
-            # Append timestamp as query parameter for cache-busting
-            self._stream_metadata.image_url = f"{base_url}&t={timestamp}"
+            self._stream_metadata.image_url = self.mass.metadata.get_image_url(image)
         elif self._metadata_reader and self._metadata_reader.cover_art_bytes:
             # Maintain image URL if we have cover art but didn't receive it in this update
             # This ensures the image URL persists across metadata updates
             if not self._stream_metadata.image_url:
-                # Generate timestamp for cache-busting even in fallback case
                 timestamp = str(int(time.time() * 1000))
                 image = MediaItemImage(
                     type=ImageType.THUMB,
-                    path="cover_art",
+                    path=f"cover_art_{timestamp}",
                     provider=self.instance_id,
                     remotely_accessible=False,
                 )
-                base_url = self.mass.metadata.get_image_url(image)
-                self._stream_metadata.image_url = f"{base_url}&t={timestamp}"
+                self._stream_metadata.image_url = self.mass.metadata.get_image_url(image)
 
     async def resolve_image(self, path: str) -> bytes:
         """Resolve an image from an image path.
 
         This returns raw bytes of the cover art image received from AirPlay metadata.
 
-        :param path: The image path (should be "cover_art" for AirPlay cover art).
+        :param path: The image path ("cover_art" or "cover_art_{timestamp}" for AirPlay cover art).
         """
-        if path == "cover_art" and self._metadata_reader and self._metadata_reader.cover_art_bytes:
+        if path.startswith("cover_art") and self._metadata_reader and self._metadata_reader.cover_art_bytes:
             return self._metadata_reader.cover_art_bytes
         # Return empty bytes if no cover art is available
         return b""


### PR DESCRIPTION
## Problem

After the first AirPlay session the album artwork was permanently stuck on that session's cover art — every subsequent stream (different app, different device, different album) still showed the original artwork.

## Root Cause

`_update_cover_art` built the proxy URL as:

```
/imageproxy?provider=<id>&size=0&fmt=jpeg&path=cover_art   +   &t=<timestamp>
```

The idea was that changing `&t=` would bust caches. It busts the **browser** cache (different URL), but **not the server-side thumbnail cache**.

The imageproxy handler (`handle_imageproxy` in `controllers/metadata.py`) only reads `path`, `provider`, `size`, and `fmt` — the `t=` parameter is silently ignored. Downstream, `get_image_thumb` (in `helpers/images.py`) builds its disk-cache key as:

```python
SHA256(f"{provider}/{path_or_url}")
```

Because `path` was always the literal string `"cover_art"`, the cache key never changed. After the first track's thumbnail was written to disk, every subsequent request returned those stale bytes regardless of artwork updates.

## Fix

Embed the per-track timestamp **inside the `path`** field of `MediaItemImage`:

```python
# before
path="cover_art"           → cache key: SHA256("provider/cover_art")   (never changes)

# after
path=f"cover_art_{timestamp}"  → cache key: SHA256("provider/cover_art_1234567890")  (unique per artwork)
```

This gives each new artwork its own cache entry so the imageproxy fetches fresh bytes from `resolve_image`.

`resolve_image` is updated to accept any path starting with `"cover_art"` so both old and new path formats resolve correctly.

## Files changed

- `music_assistant/providers/airplay_receiver/__init__.py`
  - `_update_cover_art`: use `path=f"cover_art_{timestamp}"`, drop the `&t=` suffix
  - `resolve_image`: `path.startswith("cover_art")` instead of `path == "cover_art"`

---
_Generated by [Claude Code](https://claude.ai/code/session_012GNV57s1hUJSimXzxa8VeW)_