### PR TITLE
Fix KeyError for CONF_SMART_FADES_MODE in streams controller get_value calls

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -92,7 +92,7 @@ from music_assistant.providers.universal_group.player import UniversalGroupPlaye
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import CoreConfig
     from music_assistant_models.player import PlayerMedia
-    from music_assistant_models.queue_items import QueueItem
+    from music_assistant_models.queue_item import QueueItem
     from music_assistant_models.streamdetails import StreamMetadata
 
     from music_assistant.mass import MusicAssistant

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -92,7 +92,7 @@ from music_assistant.providers.universal_group.player import UniversalGroupPlaye
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import CoreConfig
     from music_assistant_models.player import PlayerMedia
-    from music_assistant_models.queue_item import QueueItem
+    from music_assistant_models.queue_items import QueueItem
     from music_assistant_models.streamdetails import StreamMetadata
 
     from music_assistant.mass import MusicAssistant
@@ -404,7 +404,8 @@ class StreamsController(CoreController):
             # gapless playback, we need to enforce flow mode
             queue_id
             and (queue_player := self.mass.players.get_player(queue_id))
-            and queue_player.config.get_value(CONF_SMART_FADES_MODE) != SmartFadesMode.DISABLED
+            and queue_player.config.get_value(CONF_SMART_FADES_MODE, SmartFadesMode.DISABLED)
+            != SmartFadesMode.DISABLED
             and protocol_player
             and not protocol_player.supports_gapless
         )
@@ -1111,7 +1112,8 @@ class StreamsController(CoreController):
                 # does not support gapless playback, we need to enforce flow mode
                 queue_id
                 and (queue_player := self.mass.players.get_player(queue_id))
-                and queue_player.config.get_value(CONF_SMART_FADES_MODE) != SmartFadesMode.DISABLED
+                and queue_player.config.get_value(CONF_SMART_FADES_MODE, SmartFadesMode.DISABLED)
+                != SmartFadesMode.DISABLED
                 and protocol_player
                 and not protocol_player.supports_gapless
             )


### PR DESCRIPTION
## Summary

Fixes two `KeyError` crash sites in `music_assistant/controllers/streams/controller.py` that were missed by PR #4020.

PR #4020 correctly fixed the four `get_player_config_value` call-sites that read `CONF_SMART_FADES_MODE`, but two additional call-sites in the same controller call `queue_player.config.get_value()` (a direct `PlayerConfig` method) **without a default**:

- `controller.py:407` — inside `resolve_stream_url()`
- `controller.py:1115` — inside `get_stream()`

For protocol-type players (synthesized MAC like `00:00:00:00:00:03`), `CONF_SMART_FADES_MODE` is never registered in `conf.values`, so these bare calls raise `KeyError` at runtime, breaking playback on such players.

**Fix:** pass `SmartFadesMode.DISABLED` as the default to both `get_value()` calls, which is the same safe fallback used everywhere else that reads this key.

Closes music-assistant/support#5550

---
_Generated by [Claude Code](https://claude.ai/code/session_01Twf7vAnMgZFMcT4efmL9kn)_