### PR TITLE
Fix Bluesound ungroup crashing on non-existent pyblu client attributes

### DIFF
--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -253,9 +253,11 @@ class BluesoundPlayer(Player):
 
     async def ungroup(self) -> None:
         """Handle UNGROUP command for BluOS player."""
-        leader = self.client.leader
-        leader_player_id = self.client.provider.player_map((leader.ip, leader.port))
-        await self.mass.players.get_player(leader_player_id).set_members(None, [self.player_id])
+        if not (leader := self.sync_status.leader):
+            return
+        leader_player_id = self.provider.player_map.get((leader.ip, leader.port))
+        if leader_player_id and (leader_player := self.mass.players.get_player(leader_player_id)):
+            await leader_player.set_members(None, [self.player_id])
 
     async def poll(self) -> None:
         """Poll player for state updates."""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
While looking at typing fixes for the Bluesound provider I came across a bug in the code.

`BluesoundPlayer.ungroup()` reads `self.client.leader` and `self.client.provider.player_map(...)`. But `self.client` is the pyblu Player, which has no `leader `and no `provider `attribute so the first line throws `AttributeError`.

The fix gets the group leader from `self.sync_status.leader` and looks up its player id via the provider's player_map, mirroring how the existing `synced_to` property already does it.

This hasn't been encountered before because the normal `ungroup `command routes through `set_members` (which works) and never calls this method. The only path that calls `ungroup()` directly is universal group teardown, so it only triggers when a Bluesound player that's part of a native sync group is a member of a universal group.

I can't test this as I don't have a Bluesound device but it just aligns `ungroup()` with the working pattern already used in `synced_to` and `update_attributes`, so it's low risk.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
