### PR TITLE
Separate library artist views from per-provider artist listings

### DIFF
--- a/music_assistant/controllers/media/artists.py
+++ b/music_assistant/controllers/media/artists.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.enums import AlbumType, MediaType, ProviderFeature, ProviderType
@@ -22,7 +23,13 @@ from music_assistant.constants import (
     VARIOUS_ARTISTS_NAME,
 )
 from music_assistant.controllers.media.base import MediaControllerBase
-from music_assistant.helpers.compare import compare_artist, compare_strings, create_safe_string
+from music_assistant.helpers.compare import (
+    compare_album,
+    compare_artist,
+    compare_strings,
+    compare_track,
+    create_safe_string,
+)
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import serialize_to_json
 from music_assistant.models.music_provider import MusicProvider
@@ -47,50 +54,9 @@ class ArtistsController(MediaControllerBase[Artist]):
         api_base = self.api_base
         self.mass.register_api_command(f"music/{api_base}/artist_albums", self.albums)
         self.mass.register_api_command(f"music/{api_base}/artist_tracks", self.tracks)
+        self.mass.register_api_command(f"music/{api_base}/top_tracks", self.top_tracks)
+        self.mass.register_api_command(f"music/{api_base}/top_albums", self.top_albums)
         self.mass.register_api_command(f"music/{api_base}/similar_artists", self.similar_artists)
-
-    async def similar_artists(
-        self,
-        item_id: str,
-        provider_instance_id_or_domain: str,
-        limit: int = 25,
-    ) -> list[Artist]:
-        """
-        Get a list of similar artists for the given artist.
-
-        :param item_id: The item ID of the artist.
-        :param provider_instance_id_or_domain: The provider instance ID or domain.
-        :param limit: Maximum number of similar artists to return.
-        """
-        ref_item = await self.get(item_id, provider_instance_id_or_domain)
-        # Try music providers mapped to the reference artist first.
-        for prov_mapping in ref_item.provider_mappings:
-            prov = self.mass.get_provider(prov_mapping.provider_instance)
-            if prov is None or not prov.available:
-                continue
-            if not isinstance(prov, MusicProvider):
-                continue
-            if ProviderFeature.SIMILAR_ARTISTS not in prov.supported_features:
-                continue
-            try:
-                if result := await prov.get_similar_artists(
-                    prov_artist_id=prov_mapping.item_id, limit=limit
-                ):
-                    return result
-            except NotImplementedError:
-                continue
-        # Fallback: metadata providers.
-        for prov in self.mass.get_providers_supporting_feature(
-            ProviderFeature.SIMILAR_ARTISTS,
-            priority=(ProviderType.METADATA,),
-        ):
-            try:
-                metadata_prov = cast("MetadataProvider", prov)
-                if result := await metadata_prov.get_similar_artists(ref_item, limit=limit):
-                    return result
-            except NotImplementedError:
-                continue
-        return []
 
     async def library_count(
         self, favorite_only: bool = False, album_artists_only: bool = False
@@ -156,92 +122,468 @@ class ArtistsController(MediaControllerBase[Artist]):
         self,
         item_id: str,
         provider_instance_id_or_domain: str,
-        in_library_only: bool = False,
-        provider_filter: str | list[str] | None = None,
+        provider_filter: str | None = None,
     ) -> list[Track]:
-        """Return all/top tracks for an artist."""
-        if provider_filter and provider_instance_id_or_domain != "library":
-            raise MusicAssistantError("Cannot use provider_filter with specific provider request")
-        if isinstance(provider_filter, str):
-            provider_filter = [provider_filter]
-        # always check if we have a library item for this artist
-        library_artist = await self.get_library_item_by_prov_id(
-            item_id, provider_instance_id_or_domain
-        )
-        if not library_artist:
-            return await self.get_provider_artist_toptracks(item_id, provider_instance_id_or_domain)
-        db_items = await self.get_library_artist_tracks(library_artist.item_id)
-        result: list[Track] = db_items
-        if in_library_only and not provider_filter:
-            # return in-library items only
-            return result
-        # return all (unique) items from all providers
-        # initialize unique_ids with db_items to prevent duplicates
-        unique_ids: set[str] = {f"{item.name}.{item.version}" for item in db_items}
-        unique_providers = self.mass.music.get_unique_providers()
-        for provider_mapping in library_artist.provider_mappings:
-            if provider_mapping.provider_instance not in unique_providers:
-                continue
-            if provider_filter and provider_mapping.provider_instance not in provider_filter:
-                continue
-            provider_tracks = await self.get_provider_artist_toptracks(
-                provider_mapping.item_id, provider_mapping.provider_instance
-            )
-            for provider_track in provider_tracks:
-                unique_id = f"{provider_track.name}.{provider_track.version}"
-                if unique_id in unique_ids:
-                    continue
-                unique_ids.add(unique_id)
-                # prefer db item
-                if db_item := await self.mass.music.tracks.get_library_item_by_prov_id(
-                    provider_track.item_id, provider_track.provider
-                ):
-                    result.append(db_item)
-                elif not in_library_only:
-                    result.append(provider_track)
-        return result
+        """
+        Return the tracks for an artist.
+
+        For a library item, the in-library tracks are returned, optionally limited to a single
+        provider instance with the provider_filter. For a provider item, that provider's
+        tracks listing is returned (which may be empty if it is not supported).
+
+        :param item_id: The item ID of the artist.
+        :param provider_instance_id_or_domain: The provider instance ID or domain of the artist.
+        :param provider_filter: Optional provider instance ID to limit the (library) result to.
+        """
+        if provider_instance_id_or_domain == "library":
+            return await self.get_library_artist_tracks(item_id, provider_filter=provider_filter)
+        self._validate_provider_filter(provider_instance_id_or_domain, provider_filter)
+        return await self.get_provider_artist_tracks(item_id, provider_instance_id_or_domain)
 
     async def albums(
         self,
         item_id: str,
         provider_instance_id_or_domain: str,
-        in_library_only: bool = False,
+        provider_filter: str | None = None,
     ) -> list[Album]:
-        """Return (all/most popular) albums for an artist."""
-        # always check if we have a library item for this artist
-        library_artist = await self.get_library_item_by_prov_id(
-            item_id, provider_instance_id_or_domain
-        )
-        if not library_artist:
-            return await self.get_provider_artist_albums(item_id, provider_instance_id_or_domain)
-        db_items = await self.get_library_artist_albums(library_artist.item_id)
-        result: list[Album] = db_items
-        if in_library_only:
-            # return in-library items only
-            return result
-        # return all (unique) items from all providers
-        # initialize unique_ids with db_items to prevent duplicates
-        unique_ids: set[str] = {f"{item.name}.{item.version}" for item in db_items}
-        unique_providers = self.mass.music.get_unique_providers()
-        for provider_mapping in library_artist.provider_mappings:
-            if provider_mapping.provider_instance not in unique_providers:
-                continue
-            provider_albums = await self.get_provider_artist_albums(
-                provider_mapping.item_id, provider_mapping.provider_instance
+        """
+        Return the albums for an artist.
+
+        For a library item, the in-library albums are returned, optionally limited to a single
+        provider instance with the provider_filter. For a provider item, that provider's
+        albums listing is returned (which may be empty if it is not supported).
+
+        :param item_id: The item ID of the artist.
+        :param provider_instance_id_or_domain: The provider instance ID or domain of the artist.
+        :param provider_filter: Optional provider instance ID to limit the (library) result to.
+        """
+        if provider_instance_id_or_domain == "library":
+            return await self.get_library_artist_albums(item_id, provider_filter=provider_filter)
+        self._validate_provider_filter(provider_instance_id_or_domain, provider_filter)
+        return await self.get_provider_artist_albums(item_id, provider_instance_id_or_domain)
+
+    async def top_tracks(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+        provider_filter: str | None = None,
+    ) -> list[Track]:
+        """
+        Return the top/featured tracks for an artist.
+
+        For a library item, the top tracks of all the artist's providers are aggregated (and
+        deduplicated), optionally limited to a single provider instance. For a provider
+        item, that provider's top tracks listing is returned (may be empty if not supported).
+
+        :param item_id: The item ID of the artist.
+        :param provider_instance_id_or_domain: The provider instance ID or domain of the artist.
+        :param provider_filter: Optional provider instance ID to limit the result to.
+        """
+        if provider_instance_id_or_domain == "library":
+            return await self.get_library_artist_toptracks(item_id, provider_filter=provider_filter)
+        self._validate_provider_filter(provider_instance_id_or_domain, provider_filter)
+        return await self.get_provider_artist_toptracks(item_id, provider_instance_id_or_domain)
+
+    async def top_albums(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+        provider_filter: str | None = None,
+    ) -> list[Album]:
+        """
+        Return the top/featured albums for an artist.
+
+        For a library item, the top albums of all the artist's providers are aggregated (and
+        deduplicated), optionally limited to a single provider instance. For a provider
+        item, that provider's top albums listing is returned (may be empty if not supported).
+
+        :param item_id: The item ID of the artist.
+        :param provider_instance_id_or_domain: The provider instance ID or domain of the artist.
+        :param provider_filter: Optional provider instance ID to limit the result to.
+        """
+        if provider_instance_id_or_domain == "library":
+            return await self.get_library_artist_topalbums(item_id, provider_filter=provider_filter)
+        self._validate_provider_filter(provider_instance_id_or_domain, provider_filter)
+        return await self.get_provider_artist_topalbums(item_id, provider_instance_id_or_domain)
+
+    async def similar_artists(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+        provider_filter: str | None = None,
+        limit: int = 25,
+    ) -> list[Artist]:
+        """
+        Return similar artists for an artist.
+
+        For a library item, the similar artists of all the artist's providers are aggregated
+        (and deduplicated), optionally limited to a single provider instance. For a provider
+        item, that provider's similar artists listing is returned (may be empty if not
+        supported).
+
+        :param item_id: The item ID of the artist.
+        :param provider_instance_id_or_domain: The provider instance ID or domain of the artist.
+        :param provider_filter: Optional provider instance ID to limit the result to.
+        :param limit: Maximum number of similar artists to return.
+        """
+        if provider_instance_id_or_domain == "library":
+            return await self.get_library_artist_similar_artists(
+                item_id, provider_filter=provider_filter, limit=limit
             )
-            for provider_album in provider_albums:
-                unique_id = f"{provider_album.name}.{provider_album.version}"
+        self._validate_provider_filter(provider_instance_id_or_domain, provider_filter)
+        return await self.get_provider_artist_similar_artists(
+            item_id, provider_instance_id_or_domain, limit=limit
+        )
+
+    async def get_provider_artist_toptracks(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+    ) -> list[Track]:
+        """
+        Return the top tracks for an artist on the given provider.
+
+        Each track is resolved to its in-library equivalent where available.
+        """
+        assert provider_instance_id_or_domain != "library"
+        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
+            return []
+        provider = cast("MusicProvider", provider)
+        if ProviderFeature.ARTIST_TOPTRACKS not in provider.supported_features:
+            self.logger.warning(
+                "Provider %s does not support fetching artist top tracks.",
+                provider.name,
+            )
+            return []  # guard against unsupported feature
+        tracks = await provider.get_artist_toptracks(item_id)
+        # resolve to in-library equivalents (in parallel) where available
+        resolved = await asyncio.gather(
+            *(
+                self.mass.music.tracks.get_library_item_by_prov_id(track.item_id, track.provider)
+                for track in tracks
+            )
+        )
+        return [
+            library_track or track for library_track, track in zip(resolved, tracks, strict=True)
+        ]
+
+    async def get_library_artist_toptracks(
+        self,
+        item_id: str | int,
+        provider_filter: str | None = None,
+    ) -> list[Track]:
+        """
+        Return the top tracks for an in-library artist, aggregated across all its providers.
+
+        The result combines (and deduplicates, preserving order) the top tracks from every
+        provider attached to the artist and any metadata/plugin provider implementing the
+        feature. Empty when no provider yields a result.
+
+        :param item_id: The library item ID of the artist.
+        :param provider_filter: Optional provider instance ID to limit the result to.
+        """
+        ref_item = await self.get_library_item(item_id)
+        allowed = self._ensure_provider_filter(provider_filter)
+        # fetch each provider's ranked top tracks in parallel
+        fetches = []
+        # streaming providers attached to the artist (results resolved to library items)
+        for provider_mapping in ref_item.provider_mappings:
+            if allowed is not None and provider_mapping.provider_instance not in allowed:
+                continue
+            music_prov = self.mass.get_provider(
+                provider_mapping.provider_instance, provider_type=MusicProvider
+            )
+            if (
+                music_prov is None
+                or ProviderFeature.ARTIST_TOPTRACKS not in music_prov.supported_features
+            ):
+                continue
+            fetches.append(
+                self.get_provider_artist_toptracks(
+                    provider_mapping.item_id, provider_mapping.provider_instance
+                )
+            )
+        # metadata/plugin providers implementing the feature
+        for prov in self.mass.get_providers_supporting_feature(
+            ProviderFeature.ARTIST_TOPTRACKS,
+            priority=(ProviderType.METADATA, ProviderType.PLUGIN),
+        ):
+            if allowed is not None and prov.instance_id not in allowed:
+                continue
+            fetches.append(cast("MetadataProvider", prov).get_artist_toptracks(ref_item))
+        per_provider = await asyncio.gather(*fetches, return_exceptions=True)
+        # interleave the providers' rankings by position (zip), deduplicating with the compare
+        # helper (which also matches on version/duration)
+        result: list[Track] = []
+        for row in zip_longest(*(items for items in per_provider if isinstance(items, list))):
+            for candidate in row:
+                if candidate is None or any(
+                    compare_track(existing, candidate) for existing in result
+                ):
+                    continue
+                result.append(candidate)
+        return result
+
+    async def get_provider_artist_topalbums(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+    ) -> list[Album]:
+        """
+        Return the top/featured albums for an artist on the given provider.
+
+        Each album is resolved to its in-library equivalent where available.
+        """
+        assert provider_instance_id_or_domain != "library"
+        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
+            return []
+        provider = cast("MusicProvider", provider)
+        if ProviderFeature.ARTIST_TOPALBUMS not in provider.supported_features:
+            self.logger.warning(
+                "Provider %s does not support fetching artist top albums.",
+                provider.name,
+            )
+            return []  # guard against unsupported feature
+        albums = await provider.get_artist_topalbums(item_id)
+        # resolve to in-library equivalents (in parallel) where available
+        resolved = await asyncio.gather(
+            *(
+                self.mass.music.albums.get_library_item_by_prov_id(album.item_id, album.provider)
+                for album in albums
+            )
+        )
+        return [
+            library_album or album for library_album, album in zip(resolved, albums, strict=True)
+        ]
+
+    async def get_library_artist_topalbums(
+        self,
+        item_id: str | int,
+        provider_filter: str | None = None,
+    ) -> list[Album]:
+        """
+        Return the top albums for an in-library artist, aggregated across all its providers.
+
+        The result combines (and deduplicates, preserving order) the top albums from every
+        provider attached to the artist and any metadata/plugin provider implementing the
+        feature. Empty when no provider yields a result.
+
+        :param item_id: The library item ID of the artist.
+        :param provider_filter: Optional provider instance ID to limit the result to.
+        """
+        ref_item = await self.get_library_item(item_id)
+        allowed = self._ensure_provider_filter(provider_filter)
+        # fetch each provider's ranked top albums in parallel
+        fetches = []
+        # streaming providers attached to the artist (results resolved to library items)
+        for provider_mapping in ref_item.provider_mappings:
+            if allowed is not None and provider_mapping.provider_instance not in allowed:
+                continue
+            music_prov = self.mass.get_provider(
+                provider_mapping.provider_instance, provider_type=MusicProvider
+            )
+            if (
+                music_prov is None
+                or ProviderFeature.ARTIST_TOPALBUMS not in music_prov.supported_features
+            ):
+                continue
+            fetches.append(
+                self.get_provider_artist_topalbums(
+                    provider_mapping.item_id, provider_mapping.provider_instance
+                )
+            )
+        # metadata/plugin providers implementing the feature
+        for prov in self.mass.get_providers_supporting_feature(
+            ProviderFeature.ARTIST_TOPALBUMS,
+            priority=(ProviderType.METADATA, ProviderType.PLUGIN),
+        ):
+            if allowed is not None and prov.instance_id not in allowed:
+                continue
+            fetches.append(cast("MetadataProvider", prov).get_artist_topalbums(ref_item))
+        per_provider = await asyncio.gather(*fetches, return_exceptions=True)
+        # interleave the providers' rankings by position (zip), deduplicating with the compare
+        # helper (which also matches on version/duration)
+        result: list[Album] = []
+        for row in zip_longest(*(items for items in per_provider if isinstance(items, list))):
+            for candidate in row:
+                if candidate is None or any(
+                    compare_album(existing, candidate) for existing in result
+                ):
+                    continue
+                result.append(candidate)
+        return result
+
+    async def get_provider_artist_tracks(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+    ) -> list[Track]:
+        """Return all tracks for an artist on given provider."""
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain, provider_type=MusicProvider
+        )
+        if provider is None or not provider.available:
+            return []  # guard against unavailable provider
+        if provider.supports_feature(ProviderFeature.ARTIST_TRACKS):
+            return await provider.get_artist_tracks(item_id)
+        # fallback: enumerate (and dedupe) the tracks of all the artist's albums on the provider
+        result: list[Track] = []
+        unique_ids: set[str] = set()
+        for album in await self.get_provider_artist_albums(item_id, provider_instance_id_or_domain):
+            for track in await self.mass.music.albums.tracks(album.item_id, album.provider):
+                unique_id = f"{track.name}.{track.version}"
                 if unique_id in unique_ids:
                     continue
                 unique_ids.add(unique_id)
-                # prefer db item
-                if db_item := await self.mass.music.albums.get_library_item_by_prov_id(
-                    provider_album.item_id, provider_album.provider
-                ):
-                    result.append(db_item)
-                elif not in_library_only:
-                    result.append(provider_album)
+                result.append(track)
         return result
+
+    async def get_library_artist_tracks(
+        self,
+        item_id: str | int,
+        provider_filter: str | None = None,
+    ) -> list[Track]:
+        """Return all in-library tracks for an artist, optionally limited to a single provider."""
+        db_id = int(item_id)  # ensure integer
+        subquery = f"SELECT track_id FROM {DB_TABLE_TRACK_ARTISTS} WHERE artist_id = :artist_id"
+        query = f"tracks.item_id in ({subquery})"
+        return await self.mass.music.tracks.get_library_items_by_query(
+            extra_query_parts=[query],
+            extra_query_params={"artist_id": db_id},
+            provider_filter=self._ensure_provider_filter(provider_filter),
+            in_library_only=True,
+        )
+
+    async def get_provider_artist_albums(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+    ) -> list[Album]:
+        """Return albums for an artist on given provider."""
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain, provider_type=MusicProvider
+        )
+        if provider is None or not provider.available:
+            return []  # guard against unavailable provider
+        if not provider.supports_feature(ProviderFeature.ARTIST_ALBUMS):
+            self.logger.warning(
+                "Provider %s does not support fetching all artist albums.",
+                provider.name,
+            )
+            return []  # guard against unsupported feature
+        return await provider.get_artist_albums(item_id)
+
+    async def get_library_artist_albums(
+        self,
+        item_id: str | int,
+        provider_filter: str | None = None,
+    ) -> list[Album]:
+        """Return all in-library albums for an artist, optionally limited to a single provider."""
+        db_id = int(item_id)  # ensure integer
+        subquery = f"SELECT album_id FROM {DB_TABLE_ALBUM_ARTISTS} WHERE artist_id = :artist_id"
+        query = f"albums.item_id in ({subquery})"
+        return await self.mass.music.albums.get_library_items_by_query(
+            extra_query_parts=[query],
+            extra_query_params={"artist_id": db_id},
+            provider_filter=self._ensure_provider_filter(provider_filter),
+            in_library_only=True,
+        )
+
+    async def get_provider_artist_similar_artists(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+        limit: int = 25,
+    ) -> list[Artist]:
+        """
+        Return similar artists for an artist on the given provider.
+
+        Each artist is resolved to its in-library equivalent where available.
+        """
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain, provider_type=MusicProvider
+        )
+        if provider is None or not provider.available:
+            return []  # guard against unavailable provider
+        if not provider.supports_feature(ProviderFeature.SIMILAR_ARTISTS):
+            self.logger.warning(
+                "Provider %s does not support fetching similar artists.",
+                provider.name,
+            )
+            return []  # guard against unsupported feature
+        artists = await provider.get_similar_artists(item_id, limit=limit)
+        # resolve to in-library equivalents (in parallel) where available
+        resolved = await asyncio.gather(
+            *(
+                self.get_library_item_by_prov_id(artist.item_id, artist.provider)
+                for artist in artists
+            )
+        )
+        return [
+            library_artist or artist
+            for library_artist, artist in zip(resolved, artists, strict=True)
+        ]
+
+    async def get_library_artist_similar_artists(
+        self,
+        item_id: str | int,
+        provider_filter: str | None = None,
+        limit: int = 25,
+    ) -> list[Artist]:
+        """
+        Return similar artists for an in-library artist, aggregated across all its providers.
+
+        The result combines (and deduplicates, preserving order) the similar artists from
+        every provider attached to the artist and any metadata/plugin provider implementing
+        the feature. Empty when no provider yields a result.
+
+        :param item_id: The library item ID of the artist.
+        :param provider_filter: Optional provider instance ID to limit the result to.
+        :param limit: Maximum number of similar artists to return.
+        """
+        ref_item = await self.get_library_item(item_id)
+        allowed = self._ensure_provider_filter(provider_filter)
+        # fetch each provider's similar artists in parallel
+        fetches = []
+        # streaming providers attached to the artist (results resolved to library items)
+        for provider_mapping in ref_item.provider_mappings:
+            if allowed is not None and provider_mapping.provider_instance not in allowed:
+                continue
+            music_prov = self.mass.get_provider(
+                provider_mapping.provider_instance, provider_type=MusicProvider
+            )
+            if (
+                music_prov is None
+                or ProviderFeature.SIMILAR_ARTISTS not in music_prov.supported_features
+            ):
+                continue
+            fetches.append(
+                self.get_provider_artist_similar_artists(
+                    provider_mapping.item_id, provider_mapping.provider_instance, limit=limit
+                )
+            )
+        # metadata/plugin providers implementing the feature
+        for prov in self.mass.get_providers_supporting_feature(
+            ProviderFeature.SIMILAR_ARTISTS,
+            priority=(ProviderType.METADATA, ProviderType.PLUGIN),
+        ):
+            if allowed is not None and prov.instance_id not in allowed:
+                continue
+            fetches.append(
+                cast("MetadataProvider", prov).get_similar_artists(ref_item, limit=limit)
+            )
+        per_provider = await asyncio.gather(*fetches, return_exceptions=True)
+        # interleave the providers' results by position (zip), deduplicating with the compare
+        # helper, and cap to the requested limit
+        result: list[Artist] = []
+        for row in zip_longest(*(items for items in per_provider if isinstance(items, list))):
+            for candidate in row:
+                if candidate is None or any(
+                    compare_artist(existing, candidate) for existing in result
+                ):
+                    continue
+                result.append(candidate)
+        return result[:limit]
 
     async def remove_item_from_library(self, item_id: str | int, recursive: bool = True) -> None:
         """Delete record from the database."""
@@ -272,85 +614,15 @@ class ArtistsController(MediaControllerBase[Artist]):
         # this will raise if the item still has references and recursive is false
         await super().remove_item_from_library(db_id)
 
-    async def get_provider_artist_toptracks(
-        self,
-        item_id: str,
-        provider_instance_id_or_domain: str,
-    ) -> list[Track]:
-        """Return top tracks for an artist on given provider."""
-        assert provider_instance_id_or_domain != "library"
-        if not (prov := self.mass.get_provider(provider_instance_id_or_domain)):
-            return []
-        prov = cast("MusicProvider", prov)
-        if ProviderFeature.ARTIST_TOPTRACKS in prov.supported_features:
-            return await prov.get_artist_toptracks(item_id)
-        # fallback implementation using the library db
-        if db_artist := await self.mass.music.artists.get_library_item_by_prov_id(
-            item_id,
-            provider_instance_id_or_domain,
-        ):
-            db_artist_id = int(db_artist.item_id)  # ensure integer
-            subquery = f"SELECT track_id FROM {DB_TABLE_TRACK_ARTISTS} WHERE artist_id = :artist_id"
-            query = f"tracks.item_id in ({subquery})"
-            return await self.mass.music.tracks.get_library_items_by_query(
-                extra_query_parts=[query],
-                extra_query_params={"artist_id": db_artist_id},
-                provider_filter=[provider_instance_id_or_domain],
+    def _validate_provider_filter(
+        self, provider_instance_id_or_domain: str, provider_filter: str | None
+    ) -> None:
+        """Raise when a provider filter is set that does not match the requested provider."""
+        if provider_filter is not None and provider_filter != provider_instance_id_or_domain:
+            raise MusicAssistantError(
+                f"provider_filter '{provider_filter}' does not match the requested "
+                f"provider '{provider_instance_id_or_domain}'"
             )
-        return []
-
-    async def get_library_artist_tracks(
-        self,
-        item_id: str | int,
-    ) -> list[Track]:
-        """Return all tracks for an artist in the library/db."""
-        db_id = int(item_id)  # ensure integer
-        subquery = f"SELECT track_id FROM {DB_TABLE_TRACK_ARTISTS} WHERE artist_id = :artist_id"
-        query = f"tracks.item_id in ({subquery})"
-        return await self.mass.music.tracks.get_library_items_by_query(
-            extra_query_parts=[query],
-            extra_query_params={"artist_id": db_id},
-        )
-
-    async def get_provider_artist_albums(
-        self,
-        item_id: str,
-        provider_instance_id_or_domain: str,
-    ) -> list[Album]:
-        """Return albums for an artist on given provider."""
-        assert provider_instance_id_or_domain != "library"
-        if not (prov := self.mass.get_provider(provider_instance_id_or_domain)):
-            return []
-        prov = cast("MusicProvider", prov)
-        if ProviderFeature.ARTIST_ALBUMS in prov.supported_features:
-            return await prov.get_artist_albums(item_id)
-        # fallback implementation using the db
-        if db_artist := await self.mass.music.artists.get_library_item_by_prov_id(
-            item_id,
-            provider_instance_id_or_domain,
-        ):
-            db_artist_id = int(db_artist.item_id)  # ensure integer
-            subquery = f"SELECT album_id FROM {DB_TABLE_ALBUM_ARTISTS} WHERE artist_id = :artist_id"
-            query = f"albums.item_id in ({subquery})"
-            return await self.mass.music.albums.get_library_items_by_query(
-                extra_query_parts=[query],
-                extra_query_params={"artist_id": db_artist_id},
-                provider_filter=[provider_instance_id_or_domain],
-            )
-        return []
-
-    async def get_library_artist_albums(
-        self,
-        item_id: str | int,
-    ) -> list[Album]:
-        """Return all in-library albums for an artist."""
-        db_id = int(item_id)  # ensure integer
-        subquery = f"SELECT album_id FROM {DB_TABLE_ALBUM_ARTISTS} WHERE artist_id = :artist_id"
-        query = f"albums.item_id in ({subquery})"
-        return await self.mass.music.albums.get_library_items_by_query(
-            extra_query_parts=[query],
-            extra_query_params={"artist_id": db_id},
-        )
 
     async def _add_library_item(
         self, item: Artist | ItemMapping, overwrite_existing: bool = False
@@ -445,11 +717,10 @@ class ArtistsController(MediaControllerBase[Artist]):
         :param item: The Artist to get base tracks for.
         :param preferred_provider_instances: List of preferred provider instance IDs to use.
         """
-        return await self.tracks(
-            item.item_id,
-            item.provider,
-            in_library_only=False,
-        )
+        # prefer the (top) tracks listing as radio seed, falling back to all tracks
+        if result := await self.top_tracks(item.item_id, item.provider):
+            return result
+        return await self.tracks(item.item_id, item.provider)
 
     async def match_provider(
         self, db_artist: Artist, provider: MusicProvider, strict: bool = True

--- a/music_assistant/controllers/media/artists.py
+++ b/music_assistant/controllers/media/artists.py
@@ -245,11 +245,12 @@ class ArtistsController(MediaControllerBase[Artist]):
 
         Each track is resolved to its in-library equivalent where available.
         """
-        assert provider_instance_id_or_domain != "library"
-        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
-            return []
-        provider = cast("MusicProvider", provider)
-        if ProviderFeature.ARTIST_TOPTRACKS not in provider.supported_features:
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain, provider_type=MusicProvider
+        )
+        if provider is None or not provider.available:
+            return []  # guard against unavailable provider
+        if not provider.supports_feature(ProviderFeature.ARTIST_TOPTRACKS):
             self.logger.warning(
                 "Provider %s does not support fetching artist top tracks.",
                 provider.name,
@@ -312,10 +313,21 @@ class ArtistsController(MediaControllerBase[Artist]):
                 continue
             fetches.append(cast("MetadataProvider", prov).get_artist_toptracks(ref_item))
         per_provider = await asyncio.gather(*fetches, return_exceptions=True)
+        # drop (and log) any provider that failed so one bad provider can't sink the listing
+        listings: list[list[Track]] = []
+        for listing in per_provider:
+            if isinstance(listing, BaseException):
+                self.logger.warning(
+                    "Error fetching top tracks for artist %s from a provider",
+                    ref_item.name,
+                    exc_info=listing,
+                )
+                continue
+            listings.append(listing)
         # interleave the providers' rankings by position (zip), deduplicating with the compare
         # helper (which also matches on version/duration)
         result: list[Track] = []
-        for row in zip_longest(*(items for items in per_provider if isinstance(items, list))):
+        for row in zip_longest(*listings):
             for candidate in row:
                 if candidate is None or any(
                     compare_track(existing, candidate) for existing in result
@@ -334,11 +346,12 @@ class ArtistsController(MediaControllerBase[Artist]):
 
         Each album is resolved to its in-library equivalent where available.
         """
-        assert provider_instance_id_or_domain != "library"
-        if not (provider := self.mass.get_provider(provider_instance_id_or_domain)):
-            return []
-        provider = cast("MusicProvider", provider)
-        if ProviderFeature.ARTIST_TOPALBUMS not in provider.supported_features:
+        provider = self.mass.get_provider(
+            provider_instance_id_or_domain, provider_type=MusicProvider
+        )
+        if provider is None or not provider.available:
+            return []  # guard against unavailable provider
+        if not provider.supports_feature(ProviderFeature.ARTIST_TOPALBUMS):
             self.logger.warning(
                 "Provider %s does not support fetching artist top albums.",
                 provider.name,
@@ -401,10 +414,21 @@ class ArtistsController(MediaControllerBase[Artist]):
                 continue
             fetches.append(cast("MetadataProvider", prov).get_artist_topalbums(ref_item))
         per_provider = await asyncio.gather(*fetches, return_exceptions=True)
+        # drop (and log) any provider that failed so one bad provider can't sink the listing
+        listings: list[list[Album]] = []
+        for listing in per_provider:
+            if isinstance(listing, BaseException):
+                self.logger.warning(
+                    "Error fetching top albums for artist %s from a provider",
+                    ref_item.name,
+                    exc_info=listing,
+                )
+                continue
+            listings.append(listing)
         # interleave the providers' rankings by position (zip), deduplicating with the compare
         # helper (which also matches on version/duration)
         result: list[Album] = []
-        for row in zip_longest(*(items for items in per_provider if isinstance(items, list))):
+        for row in zip_longest(*listings):
             for candidate in row:
                 if candidate is None or any(
                     compare_album(existing, candidate) for existing in result
@@ -573,10 +597,21 @@ class ArtistsController(MediaControllerBase[Artist]):
                 cast("MetadataProvider", prov).get_similar_artists(ref_item, limit=limit)
             )
         per_provider = await asyncio.gather(*fetches, return_exceptions=True)
+        # drop (and log) any provider that failed so one bad provider can't sink the listing
+        listings: list[list[Artist]] = []
+        for listing in per_provider:
+            if isinstance(listing, BaseException):
+                self.logger.warning(
+                    "Error fetching similar artists for %s from a provider",
+                    ref_item.name,
+                    exc_info=listing,
+                )
+                continue
+            listings.append(listing)
         # interleave the providers' results by position (zip), deduplicating with the compare
         # helper, and cap to the requested limit
         result: list[Artist] = []
-        for row in zip_longest(*(items for items in per_provider if isinstance(items, list))):
+        for row in zip_longest(*listings):
             for candidate in row:
                 if candidate is None or any(
                     compare_artist(existing, candidate) for existing in result

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -1909,12 +1909,11 @@ class MetaDataController(CoreController):
                     return mb_artist.id
 
         # start lookup of musicbrainz id using artist name, albums and tracks
-        ref_albums = await self.mass.music.artists.albums(
-            artist.item_id, artist.provider, in_library_only=False
-        )
-        ref_tracks = await self.mass.music.artists.tracks(
-            artist.item_id, artist.provider, in_library_only=False
-        )
+        ref_albums = await self.mass.music.artists.albums(artist.item_id, artist.provider)
+        # prefer the (widely supported) top tracks listing, falling back to all tracks
+        ref_tracks = await self.mass.music.artists.top_tracks(artist.item_id, artist.provider)
+        if not ref_tracks:
+            ref_tracks = await self.mass.music.artists.tracks(artist.item_id, artist.provider)
         # try with (strict) ref track(s), using recording id
         for ref_track in ref_tracks:
             if mb_artist := await musicbrainz.get_artist_details_by_track(artist.name, ref_track):

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -228,19 +228,19 @@ class PlayerQueuesController(CoreController):
                 label="Items to select when you play a (in-library) artist.",
                 options=[
                     ConfigValueOption(
-                        title="Only in-library tracks",
+                        title="Only tracks that are in your library",
                         value="library_tracks",
                     ),
                     ConfigValueOption(
-                        title="All tracks from all albums in the library",
+                        title="Tracks from all albums that are in your library",
                         value="library_album_tracks",
                     ),
                     ConfigValueOption(
-                        title="All (top) tracks from (all) streaming provider(s)",
+                        title="The artist's top tracks (from streaming provider(s))",
                         value="all_tracks",
                     ),
                     ConfigValueOption(
-                        title="All tracks from all albums from (all) streaming provider(s)",
+                        title="Tracks from all the artist's albums (from streaming provider(s))",
                         value="all_album_tracks",
                     ),
                 ],
@@ -1938,6 +1938,18 @@ class PlayerQueuesController(CoreController):
                 )
         return media
 
+    async def _resolve_library_artist(self, artist: Artist) -> Artist | None:
+        """
+        Resolve the in-library artist for the given (possibly provider) artist item.
+
+        :param artist: The artist item, which may be a library or a provider item.
+        """
+        if artist.provider == "library":
+            return artist
+        return await self.mass.music.artists.get_library_item_by_prov_id(
+            artist.item_id, artist.provider
+        )
+
     async def get_artist_tracks(self, artist: Artist) -> list[Track]:
         """Return tracks for given artist, based on user preference."""
         artist_items_conf = self.mass.config.get_raw_core_config_value(
@@ -1949,29 +1961,48 @@ class PlayerQueuesController(CoreController):
             "Fetching tracks to play for artist %s",
             artist.name,
         )
-        if artist_items_conf in ("library_tracks", "all_tracks"):
-            all_items = await self.mass.music.artists.tracks(
-                artist.item_id,
-                artist.provider,
-                in_library_only=artist_items_conf == "library_tracks",
-            )
-            random.shuffle(all_items)
-            return all_items
-        if artist_items_conf in ("library_album_tracks", "all_album_tracks"):
-            all_tracks: list[Track] = []
-            for library_album in await self.mass.music.artists.albums(
-                artist.item_id,
-                artist.provider,
-                in_library_only=artist_items_conf == "library_album_tracks",
-            ):
-                for album_track in await self.mass.music.albums.tracks(
-                    library_album.item_id, library_album.provider
+        # track-based selection
+        if artist_items_conf == "library_tracks":
+            # operates on the in-library artist; bail out if it is not (yet) saved
+            if (library_artist := await self._resolve_library_artist(artist)) is None:
+                return []
+            tracks = await self.mass.music.artists.tracks(library_artist.item_id, "library")
+            random.shuffle(tracks)
+            return tracks
+        if artist_items_conf == "all_tracks":
+            # the artist's top tracks across the (streaming) providers
+            tracks = await self.mass.music.artists.top_tracks(artist.item_id, artist.provider)
+            random.shuffle(tracks)
+            return tracks
+        # album-based selection
+        albums: list[Album] = []
+        if artist_items_conf == "library_album_tracks":
+            # operates on the in-library artist; leave albums empty if it is not (yet) saved
+            if (library_artist := await self._resolve_library_artist(artist)) is not None:
+                albums = await self.mass.music.artists.albums(library_artist.item_id, "library")
+        elif artist_items_conf == "all_album_tracks":
+            # all (unique) albums across the (streaming) providers attached to the artist,
+            # respecting the user provider filter and a single instance per streaming domain
+            unique_providers = self.mass.music.get_unique_providers()
+            unique_ids: set[str] = set()
+            for mapping in artist.provider_mappings:
+                if mapping.provider_instance not in unique_providers:
+                    continue
+                for album in await self.mass.music.artists.get_provider_artist_albums(
+                    mapping.item_id, mapping.provider_instance
                 ):
-                    if album_track not in all_tracks:
-                        all_tracks.append(album_track)
-            random.shuffle(all_tracks)
-            return all_tracks
-        return []
+                    unique_id = f"{album.name}.{album.version}"
+                    if unique_id in unique_ids:
+                        continue
+                    unique_ids.add(unique_id)
+                    albums.append(album)
+        all_tracks: list[Track] = []
+        for album in albums:
+            for album_track in await self.mass.music.albums.tracks(album.item_id, album.provider):
+                if album_track not in all_tracks:
+                    all_tracks.append(album_track)
+        random.shuffle(all_tracks)
+        return all_tracks
 
     async def get_album_tracks(
         self, album: Album, start_item: str | None, sort_by: str | None = None

--- a/music_assistant/models/metadata_provider.py
+++ b/music_assistant/models/metadata_provider.py
@@ -83,6 +83,32 @@ class MetadataProvider(Provider):
             raise NotImplementedError
         return []
 
+    async def get_artist_toptracks(self, artist: Artist, limit: int = 25) -> list[Track]:
+        """
+        Retrieve a list of top tracks for the given artist.
+
+        Will only be called if ProviderFeature.ARTIST_TOPTRACKS is declared.
+
+        :param artist: The reference artist.
+        :param limit: Maximum number of top tracks to return.
+        """
+        if ProviderFeature.ARTIST_TOPTRACKS in self.supported_features:
+            raise NotImplementedError
+        return []
+
+    async def get_artist_topalbums(self, artist: Artist, limit: int = 25) -> list[Album]:
+        """
+        Retrieve a list of top albums for the given artist.
+
+        Will only be called if ProviderFeature.ARTIST_TOPALBUMS is declared.
+
+        :param artist: The reference artist.
+        :param limit: Maximum number of top albums to return.
+        """
+        if ProviderFeature.ARTIST_TOPALBUMS in self.supported_features:
+            raise NotImplementedError
+        return []
+
     async def resolve_image(self, path: str) -> str | bytes:
         """
         Resolve an image from an image path.

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -136,66 +136,63 @@ class MusicProvider(Provider):
         raise NotImplementedError
 
     async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
-        """Get a list of all albums for the given artist.
+        """
+        Get a list of all albums for the given artist.
 
         Only called if provider supports ProviderFeature.ARTIST_ALBUMS.
         """
         raise NotImplementedError
 
+    async def get_artist_tracks(self, prov_artist_id: str) -> list[Track]:
+        """
+        Get a list of all tracks for the given artist.
+
+        Only called if provider supports ProviderFeature.ARTIST_TRACKS.
+        """
+        raise NotImplementedError
+
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
-        """Get a list of most popular tracks for the given artist.
+        """
+        Get a list of most popular tracks for the given artist.
 
         Only called if provider supports ProviderFeature.ARTIST_TOPTRACKS.
         """
         raise NotImplementedError
 
-    async def get_album(self, prov_album_id: str) -> Album:
-        """Get full album details by id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_ALBUMS.
+    async def get_artist_topalbums(self, prov_artist_id: str) -> list[Album]:
         """
+        Get a list of most popular albums for the given artist.
+
+        Only called if provider supports ProviderFeature.ARTIST_TOPALBUMS.
+        """
+        raise NotImplementedError
+
+    async def get_album(self, prov_album_id: str) -> Album:
+        """Get full album details by id."""
         raise NotImplementedError
 
     async def get_track(self, prov_track_id: str) -> Track:
-        """Get full track details by id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_TRACKS.
-        """
+        """Get full track details by id."""
         raise NotImplementedError
 
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
-        """Get full playlist details by id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_PLAYLISTS.
-        """
+        """Get full playlist details by id."""
         raise NotImplementedError
 
     async def get_radio(self, prov_radio_id: str) -> Radio:
-        """Get full radio details by id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_RADIOS.
-        """
+        """Get full radio details by id."""
         raise NotImplementedError
 
     async def get_audiobook(self, prov_audiobook_id: str) -> Audiobook:
-        """Get full audiobook details by id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_AUDIOBOOKS.
-        """
+        """Get full audiobook details by id."""
         raise NotImplementedError
 
     async def get_podcast(self, prov_podcast_id: str) -> Podcast:
-        """Get full podcast details by id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_PODCASTS.
-        """
+        """Get full podcast details by id."""
         raise NotImplementedError
 
     async def get_podcast_episode(self, prov_episode_id: str) -> PodcastEpisode:
-        """Get (full) podcast episode details by id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_PODCASTS.
-        """
+        """Get (full) podcast episode details by id."""
         raise NotImplementedError
 
     async def get_item_genre_names(self, media_type: MediaType, item_id: str) -> set[str]:
@@ -206,10 +203,7 @@ class MusicProvider(Provider):
         self,
         prov_album_id: str,
     ) -> list[Track]:
-        """Get album tracks for given album id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_ALBUMS.
-        """
+        """Get album tracks for given album id."""
         raise NotImplementedError
 
     async def get_playlist_tracks(
@@ -217,20 +211,14 @@ class MusicProvider(Provider):
         prov_playlist_id: str,
         page: int = 0,
     ) -> Sequence[PlaylistPlayableItem]:
-        """Get all playlist tracks for given playlist id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_PLAYLISTS.
-        """
+        """Get all playlist tracks for given playlist id."""
         raise NotImplementedError
 
     async def get_podcast_episodes(
         self,
         prov_podcast_id: str,
     ) -> AsyncGenerator[PodcastEpisode]:
-        """Get all PodcastEpisodes for given podcast id.
-
-        Only called if provider supports ProviderFeature.LIBRARY_PODCASTS.
-        """
+        """Get all PodcastEpisodes for given podcast id."""
         yield  # type: ignore[misc]
         raise NotImplementedError
 
@@ -377,21 +365,24 @@ class MusicProvider(Provider):
     async def remove_playlist_tracks(
         self, prov_playlist_id: str, positions_to_remove: tuple[int, ...]
     ) -> None:
-        """Remove track(s) from playlist.
+        """
+        Remove track(s) from playlist.
 
         Only called if provider supports ProviderFeature.PLAYLIST_TRACKS_EDIT.
         """
         raise NotImplementedError
 
     async def create_playlist(self, name: str, media_types: set[MediaType]) -> Playlist:
-        """Create a new playlist on provider with given name and targeting media_types.
+        """
+        Create a new playlist on provider with given name and targeting media_types.
 
         Only called if provider supports ProviderFeature.PLAYLIST_CREATE.
         """
         raise NotImplementedError
 
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
-        """Retrieve a dynamic list of similar tracks based on the provided track.
+        """
+        Retrieve a dynamic list of similar tracks based on the provided track.
 
         Only called if provider supports ProviderFeature.SIMILAR_TRACKS.
         """

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -1105,16 +1105,19 @@ class BuiltinProvider(MusicProvider):
 
     @use_cache(expiration=3600, category=CACHE_CATEGORY_PLAYLISTS)
     async def _get_builtin_playlist_random_artist(self) -> list[Track]:
-        for in_library_only in (True, False):
+        for source in ("library", "top"):
             for min_tracks_required in (25, 10, 5, 1):
                 for random_artist in await self.mass.music.artists.library_items(
                     limit=25, order_by="random"
                 ):
-                    tracks = await self.mass.music.artists.tracks(
-                        random_artist.item_id,
-                        random_artist.provider,
-                        in_library_only=in_library_only,
-                    )
+                    if source == "library":
+                        tracks = await self.mass.music.artists.tracks(
+                            random_artist.item_id, "library"
+                        )
+                    else:
+                        tracks = await self.mass.music.artists.top_tracks(
+                            random_artist.item_id, random_artist.provider
+                        )
                     if len(tracks) < min_tracks_required:
                         continue
                     for idx, track in enumerate(tracks, 1):

--- a/tests/test_cross_type_features.py
+++ b/tests/test_cross_type_features.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock
 
 from music_assistant_models.enums import MediaType, ProviderFeature, ProviderType
-from music_assistant_models.media_items import ProviderMapping, SearchResults
+from music_assistant_models.media_items import Artist, ProviderMapping, SearchResults
 
 from music_assistant.controllers.media.artists import ArtistsController
 from music_assistant.controllers.media.tracks import TracksController
@@ -115,74 +115,75 @@ async def test_similar_tracks_falls_back_to_metadata_provider() -> None:
     assert call_kwargs.get("limit") == 5
 
 
-async def test_similar_artists_uses_music_provider_first() -> None:
-    """Similar artists should prefer a music provider mapped to the artist."""
+def _artist(item_id: str, name: str, instance: str) -> Artist:
+    """Build a minimal Artist for the given provider instance."""
+    return Artist(
+        item_id=item_id,
+        provider=instance,
+        name=name,
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain=instance, provider_instance=instance)
+        },
+    )
+
+
+async def test_similar_artists_aggregates_across_providers() -> None:
+    """Similar artists for a library artist aggregate (and dedupe) across all its providers."""
     mass = Mock()
     music_prov = Mock(spec=MusicProvider)
-    music_prov.instance_id = "m_a"
-    music_prov.type = ProviderType.MUSIC
     music_prov.available = True
     music_prov.supported_features = {ProviderFeature.SIMILAR_ARTISTS}
-    music_prov.get_similar_artists = AsyncMock(return_value=["a1"])
-    mass.get_provider.return_value = music_prov
-    mass.get_providers_supporting_feature.return_value = []
-
-    ref_item = Mock()
-    ref_item.provider_mappings = [
-        ProviderMapping(
-            item_id="artist_123",
-            provider_domain="m_a",
-            provider_instance="m_a",
-            available=True,
-        )
-    ]
-
-    controller = ArtistsController.__new__(ArtistsController)
-    controller.mass = mass
-    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
-
-    result = await controller.similar_artists("artist_123", "m_a", limit=5)
-
-    assert result == ["a1"]
-    music_prov.get_similar_artists.assert_awaited_once_with(prov_artist_id="artist_123", limit=5)
-
-
-async def test_similar_artists_falls_back_to_metadata_provider() -> None:
-    """Falls through to metadata-tier provider when music provider doesn't support it."""
-    mass = Mock()
-    music_prov = Mock(spec=MusicProvider)
-    music_prov.instance_id = "m_a"
-    music_prov.type = ProviderType.MUSIC
-    music_prov.available = True
-    music_prov.supported_features = set()
+    music_prov.supports_feature = lambda feature: feature in music_prov.supported_features
+    music_prov.get_similar_artists = AsyncMock(
+        return_value=[_artist("a", "Artist A", "m_a"), _artist("b", "Artist B", "m_a")]
+    )
     metadata_prov = Mock(spec=MetadataProvider)
     metadata_prov.instance_id = "meta_a"
-    metadata_prov.type = ProviderType.METADATA
-    metadata_prov.available = True
-    metadata_prov.supported_features = {ProviderFeature.SIMILAR_ARTISTS}
-    metadata_prov.priority = 50
-    metadata_prov.get_similar_artists = AsyncMock(return_value=["a2"])
+    metadata_prov.get_similar_artists = AsyncMock(
+        return_value=[_artist("b2", "Artist B", "meta_a"), _artist("c", "Artist C", "meta_a")]
+    )
     mass.get_provider.return_value = music_prov
     mass.get_providers_supporting_feature.return_value = [metadata_prov]
 
     ref_item = Mock()
     ref_item.provider_mappings = [
-        ProviderMapping(
-            item_id="artist_123",
-            provider_domain="m_a",
-            provider_instance="m_a",
-            available=True,
-        )
+        ProviderMapping(item_id="artist_123", provider_domain="m_a", provider_instance="m_a")
     ]
 
     controller = ArtistsController.__new__(ArtistsController)
     controller.mass = mass
-    controller.get = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+    controller.get_library_item = AsyncMock(return_value=ref_item)  # type: ignore[method-assign]
+    # keep provider items (not resolved to a library equivalent)
+    controller.get_library_item_by_prov_id = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    result = await controller.similar_artists("1", "library", limit=5)
+
+    # interleaved by rank, deduped on name ("Artist B" appears in both providers)
+    assert [artist.name for artist in result] == ["Artist A", "Artist B", "Artist C"]
+    music_prov.get_similar_artists.assert_awaited_once_with("artist_123", limit=5)
+    metadata_prov.get_similar_artists.assert_awaited_once_with(ref_item, limit=5)
+
+
+async def test_similar_artists_provider_queries_named_provider() -> None:
+    """Similar artists for a provider artist should query only that provider."""
+    mass = Mock()
+    music_prov = Mock(spec=MusicProvider)
+    music_prov.name = "Music Provider A"
+    music_prov.available = True
+    music_prov.supported_features = {ProviderFeature.SIMILAR_ARTISTS}
+    music_prov.supports_feature = lambda feature: feature in music_prov.supported_features
+    music_prov.get_similar_artists = AsyncMock(return_value=[_artist("x", "Artist X", "m_a")])
+    mass.get_provider.return_value = music_prov
+
+    controller = ArtistsController.__new__(ArtistsController)
+    controller.mass = mass
+    # keep provider items (not resolved to a library equivalent)
+    controller.get_library_item_by_prov_id = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     result = await controller.similar_artists("artist_123", "m_a", limit=5)
 
-    assert result == ["a2"]
-    metadata_prov.get_similar_artists.assert_awaited_once_with(ref_item, limit=5)
+    assert [artist.name for artist in result] == ["Artist X"]
+    music_prov.get_similar_artists.assert_awaited_once_with("artist_123", limit=5)
 
 
 async def test_browse_root_includes_non_music_providers() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Browsing an artist conflated two different things: the **library artist** (the aggregated, db-backed view of an artist you've saved) and the **per-provider listing** (what a single provider returns for that artist). On top of that, `tracks()`/`albums()` were overloaded with `in_library_only`/`provider_filter` flags that silently merged "all" and "top/featured" results.

This splits the artist endpoints into a clear, predictable shape:

- **`tracks` / `albums`** → the in-library tracks/albums for the artist, with an optional `provider_filter` to narrow to a single provider instance. A provider item returns that provider's own listing (empty if the provider doesn't implement it).
- **`top_tracks` / `top_albums`** → the top/featured listing. For a library artist the top items of *all* its providers (plus any metadata/plugin provider implementing the feature) are fetched in parallel, interleaved by rank, deduplicated and resolved to their library equivalents; optional `provider_filter` narrows to one provider.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Split the artist listings: `tracks`/`albums` are now library-centric (optionally filtered to one provider), `top_tracks`/`top_albums` return the top/featured listing aggregated across all of the artist's providers.
- Add `music/artists/top_tracks` and `music/artists/top_albums` API commands.
- Top listings for a library artist are fetched per-provider in parallel, interleaved by rank, deduplicated (via the compare helpers, matching on version/duration) and resolved to library items.
- Add provider hooks: `MusicProvider.get_artist_tracks` (`ARTIST_TRACKS`, with an album-enumeration fallback when unsupported) and `get_artist_topalbums` (`ARTIST_TOPALBUMS`); plus metadata-provider `get_artist_toptracks`/`get_artist_topalbums`.
- Library tracks/albums now correctly filter on `in_library`, so only items actually in the library are returned (not merely linked ones).
- Reword the enqueue-artist options for clarity (no behaviour/value change).
- Update the radio seed, MusicBrainz lookup and builtin random-artist playlist to the new endpoints.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
