### PR TITLE
Hide HTTP profile and ICY metadata config entries for Samsung WAM

### DIFF
--- a/music_assistant/providers/samsung_wam/__init__.py
+++ b/music_assistant/providers/samsung_wam/__init__.py
@@ -1,4 +1,4 @@
-"""Samsung Wireless Audio (WAM) Player provider for Music Assistant."""
+"""Samsung WAM player provider for Music Assistant."""
 
 from __future__ import annotations
 

--- a/music_assistant/providers/samsung_wam/consts.py
+++ b/music_assistant/providers/samsung_wam/consts.py
@@ -3,7 +3,7 @@
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import PlayerFeature
 
-from music_assistant.constants import CONF_ENTRY_HTTP_PROFILE
+from music_assistant.constants import CONF_ENTRY_HTTP_PROFILE_DEFAULT_3
 
 # --- Global Provider Settings ---
 
@@ -26,5 +26,5 @@ PLAYER_FEATURES_BASE = {
 # --- Configuration Entries ---
 
 CONF_ENTRY_HTTP_PROFILE_WAM = ConfigEntry.from_dict(
-    {**CONF_ENTRY_HTTP_PROFILE.to_dict(), "default_value": "forced_content_length"}
+    {**CONF_ENTRY_HTTP_PROFILE_DEFAULT_3.to_dict(), "hidden": True}
 )

--- a/music_assistant/providers/samsung_wam/manifest.json
+++ b/music_assistant/providers/samsung_wam/manifest.json
@@ -1,13 +1,13 @@
 {
   "type": "player",
   "domain": "samsung_wam",
-  "name": "Samsung Wireless Audio (WAM)",
+  "name": "Samsung WAM",
   "description": "Support for Samsung's Wireless Audio Multiroom (WAM) speakers.",
   "codeowners": ["@oliver-stevens"],
   "requirements": [
     "pywam==0.2.0"
   ],
-  "documentation": "https://music-assistant.io/player-support/samsung_wam/",
+  "documentation": "https://music-assistant.io/player-support/samsung-wam/",
   "multi_instance": false,
   "upnp_discovery": ["urn:samsung.com:device:RemoteControlReceiver:1"]
 }

--- a/music_assistant/providers/samsung_wam/player.py
+++ b/music_assistant/providers/samsung_wam/player.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from music_assistant_models.enums import IdentifierType, PlaybackState
 from music_assistant_models.player import DeviceInfo, PlayerMedia
 
+from music_assistant.constants import CONF_ENTRY_ENABLE_ICY_METADATA_HIDDEN
 from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player
@@ -128,7 +129,7 @@ class WamPlayer(Player):
         :param values: The current configuration values.
         :return: A list of ConfigEntry objects.
         """
-        return [CONF_ENTRY_HTTP_PROFILE_WAM]
+        return [CONF_ENTRY_HTTP_PROFILE_WAM, CONF_ENTRY_ENABLE_ICY_METADATA_HIDDEN]
 
     async def on_config_updated(self) -> None:
         """Handle player config updates."""


### PR DESCRIPTION
# What does this implement/fix?

Hides the HTTP profile config entry (WAM requires Profile 3 for URL streaming; other profiles break playback) and ICY metadata entry (not applicable to WAM hardware).
Also updates the provider name to "Samsung WAM" and fixes the documentation URL (`samsung_wam` → `samsung-wam`).

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
