### PR TITLE
Allow Plugin Providers to implement ProviderFeature.SEARCH

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -321,9 +321,6 @@ class MusicController(CoreController):
         :param limit: number of items to return in the search (per type).
         """
         # use cache to avoid repeated searches
-        # include music providers (deduped per streaming domain) plus any
-        # plugin providers that declare SEARCH so plugin-supplied content
-        # (e.g. smart playlists) participates in global search
         plugin_search_providers = [
             p.instance_id
             for p in self.mass.get_providers_supporting_feature(

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -321,7 +321,17 @@ class MusicController(CoreController):
         :param limit: number of items to return in the search (per type).
         """
         # use cache to avoid repeated searches
-        search_providers = sorted(self.get_unique_providers())
+        # include music providers (deduped per streaming domain) plus any
+        # plugin providers that declare SEARCH so plugin-supplied content
+        # (e.g. smart playlists) participates in global search
+        plugin_search_providers = [
+            p.instance_id
+            for p in self.mass.get_providers_supporting_feature(
+                ProviderFeature.SEARCH,
+                priority=(ProviderType.PLUGIN,),
+            )
+        ]
+        search_providers = sorted(self.get_unique_providers() + plugin_search_providers)
         cache_provider_key = "library" if library_only else ",".join(search_providers)
         cache_key = f"{search_query}{'-'.join(sorted([mt.value for mt in media_types]))}-{limit}-{library_only}-{cache_provider_key}"
         if cache := await self.mass.cache.get(

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import ProviderFeature
+from music_assistant_models.media_items import SearchResults
 
 from .provider import Provider
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Sequence
 
-    from music_assistant_models.enums import SourceControl
+    from music_assistant_models.enums import MediaType, SourceControl
     from music_assistant_models.media_items import (
         AudioSource,
         BrowseFolder,
@@ -237,6 +238,25 @@ class PluginProvider(Provider):
         :return: The AI response as a string.
         """
         raise NotImplementedError
+
+    async def search(
+        self,
+        search_query: str,
+        media_types: list[MediaType],
+        limit: int = 5,
+    ) -> SearchResults:
+        """
+        Perform a search on this plugin.
+
+        Will only be called if ProviderFeature.SEARCH is declared.
+
+        :param search_query: Search query.
+        :param media_types: A list of media_types to include.
+        :param limit: Number of items to return in the search (per type).
+        """
+        if ProviderFeature.SEARCH in self.supported_features:
+            raise NotImplementedError
+        return SearchResults()
 
     async def get_similar_tracks(self, track: Track, limit: int = 25) -> list[Track]:
         """

--- a/music_assistant/providers/_demo_plugin_provider/__init__.py
+++ b/music_assistant/providers/_demo_plugin_provider/__init__.py
@@ -49,6 +49,7 @@ from music_assistant_models.media_items import (
     AudioSource,
     Playlist,
     ProviderMapping,
+    SearchResults,
 )
 from music_assistant_models.media_items.audio_format import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
@@ -372,6 +373,21 @@ class MyDemoPluginprovider(PluginProvider):
         #     self._active_session_id = None
         #     if self._in_use_by_queue == queue_id:
         #         self._in_use_by_queue = None
+
+    async def search(
+        self,
+        search_query: str,
+        media_types: list[MediaType],
+        limit: int = 5,
+    ) -> SearchResults:
+        """Perform a search against this plugin's content."""
+        # OPTIONAL
+        # Will only be called if ProviderFeature.SEARCH is declared.
+        # Return a SearchResults with items belonging to this plugin (typically
+        # Playlist items whose provider_mappings point back to this plugin).
+        # The global search controller interleaves the result with results
+        # from other providers.
+        return SearchResults()
 
     async def get_similar_tracks(self, track: Track, limit: int = 25) -> list[Track]:
         """Retrieve a list of similar tracks for the given track."""

--- a/tests/test_cross_type_features.py
+++ b/tests/test_cross_type_features.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from music_assistant_models.enums import ProviderFeature, ProviderType
-from music_assistant_models.media_items import ProviderMapping
+from music_assistant_models.enums import MediaType, ProviderFeature, ProviderType
+from music_assistant_models.media_items import ProviderMapping, SearchResults
 
 from music_assistant.controllers.media.artists import ArtistsController
 from music_assistant.controllers.media.tracks import TracksController
@@ -13,6 +13,7 @@ from music_assistant.controllers.music import MusicController
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.metadata_provider import MetadataProvider
 from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.plugin import PluginProvider
 
 
 def _make_prov(
@@ -214,3 +215,59 @@ async def test_browse_root_includes_non_music_providers() -> None:
         for c in mass.get_providers_supporting_feature.call_args_list
     ]
     assert ProviderFeature.BROWSE in calls
+
+
+async def test_global_search_includes_plugin_providers_with_search() -> None:
+    """Plugins declaring SEARCH should be queried alongside music providers."""
+    mass = Mock()
+    mass.cache.get = AsyncMock(return_value=None)
+    mass.cache.set = AsyncMock(return_value=None)
+    plugin_prov = _make_prov("plug_a", ProviderType.PLUGIN, {ProviderFeature.SEARCH})
+    mass.get_providers_supporting_feature.return_value = [plugin_prov]
+
+    controller = MusicController.__new__(MusicController)
+    controller.mass = mass
+    controller.domain = "music"
+    controller.get_unique_providers = Mock(return_value=["m_a"])  # type: ignore[method-assign]
+    controller.search_library = AsyncMock(return_value=SearchResults())  # type: ignore[method-assign]
+    controller._search_provider = AsyncMock(return_value=SearchResults())  # type: ignore[method-assign]
+    controller._sort_search_result = Mock(side_effect=lambda _query, items: items)  # type: ignore[method-assign]
+
+    await controller.search("foo", media_types=[MediaType.TRACK], limit=5)
+
+    queried_provider_ids = sorted(
+        call.args[1] for call in controller._search_provider.await_args_list
+    )
+    assert queried_provider_ids == ["m_a", "plug_a"]
+    args, kwargs = mass.get_providers_supporting_feature.call_args
+    assert (args[0] if args else kwargs["feature"]) == ProviderFeature.SEARCH
+    assert kwargs.get("priority") == (ProviderType.PLUGIN,)
+
+
+async def test_plugin_search_default_stub_contract() -> None:
+    """PluginProvider.search returns empty unless SEARCH is declared, then raises NotImplementedError."""
+
+    class _StubPlugin(PluginProvider):
+        _features: set[ProviderFeature] = set()
+
+        @property
+        def supported_features(self) -> set[ProviderFeature]:
+            return self._features
+
+    plugin = _StubPlugin.__new__(_StubPlugin)
+    plugin._features = set()
+
+    result = await plugin.search("foo", [MediaType.TRACK], limit=5)
+    assert isinstance(result, SearchResults)
+    assert not result.tracks
+    assert not result.artists
+    assert not result.albums
+
+    plugin._features = {ProviderFeature.SEARCH}
+    try:
+        await plugin.search("foo", [MediaType.TRACK], limit=5)
+    except NotImplementedError:
+        pass
+    else:
+        msg = "expected NotImplementedError when SEARCH is declared but not overridden"
+        raise AssertionError(msg)


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #3811, which laid the foundation for plugin and metadata providers to participate in music-related `ProviderFeature`s that were previously music-provider-exclusive. `SEARCH` was not part of that PR; this change extends the same cross-type pattern to it so plugins (e.g. an upcoming "smart playlist" plugin) can answer global search queries.

Scope is plugins only — metadata providers don't expose playable items so they have no reason to answer global searches.

**Changes:**

- `PluginProvider` gets a `search()` stub mirroring the existing `get_similar_tracks` / `recommendations` / `browse` contract (raises `NotImplementedError` when `SEARCH` is declared, returns empty `SearchResults` otherwise).
- `MusicController.search` now also iterates plugin instances declaring `SEARCH`, via `mass.get_providers_supporting_feature(ProviderFeature.SEARCH, priority=(ProviderType.PLUGIN,))`. `_search_provider` itself did not need changes — it was already provider-type-agnostic.
- `_demo_plugin_provider` gets a matching `search()` stub example next to the existing optional-feature stubs.
- New unit tests in `tests/test_cross_type_features.py` cover both the dispatch wire-up and the `PluginProvider.search` stub contract.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] \`pre-commit run --all-files\` passes.
- [x] \`pytest\` passes, and tests have been added/updated under \`tests/\` where applicable.
- [ ] For changes to shared models, the companion PR in \`music-assistant/models\` is linked.
- [ ] For changes affecting the UI, the companion PR in \`music-assistant/frontend\` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.