### PR TITLE
Musiccast stability fixes

### DIFF
--- a/music_assistant/providers/musiccast/avt_helpers.py
+++ b/music_assistant/providers/musiccast/avt_helpers.py
@@ -1,5 +1,8 @@
 """Helpers to make an UPnP request."""
 
+import logging
+from contextlib import suppress
+
 import aiohttp
 
 from music_assistant.helpers.upnp import (
@@ -21,6 +24,8 @@ from music_assistant.providers.musiccast.constants import (
 )
 from music_assistant.providers.musiccast.musiccast import MusicCastPhysicalDevice
 
+LOGGER = logging.getLogger(__name__)
+
 
 def get_headers(xml: str, soap_action: str) -> dict[str, str]:
     """Get headers for MusicCast."""
@@ -38,6 +43,30 @@ def get_upnp_ctrl_url(physical_device: MusicCastPhysicalDevice) -> str:
     return f"http://{format_ip_for_url(physical_device.device.device.ip)}:{MC_DEVICE_UPNP_PORT}/{MC_DEVICE_UPNP_CTRL_ENDPOINT}"
 
 
+async def _post_soap(
+    client: aiohttp.ClientSession,
+    ctrl_url: str,
+    xml: str,
+    soap_action: str,
+    op_name: str,
+) -> aiohttp.ClientResponse:
+    """POST a SOAP request and log a warning on 4xx/5xx error responses."""
+    headers = get_headers(xml, soap_action)
+    response = await client.post(ctrl_url, headers=headers, data=xml)
+    if response.status >= 400:
+        body_excerpt = ""
+        with suppress(aiohttp.ClientError, UnicodeError):
+            body_excerpt = (await response.read())[:300].decode(errors="replace")
+        LOGGER.warning(
+            "AVT %s failed: status=%s url=%s body=%s",
+            op_name,
+            response.status,
+            ctrl_url,
+            body_excerpt,
+        )
+    return response
+
+
 async def avt_play(
     client: aiohttp.ClientSession,
     physical_device: MusicCastPhysicalDevice,
@@ -45,52 +74,47 @@ async def avt_play(
     """Play."""
     ctrl_url = get_upnp_ctrl_url(physical_device)
     xml, soap_action = get_xml_soap_play()
-    headers = get_headers(xml, soap_action)
-    await client.post(ctrl_url, headers=headers, data=xml)
+    await _post_soap(client, ctrl_url, xml, soap_action, "Play")
 
 
 async def avt_stop(
     client: aiohttp.ClientSession,
     physical_device: MusicCastPhysicalDevice,
 ) -> None:
-    """Play."""
+    """Stop."""
     ctrl_url = get_upnp_ctrl_url(physical_device)
     xml, soap_action = get_xml_soap_stop()
-    headers = get_headers(xml, soap_action)
-    await client.post(ctrl_url, headers=headers, data=xml)
+    await _post_soap(client, ctrl_url, xml, soap_action, "Stop")
 
 
 async def avt_pause(
     client: aiohttp.ClientSession,
     physical_device: MusicCastPhysicalDevice,
 ) -> None:
-    """Play."""
+    """Pause."""
     ctrl_url = get_upnp_ctrl_url(physical_device)
     xml, soap_action = get_xml_soap_pause()
-    headers = get_headers(xml, soap_action)
-    await client.post(ctrl_url, headers=headers, data=xml)
+    await _post_soap(client, ctrl_url, xml, soap_action, "Pause")
 
 
 async def avt_next(
     client: aiohttp.ClientSession,
     physical_device: MusicCastPhysicalDevice,
 ) -> None:
-    """Play."""
+    """Next."""
     ctrl_url = get_upnp_ctrl_url(physical_device)
     xml, soap_action = get_xml_soap_next()
-    headers = get_headers(xml, soap_action)
-    await client.post(ctrl_url, headers=headers, data=xml)
+    await _post_soap(client, ctrl_url, xml, soap_action, "Next")
 
 
 async def avt_previous(
     client: aiohttp.ClientSession,
     physical_device: MusicCastPhysicalDevice,
 ) -> None:
-    """Play."""
+    """Previous."""
     ctrl_url = get_upnp_ctrl_url(physical_device)
     xml, soap_action = get_xml_soap_previous()
-    headers = get_headers(xml, soap_action)
-    await client.post(ctrl_url, headers=headers, data=xml)
+    await _post_soap(client, ctrl_url, xml, soap_action, "Previous")
 
 
 async def avt_get_media_info(
@@ -100,8 +124,9 @@ async def avt_get_media_info(
     """Get Media Info."""
     ctrl_url = get_upnp_ctrl_url(physical_device)
     xml, soap_action = get_xml_soap_media_info()
-    headers = get_headers(xml, soap_action)
-    response = await client.post(ctrl_url, headers=headers, data=xml)
+    response = await _post_soap(client, ctrl_url, xml, soap_action, "GetMediaInfo")
+    if response.status >= 400:
+        raise aiohttp.ClientError(f"GetMediaInfo returned {response.status}")
     response_text = await response.read()
     return response_text.decode()
 
@@ -110,11 +135,12 @@ async def avt_get_transport_info(
     client: aiohttp.ClientSession,
     physical_device: MusicCastPhysicalDevice,
 ) -> str:
-    """Get Media Info."""
+    """Get Transport Info."""
     ctrl_url = get_upnp_ctrl_url(physical_device)
     xml, soap_action = get_xml_soap_transport_info()
-    headers = get_headers(xml, soap_action)
-    response = await client.post(ctrl_url, headers=headers, data=xml)
+    response = await _post_soap(client, ctrl_url, xml, soap_action, "GetTransportInfo")
+    if response.status >= 400:
+        raise aiohttp.ClientError(f"GetTransportInfo returned {response.status}")
     response_text = await response.read()
     return response_text.decode()
 
@@ -132,10 +158,12 @@ async def avt_set_url(
     ctrl_url = get_upnp_ctrl_url(physical_device)
     if enqueue:
         xml, soap_action = get_xml_soap_set_next_url(player_media)
+        op_name = "SetNextAVTransportURI"
     else:
         xml, soap_action = get_xml_soap_set_url(player_media)
-    headers = get_headers(xml, soap_action)
-    await client.post(ctrl_url, headers=headers, data=xml)
+        op_name = "SetAVTransportURI"
+    LOGGER.debug("AVT %s uri=%s", op_name, player_media.uri)
+    await _post_soap(client, ctrl_url, xml, soap_action, op_name)
 
 
 def search_xml(xml: str, tag: str) -> str | None:

--- a/music_assistant/providers/musiccast/constants.py
+++ b/music_assistant/providers/musiccast/constants.py
@@ -28,6 +28,7 @@ PLAYER_ZONE_SPLITTER = "___"  # must be url ok
 CONF_PLAYER_HANDLE_SOURCE_DISABLED = "handle_source_allowed"
 CONF_PLAYER_SWITCH_SOURCE_NON_NET = "main_switch_source"
 CONF_PLAYER_TURN_OFF_ON_LEAVE = "turn_off_on_leave"
+CONF_PLAYER_AUTO_ADVANCE = "auto_advance_on_idle"
 MAIN_SWITCH_SOURCE_NON_NET = "audio1"
 PLAYER_ZONE2_SWITCH_SOURCE_NON_NET = "audio2"
 PLAYER_ZONE3_SWITCH_SOURCE_NON_NET = "audio3"

--- a/music_assistant/providers/musiccast/musiccast.py
+++ b/music_assistant/providers/musiccast/musiccast.py
@@ -340,9 +340,14 @@ class MusicCastZoneDevice:
         """Play http url."""
         await self.device.play_url_media(self.zone_name, media_url=url, title=MC_PLAY_TITLE)
 
-    async def select_source(self, source_id: str) -> None:
-        """Select input source. Internal source name."""
-        await self.device.select_source(self.zone_name, source_id)
+    async def select_source(self, source_id: str, mode: str = "") -> None:
+        """
+        Select input source. Internal source name.
+
+        :param source_id: Internal MusicCast source name.
+        :param mode: Optional MusicCast source mode, e.g. "autoplay_disabled".
+        """
+        await self.device.select_source(self.zone_name, source_id, mode)
 
     async def select_sound_mode(self, sound_mode_id: str) -> None:
         """Select sound mode. Internal sound_mode name."""

--- a/music_assistant/providers/musiccast/musiccast.py
+++ b/music_assistant/providers/musiccast/musiccast.py
@@ -559,7 +559,9 @@ class MusicCastPhysicalDevice:
 
     def disable_polling(self) -> None:
         """Disable udp polling."""
-        self.device.device.disable_polling()
+        with suppress(AttributeError):
+            # aiomusiccast raises if polling was never enabled or was already disabled
+            self.device.device.disable_polling()
 
     async def fetch(self) -> None:
         """Fetch device information.
@@ -583,11 +585,9 @@ class MusicCastPhysicalDevice:
 
     def remove(self) -> None:
         """Remove physical device."""
-        with suppress(AttributeError):
-            # might already be closed
-            self.device.device.disable_polling()
+        self.disable_polling()
         with suppress(ValueError):
-            # might already be closed
+            # might already be removed from controller
             self.controller.physical_devices.remove(self)
 
 

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -693,11 +693,7 @@ class MusicCastPlayer(Player):
         return _input_sources.difference(_net_sources)
 
     async def _set_player_unavailable(self) -> None:
-        """Set this player and associated zone players unavailable.
-
-        Only called from a main zone player.
-        """
-        assert self.zone_device.zone_name == "main", "Call only from main player!"
+        """Set this player and associated zone players unavailable."""
         self.logger.debug("Player %s became unavailable.", self.display_name)
 
         if TYPE_CHECKING:
@@ -707,19 +703,17 @@ class MusicCastPlayer(Player):
         # the next poll can recover it.
         self.physical_device.disable_polling()
 
-        async with self.update_lock:
-            self._attr_available = False
-            self.update_state()
+        # no update_lock: _cmd_run can call this while play_media already holds it
+        self._attr_available = False
+        self.update_state()
 
-        # set other zones unavailable
         for zone_device in self.zone_device.other_zones:
             if zone_device_player := self.mass.players.get_player(
                 self._get_player_id_from_zone_device(zone_device)
             ):
                 assert isinstance(zone_device_player, MusicCastPlayer)  # for type checking
-                async with zone_device_player.update_lock:
-                    zone_device_player._attr_available = False
-                    zone_device_player.update_state()
+                zone_device_player._attr_available = False
+                zone_device_player.update_state()
 
     async def _set_player_available(self) -> None:
         """Re-enable UDP polling and refresh zone players after recovery."""

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -641,14 +641,15 @@ class MusicCastPlayer(Player):
         if TYPE_CHECKING:
             assert isinstance(self.provider, MusicCastProvider)
 
-        # disable polling
-        self.physical_device.remove()
+        # UDP polling is stopped but the physical device stays registered so
+        # the next poll can recover it.
+        self.physical_device.disable_polling()
 
         async with self.update_lock:
             self._attr_available = False
             self.update_state()
 
-        # set other zone unavailable
+        # set other zones unavailable
         for zone_device in self.zone_device.other_zones:
             if zone_device_player := self.mass.players.get_player(
                 self._get_player_id_from_zone_device(zone_device)
@@ -657,6 +658,19 @@ class MusicCastPlayer(Player):
                 async with zone_device_player.update_lock:
                     zone_device_player._attr_available = False
                     zone_device_player.update_state()
+
+    async def _set_player_available(self) -> None:
+        """Re-enable UDP polling and refresh zone players after recovery."""
+        assert self.zone_device.zone_name == "main", "Call only from main player!"
+        self.logger.debug("Player %s became available again.", self.display_name)
+        await self.physical_device.enable_polling()
+        for zone_device in self.zone_device.other_zones:
+            if zone_device_player := self.mass.players.get_player(
+                self._get_player_id_from_zone_device(zone_device)
+            ):
+                assert isinstance(zone_device_player, MusicCastPlayer)  # for type checking
+                async with zone_device_player.update_lock:
+                    await zone_device_player.set_dynamic_attributes()
 
     async def poll(self) -> None:
         """Poll player."""
@@ -667,7 +681,7 @@ class MusicCastPlayer(Player):
             # we only poll main, which polls the whole device
             return
         async with self.update_lock:
-            # explicit polling on main
+            _was_unavailable = not self._attr_available
             try:
                 await self.physical_device.fetch()
             except (MusicCastConnectionException, MusicCastGroupException):
@@ -675,6 +689,8 @@ class MusicCastPlayer(Player):
                 return
             except ClientError:
                 return
+            if _was_unavailable:
+                await self._set_player_available()
             await self.set_dynamic_attributes()
 
     def _non_async_udp_callback(self, physical_device: MusicCastPhysicalDevice) -> None:

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -768,12 +768,13 @@ class MusicCastPlayer(Player):
                     await self._handle_zone_grouping(dev)
                     _zone_handling_attempted = True
         async with self.update_lock:
-            # re-assert "server" if zone handling ran (the device may have switched
-            # main as a side effect) or if the cached source is something else; AVT
-            # Play returns UPnPError 500 if main is not on the DLNA renderer input
+            # re-assert "server" when zone handling ran or the cached source is stale;
+            # autoplay_disabled stops the device resuming the input's last queue
             if _zone_handling_attempted or self.zone_device.source_id != "server":
-                await self.select_source("server")
+                await self._cmd_run(self.zone_device.select_source, "server", "autoplay_disabled")
             media.uri = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
+            # clear any pending AVT state to avoid wedging on rapid play_media
+            await avt_stop(self.mass.http_session, self.physical_device)
             await avt_set_url(self.mass.http_session, self.physical_device, player_media=media)
             await avt_play(self.mass.http_session, self.physical_device)
 

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -49,6 +49,7 @@ from music_assistant.providers.musiccast.avt_helpers import (
     search_xml,
 )
 from music_assistant.providers.musiccast.constants import (
+    CONF_PLAYER_AUTO_ADVANCE,
     CONF_PLAYER_HANDLE_SOURCE_DISABLED,
     CONF_PLAYER_SWITCH_SOURCE_NON_NET,
     CONF_PLAYER_TURN_OFF_ON_LEAVE,
@@ -145,6 +146,10 @@ class MusicCastPlayer(Player):
         self.upnp_update_helper: UpnpUpdateHelper | None = None
         # last netusb_track value, used to detect device-driven gapless transitions
         self._last_netusb_track: str | None = None
+        # used to detect when the device dropped to idle mid-queue without
+        # honouring the queued NextURI (Yamaha gapless can fail this way)
+        self._last_playback_state: PlaybackState | None = None
+        self._last_playing_elapsed_time: float = 0.0
 
     async def setup(self) -> None:
         """Set up player in Music Assistant."""
@@ -530,6 +535,63 @@ class MusicCastPlayer(Player):
             and self.upnp_update_helper.current_uri != _prev_current_uri
         ):
             self.mass.player_queues.on_player_update(self, {})
+
+        self._maybe_advance_on_track_end()
+
+    def _maybe_advance_on_track_end(self) -> None:
+        """Schedule a queue advance if the device went idle at end of track."""
+        # The device sometimes drops the queued NextURI and stops instead of
+        # transitioning. Recover by calling next() on the queue. Gated by a
+        # per-player config so users who don't want the safety net can opt out.
+        _prev_state = self._last_playback_state
+        self._last_playback_state = self._attr_playback_state
+        if self._attr_playback_state == PlaybackState.PLAYING:
+            if self._attr_elapsed_time is not None:
+                self._last_playing_elapsed_time = self._attr_elapsed_time
+            return
+        if (
+            _prev_state != PlaybackState.PLAYING
+            or self._attr_playback_state != PlaybackState.IDLE
+            or self.upnp_update_helper is None
+            or not self.upnp_update_helper.controlled_by_mass
+        ):
+            return
+        if not bool(
+            self.mass.config.get_raw_player_config_value(
+                self.player_id, CONF_PLAYER_AUTO_ADVANCE, default=True
+            )
+        ):
+            return
+        queue = self.mass.player_queues.get(self.player_id)
+        if queue is None or queue.current_item is None or queue.next_item is None:
+            return
+        _duration = queue.current_item.duration or 0
+        # only act within 4 s of track duration to minimise hijacking a user stop
+        if not _duration or self._last_playing_elapsed_time < _duration - 4:
+            return
+        self.mass.call_later(
+            3,
+            self._advance_queue_after_idle,
+            queue.current_item.queue_item_id,
+            task_id=f"musiccast_advance_after_idle_{self.player_id}",
+        )
+
+    async def _advance_queue_after_idle(self, expected_current_item_id: str) -> None:
+        """Advance the queue if the player is still idle on the same item."""
+        if self._attr_playback_state != PlaybackState.IDLE:
+            return
+        queue = self.mass.player_queues.get(self.player_id)
+        if queue is None or not queue.active:
+            return
+        if (
+            queue.current_item is None
+            or queue.current_item.queue_item_id != expected_current_item_id
+        ):
+            return
+        if queue.next_item is None:
+            return
+        self.logger.debug("Advancing queue to next item after end-of-track idle")
+        await self.mass.player_queues.next(self.player_id)
 
     @property
     def synced_to(self) -> str | None:
@@ -989,4 +1051,16 @@ class MusicCastPlayer(Player):
                     ),
                 ]
 
-        return base_entries + zone_entries + PLAYER_CONFIG_ENTRIES
+        auto_advance_entry = ConfigEntry(
+            key=CONF_PLAYER_AUTO_ADVANCE,
+            type=ConfigEntryType.BOOLEAN,
+            label="Auto-advance queue when the device stops at end of track",
+            default_value=True,
+            description="Yamaha receivers occasionally drop the queued next track and "
+            "stop playback. With this enabled, MA detects the stop and advances the "
+            "queue. As a side effect, a user-initiated stop within the last 4 seconds "
+            "of a track will also advance to the next item; disable if you prefer the "
+            "device's stop behaviour to always be respected.",
+        )
+
+        return base_entries + zone_entries + [auto_advance_entry] + PLAYER_CONFIG_ENTRIES

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -143,6 +143,8 @@ class MusicCastPlayer(Player):
         # refers to being controlled by upnp.
         self.update_lock = asyncio.Lock()
         self.upnp_update_helper: UpnpUpdateHelper | None = None
+        # last netusb_track value, used to detect device-driven gapless transitions
+        self._last_netusb_track: str | None = None
 
     async def setup(self) -> None:
         """Set up player in Music Assistant."""
@@ -282,7 +284,27 @@ class MusicCastPlayer(Player):
 
         # UPDATE UPNP HELPER
         now = time.time()
-        if self.upnp_update_helper is None or now - self.upnp_update_helper.last_poll > 5:
+        _current_netusb_track = (
+            self.physical_device.device.data.netusb_track if self.zone_device.is_netusb else None
+        )
+        _netusb_track_changed = (
+            self._last_netusb_track is not None
+            and _current_netusb_track is not None
+            and _current_netusb_track != self._last_netusb_track
+        )
+        self._last_netusb_track = _current_netusb_track
+        _upnp_cache_age = (
+            None if self.upnp_update_helper is None else now - self.upnp_update_helper.last_poll
+        )
+        # invalidate the cache on a netusb_track change so a gapless transition
+        # reflects in current_uri without waiting for the regular 5s refresh
+        _upnp_cache_hit = (
+            _upnp_cache_age is not None and _upnp_cache_age <= 5 and not _netusb_track_changed
+        )
+        _prev_current_uri = (
+            self.upnp_update_helper.current_uri if self.upnp_update_helper is not None else None
+        )
+        if not _upnp_cache_hit:
             # Let's not do this too often
             # Note: The devices always return the last UPnP xmls, even if
             # currently another source/ playback method is used
@@ -317,6 +339,9 @@ class MusicCastPlayer(Player):
                 controlled_by_mass=controlled_by_mass,
                 current_uri=_player_current_url,
             )
+
+        # either freshly assigned above or a cache hit (which implies it was set before)
+        assert self.upnp_update_helper is not None
 
         # UPDATE PLAYBACK INFORMATION
         # Note to self:
@@ -496,6 +521,15 @@ class MusicCastPlayer(Player):
 
         if update_state:
             self.update_state()
+
+        # state.current_media is queue-derived, so a current_uri change alone does not
+        # produce a state diff. Nudge the queue directly so it re-parses the new URI.
+        if (
+            update_state
+            and self.upnp_update_helper.controlled_by_mass
+            and self.upnp_update_helper.current_uri != _prev_current_uri
+        ):
+            self.mass.player_queues.on_player_update(self, {})
 
     @property
     def synced_to(self) -> str | None:

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -755,17 +755,23 @@ class MusicCastPlayer(Player):
 
     async def play_media(self, media: PlayerMedia) -> None:
         """Play media command."""
+        _zone_handling_attempted = False
         if len(self.physical_device.zone_devices) > 1:
             # zone handling
             # only a single zone may have netusb capability
             for zone_name, dev in self.physical_device.zone_devices.items():
                 if zone_name == self.zone_device.zone_name:
                     continue
-                if dev.is_netusb:
+                # skip powered-off zones: their remembered source can match netusb_input
+                # without actually consuming the resource, and switching can affect main
+                if dev.is_netusb and dev.zone_data is not None and dev.zone_data.power == "on":
                     await self._handle_zone_grouping(dev)
+                    _zone_handling_attempted = True
         async with self.update_lock:
-            # just in case
-            if self.zone_device.source_id != "server":
+            # re-assert "server" if zone handling ran (the device may have switched
+            # main as a side effect) or if the cached source is something else; AVT
+            # Play returns UPnPError 500 if main is not on the DLNA renderer input
+            if _zone_handling_attempted or self.zone_device.source_id != "server":
                 await self.select_source("server")
             media.uri = await self.provider.mass.streams.resolve_stream_url(self.player_id, media)
             await avt_set_url(self.mass.http_session, self.physical_device, player_media=media)

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -870,23 +870,48 @@ class MusicCastPlayer(Player):
         children_zones: list[str] = []  # list[ma_player_id]
         player_ids_to_add = [] if player_ids_to_add is None else player_ids_to_add
         for child_id in player_ids_to_add:
-            if child_player := self.mass.players.get_player(child_id):
-                assert isinstance(child_player, MusicCastPlayer)  # for type checking
-                _other_zone_mc: MusicCastZoneDevice | None = None
-                for x in child_player.zone_device.other_zones:
-                    if x.is_netusb:
-                        _other_zone_mc = x
-                if _other_zone_mc and _other_zone_mc != child_player.zone_device:
-                    # of the same device, we use main_sync as input
-                    if _other_zone_mc.zone_name == "main":
-                        children_zones.append(child_id)
-                    else:
-                        self.logger.warning(
-                            "It is impossible to join as a normal zone to another zone of the same "
-                            "device. Only joining to main is possible. Please refer to the docs."
-                        )
-                else:
-                    children.add(child_id)
+            child_player = self.mass.players.get_player(child_id)
+            if child_player is None:
+                continue
+            assert isinstance(child_player, MusicCastPlayer)  # for type checking
+
+            # find a sibling zone on the child's device currently using netusb;
+            # skip disabled zones (user opted out of MA managing them)
+            _other_zone_mc: MusicCastZoneDevice | None = None
+            for x in child_player.zone_device.other_zones:
+                if not x.is_netusb:
+                    continue
+                _other_player_id = self._get_player_id_from_zone_device(x)
+                _other_player = self.mass.players.get_player(_other_player_id)
+                if _other_player is None or not _other_player.enabled:
+                    continue
+                _other_zone_mc = x
+                # only one zone can hold netusb at a time
+                break
+
+            # no conflicting sibling -> standard client join
+            if _other_zone_mc is None:
+                children.add(child_id)
+                continue
+
+            # child is a non-main zone of a device whose main is the netusb consumer;
+            # join the group via main_sync so the child follows main locally
+            if child_player.zone_device.zone_name != "main" and _other_zone_mc.zone_name == "main":
+                children_zones.append(child_id)
+                continue
+
+            # child is main but a sibling holds netusb; free the sibling so main
+            # can become the netusb client, then join normally
+            if child_player.zone_device.zone_name == "main":
+                await child_player._handle_zone_grouping(_other_zone_mc)
+                children.add(child_id)
+                continue
+
+            # non-main child while another non-main sibling holds netusb is unsupported
+            self.logger.warning(
+                "It is impossible to join as a normal zone to another zone of the same "
+                "device. Only joining to main is possible. Please refer to the docs."
+            )
 
         for child_id in children_zones:
             child_player = self.mass.players.get_player(child_id)


### PR DESCRIPTION
# What does this implement/fix?

This fixes some issues I encountered while using the MusicCast Player Provider. Tested on a RX-V583 and various WX-021 devices, linked also to older WX devices.

The main contributions are:
* UPnP cache invalidation on track transitions, which did lead to some stale data
* device unavailability recovery when devices drop briefly from the network due to network reasons, which lead to a locked up state for the device, which we now recover from
* improved multi-zone receiver handling. This does not fix the known issues that are already document, but at least makes the operation a bit more stable. I don't have a multi-zone setup to really test this unfortunately, but it shouldn't affect the multi-zone cases anyways.
* stop playback before starting playback, matching what HASS does already, to play with a more "expectable" state.
* a naive auto-advance implementation. Sometimes at least the WX-021 does not honor the DLNA nextplaybackuri, but instead pauses on the last seconds of the current track. This adds a (gated) option to detect that situation and plays the track manually. IMO the most debatable change, but I could not find out what else might trigger this state with the WX-021. 
* minor deadlock fixes
* more logging for (future) diagnosis

**Related issue (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

Evidently these commits were made using Claude Code, but the code was reviewed by me and functionality tested on my devices.