### PR TITLE
Fix stale Sonos cloud queue items and idle radio prebuffer

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1366,13 +1366,17 @@ class StreamsAudio:
                         asyncio.get_event_loop().time() - stream_started_at,
                     )
                 # trigger pre-buffering of the next track well before end
-                # to ensure the raw PCM is ready when the next track needs to be streamed
+                # to ensure the raw PCM is ready when the next track needs to be streamed.
+                # only do this for tracks: live sources (radio, audio_source) open an
+                # upstream connection that would sit idle and likely time out before the
+                # player actually consumes it.
                 if (
                     not next_buffer_triggered
                     and streamdetails.duration
                     and (queue := self.mass.player_queues.get_active_queue(queue_item.queue_id))
                     and queue.next_item
                     and queue.next_item.queue_item_id != queue_item.queue_item_id
+                    and queue.next_item.media_type == MediaType.TRACK
                     and (bytes_received / pcm_format.pcm_sample_size + seek_position)
                     >= streamdetails.duration - 60
                 ):

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -72,6 +72,8 @@ class SonosQueue:
 
     items: list[PlayerMedia] = field(default_factory=list)
     last_updated: float = time.time()
+    includes_beginning: bool = False
+    includes_end: bool = False
 
 
 class SonosPlayer(Player):
@@ -781,6 +783,8 @@ class SonosPlayer(Player):
         queue = self.mass.player_queues.get(queue_id)
         if not queue:
             self.sonos_queue.items.clear()
+            self.sonos_queue.includes_beginning = False
+            self.sonos_queue.includes_end = False
             return
         current_index = queue.current_index or 0
         current_index = (
@@ -809,9 +813,11 @@ class SonosPlayer(Player):
 
         # Use get_next_item to fetch next items, which accounts for repeat mode
         last_index: int | str = current_index
+        includes_end = False
         for _ in range(5):
             next_item = self.mass.player_queues.get_next_item(queue_id, last_index)
             if next_item is None:
+                includes_end = True
                 break
             media = await self.mass.player_queues.player_media_from_queue_item(next_item)
             media.uri = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
@@ -819,6 +825,8 @@ class SonosPlayer(Player):
             last_index = next_item.queue_item_id
 
         self.sonos_queue.items = items
+        self.sonos_queue.includes_beginning = offset == 0
+        self.sonos_queue.includes_end = includes_end
         self.logger.log(
             VERBOSE_LOG_LEVEL,
             "Set Sonos queue items from MA queue %s on player %s: %s",

--- a/music_assistant/providers/sonos/player.py
+++ b/music_assistant/providers/sonos/player.py
@@ -813,16 +813,17 @@ class SonosPlayer(Player):
 
         # Use get_next_item to fetch next items, which accounts for repeat mode
         last_index: int | str = current_index
-        includes_end = False
         for _ in range(5):
             next_item = self.mass.player_queues.get_next_item(queue_id, last_index)
             if next_item is None:
-                includes_end = True
                 break
             media = await self.mass.player_queues.player_media_from_queue_item(next_item)
             media.uri = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
             items.append(media)
             last_index = next_item.queue_item_id
+
+        # check after the loop in case the window filled exactly up to the last item
+        includes_end = self.mass.player_queues.get_next_item(queue_id, last_index) is None
 
         self.sonos_queue.items = items
         self.sonos_queue.includes_beginning = offset == 0

--- a/music_assistant/providers/sonos/provider.py
+++ b/music_assistant/providers/sonos/provider.py
@@ -177,11 +177,15 @@ class SonosPlayerProvider(PlayerProvider):
         context_version = request.query.get("contextVersion", "1")
         queue_version = request.query.get("queueVersion", str(int(player.sonos_queue.last_updated)))
         # because Sonos does not show our queue in the app anyways,
-        # we just return the previous, current and next item in the queue
+        # we just return the previous, current and next item in the queue.
+        # the beginning/end flags must be honest though: signalling end-of-queue
+        # tells Sonos to drop any older items it may still have cached past our
+        # window, which is what prevents stale tracks from resurrecting after a
+        # queue rewrite (e.g. replace_next).
         items = list(player.sonos_queue.items)
         result = {
-            "includesBeginningOfQueue": False,
-            "includesEndOfQueue": False,
+            "includesBeginningOfQueue": player.sonos_queue.includes_beginning,
+            "includesEndOfQueue": player.sonos_queue.includes_end,
             "contextVersion": context_version,
             "queueVersion": queue_version,
             "items": [self._parse_sonos_queue_item(x) for x in items],


### PR DESCRIPTION
## Problem

Two related issues caused queue playback regressions after a `replace_next` (or similar tail rewrite) on a Sonos sync group:

1. **Stale items in the Sonos cloud queue.** MA's CloudQueue `itemWindow` handler always returned `includesEndOfQueue: false`, even when MA had no more items past the window. Sonos kept its older locally-cached entries as fallback, so when the current track ended it would request queue items MA had already discarded — resulting in 404s and the queue effectively jumping back in time.
2. **Radio next-tracks prebuffered way too early.** `_prepare_next_audio_buffer` fires when MA has buffered `duration - 60` seconds of the current track. Because MA fetches faster than real-time, this typically triggers within seconds of stream start. For a radio / live source that's a problem: the upstream HTTPS connection (e.g. TuneIn) gets opened minutes before the player actually consumes it, and is closed by the remote before then. The player then gets ~15s of buffered audio and silence.

## Changes

- `_handle_sonos_queue_itemwindow`: report `includesBeginningOfQueue` / `includesEndOfQueue` honestly instead of hardcoded `false`. Signalling end-of-queue lets Sonos drop stale items it had cached past the window.
- `SonosQueue` dataclass: track those boundary flags.
- `_set_sonos_queue_from_mass_queue`: populate the flags based on whether the window actually reaches index 0 / the last item of MA's master queue.
- Streams audio loop: only trigger `_prepare_next_audio_buffer` when the next item is `MediaType.TRACK`. This aligns with the existing crossfade gate — prep's only real benefit is a warm buffer for the crossfade mix, which only ever happens between tracks. Non-track next items (radio, audio source, podcast, audiobook) now connect upstream when the player asks for them, avoiding the idle-connection timeout.