### PR TITLE
Return a track sample for dynamic playlists when browsing

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -21,6 +21,9 @@ APPLICATION_NAME: Final = "Music Assistant"
 # Type alias for items that can be added to playlists
 PlaylistPlayableItem = Track | Radio | PodcastEpisode | Audiobook
 
+# Default number of tracks a music provider may return as a preview sample for a dynamic playlist
+DYNAMIC_PLAYLIST_SAMPLE_SIZE: Final[int] = 25
+
 # Corresponding MediaType enum values (must match PlaylistPlayableItem types above)
 PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
     MediaType.TRACK,

--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -119,35 +119,17 @@ class PlaylistController(MediaControllerBase[Playlist]):
         allow_dynamic_tracks: bool = False,
     ) -> AsyncGenerator[PlaylistPlayableItem, None]:
         """Return playlist tracks for the given provider playlist id."""
-        library_item: Playlist | None = None
-        provider_item: Playlist | None = None
         if provider_instance_id_or_domain == "library":
             library_item = await self.get_library_item(item_id)
             provider_instance_id_or_domain, item_id = self._select_provider_id(library_item)
-        elif not allow_dynamic_tracks:
-            library_item = await self.get_library_item_by_prov_id(
-                item_id, provider_instance_id_or_domain
-            )
-            if library_item is None:
-                with suppress(ProviderUnavailableError, MediaNotFoundError, NotImplementedError):
-                    provider_item = await self.get_provider_item(
-                        item_id, provider_instance_id_or_domain
-                    )
 
         # Dynamic playlists always need fresh tracks from the provider.
         if allow_dynamic_tracks:
             force_refresh = True
 
-        # Dynamic playlists should not expose a static track list in browse/refresh views.
-        # Only the playback queue may request tracks for dynamic refill.
-        if not allow_dynamic_tracks:
-            if (library_item is not None and library_item.is_dynamic) or (
-                provider_item is not None and provider_item.is_dynamic
-            ):
-                return
-
-        # playlist tracks are not stored in the db,
-        # we always fetched them (cached) from the provider
+        # playlist tracks are not stored in the db, we always fetch them (cached) from the
+        # provider. The provider decides how many tracks to return; for a dynamic playlist it
+        # returns a bounded sample/batch and terminates by yielding no further pages.
         page = 0
         while True:
             tracks = await self._get_provider_playlist_tracks(

--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -123,7 +123,8 @@ class PlaylistController(MediaControllerBase[Playlist]):
             library_item = await self.get_library_item(item_id)
             provider_instance_id_or_domain, item_id = self._select_provider_id(library_item)
 
-        # Dynamic playlists always need fresh tracks from the provider.
+        # Playback/refill requests for dynamic playlists need fresh tracks from the provider.
+        # Browse requests may reuse cached tracks.
         if allow_dynamic_tracks:
             force_refresh = True
 

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -36,6 +36,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.media_items.metadata import MediaItemMetadata
 
+from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
 from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.plugin import PluginProvider
@@ -203,8 +204,8 @@ class SmartPlaylistProvider(PluginProvider):
 
         Returns a full batch on page 0; empty list on subsequent pages.
         Because is_dynamic=True, MA always calls with force_refresh so results stay fresh.
-        For dynamic playlists a small buffer of 5 tracks is returned per call so that
-        dedup and shuffle stay effective across successive refreshes.
+        For dynamic playlists a bounded buffer is returned per call so the browse overview
+        shows a representative sample and queue refills stay deduped/shuffled across refreshes.
         """
         if page > 0:
             return []
@@ -212,7 +213,7 @@ class SmartPlaylistProvider(PluginProvider):
         if rules is None:
             return []
         if rules.is_dynamic:
-            rules = dc_replace(rules, limit=5)
+            rules = dc_replace(rules, limit=DYNAMIC_PLAYLIST_SAMPLE_SIZE)
         return await self._evaluate_rules(rules)
 
     async def _on_media_item_deleted(self, event: MassEvent) -> None:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -203,9 +203,10 @@ class SmartPlaylistProvider(PluginProvider):
         """Evaluate rules and return fresh tracks.
 
         Returns a full batch on page 0; empty list on subsequent pages.
-        Because is_dynamic=True, MA always calls with force_refresh so results stay fresh.
         For dynamic playlists a bounded buffer is returned per call so the browse overview
         shows a representative sample and queue refills stay deduped/shuffled across refreshes.
+        Playback/refill requests force a refresh so results stay fresh; browse requests may
+        reuse cached tracks.
         """
         if page > 0:
             return []

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -205,8 +205,6 @@ class SmartPlaylistProvider(PluginProvider):
         Returns a full batch on page 0; empty list on subsequent pages.
         For dynamic playlists a bounded buffer is returned per call so the browse overview
         shows a representative sample and queue refills stay deduped/shuffled across refreshes.
-        Playback/refill requests force a refresh so results stay fresh; browse requests may
-        reuse cached tracks.
         """
         if page > 0:
             return []

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -1,5 +1,9 @@
 """Tests for playlist parsing and generation helpers."""
 
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 from music_assistant_models.enums import ContentType, ExternalID, ImageType, MediaType
 from music_assistant_models.media_items import (
     AudioFormat,
@@ -12,6 +16,7 @@ from music_assistant_models.media_items import (
     UniqueList,
 )
 
+from music_assistant.controllers.media.playlists import PlaylistController
 from music_assistant.helpers.playlists import (
     ImageInfo,
     PlaylistItem,
@@ -619,3 +624,45 @@ def test_media_item_to_playlist_item_multiple_providers() -> None:
     assert domains == {"spotify", "tidal"}
     # primary URI uses the highest quality provider
     assert result.path == "tidal://track/t2"
+
+
+# --------------------------------------------------------------------------- #
+#  PlaylistController.tracks() — provider-driven pagination                    #
+# --------------------------------------------------------------------------- #
+
+
+def _make_controller() -> PlaylistController:
+    """Return a PlaylistController with a minimal mock mass."""
+    controller = PlaylistController.__new__(PlaylistController)
+    controller.mass = MagicMock()
+    return controller
+
+
+@pytest.mark.asyncio
+async def test_tracks_relays_all_provider_pages() -> None:
+    """tracks() relays every non-empty provider page until exhausted (provider decides size)."""
+    controller = _make_controller()
+    page0 = [MagicMock(spec=Track) for _ in range(20)]
+    page1 = [MagicMock(spec=Track) for _ in range(15)]
+    get_tracks = AsyncMock(side_effect=[page0, page1, []])
+    cast("Any", controller)._get_provider_playlist_tracks = get_tracks
+
+    result = [t async for t in controller.tracks("abc", "some_provider")]
+
+    # No controller-side cap: a multi-page (e.g. dynamic) list is relayed in full.
+    assert len(result) == 35
+    assert get_tracks.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_tracks_stops_on_empty_page() -> None:
+    """tracks() stops fetching once the provider yields an empty page."""
+    controller = _make_controller()
+    page0 = [MagicMock(spec=Track) for _ in range(7)]
+    get_tracks = AsyncMock(side_effect=[page0, []])
+    cast("Any", controller)._get_provider_playlist_tracks = get_tracks
+
+    result = [t async for t in controller.tracks("abc", "some_provider")]
+
+    assert len(result) == 7
+    assert get_tracks.await_count == 2

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -645,7 +645,7 @@ async def test_tracks_relays_all_provider_pages() -> None:
     page0 = [MagicMock(spec=Track) for _ in range(20)]
     page1 = [MagicMock(spec=Track) for _ in range(15)]
     get_tracks = AsyncMock(side_effect=[page0, page1, []])
-    cast("Any", controller)._get_provider_playlist_tracks = get_tracks
+    cast(Any, controller)._get_provider_playlist_tracks = get_tracks
 
     result = [t async for t in controller.tracks("abc", "some_provider")]
 

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -660,7 +660,7 @@ async def test_tracks_stops_on_empty_page() -> None:
     controller = _make_controller()
     page0 = [MagicMock(spec=Track) for _ in range(7)]
     get_tracks = AsyncMock(side_effect=[page0, []])
-    cast("Any", controller)._get_provider_playlist_tracks = get_tracks
+    cast(Any, controller)._get_provider_playlist_tracks = get_tracks
 
     result = [t async for t in controller.tracks("abc", "some_provider")]
 

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -645,7 +645,7 @@ async def test_tracks_relays_all_provider_pages() -> None:
     page0 = [MagicMock(spec=Track) for _ in range(20)]
     page1 = [MagicMock(spec=Track) for _ in range(15)]
     get_tracks = AsyncMock(side_effect=[page0, page1, []])
-    cast(Any, controller)._get_provider_playlist_tracks = get_tracks
+    cast("Any", controller)._get_provider_playlist_tracks = get_tracks
 
     result = [t async for t in controller.tracks("abc", "some_provider")]
 
@@ -660,7 +660,7 @@ async def test_tracks_stops_on_empty_page() -> None:
     controller = _make_controller()
     page0 = [MagicMock(spec=Track) for _ in range(7)]
     get_tracks = AsyncMock(side_effect=[page0, []])
-    cast(Any, controller)._get_provider_playlist_tracks = get_tracks
+    cast("Any", controller)._get_provider_playlist_tracks = get_tracks
 
     result = [t async for t in controller.tracks("abc", "some_provider")]
 

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from music_assistant_models.errors import InvalidDataError
 
+from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
 from music_assistant.providers.smart_playlist import (
     SmartPlaylistProvider,
 )
@@ -552,8 +553,8 @@ async def test_dedup_fallback_when_pool_exhausted() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_playlist_tracks_dynamic_limit_5(tmp_path: Any) -> None:
-    """get_playlist_tracks uses limit=5 for dynamic playlists."""
+async def test_get_playlist_tracks_dynamic_uses_sample_size(tmp_path: Any) -> None:
+    """get_playlist_tracks caps dynamic playlists at the sample size."""
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
     manifest = MagicMock()
@@ -570,7 +571,8 @@ async def test_get_playlist_tracks_dynamic_limit_5(tmp_path: Any) -> None:
     plugin._rules_store["abc"] = rules
 
     result = await plugin.get_playlist_tracks("abc")
-    assert len(result) <= 5
+    assert len(result) <= DYNAMIC_PLAYLIST_SAMPLE_SIZE
+    assert len(result) > 5  # proves the buffer is no longer capped at 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Opening a dynamic playlist (radio-style / algorithmically generated, `Playlist.is_dynamic`) in the UI previously showed an empty track list, which confused users.

`PlaylistController.tracks()` no longer returns an empty list for dynamic playlists. It now uniformly relays the provider's tracks page-by-page until the provider yields no more, letting **the provider decide** how many sample tracks to expose and when to stop. This removes the prior `is_dynamic` special-casing (the empty-return and the lookups that existed only for it), so a native provider's dynamic list spanning multiple pages is relayed in full (no controller-side cap).

The `smart_playlist` provider returns a `DYNAMIC_PLAYLIST_SAMPLE_SIZE` (25) batch for dynamic playlists (was a hardcoded 5); builtin "Infinite Mix" already returns 25.

Frontend rendering of these sample tracks for dynamic playlists is handled separately (companion frontend work).

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally. (unit tests pass; manual live-library/UI check still outstanding)
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a — no model changes)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.