### PR TITLE
Skip non-music providers in library update callback dispatch

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -37,12 +37,12 @@ from music_assistant.helpers.compare import compare_media_item, create_safe_stri
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.util import guard_single_request, parse_optional_bool
+from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Mapping
 
     from music_assistant import MusicAssistant
-    from music_assistant.models.music_provider import MusicProvider
     from music_assistant.models.plugin import PluginProvider
 
 
@@ -208,7 +208,8 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         # notify music providers of the update so they can sync their own storage
         for prov_mapping in library_item.provider_mappings:
             if provider := self.mass.get_provider(prov_mapping.provider_instance):
-                provider = cast("MusicProvider", provider)
+                if not isinstance(provider, MusicProvider):
+                    continue
                 await provider.on_item_updated(library_item)
         return library_item
 

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -10,7 +10,13 @@ from contextlib import suppress
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypeVar, cast, final
 
-from music_assistant_models.enums import EventType, ExternalID, MediaType, ProviderFeature
+from music_assistant_models.enums import (
+    EventType,
+    ExternalID,
+    MediaType,
+    ProviderFeature,
+    ProviderType,
+)
 from music_assistant_models.errors import (
     InsufficientPermissions,
     MediaNotFoundError,
@@ -37,12 +43,12 @@ from music_assistant.helpers.compare import compare_media_item, create_safe_stri
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
 from music_assistant.helpers.util import guard_single_request, parse_optional_bool
-from music_assistant.models.music_provider import MusicProvider
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Mapping
 
     from music_assistant import MusicAssistant
+    from music_assistant.models.music_provider import MusicProvider
     from music_assistant.models.plugin import PluginProvider
 
 
@@ -208,8 +214,9 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         # notify music providers of the update so they can sync their own storage
         for prov_mapping in library_item.provider_mappings:
             if provider := self.mass.get_provider(prov_mapping.provider_instance):
-                if not isinstance(provider, MusicProvider):
+                if provider.type != ProviderType.MUSIC:
                     continue
+                provider = cast("MusicProvider", provider)
                 await provider.on_item_updated(library_item)
         return library_item
 

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -762,7 +762,7 @@ async def test_update_item_in_library_skips_non_music_providers() -> None:
     mass.music = Mock()
     mass.music.match_provider_instances = Mock()
     mass.signal_event = Mock()
-    mass.get_provider = Mock(return_value=object())
+    mass.get_provider = Mock(return_value=Mock(type=ProviderType.PLUGIN))
     ctrl.mass = mass
 
     ctrl.update_item_in_library = MediaControllerBase.update_item_in_library.__get__(ctrl)

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -739,3 +739,39 @@ async def test_get_library_item_does_not_filter_in_library() -> None:
 
     call_kwargs = ctrl.get_library_items_by_query.call_args[1]
     assert call_kwargs["in_library_only"] is False
+
+
+async def test_update_item_in_library_skips_non_music_providers() -> None:
+    """Test update callback dispatch skips provider mappings that are not music providers."""
+    ctrl = Mock(spec=MediaControllerBase)
+    ctrl._update_library_item = AsyncMock()
+    ctrl.get_library_item = AsyncMock(
+        return_value=Mock(
+            uri="library://album/1",
+            provider_mappings=[
+                create_provider_mapping(
+                    provider_instance="smart_playlist_1",
+                    provider_domain="smart_playlist",
+                    item_id="abc",
+                )
+            ],
+        )
+    )
+
+    mass = Mock()
+    mass.music = Mock()
+    mass.music.match_provider_instances = Mock()
+    mass.signal_event = Mock()
+    mass.get_provider = Mock(return_value=object())
+    ctrl.mass = mass
+
+    ctrl.update_item_in_library = MediaControllerBase.update_item_in_library.__get__(ctrl)
+
+    update = create_mock_album(item_id="1")
+
+    updated = await ctrl.update_item_in_library(item_id=1, update=update, overwrite=False)
+
+    assert updated is not None
+    ctrl._update_library_item.assert_called_once()
+    mass.music.match_provider_instances.assert_called_once_with(update)
+    mass.get_provider.assert_called_once_with("smart_playlist_1")


### PR DESCRIPTION
## Summary
When updating a library item, `MediaControllerBase.update_item_in_library` iterates over all provider mappings and calls `on_item_updated` unconditionally after a cast.

Some mappings can point to plugin providers (for example smart playlist). Plugin providers do not implement `on_item_updated`, which can raise an `AttributeError` during Refresh Item / Update Metadata flows.

This change dispatches the callback only to actual `MusicProvider` instances.

## Changes
- Guard callback dispatch in `music_assistant/controllers/media/base.py` with `isinstance(provider, MusicProvider)`.
- Add regression test in `tests/test_library_sync.py` that verifies non-music providers are skipped.

## Validation
- `pytest tests/test_library_sync.py -k skips_non_music_providers` passed.
- `pre-commit run --all-files` passed except an existing unrelated repo-level mypy error in `music_assistant/providers/fastmcp_server/auth.py`.

## Context
- Checked existing PRs first; no open PR currently addresses this specific callback-dispatch bug.
