### PR TITLE
Only set torch preference for engined that actually work

### DIFF
--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -89,9 +89,9 @@ class SmartFadesProvider(AudioAnalysisProvider):
         beat_this_model = Spect2Frames(checkpoint_path="small0", device=self._device)
         # torch aarch64 wheels advertise fbgemm in supported_engines but its kernels are x86-only.
         is_arm = platform.machine().lower() in ("arm64", "aarch64", "armv8l", "armv7l")
-        preference = ("qnnpack", "fbgemm") if is_arm else ("fbgemm", "qnnpack")
+        preference = "qnnpack" if is_arm else "fbgemm"
         supported_engines = torch.backends.quantized.supported_engines
-        quantized_engine = next((e for e in preference if e in supported_engines), None)
+        quantized_engine = preference if preference in supported_engines else None
         if quantized_engine is not None and torch.backends.quantized.engine != quantized_engine:
             torch.backends.quantized.engine = quantized_engine
         beat_this_model.model = torch.ao.quantization.quantize_dynamic(  # type: ignore[no-untyped-call]


### PR DESCRIPTION
qnnpack does not work on x86 and fbgemm uses x86 specific instructions.

# What does this implement/fix?

When packaging Music Assistant for NixOS I noticed due to our systemd hardening that qnnpack failed to set up and according to the internet qnnpack probably does not even work on my x86 hardware.

```
mass[1000450]: 2026-05-25 04:53:42.852 DEBUG (MainThread) [music_assistant.webserver] Handling command config/providers/get
mass[1000450]: 2026-05-25 04:53:48.068 DEBUG (MainThread) [music_assistant.webserver] Handling command config/providers/save
mass[1000450]: 2026-05-25 04:53:48.070 DEBUG (MainThread) [music_assistant] Loading provider Smart Fades
mass[1000450]: 2026-05-25 04:53:48.071 DEBUG (MainThread) [music_assistant.smart_fades] Log level configured to VERBOSE
mass[1000450]: 2026-05-25 04:53:48.140 ERROR (MainThread) [music_assistant.webserver] Error handling message: CommandMessage(message_id='283634e7-2960-4b2d-8445-958a21ddb77f', command='config/providers/save', args={'provider_domain': 'smart_fades', 'values': {'log_level': 'VERBOSE', 'single_cpu_warning': None, 'enabled': True}, 'instance_id': 'smart_fades'})
mass[1000450]: Traceback (most recent call last):
mass[1000450]:   File "/nix/store/svpxzdazhs00q52ndc6hrs38a3xrb6dg-music-assistant-2.9.0b13/lib/python3.13/site-packages/music_assistant/controllers/webserver/websocket_client.py", line 243, in _run_handler
mass[1000450]:     result = await result
mass[1000450]:              ^^^^^^^^^^^^
mass[1000450]:   File "/nix/store/svpxzdazhs00q52ndc6hrs38a3xrb6dg-music-assistant-2.9.0b13/lib/python3.13/site-packages/music_assistant/controllers/config.py", line 479, in save_provider_config
mass[1000450]:     config = await self._update_provider_config(instance_id, values)
mass[1000450]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:   File "/nix/store/svpxzdazhs00q52ndc6hrs38a3xrb6dg-music-assistant-2.9.0b13/lib/python3.13/site-packages/music_assistant/controllers/config.py", line 1430, in _update_provider_config
mass[1000450]:     await self.mass.load_provider_config(config)
mass[1000450]:   File "/nix/store/svpxzdazhs00q52ndc6hrs38a3xrb6dg-music-assistant-2.9.0b13/lib/python3.13/site-packages/music_assistant/mass.py", line 696, in load_provider_config
mass[1000450]:     await self._load_provider(prov_conf)
mass[1000450]:   File "/nix/store/svpxzdazhs00q52ndc6hrs38a3xrb6dg-music-assistant-2.9.0b13/lib/python3.13/site-packages/music_assistant/mass.py", line 989, in _load_provider
mass[1000450]:     await provider.handle_async_init()
mass[1000450]:   File "/nix/store/svpxzdazhs00q52ndc6hrs38a3xrb6dg-music-assistant-2.9.0b13/lib/python3.13/site-packages/music_assistant/providers/smart_fades/provider.py", line 83, in handle_async_init
mass[1000450]:     ) = await asyncio.to_thread(self._initialize_models)
mass[1000450]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/lib/python3.13/asyncio/threads.py", line 25, in to_thread
mass[1000450]:     return await loop.run_in_executor(None, func_call)
mass[1000450]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/lib/python3.13/concurrent/futures/thread.py", line 59, in run
mass[1000450]:     result = self.fn(*self.args, **self.kwargs)
mass[1000450]:   File "/nix/store/svpxzdazhs00q52ndc6hrs38a3xrb6dg-music-assistant-2.9.0b13/lib/python3.13/site-packages/music_assistant/providers/smart_fades/provider.py", line 95, in _initialize_models
mass[1000450]:     beat_this_model.model = torch.ao.quantization.quantize_dynamic(  # type: ignore[no-untyped-call]
mass[1000450]:                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:         beat_this_model.model, {torch.nn.Linear}, dtype=torch.qint8
mass[1000450]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:     )
mass[1000450]:     ^
mass[1000450]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/lib/python3.13/warnings.py", line 637, in wrapper
mass[1000450]:     return arg(*args, **kwargs)
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/quantization/quantize.py", line 570, in quantize_dynamic
mass[1000450]:     convert(model, mapping, inplace=True)
mass[1000450]:     ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:   File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/lib/python3.13/warnings.py", line 637, in wrapper
mass[1000450]:     return arg(*args, **kwargs)
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/quantization/quantize.py", line 669, in convert
mass[1000450]:     _convert(
mass[1000450]:     ~~~~~~~~^
mass[1000450]:         module,
mass[1000450]:         ^^^^^^^
mass[1000450]:     ...<4 lines>...
mass[1000450]:         use_precomputed_fake_quant=use_precomputed_fake_quant,
mass[1000450]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:     )
mass[1000450]:     ^
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/quantization/quantize.py", line 726, in _convert
mass[1000450]:     _convert(
mass[1000450]:     ~~~~~~~~^
mass[1000450]:         mod,
mass[1000450]:         ^^^^
mass[1000450]:     ...<4 lines>...
mass[1000450]:         use_precomputed_fake_quant=use_precomputed_fake_quant,
mass[1000450]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:     )
mass[1000450]:     ^
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/quantization/quantize.py", line 726, in _convert
mass[1000450]:     _convert(
mass[1000450]:     ~~~~~~~~^
mass[1000450]:         mod,
mass[1000450]:         ^^^^
mass[1000450]:     ...<4 lines>...
mass[1000450]:         use_precomputed_fake_quant=use_precomputed_fake_quant,
mass[1000450]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:     )
mass[1000450]:     ^
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/quantization/quantize.py", line 726, in _convert
mass[1000450]:     _convert(
mass[1000450]:     ~~~~~~~~^
mass[1000450]:         mod,
mass[1000450]:         ^^^^
mass[1000450]:     ...<4 lines>...
mass[1000450]:         use_precomputed_fake_quant=use_precomputed_fake_quant,
mass[1000450]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:     )
mass[1000450]:     ^
mass[1000450]:   [Previous line repeated 2 more times]
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/quantization/quantize.py", line 734, in _convert
mass[1000450]:     reassign[name] = swap_module(
mass[1000450]:                      ~~~~~~~~~~~^
mass[1000450]:         mod, mapping, custom_module_class_mapping, use_precomputed_fake_quant
mass[1000450]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:     )
mass[1000450]:     ^
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/quantization/quantize.py", line 779, in swap_module
mass[1000450]:     new_mod = qmod.from_float(
mass[1000450]:         mod, use_precomputed_fake_quant=use_precomputed_fake_quant
mass[1000450]:     )
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/nn/quantized/dynamic/modules/linear.py", line 149, in from_float
mass[1000450]:     qlinear = cls(mod.in_features, mod.out_features, dtype=dtype)
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/nn/quantized/dynamic/modules/linear.py", line 43, in __init__
mass[1000450]:     super().__init__(in_features, out_features, bias_, dtype=dtype)
mass[1000450]:     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/nn/quantized/modules/linear.py", line 170, in __init__
mass[1000450]:     self._packed_params = LinearPackedParams(dtype)
mass[1000450]:                           ~~~~~~~~~~~~~~~~~~^^^^^^^
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/nn/quantized/modules/linear.py", line 30, in __init__
mass[1000450]:     self.set_weight_bias(wq, None)  # type: ignore[possibly-undefined]
mass[1000450]:     ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/ao/nn/quantized/modules/linear.py", line 35, in set_weight_bias
mass[1000450]:     self._packed_params = torch.ops.quantized.linear_prepack(weight, bias)
mass[1000450]:                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
mass[1000450]:   File "/nix/store/070g44z2sdcy2axbf1yhr5h082q3xjch-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/_ops.py", line 1269, in __call__
mass[1000450]:     return self._op(*args, **kwargs)
mass[1000450]:            ~~~~~~~~^^^^^^^^^^^^^^^^^
mass[1000450]: RuntimeError: failed to initialize QNNPACK
```

**Related issue (if applicable):**

- related issue none

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
