### PR TITLE
Fix Apple music library album tracks not showing up

### DIFF
--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -16,7 +16,7 @@ from music_assistant_models.media_items import (
 
 from music_assistant.controllers.cache import use_cache
 
-from .helpers.utils import is_catalog_id
+from .helpers.utils import is_catalog_id, is_library_id
 from .parsers import (
     parse_album,
     parse_artist,
@@ -98,8 +98,12 @@ class AppleMusicMediaManager:
     @use_cache()
     async def get_album(self, prov_album_id: str) -> Album:
         """Get full album details by id."""
-        endpoint = f"catalog/{self.provider._storefront}/albums/{prov_album_id}"
-        response = await self.api.get_data(endpoint, include="artists")
+        if is_library_id(prov_album_id):
+            endpoint = f"me/library/albums/{prov_album_id}"
+            response = await self.api.get_data(endpoint, include="catalog,artists")
+        else:
+            endpoint = f"catalog/{self.provider._storefront}/albums/{prov_album_id}"
+            response = await self.api.get_data(endpoint, include="artists")
         rating_response = await self.api.get_ratings([prov_album_id], MediaType.ALBUM)
         is_favourite = rating_response.get(prov_album_id)
         return parse_album(self.provider, response["data"][0], is_favourite)
@@ -153,8 +157,12 @@ class AppleMusicMediaManager:
     @use_cache(allow_expired_cache=True)
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
         """Get all album tracks for given album id."""
-        endpoint = f"catalog/{self.provider._storefront}/albums/{prov_album_id}/tracks"
-        response = await self.api.get_data(endpoint, include="artists")
+        if is_library_id(prov_album_id):
+            endpoint = f"me/library/albums/{prov_album_id}/tracks"
+            response = await self.api.get_data(endpoint, include="catalog,artists")
+        else:
+            endpoint = f"catalog/{self.provider._storefront}/albums/{prov_album_id}/tracks"
+            response = await self.api.get_data(endpoint, include="artists")
         album = await self.get_album(prov_album_id)
         track_ids = [track_obj["id"] for track_obj in response["data"] if "id" in track_obj]
         rating_response = await self.api.get_ratings(track_ids, MediaType.TRACK)

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -500,3 +500,119 @@ async def test_get_playlist_by_library_id_keeps_library_item_id() -> None:
     provider.api_client.get_data.assert_called_once_with("me/library/playlists/p.myLibraryPlaylist")
     assert playlist.item_id == "p.myLibraryPlaylist"
     assert all(pm.item_id == "p.myLibraryPlaylist" for pm in playlist.provider_mappings)
+
+
+@pytest.mark.asyncio
+async def test_get_album_uses_library_endpoint_for_library_id() -> None:
+    """get_album should use me/library/albums/{id} for library IDs (l. prefix)."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_data = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "l.PnamISl",
+                    "type": "library-albums",
+                    "attributes": {
+                        "name": "Uploaded Album",
+                        "artistName": "Uploaded Artist",
+                        "playParams": {"id": "l.PnamISl", "isLibrary": True},
+                    },
+                    "relationships": {},
+                }
+            ]
+        }
+    )
+    provider.api_client.get_ratings = AsyncMock(return_value={})
+
+    manager = AppleMusicMediaManager(provider)
+    album = await manager.get_album("l.PnamISl")
+
+    provider.api_client.get_data.assert_called_once_with(
+        "me/library/albums/l.PnamISl", include="catalog,artists"
+    )
+    assert isinstance(album, Album)
+    assert album.name == "Uploaded Album"
+
+
+@pytest.mark.asyncio
+async def test_get_album_tracks_uses_library_endpoint_for_library_id() -> None:
+    """get_album_tracks should use me/library/albums/{id}/tracks for library IDs."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_data = AsyncMock(
+        side_effect=[
+            # First call: get_album_tracks endpoint
+            {
+                "data": [
+                    {
+                        "id": "i.track1",
+                        "type": "library-songs",
+                        "attributes": {
+                            "name": "Track 1",
+                            "artistName": "Uploaded Artist",
+                            "durationInMillis": 180000,
+                            "playParams": {"id": "i.track1", "isLibrary": True},
+                        },
+                        "relationships": {},
+                    }
+                ]
+            },
+            # Second call: get_album (called internally)
+            {
+                "data": [
+                    {
+                        "id": "l.PnamISl",
+                        "type": "library-albums",
+                        "attributes": {
+                            "name": "Uploaded Album",
+                            "artistName": "Uploaded Artist",
+                            "playParams": {"id": "l.PnamISl", "isLibrary": True},
+                        },
+                        "relationships": {},
+                    }
+                ]
+            },
+        ]
+    )
+    provider.api_client.get_ratings = AsyncMock(return_value={})
+
+    manager = AppleMusicMediaManager(provider)
+    tracks = await manager.get_album_tracks("l.PnamISl")
+
+    first_call_args = provider.api_client.get_data.call_args_list[0]
+    assert first_call_args[0][0] == "me/library/albums/l.PnamISl/tracks"
+    assert len(tracks) == 1
+    assert tracks[0].name == "Track 1"
+
+
+@pytest.mark.asyncio
+async def test_get_album_uses_catalog_endpoint_for_catalog_id() -> None:
+    """get_album should continue using the catalog endpoint for numeric catalog IDs."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_data = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "123456789",
+                    "type": "albums",
+                    "attributes": {
+                        "name": "Catalog Album",
+                        "artistName": "Catalog Artist",
+                        "playParams": {"id": "123456789"},
+                        "url": "https://music.apple.com/album/123456789",
+                    },
+                    "relationships": {},
+                }
+            ]
+        }
+    )
+    provider.api_client.get_ratings = AsyncMock(return_value={})
+
+    manager = AppleMusicMediaManager(provider)
+    await manager.get_album("123456789")
+
+    provider.api_client.get_data.assert_called_once_with(
+        "catalog/us/albums/123456789", include="artists"
+    )


### PR DESCRIPTION
# What does this implement/fix?

Albums with a library ID (`l.`-prefix) are user-uploaded or regionally 
unavailable albums stored only in the personal library, not in the public 
Apple Music catalog. Previously, `get_album` and `get_album_tracks` always 
used the catalog endpoint (`catalog/{storefront}/albums/{id}`), which returns 
a 404 for these IDs — causing album details and track playback to fail.

This fix routes `l.`-prefix IDs through the library endpoints:
- `me/library/albums/{id}?include=catalog,artists`
- `me/library/albums/{id}/tracks?include=catalog,artists`

`parse_album` and `parse_track` already handle `library-albums`/`library-songs` 
responses and resolve to catalog IDs via the `catalog` relationship where 
available, so tracks stream correctly.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5456

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.