### PR TITLE
Fix loudness volume jumps: scope audio-analysis reads to the authoritative provider

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -67,6 +67,7 @@ from music_assistant.constants import (
     MASS_LOGGER_NAME,
     VERBOSE_LOG_LEVEL,
 )
+from music_assistant.controllers.streams.audio_analysis import LOUDNESS_ANALYSIS_DOMAIN
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.streams.constants import (
     CACHE_CATEGORY_RESOLVED_RADIO_URL,
@@ -1487,6 +1488,10 @@ class StreamsAudio:
                 streamdetails.item_id,
                 streamdetails.provider,
                 media_type=streamdetails.media_type,
+                # loudness for volume normalization must be the authoritative EBU R128
+                # value; other AA providers write loudness_integrated with different
+                # semantics (e.g. sonic_analysis stores an RMS proxy).
+                priority=(LOUDNESS_ANALYSIS_DOMAIN,),
             ):
                 if analysis.loudness_integrated is not None:
                     streamdetails.loudness = round(analysis.loudness_integrated, 2)

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1488,9 +1488,7 @@ class StreamsAudio:
                 streamdetails.item_id,
                 streamdetails.provider,
                 media_type=streamdetails.media_type,
-                # loudness for volume normalization must be the authoritative EBU R128
-                # value; other AA providers write loudness_integrated with different
-                # semantics (e.g. sonic_analysis stores an RMS proxy).
+                # use the authoritative EBU R128 value, not another provider's loudness proxy
                 priority=(LOUDNESS_ANALYSIS_DOMAIN,),
             ):
                 if analysis.loudness_integrated is not None:

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -34,6 +34,8 @@ from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
 from music_assistant.models.music_provider import MusicProvider
 
 LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
+SMART_FADES_ANALYSIS_DOMAIN = "smart_fades"
+SONIC_ANALYSIS_DOMAIN = "sonic_analysis"
 BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300
 BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER = 1.5
@@ -63,38 +65,66 @@ if TYPE_CHECKING:
     from music_assistant.controllers.streams.controller import StreamsController
 
 
+def _parse_row(row: Mapping[str, Any]) -> AudioAnalysisData | None:
+    """Parse a single audio_analysis row's analysis_data, logging and skipping on error."""
+    try:
+        return AudioAnalysisData.from_dict(json_loads(row["analysis_data"]))
+    except (ValueError, TypeError, KeyError) as err:
+        LOGGER.warning(
+            "Skipping unparsable audio_analysis row (id=%s, aa_provider_domain=%s): %s",
+            row.get("id"),
+            row["aa_provider_domain"],
+            err,
+        )
+        return None
+
+
 def _merged_from_rows(
     rows: Iterable[Mapping[str, Any]],
     available_aa_domains: set[str],
+    priority: tuple[str, ...] | None = None,
 ) -> AudioAnalysisData | None:
     """
-    Fold audio_analysis rows into one merged result (latest-write-wins).
+    Fold audio_analysis rows into one merged result.
 
-    Rows from AA providers not in available_aa_domains, and rows whose
-    analysis_data is unparsable, are skipped. Returns None when no usable
-    row remains.
+    Rows from AA providers not in available_aa_domains, and rows whose analysis_data
+    is unparsable, are always skipped. Returns None when no usable row remains.
 
     :param rows: audio_analysis rows ordered oldest-first; each must carry
         aa_provider_domain and analysis_data.
     :param available_aa_domains: AA provider domains currently available.
+    :param priority: When None, merge all available providers' rows with latest-write-wins
+        (non-None fields). When a tuple of AA provider domains is given, only those domains
+        are considered and the first-listed domain wins each per-field conflict.
     """
     merged = AudioAnalysisData()
     found = False
+    if priority is None:
+        for row in rows:
+            if row["aa_provider_domain"] not in available_aa_domains:
+                continue
+            if (row_data := _parse_row(row)) is None:
+                continue
+            merged.update(row_data)
+            found = True
+        return merged if found else None
+
+    # priority given: keep only the requested+available domains, then apply in reverse
+    # priority order so the first-listed domain wins each non-None field.
+    wanted = tuple(d for d in priority if d in available_aa_domains)
+    wanted_set = set(wanted)  # O(1) per-row membership test
+    by_domain: dict[str, AudioAnalysisData] = {}
     for row in rows:
-        if row["aa_provider_domain"] not in available_aa_domains:
+        domain = row["aa_provider_domain"]
+        if domain not in wanted_set or domain in by_domain:
             continue
-        try:
-            row_data = AudioAnalysisData.from_dict(json_loads(row["analysis_data"]))
-        except (ValueError, TypeError, KeyError) as err:
-            LOGGER.warning(
-                "Skipping unparsable audio_analysis row (id=%s, aa_provider_domain=%s): %s",
-                row.get("id"),
-                row["aa_provider_domain"],
-                err,
-            )
+        if (row_data := _parse_row(row)) is None:
             continue
-        merged.update(row_data)
-        found = True
+        by_domain[domain] = row_data
+    for domain in reversed(wanted):
+        if (row_data := by_domain.get(domain)) is not None:
+            merged.update(row_data)
+            found = True
     return merged if found else None
 
 
@@ -277,16 +307,22 @@ class AudioAnalysisController:
         item_id: str,
         provider_instance_id_or_domain: str,
         media_type: MediaType = MediaType.TRACK,
+        priority: tuple[str, ...] | None = None,
     ) -> AudioAnalysisData | None:
         """
-        Get merged audio analysis data from all enabled AA providers for a track.
+        Get merged audio analysis data for a track.
 
         Only rows from currently available AA providers are included.
-        Multiple providers' results are merged using latest-write-wins.
 
         :param item_id: Provider-native item ID from streamdetails.item_id.
         :param provider_instance_id_or_domain: Music provider instance ID or domain.
         :param media_type: The media type of the item.
+        :param priority: AA provider domains the values must come from. When None, all
+            available providers are merged latest-write-wins. With a single domain, only
+            that provider's values are used. With multiple domains, only those are merged
+            and the first-listed domain wins each per-field conflict. Use this when a field
+            (e.g. loudness_integrated) is written by several providers with different
+            semantics, so the authoritative source is selected.
         """
         provider = self.mass.get_provider(provider_instance_id_or_domain)
         if not isinstance(provider, MusicProvider):
@@ -307,7 +343,7 @@ class AudioAnalysisController:
         available_aa_domains = {
             p.domain for p in self.mass.get_providers(ProviderType.AUDIO_ANALYSIS) if p.available
         }
-        return _merged_from_rows(rows, available_aa_domains)
+        return _merged_from_rows(rows, available_aa_domains, priority)
 
     async def set_track_loudness(
         self,
@@ -475,6 +511,7 @@ class AudioAnalysisController:
         self,
         primary_aa_domain: str,
         media_type: MediaType = MediaType.TRACK,
+        priority: tuple[str, ...] | None = None,
     ) -> AsyncGenerator[tuple[str, str, AudioAnalysisData]]:
         """
         Yield one merged AudioAnalysisData per track present in primary_aa_domain.
@@ -495,6 +532,9 @@ class AudioAnalysisController:
             tracks to yield. Only (item_id, provider) pairs with at least one
             row in this domain are emitted.
         :param media_type: The media type to filter on.
+        :param priority: AA provider domains the merged values must come from, first-listed
+            wins per-field conflicts (see get_audio_analysis). When None, all available
+            providers are merged latest-write-wins.
         """
         available_aa_domains = {
             p.domain for p in self.mass.get_providers(ProviderType.AUDIO_ANALYSIS) if p.available
@@ -530,14 +570,14 @@ class AudioAnalysisController:
         ):
             key = (row["item_id"], row["provider"])
             if current_key is not None and key != current_key:
-                merged = _merged_from_rows(current_group, available_aa_domains)
+                merged = _merged_from_rows(current_group, available_aa_domains, priority)
                 if merged is not None:
                     yield (*current_key, merged)
                 current_group = []
             current_key = key
             current_group.append(row)
         if current_key is not None:
-            merged = _merged_from_rows(current_group, available_aa_domains)
+            merged = _merged_from_rows(current_group, available_aa_domains, priority)
             if merged is not None:
                 yield (*current_key, merged)
 

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -73,7 +73,7 @@ def _parse_row(row: Mapping[str, Any]) -> AudioAnalysisData | None:
         LOGGER.warning(
             "Skipping unparsable audio_analysis row (id=%s, aa_provider_domain=%s): %s",
             row.get("id"),
-            row["aa_provider_domain"],
+            row.get("aa_provider_domain"),
             err,
         )
         return None
@@ -109,10 +109,9 @@ def _merged_from_rows(
             found = True
         return merged if found else None
 
-    # priority given: keep only the requested+available domains, then apply in reverse
-    # priority order so the first-listed domain wins each non-None field.
+    # priority given: merge only these domains, first-listed wins each field.
     wanted = tuple(d for d in priority if d in available_aa_domains)
-    wanted_set = set(wanted)  # O(1) per-row membership test
+    wanted_set = set(wanted)
     by_domain: dict[str, AudioAnalysisData] = {}
     for row in rows:
         domain = row["aa_provider_domain"]

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
+from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALYSIS_DOMAIN
 from music_assistant.controllers.streams.smart_fades.fades import (
     SmartCrossFade,
     SmartFade,
@@ -90,12 +91,14 @@ class SmartFadesMixer:
         ) = await self.streams.audio_analysis.get_audio_analysis(
             fade_out_streamdetails.item_id,
             fade_out_streamdetails.provider,
+            priority=(SMART_FADES_ANALYSIS_DOMAIN,),
         )
         fade_in_analysis: (
             AudioAnalysisData | None
         ) = await self.streams.audio_analysis.get_audio_analysis(
             fade_in_streamdetails.item_id,
             fade_in_streamdetails.provider,
+            priority=(SMART_FADES_ANALYSIS_DOMAIN,),
         )
         if not (
             fade_out_analysis

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -59,6 +59,7 @@ from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
 
+from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALYSIS_DOMAIN
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player, PlayerMedia
 
@@ -1140,7 +1141,10 @@ class SendspinPlayer(SendspinBasePlayer):
             return
         sd = queue_item.streamdetails
         analysis = await self.mass.streams.audio_analysis.get_audio_analysis(
-            sd.item_id, sd.provider, media_type=sd.media_type
+            sd.item_id,
+            sd.provider,
+            media_type=sd.media_type,
+            priority=(SMART_FADES_ANALYSIS_DOMAIN,),
         )
         if analysis is None or analysis.beats is None or len(analysis.beats) == 0:
             visualizer_role.clear_beat_schedule()

--- a/music_assistant/providers/sonic_similarity/provider.py
+++ b/music_assistant/providers/sonic_similarity/provider.py
@@ -24,6 +24,7 @@ from music_assistant_models.media_items import Album, RecommendationFolder, Sear
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import DB_TABLE_AUDIO_ANALYSIS
+from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALYSIS_DOMAIN
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.sonic_similarity.clap_index import ClapIndex
 from music_assistant.providers.sonic_similarity.constants import (
@@ -858,7 +859,13 @@ class SonicSimilarityPlugin(PluginProvider):
             item_id,
             provider,
             data,
-        ) in self.mass.streams.audio_analysis.iter_merged_audio_analysis_rows(AA_PROVIDER_DOMAIN):
+        ) in self.mass.streams.audio_analysis.iter_merged_audio_analysis_rows(
+            AA_PROVIDER_DOMAIN,
+            # similarity vectors need sonic's own RMS loudness feature (not the EBU R128
+            # value from loudness_analysis) plus smart_fades' bpm/key/mode; sonic wins
+            # the shared loudness_integrated/loudness_range fields.
+            priority=(AA_PROVIDER_DOMAIN, SMART_FADES_ANALYSIS_DOMAIN),
+        ):
             total_merged_rows += 1
             if len(sampled_for_diag) < 3:
                 sampled_for_diag.append((item_id, provider, data))

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -16,8 +16,17 @@ from music_assistant_models.media_items import AudioFormat
 
 import music_assistant.controllers.streams.audio_analysis as audio_analysis_mod
 from music_assistant.constants import DEFAULT_BACKGROUND_SCAN_CONCURRENCY
-from music_assistant.controllers.streams.audio_analysis import AudioAnalysisController
+from music_assistant.controllers.streams.audio_analysis import (
+    LOUDNESS_ANALYSIS_DOMAIN,
+    SMART_FADES_ANALYSIS_DOMAIN,
+    SONIC_ANALYSIS_DOMAIN,
+    AudioAnalysisController,
+    _merged_from_rows,
+)
+from music_assistant.helpers.json import json_dumps
+from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
+from music_assistant.models.music_provider import MusicProvider
 
 
 @pytest.mark.asyncio
@@ -546,6 +555,120 @@ def _stub_controller(
     c.mass.music.database = db
     c.mass.get_providers = MagicMock(return_value=[])
     return c, db
+
+
+# --- provider-scoped merge (loudness regression fix) ---
+
+_ALL_AA_DOMAINS = {LOUDNESS_ANALYSIS_DOMAIN, SMART_FADES_ANALYSIS_DOMAIN, SONIC_ANALYSIS_DOMAIN}
+
+
+def _aa_row(domain: str, row_id: int, **fields: Any) -> dict[str, Any]:
+    """Build one audio_analysis db row (rows are passed oldest-first / ascending row_id)."""
+    return {
+        "id": row_id,
+        "item_id": "track-1",
+        "provider": "test-provider",
+        "media_type": MediaType.TRACK.value,
+        "aa_provider_domain": domain,
+        "analysis_data": json_dumps(AudioAnalysisData(**fields).to_dict()),
+    }
+
+
+def test_merged_from_rows_priority_none_is_last_write_wins() -> None:
+    """Without priority, the newest (last) row wins each non-None field (legacy behaviour)."""
+    rows = [
+        _aa_row(LOUDNESS_ANALYSIS_DOMAIN, 1, loudness_integrated=-7.5),
+        _aa_row(SONIC_ANALYSIS_DOMAIN, 2, loudness_integrated=-12.0),
+    ]
+    merged = _merged_from_rows(rows, _ALL_AA_DOMAINS)
+    assert merged is not None
+    assert merged.loudness_integrated == -12.0
+
+
+def test_merged_from_rows_single_priority_uses_only_that_provider() -> None:
+    """A single-domain priority returns only that provider's values; others are ignored."""
+    rows = [
+        _aa_row(LOUDNESS_ANALYSIS_DOMAIN, 1, loudness_integrated=-7.5),
+        _aa_row(SONIC_ANALYSIS_DOMAIN, 2, loudness_integrated=-12.0, bpm=120),
+    ]
+    merged = _merged_from_rows(rows, _ALL_AA_DOMAINS, priority=(LOUDNESS_ANALYSIS_DOMAIN,))
+    assert merged is not None
+    assert merged.loudness_integrated == -7.5
+    assert merged.bpm is None  # sonic_analysis excluded entirely
+
+
+def test_merged_from_rows_multi_priority_first_listed_wins_and_merges() -> None:
+    """Multi-domain priority merges all listed domains; the first-listed wins conflicts."""
+    rows = [
+        # sonic newer than loudness, but loudness is listed first -> wins loudness_integrated
+        _aa_row(SONIC_ANALYSIS_DOMAIN, 1, loudness_integrated=-12.0, energy=0.5),
+        _aa_row(LOUDNESS_ANALYSIS_DOMAIN, 2, loudness_integrated=-7.5),
+        _aa_row(SMART_FADES_ANALYSIS_DOMAIN, 3, bpm=120),
+    ]
+    merged = _merged_from_rows(
+        rows,
+        _ALL_AA_DOMAINS,
+        priority=(LOUDNESS_ANALYSIS_DOMAIN, SONIC_ANALYSIS_DOMAIN, SMART_FADES_ANALYSIS_DOMAIN),
+    )
+    assert merged is not None
+    assert merged.loudness_integrated == -7.5  # first-listed wins the conflict
+    assert merged.energy == 0.5  # non-conflicting field from sonic still merged in
+    assert merged.bpm == 120  # and from smart_fades
+
+
+def test_merged_from_rows_priority_domain_not_available_is_excluded() -> None:
+    """A priority domain that is not currently available is dropped (can yield None)."""
+    rows = [_aa_row(LOUDNESS_ANALYSIS_DOMAIN, 1, loudness_integrated=-7.5)]
+    merged = _merged_from_rows(rows, {SONIC_ANALYSIS_DOMAIN}, priority=(LOUDNESS_ANALYSIS_DOMAIN,))
+    assert merged is None
+
+
+def test_merged_from_rows_regression_sonic_does_not_clobber_loudness() -> None:
+    """Regression: sonic_analysis' RMS loudness must not overwrite the EBU R128 value.
+
+    Reproduces the volume-jump bug: a newer sonic_analysis row carries an RMS-proxy
+    loudness_integrated that wins under last-write-wins, but scoping to loudness_analysis
+    returns the authoritative value.
+    """
+    rows = [
+        _aa_row(LOUDNESS_ANALYSIS_DOMAIN, 1, loudness_integrated=-7.5),
+        _aa_row(SONIC_ANALYSIS_DOMAIN, 2, loudness_integrated=-12.0),
+    ]
+    legacy = _merged_from_rows(rows, _ALL_AA_DOMAINS)
+    assert legacy is not None
+    assert legacy.loudness_integrated == -12.0  # old/buggy: sonic clobbers
+    scoped = _merged_from_rows(rows, _ALL_AA_DOMAINS, priority=(LOUDNESS_ANALYSIS_DOMAIN,))
+    assert scoped is not None
+    assert scoped.loudness_integrated == -7.5  # fixed
+
+
+@pytest.mark.asyncio
+async def test_get_audio_analysis_priority_threads_through_to_merge() -> None:
+    """get_audio_analysis forwards priority so the loudness call gets the EBU R128 value."""
+    c, db = _stub_controller()
+    db.get_rows = AsyncMock(
+        return_value=[
+            _aa_row(LOUDNESS_ANALYSIS_DOMAIN, 1, loudness_integrated=-7.5),
+            _aa_row(SONIC_ANALYSIS_DOMAIN, 2, loudness_integrated=-12.0),
+        ]
+    )
+    music_prov = MagicMock(spec=MusicProvider)
+    music_prov.is_streaming_provider = True
+    music_prov.domain = "test-provider"
+    c.mass.get_provider = MagicMock(return_value=music_prov)  # type: ignore[method-assign]
+    aa_loud = MagicMock()
+    aa_loud.domain = LOUDNESS_ANALYSIS_DOMAIN
+    aa_loud.available = True
+    aa_sonic = MagicMock()
+    aa_sonic.domain = SONIC_ANALYSIS_DOMAIN
+    aa_sonic.available = True
+    c.mass.get_providers = MagicMock(return_value=[aa_loud, aa_sonic])  # type: ignore[method-assign]
+
+    result = await c.get_audio_analysis(
+        "track-1", "test-provider", priority=(LOUDNESS_ANALYSIS_DOMAIN,)
+    )
+    assert result is not None
+    assert result.loudness_integrated == -7.5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

After loudness measurement was migrated into the unified `audio_analysis` table, `get_audio_analysis()` merged **every** audio-analysis provider's row for a track into one `AudioAnalysisData` using latest-write-wins on non-None fields. Several providers write the *same* field with *different* semantics — most importantly `loudness_integrated`:

- `loudness_analysis` writes gated **EBU R128 LUFS** — authoritative for volume normalization.
- `sonic_analysis` writes a **mean-RMS-dB proxy** — a feature for its similarity vectors, explicitly *not* EBU R128.

When the `sonic_analysis` row sorted last, its RMS value (always 2.5–18 dB lower than the gated LUFS) overwrote the real measurement used for normalization. Since the value was always lower, the gain was always too high → affected tracks played **too loud**, causing volume jumps between tracks. Verified against a real library: **33/266 tracks (12%) returned the wrong loudness (avg 6.6 dB, up to ~11 dB); 0 after the fix.**

This is a read-time regression only — the measurement itself is correct, and `stable` (pre-audio-analysis-provider) stored loudness in a dedicated table with no cross-provider merge.

### Fix

Add a `priority: tuple[str, ...] | None` parameter to `get_audio_analysis()` / `iter_merged_audio_analysis_rows()` / `_merged_from_rows()`:

- `None` — unchanged (merge all available providers, latest-write-wins).
- single domain — use only that provider's values.
- multiple domains — merge only those; the **first-listed** domain wins per-field conflicts.

Each consumer now reads from its authoritative source:

| Consumer | priority |
| --- | --- |
| loudness hydration for volume normalization | `(loudness_analysis,)` |
| smart-fades crossfade + sendspin beat visualizer | `(smart_fades,)` |
| sonic-similarity vector rebuild | `(sonic_analysis, smart_fades)` |

Read-only fix — no DB migration needed; existing rows are interpreted correctly on the next read. The sonic-similarity index picks up the corrected loudness feature on its next rebuild.

Not present on `stable` (the merge was introduced with the audio-analysis provider), so **no backport** is required.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (N/A — no model changes)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (N/A)
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (N/A — internal fix, no docs impact)
