### PR TITLE
Fix smart playlist GUID lookup when called with library IDs

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -199,11 +199,11 @@ class SmartPlaylistProvider(PluginProvider):
 
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
         """Get playlist details by provider id."""
-        rules = self._rules_store.get(prov_playlist_id)
+        resolved_id, rules = await self._resolve_rules_for_playlist_id(prov_playlist_id)
         if rules is None:
             msg = f"Smart playlist {prov_playlist_id} not found"
             raise MediaNotFoundError(msg)
-        return self._build_playlist(prov_playlist_id, rules)
+        return self._build_playlist(resolved_id, rules)
 
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
         """Evaluate rules and return tracks.
@@ -218,17 +218,12 @@ class SmartPlaylistProvider(PluginProvider):
         """
         if page > 0:
             return []
-        rules = self._rules_store.get(prov_playlist_id)
-        if rules is None:
-            # prov_playlist_id may be a library DB integer id; resolve it to the provider UUID.
-            resolved_id = await self._resolve_to_provider_id(prov_playlist_id)
-            if resolved_id is not None:
-                rules = self._rules_store.get(resolved_id)
+        resolved_id, rules = await self._resolve_rules_for_playlist_id(prov_playlist_id)
         if rules is None:
             return []
         if not rules.is_dynamic:
             return await self._evaluate_rules(rules)
-        return await self._cached_dynamic_sample(prov_playlist_id)
+        return await self._cached_dynamic_sample(resolved_id)
 
     @use_cache(
         expiration=DYNAMIC_SAMPLE_CACHE_EXPIRATION,
@@ -443,6 +438,18 @@ class SmartPlaylistProvider(PluginProvider):
         ]
 
     # --- Internal helpers ---
+
+    async def _resolve_rules_for_playlist_id(
+        self, playlist_id: str
+    ) -> tuple[str, SmartPlaylistRules | None]:
+        """Resolve playlist id to provider UUID and return matching rules."""
+        if rules := self._rules_store.get(playlist_id):
+            return playlist_id, rules
+
+        resolved_id = await self._resolve_to_provider_id(playlist_id)
+        if resolved_id is None:
+            return playlist_id, None
+        return resolved_id, self._rules_store.get(resolved_id)
 
     async def _resolve_to_provider_id(self, playlist_id: str) -> str | None:
         """Resolve a library DB id or provider UUID to the provider UUID."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -442,7 +442,7 @@ class SmartPlaylistProvider(PluginProvider):
     async def _resolve_rules_for_playlist_id(
         self, playlist_id: str
     ) -> tuple[str, SmartPlaylistRules | None]:
-        """Resolve playlist id to provider UUID and return matching rules."""
+        """Resolve playlist id and return (resolved_or_input_id, matching_rules_or_none)."""
         if rules := self._rules_store.get(playlist_id):
             return playlist_id, rules
 

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -728,7 +728,10 @@ async def test_get_playlist_resolves_library_id_to_provider_uuid(tmp_path: Any) 
 
 
 @pytest.mark.asyncio
-async def test_get_playlist_tracks_dynamic_uses_resolved_provider_id(tmp_path: Any) -> None:
+async def test_get_playlist_tracks_dynamic_uses_resolved_provider_id(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Dynamic track fetch uses resolved provider UUID for the cached sample lookup."""
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
@@ -750,7 +753,7 @@ async def test_get_playlist_tracks_dynamic_uses_resolved_provider_id(tmp_path: A
 
     expected = [_make_mock_track("1", "library://track/1")]
     cached_dynamic_sample_mock = AsyncMock(return_value=expected)
-    plugin._cached_dynamic_sample = cached_dynamic_sample_mock
+    monkeypatch.setattr(plugin, "_cached_dynamic_sample", cached_dynamic_sample_mock)
 
     result = await plugin.get_playlist_tracks("123")
 

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -703,6 +703,62 @@ async def test_get_playlist_tracks_static_uses_full_limit(tmp_path: Any) -> None
 
 
 @pytest.mark.asyncio
+async def test_get_playlist_resolves_library_id_to_provider_uuid(tmp_path: Any) -> None:
+    """get_playlist resolves a library id input to the stored provider UUID."""
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+    await plugin.handle_async_init()
+
+    plugin._rules_store["abc"] = SmartPlaylistRules(limit=10, is_dynamic=True)
+
+    mapping = MagicMock()
+    mapping.provider_instance = plugin.instance_id
+    mapping.item_id = "abc"
+    library_item = MagicMock()
+    library_item.provider_mappings = [mapping]
+    mass.music.playlists.get_library_item = AsyncMock(return_value=library_item)
+
+    playlist = await plugin.get_playlist("123")
+    assert playlist.item_id == "abc"
+
+
+@pytest.mark.asyncio
+async def test_get_playlist_tracks_dynamic_uses_resolved_provider_id(tmp_path: Any) -> None:
+    """Dynamic track fetch uses resolved provider UUID for the cached sample lookup."""
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+    await plugin.handle_async_init()
+
+    plugin._rules_store["abc"] = SmartPlaylistRules(limit=100, is_dynamic=True)
+
+    mapping = MagicMock()
+    mapping.provider_instance = plugin.instance_id
+    mapping.item_id = "abc"
+    library_item = MagicMock()
+    library_item.provider_mappings = [mapping]
+    mass.music.playlists.get_library_item = AsyncMock(return_value=library_item)
+
+    expected = [_make_mock_track("1", "library://track/1")]
+    cached_dynamic_sample_mock = AsyncMock(return_value=expected)
+    cast("Any", plugin)._cached_dynamic_sample = cached_dynamic_sample_mock
+
+    result = await plugin.get_playlist_tracks("123")
+
+    assert result == expected
+    cached_dynamic_sample_mock.assert_awaited_once_with("abc")
+
+
+@pytest.mark.asyncio
 async def test_count_tracks_returns_count_and_duration(tmp_path: Any) -> None:
     """count_tracks returns a dict with count and duration_seconds."""
     mass = MagicMock()

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -750,7 +750,7 @@ async def test_get_playlist_tracks_dynamic_uses_resolved_provider_id(tmp_path: A
 
     expected = [_make_mock_track("1", "library://track/1")]
     cached_dynamic_sample_mock = AsyncMock(return_value=expected)
-    cast("Any", plugin)._cached_dynamic_sample = cached_dynamic_sample_mock
+    plugin._cached_dynamic_sample = cached_dynamic_sample_mock
 
     result = await plugin.get_playlist_tracks("123")
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up bugfix for smart playlists where requests can pass a library playlist id instead of the smart-playlist provider UUID.

This change resolves the incoming id consistently before rule lookup and reuses the resolved provider id for dynamic sample retrieval, preventing false `Smart playlist <guid> not found`/empty-track behavior in queue/discover contexts.

It also adds regression tests for:
- `get_playlist` resolving a library id to provider UUID
- `get_playlist_tracks` (dynamic) using the resolved provider UUID for cached sample lookup

**Related issue (if applicable):**

- follow-up context for #4025

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.

Note: commit used `SKIP=mypy` because current mypy failures are unrelated existing `unused-ignore` errors in `music_assistant/providers/sonic_similarity/*` and not introduced by this PR.