### PR TITLE
Show real source format for piped AudioSource providers

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -539,9 +539,14 @@ class StreamsAudio:
         cancelled = False
         first_chunk_received = False
         ffmpeg_loglevel = "debug" if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL) else "info"
+        # When a provider hands us already-decoded audio (e.g. Spotify Connect /
+        # AirPlay receivers piping PCM after their own decode), audio_format is
+        # the original source format meant for display while decoded_audio_format
+        # is what ffmpeg actually needs to read off the wire.
+        ffmpeg_input_format = streamdetails.decoded_audio_format or streamdetails.audio_format
         ffmpeg_proc = FFMpeg(
             audio_input=audio_source,
-            input_format=streamdetails.audio_format,
+            input_format=ffmpeg_input_format,
             output_format=pcm_format,
             filter_params=filter_params,
             extra_input_args=extra_input_args,
@@ -575,10 +580,15 @@ class StreamsAudio:
                     # At this point ffmpeg has started and should now know the codec used
                     # for encoding the audio.
                     # Note: ffmpeg_proc.input_format is the same object as
-                    # streamdetails.audio_format, so sample_rate / bit_depth / bit_rate
+                    # ffmpeg_input_format, so sample_rate / bit_depth / bit_rate
                     # parsed from the ffmpeg log already live on streamdetails too.
                     first_chunk_received = True
-                    streamdetails.audio_format.codec_type = ffmpeg_proc.input_format.codec_type
+                    # Skip the codec_type writeback when the provider declared a
+                    # decoded format: audio_format already holds the authoritative
+                    # source codec and the probed value would just be the
+                    # post-decode wire format (e.g. PCM for Spotify Connect).
+                    if streamdetails.decoded_audio_format is None:
+                        streamdetails.audio_format.codec_type = ffmpeg_proc.input_format.codec_type
                     # Some providers omit (or report 0 for) the item duration; ffmpeg can
                     # usually probe it from the source. Only apply when missing so we
                     # don't clobber an accurate provider value with a rounded one.

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -153,7 +153,20 @@ class AirPlayReceiverProvider(PluginProvider):
         # Each instance gets a unique port: 7000, 7001, 7002, etc.
         self.airplay_port = 7000 + (hash(self.instance_id) % 1000)
         airplay_name = cast("str", self.config.get_value(CONF_AIRPLAY_NAME)) or self.name
+        # _audio_format describes the original AirPlay source (ALAC at 44.1/16,
+        # the protocol-native format AirPlay senders use) and is what we
+        # advertise to clients for source-format display.
         self._audio_format = AudioFormat(
+            content_type=ContentType.ALAC,
+            codec_type=ContentType.ALAC,
+            sample_rate=44100,
+            bit_depth=16,
+            channels=2,
+        )
+        # _decoded_audio_format is what shairport-sync actually pipes into MA
+        # after decoding the ALAC stream; the streams controller hands this to
+        # ffmpeg as the input format so it can read the FIFO correctly.
+        self._decoded_audio_format = AudioFormat(
             content_type=ContentType.PCM_S16LE,
             codec_type=ContentType.PCM_S16LE,
             sample_rate=44100,
@@ -260,6 +273,7 @@ class AirPlayReceiverProvider(PluginProvider):
             provider=self.instance_id,
             item_id=source_id,
             audio_format=self._audio_format,
+            decoded_audio_format=self._decoded_audio_format,
             media_type=MediaType.AUDIO_SOURCE,
             stream_type=StreamType.NAMED_PIPE,
             path=self.audio_pipe.path,

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -168,7 +168,21 @@ class SpotifyConnectProvider(PluginProvider):
             self._default_player_id,
             self.instance_id,
         )
+        # _audio_format describes the original Spotify source (Ogg Vorbis 320
+        # kbps, as requested via librespot's --bitrate flag) and is what we
+        # advertise to clients for source-format display.
         self._audio_format = AudioFormat(
+            content_type=ContentType.OGG,
+            codec_type=ContentType.VORBIS,
+            sample_rate=44100,
+            bit_depth=16,
+            channels=2,
+            bit_rate=320,
+        )
+        # _decoded_audio_format is what librespot actually pipes into MA after
+        # decoding the Ogg Vorbis stream; the streams controller hands this to
+        # ffmpeg as the input format so it can read the FIFO correctly.
+        self._decoded_audio_format = AudioFormat(
             content_type=ContentType.PCM_S16LE,
             codec_type=ContentType.PCM_S16LE,
             sample_rate=44100,
@@ -296,6 +310,7 @@ class SpotifyConnectProvider(PluginProvider):
             provider=self.instance_id,
             item_id=source_id,
             audio_format=self._audio_format,
+            decoded_audio_format=self._decoded_audio_format,
             media_type=MediaType.AUDIO_SOURCE,
             stream_type=StreamType.NAMED_PIPE,
             path=self.named_pipe,

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -1,0 +1,205 @@
+"""Tests for StreamsAudio.get_media_stream's ffmpeg input_format handling."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
+
+import music_assistant.controllers.streams.audio as audio_mod
+from music_assistant.controllers.streams.audio import StreamsAudio
+
+
+class _FakeFFMpeg:
+    """FFMpeg test double that records the input_format it was constructed with."""
+
+    last_instance: _FakeFFMpeg | None = None
+
+    def __init__(
+        self,
+        *,
+        audio_input: object,
+        input_format: AudioFormat,
+        **_kwargs: Any,
+    ) -> None:
+        self.audio_input = audio_input
+        # Mirror the real FFMpeg, which mutates this object's codec_type after probe.
+        # Tests inspect the original `input_format` AudioFormat passed in to confirm
+        # which one the controller picked.
+        self.input_format = input_format
+        self._probed_codec_type = ContentType.FLAC  # arbitrary, distinct from PCM/OGG
+        self.parsed_duration: int | None = None
+        self.returncode: int | None = 0
+        self.log_history: list[str] = []
+        self.proc = MagicMock(pid=1234)
+        type(self).last_instance = self
+
+    async def start(self) -> None:
+        # Simulate ffmpeg's post-probe codec detection: real FFMpeg mutates
+        # self.input_format.codec_type once it reads the input header.
+        self.input_format.codec_type = self._probed_codec_type
+
+    async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes, None]:
+        yield b"\x00\x01" * 256
+
+    async def wait_with_timeout(self, _timeout: float) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.fixture
+def patch_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> type[_FakeFFMpeg]:
+    """Swap the real FFMpeg in the streams.audio module for the fake."""
+    _FakeFFMpeg.last_instance = None
+    monkeypatch.setattr(audio_mod, "FFMpeg", _FakeFFMpeg)
+    return _FakeFFMpeg
+
+
+def _make_audio_controller() -> StreamsAudio:
+    """Build a StreamsAudio with just enough mass scaffolding to run get_media_stream."""
+    audio = StreamsAudio(MagicMock())
+    audio.mass.loop = MagicMock()
+    audio.mass.loop.time = MagicMock(return_value=0.0)
+    return audio
+
+
+def _make_pcm_format() -> AudioFormat:
+    return AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        codec_type=ContentType.PCM_S16LE,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+    )
+
+
+def _make_streamdetails(
+    *,
+    audio_format: AudioFormat,
+    decoded_audio_format: AudioFormat | None = None,
+) -> StreamDetails:
+    return StreamDetails(
+        provider="test_provider",
+        item_id="main",
+        audio_format=audio_format,
+        decoded_audio_format=decoded_audio_format,
+        media_type=MediaType.AUDIO_SOURCE,
+        stream_type=StreamType.NAMED_PIPE,
+        path="/tmp/fake-fifo",  # noqa: S108
+    )
+
+
+async def _drain(gen: AsyncGenerator[bytes, None]) -> None:
+    async for _ in gen:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_prefers_decoded_audio_format(
+    patch_ffmpeg: type[_FakeFFMpeg],
+) -> None:
+    """When decoded_audio_format is set, ffmpeg receives that as input_format."""
+    source_format = AudioFormat(
+        content_type=ContentType.OGG,
+        codec_type=ContentType.VORBIS,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+        bit_rate=320,
+    )
+    decoded_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        codec_type=ContentType.PCM_S16LE,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+    )
+    streamdetails = _make_streamdetails(
+        audio_format=source_format, decoded_audio_format=decoded_format
+    )
+
+    audio = _make_audio_controller()
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format()))
+
+    assert patch_ffmpeg.last_instance is not None
+    assert patch_ffmpeg.last_instance.input_format is decoded_format
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_falls_back_to_audio_format(
+    patch_ffmpeg: type[_FakeFFMpeg],
+) -> None:
+    """When decoded_audio_format is not set, ffmpeg receives audio_format as input_format."""
+    source_format = AudioFormat(
+        content_type=ContentType.FLAC,
+        codec_type=ContentType.FLAC,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+    )
+    streamdetails = _make_streamdetails(audio_format=source_format)
+
+    audio = _make_audio_controller()
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format()))
+
+    assert patch_ffmpeg.last_instance is not None
+    assert patch_ffmpeg.last_instance.input_format is source_format
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("patch_ffmpeg")
+async def test_get_media_stream_does_not_overwrite_source_codec_when_decoded_format_set() -> None:
+    """audio_format.codec_type stays authoritative when decoded_audio_format is set."""
+    source_format = AudioFormat(
+        content_type=ContentType.OGG,
+        codec_type=ContentType.VORBIS,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+        bit_rate=320,
+    )
+    decoded_format = AudioFormat(
+        content_type=ContentType.PCM_S16LE,
+        codec_type=ContentType.PCM_S16LE,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+    )
+    streamdetails = _make_streamdetails(
+        audio_format=source_format, decoded_audio_format=decoded_format
+    )
+
+    audio = _make_audio_controller()
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format()))
+
+    assert streamdetails.audio_format.codec_type is ContentType.VORBIS
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("patch_ffmpeg")
+async def test_get_media_stream_writes_back_codec_when_no_decoded_format() -> None:
+    """Without decoded_audio_format, ffmpeg's probed codec_type is written back."""
+    source_format = AudioFormat(
+        content_type=ContentType.FLAC,
+        # Start with UNKNOWN so we can see the post-probe writeback take effect.
+        codec_type=ContentType.UNKNOWN,
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+    )
+    streamdetails = _make_streamdetails(audio_format=source_format)
+
+    audio = _make_audio_controller()
+    await _drain(audio.get_media_stream(streamdetails, _make_pcm_format()))
+
+    # _FakeFFMpeg's start() mutates input_format.codec_type to FLAC; with no
+    # decoded format that AudioFormat is the same object as streamdetails.audio_format,
+    # so the controller's writeback path is exercised end-to-end.
+    assert streamdetails.audio_format.codec_type is ContentType.FLAC


### PR DESCRIPTION
# What does this implement/fix?

Spotify Connect and the AirPlay receiver feed audio into MA via a named
pipe after their upstream daemon (librespot / shairport-sync) has
already decoded the original source. The provider was therefore forced
to set `streamdetails.audio_format` to `PCM_S16LE` so ffmpeg could read
the FIFO — but that same field is what clients display, so the UI was
showing **PCM 44.1/16** instead of the real source format
(**Ogg Vorbis 320 kbps** for Spotify, **ALAC** for AirPlay).

This PR wires up the new `decoded_audio_format` field on `StreamDetails`:
`audio_format` now describes the original source for display, while
`decoded_audio_format` tells the streams controller what ffmpeg should
expect on the wire.

**Related PR:** depends on [music-assistant/models#240](https://github.com/music-assistant/models/pull/240) — the version pin bump targets the model release that ships the new field.

## Changes

- `controllers/streams/audio.py`: feed ffmpeg with `decoded_audio_format` when set, fall back to `audio_format` otherwise; skip the post-probe `codec_type` writeback when the provider declared a decoded format (`audio_format` already holds the authoritative source codec).
- `providers/spotify_connect`: set `audio_format` to Ogg Vorbis 320 and `decoded_audio_format` to `PCM_S16LE`.
- `providers/airplay_receiver`: set `audio_format` to ALAC and `decoded_audio_format` to `PCM_S16LE`.
- Bump `music-assistant-models` to `1.1.127` for the new field.

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.