### PR TITLE
AcoustID Skip processing if track has an ISRC

### DIFF
--- a/music_assistant/providers/acoustid_lookup/provider.py
+++ b/music_assistant/providers/acoustid_lookup/provider.py
@@ -137,6 +137,9 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
                 "Skipping %s — track already has a MusicBrainz Recording Id", session_id
             )
             return False
+        if track.get_external_id(ExternalID.ISRC):
+            self.logger.debug("Skipping %s — track already has an ISRC", session_id)
+            return False
 
         fingerprinter = self._create_fingerprinter(audio_format.sample_rate, audio_format.channels)
         if fingerprinter is None:

--- a/tests/providers/acoustid_lookup/test_provider.py
+++ b/tests/providers/acoustid_lookup/test_provider.py
@@ -220,13 +220,22 @@ def _rg(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("provider_kwargs", "streamdetails_kwargs", "track_mbid", "track_in_library", "expected"),
+    (
+        "provider_kwargs",
+        "streamdetails_kwargs",
+        "track_mbid",
+        "track_isrc",
+        "track_in_library",
+        "expected",
+    ),
     [
-        pytest.param({}, {}, "0000-mbid", True, False, id="mbid_already_present"),
-        pytest.param({}, {}, None, False, False, id="no_library_row"),
+        pytest.param({}, {}, "0000-mbid", None, True, False, id="mbid_already_present"),
+        pytest.param({}, {}, None, "USRC17607839", True, False, id="isrc_already_present"),
+        pytest.param({}, {}, None, None, False, False, id="no_library_row"),
         pytest.param(
             {},
             {"media_type": MediaType.PODCAST_EPISODE},
+            None,
             None,
             False,
             False,
@@ -236,6 +245,7 @@ def _rg(
             {"analyse_streaming": False},
             {"stream_type": StreamType.HTTP},
             None,
+            None,
             True,
             False,
             id="streaming_toggle_off",
@@ -244,12 +254,13 @@ def _rg(
             {"analyse_streaming": True},
             {"stream_type": StreamType.HTTP},
             None,
+            None,
             True,
             True,
             id="streaming_toggle_on",
         ),
-        pytest.param({}, {}, None, True, True, id="local_file_mbid_missing"),
-        pytest.param({"api_key": None}, {}, None, False, False, id="no_api_key"),
+        pytest.param({}, {}, None, None, True, True, id="local_file_mbid_missing"),
+        pytest.param({"api_key": None}, {}, None, None, False, False, id="no_api_key"),
     ],
 )
 async def test_start_analysis_gates(
@@ -258,6 +269,7 @@ async def test_start_analysis_gates(
     provider_kwargs: dict[str, Any],
     streamdetails_kwargs: dict[str, Any],
     track_mbid: str | None,
+    track_isrc: str | None,
     track_in_library: bool,
     expected: bool,
 ) -> None:
@@ -266,7 +278,7 @@ async def test_start_analysis_gates(
     if track_in_library:
         track = MagicMock()
         track.mbid = track_mbid
-        track.get_external_id.return_value = None
+        track.get_external_id.return_value = track_isrc
         cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
             return_value=track
         )
@@ -284,8 +296,10 @@ async def test_finalize_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     """A high-score match yields mbid + acoustid + candidates + release_groups."""
     provider = _make_provider()
     _install_fake_chromaprint(monkeypatch, _FakeFingerprinter())
+    track = MagicMock(mbid=None)
+    track.get_external_id.return_value = None
     cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
-        return_value=MagicMock(mbid=None)
+        return_value=track
     )
 
     session_id = "session-final"
@@ -344,8 +358,10 @@ async def test_finalize_rejects_low_score(monkeypatch: pytest.MonkeyPatch) -> No
     """A best-result score below the threshold yields no analysis."""
     provider = _make_provider(min_score=0.85)
     _install_fake_chromaprint(monkeypatch, _FakeFingerprinter())
+    track = MagicMock(mbid=None)
+    track.get_external_id.return_value = None
     cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
-        return_value=MagicMock(mbid=None)
+        return_value=track
     )
 
     session_id = "session-lowscore"

--- a/tests/providers/acoustid_lookup/test_provider.py
+++ b/tests/providers/acoustid_lookup/test_provider.py
@@ -266,6 +266,7 @@ async def test_start_analysis_gates(
     if track_in_library:
         track = MagicMock()
         track.mbid = track_mbid
+        track.get_external_id.return_value = None
         cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
             return_value=track
         )


### PR DESCRIPTION
Add check for existing ISRC before processing track.

# What does this implement/fix?
Need to skip processing if an ISRC is present

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
