### PR TITLE
Fix Spotify Connect playback control reliability and error reporting

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -984,19 +984,15 @@ class PlayerQueuesController(CoreController):
                     break
                 except (MediaNotFoundError, AudioError) as err:
                     item_name = queue_item.name if queue_item else "unknown"
-                    # MediaNotFoundError = item unreachable (deleted, geo-blocked) —
-                    # persist so future plays skip it. AudioError is usually
-                    # transient; leave the item available so a retry can resurface
-                    # the same actionable message.
+                    # Only MediaNotFoundError (item unreachable) is persistent;
+                    # keep AudioError items available so a retry can resurface
+                    # the same actionable error.
                     if queue_item and isinstance(err, MediaNotFoundError):
                         queue_item.available = False
                     next_index = self._get_next_index(queue_id, index, allow_repeat=False)
                     if next_index is None:
-                        # AudioError carries a source-specific message worth
-                        # surfacing verbatim (e.g. "Music Assistant is not the
-                        # active Spotify playback device"). MediaNotFoundError
-                        # just means the item itself wasn't reachable, so the
-                        # generic "no more tracks available" framing fits.
+                        # Surface an AudioError's own (actionable) message;
+                        # MediaNotFoundError gets the generic wording.
                         if isinstance(err, AudioError) and str(err):
                             msg = str(err)
                         else:
@@ -3089,11 +3085,9 @@ class PlayerQueuesController(CoreController):
         # regardless of which code path (flow mode or non-flow mode) creates the task
         prev_item = prev_state["current_item"]
 
-        # Live sources (radio / AudioSource) have no natural end — when they
-        # stop it's because the source itself paused/disconnected, not because
-        # the queue ran out of content. Clearing here would strand a later
-        # resume (the queue would have no item to act on). Leave the queue
-        # intact; the user can clear manually or initiate fresh playback.
+        # Live sources (radio / AudioSource) have no natural end — stopping
+        # means the source stopped, not that the queue is exhausted. Clearing
+        # would strand a later resume, so leave the queue intact.
         if prev_item is not None and prev_item.media_type in (
             MediaType.RADIO,
             MediaType.AUDIO_SOURCE,

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -982,16 +982,28 @@ class PlayerQueuesController(CoreController):
                     queue.current_index = index
                     queue.current_item = queue_item
                     break
-                except (MediaNotFoundError, AudioError):
+                except (MediaNotFoundError, AudioError) as err:
                     item_name = queue_item.name if queue_item else "unknown"
-                    if queue_item:
+                    # MediaNotFoundError = item unreachable (deleted, geo-blocked) —
+                    # persist so future plays skip it. AudioError is usually
+                    # transient; leave the item available so a retry can resurface
+                    # the same actionable message.
+                    if queue_item and isinstance(err, MediaNotFoundError):
                         queue_item.available = False
                     next_index = self._get_next_index(queue_id, index, allow_repeat=False)
                     if next_index is None:
-                        msg = f"Playback failed for {item_name} - no more tracks available"
+                        # AudioError carries a source-specific message worth
+                        # surfacing verbatim (e.g. "Music Assistant is not the
+                        # active Spotify playback device"). MediaNotFoundError
+                        # just means the item itself wasn't reachable, so the
+                        # generic "no more tracks available" framing fits.
+                        if isinstance(err, AudioError) and str(err):
+                            msg = str(err)
+                        else:
+                            msg = f"Playback failed for {item_name} - no more tracks available"
                         self.logger.error(msg)
                         await self.stop(queue_id)
-                        raise MediaNotFoundError(msg)
+                        raise MediaNotFoundError(msg) from err
                     self.logger.warning(
                         "Skipping unplayable item %s",
                         item_name,
@@ -3076,6 +3088,17 @@ class PlayerQueuesController(CoreController):
         # retrieve prev_item here so it's available in the _clear_or_resume_delayed closure
         # regardless of which code path (flow mode or non-flow mode) creates the task
         prev_item = prev_state["current_item"]
+
+        # Live sources (radio / AudioSource) have no natural end — when they
+        # stop it's because the source itself paused/disconnected, not because
+        # the queue ran out of content. Clearing here would strand a later
+        # resume (the queue would have no item to act on). Leave the queue
+        # intact; the user can clear manually or initiate fresh playback.
+        if prev_item is not None and prev_item.media_type in (
+            MediaType.RADIO,
+            MediaType.AUDIO_SOURCE,
+        ):
+            return
 
         async def _clear_or_resume_delayed() -> None:
             for _ in range(5):

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -288,6 +288,13 @@ class StreamsAudio:
                 preferred_providers = playback_user.provider_filter
             else:
                 preferred_providers = [x.provider_instance for x in media_item.provider_mappings]
+            # Track the last AudioError so we can re-raise it verbatim if no
+            # provider produces streamdetails. AudioError carries a
+            # source-specific, user-facing reason (e.g. "Music Assistant is
+            # not the active Spotify playback device") that we lose if we
+            # always fall back to the generic "Unable to retrieve
+            # streamdetails" MediaNotFoundError below.
+            last_audio_error: AudioError | None = None
             for allow_other_provider in (False, True):
                 if streamdetails:
                     break
@@ -323,6 +330,9 @@ class StreamsAudio:
                             streamdetails = await music_prov.get_stream_details(
                                 prov_media.item_id, media_item.media_type
                             )
+                    except AudioError as err:
+                        last_audio_error = err
+                        self.logger.warning(str(err))
                     except MusicAssistantError as err:
                         self.logger.warning(str(err))
                     else:
@@ -331,6 +341,8 @@ class StreamsAudio:
                         BYPASS_THROTTLER.set(False)
 
             if not streamdetails:
+                if last_audio_error is not None:
+                    raise last_audio_error
                 msg = f"Unable to retrieve streamdetails for {queue_item.name} ({queue_item.uri})"
                 raise MediaNotFoundError(msg)
 

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -288,12 +288,8 @@ class StreamsAudio:
                 preferred_providers = playback_user.provider_filter
             else:
                 preferred_providers = [x.provider_instance for x in media_item.provider_mappings]
-            # Track the last AudioError so we can re-raise it verbatim if no
-            # provider produces streamdetails. AudioError carries a
-            # source-specific, user-facing reason (e.g. "Music Assistant is
-            # not the active Spotify playback device") that we lose if we
-            # always fall back to the generic "Unable to retrieve
-            # streamdetails" MediaNotFoundError below.
+            # Remember the last AudioError so we can re-raise its (actionable)
+            # message instead of the generic MediaNotFoundError below.
             last_audio_error: AudioError | None = None
             for allow_other_provider in (False, True):
                 if streamdetails:

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -68,11 +68,8 @@ SUPPORTED_FEATURES = {ProviderFeature.AUDIO_SOURCE}
 # combined with the provider instance_id this forms the persistent uri
 AUDIO_SOURCE_ID = "main"
 
-# How long to wait for librespot to confirm playback actually started after
-# we ask Spotify to play. /me/player/play returns 200 even when Spotify
-# silently refuses (e.g. another device became the active player in the
-# Spotify app and our context was handed away). We need an observed
-# 'playing' event from librespot to know it really started.
+# Max seconds to wait for librespot's 'playing' event after asking Spotify to
+# play: the Web API returns 200 even when playback never actually starts.
 PLAYBACK_START_TIMEOUT_S = 3.0
 
 # User-facing message for the "not the active Spotify device" failure.
@@ -215,13 +212,8 @@ class SpotifyConnectProvider(PluginProvider):
         # session_disconnected events; gates the Web API kick in on_source_selected
         # (skip if already playing) and the play_media trigger in the event handler
         self._librespot_playing: bool = False
-        # Tracks whether MA is currently the active Spotify Connect device.
-        # Flipped True on session_connected, False on session_disconnected.
-        # Used by get_stream_details to fail fast (with a user-facing message)
-        # when MA tries to resume a Spotify Connect session that the user has
-        # since handed to another device in the Spotify app — without this,
-        # Spotify silently accepts our /me/player/play call and never starts
-        # playback, leaving MA in "playing" with permanent silence.
+        # True while MA is the active Spotify Connect device (set/cleared on the
+        # session connect/disconnect events); gates get_stream_details.
         self._spotify_session_active: bool = False
         # holds the single in-flight deferred play_media task scheduled from a
         # librespot 'playing' event; cancelled if a 'paused' or 'session_connected'
@@ -291,12 +283,8 @@ class SpotifyConnectProvider(PluginProvider):
                 "start playback from the Spotify app, or configure the matching "
                 "Spotify music provider to enable Web API control"
             )
-        # Bail out early if MA is no longer the active Spotify Connect device.
-        # Without this, /me/player/play returns 200 but Spotify hands librespot
-        # a stop (context belongs to whichever device the user picked in the
-        # Spotify app) and MA sits in "playing" with silence. Surfacing the
-        # failure here propagates through play_media so the user sees an error
-        # immediately instead of after a 3 s wait inside the stream handler.
+        # Fail clearly when MA is no longer the active Spotify device: the Web
+        # API would accept a play call but never actually start playback on us.
         if not self._librespot_playing and not self._spotify_session_active:
             raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
         # NAMED_PIPE (not CUSTOM): the core opens the FIFO with ffmpeg directly
@@ -304,11 +292,8 @@ class SpotifyConnectProvider(PluginProvider):
         # Python generator + StreamReader would let librespot's pipe backend
         # (which is not realtime-paced) fill an arbitrary-size buffer ahead of
         # us; pause/skip would then take seconds to react.
-        # expiration=0 means streamdetails are always considered stale → the
-        # queue re-fetches them on every play_media. We need that because the
-        # session-active / librespot-playing state we check above can change
-        # between plays (pause + Spotify-side device switch is the common
-        # case), and a cached streamdetails would skip the re-check.
+        # expiration=0: never reuse a cached streamdetails so the active-device
+        # check above re-runs on every play attempt.
         return StreamDetails(
             provider=self.instance_id,
             item_id=source_id,
@@ -366,13 +351,8 @@ class SpotifyConnectProvider(PluginProvider):
             can_next_previous=has_web_api,
             exclusive=True,
             allow_external_trigger=True,
-            # Spotify Connect cannot be reliably initiated from MA: the Web API
-            # (transfer / /me/player/play) needs a current playback context to
-            # resume, which is absent after any meaningful idle period — Spotify
-            # then accepts the call but never starts playback. Reliable entry is
-            # always external (Spotify app → pick MA), so we don't offer MA-side
-            # initiation. Pause/play/seek control during an external session
-            # still works via on_source_control.
+            # Web API can't reliably cold-start playback (it needs an existing
+            # Spotify context), so only allow external entry via the Spotify app.
             can_initiate=False,
         )
 
@@ -535,11 +515,8 @@ class SpotifyConnectProvider(PluginProvider):
                 await self._ensure_active_device(play=True)
             except Exception as err:
                 raise AudioError(f"Failed to acquire Spotify Connect via Web API: {err}") from err
-            # Confirm Spotify actually started playback. The Web API returns
-            # 200 even when our device isn't really the active one (e.g. the
-            # user picked another device in the Spotify app while our queue
-            # still pointed at this AudioSource). Without this check MA would
-            # show "playing" with silence forever.
+            # The Web API returns 200 even when Spotify won't actually start
+            # playing on us; confirm via librespot before reporting success.
             if not await self._wait_for_librespot_playing():
                 raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
 
@@ -658,9 +635,7 @@ class SpotifyConnectProvider(PluginProvider):
         except Exception as err:
             self.logger.warning("Failed to send play command via Spotify Web API: %s", err)
             raise
-        # See on_source_selected: 200 OK doesn't mean Spotify will actually
-        # play, so wait for librespot to confirm and raise a friendly error
-        # otherwise.
+        # 200 OK doesn't guarantee playback actually started — confirm.
         if not await self._wait_for_librespot_playing():
             raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
 
@@ -769,16 +744,10 @@ class SpotifyConnectProvider(PluginProvider):
 
     async def _wait_for_librespot_playing(self, timeout: float = PLAYBACK_START_TIMEOUT_S) -> bool:
         """
-        Wait briefly for librespot to confirm playback started.
+        Wait up to ``timeout`` seconds for librespot to report it is playing.
 
-        Returns True if librespot's 'playing' event arrived within the timeout,
-        False otherwise. Spotify's Web API returns 200 to /me/player/play even
-        when it silently refuses (e.g. when another device is the active player
-        in the Spotify app and Spotify won't hand the context back via a simple
-        play call), so the only reliable success signal is observing librespot
-        actually enter the playing state.
-
-        :param timeout: Maximum seconds to wait for the 'playing' event.
+        :param timeout: Maximum seconds to wait.
+        :return: True once playback is confirmed, False if the timeout elapses.
         """
         deadline = self.mass.loop.time() + timeout
         while True:
@@ -790,19 +759,10 @@ class SpotifyConnectProvider(PluginProvider):
 
     async def _ensure_active_device(self, play: bool | None = None) -> None:
         """
-        Ensure this Spotify Connect device is the active player on Spotify.
+        Make this device the active Spotify player, optionally starting playback.
 
-        When ``play`` is True, prefers ``PUT /me/player/play?device_id=X`` over
-        the transfer-with-play endpoint — empirically the transfer endpoint can
-        leave the device in a stale paused state for up to a minute before
-        actually starting playback, while ``/play`` targeting our device_id
-        starts playback promptly. Falls back to transfer-with-play if ``/play``
-        fails (e.g. nothing to resume / no current context).
-
-        :param play: When True, also start playback on this device. When False,
-            pause it. When None (default), leave the playback state of the
-            previous device untouched (useful for externally-triggered flows
-            where librespot is already playing).
+        :param play: When True, also start playback on this device; when False,
+            pause it; when None, leave the current playback state untouched.
         """
         if not self._spotify_provider:
             return
@@ -813,6 +773,8 @@ class SpotifyConnectProvider(PluginProvider):
             self.logger.debug("Cannot transfer playback - device ID not found")
             return
         if play is True:
+            # Prefer the direct play endpoint: transfer-with-play can leave the
+            # device paused for a long time before it actually starts.
             try:
                 await self._spotify_provider._put_data(
                     "me/player/play", device_id=self._spotify_device_id
@@ -976,12 +938,9 @@ class SpotifyConnectProvider(PluginProvider):
             elif not username:
                 self.logger.warning("Session connected event received but no username in payload")
 
-        # handle session disconnected event.
-        # Keep _connected_spotify_username and _spotify_provider: librespot is
-        # still authenticated and the matching music provider is still loaded,
-        # so Web API control (transfer + play) keeps working — and MA can
-        # re-acquire the device after the Spotify app drops it. Provider-lifecycle
-        # cleanup is handled separately via the PROVIDERS_UPDATED subscription.
+        # Keep _connected_spotify_username/_spotify_provider so Web API control
+        # still works and MA can re-acquire after the Spotify app drops the
+        # device; provider lifecycle is handled via PROVIDERS_UPDATED.
         if event_name == "session_disconnected":
             self.logger.info("Spotify Connect session disconnected")
             self._spotify_session_active = False

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -68,6 +68,20 @@ SUPPORTED_FEATURES = {ProviderFeature.AUDIO_SOURCE}
 # combined with the provider instance_id this forms the persistent uri
 AUDIO_SOURCE_ID = "main"
 
+# How long to wait for librespot to confirm playback actually started after
+# we ask Spotify to play. /me/player/play returns 200 even when Spotify
+# silently refuses (e.g. another device became the active player in the
+# Spotify app and our context was handed away). We need an observed
+# 'playing' event from librespot to know it really started.
+PLAYBACK_START_TIMEOUT_S = 3.0
+
+# User-facing message for the "not the active Spotify device" failure.
+NOT_ACTIVE_DEVICE_MESSAGE = (
+    "Music Assistant is not the active Spotify playback device. "
+    "Open the Spotify app, pick Music Assistant as the playback device, "
+    "and try again."
+)
+
 
 async def setup(
     mass: MusicAssistant, manifest: ProviderManifest, config: ProviderConfig
@@ -201,6 +215,14 @@ class SpotifyConnectProvider(PluginProvider):
         # session_disconnected events; gates the Web API kick in on_source_selected
         # (skip if already playing) and the play_media trigger in the event handler
         self._librespot_playing: bool = False
+        # Tracks whether MA is currently the active Spotify Connect device.
+        # Flipped True on session_connected, False on session_disconnected.
+        # Used by get_stream_details to fail fast (with a user-facing message)
+        # when MA tries to resume a Spotify Connect session that the user has
+        # since handed to another device in the Spotify app — without this,
+        # Spotify silently accepts our /me/player/play call and never starts
+        # playback, leaving MA in "playing" with permanent silence.
+        self._spotify_session_active: bool = False
         # holds the single in-flight deferred play_media task scheduled from a
         # librespot 'playing' event; cancelled if a 'paused' or 'session_connected'
         # arrives during the debounce so we don't act on stale state from a dying
@@ -258,7 +280,8 @@ class SpotifyConnectProvider(PluginProvider):
         source and blocking a subsequent cross-queue handoff.
 
         Raises AudioError when MA has no way to acquire the source (librespot
-        idle and no Spotify music provider for Web API control).
+        idle and no Spotify music provider for Web API control, or MA is no
+        longer the active Spotify Connect device).
         """
         if source_id != AUDIO_SOURCE_ID:
             raise MediaNotFoundError(f"Unknown AudioSource: {source_id}")
@@ -268,11 +291,24 @@ class SpotifyConnectProvider(PluginProvider):
                 "start playback from the Spotify app, or configure the matching "
                 "Spotify music provider to enable Web API control"
             )
+        # Bail out early if MA is no longer the active Spotify Connect device.
+        # Without this, /me/player/play returns 200 but Spotify hands librespot
+        # a stop (context belongs to whichever device the user picked in the
+        # Spotify app) and MA sits in "playing" with silence. Surfacing the
+        # failure here propagates through play_media so the user sees an error
+        # immediately instead of after a 3 s wait inside the stream handler.
+        if not self._librespot_playing and not self._spotify_session_active:
+            raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
         # NAMED_PIPE (not CUSTOM): the core opens the FIFO with ffmpeg directly
         # using `-re`, which paces the read at native rate. Going through a
         # Python generator + StreamReader would let librespot's pipe backend
         # (which is not realtime-paced) fill an arbitrary-size buffer ahead of
         # us; pause/skip would then take seconds to react.
+        # expiration=0 means streamdetails are always considered stale → the
+        # queue re-fetches them on every play_media. We need that because the
+        # session-active / librespot-playing state we check above can change
+        # between plays (pause + Spotify-side device switch is the common
+        # case), and a cached streamdetails would skip the re-check.
         return StreamDetails(
             provider=self.instance_id,
             item_id=source_id,
@@ -281,6 +317,7 @@ class SpotifyConnectProvider(PluginProvider):
             stream_type=StreamType.NAMED_PIPE,
             path=self.named_pipe,
             stream_metadata=self._stream_metadata,
+            expiration=0,
         )
 
     async def on_source_control(
@@ -329,8 +366,14 @@ class SpotifyConnectProvider(PluginProvider):
             can_next_previous=has_web_api,
             exclusive=True,
             allow_external_trigger=True,
-            # Web API is required to kick librespot when MA initiates
-            can_initiate=has_web_api,
+            # Spotify Connect cannot be reliably initiated from MA: the Web API
+            # (transfer / /me/player/play) needs a current playback context to
+            # resume, which is absent after any meaningful idle period — Spotify
+            # then accepts the call but never starts playback. Reliable entry is
+            # always external (Spotify app → pick MA), so we don't offer MA-side
+            # initiation. Pause/play/seek control during an external session
+            # still works via on_source_control.
+            can_initiate=False,
         )
 
     @property
@@ -489,10 +532,16 @@ class SpotifyConnectProvider(PluginProvider):
                     "for MA-initiated playback"
                 )
             try:
-                # combined transfer + play in one Web API call
                 await self._ensure_active_device(play=True)
             except Exception as err:
                 raise AudioError(f"Failed to acquire Spotify Connect via Web API: {err}") from err
+            # Confirm Spotify actually started playback. The Web API returns
+            # 200 even when our device isn't really the active one (e.g. the
+            # user picked another device in the Spotify app while our queue
+            # still pointed at this AudioSource). Without this check MA would
+            # show "playing" with silence forever.
+            if not await self._wait_for_librespot_playing():
+                raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
 
     async def on_source_unselected(
         self, source_id: str, queue_id: str, stream_session_id: str
@@ -605,12 +654,15 @@ class SpotifyConnectProvider(PluginProvider):
                 "Playback control requires a matching Spotify music provider"
             )
         try:
-            # combined transfer + play in one call (avoids ~2 s of API throttle
-            # we'd otherwise hit doing them sequentially)
             await self._ensure_active_device(play=True)
         except Exception as err:
             self.logger.warning("Failed to send play command via Spotify Web API: %s", err)
             raise
+        # See on_source_selected: 200 OK doesn't mean Spotify will actually
+        # play, so wait for librespot to confirm and raise a friendly error
+        # otherwise.
+        if not await self._wait_for_librespot_playing():
+            raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
 
     async def _on_pause(self) -> None:
         """Handle pause command via Spotify Web API."""
@@ -715,13 +767,37 @@ class SpotifyConnectProvider(PluginProvider):
             self.logger.debug("Failed to get Spotify devices: %s", err)
             return None
 
+    async def _wait_for_librespot_playing(self, timeout: float = PLAYBACK_START_TIMEOUT_S) -> bool:
+        """
+        Wait briefly for librespot to confirm playback started.
+
+        Returns True if librespot's 'playing' event arrived within the timeout,
+        False otherwise. Spotify's Web API returns 200 to /me/player/play even
+        when it silently refuses (e.g. when another device is the active player
+        in the Spotify app and Spotify won't hand the context back via a simple
+        play call), so the only reliable success signal is observing librespot
+        actually enter the playing state.
+
+        :param timeout: Maximum seconds to wait for the 'playing' event.
+        """
+        deadline = self.mass.loop.time() + timeout
+        while True:
+            if self._librespot_playing:
+                return True
+            if self.mass.loop.time() >= deadline:
+                return False
+            await asyncio.sleep(0.1)
+
     async def _ensure_active_device(self, play: bool | None = None) -> None:
         """
         Ensure this Spotify Connect device is the active player on Spotify.
 
-        Combined transfer-and-(optionally-)play in a single Web API call —
-        Spotify's API is heavily throttled (~2 s/call) so each round trip we
-        avoid is two seconds shaved off perceived play latency.
+        When ``play`` is True, prefers ``PUT /me/player/play?device_id=X`` over
+        the transfer-with-play endpoint — empirically the transfer endpoint can
+        leave the device in a stale paused state for up to a minute before
+        actually starting playback, while ``/play`` targeting our device_id
+        starts playback promptly. Falls back to transfer-with-play if ``/play``
+        fails (e.g. nothing to resume / no current context).
 
         :param play: When True, also start playback on this device. When False,
             pause it. When None (default), leave the playback state of the
@@ -736,6 +812,17 @@ class SpotifyConnectProvider(PluginProvider):
         if not self._spotify_device_id:
             self.logger.debug("Cannot transfer playback - device ID not found")
             return
+        if play is True:
+            try:
+                await self._spotify_provider._put_data(
+                    "me/player/play", device_id=self._spotify_device_id
+                )
+                return
+            except Exception as err:
+                self.logger.debug(
+                    "Direct /me/player/play failed (%s), falling back to transfer-with-play",
+                    err,
+                )
         data: dict[str, object] = {"device_ids": [self._spotify_device_id]}
         if play is not None:
             data["play"] = play
@@ -875,6 +962,7 @@ class SpotifyConnectProvider(PluginProvider):
         if event_name == "session_connected":
             # Track when session connected for volume event filtering
             self._last_session_connected_time = time.time()
+            self._spotify_session_active = True
             username = json_data.get("user_name")
             self.logger.debug(
                 "Session connected event - username from event: %s, current username: %s",
@@ -888,14 +976,15 @@ class SpotifyConnectProvider(PluginProvider):
             elif not username:
                 self.logger.warning("Session connected event received but no username in payload")
 
-        # handle session disconnected event
+        # handle session disconnected event.
+        # Keep _connected_spotify_username and _spotify_provider: librespot is
+        # still authenticated and the matching music provider is still loaded,
+        # so Web API control (transfer + play) keeps working — and MA can
+        # re-acquire the device after the Spotify app drops it. Provider-lifecycle
+        # cleanup is handled separately via the PROVIDERS_UPDATED subscription.
         if event_name == "session_disconnected":
             self.logger.info("Spotify Connect session disconnected")
-            self._connected_spotify_username = None
-            if self._spotify_provider is not None:
-                self._spotify_provider = None
-                self._update_source_capabilities()
-            # Clear active player and stop the player on session disconnect
+            self._spotify_session_active = False
             prev_player_id = self._active_player_id
             self._clear_active_player()
             if prev_player_id:


### PR DESCRIPTION
# What does this implement/fix?

Spotify Connect (exposed as an AudioSource) had several control and UX issues once a session was active or handed between devices: control silently broke after deselecting Music Assistant in the Spotify app, resuming from MA was unreliable, "MA is not the active device" surfaced as a misleading "no more tracks available" error, and pausing/stopping a live source cleared the queue so it could not be resumed.

## Changes

- Keep the matched Spotify music provider on `session_disconnected` so Web API control survives the Spotify app dropping the device.
- Prefer `PUT /me/player/play?device_id=…` for reliable resume, with transfer-with-play as fallback.
- Track whether MA is the active Spotify Connect device and fail fast in `get_stream_details` with a user-friendly message when it isn't.
- Set `can_initiate=False` on the AudioSource — cold-start from MA can't be made reliable via the Web API (it needs an existing Spotify playback context); reliable entry stays external (pick MA in the Spotify app).
- Surface provider `AudioError` messages verbatim through the queue and stream layers instead of flattening them to "no more tracks available".
- Don't clear the queue when a live source (radio / AudioSource) stops, so playback can be resumed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.