### PR TITLE
Use Protocol-bounded TypeVar for @use_cache decorator

### DIFF
--- a/music_assistant/controllers/cache/helpers.py
+++ b/music_assistant/controllers/cache/helpers.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Awaitable, Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, Protocol, TypeVar, cast, get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Concatenate,
+    ParamSpec,
+    Protocol,
+    TypeVar,
+    cast,
+    get_type_hints,
+)
 
 from music_assistant.controllers.cache.constants import (
     DEFAULT_CACHE_EXPIRATION,

--- a/music_assistant/controllers/cache/helpers.py
+++ b/music_assistant/controllers/cache/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Awaitable, Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar, cast, get_type_hints
+from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, Protocol, TypeVar, cast, get_type_hints
 
 from music_assistant.controllers.cache.constants import (
     DEFAULT_CACHE_EXPIRATION,
@@ -14,11 +14,20 @@ from music_assistant.controllers.cache.constants import (
 from music_assistant.helpers.api import parse_value
 
 if TYPE_CHECKING:
-    from music_assistant.models.core_controller import CoreController
-    from music_assistant.models.provider import Provider
+    from music_assistant import MusicAssistant
 
 
-ProviderT = TypeVar("ProviderT", bound="Provider | CoreController")
+class _Cacheable(Protocol):
+    """Protocol for objects that can use the @use_cache decorator."""
+
+    @property
+    def domain(self) -> str: ...
+
+    @property
+    def mass(self) -> MusicAssistant: ...
+
+
+ProviderT = TypeVar("ProviderT", bound="_Cacheable")
 P = ParamSpec("P")
 R = TypeVar("R")
 


### PR DESCRIPTION
# What does this implement/fix?

The `@use_cache` decorator's `ProviderT` TypeVar is bounded to `Provider | CoreController`, but several providers use the decorator on helper/manager classes that aren't subclasses of either. This forces every call site to add `# type: ignore[type-var]`. 26 suppressions in the upcoming Deezer provider (#3900) alone.

The decorator only accesses `self.mass` and `self.domain` (via `getattr(self, "instance_id", self.domain)`), so the type bound is stricter than necessary.

This PR replaces the union bound with a `_Cacheable` Protocol that captures exactly what `@use_cache` needs:

```python
class _Cacheable(Protocol):
    @property
    def domain(self) -> str: ...

    @property
    def mass(self) -> MusicAssistant: ...
```

Using `@property` in the Protocol means read-only properties, class attributes, and instance attributes all satisfy the constraint.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
