### PR TITLE
fix(tidal): serve DASH manifests via HTTP route instead of data: URI

### DIFF
--- a/music_assistant/providers/tidal/streaming.py
+++ b/music_assistant/providers/tidal/streaming.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 from sqlite3 import OperationalError
 from typing import TYPE_CHECKING
 
+from aiohttp import web
 from music_assistant_models.enums import ContentType, ExternalID, StreamType
 from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import AudioFormat
@@ -16,6 +19,11 @@ if TYPE_CHECKING:
     from music_assistant_models.media_items import Track
 
     from .provider import TidalProvider
+
+# Time (seconds) after which an unused DASH manifest route is cleaned up.
+# Must be longer than any single track's playback to avoid premature expiry
+# while ffmpeg is still streaming. 10 minutes safely covers even long tracks.
+_DASH_ROUTE_TTL: int = 600
 
 
 class TidalStreamingManager:
@@ -57,7 +65,35 @@ class TidalStreamingManager:
         # 4. Parse stream URL
         manifest_type = stream_data.get("manifestMimeType", "")
         if "dash+xml" in manifest_type and "manifest" in stream_data:
-            url = f"data:application/dash+xml;base64,{stream_data['manifest']}"
+            # Tidal returns a dynamic DASH manifest (MPD) that ffmpeg needs
+            # to re-fetch during playback to get the next segment window.
+            # A data: URI can't be re-fetched, so we serve the decoded
+            # manifest from a real HTTP endpoint on the stream server.
+            manifest_bytes = base64.b64decode(stream_data["manifest"])
+            manifest_hash = hashlib.md5(manifest_bytes).hexdigest()
+            route_path = f"/tidal-dash/{manifest_hash}"
+
+            async def _serve_manifest(request: web.Request) -> web.Response:
+                return web.Response(
+                    body=manifest_bytes,
+                    content_type="application/dash+xml",
+                )
+
+            try:
+                remove_route = self.mass.streams.register_dynamic_route(
+                    route_path, _serve_manifest, method="GET"
+                )
+                # Clean up after the TTL expires. The route is reused for
+                # repeated plays of the same track via the content hash,
+                # so a generous timeout prevents spurious 404s without
+                # leaking routes.
+                self.mass.call_later(_DASH_ROUTE_TTL, remove_route)
+            except RuntimeError:
+                # Route already registered (same hash = same manifest),
+                # keep the existing one — its TTL was set when first created.
+                pass
+
+            url = f"{self.mass.streams.base_url}{route_path}"
         else:
             urls = stream_data.get("urls", [])
             if not urls:

--- a/tests/providers/tidal/test_streaming.py
+++ b/tests/providers/tidal/test_streaming.py
@@ -117,21 +117,28 @@ async def test_get_stream_details_hires(
 async def test_get_stream_details_with_dash_manifest(
     streaming_manager: TidalStreamingManager, provider_mock: Mock, mock_track: Mock
 ) -> None:
-    """Test get_stream_details with DASH manifest."""
+    """Test get_stream_details with DASH manifest served via HTTP route."""
     provider_mock.get_track.return_value = mock_track
     provider_mock.api.get.return_value = {
         "manifestMimeType": "application/dash+xml",
-        "manifest": "base64encodedmanifestdata",
+        "manifest": "bWFuaWZlc3REYXRh",
         "audioQuality": "HIGH",
         "sampleRate": 44100,
         "bitDepth": 16,
     }
+    # Mock the stream server's dynamic route registration
+    provider_mock.mass.streams.register_dynamic_route = Mock(return_value=lambda: None)
+    provider_mock.mass.streams.base_url = "http://localhost:8097"
 
     stream_details = await streaming_manager.get_stream_details("123")
 
     assert isinstance(stream_details.path, str)
-    assert stream_details.path.startswith("data:application/dash+xml;base64,")
-    assert "base64encodedmanifestdata" in stream_details.path
+    assert stream_details.path.startswith("http://localhost:8097/tidal-dash/")
+    assert "base64" not in stream_details.path
+    # Verify the route was registered
+    provider_mock.mass.streams.register_dynamic_route.assert_called_once()
+    # Verify a delayed cleanup was scheduled
+    provider_mock.mass.call_later.assert_called()
 
 
 async def test_get_stream_details_with_codec(


### PR DESCRIPTION
## Problem

Tidal returns dynamic DASH manifests (MPD) with a sliding segment window (~35s). ffmpeg needs to re-fetch the manifest during playback to obtain the next segment window. The current code encodes the manifest as a `data:` URI — ffmpeg reads it once, plays the initial segments, then when it tries to re-fetch the MPD for the next window, the `data:` URI has nothing left. The stream dies silently at ~35s.

Closes #5077

## Fix

Decode the base64 manifest and register it as a real HTTP endpoint on the internal stream server using the existing `register_dynamic_route` API. ffmpeg can re-fetch the MPD on demand just like any other HTTP stream.

## Design decisions

- **Content-hashed path** (`/tidal-dash/{md5(manifest)}`): identical manifests reuse the same route, avoiding redundant registrations. The `RuntimeError` on duplicate registration is caught silently.
- **Fixed TTL cleanup** (10 minutes): the route self-destructs after 10 minutes via `call_later`. This is generous enough for even long tracks. The previous attempt (PR #3369) used a timer that fired too early for long/slow streams. A 600s TTL eliminates that race while preventing route leaks.
- **No new dependencies**: uses `base64`, `hashlib` (stdlib), and `aiohttp.web\Response` (already a dependency).

## Testing

- Verified syntax on both modified files
- Unit test updated to assert HTTP route URL instead of `data:` URI
- Test verifies `register_dynamic_route` is called and `call_later` schedules cleanup
- The test manifest base64 decodes to `manifestData` and produces a deterministic hash