### PR TITLE
Fix Apple Music playlist add for catalog-backed library playlists

### DIFF
--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -170,12 +170,15 @@ class AppleMusicLibraryManager:
         )
         for item in playlist_items:
             is_favourite = rating_library_response.get(item["id"])
-            # Prefer catalog information over library information in case of public playlists
+            # Prefer catalog information over library information in case of public playlists.
+            # Pass the library ID as override so that write operations (add_playlist_tracks)
+            # use the library endpoint instead of the catalog global ID, which Apple rejects.
             if item["attributes"]["hasCatalog"]:
                 yield await self.provider.media_manager.get_playlist(
                     item["attributes"]["playParams"]["globalId"],
                     is_favourite,
                     can_edit_hint=item["attributes"].get("canEdit"),
+                    library_id_override=item["id"] if is_library_id(item["id"]) else None,
                 )
             elif item and item["id"]:
                 yield parse_playlist(self.provider, item, is_favourite)

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -170,9 +170,7 @@ class AppleMusicLibraryManager:
         )
         for item in playlist_items:
             is_favourite = rating_library_response.get(item["id"])
-            # Prefer catalog information over library information in case of public playlists.
-            # Pass the library ID as override so that write operations (add_playlist_tracks)
-            # use the library endpoint instead of the catalog global ID, which Apple rejects.
+            # Fetch catalog metadata, but keep library ID for write operations.
             if item["attributes"]["hasCatalog"]:
                 yield await self.provider.media_manager.get_playlist(
                     item["attributes"]["playParams"]["globalId"],

--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -118,10 +118,14 @@ class AppleMusicMediaManager:
         prov_playlist_id: str,
         is_favourite: bool = False,
         can_edit_hint: bool | None = None,
+        library_id_override: str | None = None,
     ) -> Playlist:
         """Get full playlist details by id."""
         return await self._get_regular_playlist(
-            prov_playlist_id, is_favourite, can_edit_hint=can_edit_hint
+            prov_playlist_id,
+            is_favourite,
+            can_edit_hint=can_edit_hint,
+            library_id_override=library_id_override,
         )
 
     @use_cache()
@@ -130,6 +134,7 @@ class AppleMusicMediaManager:
         prov_playlist_id: str,
         is_favourite: bool = False,
         can_edit_hint: bool | None = None,
+        library_id_override: str | None = None,
     ) -> Playlist:
         """Fetch and cache details for a regular (non-station) playlist."""
         if not is_catalog_id(prov_playlist_id):
@@ -142,6 +147,7 @@ class AppleMusicMediaManager:
             response["data"][0],
             is_favourite,
             can_edit_hint=can_edit_hint,
+            library_id_override=library_id_override,
         )
 
     @use_cache(allow_expired_cache=True)

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -289,11 +289,7 @@ def parse_playlist(
     attributes = playlist_obj["attributes"]
     play_params = attributes.get("playParams", {})
     # Use library ID for writes; otherwise use catalog/global ID.
-    playlist_id = (
-        library_id_override
-        or play_params.get("globalId")
-        or playlist_obj["id"]
-    )
+    playlist_id = library_id_override or play_params.get("globalId") or playlist_obj["id"]
     is_editable = can_edit_hint if can_edit_hint is not None else attributes.get("canEdit", False)
     playlist = Playlist(
         item_id=playlist_id,

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -24,6 +24,7 @@ from music_assistant.helpers.util import (
 )
 
 from .constants import MAX_ARTWORK_DIMENSION, UNKNOWN_PLAYLIST_NAME
+from .helpers.utils import is_library_id
 
 if TYPE_CHECKING:
     from .provider import AppleMusicProvider
@@ -287,9 +288,14 @@ def parse_playlist(
 ) -> Playlist:
     """Parse Apple Music playlist object to generic layout."""
     attributes = playlist_obj["attributes"]
+    raw_playlist_id = playlist_obj["id"]
     play_params = attributes.get("playParams", {})
-    # Use library ID for writes; otherwise use catalog/global ID.
-    playlist_id = library_id_override or play_params.get("globalId") or playlist_obj["id"]
+    # Prefer write-safe library IDs when available.
+    playlist_id = (
+        library_id_override
+        or (raw_playlist_id if is_library_id(raw_playlist_id) else play_params.get("globalId"))
+        or raw_playlist_id
+    )
     is_editable = can_edit_hint if can_edit_hint is not None else attributes.get("canEdit", False)
     playlist = Playlist(
         item_id=playlist_id,

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -287,10 +287,12 @@ def parse_playlist(
 ) -> Playlist:
     """Parse Apple Music playlist object to generic layout."""
     attributes = playlist_obj["attributes"]
-    # Prefer the library ID override (for write operations) if provided,
-    # otherwise fall back to globalId (catalog) or the raw object ID.
+    play_params = attributes.get("playParams", {})
+    # Use library ID for writes; otherwise use catalog/global ID.
     playlist_id = (
-        library_id_override or attributes["playParams"].get("globalId") or playlist_obj["id"]
+        library_id_override
+        or play_params.get("globalId")
+        or playlist_obj["id"]
     )
     is_editable = can_edit_hint if can_edit_hint is not None else attributes.get("canEdit", False)
     playlist = Playlist(

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -283,10 +283,15 @@ def parse_playlist(
     playlist_obj: dict[str, Any],
     is_favourite: bool | None = None,
     can_edit_hint: bool | None = None,
+    library_id_override: str | None = None,
 ) -> Playlist:
     """Parse Apple Music playlist object to generic layout."""
     attributes = playlist_obj["attributes"]
-    playlist_id = attributes["playParams"].get("globalId") or playlist_obj["id"]
+    # Prefer the library ID override (for write operations) if provided,
+    # otherwise fall back to globalId (catalog) or the raw object ID.
+    playlist_id = (
+        library_id_override or attributes["playParams"].get("globalId") or playlist_obj["id"]
+    )
     is_editable = can_edit_hint if can_edit_hint is not None else attributes.get("canEdit", False)
     playlist = Playlist(
         item_id=playlist_id,

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -157,6 +157,7 @@ async def test_library_playlists_preserve_can_edit_for_catalog_copy() -> None:
         "pl.catalog1",
         ANY,
         can_edit_hint=True,
+        library_id_override="p.library1",
     )
 
 
@@ -415,3 +416,59 @@ async def test_library_tracks_fetches_detail_for_album_name_only_mapping() -> No
     provider.api_client.get_data.assert_called_once_with(
         "me/library/songs/i.librarytrack4", include="catalog,albums,artists"
     )
+
+
+@pytest.mark.asyncio
+async def test_catalog_backed_playlist_uses_library_id_as_item_id() -> None:
+    """Catalog-backed library playlists must use the library ID as item_id.
+
+    When a playlist has hasCatalog=True, Apple only accepts write operations
+    (add tracks) against the library endpoint using the library ID (p.XXXXX),
+    not the catalog global ID (pl.u-...).
+    """
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_all_items = AsyncMock(
+        return_value=[
+            {
+                "id": "p.myLibraryPlaylist",
+                "attributes": {
+                    "hasCatalog": True,
+                    "canEdit": True,
+                    "playParams": {"globalId": "pl.u-abcd1234"},
+                    "name": "My Public Playlist",
+                    "curatorName": "me",
+                    "artwork": None,
+                },
+            }
+        ]
+    )
+    provider.api_client.get_ratings = AsyncMock(return_value={})
+    provider.api_client.get_data = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "pl.u-abcd1234",
+                    "attributes": {
+                        "name": "My Public Playlist",
+                        "curatorName": "me",
+                        "playParams": {"globalId": "pl.u-abcd1234"},
+                        "canEdit": True,
+                    },
+                }
+            ]
+        }
+    )
+
+    manager = AppleMusicLibraryManager(provider)
+    # Wire up the real media manager so parse_playlist is exercised end-to-end.
+    provider.media_manager = AppleMusicMediaManager(provider)
+
+    playlists = [pl async for pl in manager.get_library_playlists()]
+
+    assert len(playlists) == 1
+    playlist = playlists[0]
+    # The item_id and ProviderMapping must use the library ID so that
+    # add_playlist_tracks POSTs to me/library/playlists/p.myLibraryPlaylist/tracks.
+    assert playlist.item_id == "p.myLibraryPlaylist"
+    assert all(pm.item_id == "p.myLibraryPlaylist" for pm in playlist.provider_mappings)

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -471,3 +471,32 @@ async def test_catalog_backed_playlist_uses_library_id_as_item_id() -> None:
     # Must use library ID so add_playlist_tracks targets /me/library/playlists/{id}/tracks.
     assert playlist.item_id == "p.myLibraryPlaylist"
     assert all(pm.item_id == "p.myLibraryPlaylist" for pm in playlist.provider_mappings)
+
+
+@pytest.mark.asyncio
+async def test_get_playlist_by_library_id_keeps_library_item_id() -> None:
+    """Direct library playlist fetch must keep the library playlist ID."""
+    provider = _create_provider_mock()
+    provider.api_client = MagicMock()
+    provider.api_client.get_data = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "id": "p.myLibraryPlaylist",
+                    "attributes": {
+                        "name": "My Public Playlist",
+                        "curatorName": "me",
+                        "playParams": {"globalId": "pl.u-abcd1234"},
+                        "canEdit": True,
+                    },
+                }
+            ]
+        }
+    )
+
+    manager = AppleMusicMediaManager(provider)
+    playlist = await manager.get_playlist("p.myLibraryPlaylist")
+
+    provider.api_client.get_data.assert_called_once_with("me/library/playlists/p.myLibraryPlaylist")
+    assert playlist.item_id == "p.myLibraryPlaylist"
+    assert all(pm.item_id == "p.myLibraryPlaylist" for pm in playlist.provider_mappings)

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -422,7 +422,7 @@ async def test_library_tracks_fetches_detail_for_album_name_only_mapping() -> No
 async def test_catalog_backed_playlist_uses_library_id_as_item_id() -> None:
     """Catalog-backed library playlists must use the library ID as item_id.
 
-    When a playlist has hasCatalog=True, Apple only accepts write operations
+    When a playlist hasCatalog=True, Apple only accepts write operations
     (add tracks) against the library endpoint using the library ID (p.XXXXX),
     not the catalog global ID (pl.u-...).
     """
@@ -461,14 +461,13 @@ async def test_catalog_backed_playlist_uses_library_id_as_item_id() -> None:
     )
 
     manager = AppleMusicLibraryManager(provider)
-    # Wire up the real media manager so parse_playlist is exercised end-to-end.
+    # Exercise parse_playlist through the real media manager.
     provider.media_manager = AppleMusicMediaManager(provider)
 
     playlists = [pl async for pl in manager.get_library_playlists()]
 
     assert len(playlists) == 1
     playlist = playlists[0]
-    # The item_id and ProviderMapping must use the library ID so that
-    # add_playlist_tracks POSTs to me/library/playlists/p.myLibraryPlaylist/tracks.
+    # Must use library ID so add_playlist_tracks targets /me/library/playlists/{id}/tracks.
     assert playlist.item_id == "p.myLibraryPlaylist"
     assert all(pm.item_id == "p.myLibraryPlaylist" for pm in playlist.provider_mappings)


### PR DESCRIPTION
# What does this implement/fix?

Fixes adding tracks to Apple Music playlists when the playlist is catalog-backed (e.g. `pl.u-...`) but still editable from the user library.

Root cause:
- During library playlist sync, catalog-backed playlists were resolved via `globalId` and stored/used with a catalog playlist ID.
- `add_playlist_tracks` writes to `me/library/playlists/{id}/tracks`, which must use a **library playlist ID** (`p....`), not a catalog ID (`pl...`).

This change:
- Keeps fetching playlist metadata via catalog copy when needed.
- Preserves the **library playlist ID** for write operations by passing a `library_id_override` through playlist parsing.
- Ensures `Playlist.item_id` / provider mapping use the library ID for catalog-backed editable library playlists.

**Related issue (if applicable):**
- related issue https://github.com/music-assistant/support/issues/5433

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.

## Validation notes

- Local regression test added for catalog-backed library playlists to verify `item_id` resolves to `p....`.
- Manual local validation with playlist `Zeller-Chilbi` succeeded: adding a track now appears in Apple Music.
- Full pre-commit on this machine currently fails due to pre-existing unrelated mypy errors in `music_assistant/providers/sonic_similarity/*` (unused ignore comments).
