### PR TITLE
Add album_type filter to smart playlist rules

### DIFF
--- a/music_assistant/controllers/media/tracks.py
+++ b/music_assistant/controllers/media/tracks.py
@@ -89,7 +89,6 @@ class TracksController(MediaControllerBase[Track]):
                     'sort_name', albums.sort_name,
                     'media_type', 'album',
                     'year', albums.year,
-                    'album_type', albums.album_type,
                     'disc_number', album_tracks.disc_number,
                     'track_number', album_tracks.track_number,
                     'images', json_extract(albums.metadata, '$.images')

--- a/music_assistant/controllers/media/tracks.py
+++ b/music_assistant/controllers/media/tracks.py
@@ -89,6 +89,7 @@ class TracksController(MediaControllerBase[Track]):
                     'sort_name', albums.sort_name,
                     'media_type', 'album',
                     'year', albums.year,
+                    'album_type', albums.album_type,
                     'disc_number', album_tracks.disc_number,
                     'track_number', album_tracks.track_number,
                     'images', json_extract(albums.metadata, '$.images')

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -21,7 +21,7 @@ from dataclasses import replace as dc_replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.enums import EventType, ImageType, MediaType, ProviderFeature
+from music_assistant_models.enums import AlbumType, EventType, ImageType, MediaType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
     BrowseFolder,
@@ -550,6 +550,16 @@ class SmartPlaylistProvider(PluginProvider):
                     )
                 ]
 
+            if rules.album_types:
+                allowed_types = {AlbumType(at) for at in rules.album_types}
+                tracks = [
+                    t
+                    for t in tracks
+                    if t.album is None
+                    or getattr(t.album, "album_type", AlbumType.UNKNOWN) == AlbumType.UNKNOWN
+                    or getattr(t.album, "album_type", AlbumType.UNKNOWN) in allowed_types
+                ]
+
         # Apply exclusions and dedup regardless of source mode
         excluded_genre_names = await self._resolve_excluded_genre_names(rules)
         tracks = self._apply_exclusions(tracks, rules, excluded_genre_names)
@@ -624,6 +634,15 @@ class SmartPlaylistProvider(PluginProvider):
                     and (rules.year_to is None or t.album.year <= rules.year_to)
                 )
             ]
+        if rules.album_types:
+            allowed_types = {AlbumType(at) for at in rules.album_types}
+            tracks = [
+                t
+                for t in tracks
+                if t.album is None
+                or getattr(t.album, "album_type", AlbumType.UNKNOWN) == AlbumType.UNKNOWN
+                or getattr(t.album, "album_type", AlbumType.UNKNOWN) in allowed_types
+            ]
         return tracks
 
     def _apply_exclusions(
@@ -632,17 +651,19 @@ class SmartPlaylistProvider(PluginProvider):
         rules: SmartPlaylistRules,
         excluded_genre_names: set[str] | None = None,
     ) -> list[Track]:
-        """Filter out tracks whose artist, album, URI, or genre is in the exclusion lists."""
+        """Filter out tracks whose artist, album, URI, genre or album type is in the exclusion lists."""
         if (
             not rules.excluded_artist_ids
             and not rules.excluded_album_ids
             and not rules.excluded_track_uris
             and not excluded_genre_names
+            and not rules.excluded_album_types
         ):
             return tracks
         excl_artists = set(rules.excluded_artist_ids)
         excl_albums = set(rules.excluded_album_ids)
         excl_uris = set(rules.excluded_track_uris)
+        excl_album_types = {AlbumType(at) for at in rules.excluded_album_types}
         result = []
         for track in tracks:
             if track.uri and track.uri in excl_uris:
@@ -668,6 +689,12 @@ class SmartPlaylistProvider(PluginProvider):
                 and track.metadata
                 and track.metadata.genres
                 and any(g.lower() in excluded_genre_names for g in track.metadata.genres)
+            ):
+                continue
+            if (
+                excl_album_types
+                and track.album is not None
+                and getattr(track.album, "album_type", AlbumType.UNKNOWN) in excl_album_types
             ):
                 continue
             result.append(track)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -551,11 +551,15 @@ class SmartPlaylistProvider(PluginProvider):
                 ]
 
             if rules.album_types:
-                tracks = self._filter_by_album_types(tracks, rules.album_types)
+                allowed_album_ids = await self._get_album_ids_for_types(rules.album_types)
+                tracks = self._filter_by_album_ids(tracks, allowed_album_ids)
 
         # Apply exclusions and dedup regardless of source mode
         excluded_genre_names = await self._resolve_excluded_genre_names(rules)
-        tracks = self._apply_exclusions(tracks, rules, excluded_genre_names)
+        excl_album_type_ids: set[int] | None = None
+        if rules.excluded_album_types:
+            excl_album_type_ids = await self._get_album_ids_for_types(rules.excluded_album_types)
+        tracks = self._apply_exclusions(tracks, rules, excluded_genre_names, excl_album_type_ids)
         tracks = self._deduplicate_tracks(tracks)
         if rules.dedup_hours is not None:
             deduped = self._apply_dedup(tracks, rules.dedup_hours)
@@ -628,7 +632,8 @@ class SmartPlaylistProvider(PluginProvider):
                 )
             ]
         if rules.album_types:
-            tracks = self._filter_by_album_types(tracks, rules.album_types)
+            allowed_album_ids = await self._get_album_ids_for_types(rules.album_types)
+            tracks = self._filter_by_album_ids(tracks, allowed_album_ids)
         return tracks
 
     def _apply_exclusions(
@@ -636,6 +641,7 @@ class SmartPlaylistProvider(PluginProvider):
         tracks: list[Track],
         rules: SmartPlaylistRules,
         excluded_genre_names: set[str] | None = None,
+        excl_album_type_ids: set[int] | None = None,
     ) -> list[Track]:
         """Filter out tracks whose artist, album, URI, genre or album type is in the exclusion lists."""
         if (
@@ -643,13 +649,12 @@ class SmartPlaylistProvider(PluginProvider):
             and not rules.excluded_album_ids
             and not rules.excluded_track_uris
             and not excluded_genre_names
-            and not rules.excluded_album_types
+            and not excl_album_type_ids
         ):
             return tracks
         excl_artists = set(rules.excluded_artist_ids)
         excl_albums = set(rules.excluded_album_ids)
         excl_uris = set(rules.excluded_track_uris)
-        excl_album_types = set(rules.excluded_album_types)
         result = []
         for track in tracks:
             if track.uri and track.uri in excl_uris:
@@ -678,24 +683,33 @@ class SmartPlaylistProvider(PluginProvider):
             ):
                 continue
             if (
-                excl_album_types
+                excl_album_type_ids
                 and track.album is not None
-                and getattr(track.album, "album_type", AlbumType.UNKNOWN).value in excl_album_types
+                and track.album.item_id
+                and str(track.album.item_id).isdigit()
+                and int(track.album.item_id) in excl_album_type_ids
             ):
                 continue
             result.append(track)
         return result
 
-    def _filter_by_album_types(self, tracks: list[Track], album_types: list[str]) -> list[Track]:
-        """Keep only tracks whose album type is in the allowed set (or is unknown/missing)."""
-        allowed = set(album_types)
+    def _filter_by_album_ids(self, tracks: list[Track], allowed_album_ids: set[int]) -> list[Track]:
+        """Keep only tracks whose album ID is in the allowed set (or has no album)."""
         return [
             t
             for t in tracks
             if t.album is None
-            or getattr(t.album, "album_type", AlbumType.UNKNOWN) == AlbumType.UNKNOWN
-            or getattr(t.album, "album_type", AlbumType.UNKNOWN).value in allowed
+            or not (t.album.item_id and str(t.album.item_id).isdigit())
+            or int(t.album.item_id) in allowed_album_ids
         ]
+
+    async def _get_album_ids_for_types(self, album_types: list[str]) -> set[int]:
+        """Return library album IDs matching the given album type values."""
+        albums = await self.mass.music.albums.library_items(
+            album_types=[AlbumType(t) for t in album_types],
+            limit=10000,
+        )
+        return {int(a.item_id) for a in albums if a.item_id and str(a.item_id).isdigit()}
 
     def _deduplicate_tracks(self, tracks: list[Track]) -> list[Track]:
         """Remove duplicates and skip unavailable tracks while keeping order stable."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -551,13 +551,13 @@ class SmartPlaylistProvider(PluginProvider):
                 ]
 
             if rules.album_types:
-                allowed_types = {AlbumType(at) for at in rules.album_types}
+                allowed_types = set(rules.album_types)
                 tracks = [
                     t
                     for t in tracks
                     if t.album is None
                     or getattr(t.album, "album_type", AlbumType.UNKNOWN) == AlbumType.UNKNOWN
-                    or getattr(t.album, "album_type", AlbumType.UNKNOWN) in allowed_types
+                    or getattr(t.album, "album_type", AlbumType.UNKNOWN).value in allowed_types
                 ]
 
         # Apply exclusions and dedup regardless of source mode
@@ -635,13 +635,13 @@ class SmartPlaylistProvider(PluginProvider):
                 )
             ]
         if rules.album_types:
-            allowed_types = {AlbumType(at) for at in rules.album_types}
+            allowed_types = set(rules.album_types)
             tracks = [
                 t
                 for t in tracks
                 if t.album is None
                 or getattr(t.album, "album_type", AlbumType.UNKNOWN) == AlbumType.UNKNOWN
-                or getattr(t.album, "album_type", AlbumType.UNKNOWN) in allowed_types
+                or getattr(t.album, "album_type", AlbumType.UNKNOWN).value in allowed_types
             ]
         return tracks
 
@@ -663,7 +663,7 @@ class SmartPlaylistProvider(PluginProvider):
         excl_artists = set(rules.excluded_artist_ids)
         excl_albums = set(rules.excluded_album_ids)
         excl_uris = set(rules.excluded_track_uris)
-        excl_album_types = {AlbumType(at) for at in rules.excluded_album_types}
+        excl_album_types = set(rules.excluded_album_types)
         result = []
         for track in tracks:
             if track.uri and track.uri in excl_uris:
@@ -694,7 +694,7 @@ class SmartPlaylistProvider(PluginProvider):
             if (
                 excl_album_types
                 and track.album is not None
-                and getattr(track.album, "album_type", AlbumType.UNKNOWN) in excl_album_types
+                and getattr(track.album, "album_type", AlbumType.UNKNOWN).value in excl_album_types
             ):
                 continue
             result.append(track)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -555,11 +555,15 @@ class SmartPlaylistProvider(PluginProvider):
                 tracks = self._filter_by_album_ids(tracks, allowed_album_ids)
 
         # Apply exclusions and dedup regardless of source mode
-        excluded_genre_names = await self._resolve_excluded_genre_names(rules)
-        excl_album_type_ids: set[int] | None = None
-        if rules.excluded_album_types:
-            excl_album_type_ids = await self._get_album_ids_for_types(rules.excluded_album_types)
-        tracks = self._apply_exclusions(tracks, rules, excluded_genre_names, excl_album_type_ids)
+        excluded_genre_names, excl_album_type_ids = await asyncio.gather(
+            self._resolve_excluded_genre_names(rules),
+            self._get_album_ids_for_types(rules.excluded_album_types)
+            if rules.excluded_album_types
+            else asyncio.sleep(0),
+        )
+        tracks = self._apply_exclusions(
+            tracks, rules, excluded_genre_names, excl_album_type_ids or None
+        )
         tracks = self._deduplicate_tracks(tracks)
         if rules.dedup_hours is not None:
             deduped = self._apply_dedup(tracks, rules.dedup_hours)
@@ -694,7 +698,7 @@ class SmartPlaylistProvider(PluginProvider):
         return result
 
     def _filter_by_album_ids(self, tracks: list[Track], allowed_album_ids: set[int]) -> list[Track]:
-        """Keep only tracks whose album ID is in the allowed set (or has no album)."""
+        """Keep only tracks whose album ID is in the allowed set; pass through tracks with no resolvable album ID."""
         return [
             t
             for t in tracks
@@ -705,11 +709,23 @@ class SmartPlaylistProvider(PluginProvider):
 
     async def _get_album_ids_for_types(self, album_types: list[str]) -> set[int]:
         """Return library album IDs matching the given album type values."""
-        albums = await self.mass.music.albums.library_items(
-            album_types=[AlbumType(t) for t in album_types],
-            limit=10000,
-        )
-        return {int(a.item_id) for a in albums if a.item_id and str(a.item_id).isdigit()}
+        album_type_enums = [AlbumType(t) for t in album_types]
+        album_ids: set[int] = set()
+        offset = 0
+        chunk = 500
+        while True:
+            page = await self.mass.music.albums.library_items(
+                album_types=album_type_enums,
+                limit=chunk,
+                offset=offset,
+            )
+            for a in page:
+                if a.item_id and str(a.item_id).isdigit():
+                    album_ids.add(int(a.item_id))
+            if len(page) < chunk:
+                break
+            offset += chunk
+        return album_ids
 
     def _deduplicate_tracks(self, tracks: list[Track]) -> list[Track]:
         """Remove duplicates and skip unavailable tracks while keeping order stable."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -551,14 +551,7 @@ class SmartPlaylistProvider(PluginProvider):
                 ]
 
             if rules.album_types:
-                allowed_types = set(rules.album_types)
-                tracks = [
-                    t
-                    for t in tracks
-                    if t.album is None
-                    or getattr(t.album, "album_type", AlbumType.UNKNOWN) == AlbumType.UNKNOWN
-                    or getattr(t.album, "album_type", AlbumType.UNKNOWN).value in allowed_types
-                ]
+                tracks = self._filter_by_album_types(tracks, rules.album_types)
 
         # Apply exclusions and dedup regardless of source mode
         excluded_genre_names = await self._resolve_excluded_genre_names(rules)
@@ -635,14 +628,7 @@ class SmartPlaylistProvider(PluginProvider):
                 )
             ]
         if rules.album_types:
-            allowed_types = set(rules.album_types)
-            tracks = [
-                t
-                for t in tracks
-                if t.album is None
-                or getattr(t.album, "album_type", AlbumType.UNKNOWN) == AlbumType.UNKNOWN
-                or getattr(t.album, "album_type", AlbumType.UNKNOWN).value in allowed_types
-            ]
+            tracks = self._filter_by_album_types(tracks, rules.album_types)
         return tracks
 
     def _apply_exclusions(
@@ -699,6 +685,17 @@ class SmartPlaylistProvider(PluginProvider):
                 continue
             result.append(track)
         return result
+
+    def _filter_by_album_types(self, tracks: list[Track], album_types: list[str]) -> list[Track]:
+        """Keep only tracks whose album type is in the allowed set (or is unknown/missing)."""
+        allowed = set(album_types)
+        return [
+            t
+            for t in tracks
+            if t.album is None
+            or getattr(t.album, "album_type", AlbumType.UNKNOWN) == AlbumType.UNKNOWN
+            or getattr(t.album, "album_type", AlbumType.UNKNOWN).value in allowed
+        ]
 
     def _deduplicate_tracks(self, tracks: list[Track]) -> list[Track]:
         """Remove duplicates and skip unavailable tracks while keeping order stable."""

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -302,11 +302,11 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
     valid_album_types = {t.value for t in AlbumType}
     for at in rules.album_types:
         if at not in valid_album_types:
-            msg = f"Invalid album_type: {at!r}. Must be one of {sorted(valid_album_types)}"
+            msg = f"Invalid album_types value: {at!r}. Must be one of {sorted(valid_album_types)}"
             raise InvalidDataError(msg)
     for at in rules.excluded_album_types:
         if at not in valid_album_types:
-            msg = f"Invalid excluded_album_type: {at!r}. Must be one of {sorted(valid_album_types)}"
+            msg = f"Invalid excluded_album_types value: {at!r}. Must be one of {sorted(valid_album_types)}"
             raise InvalidDataError(msg)
 
 

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any, cast
 
 import aiofiles
+from music_assistant_models.enums import AlbumType
 from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.helpers.json import json_dumps, json_loads
@@ -111,6 +112,8 @@ class SmartPlaylistRules:
     excluded_genre_ids: list[int] = field(default_factory=list)
     excluded_genre_names: dict[int, str] = field(default_factory=dict)
     dedup_hours: int | None = None
+    album_types: list[str] = field(default_factory=list)
+    excluded_album_types: list[str] = field(default_factory=list)
 
     def all_seed_uris(self) -> list[str]:
         """Return every seed URI across the four seed lists, deduplicated, original order."""
@@ -156,6 +159,8 @@ class SmartPlaylistRules:
             "excluded_genre_ids": self.excluded_genre_ids,
             "excluded_genre_names": {str(k): v for k, v in self.excluded_genre_names.items()},
             "dedup_hours": self.dedup_hours,
+            "album_types": self.album_types,
+            "excluded_album_types": self.excluded_album_types,
         }
 
     @classmethod
@@ -204,6 +209,10 @@ class SmartPlaylistRules:
                 data.get("excluded_genre_names"), "excluded_genre_names"
             ),
             dedup_hours=_coerce_optional_int(data.get("dedup_hours"), "dedup_hours"),
+            album_types=_coerce_str_list(data.get("album_types"), "album_types"),
+            excluded_album_types=_coerce_str_list(
+                data.get("excluded_album_types"), "excluded_album_types"
+            ),
         )
 
     def human_readable(self) -> str:
@@ -243,6 +252,10 @@ class SmartPlaylistRules:
             parts.append(f"Excl. {len(self.excluded_track_uris)} track(s)")
         if self.dedup_hours is not None:
             parts.append(f"No repeat within {self.dedup_hours}h")
+        if self.album_types:
+            parts.append(f"Album types: {', '.join(self.album_types)}")
+        if self.excluded_album_types:
+            parts.append(f"Excl. album types: {', '.join(self.excluded_album_types)}")
         if self.min_popularity is not None:
             parts.append(f"Min. popularity: {self.min_popularity}")
         if self.year_from is not None or self.year_to is not None:
@@ -286,6 +299,15 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
     if rules.dedup_hours is not None and not (1 <= rules.dedup_hours <= 8760):
         msg = f"dedup_hours must be between 1 and 8760, got {rules.dedup_hours}"
         raise InvalidDataError(msg)
+    valid_album_types = {t.value for t in AlbumType}
+    for at in rules.album_types:
+        if at not in valid_album_types:
+            msg = f"Invalid album_type: {at!r}. Must be one of {sorted(valid_album_types)}"
+            raise InvalidDataError(msg)
+    for at in rules.excluded_album_types:
+        if at not in valid_album_types:
+            msg = f"Invalid excluded_album_type: {at!r}. Must be one of {sorted(valid_album_types)}"
+            raise InvalidDataError(msg)
 
 
 async def read_json(path: str) -> dict[str, Any]:

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -880,7 +880,7 @@ def _make_mock_track_with_album_type(
     uri: str,
     album_type: str = "unknown",
 ) -> MagicMock:
-    """Build a minimal mock Track with a specific album.album_type string value."""
+    """Build a minimal mock Track with a specific album.album_type (AlbumType enum)."""
     track = _make_mock_track(item_id, uri)
     track.album = MagicMock()
     track.album.item_id = "200"

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.enums import AlbumType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import ProviderMapping, Track
 
@@ -867,3 +868,155 @@ async def test_count_tracks_returns_count_and_duration(tmp_path: Any) -> None:
     result = await plugin.count_tracks(SmartPlaylistRules(limit=10).to_dict())
     assert result["count"] == 3
     assert result["duration_seconds"] == 600
+
+
+# ---------------------------------------------------------------------------
+# album_type filter tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_track_with_album_type(
+    item_id: str,
+    uri: str,
+    album_type: str = "unknown",
+) -> MagicMock:
+    """Build a minimal mock Track with a specific album.album_type string value."""
+    track = _make_mock_track(item_id, uri)
+    track.album = MagicMock()
+    track.album.item_id = "200"
+    track.album.year = None
+    album_type_enum = AlbumType(album_type)
+    track.album.album_type = album_type_enum
+    return track
+
+
+class TestSmartPlaylistRulesAlbumType:
+    """Tests for album_types / excluded_album_types fields on SmartPlaylistRules."""
+
+    def test_album_types_defaults_to_empty(self) -> None:
+        """album_types and excluded_album_types default to empty lists."""
+        rules = SmartPlaylistRules()
+        assert rules.album_types == []
+        assert rules.excluded_album_types == []
+
+    def test_album_types_round_trip(self) -> None:
+        """album_types / excluded_album_types survive a to_dict / from_dict round-trip."""
+        rules = SmartPlaylistRules(
+            album_types=["album", "ep"],
+            excluded_album_types=["single", "compilation"],
+        )
+        recovered = SmartPlaylistRules.from_dict(rules.to_dict())
+        assert recovered.album_types == ["album", "ep"]
+        assert recovered.excluded_album_types == ["single", "compilation"]
+
+    def test_old_json_without_album_types_loads_cleanly(self) -> None:
+        """Rules JSON without album_types fields deserializes with empty defaults."""
+        rules = SmartPlaylistRules.from_dict({"limit": 50, "favorites_only": True})
+        assert rules.album_types == []
+        assert rules.excluded_album_types == []
+
+    def test_human_readable_includes_album_types(self) -> None:
+        """human_readable mentions album_types when set."""
+        rules = SmartPlaylistRules(album_types=["album", "ep"])
+        summary = rules.human_readable()
+        assert "album" in summary
+        assert "ep" in summary
+
+    def test_human_readable_includes_excluded_album_types(self) -> None:
+        """human_readable mentions excluded_album_types when set."""
+        rules = SmartPlaylistRules(excluded_album_types=["single"])
+        assert "single" in rules.human_readable()
+
+
+class TestAlbumTypeValidation:
+    """Tests for album_type validation in validate_rules."""
+
+    def _make_plugin(self) -> SmartPlaylistProvider:
+        mass = MagicMock()
+        manifest = MagicMock()
+        manifest.domain = "smart_playlist"
+        config = MagicMock()
+        config.get_value.return_value = "GLOBAL"
+        return SmartPlaylistProvider(mass, manifest, config, set())
+
+    def test_valid_album_types_pass(self) -> None:
+        """All AlbumType values are valid."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(
+            album_types=["album", "single", "ep", "live", "soundtrack", "compilation"]
+        )
+        plugin._validate_rules(rules)  # must not raise
+
+    def test_invalid_album_type_raises(self) -> None:
+        """Unknown album_type value raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(album_types=["not_a_real_type"])
+        with pytest.raises(InvalidDataError, match="album_type"):
+            plugin._validate_rules(rules)
+
+    def test_invalid_excluded_album_type_raises(self) -> None:
+        """Unknown excluded_album_type value raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(excluded_album_types=["bogus"])
+        with pytest.raises(InvalidDataError, match="excluded_album_type"):
+            plugin._validate_rules(rules)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_rules_album_types_filter() -> None:
+    """album_types filter keeps only tracks whose album.album_type matches."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    album_track = _make_mock_track_with_album_type("1", "library://track/1", "album")
+    single_track = _make_mock_track_with_album_type("2", "library://track/2", "single")
+    unknown_track = _make_mock_track_with_album_type("3", "library://track/3", "unknown")
+
+    for t in (album_track, single_track, unknown_track):
+        t.available = True
+        t.last_played = 0
+        t.metadata = MagicMock()
+        t.metadata.genres = None
+
+    cast("Any", plugin)._get_library_tracks = AsyncMock(
+        return_value=[album_track, single_track, unknown_track]
+    )
+
+    rules = SmartPlaylistRules(album_types=["album"], limit=10)
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris  # album → included
+    assert "library://track/2" not in uris  # single → excluded
+    assert "library://track/3" in uris  # unknown → kept (lenient)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_rules_excluded_album_types_filter() -> None:
+    """excluded_album_types removes tracks whose album.album_type is in the exclusion list."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    album_track = _make_mock_track_with_album_type("1", "library://track/1", "album")
+    single_track = _make_mock_track_with_album_type("2", "library://track/2", "single")
+
+    for t in (album_track, single_track):
+        t.available = True
+        t.last_played = 0
+        t.metadata = MagicMock()
+        t.metadata.genres = None
+
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[album_track, single_track])
+
+    rules = SmartPlaylistRules(excluded_album_types=["single"], limit=10)
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris  # album → kept
+    assert "library://track/2" not in uris  # single → excluded

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.enums import AlbumType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import ProviderMapping, Track
 
@@ -877,7 +878,7 @@ async def test_count_tracks_returns_count_and_duration(tmp_path: Any) -> None:
 def _make_mock_track_with_album_type(
     item_id: str,
     uri: str,
-    album_type: str = "unknown",  # noqa: ARG001
+    album_type: str = "unknown",
 ) -> MagicMock:
     """Build a minimal mock Track with a unique album.item_id per item_id."""
     track = _make_mock_track(item_id, uri)
@@ -885,6 +886,7 @@ def _make_mock_track_with_album_type(
     # Unique album ID per track (item_id "1" → album "1000") so library_items mocks are precise.
     track.album.item_id = str(int(item_id) * 1000)
     track.album.year = None
+    track.album.album_type = AlbumType(album_type)
     return track
 
 
@@ -949,20 +951,20 @@ class TestAlbumTypeValidation:
         """Unknown album_type value raises InvalidDataError."""
         plugin = self._make_plugin()
         rules = SmartPlaylistRules(album_types=["not_a_real_type"])
-        with pytest.raises(InvalidDataError, match="album_type"):
+        with pytest.raises(InvalidDataError, match="album_types"):
             plugin._validate_rules(rules)
 
     def test_invalid_excluded_album_type_raises(self) -> None:
         """Unknown excluded_album_type value raises InvalidDataError."""
         plugin = self._make_plugin()
         rules = SmartPlaylistRules(excluded_album_types=["bogus"])
-        with pytest.raises(InvalidDataError, match="excluded_album_type"):
+        with pytest.raises(InvalidDataError, match="excluded_album_types"):
             plugin._validate_rules(rules)
 
 
 @pytest.mark.asyncio
 async def test_evaluate_rules_album_types_filter() -> None:
-    """album_types filter keeps only tracks whose album.album_type matches."""
+    """album_types filter keeps only tracks whose album ID is in the allowed set."""
     mass = MagicMock()
     manifest = MagicMock()
     manifest.domain = "smart_playlist"

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -7,7 +7,6 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import AlbumType
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import ProviderMapping, Track
 
@@ -878,15 +877,14 @@ async def test_count_tracks_returns_count_and_duration(tmp_path: Any) -> None:
 def _make_mock_track_with_album_type(
     item_id: str,
     uri: str,
-    album_type: str = "unknown",
+    album_type: str = "unknown",  # noqa: ARG001
 ) -> MagicMock:
-    """Build a minimal mock Track with a specific album.album_type (AlbumType enum)."""
+    """Build a minimal mock Track with a unique album.item_id per item_id."""
     track = _make_mock_track(item_id, uri)
     track.album = MagicMock()
-    track.album.item_id = "200"
+    # Unique album ID per track (item_id "1" → album "1000") so library_items mocks are precise.
+    track.album.item_id = str(int(item_id) * 1000)
     track.album.year = None
-    album_type_enum = AlbumType(album_type)
-    track.album.album_type = album_type_enum
     return track
 
 
@@ -985,13 +983,17 @@ async def test_evaluate_rules_album_types_filter() -> None:
     cast("Any", plugin)._get_library_tracks = AsyncMock(
         return_value=[album_track, single_track, unknown_track]
     )
+    # albums.library_items returns only the "album" type album (album_track.album.item_id = "1000")
+    mock_album = MagicMock()
+    mock_album.item_id = "1000"
+    mass.music.albums.library_items = AsyncMock(return_value=[mock_album])
 
     rules = SmartPlaylistRules(album_types=["album"], limit=10)
     result = await plugin._evaluate_rules(rules)
     uris = [t.uri for t in result]
     assert "library://track/1" in uris  # album → included
     assert "library://track/2" not in uris  # single → excluded
-    assert "library://track/3" in uris  # unknown → kept (lenient)
+    assert "library://track/3" not in uris  # unknown album type → excluded
 
 
 @pytest.mark.asyncio
@@ -1014,6 +1016,10 @@ async def test_evaluate_rules_excluded_album_types_filter() -> None:
         t.metadata.genres = None
 
     cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[album_track, single_track])
+    # albums.library_items returns only the "single" type album (single_track.album.item_id = "2000")
+    mock_album = MagicMock()
+    mock_album.item_id = "2000"
+    mass.music.albums.library_items = AsyncMock(return_value=[mock_album])
 
     rules = SmartPlaylistRules(excluded_album_types=["single"], limit=10)
     result = await plugin._evaluate_rules(rules)
@@ -1047,6 +1053,10 @@ async def test_seed_mode_album_types_filter_is_applied() -> None:
     # Seed mode is triggered when seed_track_uris is non-empty.
     # Mock _tracks_from_seeds to return mixed album types.
     cast("Any", plugin)._tracks_from_seeds = AsyncMock(return_value=[album_track, single_track])
+    # albums.library_items returns only the "album" type album (album_track.album.item_id = "1000")
+    mock_album = MagicMock()
+    mock_album.item_id = "1000"
+    mass.music.albums.library_items = AsyncMock(return_value=[mock_album])
 
     rules = SmartPlaylistRules(
         seed_track_uris=["library://track/99"],

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -1020,3 +1020,40 @@ async def test_evaluate_rules_excluded_album_types_filter() -> None:
     uris = [t.uri for t in result]
     assert "library://track/1" in uris  # album → kept
     assert "library://track/2" not in uris  # single → excluded
+
+
+@pytest.mark.asyncio
+async def test_seed_mode_album_types_filter_is_applied() -> None:
+    """album_types filter is enforced in seed mode via _apply_seed_post_filters."""
+    mass = MagicMock()
+    mass.music.genres.get_library_item = AsyncMock(side_effect=Exception("not called"))
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    album_track = _make_mock_track_with_album_type("1", "library://track/1", "album")
+    single_track = _make_mock_track_with_album_type("2", "library://track/2", "single")
+
+    for t in (album_track, single_track):
+        t.available = True
+        t.last_played = 0
+        t.metadata = MagicMock()
+        t.metadata.popularity = None
+        t.metadata.genres = None
+        t.favorite = False
+
+    # Seed mode is triggered when seed_track_uris is non-empty.
+    # Mock _tracks_from_seeds to return mixed album types.
+    cast("Any", plugin)._tracks_from_seeds = AsyncMock(return_value=[album_track, single_track])
+
+    rules = SmartPlaylistRules(
+        seed_track_uris=["library://track/99"],
+        album_types=["album"],
+        limit=10,
+    )
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris  # album → kept
+    assert "library://track/2" not in uris  # single → filtered out by _apply_seed_post_filters


### PR DESCRIPTION
# What does this implement/fix?

Adds `album_types` and `excluded_album_types` filter fields to `SmartPlaylistRules`, allowing users to narrow or exclude tracks based on their album's type (Album, Single, EP, Live, Soundtrack, Compilation).

The filter is applied in all three evaluation paths: library mode (`_evaluate_rules`), seed post-filter (`_apply_seed_post_filters`), and exclusions (`_apply_exclusions`).

> **Note:** This PR can be included in **v2.10.0** if desired — there is no urgency to merge it sooner.
> Most music providers (Spotify, Tidal, etc.) already supply `album_type` during sync, so the filter works out of the box for those. A separate MusicBrainz PR will extend coverage to local files and providers that do not natively set `album_type`.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked: music-assistant/frontend#1847
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.