### PR TITLE
feat(plex): implement library type switching with cleanup and tests

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -396,10 +396,40 @@ class ConfigController:
 
         # add dynamic optional config entries that depend on features
         if instance_id and (provider := self.mass.get_provider(instance_id)):
-            supported_features = provider.supported_features
+            # When the user is editing a loaded provider and the form contains a new
+            # library_type, prefer the dynamic feature set from the form so sync
+            # options match the selected type rather than the old loaded type.
+            new_library_type = (values or {}).get("library_type")
+            if (
+                new_library_type is not None
+                and hasattr(provider, "_get_library_type")
+                and new_library_type != provider._get_library_type()
+            ):
+                raw_features = getattr(prov_mod, "get_supported_features", None)
+                if callable(raw_features):
+                    supported_features: set[ProviderFeature] = cast(
+                        "set[ProviderFeature]", raw_features(values)
+                    )
+                else:
+                    supported_features = provider.supported_features
+            else:
+                supported_features = provider.supported_features
         else:
             provider = None
-            supported_features = getattr(prov_mod, "SUPPORTED_FEATURES", set())
+            # Prefer a dynamic callable that can react to intermediate form
+            # values (e.g. library type selector). Fall back to static set.
+            raw_features = getattr(prov_mod, "get_supported_features", None)
+            if raw_features is None:
+                raw_features = getattr(prov_mod, "SUPPORTED_FEATURES", None)
+            if raw_features is None:
+                _sf: set[ProviderFeature] = set()
+            elif callable(raw_features):
+                _sf = cast("set[ProviderFeature]", raw_features(values))
+            elif isinstance(raw_features, set):
+                _sf = raw_features
+            else:
+                _sf = set()
+            supported_features = _sf
         extra_entries: list[ConfigEntry] = []
         if manifest.type == ProviderType.MUSIC:
             # library sync settings

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -7,6 +7,7 @@ import logging
 import warnings
 from asyncio import Task, TaskGroup
 from collections.abc import Awaitable
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
 import plexapi.exceptions
@@ -35,18 +36,22 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import (
     Album,
     Artist,
+    Audiobook,
     AudioFormat,
     ItemMapping,
     MediaItem,
+    MediaItemChapter,
     MediaItemImage,
     Playlist,
+    Podcast,
+    PodcastEpisode,
     ProviderMapping,
     RecommendationFolder,
     SearchResults,
     Track,
     UniqueList,
 )
-from music_assistant_models.streamdetails import StreamDetails
+from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 from plexapi.audio import Album as PlexAlbum
 from plexapi.audio import Artist as PlexArtist
 from plexapi.audio import Track as PlexTrack
@@ -55,17 +60,31 @@ from plexapi.myplex import MyPlexAccount, MyPlexPinLogin
 from plexapi.playlist import Playlist as PlexPlaylist
 from plexapi.server import PlexServer
 
-from music_assistant.constants import UNKNOWN_ARTIST
+from music_assistant.constants import DB_TABLE_PROVIDER_MAPPINGS, UNKNOWN_ARTIST
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.auth import AuthenticationHelper
 from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.util import parse_title_and_version
 from music_assistant.models.music_provider import MusicProvider
-from music_assistant.providers.plex.helpers import discover_local_servers, get_libraries
+from music_assistant.providers.plex.helpers import (
+    AUDIOBOOK_FEATURES,
+    CONF_LIBRARY_TYPE,
+    LIBRARY_TYPE_AUDIOBOOKS,
+    LIBRARY_TYPE_MUSIC,
+    LIBRARY_TYPE_PODCASTS,
+    LIBRARY_TYPE_TO_MEDIA_TYPES,
+    PODCAST_FEATURES,
+    SUPPORTED_FEATURES,
+    discover_local_servers,
+    extract_library_name,
+    get_section_info,
+    get_supported_features,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable, Coroutine
 
+    from music_assistant_models.media_items import MediaItemType
     from music_assistant_models.provider import ProviderManifest
     from plexapi.library import LibraryMediaTag as PlexCollection
     from plexapi.library import MusicSection as PlexMusicSection
@@ -79,11 +98,18 @@ if TYPE_CHECKING:
 CONF_ACTION_AUTH_MYPLEX = "auth_myplex"
 CONF_ACTION_AUTH_LOCAL = "auth_local"
 CONF_ACTION_CLEAR_AUTH = "auth"
-CONF_ACTION_LIBRARY = "library"
 CONF_ACTION_GDM = "gdm"
 
 CONF_AUTH_TOKEN = "token"
 CONF_LIBRARY_ID = "library_id"
+
+UNKNOWN_NAME = "[Unknown]"
+PODCAST_PREFIX = "podcast:"
+PODCAST_EPISODE_PREFIX = "podcast_episode:"
+AUDIOBOOK_PREFIX = "audiobook:"
+CHAPTER_PREFIX = "Chapter"
+EPISODE_PREFIX = "Episode"
+
 CONF_LOCAL_SERVER_IP = "local_server_ip"
 CONF_LOCAL_SERVER_PORT = "local_server_port"
 CONF_LOCAL_SERVER_SSL = "local_server_ssl"
@@ -98,21 +124,6 @@ CONF_HUB_ITEMS_LIMIT = "hub_items_limit"
 FAKE_ARTIST_PREFIX = "_fake://"
 
 AUTH_TOKEN_UNAUTH = "local_auth"
-
-SUPPORTED_FEATURES = {
-    ProviderFeature.LIBRARY_ARTISTS,
-    ProviderFeature.LIBRARY_ALBUMS,
-    ProviderFeature.LIBRARY_TRACKS,
-    ProviderFeature.LIBRARY_PLAYLISTS,
-    ProviderFeature.FAVORITE_ALBUMS_EDIT,
-    ProviderFeature.FAVORITE_TRACKS_EDIT,
-    ProviderFeature.BROWSE,
-    ProviderFeature.SEARCH,
-    ProviderFeature.ARTIST_ALBUMS,
-    ProviderFeature.ARTIST_TOPTRACKS,
-    ProviderFeature.SIMILAR_TRACKS,
-    ProviderFeature.RECOMMENDATIONS,
-}
 
 
 async def setup(
@@ -268,47 +279,120 @@ async def get_config_entries(  # noqa: PLR0915
             type=ConfigEntryType.STRING,
             label="Library",
             required=True,
-            description="The library to connect to (e.g. Music)",
+            description="The Plex music library section to connect to.",
             depends_on=CONF_AUTH_TOKEN,
-            action=CONF_ACTION_LIBRARY,
-            action_label="Select Plex Music Library",
         )
-        if action in (
-            CONF_ACTION_LIBRARY,
-            CONF_ACTION_AUTH_MYPLEX,
-            CONF_ACTION_AUTH_LOCAL,
-        ):
-            token = mass.config.decrypt_string(str(values.get(CONF_AUTH_TOKEN)))
-            server_http_ip = str(values.get(CONF_LOCAL_SERVER_IP))
-            server_http_port = str(values.get(CONF_LOCAL_SERVER_PORT))
-            server_http_ssl = bool(values.get(CONF_LOCAL_SERVER_SSL))
-            server_http_verify_cert = bool(values.get(CONF_LOCAL_SERVER_VERIFY_CERT))
-            if not (
-                libraries := await get_libraries(
-                    mass,
-                    token,
-                    server_http_ssl,
-                    server_http_ip,
-                    server_http_port,
-                    server_http_verify_cert,
-                    instance_id,
+        conf_library_type = ConfigEntry(
+            key=CONF_LIBRARY_TYPE,
+            type=ConfigEntryType.STRING,
+            label="Library Type",
+            required=True,
+            description="Select whether this Plex library should be treated as Music, Audiobooks, or Podcasts.",
+            depends_on=CONF_AUTH_TOKEN,
+            options=[
+                ConfigValueOption(title="Music", value=LIBRARY_TYPE_MUSIC),
+                ConfigValueOption(title="Audiobooks", value=LIBRARY_TYPE_AUDIOBOOKS),
+                ConfigValueOption(title="Podcasts", value=LIBRARY_TYPE_PODCASTS),
+            ],
+            default_value=LIBRARY_TYPE_MUSIC,
+        )
+
+        token = mass.config.decrypt_string(str(values.get(CONF_AUTH_TOKEN)))
+        server_http_ip = str(values.get(CONF_LOCAL_SERVER_IP))
+        server_http_port = str(values.get(CONF_LOCAL_SERVER_PORT, 32400))
+        server_http_ssl = bool(values.get(CONF_LOCAL_SERVER_SSL))
+        server_http_verify_cert = bool(values.get(CONF_LOCAL_SERVER_VERIFY_CERT))
+        sections = await get_section_info(
+            mass,
+            token,
+            server_http_ssl,
+            server_http_ip,
+            server_http_port,
+            server_http_verify_cert,
+            instance_id,
+        )
+        if not sections:
+            msg = (
+                "Unable to retrieve Servers and/or Music Libraries. "
+                "Please verify the local server IP and port are correct and the Plex server is running."
+            )
+            LOGGER.warning(msg)
+        library_options = [
+            ConfigValueOption(title=s.display_name, value=s.display_name) for s in sections
+        ]
+        conf_libraries.options = library_options
+
+        # Determine which libraries are already claimed by other plex provider instances.
+        # We read raw stored config values directly (without include_values=True) to avoid
+        # recursively triggering get_config_entries for every plex instance.
+        used_libraries: set[str] = set()
+        has_audiobook_provider = False
+        raw_provs = mass.config.get("providers", {})
+        for prov_id, prov_conf in raw_provs.items():
+            if prov_conf.get("domain") != "plex":
+                continue
+            # Skip the current instance when editing so its own library isn't "used"
+            if prov_id == instance_id:
+                continue
+            prov_values = prov_conf.get("values", {})
+            if lib_val := prov_values.get(CONF_LIBRARY_ID):
+                used_libraries.add(str(lib_val))
+            if prov_values.get(CONF_LIBRARY_TYPE) == LIBRARY_TYPE_AUDIOBOOKS:
+                has_audiobook_provider = True
+
+        available_sections = [s for s in sections if s.display_name not in used_libraries]
+
+        # Only auto-select defaults if the user has not yet manually picked a library.
+        if not values.get(CONF_LIBRARY_ID):
+            # Sort: non-tracking first, then A-Z
+            sorted_available = sorted(
+                available_sections,
+                key=lambda s: (s.is_tracking_progress, s.display_name),
+            )
+            default_library = (
+                sorted_available[0].display_name
+                if sorted_available
+                else (
+                    available_sections[0].display_name
+                    if available_sections
+                    else (sections[0].display_name if sections else "")
                 )
-            ):
-                msg = "Unable to retrieve Servers and/or Music Libraries"
-                raise LoginFailed(msg)
-            conf_libraries.options = [
-                # use the same value for both the value and the title
-                # until we find out what plex uses as stable identifiers
-                ConfigValueOption(
-                    title=x,
-                    value=x,
+            )
+
+            # Determine default type from the selected library's tracking setting
+            selected_section = next(
+                (s for s in sections if s.display_name == default_library), None
+            )
+            if selected_section and selected_section.is_tracking_progress:
+                default_type = (
+                    LIBRARY_TYPE_PODCASTS if has_audiobook_provider else LIBRARY_TYPE_AUDIOBOOKS
                 )
-                for x in libraries
-            ]
-            # select first library as (default) value
-            conf_libraries.default_value = libraries[0]
-            conf_libraries.value = libraries[0]
+            else:
+                default_type = LIBRARY_TYPE_MUSIC
+
+            conf_library_type.default_value = default_type
+            conf_library_type.value = default_type
+            conf_libraries.default_value = default_library
+            conf_libraries.value = default_library
+        else:
+            # Type may need updating if user changed the library
+            current_library = str(values.get(CONF_LIBRARY_ID, ""))
+            selected_section = next(
+                (s for s in sections if s.display_name == current_library), None
+            )
+            if selected_section and selected_section.is_tracking_progress:
+                suggested_type = (
+                    LIBRARY_TYPE_PODCASTS if has_audiobook_provider else LIBRARY_TYPE_AUDIOBOOKS
+                )
+            else:
+                suggested_type = LIBRARY_TYPE_MUSIC
+            current_type = values.get(CONF_LIBRARY_TYPE, suggested_type)
+            conf_library_type.default_value = suggested_type
+            conf_library_type.value = current_type
+            conf_libraries.value = current_library
+
         entries.append(conf_libraries)
+        entries.append(conf_library_type)
 
     # show authentication options
     if values is None or not values.get(CONF_AUTH_TOKEN):
@@ -437,17 +521,37 @@ class PlexProvider(MusicProvider):
     _myplex_account: MyPlexAccount = None
     _baseurl: str
 
+    def _get_library_type(self) -> str:
+        """Return the configured library type, defaulting to music."""
+        return str(self.config.get_value(CONF_LIBRARY_TYPE) or LIBRARY_TYPE_MUSIC)
+
+    @property
+    def instance_name_postfix(self) -> str | None:
+        """Return a postfix with the library name and type."""
+        library_name = extract_library_name(str(self.config.get_value(CONF_LIBRARY_ID) or ""))
+        library_type = self._get_library_type()
+        if library_type in (LIBRARY_TYPE_AUDIOBOOKS, LIBRARY_TYPE_PODCASTS):
+            type_label = library_type.title()
+            # Avoid duplication when the library name already indicates its type
+            if library_name.lower() == type_label.lower():
+                return library_name
+            return f"{library_name} - {type_label}"
+        if library_name:
+            return library_name
+        return None
+
     async def handle_async_init(self) -> None:
         """Set up the music provider by connecting to the server."""
         # silence loggers
         logging.getLogger("plexapi").setLevel(self.logger.level + 10)
-        _, library_name = str(self.config.get_value(CONF_LIBRARY_ID)).split(" / ", 1)
+
+        library_name = extract_library_name(str(self.config.get_value(CONF_LIBRARY_ID)))
 
         def connect() -> PlexServer:
             try:
                 session = requests.Session()
                 session.verify = (
-                    bool(self.config.get_value(CONF_LOCAL_SERVER_VERIFY_CERT))
+                    self.config.get_value(CONF_LOCAL_SERVER_VERIFY_CERT)
                     if self.config.get_value(CONF_LOCAL_SERVER_SSL)
                     else False
                 )
@@ -511,6 +615,77 @@ class PlexProvider(MusicProvider):
         except requests.exceptions.ConnectionError as err:
             raise SetupFailedError from err
 
+    async def update_config(self, config: ProviderConfig, changed_keys: set[str]) -> None:
+        """Handle library type changes by cleaning up old media type entries."""
+        old_library_type = self._get_library_type()
+
+        await super().update_config(config, changed_keys)
+
+        if f"values/{CONF_LIBRARY_TYPE}" not in changed_keys:
+            return
+
+        new_library_type = self._get_library_type()
+        if old_library_type == new_library_type:
+            return
+
+        old_types = LIBRARY_TYPE_TO_MEDIA_TYPES.get(old_library_type, ())
+        new_types = LIBRARY_TYPE_TO_MEDIA_TYPES.get(new_library_type, ())
+        stale_types = tuple(t for t in old_types if t not in new_types)
+
+        if not stale_types:
+            return
+
+        self.logger.info(
+            "Library type changed from %s to %s, cleaning up %s entries",
+            old_library_type,
+            new_library_type,
+            ", ".join(t.value for t in stale_types),
+        )
+
+        # Remove provider mappings for stale media types
+        for media_type in stale_types:
+            controller = self.mass.music.get_controller(media_type)
+            if controller is None:
+                continue
+            query = (
+                f"SELECT item_id FROM {DB_TABLE_PROVIDER_MAPPINGS} "
+                f"WHERE media_type = '{media_type.value}' "
+                f"AND provider_instance = '{self.instance_id}'"
+            )
+            for db_row in await self.mass.music.database.get_rows_from_query(query, limit=100000):
+                try:
+                    await controller.remove_provider_mappings(db_row["item_id"], self.instance_id)
+                except Exception as err:
+                    self.logger.warning(
+                        "Failed to remove provider mapping for %s item %s: %s",
+                        media_type.value,
+                        db_row["item_id"],
+                        err,
+                    )
+            # also clear any cached previous library IDs for this media type
+            await self.mass.cache.delete(
+                key=media_type.value,
+                provider=self.instance_id,
+                category="prev_library_ids",
+            )
+
+        # Remove stale sync config values so they don't leak back on future form renders
+        _SYNC_KEY_MAP: dict[MediaType, str] = {
+            MediaType.ARTIST: "library_sync_artists",
+            MediaType.ALBUM: "library_sync_albums",
+            MediaType.TRACK: "library_sync_tracks",
+            MediaType.PLAYLIST: "library_sync_playlists",
+            MediaType.AUDIOBOOK: "library_sync_audiobooks",
+            MediaType.PODCAST: "library_sync_podcasts",
+            MediaType.RADIO: "library_sync_radios",
+        }
+        for media_type in stale_types:
+            if sync_key := _SYNC_KEY_MAP.get(media_type):
+                try:
+                    await self.mass.config.remove_provider_config_value(self.instance_id, sync_key)
+                except Exception:
+                    pass  # value may not exist, ignore
+
     @property
     def is_streaming_provider(self) -> bool:
         """
@@ -526,6 +701,16 @@ class PlexProvider(MusicProvider):
         """
         return False
 
+    @property
+    def supported_features(self) -> set[ProviderFeature]:
+        """Return the features supported by this Provider."""
+        library_type = self._get_library_type()
+        if library_type == LIBRARY_TYPE_AUDIOBOOKS:
+            return AUDIOBOOK_FEATURES.copy()
+        if library_type == LIBRARY_TYPE_PODCASTS:
+            return PODCAST_FEATURES.copy()
+        return self._supported_features.copy()
+
     async def resolve_image(self, path: str) -> str | bytes:
         """Return the full image URL including the auth token."""
         return str(self._plex_server.url(path, True))
@@ -537,7 +722,11 @@ class PlexProvider(MusicProvider):
         return await asyncio.to_thread(call, *args, **kwargs)
 
     async def _get_data(self, key: str, cls: type[PlexObjectT]) -> PlexObjectT:
-        results = await self._run_async(self._plex_library.fetchItem, key, cls)
+        try:
+            results = await self._run_async(self._plex_library.fetchItem, key, cls)
+        except plexapi.exceptions.NotFound as err:
+            msg = f"Item {key} not found"
+            raise MediaNotFoundError(msg) from err
         return cast("PlexObjectT", results)
 
     def _get_item_mapping(self, media_type: MediaType, key: str, name: str) -> ItemMapping:
@@ -548,7 +737,7 @@ class PlexProvider(MusicProvider):
                 media_type,
                 key,
             )
-            name = "[Unknown]"
+            name = UNKNOWN_NAME
 
         mapped_name, mapped_version = parse_title_and_version(name)
 
@@ -559,7 +748,7 @@ class PlexProvider(MusicProvider):
                 key,
                 name,
             )
-            mapped_name = "[Unknown]"
+            mapped_name = UNKNOWN_NAME
         if not mapped_version and media_type not in (MediaType.ALBUM, MediaType.TRACK):
             mapped_version = ""
 
@@ -674,7 +863,7 @@ class PlexProvider(MusicProvider):
         album = Album(
             item_id=album_id,
             provider=self.instance_id,
-            name=plex_album.title or "[Unknown]",
+            name=plex_album.title or UNKNOWN_NAME,
             provider_mappings={
                 ProviderMapping(
                     item_id=str(album_id),
@@ -754,7 +943,7 @@ class PlexProvider(MusicProvider):
         playlist = Playlist(
             item_id=plex_playlist.key,
             provider=self.instance_id,
-            name=plex_playlist.title or "[Unknown]",
+            name=plex_playlist.title or UNKNOWN_NAME,
             provider_mappings={
                 ProviderMapping(
                     item_id=plex_playlist.key,
@@ -828,7 +1017,7 @@ class PlexProvider(MusicProvider):
         track = Track(
             item_id=plex_track.key,
             provider=self.instance_id,
-            name=plex_track.title or "[Unknown]",
+            name=plex_track.title or UNKNOWN_NAME,
             provider_mappings={
                 ProviderMapping(
                     item_id=plex_track.key,
@@ -892,6 +1081,218 @@ class PlexProvider(MusicProvider):
             pass  # TODO!
 
         return track
+
+    async def _parse_audiobook(
+        self, plex_album: PlexAlbum, *, include_chapters: bool = False
+    ) -> Audiobook:
+        """Parse a Plex Album from the audiobook library into an Audiobook model."""
+        audiobook_id = f"{AUDIOBOOK_PREFIX}{plex_album.key}"
+        audiobook = Audiobook(
+            item_id=audiobook_id,
+            provider=self.instance_id,
+            name=plex_album.title or UNKNOWN_NAME,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=audiobook_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                    url=plex_album.getWebURL(self._baseurl),
+                )
+            },
+        )
+        # Author: parentTitle is the album artist; grandparentTitle is the album
+        # artist parent (for multi-level nesting in Plex). Some setups vary.
+        if author_name := plex_album.parentTitle or plex_album.grandparentTitle:
+            audiobook.authors = UniqueList([author_name])
+        if plex_album.summary:
+            audiobook.metadata.description = plex_album.summary
+        if plex_album.year:
+            audiobook.metadata.release_date = datetime(plex_album.year, 1, 1, tzinfo=UTC)
+        if thumb := plex_album.firstAttr("thumb", "parentThumb", "grandparentThumb"):
+            audiobook.metadata.images = UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=thumb,
+                        provider=self.instance_id,
+                        remotely_accessible=False,
+                    )
+                ]
+            )
+        # minified path: use album-level duration if Plex exposes it
+        if album_duration := getattr(plex_album, "duration", None):
+            audiobook.duration = int(album_duration / 1000)
+
+        if include_chapters:
+            chapters = await self._build_audiobook_chapters(plex_album)
+            audiobook.metadata.chapters = chapters
+            if chapters and chapters[-1].end is not None:
+                audiobook.duration = int(chapters[-1].end)
+
+        return audiobook
+
+    async def _build_audiobook_chapters(self, plex_album: PlexAlbum) -> list[MediaItemChapter]:
+        """Build chapter list from Plex tracks, skipping tracks without playable media."""
+        plex_tracks = cast("list[PlexTrack]", await self._run_async(plex_album.tracks))
+        plex_tracks.sort(key=lambda t: (t.parentIndex or 0, t.trackNumber or 0))
+        chapters: list[MediaItemChapter] = []
+        cumulative = 0.0
+        chapter_num = 0
+        for plex_track in plex_tracks:
+            if not plex_track.media or not plex_track.media[0].parts:
+                continue
+            chapter_num += 1
+            # plex_track.duration is in milliseconds (Plex native unit)
+            duration_s = (plex_track.duration or 0) / 1000.0
+            chapters.append(
+                MediaItemChapter(
+                    position=chapter_num,
+                    name=plex_track.title or f"{CHAPTER_PREFIX} {chapter_num}",
+                    start=cumulative,
+                    end=cumulative + duration_s,
+                )
+            )
+            cumulative += duration_s
+        return chapters
+
+    async def _parse_podcast(
+        self, plex_album: PlexAlbum, *, include_episodes: bool = False
+    ) -> Podcast:
+        """Parse a Plex Album from the podcast library into a Podcast model."""
+        podcast_id = f"{PODCAST_PREFIX}{plex_album.key}"
+        podcast = Podcast(
+            item_id=podcast_id,
+            provider=self.instance_id,
+            name=plex_album.title or UNKNOWN_NAME,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=podcast_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                    url=plex_album.getWebURL(self._baseurl),
+                )
+            },
+        )
+        publisher = plex_album.studio or plex_album.parentTitle or plex_album.grandparentTitle
+        if publisher:
+            podcast.publisher = publisher
+        if plex_album.summary:
+            podcast.metadata.description = plex_album.summary
+        if plex_album.year:
+            podcast.metadata.release_date = datetime(plex_album.year, 1, 1, tzinfo=UTC)
+        if thumb := plex_album.firstAttr("thumb", "parentThumb", "grandparentThumb"):
+            podcast.metadata.images = UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=thumb,
+                        provider=self.instance_id,
+                        remotely_accessible=False,
+                    )
+                ]
+            )
+        if include_episodes:
+            podcast.total_episodes = await self._count_podcast_episodes(plex_album)
+        return podcast
+
+    async def _count_podcast_episodes(self, plex_album: PlexAlbum) -> int:
+        """Count playable tracks without building full PodcastEpisode objects."""
+        plex_tracks = cast("list[PlexTrack]", await self._run_async(plex_album.tracks))
+        return sum(1 for t in plex_tracks if t.media and t.media[0].parts)
+
+    async def _build_podcast_episodes(self, plex_album: PlexAlbum) -> list[PodcastEpisode]:
+        """Build episode list from Plex tracks, skipping tracks without playable media."""
+        plex_tracks = cast("list[PlexTrack]", await self._run_async(plex_album.tracks))
+        plex_tracks.sort(key=lambda t: (t.parentIndex or 0, t.trackNumber or 0))
+        episodes: list[PodcastEpisode] = []
+        episode_num = 0
+        for plex_track in plex_tracks:
+            if not plex_track.media or not plex_track.media[0].parts:
+                continue
+            episode_num += 1
+            duration_s = (plex_track.duration or 0) / 1000.0
+            episode = PodcastEpisode(
+                item_id=f"{PODCAST_EPISODE_PREFIX}{plex_track.key}",
+                provider=self.instance_id,
+                name=plex_track.title or f"{EPISODE_PREFIX} {episode_num}",
+                position=episode_num,
+                duration=int(duration_s),
+                podcast=ItemMapping(
+                    media_type=MediaType.PODCAST,
+                    item_id=f"{PODCAST_PREFIX}{plex_album.key}",
+                    provider=self.instance_id,
+                    name=plex_album.title or UNKNOWN_NAME,
+                ),
+                provider_mappings={
+                    ProviderMapping(
+                        item_id=f"{PODCAST_EPISODE_PREFIX}{plex_track.key}",
+                        provider_domain=self.domain,
+                        provider_instance=self.instance_id,
+                        url=plex_track.getWebURL(self._baseurl),
+                        audio_format=AudioFormat(
+                            content_type=(
+                                ContentType.try_parse(plex_track.media[0].container)
+                                if plex_track.media[0].container
+                                else ContentType.UNKNOWN
+                            )
+                        ),
+                    )
+                },
+            )
+            if thumb := plex_track.firstAttr("thumb", "parentThumb", "grandparentThumb"):
+                episode.metadata.images = UniqueList(
+                    [
+                        MediaItemImage(
+                            type=ImageType.THUMB,
+                            path=thumb,
+                            provider=self.instance_id,
+                            remotely_accessible=False,
+                        )
+                    ]
+                )
+            episodes.append(episode)
+        return episodes
+
+    async def _parse_podcast_episode(self, plex_track: PlexTrack) -> PodcastEpisode:
+        """Parse a Plex Track from the podcast library into a PodcastEpisode model."""
+        duration_s = (plex_track.duration or 0) / 1000.0
+        content_type = ContentType.UNKNOWN
+        if plex_track.media and plex_track.media[0].container:
+            content_type = ContentType.try_parse(plex_track.media[0].container)
+        episode = PodcastEpisode(
+            item_id=f"{PODCAST_EPISODE_PREFIX}{plex_track.key}",
+            provider=self.instance_id,
+            name=plex_track.title or UNKNOWN_NAME,
+            position=plex_track.trackNumber or 0,
+            duration=int(duration_s),
+            podcast=ItemMapping(
+                media_type=MediaType.PODCAST,
+                item_id=f"{PODCAST_PREFIX}{plex_track.parentKey}",
+                provider=self.instance_id,
+                name=plex_track.parentTitle or UNKNOWN_NAME,
+            ),
+            provider_mappings={
+                ProviderMapping(
+                    item_id=f"{PODCAST_EPISODE_PREFIX}{plex_track.key}",
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                    url=plex_track.getWebURL(self._baseurl),
+                    audio_format=AudioFormat(content_type=content_type),
+                )
+            },
+        )
+        if thumb := plex_track.firstAttr("thumb", "parentThumb", "grandparentThumb"):
+            episode.metadata.images = UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=thumb,
+                        provider=self.instance_id,
+                        remotely_accessible=False,
+                    )
+                ]
+            )
+        return episode
 
     @use_cache(3600)  # Cache for 1 hour
     async def search(
@@ -1001,13 +1402,315 @@ class PlexProvider(MusicProvider):
                 yield await self._parse_track(plex_track)
             offset += page_size
 
+    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook, None]:
+        """Retrieve all library audiobooks from the configured Plex audiobook section."""
+        if self._get_library_type() != LIBRARY_TYPE_AUDIOBOOKS:
+            return
+        try:
+            albums_obj = await self._run_async(self._plex_library.albums)
+        except Exception:
+            self.logger.exception("Failed to list albums from audiobook library")
+            return
+        self.logger.debug(
+            "Found %d albums in audiobook library '%s'",
+            len(albums_obj),
+            self._plex_library.title,
+        )
+        for album in albums_obj:
+            try:
+                yield await self._parse_audiobook(album, include_chapters=False)
+            except Exception:
+                self.logger.warning(
+                    "Failed to parse audiobook album '%s' (key=%s); skipping",
+                    getattr(album, "title", "[unknown]"),
+                    getattr(album, "key", "[no key]"),
+                    exc_info=True,
+                )
+
+    @use_cache(3600 * 3)  # Cache for 3 hours
+    async def get_audiobook(self, prov_audiobook_id: str) -> Audiobook:
+        """Get full audiobook details (including chapters) by id."""
+        if self._get_library_type() != LIBRARY_TYPE_AUDIOBOOKS:
+            msg = "Audiobook library not configured"
+            raise MediaNotFoundError(msg)
+        album_key = prov_audiobook_id.removeprefix(AUDIOBOOK_PREFIX)
+        try:
+            plex_album = cast(
+                "PlexAlbum",
+                await self._run_async(self._plex_library.fetchItem, album_key, PlexAlbum),
+            )
+        except plexapi.exceptions.NotFound:
+            msg = f"Audiobook {prov_audiobook_id} not found"
+            raise MediaNotFoundError(msg)
+        return await self._parse_audiobook(plex_album, include_chapters=True)
+
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+        """Retrieve all library podcasts from the configured Plex podcast section."""
+        if self._get_library_type() != LIBRARY_TYPE_PODCASTS:
+            return
+        try:
+            albums_obj = await self._run_async(self._plex_library.albums)
+        except Exception:
+            self.logger.exception("Failed to list albums from podcast library")
+            return
+        for album in albums_obj:
+            try:
+                yield await self._parse_podcast(album, include_episodes=False)
+            except Exception:
+                self.logger.warning(
+                    "Failed to parse podcast album '%s' (key=%s); skipping",
+                    getattr(album, "title", "[unknown]"),
+                    getattr(album, "key", "[no key]"),
+                    exc_info=True,
+                )
+
+    @use_cache(3600 * 3)  # Cache for 3 hours
+    async def get_podcast(self, prov_podcast_id: str) -> Podcast:
+        """Get full podcast details (including episodes) by id."""
+        if self._get_library_type() != LIBRARY_TYPE_PODCASTS:
+            msg = "Podcast library not configured"
+            raise MediaNotFoundError(msg)
+        album_key = prov_podcast_id.removeprefix(PODCAST_PREFIX)
+        try:
+            plex_album = cast(
+                "PlexAlbum",
+                await self._run_async(self._plex_library.fetchItem, album_key, PlexAlbum),
+            )
+        except plexapi.exceptions.NotFound:
+            msg = f"Podcast {prov_podcast_id} not found"
+            raise MediaNotFoundError(msg)
+        return await self._parse_podcast(plex_album, include_episodes=True)
+
+    async def get_podcast_episodes(
+        self, prov_podcast_id: str
+    ) -> AsyncGenerator[PodcastEpisode, None]:
+        """Get all PodcastEpisodes for given podcast id."""
+        if self._get_library_type() != LIBRARY_TYPE_PODCASTS:
+            return
+        album_key = prov_podcast_id.removeprefix(PODCAST_PREFIX)
+        try:
+            plex_album = cast(
+                "PlexAlbum",
+                await self._run_async(self._plex_library.fetchItem, album_key, PlexAlbum),
+            )
+        except plexapi.exceptions.NotFound:
+            msg = f"Podcast {prov_podcast_id} not found"
+            raise MediaNotFoundError(msg)
+        for episode in await self._build_podcast_episodes(plex_album):
+            yield episode
+
+    @use_cache(3600 * 3)  # Cache for 3 hours
+    async def get_podcast_episode(self, prov_episode_id: str) -> PodcastEpisode:
+        """Get full podcast episode details by id."""
+        if self._get_library_type() != LIBRARY_TYPE_PODCASTS:
+            msg = "Podcast library not configured"
+            raise MediaNotFoundError(msg)
+        track_key = prov_episode_id.removeprefix(PODCAST_EPISODE_PREFIX)
+        try:
+            plex_track = cast(
+                "PlexTrack",
+                await self._run_async(self._plex_library.fetchItem, track_key, PlexTrack),
+            )
+        except plexapi.exceptions.NotFound:
+            msg = f"Podcast episode {prov_episode_id} not found"
+            raise MediaNotFoundError(msg)
+        return await self._parse_podcast_episode(plex_track)
+
+    async def get_resume_position(
+        self, item_id: str, media_type: MediaType
+    ) -> tuple[bool, int, datetime | None]:
+        """Get progress (resume point) details for the given audiobook or podcast.
+
+        :param item_id: provider item id (e.g. "audiobook:<plex_key>").
+        :param media_type: the media type (AUDIOBOOK or PODCAST).
+        :return: (fully_played, position_ms, timestamp)
+        """
+        library_type = self._get_library_type()
+        if media_type == MediaType.AUDIOBOOK and library_type == LIBRARY_TYPE_AUDIOBOOKS:
+            album_key = item_id.removeprefix(AUDIOBOOK_PREFIX)
+        elif media_type == MediaType.PODCAST and library_type == LIBRARY_TYPE_PODCASTS:
+            album_key = item_id.removeprefix(PODCAST_PREFIX)
+        elif media_type == MediaType.PODCAST_EPISODE and library_type == LIBRARY_TYPE_PODCASTS:
+            episode_key = item_id.removeprefix(PODCAST_EPISODE_PREFIX)
+            plex_track = cast(
+                "PlexTrack",
+                await self._run_async(self._plex_library.fetchItem, episode_key, PlexTrack),
+            )
+            # Resume position lives on the parent album; delegate to it.
+            album_key = str(plex_track.parentKey)
+        else:
+            raise NotImplementedError
+        try:
+            plex_album = cast(
+                "PlexAlbum",
+                await self._run_async(self._plex_library.fetchItem, album_key, PlexAlbum),
+            )
+        except plexapi.exceptions.NotFound:
+            msg = f"Item {item_id} not found"
+            raise MediaNotFoundError(msg)
+
+        try:
+            await self._run_async(plex_album.reload)
+        except (plexapi.exceptions.PlexApiException, requests.exceptions.RequestException):
+            self.logger.warning(
+                "Failed to reload metadata for position check (%s), using cached metadata",
+                item_id,
+            )
+
+        fully_played = bool(getattr(plex_album, "viewCount", 0) > 0)
+        timestamp = getattr(plex_album, "lastViewedAt", None)
+        if timestamp is not None and timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=UTC)
+
+        resume_position_ms = await self._calc_resume_position_ms(plex_album, fully_played)
+        return fully_played, resume_position_ms, timestamp
+
+    async def _calc_resume_position_ms(self, plex_album: PlexAlbum, fully_played: bool) -> int:
+        """Calculate resume position from per-track viewOffset values."""
+        plex_tracks = cast("list[PlexTrack]", await self._run_async(plex_album.tracks))
+        plex_tracks.sort(key=lambda t: (t.parentIndex or 0, t.trackNumber or 0))
+
+        # Per-track durations and viewOffset are in milliseconds (Plex native).
+        resume_position_ms = 0
+        cumulative_ms = 0
+        for plex_track in plex_tracks:
+            track_offset = getattr(plex_track, "viewOffset", 0) or 0
+            if track_offset > 0:
+                # Use the last non-zero offset — for sequential listening this
+                # is the final playback position; it also handles non-linear
+                # skipping better than first-match.
+                resume_position_ms = cumulative_ms + track_offset
+            cumulative_ms += getattr(plex_track, "duration", 0) or 0
+
+        if resume_position_ms == 0 and fully_played:
+            album_duration = getattr(plex_album, "duration", 0) or 0
+            resume_position_ms = int(album_duration)
+
+        return resume_position_ms
+
+    async def on_played(
+        self,
+        media_type: MediaType,
+        prov_item_id: str,
+        fully_played: bool,
+        position: int,
+        media_item: MediaItemType,
+        is_playing: bool = False,
+    ) -> None:
+        """Handle callback when an audiobook or podcast has been played.
+
+        Syncs progress back to the Plex server using the timeline/progress API.
+
+        :param media_type: The media type (AUDIOBOOK or PODCAST).
+        :param prov_item_id: The provider-specific item id.
+        :param fully_played: True when the item has been played to the end.
+        :param position: Last known position in seconds.
+        :param media_item: The full media item details.
+        :param is_playing: True when currently playing.
+        """
+        library_type = self._get_library_type()
+        if media_type == MediaType.AUDIOBOOK and library_type == LIBRARY_TYPE_AUDIOBOOKS:
+            album_key = prov_item_id.removeprefix(AUDIOBOOK_PREFIX)
+        elif media_type == MediaType.PODCAST and library_type == LIBRARY_TYPE_PODCASTS:
+            album_key = prov_item_id.removeprefix(PODCAST_PREFIX)
+        elif media_type == MediaType.PODCAST_EPISODE and library_type == LIBRARY_TYPE_PODCASTS:
+            episode_key = prov_item_id.removeprefix(PODCAST_EPISODE_PREFIX)
+            plex_track = cast(
+                "PlexTrack",
+                await self._run_async(self._plex_library.fetchItem, episode_key, PlexTrack),
+            )
+            album_key = str(plex_track.parentKey)
+        else:
+            return
+
+        try:
+            plex_album = cast(
+                "PlexAlbum",
+                await self._run_async(self._plex_library.fetchItem, album_key, PlexAlbum),
+            )
+        except plexapi.exceptions.NotFound:
+            self.logger.warning(
+                "Failed to fetch %s %s for played sync", media_type.value, prov_item_id
+            )
+            return
+        except Exception:
+            self.logger.warning(
+                "Failed to fetch %s %s for played sync",
+                media_type.value,
+                prov_item_id,
+                exc_info=True,
+            )
+            return
+
+        if fully_played:
+            await self._run_async(plex_album.markPlayed)
+            self.logger.debug("Marked %s %s as played in Plex", media_type.value, prov_item_id)
+            return
+
+        if position <= 0:
+            await self._run_async(plex_album.markUnplayed)
+            self.logger.debug("Marked %s %s as unplayed in Plex", media_type.value, prov_item_id)
+            return
+
+        try:
+            target_track, target_offset_ms = await self._find_track_for_position(
+                plex_album, position
+            )
+            if target_track is None:
+                return
+
+            state = "playing" if is_playing else "paused"
+            # updateTimeline expects time in milliseconds (Plex native unit)
+            await self._run_async(
+                target_track.updateTimeline,
+                target_offset_ms,
+                state=state,
+                duration=getattr(target_track, "duration", None),
+            )
+            self.logger.debug(
+                "Synced %s %s progress to Plex: track %s at %dms (%s)",
+                media_type.value,
+                prov_item_id,
+                target_track.title,
+                target_offset_ms,
+                state,
+            )
+        except Exception:
+            self.logger.warning(
+                "Failed to sync %s %s progress to Plex",
+                media_type.value,
+                prov_item_id,
+                exc_info=True,
+            )
+
+    async def _find_track_for_position(
+        self, plex_album: PlexAlbum, position: int
+    ) -> tuple[PlexTrack | None, int]:
+        """Find the track and offset (ms) corresponding to the given position (s)."""
+        plex_tracks = cast("list[PlexTrack]", await self._run_async(plex_album.tracks))
+        plex_tracks.sort(key=lambda t: (t.parentIndex or 0, t.trackNumber or 0))
+
+        position_ms = position * 1000
+        cumulative_ms = 0
+        for plex_track in plex_tracks:
+            track_duration = getattr(plex_track, "duration", 0) or 0
+            if cumulative_ms + track_duration > position_ms:
+                return plex_track, position_ms - cumulative_ms
+            cumulative_ms += track_duration
+
+        if plex_tracks:
+            # Position is past all tracks — clamp to end of the last track.
+            last_track = plex_tracks[-1]
+            last_duration = getattr(last_track, "duration", 0) or 0
+            return last_track, last_duration
+
+        return None, 0
+
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_album(self, prov_album_id: str) -> Album:
         """Get full album details by id."""
-        if plex_album := await self._get_data(prov_album_id, PlexAlbum):
-            return await self._parse_album(plex_album)
-        msg = f"Item {prov_album_id} not found"
-        raise MediaNotFoundError(msg)
+        plex_album = await self._get_data(prov_album_id, PlexAlbum)
+        return await self._parse_album(plex_album)
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
@@ -1034,18 +1737,14 @@ class PlexProvider(MusicProvider):
             msg = f"Artist not found: {prov_artist_id}"
             raise MediaNotFoundError(msg)
 
-        if plex_artist := await self._get_data(prov_artist_id, PlexArtist):
-            return await self._parse_artist(plex_artist)
-        msg = f"Item {prov_artist_id} not found"
-        raise MediaNotFoundError(msg)
+        plex_artist = await self._get_data(prov_artist_id, PlexArtist)
+        return await self._parse_artist(plex_artist)
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
-        if plex_track := await self._get_data(prov_track_id, PlexTrack):
-            return await self._parse_track(plex_track)
-        msg = f"Item {prov_track_id} not found"
-        raise MediaNotFoundError(msg)
+        plex_track = await self._get_data(prov_track_id, PlexTrack)
+        return await self._parse_track(plex_track)
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
@@ -1055,17 +1754,17 @@ class PlexProvider(MusicProvider):
             # Extract the collection key
             collection_key = prov_playlist_id.replace("collection:", "")
             # Fetch the collection
-            if plex_collection := await self._run_async(
-                self._plex_library.fetchItem, collection_key
-            ):
-                return await self._parse_collection(plex_collection)
-            msg = f"Collection {prov_playlist_id} not found"
-            raise MediaNotFoundError(msg)
+            try:
+                plex_collection = await self._run_async(
+                    self._plex_library.fetchItem, collection_key
+                )
+            except plexapi.exceptions.NotFound:
+                msg = f"Collection {prov_playlist_id} not found"
+                raise MediaNotFoundError(msg)
+            return await self._parse_collection(plex_collection)
 
-        if plex_playlist := await self._get_data(prov_playlist_id, PlexPlaylist):
-            return await self._parse_playlist(plex_playlist)
-        msg = f"Item {prov_playlist_id} not found"
-        raise MediaNotFoundError(msg)
+        plex_playlist = await self._get_data(prov_playlist_id, PlexPlaylist)
+        return await self._parse_playlist(plex_playlist)
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
@@ -1080,8 +1779,11 @@ class PlexProvider(MusicProvider):
             # Extract the collection key
             collection_key = prov_playlist_id.replace("collection:", "")
             # Fetch the collection
-            plex_collection = await self._run_async(self._plex_library.fetchItem, collection_key)
-            if not plex_collection:
+            try:
+                plex_collection = await self._run_async(
+                    self._plex_library.fetchItem, collection_key
+                )
+            except plexapi.exceptions.NotFound:
                 msg = f"Collection {prov_playlist_id} not found"
                 raise MediaNotFoundError(msg)
             if not (collection_items := await self._run_async(plex_collection.items)):
@@ -1271,11 +1973,116 @@ class PlexProvider(MusicProvider):
             self.logger.warning("Error getting recommendations from Plex: %s", err)
             return []
 
+    async def _get_audiobook_stream_details(self, item_id: str) -> StreamDetails:
+        """Build multi-part StreamDetails for an audiobook (one part per Plex track)."""
+        if self._get_library_type() != LIBRARY_TYPE_AUDIOBOOKS:
+            msg = "Library not configured for audiobooks"
+            raise MediaNotFoundError(msg)
+        album_key = item_id.removeprefix(AUDIOBOOK_PREFIX)
+        try:
+            plex_album = cast(
+                "PlexAlbum",
+                await self._run_async(self._plex_library.fetchItem, album_key, PlexAlbum),
+            )
+        except plexapi.exceptions.NotFound:
+            msg = f"Audiobook {item_id} not found"
+            raise MediaNotFoundError(msg)
+
+        plex_tracks = cast("list[PlexTrack]", await self._run_async(plex_album.tracks))
+        plex_tracks.sort(key=lambda t: (t.parentIndex or 0, t.trackNumber or 0))
+
+        parts, total_duration, first_container = self._build_stream_parts(plex_tracks, item_id)
+        if not parts:
+            self.logger.error(
+                "Audiobook %s (%s) has no playable parts (%d tracks checked)",
+                item_id,
+                plex_album.title,
+                len(plex_tracks),
+            )
+            msg = f"Audiobook {item_id} has no playable parts"
+            raise MediaNotFoundError(msg)
+
+        self.logger.debug(
+            "Built StreamDetails for audiobook %s with %d parts, total_duration=%.1fs",
+            item_id,
+            len(parts),
+            total_duration,
+        )
+
+        content_type = (
+            ContentType.try_parse(first_container) if first_container else ContentType.UNKNOWN
+        )
+
+        return StreamDetails(
+            provider=self.instance_id,
+            item_id=item_id,
+            media_type=MediaType.AUDIOBOOK,
+            audio_format=AudioFormat(content_type=content_type),
+            stream_type=StreamType.HTTP,
+            duration=int(total_duration),
+            path=parts[0].path if len(parts) == 1 else parts,
+            can_seek=True,
+            allow_seek=True,
+        )
+
+    def _build_stream_parts(
+        self, plex_tracks: list[PlexTrack], item_id: str
+    ) -> tuple[list[MultiPartPath], float, str | None]:
+        """Convert Plex tracks to MultiPartPath entries for streaming."""
+        parts: list[MultiPartPath] = []
+        total_duration = 0.0
+        first_container: str | None = None
+        for plex_track in plex_tracks:
+            media = self._track_media_or_log(plex_track, item_id)
+            if media is None:
+                continue
+            if first_container is None and media.container:
+                first_container = media.container
+            media_part: PlexMediaPart = media.parts[0]
+            url = self._plex_server.url(f"{media_part.key}?download=1", True)
+            duration_s = (plex_track.duration or 0) / 1000.0
+            parts.append(MultiPartPath(path=url, duration=duration_s))
+            total_duration += duration_s
+            self.logger.debug(
+                "Added audiobook part: track '%s' (%s) duration=%.1fs url=%s",
+                plex_track.title,
+                plex_track.key,
+                duration_s,
+                url,
+            )
+        return parts, total_duration, first_container
+
+    def _track_media_or_log(self, plex_track: PlexTrack, item_id: str) -> PlexMedia | None:
+        """Return the first PlexMedia for a track, or log and return None if unavailable."""
+        if not plex_track.media:
+            self.logger.debug(
+                "Skipping track '%s' (key=%s) in audiobook %s: no media",
+                plex_track.title,
+                plex_track.key,
+                item_id,
+            )
+            return None
+        media: PlexMedia = plex_track.media[0]
+        if not media.parts:
+            self.logger.debug(
+                "Skipping track '%s' (key=%s) in audiobook %s: media has no parts",
+                plex_track.title,
+                plex_track.key,
+                item_id,
+            )
+            return None
+        return media
+
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
-        """Get streamdetails for a track."""
+        """Get streamdetails for a track/audiobook/podcast episode."""
+        if media_type == MediaType.AUDIOBOOK:
+            return await self._get_audiobook_stream_details(item_id)
+        if media_type == MediaType.PODCAST_EPISODE:
+            return await self._get_podcast_episode_stream_details(item_id)
+
         plex_track = await self._get_data(item_id, PlexTrack)
-        if not plex_track or not plex_track.media:
-            msg = f"track {item_id} not found"
+        if not plex_track.media:
+            msg = f"track {item_id} has no media"
             raise MediaNotFoundError(msg)
 
         media: PlexMedia = plex_track.media[0]
@@ -1319,6 +2126,47 @@ class PlexProvider(MusicProvider):
             stream_details.audio_format.bit_depth = media_info.bits_per_sample
 
         return stream_details
+
+    async def _get_podcast_episode_stream_details(self, item_id: str) -> StreamDetails:
+        """Build streamdetails for a single podcast episode from a Plex track."""
+        if self._get_library_type() != LIBRARY_TYPE_PODCASTS:
+            msg = "Library not configured for podcasts"
+            raise MediaNotFoundError(msg)
+        track_key = item_id.removeprefix(PODCAST_EPISODE_PREFIX)
+        try:
+            plex_track = cast(
+                "PlexTrack",
+                await self._run_async(self._plex_library.fetchItem, track_key, PlexTrack),
+            )
+        except plexapi.exceptions.NotFound:
+            msg = f"Podcast episode {item_id} not found"
+            raise MediaNotFoundError(msg)
+
+        if not plex_track.media:
+            msg = f"Podcast episode {item_id} has no media"
+            raise MediaNotFoundError(msg)
+
+        media: PlexMedia = plex_track.media[0]
+        if not media.parts:
+            msg = f"Podcast episode {item_id} has no playable media parts"
+            raise MediaNotFoundError(msg)
+        content_type = (
+            ContentType.try_parse(media.container) if media.container else ContentType.UNKNOWN
+        )
+        media_part: PlexMediaPart = media.parts[0]
+        download_url = self._plex_server.url(f"{media_part.key}?download=1", True)
+
+        return StreamDetails(
+            provider=self.instance_id,
+            item_id=item_id,
+            media_type=MediaType.PODCAST_EPISODE,
+            audio_format=AudioFormat(content_type=content_type),
+            stream_type=StreamType.HTTP,
+            duration=plex_track.duration,
+            path=download_url,
+            can_seek=True,
+            allow_seek=True,
+        )
 
     async def get_myplex_account_and_refresh_token(self, auth_token: str) -> MyPlexAccount:
         """Get a MyPlexAccount object and refresh the token if needed."""

--- a/music_assistant/providers/plex/helpers.py
+++ b/music_assistant/providers/plex/helpers.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, cast
+import dataclasses
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
 
 import requests
+from music_assistant_models.enums import MediaType, ProviderFeature
 from plexapi.gdm import GDM
 from plexapi.library import LibrarySection as PlexLibrarySection
 from plexapi.library import MusicSection as PlexMusicSection
@@ -14,8 +18,131 @@ from plexapi.server import PlexServer
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
 
+LOGGER = logging.getLogger(__name__)
 
-async def get_libraries(
+# Library type constants
+CONF_LIBRARY_TYPE = "library_type"
+LIBRARY_TYPE_MUSIC = "music"
+LIBRARY_TYPE_AUDIOBOOKS = "audiobooks"
+LIBRARY_TYPE_PODCASTS = "podcasts"
+
+# Feature sets per library type
+SUPPORTED_FEATURES: set[ProviderFeature] = {
+    ProviderFeature.LIBRARY_ARTISTS,
+    ProviderFeature.LIBRARY_ALBUMS,
+    ProviderFeature.LIBRARY_TRACKS,
+    ProviderFeature.LIBRARY_PLAYLISTS,
+    ProviderFeature.FAVORITE_ALBUMS_EDIT,
+    ProviderFeature.FAVORITE_TRACKS_EDIT,
+    ProviderFeature.BROWSE,
+    ProviderFeature.SEARCH,
+    ProviderFeature.ARTIST_ALBUMS,
+    ProviderFeature.ARTIST_TOPTRACKS,
+    ProviderFeature.SIMILAR_TRACKS,
+    ProviderFeature.RECOMMENDATIONS,
+}
+
+AUDIOBOOK_FEATURES: set[ProviderFeature] = {
+    ProviderFeature.LIBRARY_AUDIOBOOKS,
+    ProviderFeature.BROWSE,
+    ProviderFeature.SEARCH,
+    ProviderFeature.RECOMMENDATIONS,
+}
+
+PODCAST_FEATURES: set[ProviderFeature] = {
+    ProviderFeature.LIBRARY_PODCASTS,
+    ProviderFeature.BROWSE,
+    ProviderFeature.SEARCH,
+    ProviderFeature.RECOMMENDATIONS,
+}
+
+# Mapping of library type to the media types it supports
+LIBRARY_TYPE_TO_MEDIA_TYPES: dict[str, tuple[MediaType, ...]] = {
+    LIBRARY_TYPE_MUSIC: (MediaType.ARTIST, MediaType.ALBUM, MediaType.TRACK, MediaType.PLAYLIST),
+    LIBRARY_TYPE_AUDIOBOOKS: (MediaType.AUDIOBOOK,),
+    LIBRARY_TYPE_PODCASTS: (MediaType.PODCAST, MediaType.PODCAST_EPISODE),
+}
+
+
+def get_supported_features(
+    values: dict[str, Any] | None,
+) -> set[ProviderFeature]:
+    """Return supported features adjusted for the selected library type."""
+    library_type = str((values or {}).get(CONF_LIBRARY_TYPE, LIBRARY_TYPE_MUSIC))
+    if library_type == LIBRARY_TYPE_AUDIOBOOKS:
+        return AUDIOBOOK_FEATURES.copy()
+    if library_type == LIBRARY_TYPE_PODCASTS:
+        return PODCAST_FEATURES.copy()
+    return SUPPORTED_FEATURES.copy()
+
+
+@dataclass(frozen=True)
+class PlexSectionInfo:
+    """Metadata about a Plex library section for config auto-detection."""
+
+    display_name: str
+    section_title: str
+    server_name: str
+    section_type: str
+    is_tracking_progress: bool
+
+
+def _library_tracks_progress(section: PlexLibrarySection) -> bool:
+    """Check if a music section stores per-track progress (resumable content).
+
+    Uses the ``enableTrackOffsets`` library preference ("Store track progress"
+    advanced setting). When enabled, Plex treats tracks as resumable content,
+    which is characteristic of long-form audio libraries such as audiobooks and podcasts.
+    """
+    try:
+        settings = section.settings()
+        section_title = getattr(section, "title", "<unknown>")
+        LOGGER.debug(
+            "Library '%s' settings: %r",
+            section_title,
+            [{"id": s.id, "value": s.value, "type": getattr(s, "type", "?")} for s in settings],
+        )
+        for setting in settings:
+            if setting.id == "enableTrackOffsets":
+                # Plex may return the value as a bool or string.
+                val = setting.value
+                is_enabled = val is True or (isinstance(val, str) and val.lower() in ("true", "1"))
+                if is_enabled:
+                    LOGGER.debug(
+                        "Library '%s' flagged as resumable (enableTrackOffsets=%s)",
+                        section_title,
+                        val,
+                    )
+                    return True
+        LOGGER.debug(
+            "Library '%s' not flagged as resumable (enableTrackOffsets absent or disabled)",
+            section_title,
+        )
+    except Exception as err:
+        LOGGER.warning(
+            "Failed to read library settings for '%s': %s",
+            getattr(section, "title", "<unknown>"),
+            err,
+        )
+    return False
+
+
+def extract_library_name(conf_value: str) -> str:
+    """Extract the library name from a config value that may include server name.
+
+    Config values from get_config_entries include the server prefix:
+    '<server name> / <library name>'. When typed manually by the user,
+    the value may just be '<library name>'.
+
+    :param conf_value: The raw config value for a library setting.
+    :return: The library name (without server prefix if present).
+    """
+    if " / " in conf_value:
+        return conf_value.split(" / ", 1)[1].strip()
+    return conf_value.strip()
+
+
+async def get_section_info(
     mass: MusicAssistant,
     auth_token: str | None,
     local_server_ssl: bool,
@@ -23,11 +150,11 @@ async def get_libraries(
     local_server_port: str,
     local_server_verify_cert: bool,
     instance_id: str | None = None,
-) -> list[str]:
+) -> list[PlexSectionInfo]:
     """
-    Get all music libraries for all plex servers.
+    Get metadata for all music library sections on the Plex server.
 
-    Returns a list of Library names in format ['servername / library name', ...]
+    Returns PlexSectionInfo objects including auto-detection hints for resumable content.
 
     :param mass: MusicAssistant instance.
     :param auth_token: Authentication token for Plex server.
@@ -37,45 +164,65 @@ async def get_libraries(
     :param local_server_verify_cert: Whether to verify SSL certificate.
     :param instance_id: Provider instance ID to use for cache isolation.
     """
-    cache_key = "plex_libraries"
+    cache_key = "plex_section_info"
 
-    def _get_libraries() -> list[str]:
-        # create a listing of available music libraries on all servers
-        all_libraries: list[str] = []
+    def _get_section_info() -> list[PlexSectionInfo]:
         session = requests.Session()
         session.verify = local_server_verify_cert
         local_server_protocol = "https" if local_server_ssl else "http"
         plex_server: PlexServer
-        if auth_token is None:
-            plex_server = PlexServer(
-                f"{local_server_protocol}://{local_server_ip}:{local_server_port}"
+        try:
+            if auth_token is None:
+                plex_server = PlexServer(
+                    f"{local_server_protocol}://{local_server_ip}:{local_server_port}"
+                )
+            else:
+                plex_server = PlexServer(
+                    f"{local_server_protocol}://{local_server_ip}:{local_server_port}",
+                    auth_token,
+                    session=session,
+                )
+        except requests.exceptions.ConnectionError as err:
+            LOGGER.warning(
+                "Could not connect to Plex server at %s:%s: %s",
+                local_server_ip,
+                local_server_port,
+                err,
             )
-        else:
-            plex_server = PlexServer(
-                f"{local_server_protocol}://{local_server_ip}:{local_server_port}",
-                auth_token,
-                session=session,
-            )
+            return []
+        results: list[PlexSectionInfo] = []
         for media_section in cast("list[PlexLibrarySection]", plex_server.library.sections()):
             if media_section.type != PlexMusicSection.TYPE:
                 continue
-            # TODO: figure out what plex uses as stable id and use that instead of names
-            all_libraries.append(f"{plex_server.friendlyName} / {media_section.title}")
-        return all_libraries
+            results.append(
+                PlexSectionInfo(
+                    display_name=f"{plex_server.friendlyName} / {media_section.title}",
+                    section_title=media_section.title,
+                    server_name=plex_server.friendlyName,
+                    section_type=media_section.type,
+                    is_tracking_progress=_library_tracks_progress(media_section),
+                )
+            )
+        return results
 
     if cache := await mass.cache.get(
         cache_key, checksum=auth_token, provider=instance_id or local_server_ip
     ):
-        return cast("list[str]", cache)
+        if isinstance(cache, list) and cache and all(isinstance(item, dict) for item in cache):
+            try:
+                return [PlexSectionInfo(**item) for item in cache]
+            except TypeError:
+                LOGGER.debug("Discarding corrupt plex_section_info cache entry", exc_info=True)
+        else:
+            LOGGER.debug("Discarding corrupt plex_section_info cache entry: %r", type(cache))
 
-    result = await asyncio.to_thread(_get_libraries)
-    # use short expiration for in-memory cache
+    result = await asyncio.to_thread(_get_section_info)
     await mass.cache.set(
         cache_key,
-        result,
+        [dataclasses.asdict(section) for section in result],
         checksum=auth_token,
         expiration=3600,
-        provider=instance_id or "default",
+        provider=instance_id or local_server_ip,
     )
     return result
 

--- a/tests/providers/plex/test_audiobook_helpers.py
+++ b/tests/providers/plex/test_audiobook_helpers.py
@@ -1,0 +1,216 @@
+"""Unit tests for the Plex Music Provider audiobook helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from music_assistant.providers.plex.helpers import (
+    PlexSectionInfo,
+    _library_tracks_progress,
+    extract_library_name,
+)
+
+
+class TestPlexSectionInfo:
+    """Tests for PlexSectionInfo dataclass."""
+
+    def test_from_dict_kwargs_reconstruction(self) -> None:
+        """PlexSectionInfo can be reconstructed from a dict via **kwargs."""
+        data: dict[str, Any] = {
+            "display_name": "My Server / Audiobooks",
+            "section_title": "Audiobooks",
+            "server_name": "My Server",
+            "section_type": "artist",
+            "is_tracking_progress": True,
+        }
+        info = PlexSectionInfo(**data)
+        assert info.display_name == "My Server / Audiobooks"
+        assert info.section_title == "Audiobooks"
+        assert info.is_tracking_progress is True
+
+
+class TestExtractLibraryName:
+    """Tests for extract_library_name() config value parser."""
+
+    @pytest.mark.parametrize(
+        ("input_value", "expected"),
+        [
+            ("My Server / Music", "Music"),
+            ("My Server / Audiobooks", "Audiobooks"),
+            ("  My Server  /  Audiobooks  ", "Audiobooks"),
+            ("Audiobooks", "Audiobooks"),
+            ("  Audiobooks  ", "Audiobooks"),
+        ],
+    )
+    def test_extract_library_name(self, input_value: str, expected: str) -> None:
+        """Extract library name handles both 'server / name' and plain 'name' formats."""
+        assert extract_library_name(input_value) == expected
+
+    def test_empty_string_returns_empty(self) -> None:
+        """Empty string should be returned as-is (not an error)."""
+        assert extract_library_name("") == ""
+
+
+class TestLibraryUsesTrackProgress:
+    """Tests for     _library_tracks_progress() using storeTrackProgress preference."""
+
+    class FakeSetting:
+        """Minimal Setting stub for unit tests."""
+
+        def __init__(self, setting_id: str, value: bool) -> None:
+            """Initialize fake setting."""
+            self.id = setting_id
+            self.value = value
+
+    class FakeSection:
+        """Minimal LibrarySection stub for unit tests."""
+
+        def __init__(self, title: str, settings_data: list[tuple[str, bool]]) -> None:
+            """Initialize fake section with given title and settings."""
+            self.title = title
+            self._settings = [
+                TestLibraryUsesTrackProgress.FakeSetting(setting_id, value)
+                for setting_id, value in settings_data
+            ]
+
+        def settings(self) -> list[TestLibraryUsesTrackProgress.FakeSetting]:
+            """Return fake settings list."""
+            return self._settings
+
+    def test_enable_track_offsets_enabled(self) -> None:
+        """Section with enableTrackOffsets=True should be flagged as resumable."""
+        section = self.FakeSection("Audiobooks", [("enableTrackOffsets", True)])
+        assert _library_tracks_progress(section) is True  # type: ignore[arg-type]
+
+    def test_enable_track_offsets_disabled(self) -> None:
+        """Section with enableTrackOffsets=False should not be flagged."""
+        section = self.FakeSection("Music", [("enableTrackOffsets", False)])
+        assert _library_tracks_progress(section) is False  # type: ignore[arg-type]
+
+    def test_setting_absent(self) -> None:
+        """Section without enableTrackOffsets should not be flagged."""
+        section = self.FakeSection("Music", [("someOtherSetting", True)])
+        assert _library_tracks_progress(section) is False  # type: ignore[arg-type]
+
+    def test_empty_settings(self) -> None:
+        """Section with no settings should not raise."""
+        section = self.FakeSection("Music", [])
+        assert _library_tracks_progress(section) is False  # type: ignore[arg-type]
+
+    def test_settings_call_raises(self) -> None:
+        """If settings() raises, should gracefully fall back to False."""
+
+        class BrokenSection:
+            """Stub that raises on settings() call."""
+
+            title = "Broken"
+
+            def settings(self) -> list[Any]:
+                """Simulate a failing settings call."""
+                raise RuntimeError("Network error")
+
+        assert _library_tracks_progress(BrokenSection()) is False  # type: ignore[arg-type]
+
+
+class TestGetSectionInfo:
+    """Tests for get_section_info audiobook-first behaviour."""
+
+    class FakePlexServer:
+        """Minimal PlexServer stub."""
+
+        def __init__(self, sections: list[Any]) -> None:
+            """Initialize fake server with given sections."""
+            self.friendlyName = "Test Server"
+            self._sections = sections
+
+        def library(self) -> TestGetSectionInfo.FakeLibrary:
+            """Return fake library."""
+            return TestGetSectionInfo.FakeLibrary(self._sections)
+
+    class FakeLibrary:
+        """Minimal Library stub."""
+
+        def __init__(self, sections: list[Any]) -> None:
+            """Initialize fake library with given sections."""
+            self._sections = sections
+
+        def sections(self) -> list[Any]:
+            """Return contained sections."""
+            return self._sections
+
+    class FakeMusicSection:
+        """Minimal MusicSection stub."""
+
+        TYPE = "artist"
+
+        def __init__(
+            self, title: str, enable_track_offsets: bool = False, section_type: str = "artist"
+        ) -> None:
+            """Initialize fake music section."""
+            self.title = title
+            self.type = section_type
+            self._enable_track_offsets = enable_track_offsets
+
+        def settings(self) -> list[TestLibraryUsesTrackProgress.FakeSetting]:
+            """Return fake settings for this section."""
+            if self._enable_track_offsets:
+                return [TestLibraryUsesTrackProgress.FakeSetting("enableTrackOffsets", True)]
+            return []
+
+    def test_all_music_sections_with_flag_are_resume_content(self) -> None:
+        """All music sections with enableTrackOffsets=True should be flagged as resumable."""
+        sections = [
+            self.FakeMusicSection("Music (No Resume)"),
+            self.FakeMusicSection("Audiobooks", enable_track_offsets=True),
+            self.FakeMusicSection("More Audios", enable_track_offsets=True),
+        ]
+
+        # Build PlexSectionInfo manually to simulate get_section_info logic
+        results: list[PlexSectionInfo] = []
+        for section in sections:
+            if section.type != self.FakeMusicSection.TYPE:
+                continue
+            results.append(
+                PlexSectionInfo(
+                    display_name=f"Test Server / {section.title}",
+                    section_title=section.title,
+                    server_name="Test Server",
+                    section_type=section.type,
+                    is_tracking_progress=_library_tracks_progress(section),  # type: ignore[arg-type]
+                )
+            )
+
+        assert len(results) == 3
+        assert results[0].is_tracking_progress is False
+        assert results[1].is_tracking_progress is True
+        assert results[2].is_tracking_progress is True
+
+
+class TestGetSectionInfoLegacyFallback:
+    """Tests ensuring library-type filtering is still respected."""
+
+    class FakeMovieSection:
+        """Minimal non-music section stub."""
+
+        TYPE = "movie"
+
+        def __init__(self, title: str) -> None:
+            """Initialize fake movie section."""
+            self.title = title
+            self.type = "movie"
+
+        def settings(self) -> list[Any]:
+            """Return empty settings."""
+            return []
+
+    def test_non_music_sections_ignored(self) -> None:
+        """Non-music sections should be skipped entirely."""
+        movie_section = self.FakeMovieSection("Movies")
+        assert movie_section.type != "artist"
+        # Simulating the loop filter
+        results: list[bool] = []
+        if movie_section.type == "artist":
+            results.append(True)
+        assert len(results) == 0

--- a/tests/providers/plex/test_config_entries.py
+++ b/tests/providers/plex/test_config_entries.py
@@ -1,0 +1,211 @@
+"""Tests for get_config_entries to prevent recursion and validate defaults."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.providers.plex import CONF_LIBRARY_ID, get_config_entries
+from music_assistant.providers.plex.helpers import (
+    CONF_LIBRARY_TYPE,
+    LIBRARY_TYPE_AUDIOBOOKS,
+    LIBRARY_TYPE_MUSIC,
+    LIBRARY_TYPE_PODCASTS,
+    PlexSectionInfo,
+)
+
+
+def _make_mock_mass(
+    providers_config: dict[str, Any] | None = None,
+    sections: list[PlexSectionInfo] | None = None,
+) -> MagicMock:
+    """Build a MusicAssistant stub with configurable providers and section info."""
+    mass = MagicMock()
+    mass.config.get = MagicMock(return_value=providers_config or {})
+    mass.config.decrypt_string = MagicMock(return_value="token")
+    mass.cache.get = AsyncMock(return_value=None)
+    return mass
+
+
+async def test_get_config_entries_no_recursion_with_multiple_plex_instances() -> None:
+    """Calling get_config_entries should not recurse when multiple plex instances exist.
+
+    Regression test: using get_provider_configs(include_values=True) caused
+    infinite recursion because each call triggered get_config_entries for all
+    other plex instances.
+    """
+    raw_config = {
+        "plex-1": {
+            "domain": "plex",
+            "values": {
+                CONF_LIBRARY_ID: "Server / Audiobooks",
+                CONF_LIBRARY_TYPE: LIBRARY_TYPE_AUDIOBOOKS,
+            },
+        },
+        "plex-2": {
+            "domain": "plex",
+            "values": {
+                CONF_LIBRARY_ID: "Server / Music",
+                CONF_LIBRARY_TYPE: LIBRARY_TYPE_MUSIC,
+            },
+        },
+    }
+
+    sections = [
+        PlexSectionInfo(
+            display_name="Server / Audiobooks",
+            section_title="Audiobooks",
+            server_name="Server",
+            section_type="artist",
+            is_tracking_progress=True,
+        ),
+        PlexSectionInfo(
+            display_name="Server / Music",
+            section_title="Music",
+            server_name="Server",
+            section_type="artist",
+            is_tracking_progress=False,
+        ),
+        PlexSectionInfo(
+            display_name="Server / Podcasts",
+            section_title="Podcasts",
+            server_name="Server",
+            section_type="artist",
+            is_tracking_progress=True,
+        ),
+    ]
+
+    mass = _make_mock_mass(raw_config, sections)
+
+    with mock.patch(
+        "music_assistant.providers.plex.get_section_info",
+        new_callable=AsyncMock,
+        return_value=sections,
+    ):
+        # Call for a *new* instance (no instance_id) — this must not recurse
+        entries = await get_config_entries(
+            mass,
+            values={
+                "token": "encrypted",
+                "local_server_ip": "10.0.4.33",
+                "local_server_port": 32400,
+                "local_server_ssl": False,
+                "local_server_verify_cert": True,
+            },
+        )
+
+    # Verify we got entries back without hitting recursion
+    by_key = {e.key: e for e in entries}
+    assert CONF_LIBRARY_ID in by_key
+    assert CONF_LIBRARY_TYPE in by_key
+
+    library_entry = by_key[CONF_LIBRARY_ID]
+    # Default library should be the first *unclaimed* non-tracking library, A-Z
+    # Server / Music is claimed by plex-2, so Podcasts is the only unclaimed option
+    assert library_entry.default_value == "Server / Podcasts"
+
+    type_entry = by_key[CONF_LIBRARY_TYPE]
+    # Podcasts is a tracking library and an audiobook provider already exists -> Podcasts type
+    assert type_entry.default_value == LIBRARY_TYPE_PODCASTS
+
+
+async def test_get_config_entries_default_type_progress_tracking() -> None:
+    """Progress-tracking libraries default to Audiobooks (or Podcasts if one exists)."""
+    raw_config = {
+        "plex-1": {
+            "domain": "plex",
+            "values": {
+                CONF_LIBRARY_ID: "Server / Audiobooks",
+                CONF_LIBRARY_TYPE: LIBRARY_TYPE_AUDIOBOOKS,
+            },
+        },
+    }
+
+    sections = [
+        PlexSectionInfo(
+            display_name="Server / Audiobooks",
+            section_title="Audiobooks",
+            server_name="Server",
+            section_type="artist",
+            is_tracking_progress=True,
+        ),
+        PlexSectionInfo(
+            display_name="Server / More Audios",
+            section_title="More Audios",
+            server_name="Server",
+            section_type="artist",
+            is_tracking_progress=True,
+        ),
+    ]
+
+    mass = _make_mock_mass(raw_config, sections)
+
+    with mock.patch(
+        "music_assistant.providers.plex.get_section_info",
+        new_callable=AsyncMock,
+        return_value=sections,
+    ):
+        entries = await get_config_entries(
+            mass,
+            values={
+                "token": "encrypted",
+                "local_server_ip": "10.0.4.33",
+                "local_server_port": 32400,
+                "local_server_ssl": False,
+                "local_server_verify_cert": True,
+            },
+        )
+
+    by_key = {e.key: e for e in entries}
+
+    # Only unclaimed tracking library is "More Audios"
+    library_entry = by_key[CONF_LIBRARY_ID]
+    assert library_entry.default_value == "Server / More Audios"
+
+    # Audiobook provider already exists -> Podcasts
+    type_entry = by_key[CONF_LIBRARY_TYPE]
+    assert type_entry.default_value == LIBRARY_TYPE_PODCASTS
+
+
+async def test_get_config_entries_preserves_user_library_choice() -> None:
+    """When user has already selected a library, defaults are not overwritten."""
+    raw_config: dict[str, Any] = {}
+
+    sections = [
+        PlexSectionInfo(
+            display_name="Server / Music",
+            section_title="Music",
+            server_name="Server",
+            section_type="artist",
+            is_tracking_progress=False,
+        ),
+    ]
+
+    mass = _make_mock_mass(raw_config, sections)
+
+    with mock.patch(
+        "music_assistant.providers.plex.get_section_info",
+        new_callable=AsyncMock,
+        return_value=sections,
+    ):
+        entries = await get_config_entries(
+            mass,
+            instance_id="plex_test",
+            values={
+                "token": "encrypted",
+                "local_server_ip": "10.0.4.33",
+                "local_server_port": 32400,
+                "local_server_ssl": False,
+                "local_server_verify_cert": True,
+                CONF_LIBRARY_ID: "Server / Music",
+                CONF_LIBRARY_TYPE: LIBRARY_TYPE_MUSIC,
+            },
+        )
+
+    by_key = {e.key: e for e in entries}
+    library_entry = by_key[CONF_LIBRARY_ID]
+    type_entry = by_key[CONF_LIBRARY_TYPE]
+
+    assert library_entry.value == "Server / Music"
+    assert type_entry.value == LIBRARY_TYPE_MUSIC

--- a/tests/providers/plex/test_provider_methods.py
+++ b/tests/providers/plex/test_provider_methods.py
@@ -1,0 +1,902 @@
+"""Unit tests for Plex provider audiobook and podcast methods."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.errors import MediaNotFoundError
+
+from music_assistant.providers.plex import PlexProvider
+from music_assistant.providers.plex.helpers import get_supported_features
+
+LIBRARY_TYPE_AUDIOBOOKS = "audiobooks"
+LIBRARY_TYPE_MUSIC = "music"
+LIBRARY_TYPE_PODCASTS = "podcasts"
+
+
+def _make_provider(library_type: str = LIBRARY_TYPE_MUSIC) -> Any:
+    """Create a minimal PlexProvider instance for testing."""
+    mock_mass = MagicMock()
+    mock_mass.cache = MagicMock()
+
+    mock_config = MagicMock()
+    mock_config.instance_id = "plex_instance_1"
+
+    # Set up a proper dict-like values container so _get_library_type works
+    mock_config_values: dict[str, Any] = {
+        "library_type": library_type,
+        "log_level": "INFO",
+        "token": "local_auth",
+    }
+
+    class MockValue:
+        """Simple wrapper for mock config values."""
+
+        def __init__(self, val: Any) -> None:
+            self.value = val
+
+    mock_config.values = {k: MockValue(v) for k, v in mock_config_values.items()}
+    mock_config.get_value = lambda key: mock_config_values.get(key)
+
+    mock_manifest = MagicMock()
+    mock_manifest.type = "music"
+    mock_manifest.domain = "plex"
+
+    provider = PlexProvider(mock_mass, mock_manifest, mock_config)
+    provider._baseurl = "http://localhost:32400"
+    provider._plex_server = MagicMock()
+    provider._plex_library = MagicMock()
+    provider._myplex_account = MagicMock()
+
+    return provider
+
+
+class FakePlexTrack:
+    """Minimal PlexTrack stub for testing."""
+
+    def __init__(  # noqa: D107
+        self,
+        key: str = "/library/metadata/1",
+        title: str = "Track 1",
+        duration: int = 1000,
+        has_media: bool = True,
+        has_parts: bool = True,
+        parent_index: int | None = 1,
+        track_number: int | None = 1,
+        container: str | None = "mp3",
+        view_offset: int = 0,
+        parent_key: str = "/library/metadata/100",
+    ) -> None:
+        self.key = key
+        self.title = title
+        self.duration = duration
+        self.parentIndex = parent_index
+        self.trackNumber = track_number
+        self.parentKey = parent_key
+        self.viewOffset = view_offset
+        if has_media:
+            media = MagicMock()
+            media.container = container
+            media.parts = [MagicMock()] if has_parts else []
+            self.media = [media]
+        else:
+            self.media = []
+
+    def getWebURL(self, baseurl: str) -> str:  # noqa: N802, D102
+        return f"{baseurl}/web/index.html#!/server/item/{self.key}"
+
+    def firstAttr(self, *attrs: str) -> str | None:  # noqa: N802, D102
+        return None
+
+    def updateTimeline(self, offset_ms: int, *, state: str, duration: int | None = None) -> None:  # noqa: N802, D102
+        pass
+
+
+class FakePlexAlbum:
+    """Minimal PlexAlbum stub for testing."""
+
+    def __init__(  # noqa: D107
+        self,
+        tracks: list[Any],
+        title: str = "Test Album",
+        key: str = "/library/metadata/100",
+        view_count: int = 0,
+        last_viewed_at: datetime | None = None,
+        album_duration: int = 0,
+    ) -> None:
+        self._tracks = tracks
+        self.title = title
+        self.key = key
+        self.summary = ""
+        self.year = None
+        self.studio = None
+        self.parentTitle = None
+        self.grandparentTitle = None
+        self.viewCount = view_count
+        self.lastViewedAt = last_viewed_at
+        self.duration = album_duration
+
+    def tracks(self) -> list[Any]:  # noqa: D102
+        return self._tracks
+
+    def getWebURL(self, baseurl: str) -> str:  # noqa: N802, D102
+        return f"{baseurl}/web/index.html#!/server/item/{self.key}"
+
+    def firstAttr(self, *attrs: str) -> str | None:  # noqa: N802, D102
+        return None
+
+    def markPlayed(self) -> None:  # noqa: D102
+        pass
+
+    def markUnplayed(self) -> None:  # noqa: D102
+        pass
+
+    def reload(self) -> None:  # noqa: D102
+        pass
+
+
+class TestBuildAudiobookChapters:
+    """Tests for _build_audiobook_chapters numbering behavior."""
+
+    @pytest.mark.asyncio
+    async def test_chapters_numbered_sequentially(self) -> None:
+        """Chapters should have sequential positions starting from 1."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(key="/1", title="Intro", duration=3000),
+            FakePlexTrack(key="/2", title="Chapter 1", duration=5000),
+            FakePlexTrack(key="/3", title="Outro", duration=2000),
+        ]
+        album = FakePlexAlbum(tracks)
+
+        chapters = await provider._build_audiobook_chapters(album)
+
+        assert len(chapters) == 3
+        assert chapters[0].position == 1
+        assert chapters[1].position == 2
+        assert chapters[2].position == 3
+        assert chapters[0].name == "Intro"
+        assert chapters[1].name == "Chapter 1"
+        assert chapters[2].name == "Outro"
+
+    @pytest.mark.asyncio
+    async def test_chapters_skip_tracks_without_media(self) -> None:
+        """Tracks without media should be skipped without creating gaps in numbering."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(key="/1", title="Valid Track 1", duration=3000),
+            FakePlexTrack(key="/2", title="No Media", duration=5000, has_media=False),
+            FakePlexTrack(key="/3", title="Valid Track 2", duration=2000),
+        ]
+        album = FakePlexAlbum(tracks)
+
+        chapters = await provider._build_audiobook_chapters(album)
+
+        assert len(chapters) == 2
+        assert chapters[0].position == 1
+        assert chapters[1].position == 2
+        assert chapters[0].name == "Valid Track 1"
+        assert chapters[1].name == "Valid Track 2"
+
+    @pytest.mark.asyncio
+    async def test_chapters_skip_tracks_without_parts(self) -> None:
+        """Tracks with media but no parts should be skipped without gaps."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(key="/1", title="Valid", duration=3000),
+            FakePlexTrack(key="/2", title="No Parts", duration=5000, has_parts=False),
+            FakePlexTrack(key="/3", title="Another Valid", duration=2000),
+        ]
+        album = FakePlexAlbum(tracks)
+
+        chapters = await provider._build_audiobook_chapters(album)
+
+        assert len(chapters) == 2
+        assert chapters[0].position == 1
+        assert chapters[1].position == 2
+
+    @pytest.mark.asyncio
+    async def test_chapters_cumulative_times(self) -> None:
+        """Chapter start/end times should be cumulative across valid tracks."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(key="/1", title="First", duration=1000),
+            FakePlexTrack(key="/2", title="Second", duration=2000),
+            FakePlexTrack(key="/3", title="Third", duration=3000),
+        ]
+        album = FakePlexAlbum(tracks)
+
+        chapters = await provider._build_audiobook_chapters(album)
+
+        assert chapters[0].start == 0.0
+        assert chapters[0].end == 1.0
+        assert chapters[1].start == 1.0
+        assert chapters[1].end == 3.0
+        assert chapters[2].start == 3.0
+        assert chapters[2].end == 6.0
+
+
+class TestBuildPodcastEpisodes:
+    """Tests for _build_podcast_episodes numbering behavior."""
+
+    @pytest.mark.asyncio
+    async def test_episodes_numbered_sequentially(self) -> None:
+        """Episodes should have sequential positions starting from 1."""
+        provider = _make_provider(LIBRARY_TYPE_PODCASTS)
+        tracks = [
+            FakePlexTrack(key="/1", title="Intro"),
+            FakePlexTrack(key="/2", title="Main Episode"),
+            FakePlexTrack(key="/3", title="Outro"),
+        ]
+        album = FakePlexAlbum(tracks, title="Test Podcast")
+
+        episodes = await provider._build_podcast_episodes(album)
+
+        assert len(episodes) == 3
+        assert episodes[0].position == 1
+        assert episodes[1].position == 2
+        assert episodes[2].position == 3
+        assert episodes[0].name == "Intro"
+        assert episodes[1].name == "Main Episode"
+        assert episodes[2].name == "Outro"
+
+    @pytest.mark.asyncio
+    async def test_episodes_skip_tracks_without_media(self) -> None:
+        """Tracks without media should be skipped without creating gaps."""
+        provider = _make_provider(LIBRARY_TYPE_PODCASTS)
+        tracks = [
+            FakePlexTrack(key="/1", title="Valid Ep 1"),
+            FakePlexTrack(key="/2", title="No Media", has_media=False),
+            FakePlexTrack(key="/3", title="Valid Ep 2"),
+        ]
+        album = FakePlexAlbum(tracks, title="Test Podcast")
+
+        episodes = await provider._build_podcast_episodes(album)
+
+        assert len(episodes) == 2
+        assert episodes[0].position == 1
+        assert episodes[1].position == 2
+        assert episodes[0].name == "Valid Ep 1"
+        assert episodes[1].name == "Valid Ep 2"
+
+    @pytest.mark.asyncio
+    async def test_episode_default_name(self) -> None:
+        """Tracks without titles should use default episode name with correct number."""
+        provider = _make_provider(LIBRARY_TYPE_PODCASTS)
+        tracks = [
+            FakePlexTrack(key="/1", title=""),
+            FakePlexTrack(key="/2", title="Has Title"),
+            FakePlexTrack(key="/3", title=""),
+        ]
+        album = FakePlexAlbum(tracks, title="Test Podcast")
+
+        episodes = await provider._build_podcast_episodes(album)
+
+        assert episodes[0].name == "Episode 1"
+        assert episodes[1].name == "Has Title"
+        assert episodes[2].name == "Episode 3"
+
+    @pytest.mark.asyncio
+    async def test_episode_podcast_reference(self) -> None:
+        """Each episode should reference the parent podcast correctly."""
+        provider = _make_provider(LIBRARY_TYPE_PODCASTS)
+        tracks = [
+            FakePlexTrack(key="/1", title="Ep 1"),
+        ]
+        album = FakePlexAlbum(tracks, title="My Podcast", key="/library/metadata/100")
+
+        episodes = await provider._build_podcast_episodes(album)
+
+        assert len(episodes) == 1
+        assert episodes[0].podcast.name == "My Podcast"
+        assert episodes[0].podcast.item_id == "podcast:/library/metadata/100"
+
+
+class TestStreamDetailsGuards:
+    """Tests for library type guards in stream detail methods."""
+
+    @pytest.mark.asyncio
+    async def test_audiobook_stream_rejects_music_library(self) -> None:
+        """_get_audiobook_stream_details should raise when library type is music."""
+        provider = _make_provider(LIBRARY_TYPE_MUSIC)
+
+        with pytest.raises(MediaNotFoundError, match="not configured for audiobooks"):
+            await provider._get_audiobook_stream_details("audiobook:/library/metadata/1")
+
+    @pytest.mark.asyncio
+    async def test_audiobook_stream_rejects_podcast_library(self) -> None:
+        """_get_audiobook_stream_details should raise when library type is podcasts."""
+        provider = _make_provider(LIBRARY_TYPE_PODCASTS)
+
+        with pytest.raises(MediaNotFoundError, match="not configured for audiobooks"):
+            await provider._get_audiobook_stream_details("audiobook:/library/metadata/1")
+
+    @pytest.mark.asyncio
+    async def test_podcast_stream_rejects_music_library(self) -> None:
+        """_get_podcast_episode_stream_details should raise when library type is music."""
+        provider = _make_provider(LIBRARY_TYPE_MUSIC)
+
+        with pytest.raises(MediaNotFoundError, match="not configured for podcasts"):
+            await provider._get_podcast_episode_stream_details(
+                "podcast_episode:/library/metadata/1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_podcast_stream_rejects_audiobook_library(self) -> None:
+        """_get_podcast_episode_stream_details should raise when library type is audiobooks."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+
+        with pytest.raises(MediaNotFoundError, match="not configured for podcasts"):
+            await provider._get_podcast_episode_stream_details(
+                "podcast_episode:/library/metadata/1"
+            )
+
+
+class TestGetSupportedFeatures:
+    """Tests for the dynamic get_supported_features function."""
+
+    def test_music_returns_all_music_features(self) -> None:
+        """When library_type is music, all music features are returned."""
+        result = get_supported_features({"library_type": "music"})
+
+        assert ProviderFeature.LIBRARY_ARTISTS in result
+        assert ProviderFeature.LIBRARY_ALBUMS in result
+        assert ProviderFeature.LIBRARY_TRACKS in result
+        assert ProviderFeature.LIBRARY_PLAYLISTS in result
+        assert ProviderFeature.LIBRARY_AUDIOBOOKS not in result
+        assert ProviderFeature.LIBRARY_PODCASTS not in result
+
+    def test_audiobooks_returns_only_audiobook_features(self) -> None:
+        """When library_type is audiobooks, only audiobook features are returned."""
+        result = get_supported_features({"library_type": "audiobooks"})
+
+        assert ProviderFeature.LIBRARY_AUDIOBOOKS in result
+        assert ProviderFeature.BROWSE in result
+        assert ProviderFeature.SEARCH in result
+        assert ProviderFeature.LIBRARY_ARTISTS not in result
+        assert ProviderFeature.LIBRARY_ALBUMS not in result
+        assert ProviderFeature.LIBRARY_TRACKS not in result
+        assert ProviderFeature.LIBRARY_PLAYLISTS not in result
+        assert ProviderFeature.LIBRARY_PODCASTS not in result
+
+    def test_podcasts_returns_only_podcast_features(self) -> None:
+        """When library_type is podcasts, only podcast features are returned."""
+        result = get_supported_features({"library_type": "podcasts"})
+
+        assert ProviderFeature.LIBRARY_PODCASTS in result
+        assert ProviderFeature.BROWSE in result
+        assert ProviderFeature.SEARCH in result
+        assert ProviderFeature.LIBRARY_ARTISTS not in result
+        assert ProviderFeature.LIBRARY_ALBUMS not in result
+        assert ProviderFeature.LIBRARY_TRACKS not in result
+        assert ProviderFeature.LIBRARY_PLAYLISTS not in result
+        assert ProviderFeature.LIBRARY_AUDIOBOOKS not in result
+
+    def test_default_none_returns_music_features(self) -> None:
+        """When values is None, music features are returned as default."""
+        result = get_supported_features(None)
+
+        assert ProviderFeature.LIBRARY_ARTISTS in result
+        assert ProviderFeature.LIBRARY_ALBUMS in result
+        assert ProviderFeature.LIBRARY_TRACKS in result
+
+    def test_default_empty_dict_returns_music_features(self) -> None:
+        """When values is an empty dict, music features are returned as default."""
+        result = get_supported_features({})
+
+        assert ProviderFeature.LIBRARY_ARTISTS in result
+        assert ProviderFeature.LIBRARY_ALBUMS in result
+        assert ProviderFeature.LIBRARY_TRACKS in result
+
+
+# ---------------------------------------------------------------------------
+# Resume / progress system tests
+# ---------------------------------------------------------------------------
+
+
+class TestCalcResumePosition:
+    """Tests for _calc_resume_position_ms."""
+
+    @pytest.mark.asyncio
+    async def test_no_progress_returns_zero(self) -> None:
+        """When no track has a viewOffset, resume position is zero."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(duration=10000, view_offset=0),
+            FakePlexTrack(duration=20000, view_offset=0),
+        ]
+        album = FakePlexAlbum(tracks)
+        result = await provider._calc_resume_position_ms(album, fully_played=False)
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_last_offset_determines_position(self) -> None:
+        """The last track with a non-zero viewOffset sets the resume point."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(duration=10000, view_offset=5000),
+            FakePlexTrack(duration=20000, view_offset=12000),
+        ]
+        album = FakePlexAlbum(tracks)
+        result = await provider._calc_resume_position_ms(album, fully_played=False)
+        # First track contributes 10000 ms, second offset is 12000 ms
+        assert result == 10000 + 12000
+
+    @pytest.mark.asyncio
+    async def test_fully_played_with_no_offset_uses_album_duration(self) -> None:
+        """When fully played and no offsets, return album duration."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(duration=10000, view_offset=0),
+            FakePlexTrack(duration=20000, view_offset=0),
+        ]
+        album = FakePlexAlbum(tracks, album_duration=30000)
+        result = await provider._calc_resume_position_ms(album, fully_played=True)
+        assert result == 30000
+
+    @pytest.mark.asyncio
+    async def test_mixed_offsets_with_gap(self) -> None:
+        """Only the last offset matters; gaps are ignored."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(duration=10000, view_offset=8000),
+            FakePlexTrack(duration=20000, view_offset=0),
+            FakePlexTrack(duration=15000, view_offset=5000),
+        ]
+        album = FakePlexAlbum(tracks)
+        result = await provider._calc_resume_position_ms(album, fully_played=False)
+        # Cumulative before last track = 10000 + 20000 = 30000
+        # Last offset = 5000
+        assert result == 30000 + 5000
+
+
+class TestFindTrackForPosition:
+    """Tests for _find_track_for_position."""
+
+    @pytest.mark.asyncio
+    async def test_position_in_first_track(self) -> None:
+        """Position inside the first track returns it with correct offset."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(key="/1", duration=10000),
+            FakePlexTrack(key="/2", duration=20000),
+        ]
+        album = FakePlexAlbum(tracks)
+        track, offset = await provider._find_track_for_position(album, position=5)
+        assert track is not None
+        assert track.key == "/1"
+        assert offset == 5000  # 5 seconds = 5000 ms
+
+    @pytest.mark.asyncio
+    async def test_position_in_second_track(self) -> None:
+        """Position inside second track returns it with offset relative to track start."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(key="/1", duration=10000),
+            FakePlexTrack(key="/2", duration=20000),
+        ]
+        album = FakePlexAlbum(tracks)
+        track, offset = await provider._find_track_for_position(album, position=12)
+        # 12 seconds = 12000 ms. First track is 10000 ms, so 2000 ms into second track.
+        assert track is not None
+        assert track.key == "/2"
+        assert offset == 2000
+
+    @pytest.mark.asyncio
+    async def test_position_past_end_clamps_to_last_track(self) -> None:
+        """Position beyond all tracks clamps to the end of the last track."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(key="/1", duration=10000),
+            FakePlexTrack(key="/2", duration=20000),
+        ]
+        album = FakePlexAlbum(tracks)
+        track, offset = await provider._find_track_for_position(album, position=40)
+        # Total duration is 30 seconds; position 40 is past end.
+        assert track is not None
+        assert track.key == "/2"
+        assert offset == 20000  # full duration of last track
+
+    @pytest.mark.asyncio
+    async def test_empty_album_returns_none(self) -> None:
+        """An album with no tracks returns (None, 0)."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        album = FakePlexAlbum([])
+        track, offset = await provider._find_track_for_position(album, position=5)
+        assert track is None
+        assert offset == 0
+
+
+class TestOnPlayed:
+    """Tests for on_played progress sync."""
+
+    @pytest.mark.asyncio
+    async def test_fully_played_calls_mark_played(self) -> None:
+        """When fully_played=True, markPlayed is called on the album."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        album = FakePlexAlbum(
+            [FakePlexTrack(key="/1", duration=10000)],
+            key="/library/metadata/100",
+        )
+        provider._plex_library.fetchItem = MagicMock(return_value=album)
+
+        call_log: list[Any] = []
+
+        async def _run_async(call: Any, *args: Any, **kwargs: Any) -> Any:
+            call_log.append((call, args, kwargs))
+            return call(*args, **kwargs)
+
+        provider._run_async = _run_async
+
+        await provider.on_played(
+            MediaType.AUDIOBOOK,
+            "audiobook:/library/metadata/100",
+            fully_played=True,
+            position=0,
+            media_item=MagicMock(),
+        )
+
+        mark_played_called = any(call_info[0] == album.markPlayed for call_info in call_log)
+        assert mark_played_called
+
+    @pytest.mark.asyncio
+    async def test_zero_position_calls_mark_unplayed(self) -> None:
+        """When position is 0, markUnplayed is called on the album."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        album = FakePlexAlbum(
+            [FakePlexTrack(key="/1", duration=10000)],
+            key="/library/metadata/100",
+        )
+        provider._plex_library.fetchItem = MagicMock(return_value=album)
+
+        call_log: list[Any] = []
+
+        async def _run_async(call: Any, *args: Any, **kwargs: Any) -> Any:
+            call_log.append((call, args, kwargs))
+            return call(*args, **kwargs)
+
+        provider._run_async = _run_async
+
+        await provider.on_played(
+            MediaType.AUDIOBOOK,
+            "audiobook:/library/metadata/100",
+            fully_played=False,
+            position=0,
+            media_item=MagicMock(),
+        )
+
+        mark_unplayed_called = any(call_info[0] == album.markUnplayed for call_info in call_log)
+        assert mark_unplayed_called
+
+    @pytest.mark.asyncio
+    async def test_mid_position_updates_timeline(self) -> None:
+        """When position is in the middle, updateTimeline is called on the correct track."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        track = FakePlexTrack(key="/1", duration=30000)
+        album = FakePlexAlbum([track], key="/library/metadata/100")
+        provider._plex_library.fetchItem = MagicMock(return_value=album)
+
+        call_log: list[Any] = []
+
+        async def _run_async(call: Any, *args: Any, **kwargs: Any) -> Any:
+            call_log.append((call, args, kwargs))
+            return call(*args, **kwargs)
+
+        provider._run_async = _run_async
+
+        await provider.on_played(
+            MediaType.AUDIOBOOK,
+            "audiobook:/library/metadata/100",
+            fully_played=False,
+            position=10,
+            media_item=MagicMock(),
+            is_playing=True,
+        )
+
+        timeline_called = any(
+            call_info[0] == track.updateTimeline and call_info[2].get("state") == "playing"
+            for call_info in call_log
+        )
+        assert timeline_called
+
+
+class TestGetResumePosition:
+    """Tests for get_resume_position."""
+
+    @pytest.mark.asyncio
+    async def test_audiobook_with_progress(self) -> None:
+        """Returns correct resume position for an audiobook with track offsets."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [
+            FakePlexTrack(duration=10000, view_offset=0),
+            FakePlexTrack(duration=20000, view_offset=15000),
+        ]
+        viewed_at = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        album = FakePlexAlbum(
+            tracks,
+            key="/library/metadata/100",
+            last_viewed_at=viewed_at,
+        )
+
+        provider._plex_library.fetchItem = MagicMock(return_value=album)
+
+        fully_played, position_ms, timestamp = await provider.get_resume_position(
+            "audiobook:/library/metadata/100", MediaType.AUDIOBOOK
+        )
+
+        assert fully_played is False
+        assert position_ms == 10000 + 15000
+        assert timestamp == viewed_at
+
+    @pytest.mark.asyncio
+    async def test_fully_played_audiobook(self) -> None:
+        """When fully played, returns album duration as resume position."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        tracks = [FakePlexTrack(duration=30000, view_offset=0)]
+        album = FakePlexAlbum(
+            tracks,
+            key="/library/metadata/100",
+            view_count=1,
+            album_duration=30000,
+        )
+
+        provider._plex_library.fetchItem = MagicMock(return_value=album)
+
+        fully_played, position_ms, _ = await provider.get_resume_position(
+            "audiobook:/library/metadata/100", MediaType.AUDIOBOOK
+        )
+
+        assert fully_played is True
+        assert position_ms == 30000
+
+    @pytest.mark.asyncio
+    async def test_podcast_episode_delegates_to_album(self) -> None:
+        """Podcast episode delegates resume position to parent album."""
+        provider = _make_provider(LIBRARY_TYPE_PODCASTS)
+        episode_track = FakePlexTrack(
+            key="/library/metadata/200",
+            duration=15000,
+            parent_key="/library/metadata/100",
+        )
+        album = FakePlexAlbum(
+            [episode_track],
+            key="/library/metadata/100",
+            album_duration=15000,
+        )
+
+        provider._plex_library.fetchItem = MagicMock(side_effect=[episode_track, album])
+
+        fully_played, position_ms, _ = await provider.get_resume_position(
+            "podcast_episode:/library/metadata/200", MediaType.PODCAST_EPISODE
+        )
+
+        assert fully_played is False
+        assert position_ms == 0
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises_media_not_found(self) -> None:
+        """If the Plex item is missing, MediaNotFoundError is raised."""
+        import plexapi.exceptions
+
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        provider._run_async = AsyncMock(side_effect=plexapi.exceptions.NotFound("Item not found"))
+
+        with pytest.raises(MediaNotFoundError):
+            await provider.get_resume_position(
+                "audiobook:/library/metadata/999", MediaType.AUDIOBOOK
+            )
+
+
+class TestUpdateConfig:
+    """Tests for update_config media type cleanup when library_type changes."""
+
+    @pytest.mark.asyncio
+    async def test_type_change_from_audiobooks_to_podcasts_cleans_audiobooks(self) -> None:
+        """Changing library_type from audiobooks to podcasts removes audiobook entries."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        provider.mass.music.database = MagicMock()
+        provider.mass.music.database.get_rows_from_query = AsyncMock(
+            return_value=[{"item_id": 1}, {"item_id": 2}]
+        )
+        provider.mass.music.get_controller = MagicMock()
+        mock_ctrl = MagicMock()
+        mock_ctrl.remove_provider_mappings = AsyncMock()
+        provider.mass.music.get_controller.return_value = mock_ctrl
+        provider.mass.cache.delete = AsyncMock()
+
+        new_config = MagicMock()
+        new_config.get_value = lambda key: (
+            LIBRARY_TYPE_PODCASTS if key == "library_type" else "plex_instance_1"
+        )
+        new_config.values = {"library_type": LIBRARY_TYPE_PODCASTS}
+        new_config.instance_id = "plex_instance_1"
+
+        async def _mock_super_update_config(config: Any, changed_keys: set[str]) -> None:
+            """Mock super().update_config that updates provider.config."""
+            provider.config = config
+
+        with mock.patch(
+            "music_assistant.models.provider.Provider.update_config",
+            side_effect=_mock_super_update_config,
+        ) as mock_super:
+            await provider.update_config(
+                new_config,
+                changed_keys={"values/library_type"},
+            )
+
+        mock_super.assert_awaited_once()
+
+        # The old type was audiobooks, new type is podcasts
+        # Audiobook is a stale media type (not present in podcasts)
+        mock_ctrl.remove_provider_mappings.assert_has_awaits(
+            [
+                mock.call(1, "plex_instance_1"),
+                mock.call(2, "plex_instance_1"),
+            ]
+        )
+        # Cache clear for audiobook IDs
+        provider.mass.cache.delete.assert_awaited_once_with(
+            key="audiobook",
+            provider="plex_instance_1",
+            category="prev_library_ids",
+        )
+
+    @pytest.mark.asyncio
+    async def test_type_change_from_music_to_audiobooks_cleans_music_items(self) -> None:
+        """Changing library_type from music to audiobooks removes music entries."""
+        provider = _make_provider(LIBRARY_TYPE_MUSIC)
+        provider.mass.music.database = MagicMock()
+        provider.mass.music.database.get_rows_from_query = AsyncMock(return_value=[{"item_id": 10}])
+        provider.mass.music.get_controller = MagicMock()
+        mock_ctrl = MagicMock()
+        mock_ctrl.remove_provider_mappings = AsyncMock()
+        provider.mass.music.get_controller.return_value = mock_ctrl
+        provider.mass.cache.delete = AsyncMock()
+
+        new_config = MagicMock()
+        new_config.get_value = lambda key: (
+            LIBRARY_TYPE_AUDIOBOOKS if key == "library_type" else "plex_instance_1"
+        )
+        new_config.values = {"library_type": LIBRARY_TYPE_AUDIOBOOKS}
+        new_config.instance_id = "plex_instance_1"
+
+        async def _mock_super_update_config(config: Any, changed_keys: set[str]) -> None:
+            """Mock super().update_config that updates provider.config."""
+            provider.config = config
+
+        with mock.patch(
+            "music_assistant.models.provider.Provider.update_config",
+            side_effect=_mock_super_update_config,
+        ):
+            await provider.update_config(
+                new_config,
+                changed_keys={"values/library_type"},
+            )
+
+        # Music types (artist, album, track, playlist) are stale
+        # All of them should have had their provider mappings queried and removed
+        music_ctrl = provider.mass.music.get_controller
+        assert music_ctrl.call_count == 4  # artist, album, track, playlist
+        mock_ctrl.remove_provider_mappings.assert_has_awaits(
+            [
+                mock.call(10, "plex_instance_1"),
+                mock.call(10, "plex_instance_1"),
+                mock.call(10, "plex_instance_1"),
+                mock.call(10, "plex_instance_1"),
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_change_does_nothing(self) -> None:
+        """When library_type does not change, no cleanup is performed."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        provider.mass.music.database = MagicMock()
+        provider.mass.music.database.get_rows_from_query = AsyncMock()
+        provider.mass.music.get_controller = MagicMock()
+        provider.mass.cache.delete = AsyncMock()
+
+        new_config = MagicMock()
+        new_config.get_value = lambda key: (
+            LIBRARY_TYPE_AUDIOBOOKS if key == "library_type" else "plex_instance_1"
+        )
+        new_config.values = {"library_type": LIBRARY_TYPE_AUDIOBOOKS}
+
+        async def _mock_super_update_config(config: Any, changed_keys: set[str]) -> None:
+            """Mock super().update_config that updates provider.config."""
+            provider.config = config
+
+        with mock.patch(
+            "music_assistant.models.provider.Provider.update_config",
+            side_effect=_mock_super_update_config,
+        ):
+            await provider.update_config(
+                new_config,
+                changed_keys={"values/library_type"},
+            )
+
+        # No database queries, no controller lookups
+        provider.mass.music.database.get_rows_from_query.assert_not_awaited()
+        provider.mass.music.get_controller.assert_not_called()
+        provider.mass.cache.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_other_config_changes_ignored(self) -> None:
+        """Non-library_type config changes do not trigger cleanup."""
+        provider = _make_provider(LIBRARY_TYPE_AUDIOBOOKS)
+        provider.mass.music.database = MagicMock()
+        provider.mass.music.database.get_rows_from_query = AsyncMock()
+        provider.mass.music.get_controller = MagicMock()
+        provider.mass.cache.delete = AsyncMock()
+
+        new_config = MagicMock()
+        new_config.get_value = lambda key: (
+            LIBRARY_TYPE_AUDIOBOOKS if key == "library_type" else "plex_instance_1"
+        )
+        new_config.values = {"library_type": LIBRARY_TYPE_AUDIOBOOKS}
+
+        async def _mock_super_update_config(config: Any, changed_keys: set[str]) -> None:
+            """Mock super().update_config that updates provider.config."""
+            provider.config = config
+
+        with mock.patch(
+            "music_assistant.models.provider.Provider.update_config",
+            side_effect=_mock_super_update_config,
+        ):
+            await provider.update_config(
+                new_config,
+                changed_keys={"values/token"},
+            )
+
+        provider.mass.music.database.get_rows_from_query.assert_not_awaited()
+        provider.mass.music.get_controller.assert_not_called()
+        provider.mass.cache.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stale_sync_config_values_are_removed(self) -> None:
+        """When library_type changes, old sync config values are purged."""
+        provider = _make_provider(LIBRARY_TYPE_MUSIC)
+        provider.mass.music.database = MagicMock()
+        provider.mass.music.database.get_rows_from_query = AsyncMock(return_value=[])
+        provider.mass.music.get_controller = MagicMock(return_value=None)
+        provider.mass.cache.delete = AsyncMock()
+        provider.mass.config.remove_provider_config_value = AsyncMock()
+
+        new_config = MagicMock()
+        new_config.get_value = lambda key: (
+            LIBRARY_TYPE_AUDIOBOOKS if key == "library_type" else "plex_instance_1"
+        )
+        new_config.values = {"library_type": LIBRARY_TYPE_AUDIOBOOKS}
+
+        async def _mock_super_update_config(config: Any, changed_keys: set[str]) -> None:
+            """Mock super().update_config that updates provider.config."""
+            provider.config = config
+
+        with (
+            mock.patch(
+                "music_assistant.models.provider.Provider.update_config",
+                side_effect=_mock_super_update_config,
+            ),
+            mock.patch.object(
+                type(provider), "instance_id", new_callable=mock.PropertyMock
+            ) as mock_instance_id,
+        ):
+            mock_instance_id.return_value = "plex_instance_1"
+            await provider.update_config(
+                new_config,
+                changed_keys={"values/library_type"},
+            )
+
+        # Music sync config keys should be removed for the stale types
+        provider.mass.config.remove_provider_config_value.assert_has_awaits(
+            [
+                mock.call("plex_instance_1", "library_sync_artists"),
+                mock.call("plex_instance_1", "library_sync_albums"),
+                mock.call("plex_instance_1", "library_sync_tracks"),
+                mock.call("plex_instance_1", "library_sync_playlists"),
+            ]
+        )


### PR DESCRIPTION
## Summary

Implements backend support for switching Plex library types (Music / Audiobooks / Podcasts) with proper cleanup and a comprehensive test suite.

## Changes

- **Dynamic `supported_features`**: Returns only the features appropriate for the configured library type
- **`update_config` cleanup**: On type change, removes stale provider mappings and purges old sync config values
- **Config recursion prevention**: Uses raw config values (not `include_values=True`) when checking other Plex instances to avoid infinite recursion
- **Library choice preservation**: Existing user selections are preserved in config entries
- **Test suite**: 54 tests covering config entries, provider methods, audiobook helpers, and type switching behavior

## Frontend impact

None required. The existing frontend already respects `supported_features` for:
- Provider filters in library views
- Config page checkbox injection
- Sync engine scheduling

The sidebar navigation menu will still show all library views unconditionally, but empty views are already the norm when no provider supports that media type.

## Testing

All 54 Plex provider tests pass:
- Config entry defaults and recursion prevention
- Provider method behavior per library type
- Audiobook/podcast helper functions
- Type switching cleanup (mappings + sync config values)

Co-authored-by: Kimi <kimi-k2.6:cloud@ai>