### PR TITLE
Fix queue cleared prematurely when radio follows tracks in flow stream

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -3114,7 +3114,15 @@ class PlayerQueuesController(CoreController):
         if queue.flow_mode and queue.flow_mode_stream_log:
             last_log_entry = queue.flow_mode_stream_log[-1]
             if last_log_entry.seconds_streamed is not None:
-                # The last track finished streaming, safe to clear queue
+                # Guard: if a next item (e.g. a radio that caused the flow stream to break
+                # out early) is already queued, the queue_buffer_completed path
+                # (_resume_on_idle) is responsible for starting it. Creating
+                # _clear_or_resume_delayed here would race with that restart and could
+                # incorrectly clear the queue or trigger a double play_index call.
+                if queue.current_index is not None and self.get_next_item(
+                    queue.queue_id, queue.current_index
+                ):
+                    return
                 self.mass.create_task(_clear_or_resume_delayed())
             return
 


### PR DESCRIPTION
# What does this implement/fix?

When a queue contains a mix of regular tracks followed by a radio station, and the queue plays in flow mode, the radio station would stop after ~30–60 seconds and the queue would be cleared unexpectedly.

The flow stream breaks out early when it encounters the radio item (live sources cannot be played inside a flow stream). When the buffered track audio finishes and the player goes idle, `_handle_end_of_queue` fires and unconditionally creates a `_clear_or_resume_delayed` task. However, `queue_buffer_completed` had already launched a `_resume_on_idle` task for the same purpose. Both tasks found the radio as the next item and called `play_index` concurrently, causing the radio stream to be started twice in quick succession. The double-start disrupted the session and eventually led to `_clear_or_resume_delayed` running to completion and clearing the queue.

**Related issue (if applicable):**

- related issue <link to issue>

## Changes

- In `_handle_end_of_queue`, the flow mode path now checks for a pending next item via `get_next_item` before creating `_clear_or_resume_delayed`. If one exists (e.g. a radio item that caused the flow stream to break out), the `queue_buffer_completed` / `_resume_on_idle` path already owns the restart — creating a competing task is skipped.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.