### PR TITLE
Use passthrough PCM format for realtime AudioSource items

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1192,12 +1192,16 @@ class StreamsAudio:
         rate the player supports that is <= the source rate, so the source is never
         upsampled. The bit depth follows the source unless audio processing
         (crossfade, volume normalization, DSP) is active — those need F32 headroom
-        to avoid clipping/precision loss.
+        to avoid clipping/precision loss. Realtime AudioSource items skip all
+        processing and get a pure passthrough format (source rate/bit depth when
+        the player supports them).
 
         :param player: The player requesting the stream.
         :param streamdetails: Stream details for the current item.
         :param smartfades_enabled: Whether crossfade is enabled for this stream.
         """
+        if streamdetails.media_type == MediaType.AUDIO_SOURCE:
+            return self._select_audio_source_pcm_format(player, streamdetails)
         supported_sample_rates = [sr for sr, _ in player.get_supported_sample_rates()]
         # snap-down: pick the highest supported rate <= source. when the source rate
         # is below every supported rate (e.g. 22 kHz content on a 44.1k-only player),
@@ -1236,7 +1240,9 @@ class StreamsAudio:
         modes it snaps to the configured rate. The bit depth follows the first
         track's source unless audio processing is active (then F32 for headroom),
         avoiding an unnecessary up-convert to 32-bit when none of the consumers
-        will benefit from it.
+        will benefit from it. When the first item is a realtime AudioSource, the
+        flow mode config is ignored and a pure passthrough format is used so the
+        source audio is delivered with minimum overhead and latency.
 
         :param player: The player the flow stream is being prepared for.
         :param start_streamdetails: Stream details of the first track in the flow.
@@ -1245,6 +1251,10 @@ class StreamsAudio:
             omitted the bit depth defaults to F32.
         :param smartfades_enabled: Whether the queue will use crossfade transitions.
         """
+        if start_streamdetails is not None and (
+            start_streamdetails.media_type == MediaType.AUDIO_SOURCE
+        ):
+            return self._select_audio_source_pcm_format(player, start_streamdetails)
         supported_sample_rates = sorted({sr for sr, _ in player.get_supported_sample_rates()})
         flow_mode_conf = cast(
             "str",
@@ -2391,6 +2401,38 @@ class StreamsAudio:
             return INTERNAL_PCM_FORMAT.content_type, INTERNAL_PCM_FORMAT.bit_depth
         bit_depth = streamdetails.audio_format.bit_depth
         return ContentType.from_bit_depth(bit_depth), bit_depth
+
+    def _select_audio_source_pcm_format(
+        self, player: Player, streamdetails: StreamDetails
+    ) -> AudioFormat:
+        """
+        Return a passthrough PCM format for a realtime AudioSource item.
+
+        The format matches the source's native sample rate, bit depth and
+        channel count whenever the player can accept them; if the player does
+        not support the source's sample rate, it is snapped down to the
+        closest supported rate. No F32 widening, no forced stereo — realtime
+        sources skip every processing stage that would otherwise need them.
+
+        :param player: The player requesting the stream.
+        :param streamdetails: Stream details for the AudioSource item.
+        """
+        supported_sample_rates = [sr for sr, _ in player.get_supported_sample_rates()]
+        source_rate = streamdetails.audio_format.sample_rate
+        if source_rate in supported_sample_rates:
+            output_sample_rate = source_rate
+        else:
+            output_sample_rate = max(
+                (r for r in supported_sample_rates if r <= source_rate),
+                default=min(supported_sample_rates),
+            )
+        bit_depth = streamdetails.audio_format.bit_depth
+        return AudioFormat(
+            content_type=ContentType.from_bit_depth(bit_depth),
+            sample_rate=output_sample_rate,
+            bit_depth=bit_depth,
+            channels=streamdetails.audio_format.channels,
+        )
 
     def _flow_stream_needs_restart(
         self,

--- a/tests/controllers/streams/test_flow_format.py
+++ b/tests/controllers/streams/test_flow_format.py
@@ -227,6 +227,86 @@ async def test_select_flow_pcm_format_uses_f32_when_no_start_streamdetails() -> 
     assert fmt.bit_depth == 32
 
 
+# --- select_pcm_format (AUDIO_SOURCE passthrough) ---
+
+
+@pytest.mark.asyncio
+async def test_select_pcm_format_audio_source_passthrough_when_supported() -> None:
+    """AUDIO_SOURCE keeps source rate/bit depth/channels even with smartfades requested."""
+    audio = _make_streams_audio()
+    player = _make_player(supported=[(44100, 16), (48000, 24), (96000, 24)])
+    streamdetails = _make_streamdetails(
+        sample_rate=48000, bit_depth=24, channels=1, media_type=MediaType.AUDIO_SOURCE
+    )
+    fmt = await audio.select_pcm_format(player, streamdetails, smartfades_enabled=True)
+    assert fmt.sample_rate == 48000
+    assert fmt.bit_depth == 24
+    assert fmt.channels == 1
+
+
+@pytest.mark.asyncio
+async def test_select_pcm_format_audio_source_snaps_down_unsupported_rate() -> None:
+    """AUDIO_SOURCE snaps the sample rate down when the player can't accept the source rate."""
+    audio = _make_streams_audio()
+    player = _make_player(supported=[(44100, 16), (48000, 24)])
+    streamdetails = _make_streamdetails(
+        sample_rate=88200, bit_depth=24, media_type=MediaType.AUDIO_SOURCE
+    )
+    fmt = await audio.select_pcm_format(player, streamdetails, smartfades_enabled=False)
+    assert fmt.sample_rate == 48000
+    assert fmt.bit_depth == 24
+
+
+@pytest.mark.asyncio
+async def test_select_pcm_format_audio_source_falls_back_to_min_supported() -> None:
+    """When the source rate is below every supported rate, fall back to the player's lowest."""
+    audio = _make_streams_audio()
+    player = _make_player(supported=[(44100, 16), (48000, 24)])
+    streamdetails = _make_streamdetails(
+        sample_rate=22050, bit_depth=16, media_type=MediaType.AUDIO_SOURCE
+    )
+    fmt = await audio.select_pcm_format(player, streamdetails, smartfades_enabled=False)
+    assert fmt.sample_rate == 44100
+
+
+# --- select_flow_pcm_format (AUDIO_SOURCE passthrough) ---
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_audio_source_bypasses_flow_mode() -> None:
+    """AUDIO_SOURCE as start item ignores flow mode config and passes the source through."""
+    audio = _make_streams_audio()
+    # 'highest' would normally pick 96000 — passthrough must override that.
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24), (96000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_HIGHEST,
+    )
+    streamdetails = _make_streamdetails(
+        sample_rate=44100, bit_depth=16, media_type=MediaType.AUDIO_SOURCE
+    )
+    fmt = await audio.select_flow_pcm_format(
+        player, start_streamdetails=streamdetails, smartfades_enabled=True
+    )
+    assert fmt.sample_rate == 44100
+    assert fmt.bit_depth == 16
+    assert fmt.channels == 2
+
+
+@pytest.mark.asyncio
+async def test_select_flow_pcm_format_audio_source_preserves_mono() -> None:
+    """AUDIO_SOURCE keeps source channels — no forced stereo widening."""
+    audio = _make_streams_audio()
+    player = _make_player(
+        supported=[(44100, 16), (48000, 24)],
+        flow_mode=FLOW_MODE_SAMPLE_RATE_SMART,
+    )
+    streamdetails = _make_streamdetails(
+        sample_rate=44100, bit_depth=16, channels=1, media_type=MediaType.AUDIO_SOURCE
+    )
+    fmt = await audio.select_flow_pcm_format(player, start_streamdetails=streamdetails)
+    assert fmt.channels == 1
+
+
 # --- _flow_stream_needs_restart ---
 
 
@@ -405,7 +485,11 @@ def _make_streams_audio() -> StreamsAudio:
     return audio
 
 
-def _make_player(*, supported: list[tuple[int, int]], flow_mode: str) -> MagicMock:
+def _make_player(
+    *,
+    supported: list[tuple[int, int]],
+    flow_mode: str = FLOW_MODE_SAMPLE_RATE_SMART,
+) -> MagicMock:
     """Build a player double exposing only what select_flow_pcm_format needs."""
     player = MagicMock()
     player.get_supported_sample_rates = MagicMock(return_value=supported)
@@ -421,14 +505,17 @@ def _make_streamdetails(
     *,
     sample_rate: int,
     bit_depth: int,
+    channels: int = 2,
     volume_normalization_mode: VolumeNormalizationMode = VolumeNormalizationMode.DISABLED,
+    media_type: MediaType = MediaType.TRACK,
 ) -> MagicMock:
     """Build a StreamDetails double carrying just the fields the format selector reads."""
     streamdetails = MagicMock()
     streamdetails.audio_format = AudioFormat(
-        sample_rate=sample_rate, bit_depth=bit_depth, channels=2
+        sample_rate=sample_rate, bit_depth=bit_depth, channels=channels
     )
     streamdetails.volume_normalization_mode = volume_normalization_mode
+    streamdetails.media_type = media_type
     return streamdetails
 
 


### PR DESCRIPTION
# What does this implement/fix?

Realtime `AudioSource` items (live/streaming providers) currently went through the same PCM format selection as regular tracks: sample rate snap-down logic shared with tracks, F32 bit depth when crossfade/normalization/DSP looked active, and channels forced to stereo for crossfade headroom. None of that processing actually runs for an `AudioSource` (see `get_audio_source_stream`), so the conversions were pure overhead — adding ffmpeg in the data path and extra latency for no benefit.

This change makes both `select_pcm_format` and `select_flow_pcm_format` short-circuit for `MediaType.AUDIO_SOURCE` and return a passthrough format that matches the source as closely as the player allows. With this, the fast path in `_iter_audio_source_pcm` (no ffmpeg, direct pacing) actually triggers whenever the player natively supports the source format.

## Changes

- New `_select_audio_source_pcm_format` helper that returns the source's native sample rate, bit depth and channel count, only snapping the sample rate down when the player doesn't support it.
- `select_pcm_format` short-circuits to the helper for `AUDIO_SOURCE` items (skips F32 widening and forced stereo).
- `select_flow_pcm_format` short-circuits to the helper when the first item is an `AUDIO_SOURCE` (ignores `CONF_FLOW_MODE_SAMPLE_RATE` which would otherwise resample).

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.