### PR TITLE
Fix smart playlist track evaluation from Discover and background queue context

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -78,7 +78,10 @@ from music_assistant.constants import (
 )
 from music_assistant.controllers.players.constants import PlayerLockPurpose
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    get_current_user,
+    set_current_user,
+)
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
 from music_assistant.helpers.util import get_changed_keys, percentage
@@ -2295,6 +2298,11 @@ class PlayerQueuesController(CoreController):
         if dynamic_playlist is not None:
             # Dynamic playlist (e.g. a station): fetch next batch of tracks from the provider.
             # Do NOT fall back to generic radio - stations manage their own track supply.
+            # Restore the queue owner's user context so that provider filters are respected.
+            playback_user = (
+                await self.mass.webserver.auth.get_user(queue.userid) if queue.userid else None
+            )
+            set_current_user(playback_user)
             try:
                 dynamic_tracks = await self.get_playlist_tracks(dynamic_playlist, start_item=None)
                 queue_items = [

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -210,6 +210,11 @@ class SmartPlaylistProvider(PluginProvider):
             return []
         rules = self._rules_store.get(prov_playlist_id)
         if rules is None:
+            # prov_playlist_id may be a library DB integer id; resolve it to the provider UUID.
+            resolved_id = await self._resolve_to_provider_id(prov_playlist_id)
+            if resolved_id is not None:
+                rules = self._rules_store.get(resolved_id)
+        if rules is None:
             return []
         if rules.is_dynamic:
             rules = dc_replace(rules, limit=DYNAMIC_PLAYLIST_SAMPLE_SIZE)


### PR DESCRIPTION
## What does this implement/fix?

Fixes two bugs in the smart playlist provider:

**1. Discover page shows no sample tracks for rule-based smart playlists**

Opening a smart playlist from Discover/Recommendations navigates using the provider UUID. The server's `get()` call resolves this to the library item and returns its DB integer `item_id`. `get_playlist_tracks` then receives that integer ID, but `_rules_store` is keyed by UUID — so the lookup returns `None` and the sample is empty.

Fix: `get_playlist_tracks` now falls back to `_resolve_to_provider_id` when the direct store lookup fails, so both UUID and DB integer IDs work correctly.

**2. Provider filter ignored during background queue refill**

`_fill_radio_tracks` runs as a background task without a request context, so `get_current_user()` returns `None` and `_ensure_provider_filter` cannot apply the queue owner's provider filter. Tracks from disallowed providers could appear in dynamic playlist refills.

Fix: Before fetching tracks, the queue owner's user is looked up via `queue.userid` and set as the current user context.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.