### PR TITLE
Import album tracks when manually adding an album and Import Album Tracks setting enabled

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1165,9 +1165,23 @@ class MusicController(CoreController):
         # add (or overwrite) to library
         ctrl = self.get_controller(full_item.media_type)
         library_item = await ctrl.add_item_to_library(full_item, overwrite_existing)
+        # optionally import all album tracks into the library, mirroring the behavior
+        # of the library sync (which only triggers on a (scheduled) full sync run)
+        if full_item.media_type == MediaType.ALBUM:
+            self._import_album_tracks_if_enabled(cast("Album", library_item))
         # perform full metadata scan
         await self.mass.metadata.update_metadata(library_item, overwrite_existing)
         return library_item
+
+    def _import_album_tracks_if_enabled(self, album: Album) -> None:
+        """Import all album tracks into the library for providers that have this enabled."""
+        for prov_mapping in album.provider_mappings:
+            provider = self.mass.get_provider(prov_mapping.provider_instance)
+            if not isinstance(provider, MusicProvider):
+                continue
+            if not provider.library_sync_album_tracks_enabled():
+                continue
+            self.mass.create_task(provider.import_album_tracks(prov_mapping.item_id, album.name))
 
     async def refresh_items(self, items: list[MediaItemType]) -> None:
         """Refresh MediaItems to force retrieval of full info and matches.

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1176,6 +1176,11 @@ class MusicController(CoreController):
     def _import_album_tracks_if_enabled(self, album: Album) -> None:
         """Import all album tracks into the library for providers that have this enabled."""
         for prov_mapping in album.provider_mappings:
+            # only consider mappings the album was actually added on; additional
+            # mappings auto-created for other instances of the same provider
+            # (via match_provider_instances) carry in_library=None and must be skipped
+            if not prov_mapping.in_library:
+                continue
             provider = self.mass.get_provider(prov_mapping.provider_instance)
             if not isinstance(provider, MusicProvider):
                 continue

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -857,15 +857,20 @@ class MusicProvider(Provider):
                 self._report_sync_task_failure(MediaType.ARTIST, prov_item.uri, err)
         return cur_db_ids
 
+    def library_sync_album_tracks_enabled(self) -> bool:
+        """Return whether all tracks of an album should be imported into the library."""
+        return bool(
+            self.config.get_value(
+                CONF_ENTRY_LIBRARY_SYNC_ALBUM_TRACKS.key,
+                CONF_ENTRY_LIBRARY_SYNC_ALBUM_TRACKS.default_value,
+            )
+        )
+
     async def _sync_library_albums(self) -> set[int]:
         """Sync Library Albums to Music Assistant library."""
         self.logger.debug("Start sync of Albums to Music Assistant library.")
         cur_db_ids: set[int] = set()
-        conf_sync_album_tracks = self.config.get_value(
-            CONF_ENTRY_LIBRARY_SYNC_ALBUM_TRACKS.key,
-            CONF_ENTRY_LIBRARY_SYNC_ALBUM_TRACKS.default_value,
-        )
-        sync_album_tracks = bool(conf_sync_album_tracks)
+        sync_album_tracks = self.library_sync_album_tracks_enabled()
         item_count = 0
         async for prov_item in self.get_library_albums():
             item_count += 1
@@ -907,7 +912,7 @@ class MusicProvider(Provider):
                 await asyncio.sleep(0)  # yield to eventloop
                 # optionally add album tracks to library
                 if sync_album_tracks:
-                    await self._sync_album_tracks(prov_item)
+                    await self.import_album_tracks(prov_item.item_id, prov_item.name)
             except MusicAssistantError as err:
                 self.logger.warning(
                     "Skipping sync of album %s - error details: %s",
@@ -917,14 +922,19 @@ class MusicProvider(Provider):
                 self._report_sync_task_failure(MediaType.ALBUM, prov_item.uri, err)
         return cur_db_ids
 
-    async def _sync_album_tracks(self, provider_album: Album) -> None:
-        """Sync Album Tracks to Music Assistant library."""
+    async def import_album_tracks(self, prov_album_id: str, album_name: str | None = None) -> None:
+        """
+        Import all tracks of the given (provider) album into the Music Assistant library.
+
+        :param prov_album_id: The provider item id of the album.
+        :param album_name: Optional album name, used for logging/progress only.
+        """
         self.logger.debug(
-            "Start sync of Album Tracks to Music Assistant library for album %s.",
-            provider_album.name,
+            "Importing Album Tracks into the Music Assistant library for album %s.",
+            album_name or prov_album_id,
         )
         for item_count, prov_track in enumerate(
-            await self.get_album_tracks(provider_album.item_id), start=1
+            await self.get_album_tracks(prov_album_id), start=1
         ):
             self._update_sync_task_item_status(MediaType.TRACK, item_count, prov_track.name)
             library_track = await self.mass.music.tracks.get_library_item_by_prov_mappings(

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -12,7 +12,10 @@ from music_assistant_models.media_items import Album, AudioFormat, ProviderMappi
 from music_assistant.constants import CONF_ENTRY_LIBRARY_SYNC_BACK
 from music_assistant.controllers.media.base import MediaControllerBase
 from music_assistant.controllers.music import MusicController
-from music_assistant.models.music_provider import CACHE_CATEGORY_PREV_LIBRARY_IDS
+from music_assistant.models.music_provider import (
+    CACHE_CATEGORY_PREV_LIBRARY_IDS,
+    MusicProvider,
+)
 
 # --- Helpers ---
 
@@ -164,6 +167,76 @@ async def test_add_item_to_library_sets_in_library_even_when_edit_not_supported(
         await music_ctrl.add_item_to_library(album)
 
     assert mapping.in_library is True
+    mass.create_task.assert_not_called()
+
+
+async def test_add_album_imports_tracks_when_enabled() -> None:
+    """Test that adding an album imports its tracks when the setting is enabled.
+
+    The "Import album tracks" behavior previously only triggered during a (scheduled)
+    library sync. Adding an album manually should mirror it when the provider has the
+    setting enabled.
+    """
+    mapping = create_provider_mapping(
+        provider_instance="qobuz_1", provider_domain="qobuz", item_id="album_xyz", in_library=None
+    )
+    album = create_mock_album(provider="qobuz", provider_mappings=[mapping])
+
+    mass = Mock()
+    ctrl_mock = AsyncMock()
+    ctrl_mock.add_item_to_library = AsyncMock(return_value=album)
+
+    provider_mock = Mock(spec=MusicProvider)
+    provider_mock.type = ProviderType.MUSIC
+    provider_mock.supports_feature.return_value = False
+    provider_mock.library_sync_album_tracks_enabled.return_value = True
+    sentinel = object()
+    provider_mock.import_album_tracks = Mock(return_value=sentinel)
+
+    music_ctrl = MusicController.__new__(MusicController)
+    music_ctrl.mass = mass
+    mass.get_provider.return_value = provider_mock
+    mass.metadata = AsyncMock()
+
+    with (
+        patch.object(music_ctrl, "get_controller", return_value=ctrl_mock),
+        patch.object(music_ctrl, "get_item", new_callable=AsyncMock, return_value=album),
+    ):
+        await music_ctrl.add_item_to_library(album)
+
+    provider_mock.import_album_tracks.assert_called_once_with("album_xyz", album.name)
+    mass.create_task.assert_called_once_with(sentinel)
+
+
+async def test_add_album_does_not_import_tracks_when_disabled() -> None:
+    """Test that adding an album does NOT import its tracks when the setting is disabled."""
+    mapping = create_provider_mapping(
+        provider_instance="qobuz_1", provider_domain="qobuz", item_id="album_xyz", in_library=None
+    )
+    album = create_mock_album(provider="qobuz", provider_mappings=[mapping])
+
+    mass = Mock()
+    ctrl_mock = AsyncMock()
+    ctrl_mock.add_item_to_library = AsyncMock(return_value=album)
+
+    provider_mock = Mock(spec=MusicProvider)
+    provider_mock.type = ProviderType.MUSIC
+    provider_mock.supports_feature.return_value = False
+    provider_mock.library_sync_album_tracks_enabled.return_value = False
+    provider_mock.import_album_tracks = Mock()
+
+    music_ctrl = MusicController.__new__(MusicController)
+    music_ctrl.mass = mass
+    mass.get_provider.return_value = provider_mock
+    mass.metadata = AsyncMock()
+
+    with (
+        patch.object(music_ctrl, "get_controller", return_value=ctrl_mock),
+        patch.object(music_ctrl, "get_item", new_callable=AsyncMock, return_value=album),
+    ):
+        await music_ctrl.add_item_to_library(album)
+
+    provider_mock.import_album_tracks.assert_not_called()
     mass.create_task.assert_not_called()
 
 

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -240,6 +240,53 @@ async def test_add_album_does_not_import_tracks_when_disabled() -> None:
     mass.create_task.assert_not_called()
 
 
+async def test_add_album_only_imports_tracks_for_added_instance() -> None:
+    """Test that track import skips auto-added mappings for other provider instances.
+
+    match_provider_instances adds extra mappings (in_library=None) for sibling
+    instances of the same provider. Those must not trigger a track import; only the
+    mapping the album was actually added on (in_library=True) should.
+    """
+    added_mapping = create_provider_mapping(
+        provider_instance="qobuz_1", provider_domain="qobuz", item_id="album_xyz", in_library=True
+    )
+    sibling_mapping = create_provider_mapping(
+        provider_instance="qobuz_2", provider_domain="qobuz", item_id="album_xyz", in_library=None
+    )
+    input_album = create_mock_album(
+        provider="qobuz", provider_mappings=[create_provider_mapping(in_library=None)]
+    )
+    # the controller returns the merged library item with both mappings present
+    library_album = create_mock_album(
+        provider="library", provider_mappings=[added_mapping, sibling_mapping]
+    )
+
+    mass = Mock()
+    ctrl_mock = AsyncMock()
+    ctrl_mock.add_item_to_library = AsyncMock(return_value=library_album)
+
+    provider_mock = Mock(spec=MusicProvider)
+    provider_mock.type = ProviderType.MUSIC
+    provider_mock.supports_feature.return_value = False
+    provider_mock.library_sync_album_tracks_enabled.return_value = True
+    sentinel = object()
+    provider_mock.import_album_tracks = Mock(return_value=sentinel)
+
+    music_ctrl = MusicController.__new__(MusicController)
+    music_ctrl.mass = mass
+    mass.get_provider.return_value = provider_mock
+    mass.metadata = AsyncMock()
+
+    with (
+        patch.object(music_ctrl, "get_controller", return_value=ctrl_mock),
+        patch.object(music_ctrl, "get_item", new_callable=AsyncMock, return_value=input_album),
+    ):
+        await music_ctrl.add_item_to_library(input_album)
+
+    provider_mock.import_album_tracks.assert_called_once_with("album_xyz", library_album.name)
+    mass.create_task.assert_called_once_with(sentinel)
+
+
 # --- Group 2: Refresh item preserves in_library ---
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The "Import album tracks" library option only took effect during a library sync via `_sync_library_albums`. When a user enabled the setting and added an album to the library from the UI, the album's tracks were never imported, since the manual add path (music/library/add_item) never invoked the album-track import logic.

This PR extracts the album-track import into a reusable `MusicProvider.import_album_tracks` method (plus a `library_sync_album_tracks_enabled` helper) and invokes it from `add_item_to_library` for any provider mapping that has the setting enabled, mirroring the sync behavior. This affects all streaming providers but was reported against Qobuz.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
