### PR TITLE
Improve error handling for Spotify API responses 

### DIFF
--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -18,8 +18,8 @@ from music_assistant_models.enums import (
 )
 from music_assistant_models.errors import (
     AudioError,
-    LoginFailed,
     InvalidDataError,
+    LoginFailed,
     MediaNotFoundError,
     ProviderUnavailableError,
     ResourceTemporarilyUnavailable,
@@ -1252,11 +1252,12 @@ class SpotifyProvider(MusicProvider):
                 )
 
                 if response.status == 400:
-                    raise InvalidDataError (f"Spotify API error ({response.status}): {message}")
-                elif response.status == 403:
-                    raise ProviderUnavailableError(f"Spotify API error ({response.status}): {message}")
-                else:
-                    raise MediaNotFoundError(f"{endpoint} not found")
+                    raise InvalidDataError(f"Spotify API error ({response.status}): {message}")
+                if response.status == 403:
+                    raise ProviderUnavailableError(
+                        f"Spotify API error ({response.status}): {message}"
+                    )
+                raise MediaNotFoundError(f"{endpoint} not found")
 
             response.raise_for_status()
             result: dict[str, Any] = await response.json(loads=json_loads)

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -19,6 +19,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import (
     AudioError,
     LoginFailed,
+    InvalidDataError,
     MediaNotFoundError,
     ProviderUnavailableError,
     ResourceTemporarilyUnavailable,
@@ -1250,7 +1251,12 @@ class SpotifyProvider(MusicProvider):
                     message,
                 )
 
-                raise MediaNotFoundError(f"{endpoint} not found")
+                if response.status == 400:
+                        raise InvalidDataError (f"Spotify API error ({response.status}): {message}")
+                elif response.status == 403:
+                        raise ProviderUnavailableError(f"Spotify API error ({response.status}): {message}")
+                else:
+                        raise MediaNotFoundError(f"{endpoint} not found")
 
             response.raise_for_status()
             result: dict[str, Any] = await response.json(loads=json_loads)

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -1252,11 +1252,11 @@ class SpotifyProvider(MusicProvider):
                 )
 
                 if response.status == 400:
-                        raise InvalidDataError (f"Spotify API error ({response.status}): {message}")
+                    raise InvalidDataError (f"Spotify API error ({response.status}): {message}")
                 elif response.status == 403:
-                        raise ProviderUnavailableError(f"Spotify API error ({response.status}): {message}")
+                    raise ProviderUnavailableError(f"Spotify API error ({response.status}): {message}")
                 else:
-                        raise MediaNotFoundError(f"{endpoint} not found")
+                    raise MediaNotFoundError(f"{endpoint} not found")
 
             response.raise_for_status()
             result: dict[str, Any] = await response.json(loads=json_loads)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Handle specific Spotify API error responses for better error management.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
