### PR TITLE
Add error handling for provider search

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -505,11 +505,15 @@ class MusicController(CoreController):
 
         # create safe search string
         search_query = search_query.replace("/", " ").replace("'", "")
-        prov_search_results = await prov.search(
-            search_query,
-            media_types,
-            limit,
-        )
+        try:
+            prov_search_results = await prov.search(
+                search_query,
+                media_types,
+                limit,
+            )
+        except MusicAssistantError as err:
+            self.logger.warning("Search on provider %s failed: %s", prov.name, err)
+            return SearchResults()
         if skip_item_ids:
             # filter out items already in skip_item_ids
             prov_search_results.artists = [

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -513,7 +513,7 @@ class MusicController(CoreController):
             )
         except MusicAssistantError as err:
             self.logger.warning("Search on provider %s failed: %s", prov.name, err)
-            raise MusicAssistantError(f"{prov.name} search failed") from err
+            raise MusicAssistantError(f"Search failed due to an error on {prov.name}") from err
         if skip_item_ids:
             # filter out items already in skip_item_ids
             prov_search_results.artists = [

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -513,7 +513,7 @@ class MusicController(CoreController):
             )
         except MusicAssistantError as err:
             self.logger.warning("Search on provider %s failed: %s", prov.name, err)
-            return SearchResults()
+            raise MusicAssistantError(f"{prov.name} search failed") from err
         if skip_item_ids:
             # filter out items already in skip_item_ids
             prov_search_results.artists = [


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Dont crash the whole search if a provider errors out

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5561

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
