### PR TITLE
Add PR template and auto-label from Types of changes checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+# What does this implement/fix?
+
+<!-- Quick description and explanation of changes. -->
+
+**Related issue (if applicable):**
+
+- related issue <link to issue>
+
+## Types of changes
+
+<!--
+Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
+the label from the ticked box and applies it automatically; the
+release-notes generator uses that same label to slot this change
+into the next release notes.
+-->
+
+- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
+- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
+- [ ] Enhancement to an existing feature — `enhancement`
+- [ ] New music/player/metadata/plugin provider — `new-provider`
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
+- [ ] Refactor (no behaviour change) — `refactor`
+- [ ] Documentation only — `documentation`
+- [ ] Maintenance / chore — `maintenance`
+- [ ] CI / workflow change — `ci`
+- [ ] Dependencies bump — `dependencies`
+
+## Checklist
+
+- [ ] The code change is tested and works locally.
+- [ ] `pre-commit run --all-files` passes.
+- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
+- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
+- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
+- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,41 +1,98 @@
 ---
 name: PR Labels
 
+# Each PR must carry exactly one of the labels the release-notes
+# generator knows how to slot into a section. We derive that label
+# from the "Types of changes" checkbox in the PR template and apply
+# it automatically — most external contributors can't label their
+# own PRs. The job fails when zero or more than one checkbox is
+# ticked.
+
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
-      - ready_for_review
-    branches:
-      - stable
-      - dev
   pull_request_target:
     types:
       - opened
+      - edited
       - synchronize
-      - reopened
       - labeled
       - unlabeled
+      - reopened
       - ready_for_review
     branches:
-      - stable
       - dev
 
 permissions:
-  contents: read
+  pull-requests: write
 
 jobs:
-  pr_labels:
-    name: Verify
+  apply_label:
+    name: Apply
     runs-on: ubuntu-latest
+    # Bot-authored PRs (Dependabot, etc.) don't follow the PR
+    # template and apply their own labels — the release-notes
+    # generator picks those up without this job's help.
+    if: github.event.pull_request.user.type != 'Bot'
     steps:
-      - name: 🏷 Verify PR has a valid label
-        uses: ludeeus/action-require-labels@1.1.0
+      - name: 🏷 Apply label from PR description checkbox
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
-          labels: >-
-            breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies, documentation, new-provider, enhancement
+          script: |
+            const known = [
+              'breaking-change', 'bugfix', 'refactor',
+              'new-feature', 'enhancement', 'new-provider',
+              'maintenance', 'ci', 'dependencies', 'documentation',
+            ];
+
+            // Match a ticked checkbox bullet whose line ends with a
+            // backticked label, e.g.  - [x] CI / workflow change — `ci`
+            // The PR template puts the canonical label name in
+            // backticks at the end of each "Types of changes" bullet.
+            const body = context.payload.pull_request.body || '';
+            const re = /^\s*-\s*\[x\][^`\n]*`([^`]+)`/gim;
+            const ticked = [];
+            for (const m of body.matchAll(re)) {
+              const name = m[1];
+              if (known.includes(name) && !ticked.includes(name)) {
+                ticked.push(name);
+              }
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            if (ticked.length === 0) {
+              core.setFailed(
+                'No "Types of changes" checkbox is ticked in the PR ' +
+                'description. Edit the description and tick exactly ' +
+                'one box so this PR can be release-noted.'
+              );
+              return;
+            }
+            if (ticked.length > 1) {
+              core.setFailed(
+                `Multiple "Types of changes" checkboxes are ticked ` +
+                `(${ticked.join(', ')}). Tick exactly one.`
+              );
+              return;
+            }
+
+            const desired = ticked[0];
+            const current = (context.payload.pull_request.labels || [])
+              .map(l => l.name);
+
+            // Strip any stale labels from the known set so a
+            // contributor changing their mind in the description
+            // doesn't leave the previous label behind.
+            for (const name of current) {
+              if (known.includes(name) && name !== desired) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number, name,
+                }).catch(() => {});
+              }
+            }
+            if (!current.includes(desired)) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number, labels: [desired],
+              });
+            }


### PR DESCRIPTION
## Summary

- Adds `.github/PULL_REQUEST_TEMPLATE.md` with a "Types of changes" section where each entry ends with the canonical label in backticks, plus a checklist that includes an acknowledgement of the project [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md).
- Replaces the verify-only `pr-labels.yaml` (which used `ludeeus/action-require-labels`) with an `actions/github-script` job that parses the ticked checkbox out of the PR body, strips any stale known-set labels, and applies the matching one. Fails when 0 or >1 boxes are ticked. Pattern is borrowed from `esphome/device-builder` and `esphome/device-builder-frontend`.
- Trigger narrowed to `pull_request_target` on `dev` only (contributor PRs land here; backport-bot PRs to `stable` already arrive labelled and would fail body-parsing). Bumps permissions to `pull-requests: write` and skips bot-authored PRs so Dependabot's own labels are left alone.
- A new `documentation` label was created on the repo to match the `documentation` entry already referenced by `release-notes-config.yml`.

The `known` list of labels the workflow accepts: `breaking-change, bugfix, refactor, new-feature, enhancement, new-provider, maintenance, ci, dependencies, documentation`.

## Test plan

- [ ] On this PR, tick exactly one "Types of changes" box (e.g. `ci`) and confirm the workflow applies the matching label.
- [ ] Change the ticked box to a different one (e.g. `maintenance`); confirm the previous label is removed and the new one applied.
- [ ] Untick all boxes; confirm the workflow fails with the "No checkbox is ticked" message.
- [ ] Tick two boxes; confirm the workflow fails with the "Multiple checkboxes" message.
- [ ] Re-trigger via a Dependabot or other bot-authored PR (if available) and confirm the `apply_label` job is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)