### PR TITLE
Spotify Connect: clearer transport errors and automatic stall recovery

### DIFF
--- a/music_assistant/controllers/streams/ogg_handler.py
+++ b/music_assistant/controllers/streams/ogg_handler.py
@@ -404,47 +404,67 @@ def _resync_ogg_buffer(buffer: bytearray) -> int:
 _MAX_BUFFER_SIZE = 65536
 
 
+async def chain_ogg_pages(
+    source: AsyncGenerator[bytes, None],
+    metadata_callback: Callable[[dict[str, str]], Any] | None = None,
+) -> AsyncGenerator[bytes, None]:
+    """
+    Yield continuous OGG data from a chained byte source, stitching chain boundaries.
+
+    Use this when the source provides multiple concatenated OGG logical bitstreams
+    (e.g. internet radio reconnects, librespot --passthrough emitting per-track
+    streams). FFmpeg can't demux chained OGG directly; this stitches them into
+    one continuous bitstream so downstream decoding works.
+
+    :param source: Async byte source producing the chained OGG data.
+    :param metadata_callback: Optional callback invoked on metadata changes.
+    """
+    state = _ChainedOggState(metadata_callback)
+    buffer = bytearray()
+
+    async for chunk in source:
+        buffer.extend(chunk)
+
+        while True:
+            result = parse_ogg_page(buffer, 0)
+            if result is None:
+                if len(buffer) > _MAX_BUFFER_SIZE:
+                    skip = _resync_ogg_buffer(buffer)
+                    if skip > 0:
+                        buffer = buffer[skip:]
+                        continue
+                    discard = len(buffer) // 2
+                    LOGGER.warning("Buffer overflow, discarding %d bytes", discard)
+                    buffer = buffer[discard:]
+                break
+
+            page, consumed = result
+            buffer = buffer[consumed:]
+
+            output = state.process_page(page)
+            if output is not None:
+                yield output
+
+
 async def get_chained_ogg_stream(
     mass: MusicAssistant,
     url: str,
     metadata_callback: Callable[[dict[str, str]], Any] | None = None,
 ) -> AsyncGenerator[bytes, None]:
     """
-    Yield continuous OGG data from a chained stream, stitching chain boundaries.
+    Yield continuous OGG data from a chained HTTP stream, stitching chain boundaries.
 
     :param mass: MusicAssistant instance.
     :param url: URL of the OGG radio stream.
     :param metadata_callback: Optional callback invoked on metadata changes.
     """
-    state = _ChainedOggState(metadata_callback)
-    buffer = bytearray()
-
     LOGGER.debug("Starting chained OGG stream handler for %s", url)
-
     try:
-        async for chunk in mass.streams.audio.get_reconnecting_radio_stream(url):
-            buffer.extend(chunk)
-
-            while True:
-                result = parse_ogg_page(buffer, 0)
-                if result is None:
-                    if len(buffer) > _MAX_BUFFER_SIZE:
-                        skip = _resync_ogg_buffer(buffer)
-                        if skip > 0:
-                            buffer = buffer[skip:]
-                            continue
-                        discard = len(buffer) // 2
-                        LOGGER.warning("Buffer overflow, discarding %d bytes", discard)
-                        buffer = buffer[discard:]
-                    break
-
-                page, consumed = result
-                buffer = buffer[consumed:]
-
-                output = state.process_page(page)
-                if output is not None:
-                    yield output
+        async for output in chain_ogg_pages(
+            mass.streams.audio.get_reconnecting_radio_stream(url),
+            metadata_callback,
+        ):
+            yield output
     except aiohttp.ClientError as err:
         raise ProviderUnavailableError(f"Failed to fetch OGG stream: {err}") from err
-
     LOGGER.debug("Chained OGG stream handler ended for %s", url)

--- a/music_assistant/controllers/streams/ogg_handler.py
+++ b/music_assistant/controllers/streams/ogg_handler.py
@@ -404,67 +404,47 @@ def _resync_ogg_buffer(buffer: bytearray) -> int:
 _MAX_BUFFER_SIZE = 65536
 
 
-async def chain_ogg_pages(
-    source: AsyncGenerator[bytes, None],
-    metadata_callback: Callable[[dict[str, str]], Any] | None = None,
-) -> AsyncGenerator[bytes, None]:
-    """
-    Yield continuous OGG data from a chained byte source, stitching chain boundaries.
-
-    Use this when the source provides multiple concatenated OGG logical bitstreams
-    (e.g. internet radio reconnects, librespot --passthrough emitting per-track
-    streams). FFmpeg can't demux chained OGG directly; this stitches them into
-    one continuous bitstream so downstream decoding works.
-
-    :param source: Async byte source producing the chained OGG data.
-    :param metadata_callback: Optional callback invoked on metadata changes.
-    """
-    state = _ChainedOggState(metadata_callback)
-    buffer = bytearray()
-
-    async for chunk in source:
-        buffer.extend(chunk)
-
-        while True:
-            result = parse_ogg_page(buffer, 0)
-            if result is None:
-                if len(buffer) > _MAX_BUFFER_SIZE:
-                    skip = _resync_ogg_buffer(buffer)
-                    if skip > 0:
-                        buffer = buffer[skip:]
-                        continue
-                    discard = len(buffer) // 2
-                    LOGGER.warning("Buffer overflow, discarding %d bytes", discard)
-                    buffer = buffer[discard:]
-                break
-
-            page, consumed = result
-            buffer = buffer[consumed:]
-
-            output = state.process_page(page)
-            if output is not None:
-                yield output
-
-
 async def get_chained_ogg_stream(
     mass: MusicAssistant,
     url: str,
     metadata_callback: Callable[[dict[str, str]], Any] | None = None,
 ) -> AsyncGenerator[bytes, None]:
     """
-    Yield continuous OGG data from a chained HTTP stream, stitching chain boundaries.
+    Yield continuous OGG data from a chained stream, stitching chain boundaries.
 
     :param mass: MusicAssistant instance.
     :param url: URL of the OGG radio stream.
     :param metadata_callback: Optional callback invoked on metadata changes.
     """
+    state = _ChainedOggState(metadata_callback)
+    buffer = bytearray()
+
     LOGGER.debug("Starting chained OGG stream handler for %s", url)
+
     try:
-        async for output in chain_ogg_pages(
-            mass.streams.audio.get_reconnecting_radio_stream(url),
-            metadata_callback,
-        ):
-            yield output
+        async for chunk in mass.streams.audio.get_reconnecting_radio_stream(url):
+            buffer.extend(chunk)
+
+            while True:
+                result = parse_ogg_page(buffer, 0)
+                if result is None:
+                    if len(buffer) > _MAX_BUFFER_SIZE:
+                        skip = _resync_ogg_buffer(buffer)
+                        if skip > 0:
+                            buffer = buffer[skip:]
+                            continue
+                        discard = len(buffer) // 2
+                        LOGGER.warning("Buffer overflow, discarding %d bytes", discard)
+                        buffer = buffer[discard:]
+                    break
+
+                page, consumed = result
+                buffer = buffer[consumed:]
+
+                output = state.process_page(page)
+                if output is not None:
+                    yield output
     except aiohttp.ClientError as err:
         raise ProviderUnavailableError(f"Failed to fetch OGG stream: {err}") from err
+
     LOGGER.debug("Chained OGG stream handler ended for %s", url)

--- a/music_assistant/providers/spotify_connect/ARCHITECTURE.md
+++ b/music_assistant/providers/spotify_connect/ARCHITECTURE.md
@@ -64,8 +64,10 @@ Unlike traditional Spotify integrations that require Web API authentication, Spo
   - Authentication using Spotify credentials
   - Audio streaming and decoding to PCM
   - Session management (connect/disconnect)
-- Outputs raw PCM audio to stdout (piped to ffmpeg)
-- Sends events to the custom webservice via HTTP
+- Writes raw PCM audio (44.1 kHz / 16-bit / stereo) to a named FIFO via
+  `--backend pipe --device <fifo>`; the core's streams controller opens the
+  FIFO with ffmpeg using `-re` (rate-paced read) when the stream starts
+- Sends events to the custom webservice via HTTP (see events.py)
 
 #### 2. **events.py Webservice**
 - Python script that receives event callbacks from librespot
@@ -89,11 +91,22 @@ the same way radio stations do.
 - `name`: Display name (e.g., "Music Assistant")
 - `exclusive`: True (a single librespot stream can only serve one queue at a time)
 - `allow_external_trigger`: True (Spotify app picks MA → plugin starts playback)
+- `can_initiate`: False — see "Cold-start limitation" below
 
 **Dynamic Capabilities:**
 - `can_play_pause`: Enabled when Web API control available
 - `can_seek`: Enabled when Web API control available
 - `can_next_previous`: Enabled when Web API control available
+
+**Cold-start limitation (`can_initiate=False`):**
+MA cannot reliably initiate Spotify Connect playback from a cold start. The Web
+API's `PUT /me/player/play?device_id=X` and `PUT /me/player` transfer endpoints
+return 200, but Spotify silently refuses to start when no playback context
+exists — librespot logs `context is not available` and the device stays idle.
+The "context" expires on any meaningful idle, so MA-initiated entry is
+fundamentally flaky. We therefore only advertise external entry (Spotify app →
+pick MA). Resume from MA *during* an existing Spotify session works, because a
+context is still present at that point.
 
 When capabilities flip (Web API becomes available/unavailable) the AudioSource is rebuilt
 via ``_build_audio_source()`` so the next ``get_audio_sources()`` returns the updated flags.
@@ -106,14 +119,25 @@ metadata uses.
 
 #### 4. **Audio Pipeline**
 ```
-librespot → PCM audio → ffmpeg → format conversion → Music Assistant Player
+librespot ──PCM──▶ FIFO ──▶ ffmpeg (-re, rate-paced) ──▶ MA player
 ```
 
-The provider streams audio through an async generator that:
-1. Starts librespot process
-2. Pipes audio through ffmpeg for format conversion
-3. Yields audio chunks to the player
-4. Handles cleanup on stream end
+The stream is exposed as ``StreamType.NAMED_PIPE`` so the streams controller
+can open the FIFO with ffmpeg directly. ffmpeg's `-re` flag paces the read at
+native rate, which is what keeps librespot's (non-realtime) pipe writer from
+filling an unbounded buffer ahead of playback. Routing through a Python
+``CUSTOM`` generator instead would re-introduce that buffering and make
+pause/skip take seconds to react.
+
+**Session-stall watchdog.** If librespot starts producing audio before the
+streams controller has attached ffmpeg, the FIFO's kernel pipe buffer (~64KB)
+fills, librespot's next pipe write blocks, and the daemon's main loop wedges —
+no further `playing`/`paused` events fire. To recover, `_arm_session_watchdog`
+is armed on every `session_connected`; if no definitive state event lands
+within ``SESSION_STALL_TIMEOUT_S`` (8s), `_emergency_drain_fifo` opens the
+FIFO with ``O_RDONLY | O_NONBLOCK`` for up to ``SESSION_STALL_DRAIN_TIMEOUT_S``
+(2s) to unblock the write. The drain bails out early if librespot recovers or
+the normal stream attaches, so it doesn't compete with ffmpeg for bytes.
 
 ## Multi-Instance Support
 
@@ -152,6 +176,16 @@ By default, Spotify Connect is a **passive source** - it receives audio but Musi
 
 ### Solution: Web API Integration
 When the Spotify account logged into Connect matches a configured Spotify music provider, the provider enables bidirectional control by using Spotify's Web API.
+
+### Active-device gating
+All transport commands (`on_source_control`) and volume changes
+(`on_volume_change`) check that MA is still the active Spotify device before
+calling the Web API. Without this guard the API answers 403 for any command
+issued while another Spotify device is active, surfacing as a generic failure
+in the UI. The guard raises ``AudioError(NOT_ACTIVE_DEVICE_MESSAGE)`` instead,
+which the queue/streams layer propagates verbatim to the frontend so the user
+sees a clear "Music Assistant is not the active Spotify playback device" hint
+and can re-select MA in the Spotify app.
 
 ### Architecture
 
@@ -198,25 +232,29 @@ async def on_source_control(
   from `on_source_control`
 
 **Web API Commands:**
-- `PUT /me/player/play` - Resume playback
+- `PUT /me/player/play?device_id={id}` - Resume playback on this device
+  (preferred for the play/resume path: transfer-with-play sometimes leaves the
+  device paused for a long time before it actually starts)
+- `PUT /me/player` with `{device_ids:[id], play:?}` - Transfer fallback
 - `PUT /me/player/pause` - Pause playback
 - `POST /me/player/next` - Skip to next track
 - `POST /me/player/previous` - Skip to previous track
 - `PUT /me/player/seek?position_ms={ms}` - Seek to position
+- `PUT /me/player/volume?volume_percent={pct}` - Set volume
 
 ### Event-Driven Updates
 
 The provider subscribes to events to maintain accurate state:
 
 **Events Monitored:**
-- `EventType.PROVIDERS_UPDATED`: Check for new Spotify provider
-- Custom session events: Update username and check for matches
-- Playback events (`sink`, `playing`): Trigger provider matching
+- `EventType.PROVIDERS_UPDATED`: Re-check Spotify music provider availability
+- Custom librespot events (via the events.py webservice): drive session and
+  playback state — see "Event Handling" below
 
 **State Changes:**
-- Session connected → Check for provider match
-- Session disconnected → Disable Web API control
-- Provider added/removed → Re-check matches
+- Session connected → record username, arm stall watchdog, re-check provider match
+- Session disconnected → clear active player and stop the consuming MA player
+- Provider added/removed → re-check matches and rebuild AudioSource capabilities
 
 ## Event Handling
 
@@ -303,38 +341,51 @@ The provider subscribes to events to maintain accurate state:
 ## Code Organization
 
 ### Main Class: `SpotifyConnectProvider`
-Inherits from `PluginProvider`
+Inherits from `PluginProvider`. File layout follows the project convention of
+"public methods at the top, private helpers below."
 
-**Key Methods:**
-- `handle_async_init()`: Setup provider, start webservice, load credentials
-- `unload()`: Cleanup, stop processes
-- `get_audio_sources()`: Return the AudioSource MediaItem(s) for browse/play
-- `get_stream_details()`: Return StreamDetails for a playback session.
-  Side-effect-free — exclusivity is claimed in `on_source_selected`, not here,
-  so preload paths (player_queues._load_item) can fetch streamdetails without
-  blocking a later cross-queue handoff.
-- `get_audio_stream()`: Provide audio bytes to the queue (when stream_type=CUSTOM)
-- `on_source_control()`: Dispatch playback commands to `_on_play/pause/next/previous/seek/volume`
-- `on_source_selected()`: Claim `_in_use_by_queue` and record `_active_session_id`;
-  stop the previous active player on cross-queue handoff. Raises `RuntimeError`
-  to abort the original request after redirecting to the configured target when
-  `allow_player_switch=False`.
-- `on_source_unselected()`: Release `_in_use_by_queue` if the per-request
-  `stream_session_id` still matches the active session (paired with `on_source_selected`).
+**Public API (called by Music Assistant core):**
+- `handle_async_init()` / `unload()` — provider lifecycle
+- `get_audio_sources()` — exposes the single AudioSource MediaItem
+- `get_stream_details()` — returns `StreamType.NAMED_PIPE` streamdetails with
+  `expiration=0`. Side-effect-free; exclusivity is claimed in
+  `on_source_selected`. Raises `AudioError` when MA cannot acquire the source
+  (idle librespot + no Web API provider, or MA is not the active Spotify
+  device).
+- `on_source_selected()` — claims `_in_use_by_queue` + `_active_session_id`,
+  stops a previously active MA player on cross-queue handoff, and (for
+  MA-initiated resume during an existing Spotify session) kicks the Web API
+  to start playback then waits for librespot's `playing` event.
+- `on_source_unselected()` — releases the claim, but only if `stream_session_id`
+  still matches the active session (rejects stale callbacks from superseded
+  same-queue requests).
+- `on_source_control()` / `on_volume_change()` — proxy transport and volume to
+  the Spotify Web API. Both gated on `_spotify_session_active`; bail out with
+  `AudioError(NOT_ACTIVE_DEVICE_MESSAGE)` when MA isn't the active device.
 
-**Event Handlers:**
-- `_handle_session_connected()`: Process session connect
-- `_handle_session_disconnected()`: Process session disconnect
-- `_handle_playback_started()`: Initialize playback
-- `_handle_metadata_update()`: Update track info
-- `_handle_volume_changed()`: Sync volume
-- `_handle_custom_webservice()`: Main event dispatcher
-
-**Playback Control:**
-- `_check_spotify_provider_match()`: Find matching provider
-- `_build_audio_source()`: Build AudioSource with current capability flags
-- `_update_source_capabilities()`: Rebuild AudioSource when Web API availability changes
-- `_on_play/pause/next/previous/seek/volume()`: Web API call implementations
+**Private helpers:**
+- `_build_audio_source()` / `_update_source_capabilities()` — construct and
+  refresh the AudioSource, propagating capability flags onto the live queue
+  item so the UI updates without waiting for the next play_media.
+- `_get_target_player_id()` — apply the auto/configured-player selection rules.
+- Watchdog + deferred fire: `_arm_session_watchdog`, `_cancel_session_watchdog`,
+  `_session_watchdog_body`, `_emergency_drain_fifo`,
+  `_deferred_play_media_fire`, `_cancel_pending_play_media`.
+- `_clear_active_player()` / `_save_last_player_id()` — state reset and config
+  persistence.
+- `_check_spotify_provider_match()` — match the Connect username to a
+  configured Spotify music provider; toggles Web API availability.
+- `_on_play/pause/next/previous/seek/volume()` — Web API call implementations.
+- `_get_spotify_device_id()`, `_wait_for_librespot_playing()`,
+  `_ensure_active_device()` — Web API plumbing.
+- `_on_provider_event()` — PROVIDERS_UPDATED subscriber.
+- `_process_librespot_stderr_line()`, `_librespot_runner()`,
+  `_setup_player_daemon()` — librespot subprocess lifecycle. Daemon readiness
+  is signalled by the codec/backend-independent "Connecting to AP" sentinel
+  in librespot's stderr.
+- `_handle_custom_webservice()` — single dispatcher for all events posted by
+  events.py (session connect/disconnect, sink/playing/paused, metadata,
+  volume_changed).
 
 ## Dependencies
 
@@ -389,6 +440,19 @@ Inherits from `PluginProvider`
 3. Volume control only works if player supports it
 4. Seek requires Web API (not available in passive mode)
 5. No native gapless playback support
+6. **MA-initiated cold start is intentionally disabled** (`can_initiate=False`)
+   because Spotify will not start playback when there is no current context;
+   entry must come from the Spotify app.
+7. Pausing from MA closes librespot's pipe sink so the player state transitions
+   to IDLE rather than PAUSED. The queue's auto-clear-on-end is guarded for
+   `MediaType.AUDIO_SOURCE` items so the queue item survives a pause-as-stop
+   and resume still works.
+8. Codec badge in the frontend shows PCM (the format on the FIFO), not Ogg
+   Vorbis (Spotify's actual stream codec). A `--passthrough` experiment to fix
+   this introduced multi-second track-change latency from chained-Ogg
+   buffering and was reverted; a future migration to librespot-go (with its
+   WebSocket API) or a display-only `source_audio_format` field on
+   `StreamDetails` are the parked options.
 
 ## Related Documentation
 

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -12,7 +12,7 @@ import asyncio
 import os
 import pathlib
 import time
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
 from contextlib import suppress
 from typing import TYPE_CHECKING, cast
 
@@ -38,6 +38,8 @@ from music_assistant_models.media_items import AudioFormat, AudioSource, Provide
 from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 
 from music_assistant.constants import CONF_ENTRY_WARN_PREVIEW
+from music_assistant.controllers.streams.ogg_handler import chain_ogg_pages
+from music_assistant.helpers.named_pipe import read_named_pipe
 from music_assistant.helpers.process import AsyncProcess, check_output
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.spotify.helpers import get_librespot_binary
@@ -305,11 +307,10 @@ class SpotifyConnectProvider(PluginProvider):
         # API would accept a play call but never actually start playback on us.
         if not self._librespot_playing and not self._spotify_session_active:
             raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
-        # NAMED_PIPE (not CUSTOM): the core opens the FIFO with ffmpeg directly
-        # using `-re`, which paces the read at native rate. Going through a
-        # Python generator + StreamReader would let librespot's pipe backend
-        # (which is not realtime-paced) fill an arbitrary-size buffer ahead of
-        # us; pause/skip would then take seconds to react.
+        # CUSTOM (not NAMED_PIPE): librespot --passthrough emits a fresh OGG
+        # bitstream per Spotify track and ffmpeg can't demux those chained
+        # streams; get_audio_stream below pipes through chain_ogg_pages so
+        # ffmpeg sees one continuous OGG.
         # expiration=0: never reuse a cached streamdetails so the active-device
         # check above re-runs on every play attempt.
         return StreamDetails(
@@ -317,11 +318,22 @@ class SpotifyConnectProvider(PluginProvider):
             item_id=source_id,
             audio_format=self._audio_format,
             media_type=MediaType.AUDIO_SOURCE,
-            stream_type=StreamType.NAMED_PIPE,
-            path=self.named_pipe,
+            stream_type=StreamType.CUSTOM,
             stream_metadata=self._stream_metadata,
             expiration=0,
         )
+
+    async def get_audio_stream(
+        self,
+        streamdetails: StreamDetails,
+        seek_position: int = 0,
+    ) -> AsyncGenerator[bytes, None]:
+        """Stream chained-OGG bytes from librespot's FIFO."""
+        # Each Spotify track is a separate OGG bitstream from librespot
+        # --passthrough; chain_ogg_pages stitches them so ffmpeg sees one
+        # continuous stream and doesn't choke on bitstream boundaries.
+        async for chunk in chain_ogg_pages(read_named_pipe(self.named_pipe)):
+            yield chunk
 
     async def on_source_control(
         self,

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -53,8 +53,6 @@ if TYPE_CHECKING:
     from music_assistant.providers.spotify.provider import SpotifyProvider
 
 CONF_MASS_PLAYER_ID = "mass_player_id"
-CONF_HANDOFF_MODE = "handoff_mode"
-CONNECT_ITEM_ID = "spotify_connect"
 CONF_PUBLISH_NAME = "publish_name"
 
 # Special value for auto player selection
@@ -104,9 +102,9 @@ async def get_config_entries(
     """
     Return Config entries to setup this provider.
 
-    instance_id: id of an existing provider instance (None if new instance setup).
-    action: [optional] action key called from config entries UI.
-    values: the (intermediate) raw values for config entries sent with the action.
+    :param instance_id: id of an existing provider instance (None if new instance setup).
+    :param action: [optional] action key called from config entries UI.
+    :param values: the (intermediate) raw values for config entries sent with the action.
     """
     return (
         CONF_ENTRY_WARN_PREVIEW,
@@ -139,25 +137,6 @@ async def get_config_entries(
             description="How should this Spotify Connect device be named in the Spotify app?",
             default_value="Music Assistant",
         ),
-        # ConfigEntry(
-        #     key=CONF_HANDOFF_MODE,
-        #     type=ConfigEntryType.BOOLEAN,
-        #     label="Enable handoff mode",
-        #     default_value=False,
-        #     description="The default behavior of the Spotify Connect plugin is to "
-        #     "forward the actual Spotify Connect audio stream as-is to the player. "
-        #     "The Spotify audio is basically just a live audio stream. \n\n"
-        #     "For controlling the playback (and queue contents), "
-        #     "you need to use the Spotify app. Also, depending on the player's "
-        #     "buffering strategy and capabilities, the audio may not be fully in sync with "
-        #     "what is shown in the Spotify app. \n\n"
-        #     "When enabling handoff mode, the Spotify Connect plugin will instead "
-        #     "forward the Spotify playback request to the Music Assistant Queue, so basically "
-        #     "the spotify app can be used to initiate playback, but then MA will take over "
-        #     "the playback and manage the queue, which is the normal operating mode of MA. \n\n"
-        #     "This mode however means that the Spotify app will not report the actual playback ",
-        #     required=False,
-        # ),
     )
 
 
@@ -271,6 +250,11 @@ class SpotifyConnectProvider(PluginProvider):
         for callback in self._on_unload_callbacks:
             callback()
 
+    @property
+    def active_player_id(self) -> str | None:
+        """Return the currently active player ID for this plugin."""
+        return self._active_player_id
+
     async def get_audio_sources(self) -> list[AudioSource]:
         """Return the AudioSources this plugin currently exposes."""
         return [self._audio_source]
@@ -318,6 +302,91 @@ class SpotifyConnectProvider(PluginProvider):
             stream_metadata=self._stream_metadata,
             expiration=0,
         )
+
+    async def on_source_selected(
+        self,
+        source_id: str,
+        player_id: str,
+        queue_id: str,
+        stream_session_id: str,
+    ) -> None:
+        """Handle callback when this AudioSource has been selected/started on a player."""
+        if source_id != AUDIO_SOURCE_ID or not player_id:
+            return
+
+        # Cache the queue_id (== user-facing MA player) rather than the
+        # protocol-level player_id. Some protocol players are ephemeral bridges
+        # (e.g. Sendspin's spb_… bridges that tear down between streams) — their
+        # ID is invalid for play_media / queue lookups once the bridge is gone.
+        active_player_id = queue_id
+
+        # If there's already an active player and it's different, kick it out.
+        # The lock claim a few lines below replaces the previous queue's claim;
+        # the prior stream's on_source_unselected may fire later, but its
+        # session-id guard keeps it from clobbering the new claim.
+        if self._active_player_id and self._active_player_id != active_player_id:
+            prev_player_id = self._active_player_id
+            self.logger.info(
+                "Source selected on player %s, stopping playback on %s",
+                active_player_id,
+                prev_player_id,
+            )
+            try:
+                await self.mass.players.cmd_stop(prev_player_id)
+            except Exception as err:
+                self.logger.debug("Failed to stop previous player %s: %s", prev_player_id, err)
+
+        # Claim ownership for this queue. The lock lives here (not in
+        # get_stream_details) so preload paths can fetch streamdetails without
+        # accidentally blocking a subsequent cross-queue handoff at the actual
+        # stream request.
+        self._in_use_by_queue = queue_id
+        # Record this request's session id so a later on_source_unselected can
+        # tell whether it is the live teardown or a stale callback from a
+        # superseded same-queue request.
+        self._active_session_id = stream_session_id
+
+        # Update the active player
+        self._active_player_id = active_player_id
+        self.logger.debug("Active player set to: %s", active_player_id)
+
+        # Only persist the selected player as the new default if not in auto mode
+        if self._default_player_id != PLAYER_ID_AUTO:
+            self._save_last_player_id(active_player_id)
+
+        # MA-initiated: librespot is idle; kick Spotify via Web API.
+        # Externally triggered: librespot is already playing → skip.
+        if not self._librespot_playing:
+            if not self._spotify_provider:
+                raise AudioError(
+                    "Spotify Connect requires the matching Spotify music provider "
+                    "for MA-initiated playback"
+                )
+            try:
+                await self._ensure_active_device(play=True)
+            except Exception as err:
+                raise AudioError(f"Failed to acquire Spotify Connect via Web API: {err}") from err
+            # The Web API returns 200 even when Spotify won't actually start
+            # playing on us; confirm via librespot before reporting success.
+            if not await self._wait_for_librespot_playing():
+                raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
+
+    async def on_source_unselected(
+        self, source_id: str, queue_id: str, stream_session_id: str
+    ) -> None:
+        """Release the queue-scoped exclusive claim when MA tears down the stream."""
+        if source_id != AUDIO_SOURCE_ID:
+            return
+        # Reject stale callbacks: only release if this is still the active
+        # session. A queue_id check alone is not sufficient — same-queue
+        # reconnects (player drops + reopens the same stream URL before the
+        # original request's finally fires) would otherwise let the old
+        # request's late callback clear the live claim of the new stream.
+        if self._active_session_id != stream_session_id:
+            return
+        self._active_session_id = None
+        if self._in_use_by_queue == queue_id:
+            self._in_use_by_queue = None
 
     async def on_source_control(
         self,
@@ -375,11 +444,6 @@ class SpotifyConnectProvider(PluginProvider):
             # Spotify context), so only allow external entry via the Spotify app.
             can_initiate=False,
         )
-
-    @property
-    def active_player_id(self) -> str | None:
-        """Return the currently active player ID for this plugin."""
-        return self._active_player_id
 
     def _get_target_player_id(self) -> str | None:
         """
@@ -539,91 +603,6 @@ class SpotifyConnectProvider(PluginProvider):
             self.mass.player_queues.play_media(target_player_id, str(self._audio_source.uri))
         )
 
-    async def on_source_selected(
-        self,
-        source_id: str,
-        player_id: str,
-        queue_id: str,
-        stream_session_id: str,
-    ) -> None:
-        """Handle callback when this AudioSource has been selected/started on a player."""
-        if source_id != AUDIO_SOURCE_ID or not player_id:
-            return
-
-        # Cache the queue_id (== user-facing MA player) rather than the
-        # protocol-level player_id. Some protocol players are ephemeral bridges
-        # (e.g. Sendspin's spb_… bridges that tear down between streams) — their
-        # ID is invalid for play_media / queue lookups once the bridge is gone.
-        active_player_id = queue_id
-
-        # If there's already an active player and it's different, kick it out.
-        # The lock claim a few lines below replaces the previous queue's claim;
-        # the prior stream's on_source_unselected may fire later, but its
-        # session-id guard keeps it from clobbering the new claim.
-        if self._active_player_id and self._active_player_id != active_player_id:
-            prev_player_id = self._active_player_id
-            self.logger.info(
-                "Source selected on player %s, stopping playback on %s",
-                active_player_id,
-                prev_player_id,
-            )
-            try:
-                await self.mass.players.cmd_stop(prev_player_id)
-            except Exception as err:
-                self.logger.debug("Failed to stop previous player %s: %s", prev_player_id, err)
-
-        # Claim ownership for this queue. The lock lives here (not in
-        # get_stream_details) so preload paths can fetch streamdetails without
-        # accidentally blocking a subsequent cross-queue handoff at the actual
-        # stream request.
-        self._in_use_by_queue = queue_id
-        # Record this request's session id so a later on_source_unselected can
-        # tell whether it is the live teardown or a stale callback from a
-        # superseded same-queue request.
-        self._active_session_id = stream_session_id
-
-        # Update the active player
-        self._active_player_id = active_player_id
-        self.logger.debug("Active player set to: %s", active_player_id)
-
-        # Only persist the selected player as the new default if not in auto mode
-        if self._default_player_id != PLAYER_ID_AUTO:
-            self._save_last_player_id(active_player_id)
-
-        # MA-initiated: librespot is idle; kick Spotify via Web API.
-        # Externally triggered: librespot is already playing → skip.
-        if not self._librespot_playing:
-            if not self._spotify_provider:
-                raise AudioError(
-                    "Spotify Connect requires the matching Spotify music provider "
-                    "for MA-initiated playback"
-                )
-            try:
-                await self._ensure_active_device(play=True)
-            except Exception as err:
-                raise AudioError(f"Failed to acquire Spotify Connect via Web API: {err}") from err
-            # The Web API returns 200 even when Spotify won't actually start
-            # playing on us; confirm via librespot before reporting success.
-            if not await self._wait_for_librespot_playing():
-                raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
-
-    async def on_source_unselected(
-        self, source_id: str, queue_id: str, stream_session_id: str
-    ) -> None:
-        """Release the queue-scoped exclusive claim when MA tears down the stream."""
-        if source_id != AUDIO_SOURCE_ID:
-            return
-        # Reject stale callbacks: only release if this is still the active
-        # session. A queue_id check alone is not sufficient — same-queue
-        # reconnects (player drops + reopens the same stream URL before the
-        # original request's finally fires) would otherwise let the old
-        # request's late callback clear the live claim of the new stream.
-        if self._active_session_id != stream_session_id:
-            return
-        self._active_session_id = None
-        if self._in_use_by_queue == queue_id:
-            self._in_use_by_queue = None
-
     def _clear_active_player(self) -> None:
         """
         Clear the active player and revert to default if configured.
@@ -777,7 +756,8 @@ class SpotifyConnectProvider(PluginProvider):
             raise
 
     async def _on_volume(self, volume: int) -> None:
-        """Handle volume change command via Spotify Web API.
+        """
+        Handle volume change command via Spotify Web API.
 
         :param volume: Volume level (0-100) from Music Assistant.
         """
@@ -801,7 +781,8 @@ class SpotifyConnectProvider(PluginProvider):
             raise
 
     async def _get_spotify_device_id(self) -> str | None:
-        """Get the Spotify Connect device ID for this instance.
+        """
+        Get the Spotify Connect device ID for this instance.
 
         :return: Device ID if found, None otherwise.
         """

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -12,7 +12,7 @@ import asyncio
 import os
 import pathlib
 import time
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import Callable
 from contextlib import suppress
 from typing import TYPE_CHECKING, cast
 
@@ -38,8 +38,6 @@ from music_assistant_models.media_items import AudioFormat, AudioSource, Provide
 from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 
 from music_assistant.constants import CONF_ENTRY_WARN_PREVIEW
-from music_assistant.controllers.streams.ogg_handler import chain_ogg_pages
-from music_assistant.helpers.named_pipe import read_named_pipe
 from music_assistant.helpers.process import AsyncProcess, check_output
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.spotify.helpers import get_librespot_binary
@@ -191,16 +189,12 @@ class SpotifyConnectProvider(PluginProvider):
             self._default_player_id,
             self.instance_id,
         )
-        # librespot is started with --passthrough below, so the FIFO carries
-        # the original Ogg-Vorbis bytes from Spotify rather than decoded PCM —
-        # advertise that to the frontend and let ffmpeg decode downstream.
         self._audio_format = AudioFormat(
-            content_type=ContentType.OGG,
-            codec_type=ContentType.VORBIS,
+            content_type=ContentType.PCM_S16LE,
+            codec_type=ContentType.PCM_S16LE,
             sample_rate=44100,
             bit_depth=16,
             channels=2,
-            bit_rate=320,
         )
         self._stream_metadata = StreamMetadata(title=f"Spotify Connect | {connect_name}")
         # Web API integration for playback control - must come before _build_audio_source
@@ -307,10 +301,11 @@ class SpotifyConnectProvider(PluginProvider):
         # API would accept a play call but never actually start playback on us.
         if not self._librespot_playing and not self._spotify_session_active:
             raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
-        # CUSTOM (not NAMED_PIPE): librespot --passthrough emits a fresh OGG
-        # bitstream per Spotify track and ffmpeg can't demux those chained
-        # streams; get_audio_stream below pipes through chain_ogg_pages so
-        # ffmpeg sees one continuous OGG.
+        # NAMED_PIPE (not CUSTOM): the core opens the FIFO with ffmpeg directly
+        # using `-re`, which paces the read at native rate. Going through a
+        # Python generator + StreamReader would let librespot's pipe backend
+        # (which is not realtime-paced) fill an arbitrary-size buffer ahead of
+        # us; pause/skip would then take seconds to react.
         # expiration=0: never reuse a cached streamdetails so the active-device
         # check above re-runs on every play attempt.
         return StreamDetails(
@@ -318,22 +313,11 @@ class SpotifyConnectProvider(PluginProvider):
             item_id=source_id,
             audio_format=self._audio_format,
             media_type=MediaType.AUDIO_SOURCE,
-            stream_type=StreamType.CUSTOM,
+            stream_type=StreamType.NAMED_PIPE,
+            path=self.named_pipe,
             stream_metadata=self._stream_metadata,
             expiration=0,
         )
-
-    async def get_audio_stream(
-        self,
-        streamdetails: StreamDetails,
-        seek_position: int = 0,
-    ) -> AsyncGenerator[bytes, None]:
-        """Stream chained-OGG bytes from librespot's FIFO."""
-        # Each Spotify track is a separate OGG bitstream from librespot
-        # --passthrough; chain_ogg_pages stitches them so ffmpeg sees one
-        # continuous stream and doesn't choke on bitstream boundaries.
-        async for chunk in chain_ogg_pages(read_named_pipe(self.named_pipe)):
-            yield chunk
 
     async def on_source_control(
         self,
@@ -973,10 +957,8 @@ class SpotifyConnectProvider(PluginProvider):
                 "pipe",
                 "--device",
                 self.named_pipe,
-                # Forward the raw Ogg-Vorbis bytes to the pipe instead of
-                # librespot's decoded PCM; lets MA expose the real source
-                # codec and bit_rate to the frontend.
-                "--passthrough",
+                "--dither",
+                "none",
                 # disable volume control
                 "--mixer",
                 "passthrough",
@@ -984,6 +966,7 @@ class SpotifyConnectProvider(PluginProvider):
                 "passthrough",
                 "--initial-volume",
                 str(initial_volume),
+                "--enable-volume-normalisation",
                 # forward events to the events script
                 "--onevent",
                 str(EVENTS_SCRIPT),

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -899,7 +899,9 @@ class SpotifyConnectProvider(PluginProvider):
         """
         if (
             not self._librespot_started.is_set()
-            and "Using StdoutSink (pipe) with format: S16" in line
+            # Codec/backend-independent readiness signal: librespot reaches this
+            # only after audio backend + spirc setup completed without errors.
+            and "Connecting to AP" in line
         ):
             self._librespot_started.set()
         if "error sending packet Os" in line:

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -181,12 +181,16 @@ class SpotifyConnectProvider(PluginProvider):
             self._default_player_id,
             self.instance_id,
         )
+        # librespot is started with --passthrough below, so the FIFO carries
+        # the original Ogg-Vorbis bytes from Spotify rather than decoded PCM —
+        # advertise that to the frontend and let ffmpeg decode downstream.
         self._audio_format = AudioFormat(
-            content_type=ContentType.PCM_S16LE,
-            codec_type=ContentType.PCM_S16LE,
+            content_type=ContentType.OGG,
+            codec_type=ContentType.VORBIS,
             sample_rate=44100,
             bit_depth=16,
             channels=2,
+            bit_rate=320,
         )
         self._stream_metadata = StreamMetadata(title=f"Spotify Connect | {connect_name}")
         # Web API integration for playback control - must come before _build_audio_source
@@ -314,6 +318,10 @@ class SpotifyConnectProvider(PluginProvider):
         """Proxy playback control commands to Spotify via the Web API."""
         if source_id != AUDIO_SOURCE_ID:
             return
+        # Without an active Spotify session the Web API answers 403 to every
+        # transport command; fail fast with the user-facing message instead.
+        if not self._librespot_playing and not self._spotify_session_active:
+            raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
         if action == SourceControl.PLAY:
             await self._on_play()
         elif action == SourceControl.PAUSE:
@@ -329,6 +337,8 @@ class SpotifyConnectProvider(PluginProvider):
         """Sync the Spotify app's volume slider with the player's new volume."""
         if source_id != AUDIO_SOURCE_ID:
             return
+        if not self._librespot_playing and not self._spotify_session_active:
+            raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
         await self._on_volume(volume)
 
     def _build_audio_source(self) -> AudioSource:
@@ -868,8 +878,10 @@ class SpotifyConnectProvider(PluginProvider):
                 "pipe",
                 "--device",
                 self.named_pipe,
-                "--dither",
-                "none",
+                # Forward the raw Ogg-Vorbis bytes to the pipe instead of
+                # librespot's decoded PCM; lets MA expose the real source
+                # codec and bit_rate to the frontend.
+                "--passthrough",
                 # disable volume control
                 "--mixer",
                 "passthrough",
@@ -877,7 +889,6 @@ class SpotifyConnectProvider(PluginProvider):
                 "passthrough",
                 "--initial-volume",
                 str(initial_volume),
-                "--enable-volume-normalisation",
                 # forward events to the events script
                 "--onevent",
                 str(EVENTS_SCRIPT),

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -72,6 +72,14 @@ AUDIO_SOURCE_ID = "main"
 # play: the Web API returns 200 even when playback never actually starts.
 PLAYBACK_START_TIMEOUT_S = 3.0
 
+# How long to wait after session_connected for a definitive 'playing' or
+# 'paused' event before assuming librespot is wedged (typically blocked on
+# a pipe write because no consumer is reading the FIFO yet).
+SESSION_STALL_TIMEOUT_S = 8.0
+
+# How long the emergency drain reads the FIFO once a stall is detected.
+SESSION_STALL_DRAIN_TIMEOUT_S = 2.0
+
 # User-facing message for the "not the active Spotify device" failure.
 NOT_ACTIVE_DEVICE_MESSAGE = (
     "Music Assistant is not the active Spotify playback device. "
@@ -229,6 +237,11 @@ class SpotifyConnectProvider(PluginProvider):
         self._spotify_device_id: str | None = None
         self._last_session_connected_time: float = 0
         self._last_volume_sent_to_spotify: int | None = None
+        # Armed on session_connected, cancelled on the first definitive
+        # state event ('playing' / 'paused' / 'session_disconnected'). If
+        # neither lands within SESSION_STALL_TIMEOUT_S, the watchdog drains
+        # the FIFO to unblock a likely pipe-write deadlock in librespot.
+        self._session_watchdog: asyncio.Task[None] | None = None
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
@@ -254,6 +267,7 @@ class SpotifyConnectProvider(PluginProvider):
         """Handle close/cleanup of the provider."""
         self._stop_called = True
         self._cancel_pending_play_media()
+        self._cancel_session_watchdog()
         if self._runner_task and not self._runner_task.done():
             self._runner_task.cancel()
             with suppress(asyncio.CancelledError):
@@ -422,6 +436,73 @@ class SpotifyConnectProvider(PluginProvider):
         if task is not None and not task.done():
             task.cancel()
         self._pending_play_media_task = None
+
+    def _arm_session_watchdog(self) -> None:
+        """Arm the post-session_connected stall watchdog."""
+        self._cancel_session_watchdog()
+        self._session_watchdog = self.mass.create_task(self._session_watchdog_body())
+
+    def _cancel_session_watchdog(self) -> None:
+        """Cancel the stall watchdog."""
+        task = self._session_watchdog
+        if task is not None and not task.done():
+            task.cancel()
+        self._session_watchdog = None
+
+    async def _session_watchdog_body(self) -> None:
+        """
+        Recover librespot when a session_connected isn't followed by a state event.
+
+        The typical cause is a pipe-write deadlock: librespot starts producing
+        audio, the FIFO has no consumer yet, the kernel pipe buffer fills, the
+        next write blocks, and the main loop is stuck — so no 'playing' or
+        'paused' event ever fires. Draining the FIFO unblocks the write; the
+        normal flow then resumes on its own.
+        """
+        try:
+            await asyncio.sleep(SESSION_STALL_TIMEOUT_S)
+        except asyncio.CancelledError:
+            return
+        if self._librespot_playing or self._in_use_by_queue:
+            return
+        self.logger.warning(
+            "Spotify Connect session connected but no playing/paused event "
+            "within %ss — draining FIFO to unblock librespot",
+            SESSION_STALL_TIMEOUT_S,
+        )
+        await self._emergency_drain_fifo()
+
+    async def _emergency_drain_fifo(self) -> None:
+        """Open the FIFO and read+discard briefly to unblock librespot."""
+        try:
+            fd = os.open(self.named_pipe, os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC)
+        except OSError as err:
+            self.logger.debug("Emergency drain: cannot open FIFO: %s", err)
+            return
+        drained = 0
+        deadline = self.mass.loop.time() + SESSION_STALL_DRAIN_TIMEOUT_S
+        try:
+            while self.mass.loop.time() < deadline:
+                # Bail out as soon as librespot recovers or the normal stream
+                # pipeline is about to attach; closing our fd before ffmpeg
+                # opens avoids two readers splitting the audio bytes.
+                if self._librespot_playing or self._in_use_by_queue:
+                    break
+                try:
+                    data = os.read(fd, 65536)
+                except BlockingIOError:
+                    await asyncio.sleep(0.01)
+                    continue
+                except OSError:
+                    break
+                if data == b"":
+                    await asyncio.sleep(0.01)
+                else:
+                    drained += len(data)
+        finally:
+            with suppress(Exception):
+                os.close(fd)
+        self.logger.info("Emergency FIFO drain complete: %d bytes", drained)
 
     async def _deferred_play_media_fire(self) -> None:
         """
@@ -936,6 +1017,7 @@ class SpotifyConnectProvider(PluginProvider):
             # Track when session connected for volume event filtering
             self._last_session_connected_time = time.time()
             self._spotify_session_active = True
+            self._arm_session_watchdog()
             username = json_data.get("user_name")
             self.logger.debug(
                 "Session connected event - username from event: %s, current username: %s",
@@ -955,6 +1037,7 @@ class SpotifyConnectProvider(PluginProvider):
         if event_name == "session_disconnected":
             self.logger.info("Spotify Connect session disconnected")
             self._spotify_session_active = False
+            self._cancel_session_watchdog()
             prev_player_id = self._active_player_id
             self._clear_active_player()
             if prev_player_id:
@@ -975,8 +1058,13 @@ class SpotifyConnectProvider(PluginProvider):
         # state regardless of which lands first.
         if event_name in ("sink", "playing"):
             self._librespot_playing = True
+            # Definitive state signal — the watchdog can stand down.
+            if event_name == "playing":
+                self._cancel_session_watchdog()
         elif event_name == "paused":
             self._librespot_playing = False
+            # Definitive state signal — the watchdog can stand down.
+            self._cancel_session_watchdog()
             # cancel any deferred play_media — pause is the definitive "don't".
             # We deliberately do NOT cmd_stop the consumer here even though it
             # would make pause UX feel snappier: cmd_stop ends the stream →


### PR DESCRIPTION
# What does this implement/fix?

Three small follow-ups to #4001 that make Spotify Connect playback control feel less fragile:

- **Friendlier errors for transport commands.** When MA is no longer the active Spotify device, next/previous/seek/volume now surface the same "select Music Assistant in the Spotify app" hint as play. Previously only play caught this — the others fell through to a generic 403.
- **Self-recovery from pipe stalls.** Occasionally librespot would start producing audio before MA attached a consumer; the FIFO would fill, librespot's write would block, and the device looked frozen until Spotify timed out (~14 s). A short watchdog now drains the FIFO once and lets librespot proceed on its own.
- **Codec-independent readiness sentinel.** The "librespot is up" check no longer keys on a PCM-specific log line, so a future backend or codec change doesn't silently break startup detection.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.