### PR TITLE
Phishin fixes and optimisations

### DIFF
--- a/music_assistant/providers/phishin/helpers.py
+++ b/music_assistant/providers/phishin/helpers.py
@@ -172,7 +172,8 @@ async def get_phish_artist(provider: MusicProvider) -> Artist:
 
 
 def _extract_version_from_title(full_title: str) -> tuple[str, str]:
-    """Extract song title and version from full title with performance indicators.
+    """
+    Extract song title and version from full title with performance indicators.
 
     Returns:
         Tuple of (clean_song_title, version_string)
@@ -226,7 +227,8 @@ def _build_track_details(
 
 
 def _flat_track_show(track_data: dict[str, Any]) -> dict[str, Any]:
-    """Build a show_data dict from a track's flat fields.
+    """
+    Build a show_data dict from a track's flat fields.
 
     Some endpoints (search results, playlist entries) return track objects
     without a nested ``show`` object, exposing the show details as flat fields.

--- a/music_assistant/providers/phishin/helpers.py
+++ b/music_assistant/providers/phishin/helpers.py
@@ -278,6 +278,22 @@ def _build_track_details(
     return "|".join(details_parts)
 
 
+def _flat_track_show(track_data: dict[str, Any]) -> dict[str, Any]:
+    """Build a show_data dict from a track's flat fields.
+
+    Some endpoints (search results, playlist entries) return track objects
+    without a nested ``show`` object, exposing the show details as flat fields.
+    """
+    return {
+        "date": track_data.get("show_date"),
+        "album_cover_url": track_data.get("show_album_cover_url"),
+        "venue": {
+            "name": track_data.get("venue_name"),
+            "location": track_data.get("venue_location"),
+        },
+    }
+
+
 def track_to_ma_track(
     provider: MusicProvider,
     track_data: dict[str, Any],
@@ -299,9 +315,9 @@ def track_to_ma_track(
     track_number = int(position) if position is not None else 0
     set_name = track_data.get("set_name", "")
 
-    # Get show information
+    # Get show information; fall back to the nested show or flat track fields
     if show_data is None:
-        show_data = track_data.get("show", {})
+        show_data = track_data.get("show") or _flat_track_show(track_data)
     show_date = show_data.get("date", "")
     venue_name = show_data.get("venue", {}).get("name", "")
 

--- a/music_assistant/providers/phishin/helpers.py
+++ b/music_assistant/providers/phishin/helpers.py
@@ -62,8 +62,17 @@ async def api_request(
         raise ProviderUnavailableError(f"Phish.in API unavailable: {err}") from err
 
 
-def show_to_album(provider: MusicProvider, show_data: dict[str, Any]) -> Album:
-    """Convert a Phish.in show to a Music Assistant Album."""
+def show_to_album(
+    provider: MusicProvider,
+    show_data: dict[str, Any],
+    *,
+    available: bool | None = None,
+) -> Album:
+    """
+    Convert a Phish.in show to a Music Assistant Album.
+
+    :param available: Override album availability; defaults to the show's audio_status.
+    """
     show_date = show_data.get("date", "")
     venue_data = show_data.get("venue", {})
     venue_name = venue_data.get("name", "Unknown Venue")
@@ -103,6 +112,7 @@ def show_to_album(provider: MusicProvider, show_data: dict[str, Any]) -> Album:
 
     audio_status = show_data.get("audio_status", "missing")
     details_parts.append(f"audio_status:{audio_status}")
+    is_available = available if available is not None else audio_status in ["complete", "partial"]
 
     if show_data.get("tour_name"):
         details_parts.append(f"tour:{show_data.get('tour_name')}")
@@ -129,7 +139,7 @@ def show_to_album(provider: MusicProvider, show_data: dict[str, Any]) -> Album:
                 item_id=show_date,
                 provider_domain=provider.domain,
                 provider_instance=provider.instance_id,
-                available=audio_status in ["complete", "partial"],
+                available=is_available,
                 audio_format=AudioFormat(content_type=ContentType.MP3),
                 details="|".join(details_parts),
             )
@@ -188,69 +198,6 @@ def _extract_version_from_title(full_title: str) -> tuple[str, str]:
             song_title = base_title
 
     return song_title, version or ""
-
-
-def _create_track_album(
-    provider: MusicProvider,
-    show_date: str,
-    show_data: dict[str, Any] | None,
-) -> Album | None:
-    """Create the parent Album for a track.
-
-    A full Album (rather than an ItemMapping) is required so the track's show
-    surfaces in the UI's "Appears On" section, which only accepts Album instances.
-    """
-    if not show_date:
-        return None
-
-    venue_name = show_data.get("venue", {}).get("name", "") if show_data else ""
-    album_name = f"{show_date} - {venue_name}" if venue_name else show_date
-
-    image_url = (show_data.get("album_cover_url") if show_data else None) or FALLBACK_ALBUM_IMAGE
-    metadata = MediaItemMetadata(
-        images=UniqueList(
-            [
-                MediaItemImage(
-                    type=ImageType.THUMB,
-                    path=image_url,
-                    provider=provider.instance_id,
-                    remotely_accessible=True,
-                )
-            ]
-        )
-    )
-
-    year = None
-    if "-" in show_date:
-        with contextlib.suppress(ValueError, IndexError):
-            year = int(show_date.split("-", maxsplit=1)[0])
-
-    phish_artist = ItemMapping(
-        item_id=PHISH_ARTIST_ID,
-        provider=provider.instance_id,
-        name=PHISH_ARTIST_NAME,
-        media_type=MediaType.ARTIST,
-        available=True,
-    )
-
-    return Album(
-        item_id=show_date,
-        provider=provider.instance_id,
-        name=album_name,
-        artists=UniqueList([phish_artist]),
-        year=year,
-        album_type=AlbumType.LIVE,
-        metadata=metadata,
-        provider_mappings={
-            ProviderMapping(
-                item_id=show_date,
-                provider_domain=provider.domain,
-                provider_instance=provider.instance_id,
-                available=True,
-                audio_format=AudioFormat(content_type=ContentType.MP3),
-            )
-        },
-    )
 
 
 def _build_track_details(
@@ -330,8 +277,9 @@ def track_to_ma_track(
         available=True,
     )
 
-    # Create the parent album (full Album so the track shows under "Appears On")
-    track_album = _create_track_album(provider, show_date, show_data)
+    # Build the parent album (full Album so the track shows under "Appears On").
+    # Tracks we surface always have audio, so force the album available.
+    track_album = show_to_album(provider, show_data, available=True) if show_date else None
 
     # Build details string
     details = _build_track_details(track_data, song_data, show_date, set_name, venue_name)
@@ -566,13 +514,7 @@ def _parse_tracks(
         clean_title = strip_performance_indicators(full_title)
 
         if contains_search_term(clean_title):
-            # Extract show data from track data for image
-            show_data = {
-                "date": track_data.get("show_date"),
-                "album_cover_url": track_data.get("show_album_cover_url"),
-                "venue": {"name": track_data.get("venue_name")},
-            }
-            tracks.append(track_to_ma_track(provider, track_data, show_data))
+            tracks.append(track_to_ma_track(provider, track_data))
 
     # Deduplicate by album - only return one track per show
     seen_albums = set()

--- a/music_assistant/providers/phishin/helpers.py
+++ b/music_assistant/providers/phishin/helpers.py
@@ -190,35 +190,66 @@ def _extract_version_from_title(full_title: str) -> tuple[str, str]:
     return song_title, version or ""
 
 
-def _create_album_mapping(
+def _create_track_album(
     provider: MusicProvider,
     show_date: str,
     show_data: dict[str, Any] | None,
-) -> ItemMapping | None:
-    """Create album ItemMapping with image for a track."""
+) -> Album | None:
+    """Create the parent Album for a track.
+
+    A full Album (rather than an ItemMapping) is required so the track's show
+    surfaces in the UI's "Appears On" section, which only accepts Album instances.
+    """
     if not show_date:
         return None
 
     venue_name = show_data.get("venue", {}).get("name", "") if show_data else ""
+    album_name = f"{show_date} - {venue_name}" if venue_name else show_date
 
-    # Create the image for the album mapping
-    album_image = None
-    if show_data:
-        image_url = show_data.get("album_cover_url") or FALLBACK_ALBUM_IMAGE
-        album_image = MediaItemImage(
-            type=ImageType.THUMB,
-            path=image_url,
-            provider=provider.instance_id,
-            remotely_accessible=True,
+    image_url = (show_data.get("album_cover_url") if show_data else None) or FALLBACK_ALBUM_IMAGE
+    metadata = MediaItemMetadata(
+        images=UniqueList(
+            [
+                MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=image_url,
+                    provider=provider.instance_id,
+                    remotely_accessible=True,
+                )
+            ]
         )
+    )
 
-    return ItemMapping(
+    year = None
+    if "-" in show_date:
+        with contextlib.suppress(ValueError, IndexError):
+            year = int(show_date.split("-", maxsplit=1)[0])
+
+    phish_artist = ItemMapping(
+        item_id=PHISH_ARTIST_ID,
+        provider=provider.instance_id,
+        name=PHISH_ARTIST_NAME,
+        media_type=MediaType.ARTIST,
+        available=True,
+    )
+
+    return Album(
         item_id=show_date,
         provider=provider.instance_id,
-        name=f"{show_date} - {venue_name}" if venue_name else show_date,
-        media_type=MediaType.ALBUM,
-        available=True,
-        image=album_image,
+        name=album_name,
+        artists=UniqueList([phish_artist]),
+        year=year,
+        album_type=AlbumType.LIVE,
+        metadata=metadata,
+        provider_mappings={
+            ProviderMapping(
+                item_id=show_date,
+                provider_domain=provider.domain,
+                provider_instance=provider.instance_id,
+                available=True,
+                audio_format=AudioFormat(content_type=ContentType.MP3),
+            )
+        },
     )
 
 
@@ -283,8 +314,8 @@ def track_to_ma_track(
         available=True,
     )
 
-    # Create album mapping with image
-    album_mapping = _create_album_mapping(provider, show_date, show_data)
+    # Create the parent album (full Album so the track shows under "Appears On")
+    track_album = _create_track_album(provider, show_date, show_data)
 
     # Build details string
     details = _build_track_details(track_data, song_data, show_date, set_name, venue_name)
@@ -313,7 +344,7 @@ def track_to_ma_track(
         name=song_title,
         version=version,
         artists=UniqueList([phish_artist]),
-        album=album_mapping,
+        album=track_album,
         duration=duration,
         track_number=track_number,
         metadata=metadata,

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -222,13 +222,7 @@ class PhishInProvider(MusicProvider):
                     break
 
                 for track_data in tracks_on_page:
-                    show_data = {
-                        "date": track_data.get("show_date"),
-                        "album_cover_url": track_data.get("show_album_cover_url"),
-                        "venue": {"name": track_data.get("venue_name")},
-                    }
-                    track = track_to_ma_track(self, track_data, show_data)
-                    all_tracks.append(track)
+                    all_tracks.append(track_to_ma_track(self, track_data))
 
                 # a short page means we've reached the end
                 if len(tracks_on_page) < per_page:

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import (
     ContentType,
-    ImageType,
     MediaType,
     StreamType,
 )
@@ -18,15 +17,11 @@ from music_assistant_models.media_items import (
     AudioFormat,
     BrowseFolder,
     ItemMapping,
-    MediaItemImage,
-    MediaItemMetadata,
     Playlist,
-    ProviderMapping,
     SearchResults,
     Track,
 )
 from music_assistant_models.streamdetails import StreamDetails
-from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.datetime import now
@@ -34,7 +29,6 @@ from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
     ENDPOINTS,
-    FALLBACK_ALBUM_IMAGE,
     MAX_SEARCH_RESULTS,
     PHISH_ARTIST_ID,
 )
@@ -42,6 +36,7 @@ from .helpers import (
     api_request,
     get_phish_artist,
     parse_search_results,
+    playlist_to_ma_playlist,
     show_to_album,
     track_to_ma_track,
 )
@@ -363,43 +358,9 @@ class PhishInProvider(MusicProvider):
     async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
         """Retrieve library playlists from the provider."""
         try:
-            playlists_data = await api_request(
-                self, ENDPOINTS["playlists"], params={"per_page": 100, "sort": "likes_count:desc"}
-            )
-
-            for playlist_data in playlists_data.get("playlists", []):
-                track_count = playlist_data.get("tracks_count", 0)
-                if track_count > 0:
-                    playlist_id = str(playlist_data.get("id"))
-
-                    metadata = MediaItemMetadata(
-                        images=UniqueList(
-                            [
-                                MediaItemImage(
-                                    type=ImageType.THUMB,
-                                    path=FALLBACK_ALBUM_IMAGE,
-                                    provider=self.instance_id,
-                                    remotely_accessible=True,
-                                )
-                            ]
-                        )
-                    )
-                    yield Playlist(
-                        item_id=playlist_id,
-                        provider=self.instance_id,
-                        name=playlist_data.get("name", ""),
-                        owner=playlist_data.get("username", ""),
-                        is_editable=False,
-                        metadata=metadata,
-                        provider_mappings={
-                            ProviderMapping(
-                                item_id=playlist_id,
-                                provider_domain=self.domain,
-                                provider_instance=self.instance_id,
-                                available=True,
-                            )
-                        },
-                    )
+            for playlist_data in await self._get_playlists():
+                if playlist_data.get("tracks_count", 0) > 0:
+                    yield playlist_to_ma_playlist(self, playlist_data)
         except (MediaNotFoundError, ProviderUnavailableError):
             raise
         except Exception as err:
@@ -410,35 +371,10 @@ class PhishInProvider(MusicProvider):
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
         """Get full playlist details by id."""
         try:
-            playlists_data = await api_request(self, ENDPOINTS["playlists"])
-            playlist_slug = None
-            playlist_info = None
-
-            for playlist in playlists_data.get("playlists", []):
-                if str(playlist.get("id")) == prov_playlist_id:
-                    playlist_slug = playlist.get("slug")
-                    playlist_info = playlist
-                    break
-
-            if not playlist_slug or not playlist_info:
+            playlist_info = await self._resolve_playlist(prov_playlist_id)
+            if not playlist_info:
                 raise MediaNotFoundError(f"Playlist {prov_playlist_id} not found")
-
-            return Playlist(
-                item_id=prov_playlist_id,
-                provider=self.instance_id,
-                name=playlist_info.get("name", ""),
-                owner=playlist_info.get("username", ""),
-                is_editable=False,
-                provider_mappings={
-                    ProviderMapping(
-                        item_id=prov_playlist_id,
-                        provider_domain=self.domain,
-                        provider_instance=self.instance_id,
-                        available=True,
-                    )
-                },
-            )
-
+            return playlist_to_ma_playlist(self, playlist_info)
         except MediaNotFoundError:
             raise
         except Exception as err:
@@ -450,29 +386,21 @@ class PhishInProvider(MusicProvider):
         if page > 0:
             return []
         try:
-            playlists_data = await api_request(self, ENDPOINTS["playlists"])
-            playlist_slug = None
-
-            for playlist in playlists_data.get("playlists", []):
-                if str(playlist.get("id")) == prov_playlist_id:
-                    playlist_slug = playlist.get("slug")
-                    break
-
-            if not playlist_slug:
+            playlist_info = await self._resolve_playlist(prov_playlist_id)
+            if not playlist_info:
                 return []
 
             playlist_data = await api_request(
-                self, ENDPOINTS["playlist_by_slug"].format(slug=playlist_slug)
+                self, ENDPOINTS["playlist_by_slug"].format(slug=playlist_info["slug"])
             )
 
-            all_tracks = []
+            tracks = []
             for entry in playlist_data.get("entries", []):
                 track_data = entry.get("track")
                 if track_data and track_data.get("mp3_url"):
-                    track = track_to_ma_track(self, track_data)
-                    all_tracks.append(track)
+                    tracks.append(track_to_ma_track(self, track_data))
 
-            return all_tracks
+            return tracks
 
         except (MediaNotFoundError, ProviderUnavailableError):
             raise
@@ -957,3 +885,20 @@ class PhishInProvider(MusicProvider):
         except Exception as err:
             self.logger.error("Failed to get shows for tag %s: %s", tag_slug, err)
             raise ProviderUnavailableError(f"Tag shows error: {err}") from err
+
+    @use_cache(expiration=86400)  # 24 hours - the playlist list changes rarely
+    async def _get_playlists(self) -> list[dict[str, Any]]:
+        """Fetch the full list of Phish.in playlists (single cached request)."""
+        # cached and shared by all playlist methods to avoid repeated list fetches
+        playlists_data = await api_request(
+            self, ENDPOINTS["playlists"], params={"per_page": 100, "sort": "likes_count:desc"}
+        )
+        playlists: list[dict[str, Any]] = playlists_data.get("playlists", [])
+        return playlists
+
+    async def _resolve_playlist(self, prov_playlist_id: str) -> dict[str, Any] | None:
+        """Return the raw playlist data for the given id from the cached list."""
+        for playlist in await self._get_playlists():
+            if str(playlist.get("id")) == prov_playlist_id:
+                return playlist
+        return None

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -202,15 +202,16 @@ class PhishInProvider(MusicProvider):
         try:
             all_tracks: list[Track] = []
             page = 1
+            per_page = 500
             max_pages = 5  # 2500 tracks max for UI performance
 
-            while len(all_tracks) < (max_pages * 500) and page <= max_pages:
+            while page <= max_pages:
                 tracks_data = await api_request(
                     self,
                     ENDPOINTS["tracks"],
                     params={
                         "page": page,
-                        "per_page": 500,
+                        "per_page": per_page,
                         "sort": "likes_count:desc",
                         "audio_status": "complete_or_partial",
                     },
@@ -229,7 +230,8 @@ class PhishInProvider(MusicProvider):
                     track = track_to_ma_track(self, track_data, show_data)
                     all_tracks.append(track)
 
-                if len(tracks_on_page) < 50:
+                # a short page means we've reached the end
+                if len(tracks_on_page) < per_page:
                     break
 
                 page += 1

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from music_assistant_models.enums import (
     ContentType,
@@ -72,7 +73,8 @@ class PhishInProvider(MusicProvider):
             return SearchResults()
 
         try:
-            endpoint = ENDPOINTS["search"].format(term=search_query)
+            # encode the term so values with "/" etc. don't break the URL path
+            endpoint = ENDPOINTS["search"].format(term=quote(search_query, safe=""))
             search_data = await api_request(
                 self, endpoint, params={"audio_status": "complete_or_partial"}
             )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Noticed a couple of minor bugs with the Phish-in provider

  - Fix appears on section — Tracks now expose their show as a full Album, so the "Appears On" section populates instead of showing empty.
  - Fix empty Phish.in playlists and reduce redundant playlist API calls — Playlists resolved against the full list (not just page 1), so all imported playlists show their tracks; shared cached helper removes repeated fetches.
  - URL-encode Phish.in search terms — Search terms are percent-encoded, so queries containing / (e.g. "AC/DC Bag") no longer 404.
  - Fix Phish.in top-tracks last-page detection — Pagination uses the real page size (500) to detect the final page, avoiding a wasted extra request.
  - Consolidate Phish.in album building for tracks — Removes duplicated album-building logic so all tracks get consistent names, artwork, and details.
  
**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
