### PR TITLE
Fix AcoustID scan coverage stalling

### DIFF
--- a/music_assistant/providers/acoustid_lookup/provider.py
+++ b/music_assistant/providers/acoustid_lookup/provider.py
@@ -21,6 +21,7 @@ from music_assistant_models.errors import (
 
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.compare import create_safe_string
+from music_assistant.helpers.datetime import utc_timestamp
 from music_assistant.helpers.tags import write_identifier_tags
 from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
 from music_assistant.helpers.util import parse_title_and_version
@@ -31,7 +32,7 @@ from music_assistant.providers.musicbrainz import MusicbrainzProvider
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.enums import ProviderFeature
-    from music_assistant_models.media_items import AudioFormat
+    from music_assistant_models.media_items import AudioFormat, Track
     from music_assistant_models.provider import ProviderManifest
     from music_assistant_models.streamdetails import StreamDetails
 
@@ -44,6 +45,12 @@ CONF_WRITE_TAGS_BACK = "write_tags_back"
 CONF_ANALYSE_STREAMING = "analyse_streaming"
 
 DEFAULT_MIN_SCORE = 0.85
+# Days before a track that fingerprinted but found no match is retried. The AcoustID
+# database grows over time, so an unidentifiable track may match on a later attempt.
+NO_MATCH_RETRY_DAYS = 60
+# No-match results are stored at this version so they always read as stale and are
+# re-offered to the provider, which then gates the actual retry on NO_MATCH_RETRY_DAYS.
+NO_MATCH_ANALYSIS_VERSION = -1
 MAX_FINGERPRINT_SECONDS = 120
 MAX_CANDIDATES = 5
 # Per-recording cap on stored release-groups; sized to fit popular tracks
@@ -133,13 +140,23 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
         if track is None:
             self.logger.debug("Skipping %s — track is not in the library", session_id)
             return False
-        if track.mbid:
+        if track.mbid or track.get_external_id(ExternalID.ISRC):
+            # Already identified, so fingerprinting would be wasted work. Record the
+            # existing identifiers as a result so coverage counts the track and the scan
+            # does not revisit it.
+            await self._record_existing_identifiers(streamdetails, track)
             self.logger.debug(
-                "Skipping %s — track already has a MusicBrainz Recording Id", session_id
+                "Skipping %s — track already identified (MBID/ISRC present); "
+                "recorded existing identifiers",
+                session_id,
             )
             return False
-        if track.get_external_id(ExternalID.ISRC):
-            self.logger.debug("Skipping %s — track already has an ISRC", session_id)
+
+        if await self._within_no_match_cooldown(streamdetails):
+            self.logger.debug(
+                "Skipping %s — earlier AcoustID lookup found no match; still within retry cooldown",
+                session_id,
+            )
             return False
 
         fingerprinter = self._create_fingerprinter(audio_format.sample_rate, audio_format.channels)
@@ -306,18 +323,23 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
         if chosen_mbid is None:
             if data.expected_track_title:
                 self.logger.debug(
-                    "Discarding AcoustID result — no candidate matches track title %r",
+                    "No AcoustID match for %r — recording no-match result, "
+                    "will retry after %d days",
                     data.expected_track_title,
+                    NO_MATCH_RETRY_DAYS,
                 )
+            await self._persist_no_match(session_id)
             return None
 
         if chosen_score < min_score:
             self.logger.debug(
-                "Discarding AcoustID result — match score %.3f is below the configured "
-                "minimum of %.2f",
+                "No confident AcoustID match — best score %.3f is below the configured "
+                "minimum of %.2f; recording no-match result, will retry after %d days",
                 chosen_score,
                 min_score,
+                NO_MATCH_RETRY_DAYS,
             )
+            await self._persist_no_match(session_id)
             return None
 
         return AudioAnalysisData(
@@ -328,6 +350,66 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
                 "candidates": candidates,
                 "release_groups": release_groups,
             }
+        )
+
+    async def _within_no_match_cooldown(self, streamdetails: StreamDetails) -> bool:
+        """
+        Return whether a prior no-match result for this track is still within its retry cooldown.
+
+        :param streamdetails: Stream details for the track being analysed.
+        """
+        stored = await self.mass.streams.audio_analysis.get_audio_analysis(
+            streamdetails.item_id,
+            streamdetails.provider,
+            media_type=streamdetails.media_type,
+            priority=(self.domain,),
+        )
+        if not stored or not stored.extra_data:
+            return False
+        retry_after = stored.extra_data.get("retry_after")
+        return retry_after is not None and int(utc_timestamp()) < int(retry_after)
+
+    async def _persist_no_match(self, session_id: str) -> None:
+        """
+        Record that a track fingerprinted but found no match, scheduling a later retry.
+
+        :param session_id: Active analysis session ID.
+        """
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        streamdetails = session.streamdetails
+        retry_after = int(utc_timestamp()) + NO_MATCH_RETRY_DAYS * 86400
+        await self.mass.streams.audio_analysis.set_audio_analysis(
+            item_id=streamdetails.item_id,
+            provider_instance_id_or_domain=streamdetails.provider,
+            aa_provider_domain=self.domain,
+            analysis=AudioAnalysisData(extra_data={"retry_after": retry_after}),
+            analysis_version=NO_MATCH_ANALYSIS_VERSION,
+            media_type=streamdetails.media_type,
+        )
+
+    async def _record_existing_identifiers(
+        self, streamdetails: StreamDetails, track: Track
+    ) -> None:
+        """
+        Persist a track's existing MBID/ISRC as an analysis result, as if freshly looked up.
+
+        :param streamdetails: Stream details for the already-identified track.
+        :param track: Library track carrying the existing identifiers.
+        """
+        extra_data: dict[str, Any] = {"source": "existing_tags"}
+        if track.mbid:
+            extra_data["mbid"] = track.mbid
+        if isrc := track.get_external_id(ExternalID.ISRC):
+            extra_data["isrc"] = isrc
+        await self.mass.streams.audio_analysis.set_audio_analysis(
+            item_id=streamdetails.item_id,
+            provider_instance_id_or_domain=streamdetails.provider,
+            aa_provider_domain=self.domain,
+            analysis=AudioAnalysisData(extra_data=extra_data),
+            analysis_version=self.analysis_version,
+            media_type=streamdetails.media_type,
         )
 
     @use_cache(ACOUSTID_LOOKUP_CACHE_TTL)

--- a/tests/providers/acoustid_lookup/test_provider.py
+++ b/tests/providers/acoustid_lookup/test_provider.py
@@ -10,6 +10,7 @@ import pytest
 from music_assistant_models.enums import MediaType, StreamType
 
 from music_assistant.constants import CONF_LOG_LEVEL
+from music_assistant.helpers.datetime import utc_timestamp
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import AnalysisSessionData
 from music_assistant.providers.acoustid_lookup.provider import (
@@ -17,6 +18,8 @@ from music_assistant.providers.acoustid_lookup.provider import (
     CONF_API_KEY,
     CONF_MIN_SCORE,
     CONF_WRITE_TAGS_BACK,
+    NO_MATCH_ANALYSIS_VERSION,
+    NO_MATCH_RETRY_DAYS,
     AcoustidLookupProvider,
     _parse_response,
 )
@@ -45,6 +48,7 @@ def _make_provider(
 
     mass.get_provider = MagicMock(side_effect=_default_get_provider)
     mass.streams.audio_analysis.get_audio_analysis_version = AsyncMock(return_value=None)
+    mass.streams.audio_analysis.get_audio_analysis = AsyncMock(return_value=None)
     mass.streams.audio_analysis.set_audio_analysis = AsyncMock()
     mass.music.tracks.set_identifiers = AsyncMock()
     mass.music.albums.set_release_group = AsyncMock()
@@ -292,6 +296,103 @@ async def test_start_analysis_gates(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("track_mbid", "track_isrc", "expected_extra"),
+    [
+        pytest.param(
+            "0000-mbid", None, {"source": "existing_tags", "mbid": "0000-mbid"}, id="mbid_only"
+        ),
+        pytest.param(
+            None,
+            "USRC17607839",
+            {"source": "existing_tags", "isrc": "USRC17607839"},
+            id="isrc_only",
+        ),
+        pytest.param(
+            "0000-mbid",
+            "USRC17607839",
+            {"source": "existing_tags", "mbid": "0000-mbid", "isrc": "USRC17607839"},
+            id="mbid_and_isrc",
+        ),
+    ],
+)
+async def test_start_analysis_records_existing_identifiers(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    track_mbid: str | None,
+    track_isrc: str | None,
+    expected_extra: dict[str, Any],
+) -> None:
+    """An already-identified track is recorded as analyzed (no fingerprinting, no retry)."""
+    provider = _make_provider()
+    track = MagicMock()
+    track.mbid = track_mbid
+    track.get_external_id.return_value = track_isrc
+    cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
+        return_value=track
+    )
+    _install_fake_chromaprint(monkeypatch, _FakeFingerprinter())
+    set_aa = cast("AsyncMock", provider.mass.streams.audio_analysis.set_audio_analysis)
+
+    accepted = await provider.start_analysis("session", _make_streamdetails(), _make_audio_format())
+
+    # session is declined (no streaming) but a result row is recorded
+    assert accepted is False
+    set_aa.assert_awaited_once()
+    assert set_aa.await_args is not None
+    kwargs = set_aa.await_args.kwargs
+    assert kwargs["aa_provider_domain"] == provider.domain
+    assert kwargs["item_id"] == "track-1"
+    analysis = kwargs["analysis"]
+    assert analysis.extra_data == expected_extra
+    # permanent result — never re-collected by the background scan
+    assert "retry_after" not in analysis.extra_data
+
+
+@pytest.mark.asyncio
+async def test_start_analysis_skips_within_no_match_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A track whose prior no-match result is still inside its cooldown is declined."""
+    provider = _make_provider()
+    track = MagicMock(mbid=None)
+    track.get_external_id.return_value = None
+    cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
+        return_value=track
+    )
+    cast("MagicMock", provider.mass.streams.audio_analysis).get_audio_analysis = AsyncMock(
+        return_value=AudioAnalysisData(extra_data={"retry_after": int(utc_timestamp()) + 3600})
+    )
+    fp = _FakeFingerprinter()
+    _install_fake_chromaprint(monkeypatch, fp)
+
+    accepted = await provider.start_analysis("session", _make_streamdetails(), _make_audio_format())
+
+    assert accepted is False
+    # declined before any fingerprinting work
+    assert fp.start_args is None
+
+
+@pytest.mark.asyncio
+async def test_start_analysis_retries_after_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Once the cooldown has elapsed, the track is accepted for a fresh lookup."""
+    provider = _make_provider()
+    track = MagicMock(mbid=None)
+    track.get_external_id.return_value = None
+    cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
+        return_value=track
+    )
+    cast("MagicMock", provider.mass.streams.audio_analysis).get_audio_analysis = AsyncMock(
+        return_value=AudioAnalysisData(extra_data={"retry_after": int(utc_timestamp()) - 3600})
+    )
+    _install_fake_chromaprint(monkeypatch, _FakeFingerprinter())
+
+    accepted = await provider.start_analysis("session", _make_streamdetails(), _make_audio_format())
+
+    assert accepted is True
+
+
+@pytest.mark.asyncio
 async def test_finalize_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     """A high-score match yields mbid + acoustid + candidates + release_groups."""
     provider = _make_provider()
@@ -355,7 +456,7 @@ async def test_finalize_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_finalize_rejects_low_score(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A best-result score below the threshold yields no analysis."""
+    """A best-result score below the threshold yields a retryable no-match marker."""
     provider = _make_provider(min_score=0.85)
     _install_fake_chromaprint(monkeypatch, _FakeFingerprinter())
     track = MagicMock(mbid=None)
@@ -386,7 +487,18 @@ async def test_finalize_rejects_low_score(monkeypatch: pytest.MonkeyPatch) -> No
         },
     )
 
+    # _finalize persists a no-match result itself and returns None so the base class
+    # does not overwrite it at the current analysis_version
     assert await provider._finalize(session_id) is None
+    set_aa = cast("AsyncMock", provider.mass.streams.audio_analysis.set_audio_analysis)
+    set_aa.assert_awaited_once()
+    assert set_aa.await_args is not None
+    kwargs = set_aa.await_args.kwargs
+    # stored below the current version so it is re-offered, and gated on a future retry_after
+    assert kwargs["analysis_version"] == NO_MATCH_ANALYSIS_VERSION
+    now = int(utc_timestamp())
+    retry_after = kwargs["analysis"].extra_data["retry_after"]
+    assert now < retry_after <= now + NO_MATCH_RETRY_DAYS * 86400 + 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The audio-analysis background scan only recorded successful analyses, so AcoustID never persisted a row for tracks it skips (already have an MBID/ISRC) or can't match. Those tracks stayed "pending" forever and were fully re-streamed and re-fingerprinted on every nightly run with no progress.

- Record already-identified tracks (existing MBID/ISRC) as an analysis result instead of silently declining, so they count as analyzed and drop out of the nightly scan for good.
- Persist a retryable no-match marker for tracks that fingerprint cleanly but find no match, so they are no longer re-streamed every night but are retried after a 60-day cooldown (the AcoustID/MusicBrainz database grows over time).


If the controller later exposed row age (or a generic retry mechanism), then we could drop the `retry_after` field and use that instead


**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
