### PR TITLE
Add Bandcamp feed and wishlist recommendations

### DIFF
--- a/music_assistant/providers/bandcamp/__init__.py
+++ b/music_assistant/providers/bandcamp/__init__.py
@@ -22,6 +22,7 @@ from bandcamp_async_api.models import (
     CollectionSummary,
     CollectionType,
     FanItem,
+    FeedResponse,
     FollowingItem,
 )
 from mashumaro.exceptions import UnserializableDataError
@@ -46,8 +47,10 @@ from music_assistant_models.media_items import (
     ItemMapping,
     MediaItemImage,
     MediaItemType,
+    RecommendationFolder,
     SearchResults,
     Track,
+    UniqueList,
 )
 from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.streamdetails import StreamDetails
@@ -486,6 +489,65 @@ class BandcampProvider(MusicProvider):
                 break
 
         return tracks[: self.top_tracks_limit]
+
+    async def recommendations(self) -> list[RecommendationFolder]:
+        """Surface Bandcamp's personalised feed and wishlist as recommendations."""
+        if not self._client.identity:
+            return []
+        folders: list[RecommendationFolder] = []
+        if feed_tracks := await self._get_feed_tracks():
+            folders.append(
+                RecommendationFolder(
+                    item_id="feed",
+                    provider=self.instance_id,
+                    name="Bandcamp Feed",
+                    icon="mdi-rss",
+                    items=UniqueList(feed_tracks),
+                )
+            )
+        if wishlist := await self._browse_person_content(None, CollectionType.WISHLIST):
+            folders.append(
+                RecommendationFolder(
+                    item_id="wishlist",
+                    provider=self.instance_id,
+                    name="Wishlist",
+                    icon="mdi-heart",
+                    items=UniqueList(wishlist),
+                )
+            )
+        return folders
+
+    @throttle_with_retries
+    async def _fetch_feed(self) -> FeedResponse:
+        """Fetch the authenticated user's feed with throttling and retry."""
+        try:
+            return await self._client.get_feed()
+        except BandcampRateLimitError as error:
+            raise ResourceTemporarilyUnavailable(
+                "Bandcamp rate limit reached", backoff_time=error.retry_after
+            ) from error
+
+    async def _get_feed_tracks(self) -> list[Track]:
+        """Fetch and convert the streamable tracks from the user's feed."""
+        cache_key = "_feed_tracks"
+        cached = await self.mass.cache.get(cache_key, provider=self.instance_id, base_class=Track)
+        if cached is not None:
+            return cached  # type: ignore[no-any-return]
+        tracks: list[Track] = []
+        async with self._map_api_errors("Failed to get Bandcamp feed"):
+            feed = await self._fetch_feed()
+            tracks = [
+                self._converters.track_from_feed(track)
+                for track in feed.track_list
+                if track.streaming_url
+            ]
+        await self.mass.cache.set(
+            cache_key,
+            [t.to_dict() for t in tracks],
+            expiration=CACHE_USER_LISTS if tracks else CACHE_EMPTY_RESULTS,
+            provider=self.instance_id,
+        )
+        return tracks
 
     async def browse(self, path: str) -> Sequence[MediaItemType | ItemMapping | BrowseFolder]:
         """Browse this provider's items.

--- a/music_assistant/providers/bandcamp/constants.py
+++ b/music_assistant/providers/bandcamp/constants.py
@@ -11,6 +11,7 @@ SUPPORTED_FEATURES = {
     ProviderFeature.ARTIST_ALBUMS,
     ProviderFeature.ARTIST_TOPTRACKS,
     ProviderFeature.BROWSE,
+    ProviderFeature.RECOMMENDATIONS,
 }
 
 # Config keys

--- a/music_assistant/providers/bandcamp/converters.py
+++ b/music_assistant/providers/bandcamp/converters.py
@@ -8,6 +8,7 @@ from bandcamp_async_api.models import BCAlbum as APIAlbum
 from bandcamp_async_api.models import BCArtist as APIArtist
 from bandcamp_async_api.models import BCTrack as APITrack
 from bandcamp_async_api.models import (
+    FeedTrack,
     SearchResultAlbum,
     SearchResultArtist,
     SearchResultTrack,
@@ -239,6 +240,56 @@ class BandcampConverters:
                 MediaItemImage(
                     type=ImageType.THUMB,
                     path=album_image_url,
+                    provider=self.instance_id,
+                    remotely_accessible=True,
+                )
+            )
+        return output
+
+    def track_from_feed(self, track: FeedTrack) -> MATrack:
+        """Convert a feed track_list entry to MA Track format."""
+        album_id = track.album_id or 0
+        item_id = f"{track.band_id}-{album_id}-{track.track_id}"
+        _, bitrate, content_type = self.streaming_url_from_api(track.streaming_url or {})
+        output = MATrack(
+            item_id=item_id,
+            provider=self.instance_id,
+            name=track.title,
+            duration=int(track.duration) if track.duration else 0,
+            artists=UniqueList(
+                [
+                    ItemMapping(
+                        media_type=MediaType.ARTIST,
+                        item_id=str(track.band_id),
+                        provider=self.instance_id,
+                        name=track.band_name,
+                    )
+                ]
+            ),
+            provider_mappings={
+                ProviderMapping(
+                    item_id=item_id,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                    url=track.track_url,
+                    audio_format=AudioFormat(content_type=content_type, bit_rate=bitrate),
+                )
+            },
+        )
+        if track.track_num is not None:
+            output.track_number = track.track_num
+        if album_id:
+            output.album = ItemMapping(
+                media_type=MediaType.ALBUM,
+                item_id=f"{track.band_id}-{album_id}",
+                provider=self.instance_id,
+                name=track.album_title or "",
+            )
+        if track.art_id:
+            output.metadata.add_image(
+                MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=f"https://f4.bcbits.com/img/a{track.art_id}_0.jpg",
                     provider=self.instance_id,
                     remotely_accessible=True,
                 )

--- a/tests/providers/bandcamp/test_converters.py
+++ b/tests/providers/bandcamp/test_converters.py
@@ -3,7 +3,7 @@
 from unittest.mock import Mock
 
 import pytest
-from bandcamp_async_api.models import BCAlbum, BCArtist, BCTrack
+from bandcamp_async_api.models import BCAlbum, BCArtist, BCTrack, FeedTrack
 from music_assistant_models.enums import ContentType
 
 from music_assistant.providers.bandcamp.converters import BandcampConverters, DiscographyItem
@@ -250,6 +250,43 @@ def test_track_from_api_audio_format_none_streaming_url(converters: BandcampConv
     mapping = next(iter(result.provider_mappings))
     assert mapping.audio_format.content_type == ContentType.MP3
     assert mapping.audio_format.bit_rate is None
+
+
+def test_track_from_feed(converters: BandcampConverters) -> None:
+    """Test converting a FeedTrack to MA Track."""
+    track = FeedTrack(
+        track_id=789,
+        title="Feed Track",
+        band_id=123,
+        band_name="Test Artist",
+        album_id=456,
+        album_title="Test Album",
+        track_num=3,
+        duration=212.5,
+        streaming_url={"mp3-128": "https://example.com/feed.mp3"},
+        art_id=987,
+        track_url="https://test.bandcamp.com/track/feed-track",
+    )
+
+    result = converters.track_from_feed(track)
+
+    assert result.item_id == "123-456-789"
+    assert result.name == "Feed Track"
+    assert result.duration == 212
+    assert result.track_number == 3
+    assert result.album is not None
+    assert result.album.item_id == "123-456"
+    assert result.provider == "bandcamp_test"
+
+
+def test_track_from_feed_standalone(converters: BandcampConverters) -> None:
+    """Test a feed track without an album maps to album_id 0 and omits the album."""
+    track = FeedTrack(track_id=789, title="Single", band_id=123, band_name="Test Artist")
+
+    result = converters.track_from_feed(track)
+
+    assert result.item_id == "123-0-789"
+    assert result.album is None
 
 
 def test_streaming_url_priority_v0_over_320(converters: BandcampConverters) -> None:

--- a/tests/providers/bandcamp/test_provider.py
+++ b/tests/providers/bandcamp/test_provider.py
@@ -787,6 +787,82 @@ async def test_fetch_api_track_login_error(provider: BandcampProvider) -> None:
         await provider._fetch_api_track("123-456-789")
 
 
+# --- Recommendations tests ---
+
+
+async def test_recommendations_returns_feed_and_wishlist(provider: BandcampProvider) -> None:
+    """Test recommendations surfaces the feed and wishlist as folders."""
+    feed_track = Mock()
+    wishlist_album = Mock()
+
+    with (
+        patch.object(provider, "_get_feed_tracks", new_callable=AsyncMock) as mock_feed,
+        patch.object(provider, "_browse_person_content", new_callable=AsyncMock) as mock_wishlist,
+    ):
+        mock_feed.return_value = [feed_track]
+        mock_wishlist.return_value = [wishlist_album]
+
+        folders = await provider.recommendations()
+
+        mock_wishlist.assert_called_once_with(None, CollectionType.WISHLIST)
+        assert [f.name for f in folders] == ["Bandcamp Feed", "Wishlist"]
+        assert feed_track in folders[0].items
+        assert wishlist_album in folders[1].items
+
+
+async def test_recommendations_no_identity(provider: BandcampProvider) -> None:
+    """Test recommendations returns nothing without an identity token."""
+    provider._client.identity = None
+    assert await provider.recommendations() == []
+
+
+async def test_recommendations_omits_empty_folders(provider: BandcampProvider) -> None:
+    """Test that empty feed and wishlist produce no folders."""
+    with (
+        patch.object(provider, "_get_feed_tracks", new_callable=AsyncMock) as mock_feed,
+        patch.object(provider, "_browse_person_content", new_callable=AsyncMock) as mock_wishlist,
+    ):
+        mock_feed.return_value = []
+        mock_wishlist.return_value = []
+
+        assert await provider.recommendations() == []
+
+
+async def test_get_feed_tracks_filters_non_streamable(provider: BandcampProvider) -> None:
+    """Test _get_feed_tracks skips tracks without a streaming URL and caches the result."""
+    streamable = Mock(streaming_url={"mp3-128": "https://example.com/feed.mp3"})
+    silent = Mock(streaming_url=None)
+    converted = Mock()
+
+    with (
+        patch.object(provider, "_fetch_feed", new_callable=AsyncMock) as mock_fetch,
+        patch.object(
+            provider._converters, "track_from_feed", return_value=converted
+        ) as mock_convert,
+    ):
+        mock_fetch.return_value = Mock(track_list=[streamable, silent])
+
+        result = await provider._get_feed_tracks()
+
+        mock_convert.assert_called_once_with(streamable)
+        assert result == [converted]
+        cast("AsyncMock", provider.mass.cache.set).assert_called_once()
+
+
+async def test_get_feed_tracks_cache_hit(provider: BandcampProvider) -> None:
+    """Test _get_feed_tracks returns cached tracks without hitting the API."""
+    cached = [Mock()]
+
+    with (
+        patch.object(provider.mass.cache, "get", new_callable=AsyncMock, return_value=cached),
+        patch.object(provider, "_fetch_feed", new_callable=AsyncMock) as mock_fetch,
+    ):
+        result = await provider._get_feed_tracks()
+
+        mock_fetch.assert_not_called()
+        assert result == cached
+
+
 # --- Browse tests ---
 
 


### PR DESCRIPTION
# What does this implement/fix?

Surface the authenticated user's Bandcamp feed and wishlist on the recommendations view, mirroring the existing SoundCloud feed pattern. Feed tracks are converted from the `fan_dash_feed_updates` response; the wishlist reuses the cached collection content.

Screenshots:

<img width="737" height="279" alt="Screenshot 2026-05-31 at 10 15 13 PM" src="https://github.com/user-attachments/assets/f137bad5-88b4-4357-960c-1afe5053bd83" />
<img width="722" height="311" alt="Screenshot 2026-05-31 at 10 15 21 PM" src="https://github.com/user-attachments/assets/b2986951-2639-4569-b764-8a7245d7ec02" />
<img width="725" height="340" alt="Screenshot 2026-05-31 at 10 15 07 PM" src="https://github.com/user-attachments/assets/02109d9b-514d-4923-a53c-b0877913c654" />


<!-- Quick description and explanation of changes. -->

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
