### PR TITLE
Support changing audiobook covers

### DIFF
--- a/music_assistant/controllers/media/audiobooks.py
+++ b/music_assistant/controllers/media/audiobooks.py
@@ -180,6 +180,10 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         db_id = int(item_id)  # ensure integer
         cur_item = await self.get_library_item(db_id)
         metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
+        if not overwrite and update.metadata.images is not None:
+            # audiobooks have no image picker, so keep the cover in sync with the
+            # provider instead of accumulating merged entries
+            metadata.images = update.metadata.images
         cur_item.external_ids.update(update.external_ids)
         name = update.name if overwrite else cur_item.name
         sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name

--- a/music_assistant/controllers/media/podcasts.py
+++ b/music_assistant/controllers/media/podcasts.py
@@ -181,6 +181,10 @@ class PodcastsController(MediaControllerBase[Podcast]):
         db_id = int(item_id)  # ensure integer
         cur_item = await self.get_library_item(db_id)
         metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
+        if not overwrite and update.metadata.images is not None:
+            # podcasts have no image picker, so keep the cover in sync with the
+            # provider instead of accumulating merged entries
+            metadata.images = update.metadata.images
         cur_item.external_ids.update(update.external_ids)
         name = update.name if overwrite else cur_item.name
         sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -1796,6 +1796,7 @@ class MetaDataController(CoreController):
         # note that we sort the providers by priority so that we always
         # prefer local providers over online providers
         unique_keys: set[str] = set()
+        prov_images: UniqueList[MediaItemImage] | None = None
         for prov_mapping in sorted(
             audiobook.provider_mappings, key=lambda x: x.priority, reverse=True
         ):
@@ -1813,6 +1814,8 @@ class MetaDataController(CoreController):
                 prov_item = await self.mass.music.audiobooks.get_provider_item(
                     prov_mapping.item_id, prov_mapping.provider_instance
                 )
+                if prov_images is None and prov_item.metadata.images:
+                    prov_images = prov_item.metadata.images
                 audiobook.metadata.update(prov_item.metadata)
                 if audiobook.publisher is None and prov_item.publisher:
                     audiobook.publisher = prov_item.publisher
@@ -1822,6 +1825,11 @@ class MetaDataController(CoreController):
                     audiobook.narrators = prov_item.narrators
                 if not audiobook.duration and prov_item.duration:
                     audiobook.duration = prov_item.duration
+
+        # no way to select a cover for audiobooks, so replace rather than merge the
+        # images to keep it in sync with the provider; revisit if a picker is added
+        if prov_images is not None:
+            audiobook.metadata.images = prov_images
 
         # update final item in library database
         # set timestamp, used to determine when this function was last called
@@ -1842,6 +1850,7 @@ class MetaDataController(CoreController):
         # note that we sort the providers by priority so that we always
         # prefer local providers over online providers
         unique_keys: set[str] = set()
+        prov_images: UniqueList[MediaItemImage] | None = None
         for prov_mapping in sorted(
             podcast.provider_mappings, key=lambda x: x.priority, reverse=True
         ):
@@ -1859,11 +1868,18 @@ class MetaDataController(CoreController):
                 prov_item = await self.mass.music.podcasts.get_provider_item(
                     prov_mapping.item_id, prov_mapping.provider_instance
                 )
+                if prov_images is None and prov_item.metadata.images:
+                    prov_images = prov_item.metadata.images
                 podcast.metadata.update(prov_item.metadata)
                 if podcast.publisher is None and prov_item.publisher:
                     podcast.publisher = prov_item.publisher
                 if not podcast.total_episodes and prov_item.total_episodes:
                     podcast.total_episodes = prov_item.total_episodes
+
+        # no way to select a cover for podcasts, so replace rather than merge the
+        # images to keep it in sync with the provider; revisit if a picker is added
+        if prov_images is not None:
+            podcast.metadata.images = prov_images
 
         # update final item in library database
         # set timestamp, used to determine when this function was last called

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -99,7 +99,8 @@ if TYPE_CHECKING:
 
 def _detect_image_format(path: str) -> str:
     """Detect image format from file path extension, defaulting to jpg."""
-    match pathlib.PurePath(path).suffix.lower():
+    # strip any query suffix (e.g. a cache-busting ?cs=) before extension detection
+    match pathlib.PurePath(path.split("?", 1)[0]).suffix.lower():
         case ".svg":
             return "svg"
         case ".png":

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -538,7 +538,8 @@ for more details.
                         token=self._client.token,
                         base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
                         media_progress=progress,
-                        add_cover=bool(item.library_item.media.cover_path or False),
+                        cover_path=item.library_item.media.cover_path,
+                        cover_version=item.library_item.updated_at,
                     )
                 )
         for cnt, item in enumerate(playlist_items):
@@ -727,7 +728,8 @@ for more details.
                 token=self._client.token,
                 base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
                 media_progress=progress,
-                add_cover=bool(abs_podcast.media.cover_path or False),
+                cover_path=abs_podcast.media.cover_path,
+                cover_version=abs_podcast.updated_at,
             )
             yield mass_episode
             episode_cnt += 1
@@ -756,7 +758,8 @@ for more details.
                     token=self._client.token,
                     base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
                     media_progress=progress,
-                    add_cover=bool(abs_podcast.media.cover_path or False),
+                    cover_path=abs_podcast.media.cover_path,
+                    cover_version=abs_podcast.updated_at,
                 )
 
             episode_cnt += 1
@@ -1129,9 +1132,11 @@ for more details.
                             podcast_id = entity.id_
                             if entity.recent_episode is None:
                                 continue
-                            _add_cover = False
+                            _cover_path = None
+                            _cover_version = None
                             if isinstance(entity, ShelfLibraryItemMinifiedPodcast):
-                                _add_cover = bool(entity.media.cover_path or False)
+                                _cover_path = entity.media.cover_path
+                                _cover_version = entity.updated_at
                             # we only have a PodcastEpisode here, with limited information
                             item = parse_podcast_episode(
                                 episode=entity.recent_episode,
@@ -1140,7 +1145,8 @@ for more details.
                                 domain=self.domain,
                                 token=self._client.token,
                                 base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
-                                add_cover=_add_cover,
+                                cover_path=_cover_path,
+                                cover_version=_cover_version,
                             )
                         if item is not None:
                             items.append(item)

--- a/music_assistant/providers/audiobookshelf/parsers.py
+++ b/music_assistant/providers/audiobookshelf/parsers.py
@@ -41,6 +41,23 @@ from music_assistant_models.media_items import PodcastEpisode as MassPodcastEpis
 from music_assistant.helpers.datetime import from_utc_timestamp
 
 
+def _build_cover_url(*, base_url: str, item_id: str, token: str, version: int | None = None) -> str:
+    """
+    Build the cover url for an Audiobookshelf library item.
+
+    :param base_url: Base url of the Audiobookshelf server.
+    :param item_id: Id of the library item to fetch the cover for.
+    :param token: Access token for the Audiobookshelf api.
+    :param version: Last-updated timestamp of the item.
+    """
+    # the cover endpoint is static and keeps its filename when artwork is
+    # replaced in place, so append the last-updated timestamp to bust caches
+    cover_url = f"{base_url}/api/items/{item_id}/cover?token={token}"
+    if version is not None:
+        cover_url += f"&ts={version}"
+    return cover_url
+
+
 def parse_playlist(
     *,
     abs_playlist: AbsPlaylistExpanded,
@@ -68,8 +85,12 @@ def parse_playlist(
     )
     # cover
     if abs_playlist.cover_path is not None:
-        api_url = f"/api/items/{abs_playlist.id_}/cover?token={token}"
-        cover_url = f"{base_url}{api_url}"
+        cover_url = _build_cover_url(
+            base_url=base_url,
+            item_id=abs_playlist.id_,
+            token=token,
+            version=abs_playlist.last_update,
+        )
         mass_playlist.metadata.images = UniqueList(
             [MediaItemImage(type=ImageType.THUMB, path=cover_url, provider=instance_id)]
         )
@@ -106,7 +127,12 @@ def parse_podcast(
     )
     mass_podcast.metadata.description = abs_podcast.media.metadata.description
     if token is not None and abs_podcast.media.cover_path is not None:
-        image_url = f"{base_url}/api/items/{abs_podcast.id_}/cover?token={token}"
+        image_url = _build_cover_url(
+            base_url=base_url,
+            item_id=abs_podcast.id_,
+            token=token,
+            version=abs_podcast.updated_at,
+        )
         mass_podcast.metadata.images = UniqueList(
             [MediaItemImage(type=ImageType.THUMB, path=image_url, provider=instance_id)]
         )
@@ -141,7 +167,8 @@ def parse_podcast_episode(
     token: str | None,
     base_url: str,
     media_progress: AbsMediaProgress | None = None,
-    add_cover: bool = False,
+    cover_path: str | None = None,
+    cover_version: int | None = None,
 ) -> MassPodcastEpisode:
     """Translate ABSPodcastEpisode to MassPodcastEpisode.
 
@@ -207,9 +234,13 @@ def parse_podcast_episode(
     mass_episode.metadata.release_date = release_date
 
     # cover image
-    if token is not None and add_cover:
-        url_api = f"/api/items/{prov_podcast_id}/cover?token={token}"
-        url_cover = f"{base_url}{url_api}"
+    if token is not None and cover_path:
+        url_cover = _build_cover_url(
+            base_url=base_url,
+            item_id=prov_podcast_id,
+            token=token,
+            version=cover_version,
+        )
         mass_episode.metadata.images = UniqueList(
             [MediaItemImage(type=ImageType.THUMB, path=url_cover, provider=instance_id)]
         )
@@ -275,8 +306,12 @@ def parse_audiobook(
 
     # cover
     if token is not None and abs_audiobook.media.cover_path is not None:
-        api_url = f"/api/items/{abs_audiobook.id_}/cover?token={token}"
-        cover_url = f"{base_url}{api_url}"
+        cover_url = _build_cover_url(
+            base_url=base_url,
+            item_id=abs_audiobook.id_,
+            token=token,
+            version=abs_audiobook.updated_at,
+        )
         mass_audiobook.metadata.images = UniqueList(
             [MediaItemImage(type=ImageType.THUMB, path=cover_url, provider=instance_id)]
         )

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -998,8 +998,16 @@ class LocalFileSystemProvider(MusicProvider):
         This either returns (a generator to get) raw bytes of the image or
         a string with an http(s) URL or local path that is accessible from the server.
         """
-        file_item = await self.resolve(path)
+        # drop the cache-busting suffix appended by _versioned_image_path
+        file_item = await self.resolve(path.split("?cs=", 1)[0])
         return file_item.absolute_path
+
+    @staticmethod
+    def _versioned_image_path(relative_path: str, checksum: str | None) -> str:
+        """Append the file checksum so the image cache busts when the file is replaced."""
+        if checksum:
+            return f"{relative_path}?cs={checksum}"
+        return relative_path
 
     async def _parse_track(
         self, file_item: FileSystemItem, tags: AudioTags, full_album_metadata: bool = False
@@ -1413,7 +1421,7 @@ class LocalFileSystemProvider(MusicProvider):
             audio_book.metadata.add_image(
                 MediaItemImage(
                     type=ImageType.THUMB,
-                    path=file_item.relative_path,
+                    path=self._versioned_image_path(file_item.relative_path, file_item.checksum),
                     provider=self.instance_id,
                     remotely_accessible=False,
                 )
@@ -1443,7 +1451,7 @@ class LocalFileSystemProvider(MusicProvider):
                     audio_book.metadata.add_image(
                         MediaItemImage(
                             type=ImageType.THUMB,
-                            path=_item.relative_path,
+                            path=self._versioned_image_path(_item.relative_path, _item.checksum),
                             provider=self.instance_id,
                             remotely_accessible=False,
                         )

--- a/tests/providers/filesystem/test_versioned_image_path.py
+++ b/tests/providers/filesystem/test_versioned_image_path.py
@@ -1,0 +1,56 @@
+"""Tests for LocalFileSystemProvider cover image cache-busting."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from music_assistant.providers.filesystem_local import LocalFileSystemProvider
+
+
+def _create_provider() -> LocalFileSystemProvider:
+    """Create a bare LocalFileSystemProvider without running __init__."""
+    with patch.object(LocalFileSystemProvider, "__init__", lambda *_a, **_kw: None):
+        provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
+    provider.logger = MagicMock()
+    return provider
+
+
+class TestVersionedImagePath:
+    """Test the cover image path versioning and its round-trip in resolve_image."""
+
+    def test_appends_checksum(self) -> None:
+        """A checksum is appended as a query suffix."""
+        result = LocalFileSystemProvider._versioned_image_path("Moby Dick/folder.jpg", "123")
+        assert result == "Moby Dick/folder.jpg?cs=123"
+
+    def test_changes_when_file_replaced(self) -> None:
+        """A new checksum (file replaced in place) yields a different path."""
+        old = LocalFileSystemProvider._versioned_image_path("Moby Dick/folder.jpg", "123")
+        new = LocalFileSystemProvider._versioned_image_path("Moby Dick/folder.jpg", "456")
+        assert old != new
+
+    def test_no_checksum_is_unchanged(self) -> None:
+        """Without a checksum the path is returned untouched."""
+        assert (
+            LocalFileSystemProvider._versioned_image_path("Moby Dick/folder.jpg", None)
+            == "Moby Dick/folder.jpg"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_image_strips_suffix(self) -> None:
+        """resolve_image strips the cache-busting suffix before resolving the file."""
+        provider = _create_provider()
+        versioned = LocalFileSystemProvider._versioned_image_path("Moby Dick/folder.jpg", "123")
+        with patch.object(provider, "resolve", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = MagicMock(absolute_path="/music/folder.jpg")
+            await provider.resolve_image(versioned)
+        mock_resolve.assert_awaited_once_with("Moby Dick/folder.jpg")
+
+    @pytest.mark.asyncio
+    async def test_resolve_image_without_suffix(self) -> None:
+        """A plain path without a suffix is resolved unchanged."""
+        provider = _create_provider()
+        with patch.object(provider, "resolve", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = MagicMock(absolute_path="/music/track.flac")
+            await provider.resolve_image("Moby Dick/track.flac")
+        mock_resolve.assert_awaited_once_with("Moby Dick/track.flac")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The attached issue highlighted how once audiobook covers are set they can’t be changed as the images row is not shown for audiobooks but the append-to-list behaviour is still used by the backend.

Whilst the issue is about Audiobookshelf I noticed that local filesystem books are similarly affected.

So this PR:

- Replaces rather than appends covers for audiobooks/podcasts, since there’s no picker to choose from.
- Refreshes the cached cover for Audiobookshelf by appending the item’s updated_at to the otherwise-static cover URL, so the cache fetches the new image.
- Refreshes the cached cover for local filesystem books by appending the file checksum to the cover path, so a replaced file is picked up.

Track, album, artist and playlist image behaviour is untouched.

I tested this for local files and had Fabian review the code and test for Audiobookshelf. All working.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5554

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
