### PR TITLE
Improve Apple Music library album mapping and recommendation fallback

### DIFF
--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1169,9 +1169,7 @@ class MusicProvider(Provider):
                     library_item = await self.mass.music.tracks.update_item_in_library(
                         library_item.item_id, prov_item
                     )
-                elif prov_item.album and not await self.mass.music.tracks.get_library_track_albums(
-                    library_item.item_id
-                ):
+                elif prov_item.album and not library_item.album:
                     # Backfill missing album_tracks link for existing tracks.
                     library_item = await self.mass.music.tracks.update_item_in_library(
                         library_item.item_id, prov_item

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1169,6 +1169,13 @@ class MusicProvider(Provider):
                     library_item = await self.mass.music.tracks.update_item_in_library(
                         library_item.item_id, prov_item
                     )
+                elif prov_item.album and not await self.mass.music.tracks.get_library_track_albums(
+                    library_item.item_id
+                ):
+                    # Backfill missing album_tracks link for existing tracks.
+                    library_item = await self.mass.music.tracks.update_item_in_library(
+                        library_item.item_id, prov_item
+                    )
                 if not library_item.favorite and prov_item.favorite:
                     # existing library item not favorite but should be
                     await self.mass.music.tracks.set_favorite(library_item.item_id, True)

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -122,7 +122,7 @@ class AppleMusicLibraryManager:
             return True
         album_item_id = track.album.item_id
         return (
-            track.album.item_id == track.album.name
+            album_item_id == track.album.name
             and not is_library_id(album_item_id)
             and not is_catalog_id(album_item_id)
         )

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -71,13 +71,15 @@ class AppleMusicLibraryManager:
         """Retrieve library tracks from the provider."""
         endpoint = "me/library/songs"
         song_catalog_ids = []
+        library_items_by_catalog_id: dict[str, dict] = {}
         library_only_tracks = []
-        for item in await self.api.get_all_items(endpoint):
+        for item in await self.api.get_all_items(endpoint, include="catalog,albums,artists"):
             catalog_id = item.get("attributes", {}).get("playParams", {}).get("catalogId")
             if not catalog_id:
                 library_only_tracks.append(item)
             else:
                 song_catalog_ids.append(catalog_id)
+                library_items_by_catalog_id[catalog_id] = item
         # Obtain catalog info per 150 songs; the documented limit of 300 results in a 504 timeout.
         max_limit = 150
         for i in range(0, len(song_catalog_ids), max_limit):
@@ -87,14 +89,72 @@ class AppleMusicLibraryManager:
                 catalog_endpoint, ids=",".join(catalog_ids), include="artists,albums"
             )
             rating_response = await self.api.get_ratings(catalog_ids, MediaType.TRACK)
+            returned_catalog_ids: set[str] = set()
             for item in response["data"]:
+                returned_catalog_ids.add(item["id"])
                 is_favourite = rating_response.get(item["id"])
-                yield parse_track(self.provider, item, is_favourite)
+                parsed_track = parse_track(self.provider, item, is_favourite)
+                if self._track_has_weak_album_mapping(parsed_track) and (
+                    library_item := library_items_by_catalog_id.get(item["id"])
+                ):
+                    parsed_library_track = parse_track(self.provider, library_item, is_favourite)
+                    if parsed_library_track.album and not self._track_has_weak_album_mapping(
+                        parsed_library_track
+                    ):
+                        parsed_track.album = parsed_library_track.album
+                yield parsed_track
+
+            # Some library items may not resolve on the catalog endpoint anymore.
+            for missing_catalog_id in set(catalog_ids) - returned_catalog_ids:
+                if library_item := library_items_by_catalog_id.get(missing_catalog_id):
+                    is_favourite = rating_response.get(missing_catalog_id)
+                    yield parse_track(self.provider, library_item, is_favourite)
         library_ids = [item["id"] for item in library_only_tracks if item and item["id"]]
         library_rating_response = await self.api.get_ratings(library_ids, MediaType.TRACK)
         for item in library_only_tracks:
             is_favourite = library_rating_response.get(item["id"])
-            yield parse_track(self.provider, item, is_favourite)
+            parsed_track = await self._parse_library_track_with_detail_fallback(item, is_favourite)
+            yield parsed_track
+
+    def _track_has_weak_album_mapping(self, track: Track) -> bool:
+        """Return True for missing or name-only album mapping."""
+        if not track.album:
+            return True
+        album_item_id = track.album.item_id
+        return (
+            track.album.item_id == track.album.name
+            and not is_library_id(album_item_id)
+            and not is_catalog_id(album_item_id)
+        )
+
+    async def _parse_library_track_with_detail_fallback(
+        self, item: dict, is_favourite: bool | None
+    ) -> Track:
+        """Parse library track and fetch detail when album mapping is weak."""
+        parsed_track = parse_track(self.provider, item, is_favourite)
+        initial_is_weak = self._track_has_weak_album_mapping(parsed_track)
+        if not initial_is_weak:
+            return parsed_track
+        try:
+            detail_response = await self.api.get_data(
+                f"me/library/songs/{item['id']}", include="catalog,albums,artists"
+            )
+        except MusicAssistantError as err:
+            self.logger.debug("Unable to fetch library song details for %s: %s", item["id"], err)
+            return parsed_track
+        if not detail_response.get("data"):
+            return parsed_track
+        detailed_track = parse_track(self.provider, detail_response["data"][0], is_favourite)
+        if self._track_has_weak_album_mapping(detailed_track):
+            # Keep detail album fallback if list had no album.
+            if not parsed_track.album and detailed_track.album:
+                return detailed_track
+            self.logger.debug(
+                "Library song %s still has no resolvable album mapping after detail fetch",
+                item["id"],
+            )
+            return parsed_track
+        return detailed_track
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
         """Retrieve playlists from the provider."""
@@ -112,8 +172,10 @@ class AppleMusicLibraryManager:
             is_favourite = rating_library_response.get(item["id"])
             # Prefer catalog information over library information in case of public playlists
             if item["attributes"]["hasCatalog"]:
-                yield await self.provider.get_playlist(
-                    item["attributes"]["playParams"]["globalId"], is_favourite
+                yield await self.provider.media_manager.get_playlist(
+                    item["attributes"]["playParams"]["globalId"],
+                    is_favourite,
+                    can_edit_hint=item["attributes"].get("canEdit"),
                 )
             elif item and item["id"]:
                 yield parse_playlist(self.provider, item, is_favourite)

--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -113,13 +113,23 @@ class AppleMusicMediaManager:
         is_favourite = rating_response.get(prov_track_id)
         return parse_track(self.provider, response["data"][0], is_favourite)
 
-    async def get_playlist(self, prov_playlist_id: str, is_favourite: bool = False) -> Playlist:
+    async def get_playlist(
+        self,
+        prov_playlist_id: str,
+        is_favourite: bool = False,
+        can_edit_hint: bool | None = None,
+    ) -> Playlist:
         """Get full playlist details by id."""
-        return await self._get_regular_playlist(prov_playlist_id, is_favourite)
+        return await self._get_regular_playlist(
+            prov_playlist_id, is_favourite, can_edit_hint=can_edit_hint
+        )
 
     @use_cache()
     async def _get_regular_playlist(
-        self, prov_playlist_id: str, is_favourite: bool = False
+        self,
+        prov_playlist_id: str,
+        is_favourite: bool = False,
+        can_edit_hint: bool | None = None,
     ) -> Playlist:
         """Fetch and cache details for a regular (non-station) playlist."""
         if not is_catalog_id(prov_playlist_id):
@@ -127,7 +137,12 @@ class AppleMusicMediaManager:
         else:
             endpoint = f"catalog/{self.provider._storefront}/playlists/{prov_playlist_id}"
         response = await self.api.get_data(endpoint)
-        return parse_playlist(self.provider, response["data"][0], is_favourite)
+        return parse_playlist(
+            self.provider,
+            response["data"][0],
+            is_favourite,
+            can_edit_hint=can_edit_hint,
+        )
 
     @use_cache(allow_expired_cache=True)
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -187,7 +187,7 @@ def parse_track(
 ) -> Track:
     """Parse track object to generic layout."""
     relationships = track_obj.get("relationships", {})
-    library_attributes = track_obj.get("attributes", {})
+    raw_attributes = track_obj.get("attributes", {})
     if (
         track_obj.get("type") == "library-songs"
         and relationships.get("catalog", {}).get("data", []) != []
@@ -227,7 +227,7 @@ def parse_track(
         artists = relationships["artists"]
         track.artists = [parse_artist(provider, artist) for artist in artists["data"]]
     elif artist_name := normalize_unicode(
-        attributes.get("artistName") or library_attributes.get("artistName")
+        attributes.get("artistName") or raw_attributes.get("artistName")
     ):
         track.artists = [
             ItemMapping(
@@ -243,7 +243,7 @@ def parse_track(
             if parsed_album:
                 track.album = parsed_album
     elif album_name := normalize_unicode(
-        attributes.get("albumName") or library_attributes.get("albumName")
+        attributes.get("albumName") or raw_attributes.get("albumName")
     ):
         track.album = ItemMapping(
             media_type=MediaType.ALBUM,

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -108,13 +108,6 @@ def parse_album(
             item_id=album_id,
             name=album_id,
         )
-    is_available_in_catalog = attributes.get("url") is not None
-    if not is_available_in_catalog:
-        provider.logger.debug(
-            "Skipping album %s. Album is not available in the Apple Music catalog.",
-            attributes.get("name"),
-        )
-        return None
     name, version = parse_title_and_version(attributes["name"])
     album = Album(
         item_id=album_id,
@@ -194,6 +187,7 @@ def parse_track(
 ) -> Track:
     """Parse track object to generic layout."""
     relationships = track_obj.get("relationships", {})
+    library_attributes = track_obj.get("attributes", {})
     if (
         track_obj.get("type") == "library-songs"
         and relationships.get("catalog", {}).get("data", []) != []
@@ -232,7 +226,9 @@ def parse_track(
     if "artists" in relationships:
         artists = relationships["artists"]
         track.artists = [parse_artist(provider, artist) for artist in artists["data"]]
-    elif artist_name := normalize_unicode(attributes.get("artistName")):
+    elif artist_name := normalize_unicode(
+        attributes.get("artistName") or library_attributes.get("artistName")
+    ):
         track.artists = [
             ItemMapping(
                 media_type=MediaType.ARTIST,
@@ -243,7 +239,18 @@ def parse_track(
         ]
     if albums := relationships.get("albums"):
         if "data" in albums and len(albums["data"]) > 0:
-            track.album = parse_album(provider, albums["data"][0])
+            parsed_album = parse_album(provider, albums["data"][0])
+            if parsed_album:
+                track.album = parsed_album
+    elif album_name := normalize_unicode(
+        attributes.get("albumName") or library_attributes.get("albumName")
+    ):
+        track.album = ItemMapping(
+            media_type=MediaType.ALBUM,
+            item_id=album_name,
+            provider=provider.instance_id,
+            name=album_name,
+        )
     if artwork := attributes.get("artwork"):
         url = artwork["url"]
         if artwork["width"] and artwork["height"]:
@@ -275,11 +282,12 @@ def parse_playlist(
     provider: AppleMusicProvider,
     playlist_obj: dict[str, Any],
     is_favourite: bool | None = None,
+    can_edit_hint: bool | None = None,
 ) -> Playlist:
     """Parse Apple Music playlist object to generic layout."""
     attributes = playlist_obj["attributes"]
     playlist_id = attributes["playParams"].get("globalId") or playlist_obj["id"]
-    is_editable = attributes.get("canEdit", False)
+    is_editable = can_edit_hint if can_edit_hint is not None else attributes.get("canEdit", False)
     playlist = Playlist(
         item_id=playlist_id,
         provider=provider.instance_id,

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import hashlib
 from typing import TYPE_CHECKING
 
+from aiohttp import ClientResponseError
 from music_assistant_models.enums import MediaType
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
     Artist,
     ItemMapping,
@@ -54,7 +55,18 @@ class AppleMusicRecommendationManager:
         endpoint = f"me/stations/next-tracks/ra.{prov_track_id}"
         found_tracks: list[Track] = []
         while len(found_tracks) < limit:
-            response = await self.api.post_data(endpoint, include="artists")
+            try:
+                response = await self.api.post_data(endpoint, include="artists")
+            except ClientResponseError as err:
+                if err.status == 500:
+                    self.logger.debug(
+                        "Similar tracks unavailable for %s (%s)", prov_track_id, endpoint
+                    )
+                    break
+                raise
+            except MusicAssistantError:
+                # Treat upstream server-side failures as "no recommendations".
+                break
             if not response or "data" not in response:
                 break
             track_ids = [track["id"] for track in response["data"] if track and track["id"]]

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from aiohttp import ClientResponseError
 from music_assistant_models.enums import MediaType
-from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import (
     Artist,
     ItemMapping,
@@ -64,10 +64,7 @@ class AppleMusicRecommendationManager:
                     )
                     break
                 raise
-            except MusicAssistantError:
-                # Treat upstream server-side failures as "no recommendations".
-                break
-            if not response or "data" not in response:
+            if not response or not response.get("data"):
                 break
             track_ids = [track["id"] for track in response["data"] if track and track["id"]]
             rating_response = await self.api.get_ratings(track_ids, MediaType.TRACK)

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -1,0 +1,417 @@
+"""Regression tests for Apple Music parser and library fallbacks."""
+
+from unittest.mock import ANY, AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.media_items import Album, ItemMapping
+
+from music_assistant.providers.apple_music.library import AppleMusicLibraryManager
+from music_assistant.providers.apple_music.media import AppleMusicMediaManager
+from music_assistant.providers.apple_music.parsers import parse_album, parse_track
+
+
+def _create_provider_mock() -> MagicMock:
+    """Create a provider mock with the minimum shape expected by parser functions."""
+    provider = MagicMock()
+    provider.instance_id = "apple_music_test"
+    provider.domain = "apple_music"
+    provider.logger = MagicMock()
+    provider._storefront = "us"
+    provider.mass.cache.get = AsyncMock(return_value=None)
+    provider.mass.cache.set = AsyncMock()
+    return provider
+
+
+def test_parse_album_keeps_album_without_catalog_url() -> None:
+    """Albums without catalog URL should still be parsed for library visibility."""
+    provider = _create_provider_mock()
+    album_obj = {
+        "id": "l.album1",
+        "type": "library-albums",
+        "attributes": {
+            "name": "Uploaded Album",
+            "artistName": "Uploaded Artist",
+            "playParams": {"id": "l.album1"},
+        },
+        "relationships": {},
+    }
+
+    result = parse_album(provider, album_obj)
+
+    assert isinstance(result, Album)
+    assert result.name == "Uploaded Album"
+    mapping = next(iter(result.provider_mappings))
+    assert mapping.url is None
+
+
+def test_parse_track_falls_back_to_album_name_when_relationship_missing() -> None:
+    """Track parsing should keep album info from albumName if no album relation is present."""
+    provider = _create_provider_mock()
+    track_obj = {
+        "id": "track1",
+        "type": "songs",
+        "attributes": {
+            "name": "Track 1",
+            "artistName": "Artist 1",
+            "albumName": "Album 1",
+            "durationInMillis": 180000,
+            "playParams": {"id": "track1"},
+        },
+        "relationships": {},
+    }
+
+    result = parse_track(provider, track_obj)
+
+    assert isinstance(result.album, ItemMapping)
+    assert result.album.name == "Album 1"
+
+
+def test_parse_track_library_song_uses_library_album_name_fallback() -> None:
+    """library-songs should fall back to library albumName when catalog attributes miss it."""
+    provider = _create_provider_mock()
+    track_obj = {
+        "id": "i.librarytrack1",
+        "type": "library-songs",
+        "attributes": {
+            "name": "Track 1 (Library)",
+            "artistName": "Artist 1",
+            "albumName": "Album From Library",
+            "playParams": {"catalogId": "123456789"},
+            "durationInMillis": 180000,
+        },
+        "relationships": {
+            "catalog": {
+                "data": [
+                    {
+                        "id": "123456789",
+                        "attributes": {
+                            "name": "Track 1 (Catalog)",
+                            "artistName": "Artist 1",
+                            "durationInMillis": 180000,
+                            "playParams": {"id": "123456789"},
+                        },
+                    }
+                ]
+            }
+        },
+    }
+
+    result = parse_track(provider, track_obj)
+
+    assert isinstance(result.album, ItemMapping)
+    assert result.album.name == "Album From Library"
+
+
+@pytest.mark.asyncio
+async def test_media_manager_get_playlist_applies_can_edit_hint() -> None:
+    """Catalog playlist fetch should honor library editability hint when provided."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_data = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "pl.catalog1",
+                    "attributes": {
+                        "name": "Catalog Playlist",
+                        "playParams": {"globalId": "pl.catalog1"},
+                    },
+                }
+            ]
+        }
+    )
+
+    manager = AppleMusicMediaManager(provider)
+
+    playlist = await manager.get_playlist("pl.catalog1", can_edit_hint=True)
+
+    assert playlist.is_editable is True
+
+
+@pytest.mark.asyncio
+async def test_library_playlists_preserve_can_edit_for_catalog_copy() -> None:
+    """Library playlist sync should preserve canEdit when loading via catalog copy."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_all_items = AsyncMock(
+        return_value=[
+            {
+                "id": "p.library1",
+                "attributes": {
+                    "hasCatalog": True,
+                    "canEdit": True,
+                    "playParams": {"globalId": "pl.catalog1"},
+                },
+            }
+        ]
+    )
+    provider.api_client.get_ratings = AsyncMock(return_value={})
+    provider.media_manager = MagicMock()
+    provider.media_manager.get_playlist = AsyncMock(return_value=MagicMock())
+
+    manager = AppleMusicLibraryManager(provider)
+
+    _ = [playlist async for playlist in manager.get_library_playlists()]
+
+    provider.media_manager.get_playlist.assert_called_once_with(
+        "pl.catalog1",
+        ANY,
+        can_edit_hint=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_library_tracks_request_includes_album_relations() -> None:
+    """Library track sync should request catalog/album/artist relations from Apple API."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_all_items = AsyncMock(return_value=[])
+    provider.api_client.get_ratings = AsyncMock(return_value={})
+
+    manager = AppleMusicLibraryManager(provider)
+    _ = [track async for track in manager.get_library_tracks()]
+
+    provider.api_client.get_all_items.assert_called_once_with(
+        "me/library/songs", include="catalog,albums,artists"
+    )
+
+
+@pytest.mark.asyncio
+async def test_library_tracks_falls_back_to_library_item_when_catalog_missing() -> None:
+    """Library sync should still parse track if catalog endpoint omits a catalog ID."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_all_items = AsyncMock(
+        return_value=[
+            {
+                "id": "i.librarytrack2",
+                "type": "library-songs",
+                "attributes": {
+                    "name": "Missing Catalog Track",
+                    "artistName": "Artist 2",
+                    "albumName": "Album 2",
+                    "playParams": {"catalogId": "999999"},
+                    "durationInMillis": 180000,
+                },
+                "relationships": {
+                    "catalog": {
+                        "data": [
+                            {
+                                "id": "999999",
+                                "attributes": {
+                                    "name": "Missing Catalog Track",
+                                    "artistName": "Artist 2",
+                                    "durationInMillis": 180000,
+                                    "playParams": {"id": "999999"},
+                                },
+                            }
+                        ]
+                    }
+                },
+            }
+        ]
+    )
+    provider.api_client.get_data = AsyncMock(return_value={"data": []})
+    provider.api_client.get_ratings = AsyncMock(return_value={"999999": True})
+
+    manager = AppleMusicLibraryManager(provider)
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == 1
+    assert tracks[0].name == "Missing Catalog Track"
+    assert isinstance(tracks[0].album, ItemMapping)
+    assert tracks[0].album.name == "Album 2"
+
+
+@pytest.mark.asyncio
+async def test_library_tracks_replaces_weak_catalog_album_mapping() -> None:
+    """A weak catalog albumName mapping should be replaced by library album relation."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_all_items = AsyncMock(
+        return_value=[
+            {
+                "id": "i.librarytrack5",
+                "type": "library-songs",
+                "attributes": {
+                    "name": "Weak Catalog Album Mapping",
+                    "artistName": "Artist 5",
+                    "playParams": {"catalogId": "555555"},
+                    "durationInMillis": 180000,
+                },
+                "relationships": {
+                    "catalog": {
+                        "data": [
+                            {
+                                "id": "555555",
+                                "attributes": {
+                                    "name": "Weak Catalog Album Mapping",
+                                    "artistName": "Artist 5",
+                                    "albumName": "Name Only From Catalog",
+                                    "durationInMillis": 180000,
+                                    "playParams": {"id": "555555"},
+                                },
+                            }
+                        ]
+                    },
+                    "albums": {
+                        "data": [
+                            {
+                                "id": "l.album5",
+                                "type": "library-albums",
+                                "attributes": {
+                                    "name": "Resolved Library Album",
+                                    "artistName": "Artist 5",
+                                    "playParams": {"id": "l.album5"},
+                                },
+                            }
+                        ]
+                    },
+                },
+            }
+        ]
+    )
+    provider.api_client.get_data = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "555555",
+                    "type": "songs",
+                    "attributes": {
+                        "name": "Weak Catalog Album Mapping",
+                        "artistName": "Artist 5",
+                        "albumName": "Name Only From Catalog",
+                        "durationInMillis": 180000,
+                        "playParams": {"id": "555555"},
+                    },
+                    "relationships": {},
+                }
+            ]
+        }
+    )
+    provider.api_client.get_ratings = AsyncMock(return_value={"555555": True})
+
+    manager = AppleMusicLibraryManager(provider)
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == 1
+    assert tracks[0].album is not None
+    assert tracks[0].album.item_id == "l.album5"
+    assert tracks[0].album.name == "Resolved Library Album"
+
+
+@pytest.mark.asyncio
+async def test_library_tracks_fetches_detail_when_list_item_has_no_album() -> None:
+    """Library-only tracks should be reparsed from detail endpoint when album is missing."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_all_items = AsyncMock(
+        return_value=[
+            {
+                "id": "i.librarytrack3",
+                "type": "library-songs",
+                "attributes": {
+                    "name": "No Album In List",
+                    "artistName": "Artist 3",
+                    "playParams": {"id": "i.librarytrack3", "isLibrary": True},
+                    "durationInMillis": 180000,
+                },
+                "relationships": {},
+            }
+        ]
+    )
+    provider.api_client.get_data = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "i.librarytrack3",
+                    "type": "library-songs",
+                    "attributes": {
+                        "name": "No Album In List",
+                        "artistName": "Artist 3",
+                        "albumName": "Album From Detail",
+                        "playParams": {"id": "i.librarytrack3", "isLibrary": True},
+                        "durationInMillis": 180000,
+                    },
+                    "relationships": {},
+                }
+            ]
+        }
+    )
+    provider.api_client.get_ratings = AsyncMock(return_value={"i.librarytrack3": True})
+
+    manager = AppleMusicLibraryManager(provider)
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == 1
+    assert isinstance(tracks[0].album, ItemMapping)
+    assert tracks[0].album.name == "Album From Detail"
+    provider.api_client.get_data.assert_called_once_with(
+        "me/library/songs/i.librarytrack3", include="catalog,albums,artists"
+    )
+
+
+@pytest.mark.asyncio
+async def test_library_tracks_fetches_detail_for_album_name_only_mapping() -> None:
+    """List items with only albumName fallback should be upgraded to a resolvable album id."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_all_items = AsyncMock(
+        return_value=[
+            {
+                "id": "i.librarytrack4",
+                "type": "library-songs",
+                "attributes": {
+                    "name": "Album Name Only",
+                    "artistName": "Artist 4",
+                    "albumName": "Album Only From List",
+                    "playParams": {"id": "i.librarytrack4", "isLibrary": True},
+                    "durationInMillis": 180000,
+                },
+                "relationships": {},
+            }
+        ]
+    )
+    provider.api_client.get_data = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "i.librarytrack4",
+                    "type": "library-songs",
+                    "attributes": {
+                        "name": "Album Name Only",
+                        "artistName": "Artist 4",
+                        "playParams": {"id": "i.librarytrack4", "isLibrary": True},
+                        "durationInMillis": 180000,
+                    },
+                    "relationships": {
+                        "albums": {
+                            "data": [
+                                {
+                                    "id": "l.album4",
+                                    "type": "library-albums",
+                                    "attributes": {
+                                        "name": "Resolved Album",
+                                        "artistName": "Artist 4",
+                                        "playParams": {"id": "l.album4"},
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                }
+            ]
+        }
+    )
+    provider.api_client.get_ratings = AsyncMock(return_value={"i.librarytrack4": True})
+
+    manager = AppleMusicLibraryManager(provider)
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    assert len(tracks) == 1
+    assert tracks[0].album is not None
+    assert tracks[0].album.item_id == "l.album4"
+    assert tracks[0].album.name == "Resolved Album"
+    provider.api_client.get_data.assert_called_once_with(
+        "me/library/songs/i.librarytrack4", include="catalog,albums,artists"
+    )

--- a/tests/providers/apple_music/test_similar_artists.py
+++ b/tests/providers/apple_music/test_similar_artists.py
@@ -3,7 +3,11 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp.client_exceptions import ClientResponseError
+from aiohttp.client_reqrep import RequestInfo
+from multidict import CIMultiDict, CIMultiDictProxy
 from music_assistant_models.media_items import Artist
+from yarl import URL
 
 from music_assistant.providers.apple_music.recommendations import AppleMusicRecommendationManager
 
@@ -40,6 +44,8 @@ def mock_api() -> MagicMock:
     """Return a MagicMock representing the Apple Music API client."""
     api_client = MagicMock()
     api_client.get_data = AsyncMock()
+    api_client.post_data = AsyncMock()
+    api_client.get_ratings = AsyncMock(return_value={})
     return api_client
 
 
@@ -134,3 +140,57 @@ async def test_get_similar_artists_api_error(
 
     with pytest.raises(Exception, match="API error"):
         await manager.get_similar_artists("123")
+
+
+@pytest.mark.asyncio
+async def test_get_similar_tracks_returns_tracks(
+    manager: AppleMusicRecommendationManager,
+    mock_api: MagicMock,
+) -> None:
+    """get_similar_tracks parses station tracks returned by Apple API."""
+    mock_api.post_data.return_value = {
+        "data": [
+            {
+                "id": "track1",
+                "type": "songs",
+                "attributes": {
+                    "name": "Track 1",
+                    "artistName": "Artist 1",
+                    "durationInMillis": 180000,
+                    "playParams": {"id": "track1"},
+                },
+                "relationships": {},
+            }
+        ]
+    }
+    mock_api.get_ratings.return_value = {"track1": True}
+
+    result = await manager.get_similar_tracks("123", limit=2)
+
+    assert len(result) == 2
+    assert result[0].name == "Track 1"
+
+
+@pytest.mark.asyncio
+async def test_get_similar_tracks_apple_500_returns_empty(
+    manager: AppleMusicRecommendationManager,
+    mock_api: MagicMock,
+) -> None:
+    """Apple 500 on similar tracks should not bubble up to websocket handlers."""
+    request_info = RequestInfo(
+        url=URL("https://api.music.apple.com/v1/me/stations/next-tracks/ra.i.test"),
+        method="POST",
+        headers=CIMultiDictProxy(CIMultiDict()),
+        real_url=URL("https://api.music.apple.com/v1/me/stations/next-tracks/ra.i.test"),
+    )
+    mock_api.post_data.side_effect = ClientResponseError(
+        request_info=request_info,
+        history=(),
+        status=500,
+        message="Internal Server Error",
+        headers=None,
+    )
+
+    result = await manager.get_similar_tracks("i.test", limit=5)
+
+    assert result == []

--- a/tests/providers/apple_music/test_similar_artists.py
+++ b/tests/providers/apple_music/test_similar_artists.py
@@ -148,26 +148,29 @@ async def test_get_similar_tracks_returns_tracks(
     mock_api: MagicMock,
 ) -> None:
     """get_similar_tracks parses station tracks returned by Apple API."""
-    mock_api.post_data.return_value = {
-        "data": [
-            {
-                "id": "track1",
-                "type": "songs",
-                "attributes": {
-                    "name": "Track 1",
-                    "artistName": "Artist 1",
-                    "durationInMillis": 180000,
-                    "playParams": {"id": "track1"},
-                },
-                "relationships": {},
-            }
-        ]
-    }
+    mock_api.post_data.side_effect = [
+        {
+            "data": [
+                {
+                    "id": "track1",
+                    "type": "songs",
+                    "attributes": {
+                        "name": "Track 1",
+                        "artistName": "Artist 1",
+                        "durationInMillis": 180000,
+                        "playParams": {"id": "track1"},
+                    },
+                    "relationships": {},
+                }
+            ]
+        },
+        {"data": []},
+    ]
     mock_api.get_ratings.return_value = {"track1": True}
 
     result = await manager.get_similar_tracks("123", limit=2)
 
-    assert len(result) == 2
+    assert len(result) == 1
     assert result[0].name == "Track 1"
 
 


### PR DESCRIPTION
# What does this implement/fix?

Improves Apple Music library sync/parsing so missing track→album relations are backfilled ("Appears on"), preserves playlist editability for catalog-backed library playlists, and hardens similar-tracks calls against Apple API 500 responses.

Additionally, this change includes a generic library-sync backfill in `music_assistant/models/music_provider.py` so existing tracks with missing album relations are updated when album data becomes available.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5456
- related issue https://github.com/music-assistant/support/issues/5433

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

Notes:
- Added/updated tests under `tests/providers/apple_music/`.
- Full `pytest tests/` was executed locally; remaining failures are unrelated to this Apple patch set and appear environment-dependent on this machine.
