### PR TITLE
Scale background audio-analysis timeout to track duration

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -36,8 +36,9 @@ from music_assistant.models.music_provider import MusicProvider
 LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
 BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300
-# Multiplier applied to a known track duration to derive the per-track analysis timeout.
-# Falls back to BACKGROUND_PER_TRACK_TIMEOUT_SECONDS when the duration is unknown.
+# Multiplier applied to a known track duration to scale the per-track analysis
+# timeout above BACKGROUND_PER_TRACK_TIMEOUT_SECONDS for long tracks. The floor
+# is enforced so short tracks and unknown-duration paths keep the original budget.
 BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER = 1.5
 # Per-run wall-clock cap; in-flight tracks finish, new ones defer to the next run.
 BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
@@ -696,12 +697,12 @@ class AudioAnalysisController:
             )
             return
 
-        # Scale the timeout to track length so long mixes get enough headroom; fall
-        # back to the fixed budget when duration is unknown or zero.
-        timeout_seconds = (
-            int(streamdetails.duration * BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER)
-            if streamdetails.duration
-            else BACKGROUND_PER_TRACK_TIMEOUT_SECONDS
+        # Scale the timeout up for long tracks while keeping the original fixed
+        # budget as a floor — short tracks and unknown-duration paths must still
+        # have enough headroom for ffmpeg startup and the analysis pipeline.
+        timeout_seconds = max(
+            BACKGROUND_PER_TRACK_TIMEOUT_SECONDS,
+            int((streamdetails.duration or 0) * BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER),
         )
 
         try:

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -36,6 +36,9 @@ from music_assistant.models.music_provider import MusicProvider
 LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
 BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300
+# Multiplier applied to a known track duration to derive the per-track analysis timeout.
+# Falls back to BACKGROUND_PER_TRACK_TIMEOUT_SECONDS when the duration is unknown.
+BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER = 1.5
 # Per-run wall-clock cap; in-flight tracks finish, new ones defer to the next run.
 BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
 # Per-chunk dispatch interval bounds. One PCM chunk = one audio-second of decoded data:
@@ -693,6 +696,14 @@ class AudioAnalysisController:
             )
             return
 
+        # Scale the timeout to track length so long mixes get enough headroom; fall
+        # back to the fixed budget when duration is unknown or zero.
+        timeout_seconds = (
+            int(streamdetails.duration * BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER)
+            if streamdetails.duration
+            else BACKGROUND_PER_TRACK_TIMEOUT_SECONDS
+        )
+
         try:
             await asyncio.wait_for(
                 self._run_background_streaming_inner(
@@ -702,7 +713,7 @@ class AudioAnalysisController:
                     min_interval=min_interval,
                     max_interval=max_interval,
                 ),
-                timeout=BACKGROUND_PER_TRACK_TIMEOUT_SECONDS,
+                timeout=timeout_seconds,
             )
         except asyncio.CancelledError:
             # CancelledError inherits from BaseException — the broad except below
@@ -713,13 +724,13 @@ class AudioAnalysisController:
         except TimeoutError:
             self.logger.warning(
                 "Background analysis exceeded %ds budget for %s, skipping",
-                BACKGROUND_PER_TRACK_TIMEOUT_SECONDS,
+                timeout_seconds,
                 session_key,
             )
             self._cancel_providers(session_key)
             self.mass.tasks.add_task_failure(
                 BACKGROUND_SCAN_TASK_ID,
-                f"Timed out after {BACKGROUND_PER_TRACK_TIMEOUT_SECONDS}s: {session_key}",
+                f"Timed out after {timeout_seconds}s: {session_key}",
             )
         except Exception as err:
             self.logger.warning("Background analysis failed for %s: %s", session_key, err)

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -36,9 +36,6 @@ from music_assistant.models.music_provider import MusicProvider
 LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
 BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300
-# Multiplier applied to a known track duration to scale the per-track analysis
-# timeout above BACKGROUND_PER_TRACK_TIMEOUT_SECONDS for long tracks. The floor
-# is enforced so short tracks and unknown-duration paths keep the original budget.
 BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER = 1.5
 # Per-run wall-clock cap; in-flight tracks finish, new ones defer to the next run.
 BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
@@ -697,9 +694,7 @@ class AudioAnalysisController:
             )
             return
 
-        # Scale the timeout up for long tracks while keeping the original fixed
-        # budget as a floor — short tracks and unknown-duration paths must still
-        # have enough headroom for ffmpeg startup and the analysis pipeline.
+        # Floor at the fixed budget so short tracks keep ffmpeg-startup headroom.
         timeout_seconds = max(
             BACKGROUND_PER_TRACK_TIMEOUT_SECONDS,
             int((streamdetails.duration or 0) * BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER),

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -167,6 +167,34 @@ async def test_background_streaming_per_track_timeout(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
+async def test_background_streaming_timeout_scales_with_track_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-track timeout is derived from track duration when duration is known."""
+    controller = _make_controller()
+    streamdetails = _make_streamdetails(path="/music/long_mix.flac", duration=3600)
+    p = _make_aa_provider("p1", available=True)
+    p.start_analysis = AsyncMock(return_value=True)
+    p.finalize = AsyncMock(return_value=None)
+    controller.mass.get_provider = MagicMock(return_value=p)  # type: ignore[method-assign]
+    controller.mass.streams.audio.get_media_stream = _make_stream_mock([])  # type: ignore[method-assign,assignment]
+
+    captured_timeouts: list[float | None] = []
+    real_wait_for = asyncio.wait_for
+
+    async def _spy_wait_for(coro: Any, timeout: float | None) -> Any:
+        captured_timeouts.append(timeout)
+        return await real_wait_for(coro, timeout)
+
+    monkeypatch.setattr("asyncio.wait_for", _spy_wait_for)
+
+    await controller._run_background_streaming_for_track(streamdetails, [p])
+
+    expected = int(3600 * audio_analysis_mod.BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER)
+    assert captured_timeouts[0] == expected
+
+
+@pytest.mark.asyncio
 async def test_background_streaming_ffmpeg_startup_failure() -> None:
     """get_media_stream failure cancels providers cleanly without raising."""
     controller = _make_controller()
@@ -191,7 +219,9 @@ async def test_background_streaming_ffmpeg_startup_failure() -> None:
     assert "ffmpeg startup failed" in failure_args[1]
 
 
-def _make_streamdetails(*, path: str, item_id: str = "test-item") -> MagicMock:
+def _make_streamdetails(
+    *, path: str, item_id: str = "test-item", duration: int | None = None
+) -> MagicMock:
     sd = MagicMock()
     sd.path = path
     sd.uri = f"track://test/{path}"
@@ -204,6 +234,7 @@ def _make_streamdetails(*, path: str, item_id: str = "test-item") -> MagicMock:
     sd.item_id = item_id
     sd.provider = "test-provider"
     sd.media_type = MagicMock()
+    sd.duration = duration
     return sd
 
 


### PR DESCRIPTION
# What does this implement/fix?

The background-scan audio analysis used a fixed 300-second per-track
budget. Long mix tracks (hour-plus DJ sets, long podcasts) consistently
exceeded it, so analysis re-timed-out on every nightly run and never
completed — wasting cycles on the same files indefinitely.

This derives the per-track timeout from the known track duration:
`int(streamdetails.duration * 1.5)`. When duration is unknown or zero,
behaviour falls back to the existing 300-second constant. The same
`timeout_seconds` value flows into the `asyncio.wait_for` call, the
warning log, and the task-failure message, so the recorded budget
matches what was actually waited for.

Only the background path (`_run_background_streaming_for_track`) is
affected. Real-time playback analysis (`start_analysis`) consumes
chunks as the track plays, so wall-clock is already bounded by the
track itself — no timeout protection is applied there.

**Related issue (if applicable):**

- https://github.com/orgs/music-assistant/discussions/5520

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.