### PR TITLE
Skip DSP-triggered playback restart when DSP was and remains disabled

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -948,13 +948,10 @@ class ConfigController:
         # validate the new config
         config.validate()
 
-        # Read the old enabled state before overwriting it so on_player_dsp_change
-        # can skip unnecessary restarts when DSP was already disabled.
-        old_enabled = self.get_player_dsp_config(player_id).enabled
-
-        # Save and apply the new config to the player
+        old_dsp_enabled = self.get_player_dsp_config(player_id).enabled
         self.set(f"{CONF_PLAYER_DSP}/{player_id}", config.to_dict())
-        await self.mass.players.on_player_dsp_change(player_id, was_enabled=old_enabled)
+        if old_dsp_enabled or config.enabled:
+            await self.mass.players.on_player_dsp_change(player_id)
         # send the dsp config updated event
         self.mass.signal_event(
             EventType.PLAYER_DSP_CONFIG_UPDATED,

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -948,9 +948,13 @@ class ConfigController:
         # validate the new config
         config.validate()
 
+        # Read the old enabled state before overwriting it so on_player_dsp_change
+        # can skip unnecessary restarts when DSP was already disabled.
+        old_enabled = self.get_player_dsp_config(player_id).enabled
+
         # Save and apply the new config to the player
         self.set(f"{CONF_PLAYER_DSP}/{player_id}", config.to_dict())
-        await self.mass.players.on_player_dsp_change(player_id)
+        await self.mass.players.on_player_dsp_change(player_id, was_enabled=old_enabled)
         # send the dsp config updated event
         self.mass.signal_event(
             EventType.PLAYER_DSP_CONFIG_UPDATED,

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -949,6 +949,7 @@ class ConfigController:
         config.validate()
 
         old_dsp_enabled = self.get_player_dsp_config(player_id).enabled
+        # Save and apply the new config to the player
         self.set(f"{CONF_PLAYER_DSP}/{player_id}", config.to_dict())
         if old_dsp_enabled or config.enabled:
             await self.mass.players.on_player_dsp_change(player_id)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2423,6 +2423,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     async def on_player_dsp_change(self, player_id: str) -> None:
         """Call (by config manager) when the DSP settings of a player change."""
+        # signal player provider that the config changed
         if not (player := self.get_player(player_id)):
             return
         if player.state.playback_state == PlaybackState.PLAYING:

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2421,13 +2421,17 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                     1, self.mass.player_queues.resume, resume_queue.queue_id, False
                 )
 
-    async def on_player_dsp_change(self, player_id: str) -> None:
-        """Call (by config manager) when the DSP settings of a player change."""
-        # signal player provider that the config changed
+    async def on_player_dsp_change(self, player_id: str, was_enabled: bool = True) -> None:
+        """Call (by config manager) when the DSP settings of a player change.
+
+        :param player_id: The player ID whose DSP config changed.
+        :param was_enabled: Whether DSP was enabled before this change.
+        """
         if not (player := self.get_player(player_id)):
             return
-        # DSP is disabled, changes won't affect the active audio stream
-        if not self.mass.config.get_player_dsp_config(player_id).enabled:
+        # skip restart only when DSP was already disabled before this change and still is;
+        # toggling DSP off requires a restart to remove DSP processing from the active stream
+        if not was_enabled and not self.mass.config.get_player_dsp_config(player_id).enabled:
             return
         if player.state.playback_state == PlaybackState.PLAYING:
             self.logger.info("Restarting playback of Player %s after DSP change", player_id)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2421,17 +2421,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                     1, self.mass.player_queues.resume, resume_queue.queue_id, False
                 )
 
-    async def on_player_dsp_change(self, player_id: str, was_enabled: bool = True) -> None:
-        """Call (by config manager) when the DSP settings of a player change.
-
-        :param player_id: The player ID whose DSP config changed.
-        :param was_enabled: Whether DSP was enabled before this change.
-        """
+    async def on_player_dsp_change(self, player_id: str) -> None:
+        """Call (by config manager) when the DSP settings of a player change."""
         if not (player := self.get_player(player_id)):
-            return
-        # skip restart only when DSP was already disabled before this change and still is;
-        # toggling DSP off requires a restart to remove DSP processing from the active stream
-        if not was_enabled and not self.mass.config.get_player_dsp_config(player_id).enabled:
             return
         if player.state.playback_state == PlaybackState.PLAYING:
             self.logger.info("Restarting playback of Player %s after DSP change", player_id)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2426,6 +2426,9 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # signal player provider that the config changed
         if not (player := self.get_player(player_id)):
             return
+        # DSP is disabled, changes won't affect the active audio stream
+        if not self.mass.config.get_player_dsp_config(player_id).enabled:
+            return
         if player.state.playback_state == PlaybackState.PLAYING:
             self.logger.info("Restarting playback of Player %s after DSP change", player_id)
             # this will restart the queue stream/playback


### PR DESCRIPTION
## What does this implement/fix?

When a player's DSP settings are changed while the main DSP toggle is **disabled**, the active playback was unnecessarily restarted, causing audio stutter and a misleading `Restarting playback of Player <id> after DSP change` log line.

The fix reads the old `enabled` state in `save_dsp_config` before saving the new config. `on_player_dsp_change` is only called when DSP was or is now enabled — covering all cases that actually affect the active audio stream (e.g. toggling DSP off still triggers a restart to flush the old processing chain). If DSP was already disabled and stays disabled, the call is skipped entirely.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5532

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.