### PR TITLE
Fix invalid imageproxy size on PlayerMedia URLs

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1913,11 +1913,11 @@ class PlayerQueuesController(CoreController):
                 album.name if (album := getattr(queue_item.media_item, "album", None)) else ""
             )
             if queue_item.image:
-                # the image format needs to be 500x500 jpeg for maximum compatibility with players
+                # the image format needs to be 512x512 jpeg for maximum compatibility with players
                 # we prefer the imageproxy on the streamserver here because this request is sent
                 # to the player itself which may not be able to reach the regular webserver
                 media.image_url = self.mass.metadata.get_image_url(
-                    queue_item.image, size=500, prefer_stream_server=True
+                    queue_item.image, size=512, prefer_stream_server=True
                 )
         return media
 

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1675,7 +1675,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if next_item is None or not next_item.image:
             return
         next_url = self.mass.metadata.get_image_url(
-            next_item.image, size=500, prefer_stream_server=True
+            next_item.image, size=512, prefer_stream_server=True
         )
         self._schedule_palette_fetch(player_id, next_url, trigger_update=False)
 

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1787,8 +1787,8 @@ class Player(ABC):
             active_queue = self.mass.player_queues.get(self.player_id)
         if active_queue and (current_item := active_queue.current_item):
             item_image_url = (
-                # the image format needs to be 500x500 jpeg for maximum compatibility with players
-                self.mass.metadata.get_image_url(current_item.image, size=500, image_format="jpeg")
+                # the image format needs to be 512x512 jpeg for maximum compatibility with players
+                self.mass.metadata.get_image_url(current_item.image, size=512, image_format="jpeg")
                 if current_item.image
                 else None
             )
@@ -1820,10 +1820,10 @@ class Player(ABC):
                 podcast = getattr(media_item, "podcast", None)
                 metadata = getattr(media_item, "metadata", None)
                 description = getattr(metadata, "description", None) if metadata else None
-                # the image format needs to be 500x500 jpeg for maximum player compatibility
+                # the image format needs to be 512x512 jpeg for maximum player compatibility
                 image_url = (
                     self.mass.metadata.get_image_url(
-                        current_item.media_item.image, size=500, image_format="jpeg"
+                        current_item.media_item.image, size=512, image_format="jpeg"
                     )
                     or item_image_url
                     if current_item.media_item.image

--- a/music_assistant/providers/msx_bridge/player.py
+++ b/music_assistant/providers/msx_bridge/player.py
@@ -205,7 +205,7 @@ class MSXPlayer(Player):
                     duration = getattr(queue_item.media_item, "duration", None) or duration
                 if queue_item.image:
                     image_url = self.mass.metadata.get_image_url(
-                        queue_item.image, size=500, prefer_stream_server=True
+                        queue_item.image, size=512, prefer_stream_server=True
                     )
                 if duration is None and queue_item.duration:
                     duration = queue_item.duration


### PR DESCRIPTION
# What does this implement/fix?

The imageproxy hardening in #3960 introduced a size whitelist of
`{0, 80, 160, 256, 512, 1024}`. Several internal call sites that build
`PlayerMedia`/player image URLs still pass `size=500`, producing URLs that
the imageproxy now rejects. This switches them to the nearest allowed
bucket (`512`).

Changes:

- `models/player.py`: `Player.state.current_media` image URL (queue item + media item variants).
- `controllers/player_queues.py`: `PlayerMedia.image_url` built when sending to player.
- `controllers/players/controller.py`: palette pre-warm URL for the next queue item.
- `providers/msx_bridge/player.py`: MSX bridge player image URL.

Comments referencing `500x500` were updated to `512x512` to match.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.