### PR TITLE
audiobookshelf: use from_utc_timestamp helper for ms-epoch conversions

### DIFF
--- a/music_assistant/providers/audiobookshelf/parsers.py
+++ b/music_assistant/providers/audiobookshelf/parsers.py
@@ -1,7 +1,7 @@
 """Parser for ABS -> MASS."""
 
 from contextlib import suppress
-from datetime import UTC, datetime
+from datetime import datetime
 
 from aioaudiobookshelf.schema.library import (
     LibraryItemExpandedBook as AbsLibraryItemExpandedBook,
@@ -37,6 +37,8 @@ from music_assistant_models.media_items import (
 from music_assistant_models.media_items import Playlist as MassPlaylist
 from music_assistant_models.media_items import Podcast as MassPodcast
 from music_assistant_models.media_items import PodcastEpisode as MassPodcastEpisode
+
+from music_assistant.helpers.datetime import from_utc_timestamp
 
 
 def parse_playlist(
@@ -182,7 +184,7 @@ def parse_podcast_episode(
     if episode.published_at is not None:
         position = -episode.published_at
         # abs published_at is ms epoch
-        release_date = datetime.fromtimestamp(episode.published_at / 1000, tz=UTC)
+        release_date = from_utc_timestamp(episode.published_at / 1000)
     else:
         position = 0
         if fallback_episode_cnt is not None:
@@ -303,6 +305,6 @@ def parse_audiobook(
         mass_audiobook.resume_position_ms = int(media_progress.current_time * 1000)
         mass_audiobook.fully_played = media_progress.is_finished
 
-    mass_audiobook.date_added = datetime.fromtimestamp(abs_audiobook.added_at / 1000, tz=UTC)
+    mass_audiobook.date_added = from_utc_timestamp(abs_audiobook.added_at / 1000)
 
     return mass_audiobook


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
As requested here https://github.com/music-assistant/server/pull/3525#discussion_r3295147834 Marcel wanted a helper added but it actually already exists we just have to use it!

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
