### PR TITLE
Improve imageproxy

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -31,7 +31,11 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 30
+# v31: MediaItemImage now carries `proxy_id`; clients may use the canonical
+#      /imageproxy/<proxy_id>?size=&fmt= URL form. The legacy
+#      /imageproxy?provider=&path= endpoint stays for back-compat but is
+#      deprecated and logs throttled deprecation warnings.
+API_SCHEMA_VERSION: Final[int] = 31
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -31,10 +31,6 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-# v31: MediaItemImage now carries `proxy_id`; clients may use the canonical
-#      /imageproxy/<proxy_id>?size=&fmt= URL form. The legacy
-#      /imageproxy?provider=&path= endpoint stays for back-compat but is
-#      deprecated and logs throttled deprecation warnings.
 API_SCHEMA_VERSION: Final[int] = 31
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -217,6 +217,8 @@ _IMAGE_ID_CACHE_TTL = 86400 * 365  # 1 year, refreshed on each write
 # to bound PIL memory + thumbnail cache cardinality; expand if a real use case appears.
 _ALLOWED_IMAGEPROXY_SIZES = frozenset({0, 80, 160, 256, 512, 1024})
 
+_IMAGEPROXY_PATH_PREFIX = "/imageproxy/"
+
 # Deprecation logging for the legacy /imageproxy query-string endpoint.
 _LEGACY_DEPRECATION_LOG_INTERVAL = 60  # seconds between log lines per IP
 _LEGACY_DEPRECATION_PRUNE_AFTER = 300  # drop tracking entries idle this long
@@ -663,7 +665,11 @@ class MetaDataController(CoreController):
         taking the `proxy_id` from a `MediaItemImage` and appending it as a
         single path segment, optionally with `size` and `fmt` query parameters.
         """
-        image_id = request.path.rstrip("/").rsplit("/", 1)[-1].lower()
+        # require exactly /imageproxy/<id> (optionally with a trailing slash);
+        # extra path segments such as /imageproxy/foo/<id> must not validate
+        if not request.path.startswith(_IMAGEPROXY_PATH_PREFIX):
+            return web.Response(status=400)
+        image_id = request.path[len(_IMAGEPROXY_PATH_PREFIX) :].rstrip("/").lower()
         if len(image_id) != 64 or any(c not in "0123456789abcdef" for c in image_id):
             return web.Response(status=400)
         try:

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -313,19 +313,19 @@ class MetaDataController(CoreController):
 
     async def post_setup(self) -> None:
         """Handle logic after all core controllers have been set up."""
-        self.mass.streams.register_dynamic_route("/imageproxy", self.handle_imageproxy)
-        # New opaque-id form, served via prefix match on the catch-all of both
-        # the public webserver and the streams server (the legacy form is on the
-        # webserver via a static route registered in WebserverController).
-        self.mass.streams.register_dynamic_route("/imageproxy/*", self.handle_imageproxy_v2)
-        self.mass.webserver.register_dynamic_route("/imageproxy/*", self.handle_imageproxy_v2)
+        # canonical opaque-id endpoint, served by both the public webserver
+        # and the streams server (the latter is what player metadata URLs hit)
+        self.mass.streams.register_dynamic_route("/imageproxy/*", self.handle_imageproxy)
+        self.mass.webserver.register_dynamic_route("/imageproxy/*", self.handle_imageproxy)
+        # deprecated /imageproxy?provider=&path=&size=&fmt= form (kept for back-compat)
+        self.mass.streams.register_dynamic_route("/imageproxy", self.handle_legacy_imageproxy)
         self._register_maintenance_tasks()
 
     async def close(self) -> None:
         """Handle logic on server stop."""
-        self.mass.streams.unregister_dynamic_route("/imageproxy")
         self.mass.streams.unregister_dynamic_route("/imageproxy/*")
         self.mass.webserver.unregister_dynamic_route("/imageproxy/*")
+        self.mass.streams.unregister_dynamic_route("/imageproxy")
 
     @property
     def providers(self) -> list[MetadataProvider]:
@@ -639,7 +639,40 @@ class MetaDataController(CoreController):
         return thumbnail_bytes
 
     async def handle_imageproxy(self, request: web.Request) -> web.Response:
-        """Handle a legacy /imageproxy?provider=&path=&size=&fmt= request."""
+        """
+        Serve an image for a `/imageproxy/<image_id>?size=&fmt=` request.
+
+        This is the canonical imageproxy endpoint: clients build the URL by
+        taking the `proxy_id` from a `MediaItemImage` and appending it as a
+        single path segment, optionally with `size` and `fmt` query parameters.
+        """
+        image_id = request.path.rstrip("/").rsplit("/", 1)[-1].lower()
+        if len(image_id) != 64 or any(c not in "0123456789abcdef" for c in image_id):
+            return web.Response(status=400)
+        try:
+            size = int(request.query.get("size", "0"))
+        except ValueError:
+            return web.Response(status=400)
+        if size not in _ALLOWED_IMAGEPROXY_SIZES:
+            return web.Response(status=400)
+        resolved = await self.resolve_image_id(image_id)
+        if resolved is None:
+            return web.Response(status=404)
+        provider, path = resolved
+        image_format = request.query.get("fmt") or _detect_image_format(path)
+        return await self._serve_thumbnail(path, provider, size, image_format)
+
+    async def handle_legacy_imageproxy(self, request: web.Request) -> web.Response:
+        """
+        Serve an image for a legacy `/imageproxy?provider=&path=&size=&fmt=` request.
+
+        DEPRECATED: this form requires the client to carry the full provider id
+        and (often URL-shaped) path on the query string, which produces
+        unwieldy double-encoded URLs and an open surface for arbitrary path
+        injection. New clients must use the `proxy_id` field on
+        `MediaItemImage` and hit `handle_imageproxy` instead. Each remote IP
+        gets a throttled deprecation `warning` log per minute.
+        """
         self._maybe_log_legacy_imageproxy(request)
         try:
             path = request.query["path"]
@@ -669,24 +702,6 @@ class MetaDataController(CoreController):
             return web.Response(status=400)
         if not self.mass.get_provider(provider) and not path.startswith("http"):
             return web.Response(status=404)
-        return await self._serve_thumbnail(path, provider, size, image_format)
-
-    async def handle_imageproxy_v2(self, request: web.Request) -> web.Response:
-        """Handle a /imageproxy/<image_id>?size=&fmt= request."""
-        image_id = request.path.rstrip("/").rsplit("/", 1)[-1].lower()
-        if len(image_id) != 64 or any(c not in "0123456789abcdef" for c in image_id):
-            return web.Response(status=400)
-        try:
-            size = int(request.query.get("size", "0"))
-        except ValueError:
-            return web.Response(status=400)
-        if size not in _ALLOWED_IMAGEPROXY_SIZES:
-            return web.Response(status=400)
-        resolved = await self.resolve_image_id(image_id)
-        if resolved is None:
-            return web.Response(status=404)
-        provider, path = resolved
-        image_format = request.query.get("fmt") or _detect_image_format(path)
         return await self._serve_thumbnail(path, provider, size, image_format)
 
     async def _serve_thumbnail(
@@ -733,8 +748,9 @@ class MetaDataController(CoreController):
             return
         self._legacy_imageproxy_warn_at[remote] = now
         self.logger.warning(
-            "Deprecated /imageproxy query-string request from %s (UA: %s); "
-            "clients should use the proxy_id field on MediaItemImage instead",
+            "Deprecated /imageproxy?provider=&path= request from %s (UA: %s); "
+            "clients should read the proxy_id field on MediaItemImage and use "
+            "the canonical /imageproxy/<proxy_id> endpoint instead",
             remote,
             request.headers.get("User-Agent", "?"),
         )

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import os
 import pathlib
@@ -105,25 +106,41 @@ def _detect_image_format(path: str) -> str:
             return "jpg"
 
 
-# Schemes that a client is not allowed to ask the imageproxy to fetch on its
-# behalf. Provider-supplied paths (resolved internally via `resolve_image`)
-# may still produce `data:image/...` results; only inbound client paths are
-# filtered here.
-_FORBIDDEN_IMAGEPROXY_SCHEMES = (
-    "file:",
-    "data:",
-    "gopher:",
-    "ftp:",
-    "ftps:",
-    "ws:",
-    "wss:",
-    "javascript:",
-)
+# Schemes accepted from a client on the legacy /imageproxy?path= endpoint.
+# Allowlist (not blacklist) so a leading-whitespace or unknown-scheme value
+# cannot sneak through. Provider-supplied paths resolved internally via
+# `resolve_image` are not subject to this — only inbound client paths are.
+_ALLOWED_IMAGEPROXY_REQUEST_SCHEMES: frozenset[str] = frozenset({"", "http", "https"})
 
 
 def _is_safe_imageproxy_request_path(path: str) -> bool:
-    """Return True if `path` is one we'll accept from a client imageproxy request."""
-    return not path.lower().startswith(_FORBIDDEN_IMAGEPROXY_SCHEMES)
+    r"""
+    Return True if `path` is safe to fetch on behalf of an imageproxy client.
+
+    Rejects any input containing control characters (so a leading `\t` or
+    `\x00` cannot mask an otherwise-forbidden scheme), restricts the scheme
+    to http, https, or empty (local / relative path), and for http(s) targets
+    rejects IP-literal hosts that resolve to loopback, private, link-local
+    or multicast ranges. DNS-resolved hostnames are trusted; full DNS-rebinding
+    mitigation is out of scope here.
+    """
+    if any(ord(c) < 0x20 for c in path):
+        return False
+    parsed = urllib.parse.urlparse(path)
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_IMAGEPROXY_REQUEST_SCHEMES:
+        return False
+    if scheme in ("http", "https"):
+        host = parsed.hostname  # already lowercased; brackets stripped for IPv6
+        if not host or host == "localhost":
+            return False
+        try:
+            ip = ipaddress.ip_address(host)
+        except ValueError:
+            return True
+        if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_multicast:
+            return False
+    return True
 
 
 LOCALES = {

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -117,14 +117,14 @@ def _is_safe_imageproxy_request_path(path: str) -> bool:
     r"""
     Return True if `path` is safe to fetch on behalf of an imageproxy client.
 
-    Rejects any input containing control characters (so a leading `\t` or
-    `\x00` cannot mask an otherwise-forbidden scheme), restricts the scheme
-    to http, https, or empty (local / relative path), and for http(s) targets
-    rejects IP-literal hosts that resolve to loopback, private, link-local
-    or multicast ranges. DNS-resolved hostnames are trusted; full DNS-rebinding
-    mitigation is out of scope here.
+    Rejects any input containing control characters or surrounding whitespace
+    (so a leading `\t`, ` `, or `\x00` cannot mask an otherwise-forbidden
+    scheme), restricts the scheme to http, https, or empty (local / relative
+    path), and for http(s) targets rejects IP-literal hosts that resolve to
+    loopback, private, link-local or multicast ranges. DNS-resolved hostnames
+    are trusted; full DNS-rebinding mitigation is out of scope here.
     """
-    if any(ord(c) < 0x20 for c in path):
+    if any(ord(c) < 0x20 for c in path) or path != path.strip():
         return False
     parsed = urllib.parse.urlparse(path)
     scheme = parsed.scheme.lower()

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -106,6 +106,27 @@ def _detect_image_format(path: str) -> str:
             return "jpg"
 
 
+# Map of normalised imageproxy `fmt` values to standards-compliant MIME types.
+# Used both to validate the client-supplied `fmt` query parameter and to set
+# the Content-Type on the response.
+_IMAGEPROXY_CONTENT_TYPES: dict[str, str] = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "svg": "image/svg+xml",
+}
+
+
+def _normalize_imageproxy_format(value: str | None) -> str | None:
+    """Return a validated, lowercase imageproxy format, or None when invalid."""
+    if not value:
+        return None
+    normalized = value.strip().lower()
+    if normalized in _IMAGEPROXY_CONTENT_TYPES:
+        return normalized
+    return None
+
+
 # Schemes accepted from a client on the legacy /imageproxy?path= endpoint.
 # Allowlist (not blacklist) so a leading-whitespace or unknown-scheme value
 # cannot sneak through. Provider-supplied paths resolved internally via
@@ -682,7 +703,9 @@ class MetaDataController(CoreController):
         if resolved is None:
             return web.Response(status=404)
         provider, path = resolved
-        image_format = request.query.get("fmt") or _detect_image_format(path)
+        image_format = _normalize_imageproxy_format(
+            request.query.get("fmt")
+        ) or _detect_image_format(path)
         return await self._serve_thumbnail(path, provider, size, image_format)
 
     async def handle_legacy_imageproxy(self, request: web.Request) -> web.Response:
@@ -711,7 +734,9 @@ class MetaDataController(CoreController):
             return web.Response(status=400)
         if size not in _ALLOWED_IMAGEPROXY_SIZES:
             return web.Response(status=400)
-        image_format = request.query.get("fmt") or _detect_image_format(path)
+        image_format = _normalize_imageproxy_format(
+            request.query.get("fmt")
+        ) or _detect_image_format(path)
         # path was double-encoded by old get_image_url(); decode iteratively
         # until stable so we cope with any extra wrapping clients may have done
         for _ in range(3):
@@ -747,11 +772,10 @@ class MetaDataController(CoreController):
                     exc_info=err if self.logger.isEnabledFor(10) else None,
                 )
             return web.Response(status=404)
-        content_type = "image/svg+xml" if image_format == "svg" else f"image/{image_format}"
         return web.Response(
             body=image_data,
             headers={"Cache-Control": "max-age=31536000", "Access-Control-Allow-Origin": "*"},
-            content_type=content_type,
+            content_type=_IMAGEPROXY_CONTENT_TYPES[image_format],
         )
 
     def _maybe_log_legacy_imageproxy(self, request: web.Request) -> None:

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -7,8 +7,10 @@ import logging
 import os
 import pathlib
 import random
+import threading
 import urllib.parse
 from base64 import b64encode
+from collections import OrderedDict
 from contextlib import suppress
 from dataclasses import replace
 from time import time
@@ -72,6 +74,7 @@ from music_assistant.helpers.datetime import local_clock_time_to_utc
 from music_assistant.helpers.images import (
     cleanup_thumb_cache,
     create_collage,
+    create_thumb_hash,
     get_image_data,
     get_image_thumb,
 )
@@ -100,6 +103,27 @@ def _detect_image_format(path: str) -> str:
             return "png"
         case _:
             return "jpg"
+
+
+# Schemes that a client is not allowed to ask the imageproxy to fetch on its
+# behalf. Provider-supplied paths (resolved internally via `resolve_image`)
+# may still produce `data:image/...` results; only inbound client paths are
+# filtered here.
+_FORBIDDEN_IMAGEPROXY_SCHEMES = (
+    "file:",
+    "data:",
+    "gopher:",
+    "ftp:",
+    "ftps:",
+    "ws:",
+    "wss:",
+    "javascript:",
+)
+
+
+def _is_safe_imageproxy_request_path(path: str) -> bool:
+    """Return True if `path` is one we'll accept from a client imageproxy request."""
+    return not path.lower().startswith(_FORBIDDEN_IMAGEPROXY_SCHEMES)
 
 
 LOCALES = {
@@ -162,6 +186,21 @@ METADATA_SCAN_BATCH_SIZE = 5
 CONF_THUMB_CACHE_MAX_SIZE = "thumb_cache_max_size"
 DEFAULT_THUMB_CACHE_MAX_SIZE_MB = 500
 
+# Image-id system: maps a sha256(provider+path) hash to the (provider, path) tuple
+# so the imageproxy can be addressed by an opaque short id instead of a long
+# query string carrying the raw (often URL-shaped) path.
+CACHE_CATEGORY_IMAGE_IDS = 1
+_IMAGE_ID_LRU_MAX = 10000
+_IMAGE_ID_CACHE_TTL = 86400 * 365  # 1 year, refreshed on each write
+
+# Sizes accepted by the imageproxy. 0 means "no resize". The set is small enough
+# to bound PIL memory + thumbnail cache cardinality; expand if a real use case appears.
+_ALLOWED_IMAGEPROXY_SIZES = frozenset({0, 80, 160, 256, 512, 1024})
+
+# Deprecation logging for the legacy /imageproxy query-string endpoint.
+_LEGACY_DEPRECATION_LOG_INTERVAL = 60  # seconds between log lines per IP
+_LEGACY_DEPRECATION_PRUNE_AFTER = 300  # drop tracking entries idle this long
+
 
 class MetaDataController(CoreController):
     """Several helpers to search and store metadata for mediaitems."""
@@ -180,6 +219,12 @@ class MetaDataController(CoreController):
         )
         self.manifest.icon = "book-information-variant"
         self._throttler = Throttler(1, 30)
+        # image-id LRU: image_id -> (provider, path). Acts as a write-through
+        # hot cache in front of the cache controller so that resolving an image
+        # by id never blocks on sqlite if the URL was generated recently.
+        self._image_id_lru: OrderedDict[str, tuple[str, str]] = OrderedDict()
+        # per-IP throttle for the legacy /imageproxy deprecation warning
+        self._legacy_imageproxy_warn_at: dict[str, float] = {}
 
     async def get_config_entries(
         self,
@@ -263,11 +308,18 @@ class MetaDataController(CoreController):
     async def post_setup(self) -> None:
         """Handle logic after all core controllers have been set up."""
         self.mass.streams.register_dynamic_route("/imageproxy", self.handle_imageproxy)
+        # New opaque-id form, served via prefix match on the catch-all of both
+        # the public webserver and the streams server (the legacy form is on the
+        # webserver via a static route registered in WebserverController).
+        self.mass.streams.register_dynamic_route("/imageproxy/*", self.handle_imageproxy_v2)
+        self.mass.webserver.register_dynamic_route("/imageproxy/*", self.handle_imageproxy_v2)
         self._register_maintenance_tasks()
 
     async def close(self) -> None:
         """Handle logic on server stop."""
         self.mass.streams.unregister_dynamic_route("/imageproxy")
+        self.mass.streams.unregister_dynamic_route("/imageproxy/*")
+        self.mass.webserver.unregister_dynamic_route("/imageproxy/*")
 
     @property
     def providers(self) -> list[MetadataProvider]:
@@ -398,6 +450,58 @@ class MetaDataController(CoreController):
             },
         )
 
+    def compute_image_id(self, provider: str, path: str) -> str:
+        """
+        Return the opaque imageproxy image id for the given image.
+
+        The id is deterministic: the same (provider, path) pair always
+        yields the same id, across processes and restarts. Calling this
+        also ensures the id is resolvable back to (provider, path) by
+        a subsequent imageproxy request.
+
+        Safe to call from any thread.
+
+        :param provider: Provider id that owns / can resolve the image.
+        :param path: Image path or URL as the provider knows it.
+        """
+        image_id = create_thumb_hash(provider, path)
+        if image_id in self._image_id_lru:
+            self._image_id_lru.move_to_end(image_id)
+            return image_id
+        self._image_id_lru[image_id] = (provider, path)
+        while len(self._image_id_lru) > _IMAGE_ID_LRU_MAX:
+            self._image_id_lru.popitem(last=False)
+        # the to_dict hook calls us from the executor when running under
+        # _send_message; only call create_task directly when we know we are
+        # on the loop thread, otherwise hop across via call_soon_threadsafe
+        coro = self._persist_image_id(image_id, provider, path)
+        if threading.get_ident() == self.mass.loop_thread_id:
+            self.mass.create_task(coro)
+        else:
+            self.mass.loop.call_soon_threadsafe(self.mass.create_task, coro)
+        return image_id
+
+    async def resolve_image_id(self, image_id: str) -> tuple[str, str] | None:
+        """
+        Return the (provider, path) tuple for a previously registered image id.
+
+        :param image_id: The opaque id as produced by `compute_image_id`.
+        """
+        if cached := self._image_id_lru.get(image_id):
+            self._image_id_lru.move_to_end(image_id)
+            return cached
+        cached_db = await self.cache.get(key=image_id, category=CACHE_CATEGORY_IMAGE_IDS)
+        if isinstance(cached_db, dict):
+            provider = cached_db.get("provider")
+            path = cached_db.get("path")
+            if isinstance(provider, str) and isinstance(path, str):
+                result = (provider, path)
+                self._image_id_lru[image_id] = result
+                while len(self._image_id_lru) > _IMAGE_ID_LRU_MAX:
+                    self._image_id_lru.popitem(last=False)
+                return result
+        return None
+
     async def get_image_data_for_item(
         self,
         media_item: MediaItemType,
@@ -480,16 +584,12 @@ class MetaDataController(CoreController):
             # SVGs don't need resizing
             size = 0
         if not image.remotely_accessible or prefer_proxy or size:
-            # return imageproxy url for images that need to be resolved
-            # the original path is double encoded
-            encoded_url = urllib.parse.quote(urllib.parse.quote(image.path))
+            # short opaque id form; same id as the thumbnail cache key
+            image_id = self.compute_image_id(image.provider, image.path)
             base_url = (
                 self.mass.streams.base_url if prefer_stream_server else self.mass.webserver.base_url
             )
-            return (
-                f"{base_url}/imageproxy?provider={image.provider}"
-                f"&size={size}&fmt={image_format}&path={encoded_url}"
-            )
+            return f"{base_url}/imageproxy/{image_id}?size={size}&fmt={image_format}"
         return image.path
 
     async def get_thumbnail(
@@ -526,32 +626,57 @@ class MetaDataController(CoreController):
         return thumbnail_bytes
 
     async def handle_imageproxy(self, request: web.Request) -> web.Response:
-        """Handle request for image proxy."""
-        path = request.query["path"]
+        """Handle a legacy /imageproxy?provider=&path=&size=&fmt= request."""
+        self._maybe_log_legacy_imageproxy(request)
+        try:
+            path = request.query["path"]
+        except KeyError:
+            return web.Response(status=400)
         provider = request.query.get("provider", "builtin")
         if provider in ("url", "file", "http"):
-            # temporary for backwards compatibility
+            # legacy aliases kept for backwards compatibility with old clients
             provider = "builtin"
-        size = int(request.query.get("size", "0"))
-        image_format = request.query.get("fmt", None)
-        if image_format is None:
-            image_format = _detect_image_format(path)
-        if not self.mass.get_provider(provider) and not path.startswith("http"):
-            return web.Response(status=404)
+        try:
+            size = int(request.query.get("size", "0"))
+        except ValueError:
+            return web.Response(status=400)
+        if size not in _ALLOWED_IMAGEPROXY_SIZES:
+            return web.Response(status=400)
+        image_format = request.query.get("fmt") or _detect_image_format(path)
         if "%" in path:
             # assume (double) encoded url, decode it
             path = urllib.parse.unquote_plus(path)
+        if not _is_safe_imageproxy_request_path(path):
+            return web.Response(status=400)
+        if not self.mass.get_provider(provider) and not path.startswith("http"):
+            return web.Response(status=404)
+        return await self._serve_thumbnail(path, provider, size, image_format)
+
+    async def handle_imageproxy_v2(self, request: web.Request) -> web.Response:
+        """Handle a /imageproxy/<image_id>?size=&fmt= request."""
+        image_id = request.path.rstrip("/").rsplit("/", 1)[-1].lower()
+        if len(image_id) != 64 or any(c not in "0123456789abcdef" for c in image_id):
+            return web.Response(status=400)
+        try:
+            size = int(request.query.get("size", "0"))
+        except ValueError:
+            return web.Response(status=400)
+        if size not in _ALLOWED_IMAGEPROXY_SIZES:
+            return web.Response(status=400)
+        resolved = await self.resolve_image_id(image_id)
+        if resolved is None:
+            return web.Response(status=404)
+        provider, path = resolved
+        image_format = request.query.get("fmt") or _detect_image_format(path)
+        return await self._serve_thumbnail(path, provider, size, image_format)
+
+    async def _serve_thumbnail(
+        self, path: str, provider: str, size: int, image_format: str
+    ) -> web.Response:
+        """Fetch (or render+cache) the thumbnail and produce an HTTP response."""
         try:
             image_data = await self.get_thumbnail(
                 path, size=size, provider=provider, image_format=image_format
-            )
-            # we set the cache header to 1 year (forever)
-            # assuming that images do not/rarely change
-            content_type = "image/svg+xml" if image_format == "svg" else f"image/{image_format}"
-            return web.Response(
-                body=image_data,
-                headers={"Cache-Control": "max-age=31536000", "Access-Control-Allow-Origin": "*"},
-                content_type=content_type,
             )
         except Exception as err:
             # broadly catch all exceptions here to ensure we dont crash the request handler
@@ -564,7 +689,36 @@ class MetaDataController(CoreController):
                     str(err),
                     exc_info=err if self.logger.isEnabledFor(10) else None,
                 )
-        return web.Response(status=404)
+            return web.Response(status=404)
+        content_type = "image/svg+xml" if image_format == "svg" else f"image/{image_format}"
+        return web.Response(
+            body=image_data,
+            headers={"Cache-Control": "max-age=31536000", "Access-Control-Allow-Origin": "*"},
+            content_type=content_type,
+        )
+
+    def _maybe_log_legacy_imageproxy(self, request: web.Request) -> None:
+        """Emit a throttled deprecation warning for the legacy /imageproxy form."""
+        remote = request.remote or "unknown"
+        now = time()
+        if len(self._legacy_imageproxy_warn_at) > 100:
+            self._legacy_imageproxy_warn_at = {
+                ip: ts
+                for ip, ts in self._legacy_imageproxy_warn_at.items()
+                if now - ts < _LEGACY_DEPRECATION_PRUNE_AFTER
+            }
+        if (
+            now - self._legacy_imageproxy_warn_at.get(remote, 0.0)
+            < _LEGACY_DEPRECATION_LOG_INTERVAL
+        ):
+            return
+        self._legacy_imageproxy_warn_at[remote] = now
+        self.logger.warning(
+            "Deprecated /imageproxy query-string request from %s (UA: %s); "
+            "clients should use the proxy_id field on MediaItemImage instead",
+            remote,
+            request.headers.get("User-Agent", "?"),
+        )
 
     async def create_collage_image(
         self,
@@ -1752,3 +1906,13 @@ class MetaDataController(CoreController):
         removed = await cleanup_thumb_cache(self.mass.cache_path, max_size_mb * 1024 * 1024)
         if removed:
             self.logger.debug("Thumbnail cache cleanup: removed %s file(s)", removed)
+
+    async def _persist_image_id(self, image_id: str, provider: str, path: str) -> None:
+        """Store an image-id mapping so a later imageproxy request can resolve it."""
+        await self.cache.set(
+            key=image_id,
+            data={"provider": provider, "path": path},
+            category=CACHE_CATEGORY_IMAGE_IDS,
+            expiration=_IMAGE_ID_CACHE_TTL,
+            persistent=True,
+        )

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -188,8 +188,11 @@ DEFAULT_THUMB_CACHE_MAX_SIZE_MB = 500
 
 # Image-id system: maps a sha256(provider+path) hash to the (provider, path) tuple
 # so the imageproxy can be addressed by an opaque short id instead of a long
-# query string carrying the raw (often URL-shaped) path.
-CACHE_CATEGORY_IMAGE_IDS = 1
+# query string carrying the raw (often URL-shaped) path. The high category
+# number matches the convention used elsewhere in this controller and avoids
+# collisions with providers that use low category integers under the default
+# cache namespace.
+CACHE_CATEGORY_IMAGE_IDS = 102
 _IMAGE_ID_LRU_MAX = 10000
 _IMAGE_ID_CACHE_TTL = 86400 * 365  # 1 year, refreshed on each write
 
@@ -222,7 +225,10 @@ class MetaDataController(CoreController):
         # image-id LRU: image_id -> (provider, path). Acts as a write-through
         # hot cache in front of the cache controller so that resolving an image
         # by id never blocks on sqlite if the URL was generated recently.
+        # The lock is needed because compute_image_id() runs from the executor
+        # thread during outbound websocket serialization.
         self._image_id_lru: OrderedDict[str, tuple[str, str]] = OrderedDict()
+        self._image_id_lock = threading.Lock()
         # per-IP throttle for the legacy /imageproxy deprecation warning
         self._legacy_imageproxy_warn_at: dict[str, float] = {}
 
@@ -465,12 +471,13 @@ class MetaDataController(CoreController):
         :param path: Image path or URL as the provider knows it.
         """
         image_id = create_thumb_hash(provider, path)
-        if image_id in self._image_id_lru:
-            self._image_id_lru.move_to_end(image_id)
-            return image_id
-        self._image_id_lru[image_id] = (provider, path)
-        while len(self._image_id_lru) > _IMAGE_ID_LRU_MAX:
-            self._image_id_lru.popitem(last=False)
+        with self._image_id_lock:
+            if image_id in self._image_id_lru:
+                self._image_id_lru.move_to_end(image_id)
+                return image_id
+            self._image_id_lru[image_id] = (provider, path)
+            while len(self._image_id_lru) > _IMAGE_ID_LRU_MAX:
+                self._image_id_lru.popitem(last=False)
         # the to_dict hook calls us from the executor when running under
         # _send_message; only call create_task directly when we know we are
         # on the loop thread, otherwise hop across via call_soon_threadsafe
@@ -487,18 +494,24 @@ class MetaDataController(CoreController):
 
         :param image_id: The opaque id as produced by `compute_image_id`.
         """
-        if cached := self._image_id_lru.get(image_id):
-            self._image_id_lru.move_to_end(image_id)
-            return cached
-        cached_db = await self.cache.get(key=image_id, category=CACHE_CATEGORY_IMAGE_IDS)
+        with self._image_id_lock:
+            if cached := self._image_id_lru.get(image_id):
+                self._image_id_lru.move_to_end(image_id)
+                return cached
+        cached_db = await self.cache.get(
+            key=image_id,
+            category=CACHE_CATEGORY_IMAGE_IDS,
+            provider=self.domain,
+        )
         if isinstance(cached_db, dict):
             provider = cached_db.get("provider")
             path = cached_db.get("path")
             if isinstance(provider, str) and isinstance(path, str):
                 result = (provider, path)
-                self._image_id_lru[image_id] = result
-                while len(self._image_id_lru) > _IMAGE_ID_LRU_MAX:
-                    self._image_id_lru.popitem(last=False)
+                with self._image_id_lock:
+                    self._image_id_lru[image_id] = result
+                    while len(self._image_id_lru) > _IMAGE_ID_LRU_MAX:
+                        self._image_id_lru.popitem(last=False)
                 return result
         return None
 
@@ -643,9 +656,15 @@ class MetaDataController(CoreController):
         if size not in _ALLOWED_IMAGEPROXY_SIZES:
             return web.Response(status=400)
         image_format = request.query.get("fmt") or _detect_image_format(path)
-        if "%" in path:
-            # assume (double) encoded url, decode it
-            path = urllib.parse.unquote_plus(path)
+        # path was double-encoded by old get_image_url(); decode iteratively
+        # until stable so we cope with any extra wrapping clients may have done
+        for _ in range(3):
+            if "%" not in path:
+                break
+            decoded = urllib.parse.unquote_plus(path)
+            if decoded == path:
+                break
+            path = decoded
         if not _is_safe_imageproxy_request_path(path):
             return web.Response(status=400)
         if not self.mass.get_provider(provider) and not path.startswith("http"):
@@ -1913,6 +1932,7 @@ class MetaDataController(CoreController):
             key=image_id,
             data={"provider": provider, "path": path},
             category=CACHE_CATEGORY_IMAGE_IDS,
+            provider=self.domain,
             expiration=_IMAGE_ID_CACHE_TTL,
             persistent=True,
         )

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -274,8 +274,10 @@ class WebserverController(CoreController):
         routes.append(("OPTIONS", "/info", self._handle_cors_preflight))
         # add websocket api
         routes.append(("GET", "/ws", self._handle_ws_client))
-        # also host the image proxy on the webserver
-        routes.append(("GET", "/imageproxy", self.mass.metadata.handle_imageproxy))
+        # legacy /imageproxy?provider=&path= form — deprecated; the canonical
+        # /imageproxy/<image_id> form is registered as a dynamic route on the
+        # webserver by MetaDataController.post_setup()
+        routes.append(("GET", "/imageproxy", self.mass.metadata.handle_legacy_imageproxy))
         # also host the audio preview service
         routes.append(("GET", "/preview", self.serve_preview_stream))
         # add jsonrpc api

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -27,6 +27,7 @@ from music_assistant_models.api import CommandMessage
 from music_assistant_models.auth import UserRole
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType
+from music_assistant_models.media_items.metadata import IMAGE_PROXY_ID_RESOLVER
 
 from music_assistant.constants import (
     CONF_AUTH_ALLOW_SELF_REGISTRATION,
@@ -582,7 +583,13 @@ class WebserverController(CoreController):
                 result = [item async for item in result]
             elif inspect.iscoroutine(result):
                 result = await result
-            return web.json_response(result, dumps=json_dumps)
+            # Set the image-proxy resolver so any MediaItemImage in the result
+            # gets a short opaque proxy_id injected during dict serialization.
+            token = IMAGE_PROXY_ID_RESOLVER.set(self.mass.metadata.compute_image_id)
+            try:
+                return web.json_response(result, dumps=json_dumps)
+            finally:
+                IMAGE_PROXY_ID_RESOLVER.reset(token)
         except Exception as e:
             # Return clean error message without stacktrace
             error_type = type(e).__name__

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import inspect
 import logging
 from concurrent import futures
@@ -26,6 +27,7 @@ from music_assistant_models.errors import (
     MusicAssistantError,
 )
 from music_assistant_models.event import MassEvent
+from music_assistant_models.media_items.metadata import IMAGE_PROXY_ID_RESOLVER
 
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER, VERBOSE_LOG_LEVEL
 from music_assistant.helpers.api import APICommandHandler, parse_arguments
@@ -281,9 +283,17 @@ class WebsocketClientHandler:
 
         Async friendly.
         """
-        # Run JSON serialization in executor to avoid blocking for large messages
+        # Run JSON serialization in executor to avoid blocking for large messages.
+        # copy_context() propagates the IMAGE_PROXY_ID_RESOLVER ContextVar into
+        # the executor thread so that MediaItemImage instances nested in the
+        # message can inject `proxy_id` via their `__post_serialize__` hook.
         loop = asyncio.get_running_loop()
-        _message = await loop.run_in_executor(None, message.to_json)
+        token = IMAGE_PROXY_ID_RESOLVER.set(self.mass.metadata.compute_image_id)
+        try:
+            ctx = contextvars.copy_context()
+            _message = await loop.run_in_executor(None, ctx.run, message.to_json)
+        finally:
+            IMAGE_PROXY_ID_RESOLVER.reset(token)
 
         try:
             self._to_write.put_nowait(_message)
@@ -297,7 +307,11 @@ class WebsocketClientHandler:
 
         Serializes inline without executor overhead since events are typically small.
         """
-        _message = message.to_json()
+        token = IMAGE_PROXY_ID_RESOLVER.set(self.mass.metadata.compute_image_id)
+        try:
+            _message = message.to_json()
+        finally:
+            IMAGE_PROXY_ID_RESOLVER.reset(token)
 
         try:
             self._to_write.put_nowait(_message)

--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -269,7 +269,9 @@ def peek_palette_for_url(image_url: str | None) -> MediaItemPalette | None:
     """
     if not image_url:
         return None
-    # New /imageproxy/<id> form: the id itself is the cache key.
+    # /imageproxy/<id>: `image_id` is by construction equal to
+    # `create_thumb_hash(provider, path)` (see MetaDataController.compute_image_id),
+    # which is also the key get_palette() stores under, so we can peek directly.
     if image_id := _extract_imageproxy_id(image_url):
         return _get_from_memory_cache(image_id)
     if extracted := _extract_imageproxy_params(image_url):

--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -20,8 +20,9 @@ from modern_colorthief import get_palette as _mmcq_palette
 from music_assistant_models.media_items import MediaItemPalette
 
 from music_assistant.helpers.images import (
-    _create_thumb_hash,
+    _extract_imageproxy_id,
     _extract_imageproxy_params,
+    create_thumb_hash,
     get_image_data,
 )
 
@@ -243,7 +244,7 @@ async def get_palette(
     """
     if not path_or_url:
         return None
-    key = _create_thumb_hash(provider, path_or_url)
+    key = create_thumb_hash(provider, path_or_url)
 
     if cached := _get_from_memory_cache(key):
         return cached
@@ -268,11 +269,14 @@ def peek_palette_for_url(image_url: str | None) -> MediaItemPalette | None:
     """
     if not image_url:
         return None
+    # New /imageproxy/<id> form: the id itself is the cache key.
+    if image_id := _extract_imageproxy_id(image_url):
+        return _get_from_memory_cache(image_id)
     if extracted := _extract_imageproxy_params(image_url):
         path, provider = extracted
     else:
         path, provider = image_url, "builtin"
-    key = _create_thumb_hash(provider, path)
+    key = create_thumb_hash(provider, path)
     return _get_from_memory_cache(key)
 
 
@@ -282,7 +286,13 @@ async def get_palette_for_url(
     """Resolve an imageproxy URL to (path, provider) and return its palette."""
     if not image_url:
         return None
-    if extracted := _extract_imageproxy_params(image_url):
+    # New /imageproxy/<id> form: async-resolve the id back to (provider, path).
+    if image_id := _extract_imageproxy_id(image_url):
+        resolved = await mass.metadata.resolve_image_id(image_id)
+        if resolved is None:
+            return None
+        provider, path = resolved
+    elif extracted := _extract_imageproxy_params(image_url):
         path, provider = extracted
     else:
         path, provider = image_url, "builtin"

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -258,10 +258,9 @@ async def get_image_thumb(
         return cached
 
     # 2. Check on-disk cache
-    thumb_dir = os.path.join(mass.cache_path, _THUMB_CACHE_DIR)
-    cache_filepath = os.path.join(thumb_dir, cache_filename)
-    resolved = os.path.realpath(cache_filepath)
-    if not resolved.startswith(os.path.realpath(thumb_dir) + os.sep):
+    thumb_dir_resolved = os.path.realpath(os.path.join(mass.cache_path, _THUMB_CACHE_DIR))
+    cache_filepath = os.path.realpath(os.path.join(thumb_dir_resolved, cache_filename))
+    if not cache_filepath.startswith(thumb_dir_resolved + os.sep):
         msg = f"Cache path escapes thumbnail directory: {cache_filepath}"
         raise OSError(msg)
     if await asyncio.to_thread(os.path.isfile, cache_filepath):

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -104,14 +104,19 @@ def _extract_imageproxy_params(url: str) -> tuple[str, str] | None:
 
 
 def _extract_imageproxy_id(url: str) -> str | None:
-    """Return the 64-hex image_id from a /imageproxy/<id> URL, or None."""
+    """Return the 64-hex image_id from a /imageproxy/<id> URL, or None.
+
+    The path must match the canonical shape `/imageproxy/<id>` (optionally
+    with a single trailing slash) — extra segments are rejected so this
+    helper agrees with what `MetaDataController.handle_imageproxy` accepts.
+    """
     parsed = urllib.parse.urlparse(url)
     if not parsed.path.startswith(_IMAGEPROXY_V2_PREFIX):
         return None
-    image_id = parsed.path[len(_IMAGEPROXY_V2_PREFIX) :].split("/", 1)[0].lower()
-    if len(image_id) == 64 and all(c in "0123456789abcdef" for c in image_id):
-        return image_id
-    return None
+    remainder = parsed.path[len(_IMAGEPROXY_V2_PREFIX) :].rstrip("/").lower()
+    if len(remainder) != 64 or any(c not in "0123456789abcdef" for c in remainder):
+        return None
+    return remainder
 
 
 def player_image_url(mass: MusicAssistant, url: str | None) -> str | None:

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -105,10 +105,10 @@ def _extract_imageproxy_params(url: str) -> tuple[str, str] | None:
 
 def _extract_imageproxy_id(url: str) -> str | None:
     """Return the 64-hex image_id from a /imageproxy/<id> URL, or None."""
-    if _IMAGEPROXY_V2_PREFIX not in url:
+    parsed = urllib.parse.urlparse(url)
+    if not parsed.path.startswith(_IMAGEPROXY_V2_PREFIX):
         return None
-    after = url.split(_IMAGEPROXY_V2_PREFIX, 1)[1]
-    image_id = after.split("?", 1)[0].split("/", 1)[0].split("#", 1)[0].lower()
+    image_id = parsed.path[len(_IMAGEPROXY_V2_PREFIX) :].split("/", 1)[0].lower()
     if len(image_id) == 64 and all(c in "0123456789abcdef" for c in image_id):
         return image_id
     return None

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -7,6 +7,7 @@ import hashlib
 import itertools
 import os
 import random
+import re
 import urllib.parse
 from base64 import b64decode
 from collections import OrderedDict
@@ -36,6 +37,11 @@ if TYPE_CHECKING:
 _THUMB_CACHE_DIR = "thumbnails"
 _THUMB_MEMORY_CACHE_MAX = 50
 _ALLOWED_THUMB_FORMATS: frozenset[str] = frozenset({"PNG", "JPEG"})
+
+# By construction the filename is `<sha256>_<int>.(jpg|png)`; the regex is an
+# explicit sanitizer that also lets CodeQL prove the value is safe to join
+# into a filesystem path.
+_THUMB_FILENAME_RE = re.compile(r"^[0-9a-f]{64}_\d+\.(?:jpg|png)$")
 
 _thumb_memory_cache: OrderedDict[str, bytes] = OrderedDict()
 
@@ -240,6 +246,12 @@ async def get_image_thumb(
 
     thumb_hash = create_thumb_hash(provider, path_or_url)
     cache_filename = _thumb_cache_filename(thumb_hash, size, image_format)
+    if not _THUMB_FILENAME_RE.fullmatch(cache_filename):
+        # cache_filename is built from a sha256 + int + fixed extension, so this
+        # is unreachable in practice — it is here so a future change to either
+        # builder cannot silently let an unsafe value reach the filesystem path
+        msg = f"Refusing to use unexpected cache filename: {cache_filename!r}"
+        raise OSError(msg)
 
     # 1. Check in-memory FIFO cache
     if cached := _get_from_memory_cache(cache_filename):

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -42,7 +42,7 @@ _thumb_memory_cache: OrderedDict[str, bytes] = OrderedDict()
 _MAX_IMAGEPROXY_RECURSION_DEPTH = 5
 
 
-def _create_thumb_hash(provider: str, path_or_url: str) -> str:
+def create_thumb_hash(provider: str, path_or_url: str) -> str:
     """Create a safe filesystem hash from provider and image path."""
     raw = f"{provider}/{path_or_url}"
     return hashlib.sha256(raw.encode(), usedforsecurity=False).hexdigest()
@@ -72,8 +72,11 @@ def _put_in_memory_cache(key: str, data: bytes) -> None:
         _thumb_memory_cache.popitem(last=False)
 
 
+_IMAGEPROXY_V2_PREFIX = "/imageproxy/"
+
+
 def _extract_imageproxy_params(url: str) -> tuple[str, str] | None:
-    """Extract path and provider from an imageproxy URL.
+    """Extract (path, provider) from a *legacy* /imageproxy?... URL.
 
     :param url: The URL to check for imageproxy format.
     :return: Tuple of (path, provider) if this is an imageproxy URL, None otherwise.
@@ -100,6 +103,17 @@ def _extract_imageproxy_params(url: str) -> tuple[str, str] | None:
     return None
 
 
+def _extract_imageproxy_id(url: str) -> str | None:
+    """Return the 64-hex image_id from a /imageproxy/<id> URL, or None."""
+    if _IMAGEPROXY_V2_PREFIX not in url:
+        return None
+    after = url.split(_IMAGEPROXY_V2_PREFIX, 1)[1]
+    image_id = after.split("?", 1)[0].split("/", 1)[0].split("#", 1)[0].lower()
+    if len(image_id) == 64 and all(c in "0123456789abcdef" for c in image_id):
+        return image_id
+    return None
+
+
 def player_image_url(mass: MusicAssistant, url: str | None) -> str | None:
     """Rewrite a public-webserver imageproxy URL to the internal streams server.
 
@@ -109,7 +123,7 @@ def player_image_url(mass: MusicAssistant, url: str | None) -> str | None:
     if not url:
         return url
     webserver_base = mass.webserver.base_url
-    if webserver_base and url.startswith(f"{webserver_base}/imageproxy?"):
+    if webserver_base and url.startswith(f"{webserver_base}/imageproxy"):
         return mass.streams.base_url + url[len(webserver_base) :]
     return url
 
@@ -146,6 +160,17 @@ async def get_image_data(
             if (p := urllib.parse.urlparse(b)).netloc
         }
         if url_origin in server_origins:
+            # new opaque-id form: /imageproxy/<image_id>?size=...&fmt=...
+            if image_id := _extract_imageproxy_id(path_or_url):
+                resolved = await mass.metadata.resolve_image_id(image_id)
+                if resolved is None:
+                    msg = f"Unknown image id in URL: {path_or_url}"
+                    raise FileNotFoundError(msg)
+                extracted_provider, extracted_path = resolved
+                return await get_image_data(
+                    mass, extracted_path, extracted_provider, _depth=_depth + 1
+                )
+            # legacy form: /imageproxy?provider=X&path=Y
             if imageproxy_params := _extract_imageproxy_params(path_or_url):
                 extracted_path, extracted_provider = imageproxy_params
                 # Validate extracted path before recursive call
@@ -208,7 +233,7 @@ async def get_image_thumb(
         msg = f"Unsupported thumbnail format: {image_format}"
         raise ValueError(msg)
 
-    thumb_hash = _create_thumb_hash(provider, path_or_url)
+    thumb_hash = create_thumb_hash(provider, path_or_url)
     cache_filename = _thumb_cache_filename(thumb_hash, size, image_format)
 
     # 1. Check in-memory FIFO cache

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -116,6 +116,10 @@ def _extract_imageproxy_id(url: str) -> str | None:
     with a single trailing slash) — extra segments are rejected so this
     helper agrees with what `MetaDataController.handle_imageproxy` accepts.
     """
+    # bail out early on anything that obviously can't be a v2 imageproxy URL
+    # (non-strings such as MagicMock from tests; urlparse would TypeError)
+    if not isinstance(url, str) or _IMAGEPROXY_V2_PREFIX not in url:
+        return None
     parsed = urllib.parse.urlparse(url)
     if not parsed.path.startswith(_IMAGEPROXY_V2_PREFIX):
         return None

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -134,6 +134,33 @@ def test_is_safe_imageproxy_request_path_rejects_dangerous_schemes() -> None:
     assert not _is_safe_imageproxy_request_path("ftp://example.com/a.jpg")
 
 
+def test_is_safe_imageproxy_request_path_rejects_control_char_bypass() -> None:
+    """Leading whitespace/control bytes must not mask a forbidden scheme."""
+    assert not _is_safe_imageproxy_request_path("\tfile:///etc/passwd")
+    assert not _is_safe_imageproxy_request_path("\nfile:///etc/passwd")
+    assert not _is_safe_imageproxy_request_path("\x00file:///etc/passwd")
+    assert not _is_safe_imageproxy_request_path("\rhttp://localhost/")
+
+
+def test_is_safe_imageproxy_request_path_rejects_ssrf_targets() -> None:
+    """http(s) URLs targeting localhost / private / link-local IPs are rejected."""
+    assert not _is_safe_imageproxy_request_path("http://localhost/")
+    assert not _is_safe_imageproxy_request_path("http://127.0.0.1/foo.jpg")
+    assert not _is_safe_imageproxy_request_path("http://10.0.0.1/foo.jpg")
+    assert not _is_safe_imageproxy_request_path("http://192.168.1.5/foo.jpg")
+    assert not _is_safe_imageproxy_request_path("http://172.16.0.1/foo.jpg")
+    # AWS / GCP metadata service
+    assert not _is_safe_imageproxy_request_path("http://169.254.169.254/")
+    # IPv6 loopback / link-local / unique-local
+    assert not _is_safe_imageproxy_request_path("http://[::1]/foo.jpg")
+    assert not _is_safe_imageproxy_request_path("http://[fe80::1]/foo.jpg")
+    assert not _is_safe_imageproxy_request_path("http://[fc00::1]/foo.jpg")
+    # public DNS names and IPs are still accepted
+    assert _is_safe_imageproxy_request_path("http://example.com/a.jpg")
+    assert _is_safe_imageproxy_request_path("https://cdn.example.com/a.jpg")
+    assert _is_safe_imageproxy_request_path("http://8.8.8.8/a.jpg")
+
+
 def test_extract_imageproxy_id_matches_path_only() -> None:
     """Only URLs whose path begins with /imageproxy/ should yield an id."""
     valid = "http://mass.local/imageproxy/" + "a" * 64 + "?size=256"

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -10,6 +10,7 @@ from music_assistant.controllers.metadata import (
     MetaDataController,
     _is_safe_imageproxy_request_path,
 )
+from music_assistant.helpers.images import _extract_imageproxy_id
 from music_assistant.mass import MusicAssistant
 
 
@@ -56,7 +57,11 @@ async def test_resolve_image_id_via_cache_db(metadata_controller: MetaDataContro
     # let the scheduled persist task drain
     for _ in range(20):
         await asyncio.sleep(0)
-        raw = await metadata_controller.cache.get(key=image_id, category=CACHE_CATEGORY_IMAGE_IDS)
+        raw = await metadata_controller.cache.get(
+            key=image_id,
+            category=CACHE_CATEGORY_IMAGE_IDS,
+            provider=metadata_controller.domain,
+        )
         if raw is not None:
             break
     assert raw == {"provider": "filesystem", "path": "/local/cover.jpg"}
@@ -82,7 +87,11 @@ async def test_image_id_persists_with_persistent_flag(
     # wait for the scheduled persist task to land in the cache db
     for _ in range(20):
         await asyncio.sleep(0)
-        raw = await metadata_controller.cache.get(key=image_id, category=CACHE_CATEGORY_IMAGE_IDS)
+        raw = await metadata_controller.cache.get(
+            key=image_id,
+            category=CACHE_CATEGORY_IMAGE_IDS,
+            provider=metadata_controller.domain,
+        )
         if raw is not None:
             break
     assert raw is not None
@@ -109,3 +118,15 @@ def test_is_safe_imageproxy_request_path_rejects_dangerous_schemes() -> None:
     assert not _is_safe_imageproxy_request_path("gopher://example.com/")
     assert not _is_safe_imageproxy_request_path("javascript:alert(1)")
     assert not _is_safe_imageproxy_request_path("ftp://example.com/a.jpg")
+
+
+def test_extract_imageproxy_id_matches_path_only() -> None:
+    """Only URLs whose path begins with /imageproxy/ should yield an id."""
+    valid = "http://mass.local/imageproxy/" + "a" * 64 + "?size=256"
+    assert _extract_imageproxy_id(valid) == "a" * 64
+    # an id-shaped substring inside a query string must not match
+    decoy = "http://other.example.com/foo?next=/imageproxy/" + "b" * 64
+    assert _extract_imageproxy_id(decoy) is None
+    # invalid id length / charset
+    assert _extract_imageproxy_id("http://mass.local/imageproxy/short") is None
+    assert _extract_imageproxy_id("http://mass.local/imageproxy/" + "g" * 64) is None

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -1,0 +1,111 @@
+"""Tests for the imageproxy id system on the MetaDataController."""
+
+import asyncio
+import hashlib
+
+import pytest
+
+from music_assistant.controllers.metadata import (
+    CACHE_CATEGORY_IMAGE_IDS,
+    MetaDataController,
+    _is_safe_imageproxy_request_path,
+)
+from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture
+async def metadata_controller(mass_minimal: MusicAssistant) -> MetaDataController:
+    """Construct a MetaDataController with the minimal MA fixture."""
+    await mass_minimal.cache._setup_database()
+    controller = MetaDataController(mass_minimal)
+    mass_minimal.metadata = controller
+    return controller
+
+
+async def test_compute_image_id_is_deterministic(metadata_controller: MetaDataController) -> None:
+    """The same (provider, path) must always produce the same hex id."""
+    image_id_a = metadata_controller.compute_image_id("filesystem", "/local/cover.jpg")
+    image_id_b = metadata_controller.compute_image_id("filesystem", "/local/cover.jpg")
+    assert image_id_a == image_id_b
+    expected = hashlib.sha256(b"filesystem//local/cover.jpg").hexdigest()
+    assert image_id_a == expected
+
+
+async def test_compute_image_id_differs_per_input(metadata_controller: MetaDataController) -> None:
+    """Different (provider, path) pairs must produce different ids."""
+    assert metadata_controller.compute_image_id("x", "/a") != metadata_controller.compute_image_id(
+        "x", "/b"
+    )
+    assert metadata_controller.compute_image_id("x", "/a") != metadata_controller.compute_image_id(
+        "y", "/a"
+    )
+
+
+async def test_resolve_image_id_via_in_memory_lru(
+    metadata_controller: MetaDataController,
+) -> None:
+    """A freshly computed id resolves from the in-memory LRU without hitting DB."""
+    image_id = metadata_controller.compute_image_id("filesystem", "/local/cover.jpg")
+    resolved = await metadata_controller.resolve_image_id(image_id)
+    assert resolved == ("filesystem", "/local/cover.jpg")
+
+
+async def test_resolve_image_id_via_cache_db(metadata_controller: MetaDataController) -> None:
+    """After the async persist runs, the mapping resolves from cache even with empty LRU."""
+    image_id = metadata_controller.compute_image_id("filesystem", "/local/cover.jpg")
+    # let the scheduled persist task drain
+    for _ in range(20):
+        await asyncio.sleep(0)
+        raw = await metadata_controller.cache.get(key=image_id, category=CACHE_CATEGORY_IMAGE_IDS)
+        if raw is not None:
+            break
+    assert raw == {"provider": "filesystem", "path": "/local/cover.jpg"}
+    # wipe the in-memory layer so we hit the cache db
+    metadata_controller._image_id_lru.clear()
+    resolved = await metadata_controller.resolve_image_id(image_id)
+    assert resolved == ("filesystem", "/local/cover.jpg")
+
+
+async def test_resolve_image_id_returns_none_for_unknown(
+    metadata_controller: MetaDataController,
+) -> None:
+    """An id that was never registered must resolve to None (→ 404)."""
+    resolved = await metadata_controller.resolve_image_id("0" * 64)
+    assert resolved is None
+
+
+async def test_image_id_persists_with_persistent_flag(
+    metadata_controller: MetaDataController,
+) -> None:
+    """Mappings must survive a `clear()` without include_persistent."""
+    image_id = metadata_controller.compute_image_id("filesystem", "/persistent.jpg")
+    # wait for the scheduled persist task to land in the cache db
+    for _ in range(20):
+        await asyncio.sleep(0)
+        raw = await metadata_controller.cache.get(key=image_id, category=CACHE_CATEGORY_IMAGE_IDS)
+        if raw is not None:
+            break
+    assert raw is not None
+    # simulate the user-facing "Reset cache" action: clear() without include_persistent
+    await metadata_controller.cache.clear()
+    metadata_controller._image_id_lru.clear()
+    resolved = await metadata_controller.resolve_image_id(image_id)
+    assert resolved == ("filesystem", "/persistent.jpg")
+
+
+def test_is_safe_imageproxy_request_path_allows_safe_inputs() -> None:
+    """http(s) and bare-path inputs are accepted."""
+    assert _is_safe_imageproxy_request_path("https://cdn.example.com/a.jpg")
+    assert _is_safe_imageproxy_request_path("http://cdn.example.com/a.jpg")
+    assert _is_safe_imageproxy_request_path("/local/cover.jpg")
+    assert _is_safe_imageproxy_request_path("cover.jpg")
+
+
+def test_is_safe_imageproxy_request_path_rejects_dangerous_schemes() -> None:
+    """file://, data:, gopher://, javascript: and friends are rejected."""
+    assert not _is_safe_imageproxy_request_path("file:///etc/passwd")
+    assert not _is_safe_imageproxy_request_path("FILE:///etc/passwd")
+    assert not _is_safe_imageproxy_request_path("data:image/png;base64,iVBORw0KG")
+    assert not _is_safe_imageproxy_request_path("gopher://example.com/")
+    assert not _is_safe_imageproxy_request_path("javascript:alert(1)")
+    assert not _is_safe_imageproxy_request_path("ftp://example.com/a.jpg")

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -7,9 +7,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from music_assistant.controllers.metadata import (
+    _IMAGEPROXY_CONTENT_TYPES,
     CACHE_CATEGORY_IMAGE_IDS,
     MetaDataController,
     _is_safe_imageproxy_request_path,
+    _normalize_imageproxy_format,
 )
 from music_assistant.helpers.images import _extract_imageproxy_id, create_thumb_hash
 from music_assistant.mass import MusicAssistant
@@ -169,6 +171,29 @@ def test_is_safe_imageproxy_request_path_rejects_ssrf_targets() -> None:
     assert _is_safe_imageproxy_request_path("http://example.com/a.jpg")
     assert _is_safe_imageproxy_request_path("https://cdn.example.com/a.jpg")
     assert _is_safe_imageproxy_request_path("http://8.8.8.8/a.jpg")
+
+
+def test_normalize_imageproxy_format() -> None:
+    """Client `fmt` values are lowercased / trimmed and validated."""
+    assert _normalize_imageproxy_format("jpg") == "jpg"
+    assert _normalize_imageproxy_format("JPG") == "jpg"
+    assert _normalize_imageproxy_format("jpeg") == "jpeg"
+    assert _normalize_imageproxy_format("PNG") == "png"
+    assert _normalize_imageproxy_format("svg") == "svg"
+    assert _normalize_imageproxy_format("  png  ") == "png"
+    # invalid / empty input falls through so caller can detect from path
+    assert _normalize_imageproxy_format("") is None
+    assert _normalize_imageproxy_format(None) is None
+    assert _normalize_imageproxy_format("gif") is None
+    assert _normalize_imageproxy_format("bmp") is None
+
+
+def test_imageproxy_content_types_are_standards_compliant() -> None:
+    """Every accepted fmt must produce a standards-compliant MIME type."""
+    assert _IMAGEPROXY_CONTENT_TYPES["jpg"] == "image/jpeg"
+    assert _IMAGEPROXY_CONTENT_TYPES["jpeg"] == "image/jpeg"
+    assert _IMAGEPROXY_CONTENT_TYPES["png"] == "image/png"
+    assert _IMAGEPROXY_CONTENT_TYPES["svg"] == "image/svg+xml"
 
 
 def test_extract_imageproxy_id_matches_path_only() -> None:

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import hashlib
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,6 +22,30 @@ async def metadata_controller(mass_minimal: MusicAssistant) -> MetaDataControlle
     controller = MetaDataController(mass_minimal)
     mass_minimal.metadata = controller
     return controller
+
+
+async def _wait_for_persisted_image_id(
+    controller: MetaDataController, image_id: str, timeout: float = 2.0
+) -> dict[str, str]:
+    """
+    Wait until `_persist_image_id` has written its row, or fail the test.
+
+    `_persist_image_id` runs on the loop but does real work (json dump on a
+    thread + sqlite write), so a `sleep(0)` busy-loop can race on slow CI.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        raw = await controller.cache.get(
+            key=image_id,
+            category=CACHE_CATEGORY_IMAGE_IDS,
+            provider=controller.domain,
+        )
+        if raw is not None:
+            assert isinstance(raw, dict)
+            return raw
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"image_id {image_id!r} not persisted within {timeout}s")
 
 
 async def test_compute_image_id_is_deterministic(metadata_controller: MetaDataController) -> None:
@@ -68,16 +93,7 @@ async def test_resolve_image_id_via_in_memory_lru(
 async def test_resolve_image_id_via_cache_db(metadata_controller: MetaDataController) -> None:
     """After the async persist runs, the mapping resolves from cache even with empty LRU."""
     image_id = metadata_controller.compute_image_id("filesystem", "/local/cover.jpg")
-    # let the scheduled persist task drain
-    for _ in range(20):
-        await asyncio.sleep(0)
-        raw = await metadata_controller.cache.get(
-            key=image_id,
-            category=CACHE_CATEGORY_IMAGE_IDS,
-            provider=metadata_controller.domain,
-        )
-        if raw is not None:
-            break
+    raw = await _wait_for_persisted_image_id(metadata_controller, image_id)
     assert raw == {"provider": "filesystem", "path": "/local/cover.jpg"}
     # wipe the in-memory layer so we hit the cache db
     metadata_controller._image_id_lru.clear()
@@ -98,17 +114,7 @@ async def test_image_id_persists_with_persistent_flag(
 ) -> None:
     """Mappings must survive a `clear()` without include_persistent."""
     image_id = metadata_controller.compute_image_id("filesystem", "/persistent.jpg")
-    # wait for the scheduled persist task to land in the cache db
-    for _ in range(20):
-        await asyncio.sleep(0)
-        raw = await metadata_controller.cache.get(
-            key=image_id,
-            category=CACHE_CATEGORY_IMAGE_IDS,
-            provider=metadata_controller.domain,
-        )
-        if raw is not None:
-            break
-    assert raw is not None
+    await _wait_for_persisted_image_id(metadata_controller, image_id)
     # simulate the user-facing "Reset cache" action: clear() without include_persistent
     await metadata_controller.cache.clear()
     metadata_controller._image_id_lru.clear()
@@ -171,3 +177,35 @@ def test_extract_imageproxy_id_matches_path_only() -> None:
     # invalid id length / charset
     assert _extract_imageproxy_id("http://mass.local/imageproxy/short") is None
     assert _extract_imageproxy_id("http://mass.local/imageproxy/" + "g" * 64) is None
+
+
+async def test_handle_imageproxy_rejects_extra_path_segments(
+    metadata_controller: MetaDataController,
+) -> None:
+    """`/imageproxy/<id>` is the only shape that should validate."""
+    image_id = metadata_controller.compute_image_id("filesystem", "/local/cover.jpg")
+
+    def _fake_request(path: str) -> MagicMock:
+        request = MagicMock()
+        request.path = path
+        request.query = {}
+        return request
+
+    # canonical form passes the path check and reaches resolve (404 because
+    # the (provider, path) is not actually fetchable in this minimal fixture)
+    assert (
+        await metadata_controller.handle_imageproxy(_fake_request(f"/imageproxy/{image_id}"))
+    ).status in (200, 404)
+    # extra leading segment must not be accepted
+    bad = await metadata_controller.handle_imageproxy(
+        _fake_request(f"/imageproxy/extra/{image_id}")
+    )
+    assert bad.status == 400
+    # trailing extra segment likewise
+    bad = await metadata_controller.handle_imageproxy(
+        _fake_request(f"/imageproxy/{image_id}/extra")
+    )
+    assert bad.status == 400
+    # double slash after the prefix must not be accepted either
+    bad = await metadata_controller.handle_imageproxy(_fake_request(f"/imageproxy//{image_id}"))
+    assert bad.status == 400

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -146,6 +146,10 @@ def test_is_safe_imageproxy_request_path_rejects_control_char_bypass() -> None:
     assert not _is_safe_imageproxy_request_path("\nfile:///etc/passwd")
     assert not _is_safe_imageproxy_request_path("\x00file:///etc/passwd")
     assert not _is_safe_imageproxy_request_path("\rhttp://localhost/")
+    # ASCII space is not < 0x20, so the strip() guard is what catches this
+    assert not _is_safe_imageproxy_request_path(" file:///etc/passwd")
+    assert not _is_safe_imageproxy_request_path("file:///etc/passwd ")
+    assert not _is_safe_imageproxy_request_path(" https://cdn.example.com/a.jpg")
 
 
 def test_is_safe_imageproxy_request_path_rejects_ssrf_targets() -> None:
@@ -177,6 +181,11 @@ def test_extract_imageproxy_id_matches_path_only() -> None:
     # invalid id length / charset
     assert _extract_imageproxy_id("http://mass.local/imageproxy/short") is None
     assert _extract_imageproxy_id("http://mass.local/imageproxy/" + "g" * 64) is None
+    # extra path segments must not be accepted (matches handle_imageproxy)
+    assert _extract_imageproxy_id("http://mass.local/imageproxy/" + "a" * 64 + "/extra") is None
+    assert _extract_imageproxy_id("http://mass.local/imageproxy/extra/" + "a" * 64) is None
+    # canonical form with trailing slash is fine
+    assert _extract_imageproxy_id("http://mass.local/imageproxy/" + "a" * 64 + "/") == "a" * 64
 
 
 async def test_handle_imageproxy_rejects_extra_path_segments(

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -10,7 +10,7 @@ from music_assistant.controllers.metadata import (
     MetaDataController,
     _is_safe_imageproxy_request_path,
 )
-from music_assistant.helpers.images import _extract_imageproxy_id
+from music_assistant.helpers.images import _extract_imageproxy_id, create_thumb_hash
 from music_assistant.mass import MusicAssistant
 
 
@@ -30,6 +30,20 @@ async def test_compute_image_id_is_deterministic(metadata_controller: MetaDataCo
     assert image_id_a == image_id_b
     expected = hashlib.sha256(b"filesystem//local/cover.jpg").hexdigest()
     assert image_id_a == expected
+
+
+async def test_image_id_matches_thumb_and_palette_cache_key(
+    metadata_controller: MetaDataController,
+) -> None:
+    """image_id must equal create_thumb_hash(provider, path).
+
+    The thumbnail and color-palette caches both key off
+    `create_thumb_hash(provider, path)`. If `compute_image_id` ever diverged
+    from that, `peek_palette_for_url` for /imageproxy/<id> URLs would silently
+    stop hitting and the on-disk thumbnail cache would split into two buckets.
+    """
+    image_id = metadata_controller.compute_image_id("filesystem", "/local/cover.jpg")
+    assert image_id == create_thumb_hash("filesystem", "/local/cover.jpg")
 
 
 async def test_compute_image_id_differs_per_input(metadata_controller: MetaDataController) -> None:

--- a/tests/providers/jellyfin/__snapshots__/test_parsers.ambr
+++ b/tests/providers/jellyfin/__snapshots__/test_parsers.ambr
@@ -47,6 +47,7 @@
         dict({
           'path': 'http://localhost:1234/Items/70b7288088b42d318f75dbcc41fd0091/Images/Primary?api_key=ACCESS_TOKEN',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -144,6 +145,7 @@
         dict({
           'path': 'http://localhost:1234/Items/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4/Images/Primary?api_key=ACCESS_TOKEN',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -241,6 +243,7 @@
         dict({
           'path': 'http://localhost:1234/Items/32ed6a0091733dcff57eae67010f3d4b/Images/Primary?api_key=ACCESS_TOKEN',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -399,18 +402,21 @@
         dict({
           'path': 'http://localhost:1234/Items/dd954bbf54398e247d803186d3585b79/Images/Backdrop/0?api_key=ACCESS_TOKEN',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'fanart',
         }),
         dict({
           'path': 'http://localhost:1234/Items/dd954bbf54398e247d803186d3585b79/Images/Primary?api_key=ACCESS_TOKEN',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
         dict({
           'path': 'http://localhost:1234/Items/dd954bbf54398e247d803186d3585b79/Images/Logo?api_key=ACCESS_TOKEN',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'logo',
         }),
@@ -517,6 +523,7 @@
         dict({
           'path': 'http://localhost:1234/Items/da9c458e425584680765ddc3a89cbc0c/Images/Primary?api_key=ACCESS_TOKEN',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -710,6 +717,7 @@
         dict({
           'path': 'http://localhost:1234/Items/54918f75ee8f6c8b8dc5efd680644f29/Images/Primary?api_key=ACCESS_TOKEN',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -837,6 +845,7 @@
         dict({
           'path': 'http://localhost:1234/Items/fb12a77f49616a9fc56a6fab2b94174c/Images/Primary?api_key=ACCESS_TOKEN',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),

--- a/tests/providers/kion_music/__snapshots__/test_parsers.ambr
+++ b/tests/providers/kion_music/__snapshots__/test_parsers.ambr
@@ -150,6 +150,7 @@
         dict({
           'path': 'https://avatars.yandex.net/get-music-content/xxx/yyy/1000x1000',
           'provider': 'kion_music_instance',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -428,6 +429,7 @@
           dict({
             'path': 'https://avatars.yandex.net/get-music-content/aaa/bbb/1000x1000',
             'provider': 'kion_music_instance',
+            'proxy_id': None,
             'remotely_accessible': True,
             'type': 'thumb',
           }),
@@ -561,6 +563,7 @@
         dict({
           'path': 'https://avatars.yandex.net/get-music-content/aaa/bbb/1000x1000',
           'provider': 'kion_music_instance',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),

--- a/tests/providers/nicovideo/__snapshots__/test_converters.ambr
+++ b/tests/providers/nicovideo/__snapshots__/test_converters.ambr
@@ -288,6 +288,7 @@
                 dict({
                   'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
                   'provider': 'nicovideo_test',
+                  'proxy_id': None,
                   'remotely_accessible': True,
                   'type': 'thumb',
                 }),
@@ -363,12 +364,14 @@
             dict({
               'path': 'https://img.cdn.nimg.jp/s/nicovideo/thumbnails/45285955/45285955.27227006.original/r640x360l?key=7098d92a9c12d0b14101a4c3c8297e04c6e7a59eb59ffe9e71c88fa0181b0cb5',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
             dict({
               'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.L',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -579,6 +582,7 @@
         dict({
           'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -654,6 +658,7 @@
         dict({
           'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -732,6 +737,7 @@
             dict({
               'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -807,12 +813,14 @@
         dict({
           'path': 'https://img.cdn.nimg.jp/s/nicovideo/thumbnails/45285955/45285955.27227006.original/r640x360l?key=7098d92a9c12d0b14101a4c3c8297e04c6e7a59eb59ffe9e71c88fa0181b0cb5',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.L',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -892,6 +900,7 @@
             dict({
               'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -967,12 +976,14 @@
         dict({
           'path': 'https://img.cdn.nimg.jp/s/nicovideo/thumbnails/45285955/45285955.27227006.original/r640x360l?key=7098d92a9c12d0b14101a4c3c8297e04c6e7a59eb59ffe9e71c88fa0181b0cb5',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.L',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1050,6 +1061,7 @@
         dict({
           'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1130,6 +1142,7 @@
         dict({
           'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1211,6 +1224,7 @@
           dict({
             'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
             'provider': 'nicovideo_test',
+            'proxy_id': None,
             'remotely_accessible': True,
             'type': 'thumb',
           }),
@@ -1292,6 +1306,7 @@
                 dict({
                   'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
                   'provider': 'nicovideo_test',
+                  'proxy_id': None,
                   'remotely_accessible': True,
                   'type': 'thumb',
                 }),
@@ -1367,12 +1382,14 @@
             dict({
               'path': 'https://img.cdn.nimg.jp/s/nicovideo/thumbnails/45285955/45285955.27227006.original/r640x360l?key=7098d92a9c12d0b14101a4c3c8297e04c6e7a59eb59ffe9e71c88fa0181b0cb5',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
             dict({
               'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.L',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -1452,6 +1469,7 @@
         dict({
           'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1666,6 +1684,7 @@
             dict({
               'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -1741,12 +1760,14 @@
         dict({
           'path': 'https://img.cdn.nimg.jp/s/nicovideo/thumbnails/45285955/45285955.27227006.original/r640x360l?key=7098d92a9c12d0b14101a4c3c8297e04c6e7a59eb59ffe9e71c88fa0181b0cb5',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.L',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1826,6 +1847,7 @@
             dict({
               'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -1901,12 +1923,14 @@
         dict({
           'path': 'https://img.cdn.nimg.jp/s/nicovideo/thumbnails/45285955/45285955.27227006.original/r640x360l?key=7098d92a9c12d0b14101a4c3c8297e04c6e7a59eb59ffe9e71c88fa0181b0cb5',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.L',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -2024,6 +2048,7 @@
             dict({
               'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -2099,12 +2124,14 @@
         dict({
           'path': 'https://img.cdn.nimg.jp/s/nicovideo/thumbnails/45285955/45285955.27227006.original/r640x360l?key=7098d92a9c12d0b14101a4c3c8297e04c6e7a59eb59ffe9e71c88fa0181b0cb5',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.L',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -2184,6 +2211,7 @@
             dict({
               'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -2259,12 +2287,14 @@
         dict({
           'path': 'https://img.cdn.nimg.jp/s/nicovideo/thumbnails/45285955/45285955.27227006.original/r640x360l?key=7098d92a9c12d0b14101a4c3c8297e04c6e7a59eb59ffe9e71c88fa0181b0cb5',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.L',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -2345,6 +2375,7 @@
               dict({
                 'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
                 'provider': 'nicovideo_test',
+                'proxy_id': None,
                 'remotely_accessible': True,
                 'type': 'thumb',
               }),
@@ -2485,6 +2516,7 @@
             dict({
               'path': 'https://secure-dcdn.cdn.nimg.jp/nicoaccount/usericon/defaults/blank.jpg',
               'provider': 'nicovideo_test',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -2564,18 +2596,21 @@
         dict({
           'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.L',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://nicovideo.cdn.nimg.jp/thumbnails/45285955/45285955.27227006.M',
           'provider': 'nicovideo_test',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),

--- a/tests/providers/opensubsonic/__snapshots__/test_parsers.ambr
+++ b/tests/providers/opensubsonic/__snapshots__/test_parsers.ambr
@@ -253,6 +253,7 @@
         dict({
           'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -394,12 +395,14 @@
         dict({
           'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
         dict({
           'path': 'http://localhost:8989/play/art/0f8c3cbd6b0b22c3b5402141351ac812/album/21/thumb34.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -528,6 +531,7 @@
         dict({
           'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -656,12 +660,14 @@
         dict({
           'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
         dict({
           'path': 'http://localhost:8989/play/art/0f8c3cbd6b0b22c3b5402141351ac812/album/21/thumb34.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -790,6 +796,7 @@
         dict({
           'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -918,12 +925,14 @@
         dict({
           'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
         dict({
           'path': 'http://localhost:8989/play/art/0f8c3cbd6b0b22c3b5402141351ac812/album/21/thumb34.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -999,12 +1008,14 @@
         dict({
           'path': 'ar-37ec820ca7193e17040c98f7da7c4b51_0',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://demo.org/image.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1079,18 +1090,21 @@
         dict({
           'path': 'ar-37ec820ca7193e17040c98f7da7c4b51_0',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://demo.org/image.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'http://localhost:8989/play/art/f20070e8e11611cc53542a38801d60fa/artist/2/thumb34.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1165,12 +1179,14 @@
         dict({
           'path': 'ar-37ec820ca7193e17040c98f7da7c4b51_0',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://demo.org/image.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1245,18 +1261,21 @@
         dict({
           'path': 'ar-37ec820ca7193e17040c98f7da7c4b51_0',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
         dict({
           'path': 'https://demo.org/image.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
         dict({
           'path': 'http://localhost:8989/play/art/f20070e8e11611cc53542a38801d60fa/artist/2/thumb34.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1327,6 +1346,7 @@
         dict({
           'path': 'ar-100000002',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -1397,12 +1417,14 @@
         dict({
           'path': 'ar-100000002',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
         dict({
           'path': 'http://localhost:8989/play/art/f20070e8e11611cc53542a38801d60fa/artist/2/thumb34.jpg',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -1474,6 +1496,7 @@
         dict({
           'path': 'pd-5',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -1513,6 +1536,7 @@
           dict({
             'path': 'pd-5',
             'provider': 'xx-instance-id-xx',
+            'proxy_id': None,
             'remotely_accessible': False,
             'type': 'thumb',
           }),
@@ -1615,6 +1639,7 @@
         dict({
           'path': 'pd-5',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -1654,6 +1679,7 @@
           dict({
             'path': 'pd-5',
             'provider': 'xx-instance-id-xx',
+            'proxy_id': None,
             'remotely_accessible': False,
             'type': 'thumb',
           }),
@@ -1756,6 +1782,7 @@
         dict({
           'path': 'pd-5',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -1795,6 +1822,7 @@
           dict({
             'path': 'pd-5',
             'provider': 'xx-instance-id-xx',
+            'proxy_id': None,
             'remotely_accessible': False,
             'type': 'thumb',
           }),
@@ -1897,6 +1925,7 @@
         dict({
           'path': 'al-2250',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -1970,6 +1999,7 @@
         dict({
           'path': 'pd-5',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -2041,6 +2071,7 @@
         dict({
           'path': 'pd-5',
           'provider': 'xx-instance-id-xx',
+          'proxy_id': None,
           'remotely_accessible': False,
           'type': 'thumb',
         }),
@@ -2327,6 +2358,7 @@
           dict({
             'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
             'provider': 'xx-instance-id-xx',
+            'proxy_id': None,
             'remotely_accessible': False,
             'type': 'thumb',
           }),
@@ -2749,6 +2781,7 @@
           dict({
             'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
             'provider': 'xx-instance-id-xx',
+            'proxy_id': None,
             'remotely_accessible': False,
             'type': 'thumb',
           }),
@@ -3158,6 +3191,7 @@
           dict({
             'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
             'provider': 'xx-instance-id-xx',
+            'proxy_id': None,
             'remotely_accessible': False,
             'type': 'thumb',
           }),
@@ -3554,6 +3588,7 @@
           dict({
             'path': 'al-ad0f112b6dcf83de5e9cae85d07f0d35_640a93a8',
             'provider': 'xx-instance-id-xx',
+            'proxy_id': None,
             'remotely_accessible': False,
             'type': 'thumb',
           }),

--- a/tests/providers/tidal/__snapshots__/test_parsers.ambr
+++ b/tests/providers/tidal/__snapshots__/test_parsers.ambr
@@ -24,6 +24,7 @@
             dict({
               'path': 'https://resources.tidal.com/images/1234/5678/90ab/cdef/750x750.jpg',
               'provider': 'tidal_instance',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -95,6 +96,7 @@
         dict({
           'path': 'https://resources.tidal.com/images/abcd/ef01/2345/6789/750x750.jpg',
           'provider': 'tidal_instance',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -166,6 +168,7 @@
         dict({
           'path': 'https://resources.tidal.com/images/1234/5678/90ab/cdef/750x750.jpg',
           'provider': 'tidal_instance',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -237,6 +240,7 @@
         dict({
           'path': 'http://example.com/mix-medium.jpg',
           'provider': 'tidal_instance',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -312,6 +316,7 @@
         dict({
           'path': 'https://resources.tidal.com/images/playlist/square/image/id/750x750.jpg',
           'provider': 'tidal_instance',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -404,6 +409,7 @@
             dict({
               'path': 'https://resources.tidal.com/images/1234/5678/90ab/cdef/750x750.jpg',
               'provider': 'tidal_instance',
+              'proxy_id': None,
               'remotely_accessible': True,
               'type': 'thumb',
             }),
@@ -478,6 +484,7 @@
         dict({
           'path': 'https://resources.tidal.com/images/abcd/ef01/2345/6789/750x750.jpg',
           'provider': 'tidal_instance',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),

--- a/tests/providers/yandex_music/__snapshots__/test_parsers.ambr
+++ b/tests/providers/yandex_music/__snapshots__/test_parsers.ambr
@@ -150,6 +150,7 @@
         dict({
           'path': 'https://avatars.yandex.net/get-music-content/xxx/yyy/1000x1000',
           'provider': 'yandex_music_instance',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),
@@ -428,6 +429,7 @@
           dict({
             'path': 'https://avatars.yandex.net/get-music-content/aaa/bbb/1000x1000',
             'provider': 'yandex_music_instance',
+            'proxy_id': None,
             'remotely_accessible': True,
             'type': 'thumb',
           }),
@@ -561,6 +563,7 @@
         dict({
           'path': 'https://avatars.yandex.net/get-music-content/aaa/bbb/1000x1000',
           'provider': 'yandex_music_instance',
+          'proxy_id': None,
           'remotely_accessible': True,
           'type': 'thumb',
         }),


### PR DESCRIPTION
# What does this implement/fix?

The imageproxy is one of the most fragile and exposed surfaces in MA:

- URLs are very long because the `path` query parameter often carries a full external URL on top of the wrapping URL (double-encoded). Some players/clients reject them; special characters break them.
- The endpoint accepts an unbounded `size` parameter handed straight to PIL (memory-DoS).
- `path` may be any `http(s)://` URL → effectively an open URL-fetcher (SSRF surface), and schemes like `file://` / `data:` are not blocked.

This PR introduces an opaque-id `/imageproxy/<image_id>?size=&fmt=` route alongside the existing query-string endpoint, injects a `proxy_id` field on every outbound `MediaItemImage`, and hardens the legacy form.

Key changes:

- New `/imageproxy/<image_id>?size=&fmt=` route. `image_id` is the same `sha256(provider + "/" + path)` hash already used as the on-disk thumbnail cache key, so the existing cache continues to be hit without any migration.
- `MetaDataController.compute_image_id()` registers the `id → (provider, path)` mapping in an in-memory LRU and persists it to the cache controller with `persistent=True` and a 1-year TTL. Survives "Reset cache".
- Outbound websocket and JSON-RPC responses inject `proxy_id` on every `MediaItemImage` via the new model hook. Client appends `?size=&fmt=`. Public (`remotely_accessible=True`) images stay unchanged.
- Legacy `/imageproxy?provider=&path=` keeps working for back-compat but now:
  - enforces a size whitelist `{0, 80, 160, 256, 512, 1024}`,
  - rejects `file://`, `data:`, `gopher:`, `javascript:`, `ftp:`, `ws(s):` schemes from clients,
  - rejects control-char-prefixed paths and SSRF targets (loopback / RFC 1918 / link-local / multicast / `localhost`),
  - emits a throttled per-IP deprecation warning.
- Helpers in `helpers/images.py` and `helpers/colors.py` updated to recognise both URL forms.
- `API_SCHEMA_VERSION` bumped to 31 so clients can detect the new endpoint / `proxy_id` field.

**Related issue (if applicable):**

- companion model PR: music-assistant/models#233 (merged)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.