### PR TITLE
metadata: serve imageproxy as image/jpeg, not image/jpg

### DIFF
--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -547,7 +547,14 @@ class MetaDataController(CoreController):
             )
             # we set the cache header to 1 year (forever)
             # assuming that images do not/rarely change
-            content_type = "image/svg+xml" if image_format == "svg" else f"image/{image_format}"
+            # normalize jpg -> jpeg (image/jpg is non-standard, some clients like
+            # the Sonos S2 controller app reject it silently for artwork display)
+            if image_format == "svg":
+                content_type = "image/svg+xml"
+            elif image_format in ("jpg", "jpeg"):
+                content_type = "image/jpeg"
+            else:
+                content_type = f"image/{image_format}"
             return web.Response(
                 body=image_data,
                 headers={"Cache-Control": "max-age=31536000", "Access-Control-Allow-Origin": "*"},


### PR DESCRIPTION
The handle_imageproxy endpoint was returning Content-Type: image/jpg for jpg images. That is not a registered MIME type (RFC 6838 / IANA registry has only image/jpeg). Most HTTP clients are lenient and treat both as equivalent, but the Sonos S2 controller app rejects image/jpg silently when fetching album artwork delivered via Cloud Queue v2.3, showing no artwork at all even though the body is a valid JPEG.

Normalize both "jpg" and "jpeg" image_format values to image/jpeg. Other formats (png, webp, gif, svg, ...) are unaffected.

# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
