### PR TITLE
Fix audio analysis documentation links

### DIFF
--- a/music_assistant/providers/_demo_audio_analysis_provider/manifest.json
+++ b/music_assistant/providers/_demo_audio_analysis_provider/manifest.json
@@ -5,5 +5,5 @@
   "description": "Test/Example Audio Analysis Provider for Music Assistant.",
   "codeowners": ["@yourgithubusername"],
   "requirements": [],
-  "documentation": "https://music-assistant.io/audio-analysis-providers/demo/"
+  "documentation": "https://music-assistant.io/audio-analysis/demo/"
 }

--- a/music_assistant/providers/loudness_analysis/manifest.json
+++ b/music_assistant/providers/loudness_analysis/manifest.json
@@ -9,5 +9,5 @@
   "builtin": true,
   "allow_disable": false,
   "icon": "volume-high",
-  "documentation": "https://music-assistant.io/audio-analysis-providers/loudness-analysis/"
+  "documentation": "https://music-assistant.io/audio-analysis/loudness-analysis/"
 }

--- a/music_assistant/providers/sonic_analysis/manifest.json
+++ b/music_assistant/providers/sonic_analysis/manifest.json
@@ -14,7 +14,7 @@
     "[Microsoft CLAP](https://github.com/microsoft/CLAP)",
     "[librosa](https://librosa.org)"
   ],
-  "documentation": "https://music-assistant.io/audio-analysis-providers/sonic-analysis/",
+  "documentation": "https://music-assistant.io/audio-analysis/sonic-analysis/",
   "multi_instance": false,
   "builtin": false,
   "icon": "pulse"


### PR DESCRIPTION
# What does this implement/fix?

Fixes the link on beta, stable will work with the next release

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
