### PR TITLE
Fix Deezer playback stalling on tracks with insufficient rights (error 2002)

### DIFF
--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -24,7 +24,12 @@ from music_assistant_models.enums import (
     ProviderFeature,
     StreamType,
 )
-from music_assistant_models.errors import AudioError, InvalidDataError, LoginFailed, MediaNotFoundError
+from music_assistant_models.errors import (
+    AudioError,
+    InvalidDataError,
+    LoginFailed,
+    MediaNotFoundError,
+)
 from music_assistant_models.media_items import (
     Album,
     Artist,

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -52,7 +52,7 @@ from music_assistant.helpers.util import infer_album_type, parse_title_and_versi
 from music_assistant.models import ProviderInstanceType
 from music_assistant.models.music_provider import MusicProvider
 
-from .gw_client import GWClient
+from .gw_client import DeezerGWError, GWClient
 
 SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_ARTISTS,
@@ -740,7 +740,10 @@ class DeezerProvider(MusicProvider):
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Return the content details for the given track when it will be streamed."""
-        url_details, song_data = await self.gw_client.get_deezer_track_urls(item_id)
+        try:
+            url_details, song_data = await self.gw_client.get_deezer_track_urls(item_id)
+        except DeezerGWError as err:
+            raise MediaNotFoundError(f"Track {item_id} is not available on Deezer") from err
         url = url_details["sources"][0]["url"]
         return StreamDetails(
             item_id=item_id,

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -24,7 +24,7 @@ from music_assistant_models.enums import (
     ProviderFeature,
     StreamType,
 )
-from music_assistant_models.errors import InvalidDataError, LoginFailed, MediaNotFoundError
+from music_assistant_models.errors import AudioError, InvalidDataError, LoginFailed, MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -743,7 +743,11 @@ class DeezerProvider(MusicProvider):
         try:
             url_details, song_data = await self.gw_client.get_deezer_track_urls(item_id)
         except DeezerGWError as err:
-            raise MediaNotFoundError(f"Track {item_id} is not available on Deezer") from err
+            api_errors = err.args[1] if len(err.args) > 1 else []
+            if isinstance(api_errors, list) and api_errors and api_errors[0].get("code") == 2002:
+                # code 2002: track not available in the user's region or plan
+                raise MediaNotFoundError(f"Track {item_id} is not available on Deezer") from err
+            raise AudioError(str(err)) from err
         url = url_details["sources"][0]["url"]
         return StreamDetails(
             item_id=item_id,


### PR DESCRIPTION
## What does this implement/fix?

When the Deezer API returns error code 2002 ("Track token has no sufficient rights on requested media."), `DeezerGWError` — a `BaseException` subclass, not `Exception` — escaped `get_stream_details` uncaught. Because `_do_prepare` in `player_queues.py` only catches `AudioError`/`MediaNotFoundError`, the unhandled exception left the player queue wedged indefinitely. The user had to manually click "next track" twice to resume playback.

Fix: catch `DeezerGWError` in `get_stream_details` and re-raise as `MediaNotFoundError` so the existing skip-on-error path in `_do_prepare` handles the unavailable track gracefully and continues to the next queue item.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5562

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.