### PR TITLE
Prevent duplicate songs in smart playlist dedup window

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -675,18 +675,14 @@ class SmartPlaylistProvider(PluginProvider):
 
     def _deduplicate_tracks(self, tracks: list[Track]) -> list[Track]:
         """Remove duplicate tracks while keeping first-seen order stable."""
-        seen: set[str] = set()
+        seen: set[Track] = set()
         result: list[Track] = []
         for track in tracks:
-            if track.uri:
-                unique_key = track.uri
-            else:
-                # Fallback key includes provider to avoid cross-provider collisions.
-                provider_id = track.provider if isinstance(track.provider, str) else ""
-                unique_key = f"{provider_id}://track/{track.item_id}"
-            if unique_key in seen:
+            if not track.available:
                 continue
-            seen.add(unique_key)
+            if track in seen:
+                continue
+            seen.add(track)
             result.append(track)
         return result
 

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -674,7 +674,7 @@ class SmartPlaylistProvider(PluginProvider):
         return result
 
     def _deduplicate_tracks(self, tracks: list[Track]) -> list[Track]:
-        """Remove duplicate tracks while keeping first-seen order stable."""
+        """Remove duplicates and skip unavailable tracks while keeping order stable."""
         seen: set[Track] = set()
         result: list[Track] = []
         for track in tracks:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -678,7 +678,12 @@ class SmartPlaylistProvider(PluginProvider):
         seen: set[str] = set()
         result: list[Track] = []
         for track in tracks:
-            unique_key = track.uri or str(track.item_id)
+            if track.uri:
+                unique_key = track.uri
+            else:
+                # Fallback key includes provider to avoid cross-provider collisions.
+                provider_id = track.provider if isinstance(track.provider, str) else ""
+                unique_key = f"{provider_id}://track/{track.item_id}"
             if unique_key in seen:
                 continue
             seen.add(unique_key)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -553,6 +553,7 @@ class SmartPlaylistProvider(PluginProvider):
         # Apply exclusions and dedup regardless of source mode
         excluded_genre_names = await self._resolve_excluded_genre_names(rules)
         tracks = self._apply_exclusions(tracks, rules, excluded_genre_names)
+        tracks = self._deduplicate_tracks(tracks)
         if rules.dedup_hours is not None:
             deduped = self._apply_dedup(tracks, rules.dedup_hours)
             if len(deduped) >= rules.limit:
@@ -669,6 +670,18 @@ class SmartPlaylistProvider(PluginProvider):
                 and any(g.lower() in excluded_genre_names for g in track.metadata.genres)
             ):
                 continue
+            result.append(track)
+        return result
+
+    def _deduplicate_tracks(self, tracks: list[Track]) -> list[Track]:
+        """Remove duplicate tracks while keeping first-seen order stable."""
+        seen: set[str] = set()
+        result: list[Track] = []
+        for track in tracks:
+            unique_key = track.uri or str(track.item_id)
+            if unique_key in seen:
+                continue
+            seen.add(unique_key)
             result.append(track)
         return result
 

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -602,12 +602,44 @@ async def test_evaluate_rules_removes_duplicate_track_uris() -> None:
         return_value=[dup_a_1, dup_a_2, dup_a_3, uniq_b]
     )
 
-    rules = SmartPlaylistRules(limit=10)
+    rules = SmartPlaylistRules(limit=10, logic=LOGIC_AND)
     result = await plugin._evaluate_rules(rules)
 
     uris = [track.uri for track in result]
     assert uris.count("library://track/dup") == 1
     assert "library://track/unique" in uris
+
+
+@pytest.mark.asyncio
+async def test_evaluate_rules_dedup_fallback_with_missing_uri() -> None:
+    """Fallback dedup key should deduplicate same provider/item and keep distinct providers."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    same_1 = _make_mock_track("42", "library://track/tmp-a")
+    same_1.uri = None
+    same_1.provider = "prov_a"
+    same_2 = _make_mock_track("42", "library://track/tmp-b")
+    same_2.uri = None
+    same_2.provider = "prov_a"
+    different_provider = _make_mock_track("42", "library://track/tmp-c")
+    different_provider.uri = None
+    different_provider.provider = "prov_b"
+    cast("Any", plugin)._get_library_tracks = AsyncMock(
+        return_value=[same_1, same_2, different_provider]
+    )
+
+    rules = SmartPlaylistRules(limit=10, logic=LOGIC_AND)
+    result = await plugin._evaluate_rules(rules)
+
+    # Same provider/item_id should collapse.
+    assert len([track for track in result if track.provider == "prov_a"]) == 1
+    # Different provider should remain.
+    assert len([track for track in result if track.provider == "prov_b"]) == 1
 
 
 def _swallow_task(coro: Any, **_: Any) -> None:

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.media_items import ProviderMapping, Track
 
 from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
 from music_assistant.providers.smart_playlist import (
@@ -594,10 +595,40 @@ async def test_evaluate_rules_removes_duplicate_track_uris() -> None:
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
-    dup_a_1 = _make_mock_track("1", "library://track/dup")
-    dup_a_2 = _make_mock_track("2", "library://track/dup")
-    dup_a_3 = _make_mock_track("3", "library://track/dup")
-    uniq_b = _make_mock_track("4", "library://track/unique")
+    provider_mapping = ProviderMapping(
+        item_id="1",
+        provider_domain="library",
+        provider_instance="library",
+        available=True,
+    )
+    dup_a_1 = Track(
+        item_id="1",
+        provider="library",
+        name="Track 1",
+        uri="library://track/dup",
+        provider_mappings={provider_mapping},
+    )
+    dup_a_2 = Track(
+        item_id="2",
+        provider="library",
+        name="Track 2",
+        uri="library://track/dup",
+        provider_mappings={provider_mapping},
+    )
+    dup_a_3 = Track(
+        item_id="3",
+        provider="library",
+        name="Track 3",
+        uri="library://track/dup",
+        provider_mappings={provider_mapping},
+    )
+    uniq_b = Track(
+        item_id="4",
+        provider="library",
+        name="Track 4",
+        uri="library://track/unique",
+        provider_mappings={provider_mapping},
+    )
     cast("Any", plugin)._get_library_tracks = AsyncMock(
         return_value=[dup_a_1, dup_a_2, dup_a_3, uniq_b]
     )
@@ -611,8 +642,8 @@ async def test_evaluate_rules_removes_duplicate_track_uris() -> None:
 
 
 @pytest.mark.asyncio
-async def test_evaluate_rules_dedup_fallback_with_missing_uri() -> None:
-    """Fallback dedup key should deduplicate same provider/item and keep distinct providers."""
+async def test_evaluate_rules_dedup_skips_unavailable_tracks() -> None:
+    """Dedup should skip unavailable tracks before adding to the result set."""
     mass = MagicMock()
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
@@ -620,26 +651,19 @@ async def test_evaluate_rules_dedup_fallback_with_missing_uri() -> None:
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
-    same_1 = _make_mock_track("42", "library://track/tmp-a")
-    same_1.uri = None
-    same_1.provider = "prov_a"
-    same_2 = _make_mock_track("42", "library://track/tmp-b")
-    same_2.uri = None
-    same_2.provider = "prov_a"
-    different_provider = _make_mock_track("42", "library://track/tmp-c")
-    different_provider.uri = None
-    different_provider.provider = "prov_b"
+    available_track = _make_mock_track("1", "library://track/available")
+    available_track.available = True
+    unavailable_track = _make_mock_track("2", "library://track/unavailable")
+    unavailable_track.available = False
     cast("Any", plugin)._get_library_tracks = AsyncMock(
-        return_value=[same_1, same_2, different_provider]
+        return_value=[available_track, unavailable_track]
     )
 
     rules = SmartPlaylistRules(limit=10, logic=LOGIC_AND)
     result = await plugin._evaluate_rules(rules)
 
-    # Same provider/item_id should collapse.
-    assert len([track for track in result if track.provider == "prov_a"]) == 1
-    # Different provider should remain.
-    assert len([track for track in result if track.provider == "prov_b"]) == 1
+    assert len(result) == 1
+    assert result[0].uri == "library://track/available"
 
 
 def _swallow_task(coro: Any, **_: Any) -> None:

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -584,6 +584,32 @@ async def test_dedup_fallback_when_pool_exhausted() -> None:
     assert len(result) == 5
 
 
+@pytest.mark.asyncio
+async def test_evaluate_rules_removes_duplicate_track_uris() -> None:
+    """Smart playlist evaluation should not return the same track URI multiple times."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    dup_a_1 = _make_mock_track("1", "library://track/dup")
+    dup_a_2 = _make_mock_track("2", "library://track/dup")
+    dup_a_3 = _make_mock_track("3", "library://track/dup")
+    uniq_b = _make_mock_track("4", "library://track/unique")
+    cast("Any", plugin)._get_library_tracks = AsyncMock(
+        return_value=[dup_a_1, dup_a_2, dup_a_3, uniq_b]
+    )
+
+    rules = SmartPlaylistRules(limit=10)
+    result = await plugin._evaluate_rules(rules)
+
+    uris = [track.uri for track in result]
+    assert uris.count("library://track/dup") == 1
+    assert "library://track/unique" in uris
+
+
 def _swallow_task(coro: Any, **_: Any) -> None:
     """Close coroutines passed to a mocked mass.create_task so pytest stays quiet."""
     coro.close()


### PR DESCRIPTION
# What does this implement/fix?

Smart playlists could include the same song URI multiple times in one generated result, even when a "do not repeat the same song for" (`dedup_hours`) window is configured.

This change adds URI-level deduplication before the time-window dedup filter, so identical tracks only appear once in a generated smart playlist sample.

A regression test was added to ensure duplicate track URIs are collapsed.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
