### PR TITLE
Smart Playlist: multi-seed support with album/playlist seeds

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import random
 import shutil
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from contextlib import suppress
@@ -116,6 +117,9 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 DB_SCHEMA_VERSION: Final[int] = 40
+RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60
+_DYNAMIC_RADIO_BASE_SAMPLE_SIZE: Final[int] = 5
+_DYNAMIC_RADIO_DYNAMIC_TARGET: Final[int] = 50
 
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10
 DATABASE_CLEANUP_TASK_ID: Final[str] = "music_database_cleanup"
@@ -876,6 +880,81 @@ class MusicController(CoreController):
         # return result from all providers while keeping index
         # so the result is sorted as each provider delivered
         return [item for sublist in zip_longest(*results_per_provider) for item in sublist if item]
+
+    async def get_dynamic_radio_tracks(
+        self,
+        seeds: list[MediaItemType],
+        *,
+        include_base_tracks: bool = False,
+        target_size: int = 25,
+        preferred_provider_instances: list[str] | None = None,
+    ) -> list[Track]:
+        """
+        Generate a dynamic radio track pool from one or more seed media items.
+
+        :param seeds: Seed media items (Track, Artist, Album, Playlist, ...) used as sources.
+        :param include_base_tracks: When True, interleave the sampled base tracks into the result
+            using the BDDBDD pattern. When False, only similar tracks are returned.
+        :param target_size: Maximum number of dynamic (similar) tracks to sample into the result.
+            When ``include_base_tracks`` is True, base tracks are added on top of this cap.
+        :param preferred_provider_instances: Provider instance IDs preferred for similar lookups.
+        :raises UnsupportedFeaturedException: When no base tracks could be derived from any seed.
+        """
+        available_base_tracks: list[Track] = []
+        for seed in random.sample(seeds, len(seeds)):
+            ctrl = self.get_controller(seed.media_type)
+            try:
+                base_tracks_for_seed = await ctrl.radio_mode_base_tracks(
+                    seed,  # type: ignore[arg-type]
+                    preferred_provider_instances,
+                )
+            except UnsupportedFeaturedException:
+                continue
+            for track in base_tracks_for_seed:
+                if track not in available_base_tracks:
+                    available_base_tracks.append(track)
+        if not available_base_tracks:
+            raise UnsupportedFeaturedException("Radio mode not available for source items")
+
+        base_tracks = random.sample(
+            available_base_tracks,
+            min(_DYNAMIC_RADIO_BASE_SAMPLE_SIZE, len(available_base_tracks)),
+        )
+        dynamic_tracks: set[Track] = set()
+        for allow_lookup in (False, True):
+            if dynamic_tracks:
+                break
+            for base_track in base_tracks:
+                try:
+                    similar = await self.tracks.similar_tracks(
+                        base_track.item_id,
+                        base_track.provider,
+                        allow_lookup=allow_lookup,
+                        preferred_provider_instances=preferred_provider_instances,
+                    )
+                except MediaNotFoundError:
+                    continue
+                for track in similar:
+                    if track not in base_tracks and track.duration <= RADIO_TRACK_MAX_DURATION_SECS:
+                        dynamic_tracks.add(track)
+                if len(dynamic_tracks) >= _DYNAMIC_RADIO_DYNAMIC_TARGET:
+                    break
+
+        result: list[Track] = []
+        dynamic_tracks_list = list(dynamic_tracks)
+        if include_base_tracks:
+            result.append(base_tracks[0])
+            if len(base_tracks) > 1:
+                for base_track in base_tracks[1:]:
+                    result.append(base_track)
+                    if len(dynamic_tracks_list) > 2:
+                        result += random.sample(dynamic_tracks_list, 2)
+                    else:
+                        result += dynamic_tracks_list
+        remaining_dynamic = [t for t in dynamic_tracks_list if t not in result]
+        if remaining_dynamic:
+            result += random.sample(remaining_dynamic, min(len(remaining_dynamic), target_size))
+        return result
 
     @api_command("music/item")
     async def get_item(

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -901,6 +901,7 @@ class MusicController(CoreController):
         :param preferred_provider_instances: Provider instance IDs preferred for similar lookups.
         :raises UnsupportedFeaturedException: When no base tracks could be derived from any seed.
         """
+        seen: set[Track] = set()
         available_base_tracks: list[Track] = []
         for seed in random.sample(seeds, len(seeds)):
             ctrl = self.get_controller(seed.media_type)
@@ -912,7 +913,8 @@ class MusicController(CoreController):
             except UnsupportedFeaturedException:
                 continue
             for track in base_tracks_for_seed:
-                if track not in available_base_tracks:
+                if track not in seen:
+                    seen.add(track)
                     available_base_tracks.append(track)
         if not available_base_tracks:
             raise UnsupportedFeaturedException("Radio mode not available for source items")

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -117,6 +117,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 DB_SCHEMA_VERSION: Final[int] = 40
+# tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60
 _DYNAMIC_RADIO_BASE_SAMPLE_SIZE: Final[int] = 5
 _DYNAMIC_RADIO_DYNAMIC_TARGET: Final[int] = 50

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -925,7 +925,7 @@ class MusicController(CoreController):
         )
         dynamic_tracks: set[Track] = set()
         for allow_lookup in (False, True):
-            if dynamic_tracks:
+            if len(dynamic_tracks) >= _DYNAMIC_RADIO_DYNAMIC_TARGET:
                 break
             for base_track in base_tracks:
                 try:

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -114,7 +114,6 @@ CONF_DEFAULT_ENQUEUE_OPTION_PODCAST = "default_enqueue_option_podcast"
 CONF_DEFAULT_ENQUEUE_OPTION_PODCAST_EPISODE = "default_enqueue_option_podcast_episode"
 CONF_DEFAULT_ENQUEUE_OPTION_FOLDER = "default_enqueue_option_folder"
 CONF_DEFAULT_ENQUEUE_OPTION_UNKNOWN = "default_enqueue_option_unknown"
-RADIO_TRACK_MAX_DURATION_SECS = 20 * 60  # 20 minutes
 CACHE_CATEGORY_PLAYER_QUEUE_STATE = 0
 CACHE_CATEGORY_PLAYER_QUEUE_ITEMS = 1
 
@@ -2602,8 +2601,6 @@ class PlayerQueuesController(CoreController):
         ):
             preferred_provider_instances = playback_user.provider_filter
 
-        available_base_tracks: list[Track] = []
-        base_track_sample_size = 5
         # Some providers have very deterministic similar track algorithms when providing
         # a single track item. When we have a radio mode based on 1 track and we have to
         # refill the queue (ie not initial radio mode), we use the play history as base tracks
@@ -2611,88 +2608,21 @@ class PlayerQueuesController(CoreController):
             len(queue.radio_source) == 1
             and queue.radio_source[0].media_type == MediaType.TRACK
             and not is_initial_radio_mode
+            and queue_track_items
         ):
-            available_base_tracks = queue_track_items
+            seeds: list[MediaItemType] = list(queue_track_items)
         else:
-            # Grab all the available base tracks based on the selected source items.
-            # shuffle the source items, just in case
-            for radio_item in random.sample(queue.radio_source, len(queue.radio_source)):
-                ctrl = self.mass.music.get_controller(radio_item.media_type)
-                try:
-                    available_base_tracks += [
-                        track
-                        for track in await ctrl.radio_mode_base_tracks(
-                            radio_item,  # type: ignore[arg-type]
-                            preferred_provider_instances,
-                        )
-                        # Avoid duplicate base tracks
-                        if track not in available_base_tracks
-                    ]
-                except UnsupportedFeaturedException as err:
-                    self.logger.debug(
-                        "Skip loading radio items for %s: %s ",
-                        radio_item.uri,
-                        str(err),
-                    )
-            if not available_base_tracks:
-                raise UnsupportedFeaturedException("Radio mode not available for source items")
+            seeds = list(queue.radio_source)
 
-        # Sample tracks from the base tracks, which will be used to calculate the dynamic ones
-        base_tracks = random.sample(
-            available_base_tracks,
-            min(base_track_sample_size, len(available_base_tracks)),
+        radio_tracks = await self.mass.music.get_dynamic_radio_tracks(
+            seeds,
+            include_base_tracks=is_initial_radio_mode,
+            target_size=25,
+            preferred_provider_instances=preferred_provider_instances,
         )
-        # Use a set to avoid duplicate dynamic tracks
-        dynamic_tracks: set[Track] = set()
-        # Use base tracks + Trackcontroller to obtain similar tracks for every base Track
-        for allow_lookup in (False, True):
-            if dynamic_tracks:
-                break
-            for base_track in base_tracks:
-                try:
-                    _similar_tracks = await self.mass.music.tracks.similar_tracks(
-                        base_track.item_id,
-                        base_track.provider,
-                        allow_lookup=allow_lookup,
-                        preferred_provider_instances=preferred_provider_instances,
-                    )
-                except MediaNotFoundError:
-                    # Some providers don't have similar tracks for all items. For example,
-                    # Tidal can sometimes return a 404 when the 'similar_tracks' endpoint is called.
-                    # in that case, just skip the track.
-                    self.logger.debug("Similar tracks not found for track %s", base_track.name)
-                    continue
-                for track in _similar_tracks:
-                    if (
-                        track not in base_tracks
-                        # Exclude tracks we have already played / queued
-                        and track not in queue_track_items
-                        # Ignore tracks that are too long for radio mode, e.g. mixes
-                        and track.duration <= RADIO_TRACK_MAX_DURATION_SECS
-                    ):
-                        dynamic_tracks.add(track)
-                if len(dynamic_tracks) >= 50:
-                    break
-        queue_tracks: list[Track] = []
-        dynamic_tracks_list = list(dynamic_tracks)
-        # Only include the sampled base tracks when the radio mode is first initialized
-        if is_initial_radio_mode:
-            queue_tracks += [base_tracks[0]]
-            # Exhaust base tracks with the pattern of BDDBDDBDD (1 base track + 2 dynamic tracks)
-            if len(base_tracks) > 1:
-                for base_track in base_tracks[1:]:
-                    queue_tracks += [base_track]
-                    if len(dynamic_tracks_list) > 2:
-                        queue_tracks += random.sample(dynamic_tracks_list, 2)
-                    else:
-                        queue_tracks += dynamic_tracks_list
-        # Add dynamic tracks to the queue, make sure to exclude already picked tracks
-        remaining_dynamic_tracks = [t for t in dynamic_tracks_list if t not in queue_tracks]
-        if remaining_dynamic_tracks:
-            queue_tracks += random.sample(
-                remaining_dynamic_tracks, min(len(remaining_dynamic_tracks), 25)
-            )
-        return queue_tracks
+        # Drop anything already queued/played (the helper has no concept of queue state).
+        queued_set = set(queue_track_items)
+        return [track for track in radio_tracks if track not in queued_set]
 
     async def _get_folder_tracks(self, folder: BrowseFolder) -> list[Track]:
         """Fetch (playable) tracks for given browse folder."""

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2610,7 +2610,10 @@ class PlayerQueuesController(CoreController):
             and not is_initial_radio_mode
             and queue_track_items
         ):
-            seeds: list[MediaItemType] = list(queue_track_items)
+            # Helper samples 5 internally; bound the input.
+            seeds: list[MediaItemType] = random.sample(
+                queue_track_items, min(len(queue_track_items), 10)
+            )
         else:
             seeds = list(queue.radio_source)
 

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2620,7 +2620,7 @@ class PlayerQueuesController(CoreController):
             target_size=25,
             preferred_provider_instances=preferred_provider_instances,
         )
-        # Drop anything already queued/played (the helper has no concept of queue state).
+        # Drop anything already queued/played
         queued_set = set(queue_track_items)
         return [track for track in radio_tracks if track not in queued_set]
 

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -37,12 +37,12 @@ from music_assistant_models.media_items import (
 from music_assistant_models.media_items.metadata import MediaItemMetadata
 
 from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
+from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.smart_playlist.helpers import (
     LOGIC_AND,
-    MAX_SIMILAR_TRACKS,
     RULES_FILENAME,
     SmartPlaylistRules,
     read_json,
@@ -61,6 +61,8 @@ if TYPE_CHECKING:
     from music_assistant.models import ProviderInstanceType
 
 FETCH_LIMIT = 2000
+CACHE_CATEGORY_DYNAMIC_SAMPLE = 0
+DYNAMIC_SAMPLE_CACHE_EXPIRATION = 24 * 3600  # 24h; stale entries are still served via SWR
 
 SUPPORTED_FEATURES: set[ProviderFeature] = {
     ProviderFeature.BROWSE,
@@ -170,6 +172,10 @@ class SmartPlaylistProvider(PluginProvider):
             for filename in await asyncio.to_thread(os.listdir, self._rules_dir):
                 filepath = os.path.join(self._rules_dir, filename)
                 await asyncio.to_thread(os.remove, filepath)
+            await self.mass.cache.clear(
+                category_filter=CACHE_CATEGORY_DYNAMIC_SAMPLE,
+                provider_filter=self.instance_id,
+            )
 
     # --- PluginProvider interface ---
 
@@ -200,20 +206,38 @@ class SmartPlaylistProvider(PluginProvider):
         return self._build_playlist(prov_playlist_id, rules)
 
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
-        """Evaluate rules and return fresh tracks.
+        """Evaluate rules and return tracks.
 
-        Returns a full batch on page 0; empty list on subsequent pages.
-        For dynamic playlists a bounded buffer is returned per call so the browse overview
-        shows a representative sample and queue refills stay deduped/shuffled across refreshes.
+        Returns a full batch on page 0; empty list on subsequent pages. Dynamic playlists
+        return a bounded buffer (``DYNAMIC_PLAYLIST_SAMPLE_SIZE``) cached for
+        ``DYNAMIC_SAMPLE_CACHE_EXPIRATION`` so browsing stays snappy. Stale entries are
+        still served from cache while a fresh sample is rebuilt in the background
+        (stale-while-revalidate). Callers that wrap this in
+        ``mass.cache.handle_refresh(True)`` — notably the player queue when refilling a
+        dynamic playlist — bypass the cache entirely and get a freshly-evaluated sample.
         """
         if page > 0:
             return []
         rules = self._rules_store.get(prov_playlist_id)
         if rules is None:
             return []
-        if rules.is_dynamic:
-            rules = dc_replace(rules, limit=DYNAMIC_PLAYLIST_SAMPLE_SIZE)
-        return await self._evaluate_rules(rules)
+        if not rules.is_dynamic:
+            return await self._evaluate_rules(rules)
+        return await self._cached_dynamic_sample(prov_playlist_id)
+
+    @use_cache(
+        expiration=DYNAMIC_SAMPLE_CACHE_EXPIRATION,
+        category=CACHE_CATEGORY_DYNAMIC_SAMPLE,
+        base_class=Track,
+        allow_expired_cache=True,
+    )
+    async def _cached_dynamic_sample(self, prov_playlist_id: str) -> list[Track]:
+        """Evaluate a fresh sample for a dynamic playlist (wrapped in SWR cache)."""
+        rules = self._rules_store.get(prov_playlist_id)
+        if rules is None:
+            return []
+        sample_rules = dc_replace(rules, limit=DYNAMIC_PLAYLIST_SAMPLE_SIZE)
+        return await self._evaluate_rules(sample_rules)
 
     async def _on_media_item_deleted(self, event: MassEvent) -> None:
         """Remove the rules for a deleted smart playlist."""
@@ -225,6 +249,7 @@ class SmartPlaylistProvider(PluginProvider):
                 prov_id = mapping.item_id
                 self._rules_store.pop(prov_id, None)
                 self._names_store.pop(prov_id, None)
+                await self._invalidate_dynamic_sample_cache(prov_id)
                 await self._flush_rules_to_disk()
                 break
 
@@ -480,18 +505,11 @@ class SmartPlaylistProvider(PluginProvider):
         """Evaluate the rules and return a list of matching Track objects."""
         has_genre_filter = bool(rules.genre_ids)
 
-        if rules.seed_track_uri or rules.seed_artist_uri:
-            # Seed mode: a similar-tracks/artists pool is the exclusive source.
+        seed_uris = rules.all_seed_uris()
+        if seed_uris:
+            # Seed mode: a similar-tracks pool derived from the seeds is the exclusive source.
             # artist_ids and album_ids are ignored per design.
-            if rules.seed_track_uri:
-                tracks = await self._get_similar_tracks(rules.seed_track_uri, MAX_SIMILAR_TRACKS)
-            else:
-                assert rules.seed_artist_uri is not None  # guaranteed by outer condition
-                tracks = await self._get_similar_artists_tracks(
-                    rules.seed_artist_uri,
-                    MAX_SIMILAR_TRACKS,
-                    library_only=rules.seed_artist_library_only,
-                )
+            tracks = await self._tracks_from_seeds(seed_uris, target_size=rules.limit)
             tracks = await self._apply_seed_post_filters(tracks, rules, has_genre_filter)
         else:
             if rules.logic == LOGIC_AND:
@@ -769,98 +787,31 @@ class SmartPlaylistProvider(PluginProvider):
             order_by="random",
         )
 
-    async def _get_similar_tracks(self, seed_track_uri: str, limit: int) -> list[Track]:
-        """Get similar tracks for the given seed track URI."""
-        try:
-            _media_type, provider, item_id = await parse_uri(seed_track_uri)
-        except Exception:
-            self.logger.warning("Cannot parse seed_track_uri: %s", seed_track_uri)
-            return []
-        try:
-            return await self.mass.music.tracks.similar_tracks(
-                item_id=item_id,
-                provider_instance_id_or_domain=provider,
-                limit=limit,
-            )
-        except Exception as exc:
-            self.logger.warning("Could not get similar tracks for %s: %s", seed_track_uri, exc)
-            return []
-
-    async def _get_similar_artists_tracks(
-        self, seed_artist_uri: str, limit: int, library_only: bool
-    ) -> list[Track]:
-        """Get tracks for artists similar to the given seed artist URI."""
-        try:
-            _media_type, provider, item_id = await parse_uri(seed_artist_uri)
-        except Exception:
-            self.logger.warning("Cannot parse seed_artist_uri: %s", seed_artist_uri)
-            return []
-        try:
-            similar_artists = await self.mass.music.artists.similar_artists(
-                item_id=item_id,
-                provider_instance_id_or_domain=provider,
-                limit=20,
-            )
-        except Exception as exc:
-            self.logger.warning("Could not get similar artists for %s: %s", seed_artist_uri, exc)
-            return []
-
-        similar_names = {a.name.lower() for a in similar_artists}
-        if not similar_names:
-            return []
-
-        if library_only:
-            # Match against library tracks by artist name.
-            all_tracks = await self._get_library_tracks(limit=min(limit * 20, 2000))
-            result: dict[str, Track] = {}
-            for track in all_tracks:
-                for artist in track.artists:
-                    if artist.name.lower() in similar_names and track.uri:
-                        result[track.uri] = track
-                        break
-            return list(result.values())
-
-        # Provider mode: fetch top tracks for each similar artist directly from the provider.
-        result_provider: dict[str, Track] = {}
-        per_artist = max(1, limit // max(len(similar_artists), 1))
-        self.logger.debug(
-            "seed_artist provider mode: %d similar artists, per_artist=%d",
-            len(similar_artists),
-            per_artist,
-        )
-        for artist in similar_artists:
-            if len(result_provider) >= limit:
-                break
-            mapping = next(
-                (
-                    m
-                    for m in artist.provider_mappings
-                    if provider in {m.provider_instance, m.provider_domain}
-                ),
-                None,
-            ) or next(iter(artist.provider_mappings), None)
-            if not mapping:
-                self.logger.debug("No mapping found for artist %s", artist.name)
+    async def _tracks_from_seeds(self, seed_uris: list[str], target_size: int) -> list[Track]:
+        """Resolve seed URIs to media items and feed them through the dynamic radio helper."""
+        seeds: list[MediaItemType] = []
+        for uri in seed_uris:
+            try:
+                media_type, provider, item_id = await parse_uri(uri)
+            except Exception:
+                self.logger.warning("Cannot parse seed URI: %s", uri)
                 continue
             try:
-                artist_tracks = await self.mass.music.artists.get_provider_artist_toptracks(
-                    item_id=mapping.item_id,
-                    provider_instance_id_or_domain=mapping.provider_instance,
-                )
-                self.logger.debug(
-                    "Artist %s (%s): %d top tracks",
-                    artist.name,
-                    mapping.item_id,
-                    len(artist_tracks),
-                )
+                ctrl = self.mass.music.get_controller(media_type)
+                seeds.append(await ctrl.get(item_id, provider))
             except Exception as exc:
-                self.logger.debug("Error fetching tracks for artist %s: %s", artist.name, exc)
-                continue
-            for track in artist_tracks[:per_artist]:
-                if track.uri:
-                    result_provider[track.uri] = track
-        self.logger.debug("seed_artist provider mode: %d total tracks", len(result_provider))
-        return list(result_provider.values())
+                self.logger.warning("Could not resolve seed %s: %s", uri, exc)
+        if not seeds:
+            return []
+        try:
+            return await self.mass.music.get_dynamic_radio_tracks(
+                seeds,
+                include_base_tracks=True,
+                target_size=target_size,
+            )
+        except Exception as exc:
+            self.logger.warning("Dynamic radio generation failed for seeds %s: %s", seed_uris, exc)
+            return []
 
     async def _update_playlist_description(
         self, library_item_id: int | str, rules: SmartPlaylistRules
@@ -892,7 +843,16 @@ class SmartPlaylistProvider(PluginProvider):
     async def _save_rules(self, playlist_id: str, rules: SmartPlaylistRules) -> None:
         """Persist rules to disk and update in-memory store."""
         self._rules_store[playlist_id] = rules
+        await self._invalidate_dynamic_sample_cache(playlist_id)
         await self._flush_rules_to_disk()
+
+    async def _invalidate_dynamic_sample_cache(self, playlist_id: str) -> None:
+        """Drop the cached dynamic sample for this playlist so the next browse refreshes."""
+        await self.mass.cache.clear(
+            key_filter=playlist_id,
+            category_filter=CACHE_CATEGORY_DYNAMIC_SAMPLE,
+            provider_filter=self.instance_id,
+        )
 
     async def _flush_rules_to_disk(self) -> None:
         """Write all rules + names to disk as a single JSON file."""

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -279,12 +279,7 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
             f"{rules.year_from}>{rules.year_to}"
         )
         raise InvalidDataError(msg)
-    total_seeds = (
-        len(rules.seed_track_uris)
-        + len(rules.seed_artist_uris)
-        + len(rules.seed_album_uris)
-        + len(rules.seed_playlist_uris)
-    )
+    total_seeds = len(rules.all_seed_uris())
     if total_seeds > MAX_SEEDS:
         msg = f"Too many seeds: {total_seeds} > {MAX_SEEDS}"
         raise InvalidDataError(msg)

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -13,7 +13,7 @@ from music_assistant.helpers.json import json_dumps, json_loads
 LOGIC_AND = "AND"
 LOGIC_OR = "OR"
 DEFAULT_TRACK_LIMIT = 100
-MAX_SIMILAR_TRACKS = 50
+MAX_SEEDS = 10
 RULES_FILENAME = "smart_playlist_rules.json"
 
 
@@ -72,6 +72,15 @@ def _coerce_int_keyed_dict(value: Any, field_name: str) -> dict[int, str]:
     return result
 
 
+def _coerce_str_keyed_dict(value: Any, field_name: str) -> dict[str, str]:
+    """Coerce a value to a dict[str, str], raising InvalidDataError on bad input."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise InvalidDataError(f"Expected dict for {field_name}, got {type(value).__name__}")
+    return {str(k): str(v) for k, v in value.items()}
+
+
 @dataclass
 class SmartPlaylistRules:
     """Rules that define which tracks are included in a smart playlist."""
@@ -80,8 +89,11 @@ class SmartPlaylistRules:
     artist_ids: list[int] = field(default_factory=list)
     album_ids: list[int] = field(default_factory=list)
     favorites_only: bool = False
-    seed_track_uri: str | None = None
-    seed_track_name: str | None = None
+    seed_track_uris: list[str] = field(default_factory=list)
+    seed_artist_uris: list[str] = field(default_factory=list)
+    seed_album_uris: list[str] = field(default_factory=list)
+    seed_playlist_uris: list[str] = field(default_factory=list)
+    seed_names: dict[str, str] = field(default_factory=dict)
     min_popularity: int | None = None
     logic: str = LOGIC_AND
     limit: int = DEFAULT_TRACK_LIMIT
@@ -91,9 +103,6 @@ class SmartPlaylistRules:
     album_names: dict[int, str] = field(default_factory=dict)
     year_from: int | None = None
     year_to: int | None = None
-    seed_artist_uri: str | None = None
-    seed_artist_name: str | None = None
-    seed_artist_library_only: bool = False
     excluded_artist_ids: list[int] = field(default_factory=list)
     excluded_album_ids: list[int] = field(default_factory=list)
     excluded_track_uris: list[str] = field(default_factory=list)
@@ -103,6 +112,21 @@ class SmartPlaylistRules:
     excluded_genre_names: dict[int, str] = field(default_factory=dict)
     dedup_hours: int | None = None
 
+    def all_seed_uris(self) -> list[str]:
+        """Return every seed URI across the four seed lists, deduplicated, original order."""
+        seen: set[str] = set()
+        result: list[str] = []
+        for uri in (
+            *self.seed_track_uris,
+            *self.seed_artist_uris,
+            *self.seed_album_uris,
+            *self.seed_playlist_uris,
+        ):
+            if uri and uri not in seen:
+                seen.add(uri)
+                result.append(uri)
+        return result
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dictionary."""
         return {
@@ -110,8 +134,11 @@ class SmartPlaylistRules:
             "artist_ids": self.artist_ids,
             "album_ids": self.album_ids,
             "favorites_only": self.favorites_only,
-            "seed_track_uri": self.seed_track_uri,
-            "seed_track_name": self.seed_track_name,
+            "seed_track_uris": self.seed_track_uris,
+            "seed_artist_uris": self.seed_artist_uris,
+            "seed_album_uris": self.seed_album_uris,
+            "seed_playlist_uris": self.seed_playlist_uris,
+            "seed_names": self.seed_names,
             "min_popularity": self.min_popularity,
             "logic": self.logic,
             "limit": self.limit,
@@ -121,9 +148,6 @@ class SmartPlaylistRules:
             "album_names": {str(k): v for k, v in self.album_names.items()},
             "year_from": self.year_from,
             "year_to": self.year_to,
-            "seed_artist_uri": self.seed_artist_uri,
-            "seed_artist_name": self.seed_artist_name,
-            "seed_artist_library_only": self.seed_artist_library_only,
             "excluded_artist_ids": self.excluded_artist_ids,
             "excluded_album_ids": self.excluded_album_ids,
             "excluded_track_uris": self.excluded_track_uris,
@@ -142,8 +166,13 @@ class SmartPlaylistRules:
             artist_ids=_coerce_id_list(data.get("artist_ids"), "artist_ids"),
             album_ids=_coerce_id_list(data.get("album_ids"), "album_ids"),
             favorites_only=data.get("favorites_only", False),
-            seed_track_uri=data.get("seed_track_uri"),
-            seed_track_name=data.get("seed_track_name"),
+            seed_track_uris=_coerce_str_list(data.get("seed_track_uris"), "seed_track_uris"),
+            seed_artist_uris=_coerce_str_list(data.get("seed_artist_uris"), "seed_artist_uris"),
+            seed_album_uris=_coerce_str_list(data.get("seed_album_uris"), "seed_album_uris"),
+            seed_playlist_uris=_coerce_str_list(
+                data.get("seed_playlist_uris"), "seed_playlist_uris"
+            ),
+            seed_names=_coerce_str_keyed_dict(data.get("seed_names"), "seed_names"),
             min_popularity=_coerce_optional_int(data.get("min_popularity"), "min_popularity"),
             logic=data.get("logic", LOGIC_AND),
             limit=_coerce_int(data.get("limit", DEFAULT_TRACK_LIMIT), "limit"),
@@ -153,9 +182,6 @@ class SmartPlaylistRules:
             album_names=_coerce_int_keyed_dict(data.get("album_names"), "album_names"),
             year_from=_coerce_optional_int(data.get("year_from"), "year_from"),
             year_to=_coerce_optional_int(data.get("year_to"), "year_to"),
-            seed_artist_uri=data.get("seed_artist_uri"),
-            seed_artist_name=data.get("seed_artist_name"),
-            seed_artist_library_only=data.get("seed_artist_library_only", False),
             excluded_artist_ids=_coerce_id_list(
                 data.get("excluded_artist_ids"), "excluded_artist_ids"
             ),
@@ -194,12 +220,10 @@ class SmartPlaylistRules:
         if self.album_ids:
             names = [self.album_names.get(aid, str(aid)) for aid in self.album_ids]
             parts.append(f"Albums: {', '.join(names)}")
-        if self.seed_track_uri:
-            label = self.seed_track_name or self.seed_track_uri
-            parts.append(f"Similar to track: {label}")
-        if self.seed_artist_uri:
-            label = self.seed_artist_name or self.seed_artist_uri
-            parts.append(f"Similar to artist: {label}")
+        seed_uris = self.all_seed_uris()
+        if seed_uris:
+            labels = [self.seed_names.get(uri, uri) for uri in seed_uris]
+            parts.append(f"Similar to: {', '.join(labels)}")
         if self.excluded_artist_ids:
             names = [
                 self.excluded_artist_names.get(aid, str(aid)) for aid in self.excluded_artist_ids
@@ -255,8 +279,14 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
             f"{rules.year_from}>{rules.year_to}"
         )
         raise InvalidDataError(msg)
-    if rules.seed_track_uri and rules.seed_artist_uri:
-        msg = "seed_track_uri and seed_artist_uri are mutually exclusive"
+    total_seeds = (
+        len(rules.seed_track_uris)
+        + len(rules.seed_artist_uris)
+        + len(rules.seed_album_uris)
+        + len(rules.seed_playlist_uris)
+    )
+    if total_seeds > MAX_SEEDS:
+        msg = f"Too many seeds: {total_seeds} > {MAX_SEEDS}"
         raise InvalidDataError(msg)
     if rules.dedup_hours is not None and not (1 <= rules.dedup_hours <= 8760):
         msg = f"dedup_hours must be between 1 and 8760, got {rules.dedup_hours}"

--- a/tests/core/test_dynamic_radio.py
+++ b/tests/core/test_dynamic_radio.py
@@ -127,5 +127,7 @@ async def test_multiple_seeds_dedup_base_tracks() -> None:
     )
 
     await ctrl.get_dynamic_radio_tracks([seed_a, seed_b], target_size=5)
-    # similar_tracks is called once per sampled base track; 3 unique base tracks → ≤3 calls.
-    assert cast("Any", ctrl.tracks.similar_tracks).call_count <= 3
+    # 3 unique base tracks after dedup. similar_tracks fires once per base per allow_lookup pass;
+    # with only 2 similar mocks per call we never hit the dynamic-target threshold, so both
+    # passes run → 3 * 2 = 6 calls. Without dedup it would be 4 * 2 = 8.
+    assert cast("Any", ctrl.tracks.similar_tracks).call_count <= 6

--- a/tests/core/test_dynamic_radio.py
+++ b/tests/core/test_dynamic_radio.py
@@ -1,0 +1,131 @@
+"""Tests for MusicController.get_dynamic_radio_tracks."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import UnsupportedFeaturedException
+
+from music_assistant.controllers.music import (
+    RADIO_TRACK_MAX_DURATION_SECS,
+    MusicController,
+)
+
+
+def _track(item_id: str, duration: int = 200) -> MagicMock:
+    track = MagicMock()
+    track.item_id = item_id
+    track.provider = "test"
+    track.uri = f"test://track/{item_id}"
+    track.name = f"Track {item_id}"
+    track.duration = duration
+    track.media_type = MediaType.TRACK
+    return track
+
+
+def _seed(media_type: MediaType, item_id: str) -> MagicMock:
+    item = MagicMock()
+    item.media_type = media_type
+    item.item_id = item_id
+    item.uri = f"test://{media_type.value}/{item_id}"
+    return item
+
+
+def _make_controller(
+    base_tracks_by_seed: dict[str, list[MagicMock]], similar: list[MagicMock]
+) -> MusicController:
+    """Build a MusicController with the bits required by get_dynamic_radio_tracks stubbed out."""
+    ctrl = MusicController.__new__(MusicController)
+    tracks_ctrl = MagicMock()
+    tracks_ctrl.similar_tracks = AsyncMock(return_value=similar)
+    ctrl.tracks = tracks_ctrl
+
+    media_controllers: dict[MediaType, MagicMock] = {}
+
+    def get_controller(media_type: MediaType) -> MagicMock:
+        if media_type not in media_controllers:
+            media_ctrl = MagicMock()
+            media_ctrl.radio_mode_base_tracks = AsyncMock(
+                side_effect=lambda seed, _prefs=None: base_tracks_by_seed.get(seed.item_id, [])
+            )
+            media_controllers[media_type] = media_ctrl
+        return media_controllers[media_type]
+
+    ctrl.get_controller = get_controller  # type: ignore[method-assign]
+    return ctrl
+
+
+@pytest.mark.asyncio
+async def test_no_seeds_raises() -> None:
+    """An empty seed list raises UnsupportedFeaturedException."""
+    ctrl = _make_controller({}, [])
+    with pytest.raises(UnsupportedFeaturedException):
+        await ctrl.get_dynamic_radio_tracks([])
+
+
+@pytest.mark.asyncio
+async def test_seed_with_no_base_tracks_raises() -> None:
+    """When all seeds yield zero base tracks, raises UnsupportedFeaturedException."""
+    seed = _seed(MediaType.ALBUM, "1")
+    ctrl = _make_controller({"1": []}, [])
+    with pytest.raises(UnsupportedFeaturedException):
+        await ctrl.get_dynamic_radio_tracks([seed])
+
+
+@pytest.mark.asyncio
+async def test_long_tracks_are_filtered() -> None:
+    """Tracks longer than the max-duration threshold are dropped from candidates."""
+    seed = _seed(MediaType.TRACK, "s1")
+    base = _track("s1")
+    short = _track("short", duration=100)
+    long_track = _track("long", duration=RADIO_TRACK_MAX_DURATION_SECS + 1)
+    ctrl = _make_controller({"s1": [base]}, [short, long_track])
+
+    result = await ctrl.get_dynamic_radio_tracks([seed], target_size=10)
+    ids = {t.item_id for t in result}
+    assert "short" in ids
+    assert "long" not in ids
+
+
+@pytest.mark.asyncio
+async def test_include_base_tracks_emits_seed_track() -> None:
+    """include_base_tracks=True ensures at least one base track is in the output."""
+    seed = _seed(MediaType.TRACK, "s1")
+    base = _track("s1")
+    similar = [_track(f"sim{i}") for i in range(5)]
+    ctrl = _make_controller({"s1": [base]}, similar)
+
+    result = await ctrl.get_dynamic_radio_tracks([seed], include_base_tracks=True, target_size=5)
+    assert any(t.item_id == "s1" for t in result)
+
+
+@pytest.mark.asyncio
+async def test_exclude_base_tracks_omits_seed_track() -> None:
+    """include_base_tracks=False keeps only similar tracks in the output."""
+    seed = _seed(MediaType.TRACK, "s1")
+    base = _track("s1")
+    similar = [_track(f"sim{i}") for i in range(5)]
+    ctrl = _make_controller({"s1": [base]}, similar)
+
+    result = await ctrl.get_dynamic_radio_tracks([seed], include_base_tracks=False, target_size=5)
+    assert all(t.item_id != "s1" for t in result)
+    assert len(result) == 5
+
+
+@pytest.mark.asyncio
+async def test_multiple_seeds_dedup_base_tracks() -> None:
+    """Duplicate base tracks across seeds are deduplicated before sampling."""
+    seed_a = _seed(MediaType.ALBUM, "a")
+    seed_b = _seed(MediaType.ALBUM, "b")
+    shared = _track("shared")
+    ctrl = _make_controller(
+        {"a": [shared, _track("a-only")], "b": [shared, _track("b-only")]},
+        [_track("sim1"), _track("sim2")],
+    )
+
+    await ctrl.get_dynamic_radio_tracks([seed_a, seed_b], target_size=5)
+    # similar_tracks is called once per sampled base track; 3 unique base tracks → ≤3 calls.
+    assert cast("Any", ctrl.tracks.similar_tracks).call_count <= 3

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -605,7 +605,8 @@ async def test_get_playlist_tracks_dynamic_cold_evaluates_and_caches(tmp_path: A
     await plugin.handle_async_init()
 
     tracks = [_make_mock_track(str(i), f"library://track/{i}") for i in range(50)]
-    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
+    library_mock = AsyncMock(return_value=tracks)
+    cast("Any", plugin)._get_library_tracks = library_mock
 
     rules = SmartPlaylistRules(limit=100, is_dynamic=True)
     plugin._rules_store["abc"] = rules
@@ -613,8 +614,8 @@ async def test_get_playlist_tracks_dynamic_cold_evaluates_and_caches(tmp_path: A
     result = await plugin.get_playlist_tracks("abc")
     assert len(result) <= DYNAMIC_PLAYLIST_SAMPLE_SIZE
     assert len(result) > 5
-    # @use_cache does a fresh lookup, then a stale-allowed lookup, then schedules a store.
-    assert mass.cache.get.await_count == 2
+    # Observable behaviour: the wrapped evaluator ran and a store task was scheduled.
+    library_mock.assert_awaited()
     mass.create_task.assert_called_once()
 
 

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -34,7 +34,10 @@ class TestSmartPlaylistRules:
         assert rules.artist_ids == []
         assert rules.album_ids == []
         assert rules.favorites_only is False
-        assert rules.seed_track_uri is None
+        assert rules.seed_track_uris == []
+        assert rules.seed_artist_uris == []
+        assert rules.seed_album_uris == []
+        assert rules.seed_playlist_uris == []
         assert rules.min_popularity is None
         assert rules.logic == LOGIC_AND
         assert rules.limit == 100
@@ -46,13 +49,27 @@ class TestSmartPlaylistRules:
             artist_ids=[10],
             album_ids=[],
             favorites_only=True,
-            seed_track_uri="library://track/42",
+            seed_track_uris=["library://track/42", "library://track/43"],
+            seed_artist_uris=["library://artist/7"],
+            seed_album_uris=["library://album/3"],
+            seed_playlist_uris=["library://playlist/9"],
+            seed_names={"library://track/42": "Some Track"},
             min_popularity=50,
             logic=LOGIC_OR,
             limit=25,
         )
         recovered = SmartPlaylistRules.from_dict(original.to_dict())
         assert recovered == original
+
+    def test_all_seed_uris_dedupes_across_lists(self) -> None:
+        """all_seed_uris() returns each URI once even when duplicated across lists."""
+        rules = SmartPlaylistRules(
+            seed_track_uris=["a", "b"],
+            seed_artist_uris=["b", "c"],
+            seed_album_uris=["d"],
+            seed_playlist_uris=[],
+        )
+        assert rules.all_seed_uris() == ["a", "b", "c", "d"]
 
     def test_from_dict_partial(self) -> None:
         """from_dict tolerates missing keys by using defaults."""
@@ -183,6 +200,16 @@ class TestRuleValidation:
         with pytest.raises(InvalidDataError, match="popularity"):
             plugin._validate_rules(rules)
 
+    def test_too_many_seeds_raises(self) -> None:
+        """More than MAX_SEEDS combined seeds raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(
+            seed_track_uris=[f"library://track/{i}" for i in range(6)],
+            seed_artist_uris=[f"library://artist/{i}" for i in range(6)],
+        )
+        with pytest.raises(InvalidDataError, match="Too many seeds"):
+            plugin._validate_rules(rules)
+
 
 # ---------------------------------------------------------------------------
 # Persistence tests  (using tmp_path, no real MA instance needed)
@@ -197,6 +224,7 @@ async def test_rules_persist_to_disk(tmp_path: Any) -> None:
 
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
+    mass.cache.clear = AsyncMock()
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
     config = MagicMock()
@@ -339,7 +367,6 @@ async def test_popularity_filter_applied() -> None:
     low_pop = _make_mock_track("1", uri="library://track/1", popularity=30)
     high_pop = _make_mock_track("2", uri="library://track/2", popularity=80)
     cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[low_pop, high_pop])
-    cast("Any", plugin)._get_similar_tracks = AsyncMock(return_value=[])
 
     rules = SmartPlaylistRules(min_popularity=50, logic=LOGIC_AND, limit=10)
     result = await plugin._evaluate_rules(rules)
@@ -369,7 +396,6 @@ async def test_favorites_only_filter() -> None:
         return all_tracks
 
     cast("Any", plugin)._get_library_tracks = mock_get_library
-    cast("Any", plugin)._get_similar_tracks = AsyncMock(return_value=[])
 
     rules = SmartPlaylistRules(favorites_only=True, logic=LOGIC_AND, limit=10)
     result = await plugin._evaluate_rules(rules)
@@ -390,7 +416,6 @@ async def test_limit_is_respected() -> None:
 
     tracks = [_make_mock_track(str(i), f"library://track/{i}") for i in range(50)]
     cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
-    cast("Any", plugin)._get_similar_tracks = AsyncMock(return_value=[])
 
     rules = SmartPlaylistRules(limit=5)
     result = await plugin._evaluate_rules(rules)
@@ -403,7 +428,7 @@ async def test_limit_is_respected() -> None:
 
 
 class TestNewValidation:
-    """Validate new mutual-exclusion and range checks."""
+    """Validate seed and range checks."""
 
     def _make_plugin(self) -> SmartPlaylistProvider:
         mass = MagicMock()
@@ -413,15 +438,16 @@ class TestNewValidation:
         config.get_value.return_value = "GLOBAL"
         return SmartPlaylistProvider(mass, manifest, config, set())
 
-    def test_seed_track_and_seed_artist_mutually_exclusive(self) -> None:
-        """Setting both seed_track_uri and seed_artist_uri raises InvalidDataError."""
+    def test_mixed_seeds_within_cap_passes(self) -> None:
+        """A mix of seed types under the cap validates."""
         plugin = self._make_plugin()
         rules = SmartPlaylistRules(
-            seed_track_uri="library://track/1",
-            seed_artist_uri="library://artist/2",
+            seed_track_uris=["library://track/1", "library://track/2"],
+            seed_artist_uris=["library://artist/3"],
+            seed_album_uris=["library://album/4"],
+            seed_playlist_uris=["library://playlist/5"],
         )
-        with pytest.raises(InvalidDataError, match="mutually exclusive"):
-            plugin._validate_rules(rules)
+        plugin._validate_rules(rules)  # should not raise
 
     def test_dedup_hours_out_of_range_raises(self) -> None:
         """dedup_hours outside 1-8760 raises InvalidDataError."""
@@ -438,8 +464,8 @@ class TestNewValidation:
 
 
 @pytest.mark.asyncio
-async def test_seed_artist_uses_similar_artists_tracks() -> None:
-    """seed_artist_uri calls _get_similar_artists_tracks instead of _get_similar_tracks."""
+async def test_seed_mode_delegates_to_dynamic_radio_helper() -> None:
+    """When any seed URI is set, evaluator collects tracks via _tracks_from_seeds."""
     mass = MagicMock()
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
@@ -448,14 +474,20 @@ async def test_seed_artist_uses_similar_artists_tracks() -> None:
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
     similar_tracks = [_make_mock_track("10", "library://track/10")]
-    cast("Any", plugin)._get_similar_artists_tracks = AsyncMock(return_value=similar_tracks)
-    cast("Any", plugin)._get_similar_tracks = AsyncMock(return_value=[])
+    cast("Any", plugin)._tracks_from_seeds = AsyncMock(return_value=similar_tracks)
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[])
 
-    rules = SmartPlaylistRules(seed_artist_uri="library://artist/5", limit=10)
+    rules = SmartPlaylistRules(
+        seed_artist_uris=["library://artist/5"],
+        seed_album_uris=["library://album/9"],
+        limit=10,
+    )
     result = await plugin._evaluate_rules(rules)
 
-    cast("Any", plugin)._get_similar_artists_tracks.assert_awaited_once()
-    cast("Any", plugin)._get_similar_tracks.assert_not_awaited()
+    cast("Any", plugin)._tracks_from_seeds.assert_awaited_once()
+    awaited_args = cast("Any", plugin)._tracks_from_seeds.await_args
+    assert awaited_args.args[0] == ["library://artist/5", "library://album/9"]
+    cast("Any", plugin)._get_library_tracks.assert_not_awaited()
     assert len(result) == 1
 
 
@@ -552,11 +584,19 @@ async def test_dedup_fallback_when_pool_exhausted() -> None:
     assert len(result) == 5
 
 
+def _swallow_task(coro: Any, **_: Any) -> None:
+    """Close coroutines passed to a mocked mass.create_task so pytest stays quiet."""
+    coro.close()
+
+
 @pytest.mark.asyncio
-async def test_get_playlist_tracks_dynamic_uses_sample_size(tmp_path: Any) -> None:
-    """get_playlist_tracks caps dynamic playlists at the sample size."""
+async def test_get_playlist_tracks_dynamic_cold_evaluates_and_caches(tmp_path: Any) -> None:
+    """On a fully-cold cache the sample is evaluated and a store task is scheduled."""
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
+    mass.cache.get = AsyncMock(return_value=None)
+    mass.cache.set = AsyncMock()
+    mass.create_task = MagicMock(side_effect=_swallow_task)
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
     config = MagicMock()
@@ -572,7 +612,70 @@ async def test_get_playlist_tracks_dynamic_uses_sample_size(tmp_path: Any) -> No
 
     result = await plugin.get_playlist_tracks("abc")
     assert len(result) <= DYNAMIC_PLAYLIST_SAMPLE_SIZE
-    assert len(result) > 5  # proves the buffer is no longer capped at 5
+    assert len(result) > 5
+    # @use_cache does a fresh lookup, then a stale-allowed lookup, then schedules a store.
+    assert mass.cache.get.await_count == 2
+    mass.create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_playlist_tracks_dynamic_returns_fresh_cache(tmp_path: Any) -> None:
+    """A fresh cache hit short-circuits evaluation and does not touch the stale path."""
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    cached = [_make_mock_track(str(i), f"library://track/cached-{i}") for i in range(3)]
+    mass.cache.get = AsyncMock(return_value=cached)
+    mass.cache.set = AsyncMock()
+    mass.create_task = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+    await plugin.handle_async_init()
+
+    evaluate_mock = AsyncMock(return_value=[])
+    cast("Any", plugin)._evaluate_rules = evaluate_mock
+
+    plugin._rules_store["abc"] = SmartPlaylistRules(limit=100, is_dynamic=True)
+    result = await plugin.get_playlist_tracks("abc")
+    assert result == cached
+    evaluate_mock.assert_not_awaited()
+    # Only the fresh lookup runs; no stale lookup, no scheduled refresh.
+    mass.cache.get.assert_awaited_once()
+    mass.create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_playlist_tracks_dynamic_serves_stale_and_refreshes(tmp_path: Any) -> None:
+    """A stale-only cache hit is returned immediately and refresh is scheduled."""
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    stale = [_make_mock_track(str(i), f"library://track/stale-{i}") for i in range(3)]
+    # First (fresh) lookup misses, second (stale-allowed) lookup returns the expired entry.
+    mass.cache.get = AsyncMock(side_effect=[None, stale])
+    mass.cache.set = AsyncMock()
+    mass.create_task = MagicMock(side_effect=_swallow_task)
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+    await plugin.handle_async_init()
+
+    evaluate_mock = AsyncMock(return_value=[])
+    cast("Any", plugin)._evaluate_rules = evaluate_mock
+
+    plugin._rules_store["abc"] = SmartPlaylistRules(limit=100, is_dynamic=True)
+    result = await plugin.get_playlist_tracks("abc")
+    assert result == stale
+    # Synchronous evaluation is skipped — the caller gets the stale sample immediately.
+    evaluate_mock.assert_not_awaited()
+    # A background refresh is scheduled (task_id keeps it deduped across concurrent calls).
+    mass.create_task.assert_called_once()
+    task_id = mass.create_task.call_args.kwargs.get("task_id")
+    assert task_id
+    assert "abc" in task_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Extends the Smart Playlist plugin to accept **multiple seeds across mixed media types** instead of a single track-or-artist seed. Albums and playlists are now valid seeds too. The dynamic-sample evaluation is also cached so the browse view stays snappy.

**Key changes:**

- `SmartPlaylistRules` now stores `seed_track_uris` / `seed_artist_uris` / `seed_album_uris` / `seed_playlist_uris` lists plus a `seed_names` display dict (combined cap of 10 seeds). The previous single-seed, mutually-exclusive shape is gone. No backwards-compat shim — the plugin has not been released yet.
- Extracted the player-queue radio-mode algorithm into `MusicController.get_dynamic_radio_tracks` and reused it for the smart-playlist seed flow. `_get_radio_tracks` is now a thin wrapper that handles its own queue-state filtering after the helper returns.
- The dynamic-sample evaluation is wrapped in `@use_cache` with a 24h TTL and `allow_expired_cache=True`, giving stale-while-revalidate semantics so browsing stays snappy. Queue refill paths already wrap their calls in `mass.cache.handle_refresh(True)`, so the cache is bypassed and the queue still gets fresh tracks on every refill. Rules updates / deletes invalidate the cached sample via `mass.cache.clear(key_filter=playlist_id, ...)`.

**Behavioural note for artist seeds:** the previous custom path was \`get_similar_artists\` → their top tracks. The unified radio-mode path uses the seed artist's own tracks → `similar_tracks` per sampled track. Consistent with how radio mode behaves everywhere else in MA.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] \`pre-commit run --all-files\` passes.
- [x] \`pytest\` passes, and tests have been added/updated under \`tests/\` where applicable.
- [ ] For changes to shared models, the companion PR in \`music-assistant/models\` is linked.
- [ ] For changes affecting the UI, the companion PR in \`music-assistant/frontend\` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.