### PR TITLE
Keep plugin playlist items visible for users with provider filters

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -10,7 +10,13 @@ from contextlib import suppress
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypeVar, cast, final
 
-from music_assistant_models.enums import EventType, ExternalID, MediaType, ProviderFeature
+from music_assistant_models.enums import (
+    EventType,
+    ExternalID,
+    MediaType,
+    ProviderFeature,
+    ProviderType,
+)
 from music_assistant_models.errors import (
     InsufficientPermissions,
     MediaNotFoundError,
@@ -1185,13 +1191,18 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         user_provider_filter = user.provider_filter if user and user.provider_filter else None
         final_provider_filter: list[str] | None = None
         if user_provider_filter:
+            plugin_provider_instances = {
+                prov.instance_id for prov in self.mass.providers if prov.type == ProviderType.PLUGIN
+            }
             # User has a provider filter set
             if provider:
                 # Explicit provider filter provided - validate against user's allowed providers
                 requested_providers = [provider] if isinstance(provider, str) else provider
-                # Only include providers that are in both the user's filter and the requested list
+                # Only restrict access to music providers.
                 final_provider_filter = [
-                    p for p in requested_providers if p in user_provider_filter
+                    p
+                    for p in requested_providers
+                    if p in user_provider_filter or p in plugin_provider_instances
                 ]
                 if not final_provider_filter:
                     # No overlap - user requested providers they don't have access to
@@ -1199,8 +1210,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                         "User does not have permission to access the requested provider(s)."
                     )
             else:
-                # No explicit filter - use user's provider filter
-                final_provider_filter = user_provider_filter
+                # No explicit filter - apply user music provider filter but keep plugin providers.
+                final_provider_filter = list(
+                    dict.fromkeys([*user_provider_filter, *plugin_provider_instances])
+                )
         elif provider is not None:
             # No user filter - use the provided filter as is
             final_provider_filter = [provider] if isinstance(provider, str) else provider
@@ -1213,8 +1226,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         user_provider_filter = user.provider_filter if user and user.provider_filter else None
         # prefer user provider filter if available
         for mapping in library_item.provider_mappings:
-            if user_provider_filter and mapping.provider_instance not in user_provider_filter:
-                continue
+            if user_provider_filter:
+                provider = self.mass.get_provider(mapping.provider_instance)
+                if provider and provider.type == ProviderType.PLUGIN:
+                    return (mapping.provider_instance, mapping.item_id)
+                if mapping.provider_instance not in user_provider_filter:
+                    continue
             return (mapping.provider_instance, mapping.item_id)
         # fallback to first mapping
         mapping = next(iter(library_item.provider_mappings))

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -1224,15 +1224,29 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         """Select the correct provider id to use for fetching the item."""
         user = get_current_user()
         user_provider_filter = user.provider_filter if user and user.provider_filter else None
+        if not user_provider_filter:
+            mapping = next(iter(library_item.provider_mappings))
+            return (mapping.provider_instance, mapping.item_id)
+
+        # First prefer music provider mappings that are explicitly allowed for this user.
         # prefer user provider filter if available
         for mapping in library_item.provider_mappings:
-            if user_provider_filter:
-                provider = self.mass.get_provider(mapping.provider_instance)
-                if provider and provider.type == ProviderType.PLUGIN:
+            provider = self.mass.get_provider(mapping.provider_instance)
+            if provider and provider.type == ProviderType.MUSIC:
+                if mapping.provider_instance in user_provider_filter:
                     return (mapping.provider_instance, mapping.item_id)
-                if mapping.provider_instance not in user_provider_filter:
-                    continue
-            return (mapping.provider_instance, mapping.item_id)
+
+        # If no allowed music mapping exists, fall back to plugin mappings.
+        for mapping in library_item.provider_mappings:
+            provider = self.mass.get_provider(mapping.provider_instance)
+            if provider and provider.type == ProviderType.PLUGIN:
+                return (mapping.provider_instance, mapping.item_id)
+
+        # As a final fallback, preserve previous behavior.
+        for mapping in library_item.provider_mappings:
+            if mapping.provider_instance in user_provider_filter:
+                return (mapping.provider_instance, mapping.item_id)
+
         # fallback to first mapping
         mapping = next(iter(library_item.provider_mappings))
         return (mapping.provider_instance, mapping.item_id)

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -806,6 +806,80 @@ def test_ensure_provider_filter_does_not_auto_allow_other_non_music_providers() 
     assert "meta_1" not in result
 
 
+def test_select_provider_id_prefers_allowed_music_over_plugin() -> None:
+    """Test that allowed music mappings are preferred over plugin mappings."""
+    ctrl = Mock(spec=MediaControllerBase)
+    ctrl.mass = Mock()
+    ctrl.mass.get_provider = Mock(
+        side_effect=lambda instance: {
+            "smart_playlist_1": Mock(type=ProviderType.PLUGIN),
+            "spotify_1": Mock(type=ProviderType.MUSIC),
+        }.get(instance)
+    )
+    ctrl._select_provider_id = MediaControllerBase._select_provider_id.__get__(ctrl)
+
+    item = create_mock_album(
+        provider_mappings=[
+            create_provider_mapping(
+                provider_instance="smart_playlist_1",
+                provider_domain="smart_playlist",
+                item_id="plugin_item",
+            ),
+            create_provider_mapping(
+                provider_instance="spotify_1",
+                provider_domain="spotify",
+                item_id="music_item",
+            ),
+        ]
+    )
+
+    with patch(
+        "music_assistant.controllers.media.base.get_current_user",
+        return_value=Mock(provider_filter=["spotify_1"]),
+    ):
+        provider_instance, provider_item = ctrl._select_provider_id(item)
+
+    assert provider_instance == "spotify_1"
+    assert provider_item == "music_item"
+
+
+def test_select_provider_id_falls_back_to_plugin_when_no_allowed_music() -> None:
+    """Test that plugin mapping is selected if no allowed music mapping exists."""
+    ctrl = Mock(spec=MediaControllerBase)
+    ctrl.mass = Mock()
+    ctrl.mass.get_provider = Mock(
+        side_effect=lambda instance: {
+            "smart_playlist_1": Mock(type=ProviderType.PLUGIN),
+            "qobuz_1": Mock(type=ProviderType.MUSIC),
+        }.get(instance)
+    )
+    ctrl._select_provider_id = MediaControllerBase._select_provider_id.__get__(ctrl)
+
+    item = create_mock_album(
+        provider_mappings=[
+            create_provider_mapping(
+                provider_instance="smart_playlist_1",
+                provider_domain="smart_playlist",
+                item_id="plugin_item",
+            ),
+            create_provider_mapping(
+                provider_instance="qobuz_1",
+                provider_domain="qobuz",
+                item_id="music_item",
+            ),
+        ]
+    )
+
+    with patch(
+        "music_assistant.controllers.media.base.get_current_user",
+        return_value=Mock(provider_filter=["spotify_1"]),
+    ):
+        provider_instance, provider_item = ctrl._select_provider_id(item)
+
+    assert provider_instance == "smart_playlist_1"
+    assert provider_item == "plugin_item"
+
+
 async def test_get_library_item_does_not_filter_in_library() -> None:
     """Test that get_library_item always passes in_library_only=False.
 

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType, ProviderType
+from music_assistant_models.errors import InsufficientPermissions
 from music_assistant_models.media_items import Album, AudioFormat, ProviderMapping, UniqueList
 
 from music_assistant.constants import CONF_ENTRY_LIBRARY_SYNC_BACK
@@ -720,6 +721,89 @@ async def test_library_items_default_filters_in_library_only() -> None:
     ctrl.get_library_items_by_query.assert_called_once()
     call_kwargs = ctrl.get_library_items_by_query.call_args[1]
     assert call_kwargs["in_library_only"] is True
+
+
+def test_ensure_provider_filter_keeps_plugin_provider_mappings() -> None:
+    """Test that plugin providers are kept when a user music-provider filter is active."""
+    ctrl = Mock(spec=MediaControllerBase)
+    ctrl.mass = Mock()
+    ctrl.mass.providers = [
+        Mock(instance_id="spotify_1", type=ProviderType.MUSIC),
+        Mock(instance_id="smart_playlist_1", type=ProviderType.PLUGIN),
+    ]
+    ctrl._ensure_provider_filter = MediaControllerBase._ensure_provider_filter.__get__(ctrl)
+
+    with patch(
+        "music_assistant.controllers.media.base.get_current_user",
+        return_value=Mock(provider_filter=["spotify_1"]),
+    ):
+        result = ctrl._ensure_provider_filter(None)
+
+    assert result is not None
+    assert "spotify_1" in result
+    assert "smart_playlist_1" in result
+
+
+def test_ensure_provider_filter_rejects_unallowed_music_provider() -> None:
+    """Test that requesting a disallowed music provider still raises permissions error."""
+    ctrl = Mock(spec=MediaControllerBase)
+    ctrl.mass = Mock()
+    ctrl.mass.providers = [
+        Mock(instance_id="spotify_1", type=ProviderType.MUSIC),
+        Mock(instance_id="smart_playlist_1", type=ProviderType.PLUGIN),
+    ]
+    ctrl._ensure_provider_filter = MediaControllerBase._ensure_provider_filter.__get__(ctrl)
+
+    with (
+        patch(
+            "music_assistant.controllers.media.base.get_current_user",
+            return_value=Mock(provider_filter=["spotify_1"]),
+        ),
+        pytest.raises(InsufficientPermissions),
+    ):
+        ctrl._ensure_provider_filter("qobuz_1")
+
+
+def test_ensure_provider_filter_allows_explicit_non_music_provider() -> None:
+    """Test that explicitly requesting a plugin provider is allowed for filtered users."""
+    ctrl = Mock(spec=MediaControllerBase)
+    ctrl.mass = Mock()
+    ctrl.mass.providers = [
+        Mock(instance_id="spotify_1", type=ProviderType.MUSIC),
+        Mock(instance_id="smart_playlist_1", type=ProviderType.PLUGIN),
+    ]
+    ctrl._ensure_provider_filter = MediaControllerBase._ensure_provider_filter.__get__(ctrl)
+
+    with patch(
+        "music_assistant.controllers.media.base.get_current_user",
+        return_value=Mock(provider_filter=["spotify_1"]),
+    ):
+        result = ctrl._ensure_provider_filter("smart_playlist_1")
+
+    assert result == ["smart_playlist_1"]
+
+
+def test_ensure_provider_filter_does_not_auto_allow_other_non_music_providers() -> None:
+    """Test that only plugin providers are auto-allowed when user filter is active."""
+    ctrl = Mock(spec=MediaControllerBase)
+    ctrl.mass = Mock()
+    ctrl.mass.providers = [
+        Mock(instance_id="spotify_1", type=ProviderType.MUSIC),
+        Mock(instance_id="smart_playlist_1", type=ProviderType.PLUGIN),
+        Mock(instance_id="meta_1", type=ProviderType.METADATA),
+    ]
+    ctrl._ensure_provider_filter = MediaControllerBase._ensure_provider_filter.__get__(ctrl)
+
+    with patch(
+        "music_assistant.controllers.media.base.get_current_user",
+        return_value=Mock(provider_filter=["spotify_1"]),
+    ):
+        result = ctrl._ensure_provider_filter(None)
+
+    assert result is not None
+    assert "spotify_1" in result
+    assert "smart_playlist_1" in result
+    assert "meta_1" not in result
 
 
 async def test_get_library_item_does_not_filter_in_library() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Apply user provider filters only to music providers so plugin-backed playlist items remain visible, while keeping permission checks for explicitly requested disallowed music providers.

**Related issue (if applicable):**

- related issue n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

### Notes

- `pre-commit run --all-files` currently fails in this environment due to an existing mypy error in `music_assistant/providers/fastmcp_server/auth.py`.
- Full `pytest` currently fails during collection in this environment due to missing optional dependencies (`chromaprint`, `fastmcp`), but tests for this change were added and run: `pytest tests/test_library_sync.py -k "ensure_provider_filter or select_provider_id or skips_non_music_providers"`.
- No shared model changes in this PR.
- No UI/frontend changes in this PR.
