### PR TITLE
Sonic Similarity: relax depends_on timing check + document smart_fades requirement

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1594,11 +1594,6 @@ class ConfigController:
             msg = f"Unknown provider domain: {provider_domain}"
             raise KeyError(msg)
         if prov.depends_on:
-            # Accept the dependency as long as it is configured + enabled, even if
-            # its _load_provider() is still mid-flight (e.g. sonic_analysis blocking
-            # on the initial CLAP model download). mass.load_provider_config()
-            # already cascades-loads dependents once the dep becomes available, so
-            # a config saved here will activate as soon as the dep is ready.
             dep_configs = await self.get_provider_configs(provider_domain=prov.depends_on)
             if not any(dep_conf.enabled for dep_conf in dep_configs):
                 msg = f"Provider {manifest.name} depends on {prov.depends_on}"

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1593,9 +1593,16 @@ class ConfigController:
         else:
             msg = f"Unknown provider domain: {provider_domain}"
             raise KeyError(msg)
-        if prov.depends_on and not self.mass.get_provider(prov.depends_on):
-            msg = f"Provider {manifest.name} depends on {prov.depends_on}"
-            raise ValueError(msg)
+        if prov.depends_on:
+            # Accept the dependency as long as it is configured + enabled, even if
+            # its _load_provider() is still mid-flight (e.g. sonic_analysis blocking
+            # on the initial CLAP model download). mass.load_provider_config()
+            # already cascades-loads dependents once the dep becomes available, so
+            # a config saved here will activate as soon as the dep is ready.
+            dep_configs = await self.get_provider_configs(provider_domain=prov.depends_on)
+            if not any(dep_conf.enabled for dep_conf in dep_configs):
+                msg = f"Provider {manifest.name} depends on {prov.depends_on}"
+                raise ValueError(msg)
         # create new provider config with given values
         existing = {
             x.instance_id for x in await self.get_provider_configs(provider_domain=provider_domain)

--- a/music_assistant/providers/sonic_similarity/manifest.json
+++ b/music_assistant/providers/sonic_similarity/manifest.json
@@ -3,7 +3,7 @@
   "stage": "beta",
   "domain": "sonic_similarity",
   "name": "Sonic Similarity",
-  "description": "Powers library-wide Similar Tracks, radio mode, and a discover-page row using local audio signatures from sonic_analysis.",
+  "description": "Powers library-wide Similar Tracks, radio mode, and a discover-page row using local audio signatures. Requires both sonic_analysis (perceptual scalars + CLAP embedding) and smart_fades (BPM + musical key) — vector assembly skips tracks missing either signal.",
   "codeowners": ["@music-assistant"],
   "requirements": [
     "usearch==2.25.2",


### PR DESCRIPTION
## Summary

Two related fixes for the freshly-merged Sonic Similarity plugin (#3943):

1. **Timing fix in `ConfigController._add_provider_config()`** — the user-add path rejected a provider whose `depends_on` dependency was *configured and enabled but not yet loaded*, even though `mass.load_provider_config()` already treats that exact state as legitimate and cascade-loads dependents once the dep becomes available. The asymmetry was latent until #3795 / sonic_analysis shipped: its `handle_async_init()` blocks for tens of seconds on the initial CLAP model download, and adding sonic_similarity during that window raised `ValueError("Provider Sonic Similarity depends on sonic_analysis")` — even though sonic_analysis was visibly on its way to loading. Adding it again after a warm restart succeeded.

2. **Manifest description fix** — sonic_similarity's 18-dim vector assembly reads `bpm` and musical `key` from the merged audio_analysis rows. sonic_analysis writes neither (it produces energy, loudness, brightness, harmonic_complexity, roughness, rhythmic_regularity, and CLAP scalars + embedding); both come from smart_fades' Beat-This + ChromaNet output. When smart_fades is not configured, `assemble_vector()` returns `None` for every track and the 18-dim index stays empty. The manifest now surfaces smart_fades as a required signal source in the provider-picker UI.

## Why the timing fix is safe

`mass.load_provider_config()` already walks all configs and cascade-loads dependents once a dep becomes available (`mass.py:706-707`). A `sonic_similarity` config saved while `sonic_analysis` is still loading therefore activates transparently once the model load completes. The previously-raised `ValueError` was the only path treating this state as invalid. If a dep's load fails permanently, the dependent's own `_load_provider()` early-returns at `mass.py:975-978` — same downstream behavior as today.

## What this PR does **not** do

The manifest's `depends_on` is `str | None` in upstream `music_assistant_models` and is referenced as a single-domain string in 7 places in MA server (4× `mass.py`, 3× `controllers/config.py`). Declaring sonic_similarity as formally depending on *both* sonic_analysis and smart_fades would need either list-typed `depends_on` in `music_assistant_models` + rewrites of all 7 call sites, or a new additive field like `also_depends_on: str | None`. Both are larger architectural changes than this PR's scope. Hard enforcement of the smart_fades dependency is left for a follow-up; for now, the manifest description carries the requirement.

## Test plan

- [x] Existing controller + sonic-stack tests pass locally (303 tests in `tests/core/test_config_entries.py`, `tests/controllers/`, `tests/providers/sonic_similarity`, `tests/providers/sonic_analysis`, `tests/controllers/streams/test_audio_analysis.py`)
- [ ] Manual repro of the timing fix (cold MA boot with CLAP cache cleared):
  1. Stop MA.
  2. Delete the CLAP model cache (forces re-download on next boot).
  3. Start MA with `sonic_analysis` already configured.
  4. Within ~10s of boot — while sonic_analysis is still downloading — open the UI and add `sonic_similarity`.
  5. **Expected:** add succeeds; sonic_similarity activates automatically once sonic_analysis finishes loading.
  6. **Before this fix:** `ValueError("Provider Sonic Similarity depends on sonic_analysis")` blocks the add.
- [ ] Visual check: when adding `sonic_similarity` in the UI, the provider description now mentions smart_fades as a required signal source.
