### PR TITLE
Allow scrobble providers to filter by media_type

### DIFF
--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Collection
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import (
@@ -11,7 +12,7 @@ from music_assistant_models.config_entries import (
     ConfigValueOption,
     ConfigValueType,
 )
-from music_assistant_models.enums import ConfigEntryType
+from music_assistant_models.enums import ConfigEntryType, MediaType
 
 if TYPE_CHECKING:
     from music_assistant_models.event import MassEvent
@@ -21,17 +22,25 @@ if TYPE_CHECKING:
 
 
 class ScrobblerHelper:
-    """Base class to aid scrobbling tracks."""
+    """Base class to aid scrobbling media items."""
 
     logger: logging.Logger
     config: ScrobblerConfig
     currently_playing: str | None = None
     last_scrobbled: str | None = None
 
-    def __init__(self, logger: logging.Logger, config: ScrobblerConfig | None = None) -> None:
+    def __init__(
+        self,
+        logger: logging.Logger,
+        config: ScrobblerConfig | None = None,
+        supported_media_types: Collection[MediaType] | None = None,
+    ) -> None:
         """Initialize."""
         self.logger = logger
         self.config = config or ScrobblerConfig(suffix_version=False)
+        if supported_media_types is None:
+            supported_media_types = (MediaType.TRACK,)
+        self.supported_media_types = frozenset(supported_media_types)
 
     def _is_configured(self) -> bool:
         """Override if subclass needs specific configuration."""
@@ -51,14 +60,14 @@ class ScrobblerHelper:
         """Scrobble."""
 
     async def _on_mass_media_item_played(self, event: MassEvent) -> None:
-        """Media item has finished playing, we'll scrobble the track."""
+        """Media item has finished playing, we'll scrobble the item."""
         if not self._is_configured():
             return
 
         report: MediaItemPlaybackProgressReport = event.data
 
-        if report.media_type != "track":
-            self.logger.debug("skipped scrobbling for non-track item")
+        if report.media_type not in self.supported_media_types:
+            self.logger.debug("skipped scrobbling for unsupported media type %s", report.media_type)
             return
 
         # handle optional user_id filtering

--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -57,6 +57,10 @@ class ScrobblerHelper:
 
         report: MediaItemPlaybackProgressReport = event.data
 
+        if report.media_type != "track":
+            self.logger.debug("skipped scrobbling for non-track item")
+            return
+
         # handle optional user_id filtering
         if self.config.mass_userids and report.userid not in self.config.mass_userids:
             self.logger.debug("skipped scrobbling for user %s due to user filter", report.userid)

--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -26,6 +26,7 @@ class ScrobblerHelper:
 
     logger: logging.Logger
     config: ScrobblerConfig
+    supported_media_types: frozenset[MediaType] | None
     currently_playing: str | None = None
     last_scrobbled: str | None = None
 
@@ -38,9 +39,9 @@ class ScrobblerHelper:
         """Initialize."""
         self.logger = logger
         self.config = config or ScrobblerConfig(suffix_version=False)
-        if supported_media_types is None:
-            supported_media_types = (MediaType.TRACK,)
-        self.supported_media_types = frozenset(supported_media_types)
+        self.supported_media_types = (
+            frozenset(supported_media_types) if supported_media_types is not None else None
+        )
 
     def _is_configured(self) -> bool:
         """Override if subclass needs specific configuration."""
@@ -66,7 +67,7 @@ class ScrobblerHelper:
 
         report: MediaItemPlaybackProgressReport = event.data
 
-        if report.media_type not in self.supported_media_types:
+        if self.supported_media_types and report.media_type not in self.supported_media_types:
             self.logger.debug("skipped scrobbling for unsupported media type %s", report.media_type)
             return
 

--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Collection
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import (
@@ -34,14 +33,12 @@ class ScrobblerHelper:
         self,
         logger: logging.Logger,
         config: ScrobblerConfig | None = None,
-        supported_media_types: Collection[MediaType] | None = None,
+        supported_media_types: frozenset[MediaType] | None = None,
     ) -> None:
         """Initialize."""
         self.logger = logger
         self.config = config or ScrobblerConfig(suffix_version=False)
-        self.supported_media_types = (
-            frozenset(supported_media_types) if supported_media_types is not None else None
-        )
+        self.supported_media_types = supported_media_types
 
     def _is_configured(self) -> bool:
         """Override if subclass needs specific configuration."""

--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -38,7 +38,7 @@ _DEFAULT_API_SECRET: str = app_var(13)
 # updating the PluginProvider base class
 # as well as other similar classes that also use set[ProviderFeature].
 SUPPORTED_FEATURES: Final[set[ProviderFeature]] = set()
-SUPPORTED_SCROBBLE_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (MediaType.TRACK,)
+SUPPORTED_SCROBBLE_MEDIA_TYPES: Final[frozenset[MediaType]] = frozenset({MediaType.TRACK})
 
 # Configuration keys
 CONF_API_KEY: Final[str] = "_api_key"

--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -15,7 +15,7 @@ from music_assistant_models.config_entries import (
     ProviderConfig,
 )
 from music_assistant_models.constants import SECURE_STRING_SUBSTITUTE
-from music_assistant_models.enums import ConfigEntryType, EventType, ProviderFeature
+from music_assistant_models.enums import ConfigEntryType, EventType, MediaType, ProviderFeature
 from music_assistant_models.errors import LoginFailed, SetupFailedError
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 from music_assistant_models.provider import ProviderManifest
@@ -38,6 +38,7 @@ _DEFAULT_API_SECRET: str = app_var(13)
 # updating the PluginProvider base class
 # as well as other similar classes that also use set[ProviderFeature].
 SUPPORTED_FEATURES: Final[set[ProviderFeature]] = set()
+SUPPORTED_SCROBBLE_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (MediaType.TRACK,)
 
 # Configuration keys
 CONF_API_KEY: Final[str] = "_api_key"
@@ -175,7 +176,11 @@ class LastFMEventHandler(ScrobblerHelper):
         self, network: pylast._Network, logger: logging.Logger, config: ProviderConfig
     ) -> None:
         """Initialize."""
-        super().__init__(logger, ScrobblerConfig.create_from_config(config))
+        super().__init__(
+            logger,
+            ScrobblerConfig.create_from_config(config),
+            SUPPORTED_SCROBBLE_MEDIA_TYPES,
+        )
         self._network = network
 
     async def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Callable
+from typing import Final
 
 from liblistenbrainz import Listen, ListenBrainz
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
@@ -29,7 +30,7 @@ LISTENBRAINZ_API_URL = "https://api.listenbrainz.org"
 SUPPORTED_FEATURES: set[ProviderFeature] = (
     set()
 )  # we don't have any special supported features (yet)
-SUPPORTED_SCROBBLE_MEDIA_TYPES: tuple[MediaType, ...] = (MediaType.TRACK,)
+SUPPORTED_SCROBBLE_MEDIA_TYPES: Final[frozenset[MediaType]] = frozenset({MediaType.TRACK})
 
 
 async def setup(

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from liblistenbrainz import Listen, ListenBrainz
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
 from music_assistant_models.constants import SECURE_STRING_SUBSTITUTE
-from music_assistant_models.enums import ConfigEntryType, EventType, ProviderFeature
+from music_assistant_models.enums import ConfigEntryType, EventType, MediaType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError
 from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
 from music_assistant_models.provider import ProviderManifest
@@ -29,6 +29,7 @@ LISTENBRAINZ_API_URL = "https://api.listenbrainz.org"
 SUPPORTED_FEATURES: set[ProviderFeature] = (
     set()
 )  # we don't have any special supported features (yet)
+SUPPORTED_SCROBBLE_MEDIA_TYPES: tuple[MediaType, ...] = (MediaType.TRACK,)
 
 
 async def setup(
@@ -92,7 +93,11 @@ class ListenBrainzEventHandler(ScrobblerHelper):
         self, client: ListenBrainz, logger: logging.Logger, config: ProviderConfig
     ) -> None:
         """Initialize."""
-        super().__init__(logger, ScrobblerConfig.create_from_config(config))
+        super().__init__(
+            logger,
+            ScrobblerConfig.create_from_config(config),
+            SUPPORTED_SCROBBLE_MEDIA_TYPES,
+        )
         self._client = client
 
     def _get_artist_name(self, report: MediaItemPlaybackProgressReport) -> str:

--- a/music_assistant/providers/subsonic_scrobble/__init__.py
+++ b/music_assistant/providers/subsonic_scrobble/__init__.py
@@ -76,10 +76,6 @@ class SubsonicScrobbleEventHandler(ScrobblerHelper):
         super().__init__(logger, supported_media_types=SUPPORTED_SCROBBLE_MEDIA_TYPES)
         self.mass = mass
 
-    def _is_scrobblable_media_type(self, media_type: MediaType) -> bool:
-        """Return true if the given OpenSubsonic media type can be scrobbled, false otherwise."""
-        return media_type in self.supported_media_types
-
     async def _get_subsonic_provider_and_item_id(
         self, media_type: MediaType, provider_instance_id_or_domain: str, item_id: str
     ) -> tuple[None | OpenSonicProvider, str]:
@@ -124,8 +120,6 @@ class SubsonicScrobbleEventHandler(ScrobblerHelper):
 
     async def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:
         media_type, provider_instance_id_or_domain, item_id = await parse_uri(report.uri)
-        if not self._is_scrobblable_media_type(media_type):
-            return
         prov, item_id = await self._get_subsonic_provider_and_item_id(
             media_type, provider_instance_id_or_domain, item_id
         )
@@ -142,8 +136,6 @@ class SubsonicScrobbleEventHandler(ScrobblerHelper):
 
     async def _scrobble(self, report: MediaItemPlaybackProgressReport) -> None:
         media_type, provider_instance_id_or_domain, item_id = await parse_uri(report.uri)
-        if not self._is_scrobblable_media_type(media_type):
-            return
         prov, item_id = await self._get_subsonic_provider_and_item_id(
             media_type, provider_instance_id_or_domain, item_id
         )

--- a/music_assistant/providers/subsonic_scrobble/__init__.py
+++ b/music_assistant/providers/subsonic_scrobble/__init__.py
@@ -1,4 +1,4 @@
-"""Allows scrobbling of tracks back to the Subsonic media server."""
+"""Allows scrobbling of supported media items back to the Subsonic media server."""
 
 import logging
 import time
@@ -19,6 +19,12 @@ from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.opensubsonic.parsers import EP_CHAN_SEP
 from music_assistant.providers.opensubsonic.sonic_provider import OpenSonicProvider
 
+SUPPORTED_SCROBBLE_MEDIA_TYPES: tuple[MediaType, ...] = (
+    MediaType.TRACK,
+    MediaType.AUDIOBOOK,
+    MediaType.PODCAST_EPISODE,
+)
+
 
 async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
@@ -32,7 +38,7 @@ async def setup(
 
 
 class SubsonicScrobbleProvider(PluginProvider):
-    """Plugin provider to support scrobbling of tracks."""
+    """Plugin provider to support Subsonic scrobbling."""
 
     def __init__(
         self, mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
@@ -67,16 +73,12 @@ class SubsonicScrobbleEventHandler(ScrobblerHelper):
 
     def __init__(self, mass: MusicAssistant, logger: logging.Logger) -> None:
         """Initialize."""
-        super().__init__(logger)
+        super().__init__(logger, supported_media_types=SUPPORTED_SCROBBLE_MEDIA_TYPES)
         self.mass = mass
 
     def _is_scrobblable_media_type(self, media_type: MediaType) -> bool:
         """Return true if the given OpenSubsonic media type can be scrobbled, false otherwise."""
-        return media_type in (
-            MediaType.TRACK,
-            MediaType.AUDIOBOOK,
-            MediaType.PODCAST_EPISODE,
-        )
+        return media_type in self.supported_media_types
 
     async def _get_subsonic_provider_and_item_id(
         self, media_type: MediaType, provider_instance_id_or_domain: str, item_id: str

--- a/music_assistant/providers/subsonic_scrobble/__init__.py
+++ b/music_assistant/providers/subsonic_scrobble/__init__.py
@@ -54,7 +54,7 @@ class SubsonicScrobbleProvider(PluginProvider):
         """Call after the provider has been loaded."""
         await super().loaded_in_mass()
 
-        handler = SubsonicScrobbleEventHandler(self.mass, self.logger)
+        handler = SubsonicScrobbleEventHandler(self.mass, self.logger, self.config)
 
         # subscribe to media_item_played event
         self._on_unload.append(
@@ -74,9 +74,15 @@ class SubsonicScrobbleProvider(PluginProvider):
 class SubsonicScrobbleEventHandler(ScrobblerHelper):
     """Handles the scrobbling event handling."""
 
-    def __init__(self, mass: MusicAssistant, logger: logging.Logger) -> None:
+    def __init__(
+        self, mass: MusicAssistant, logger: logging.Logger, config: ProviderConfig
+    ) -> None:
         """Initialize."""
-        super().__init__(logger, supported_media_types=SUPPORTED_SCROBBLE_MEDIA_TYPES)
+        super().__init__(
+            logger,
+            ScrobblerConfig.create_from_config(config),
+            SUPPORTED_SCROBBLE_MEDIA_TYPES,
+        )
         self.mass = mass
 
     async def _get_subsonic_provider_and_item_id(

--- a/music_assistant/providers/subsonic_scrobble/__init__.py
+++ b/music_assistant/providers/subsonic_scrobble/__init__.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from collections.abc import Callable
+from typing import Final
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
 from music_assistant_models.enums import EventType, MediaType
@@ -19,10 +20,12 @@ from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.opensubsonic.parsers import EP_CHAN_SEP
 from music_assistant.providers.opensubsonic.sonic_provider import OpenSonicProvider
 
-SUPPORTED_SCROBBLE_MEDIA_TYPES: tuple[MediaType, ...] = (
-    MediaType.TRACK,
-    MediaType.AUDIOBOOK,
-    MediaType.PODCAST_EPISODE,
+SUPPORTED_SCROBBLE_MEDIA_TYPES: Final[frozenset[MediaType]] = frozenset(
+    {
+        MediaType.TRACK,
+        MediaType.AUDIOBOOK,
+        MediaType.PODCAST_EPISODE,
+    }
 )
 
 

--- a/tests/core/test_scrobbler.py
+++ b/tests/core/test_scrobbler.py
@@ -15,9 +15,14 @@ class DummyHandler(ScrobblerHelper):
     _tracked = 0
     _now_playing = 0
 
-    def __init__(self, logger: logging.Logger, config: ScrobblerConfig | None = None) -> None:
+    def __init__(
+        self,
+        logger: logging.Logger,
+        config: ScrobblerConfig | None = None,
+        supported_media_types: frozenset[MediaType] | None = None,
+    ) -> None:
         """Initialize."""
-        super().__init__(logger, config)
+        super().__init__(logger, config, supported_media_types)
 
     def _is_configured(self) -> bool:
         return True
@@ -121,6 +126,41 @@ async def test_it_filters_scrobbles_without_player_context() -> None:
     assert handler._tracked == 0
 
 
+async def test_it_filters_unsupported_media_types() -> None:
+    """Only provider supported media types should be scrobbled."""
+    handler = DummyHandler(logging.getLogger(), supported_media_types=frozenset({MediaType.TRACK}))
+
+    await handler._on_mass_media_item_played(
+        create_report(
+            duration=180,
+            seconds_played=176,
+            uri="filesystem://audiobook/1",
+            media_type=MediaType.AUDIOBOOK,
+        )
+    )
+    assert handler._now_playing == 0
+    assert handler._tracked == 0
+
+
+async def test_it_allows_provider_supported_media_types() -> None:
+    """Providers can opt in to scrobbling additional media types."""
+    handler = DummyHandler(
+        logging.getLogger(),
+        supported_media_types=frozenset({MediaType.TRACK, MediaType.AUDIOBOOK}),
+    )
+
+    await handler._on_mass_media_item_played(
+        create_report(
+            duration=180,
+            seconds_played=176,
+            uri="filesystem://audiobook/1",
+            media_type=MediaType.AUDIOBOOK,
+        )
+    )
+    assert handler._now_playing == 1
+    assert handler._tracked == 1
+
+
 async def test_it_suffixes_the_version_if_enabled_and_available() -> None:
     """Test that the track version is suffixed to the track name when enabled."""
     report_with_version = create_report(version="Deluxe Edition").data
@@ -142,12 +182,13 @@ def create_report(
     uri: str = "filesystem://track/1",
     version: str | None = None,
     player_id: str | None = "test_player",
+    media_type: MediaType = MediaType.TRACK,
 ) -> MassEvent:
     """Create the MediaItemPlaybackProgressReport and wrap it in a MassEvent."""
     return wrap_event(
         MediaItemPlaybackProgressReport(
             uri=uri,
-            media_type=MediaType.TRACK,
+            media_type=media_type,
             name="track",
             artist=None,
             artist_mbids=None,


### PR DESCRIPTION
# What does this implement/fix?
Scrobblers don't filter by media_type, this means we send now playing and scrobble events for unsupported items to all scrobble services.
For example, Radio streams or audiobooks in Listenbrainz would show up like this:
<img width="460" height="91" alt="image" src="https://github.com/user-attachments/assets/56010c27-ca69-4fa4-bc38-ca4eff73235a" />

This PR adds a property that allow ScrobbleHelper implementations to specify the media_types the provider supports, falling back to allowing all media_types.

Couldn't test Subsonic because I don't have that set up at home, Subsonic already had it's own filtering, based on the 'uri' of the played item. I _think_ this resolves to the same as the `media_type` on the `MediaItemPlaybackProgressReport`, so an additional pair of eyes here would be nice.
Seems Subsonic was also missing the passing along of the config, so player and user filtering probably didn't work.

**Related issue (if applicable):**

- related issue <link to issue> /

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
