### PR TITLE
fix(airplay): ignore stale device volume echo after volume command

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -867,7 +867,13 @@ class AirPlayPlayer(Player):
             return
 
         cur_volume = self.volume_level or 0
-        if abs(cur_volume - volume) > 1 or (time.time() - self.last_command_sent) > 3:
+        recently_sent = (time.time() - self.last_command_sent) < 3
+        # If a volume command was recently sent and the reported value differs
+        # significantly, the device is likely echoing its pre-command state.
+        # Ignore it to avoid overriding the command we just issued.
+        if recently_sent and abs(cur_volume - volume) > 1:
+            return
+        if abs(cur_volume - volume) > 1 or not recently_sent:
             self.mass.create_task(self.volume_set(volume))
         else:
             self._attr_volume_level = volume


### PR DESCRIPTION
## What does this implement/fix?

When MA sends a volume command to an AirPlay device (e.g. WiiM Amp), some devices immediately echo back their **pre-command** volume level before applying the change. The previous logic in `update_volume_from_device` would see the large difference (>1) and call `volume_set` again with the device's old value, overriding the command that was just issued.

This caused two failure modes during announcements:
- **Mode 1**: Announcement plays at the wrong (pre-announcement) volume because the device's echo of the old level overwrites the announcement volume right after it was set.
- **Mode 2**: Volume fails to restore after the announcement because the device echoes back the announcement volume after the restore command was sent.

The fix adds an early-return guard in `update_volume_from_device`: if a volume command was sent within the last 3 seconds **and** the reported volume differs significantly from the current state, the device report is ignored (it is a stale echo of the pre-command state, not a user-initiated change).

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5543

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz9HymZT3hy3Uyn5fZCdfA)_