### PR TITLE
Final Typing fixes for Bluesound provider

### DIFF
--- a/music_assistant/providers/bluesound/player.py
+++ b/music_assistant/providers/bluesound/player.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import IdentifierType, PlaybackState
@@ -56,11 +56,11 @@ class BluesoundPlayer(Player):
         self.ip_address = ip_address
         self.connected: bool = True
         self.client = BluosPlayer(self.ip_address, self.port, self.mass.http_session)
-        self.sync_status = SyncStatus
-        self.status = Status
+        self.sync_status: SyncStatus
+        self.status: Status
         self.poll_state = POLL_STATE_STATIC
         self.dynamic_poll_count: int = 0
-        self._listen_task: asyncio.Task | None = None
+        self._listen_task: asyncio.Task[None] | None = None
         # Set base player attributes
         self._attr_supported_features = PLAYER_FEATURES_BASE.copy()
         self._attr_name = name
@@ -111,7 +111,8 @@ class BluesoundPlayer(Player):
         if self._listen_task and not self._listen_task.done():
             self._listen_task.cancel()
         if self.client:
-            await self.client.close()
+            # pyblu's Player.close lacks a return annotation; remove ignore once fixed upstream
+            await self.client.close()  # type: ignore[no-untyped-call]
         self.connected = False
         self.logger.debug("Disconnected from player API")
 
@@ -158,19 +159,19 @@ class BluesoundPlayer(Player):
         self._set_polling_dynamic()
         self.update_state()
 
-    async def next_track(self):
+    async def next_track(self) -> None:
         """Send NEXT TRACK command to BluOS player."""
         await self.client.skip()
         self._set_polling_dynamic()
         self.update_state()
 
-    async def previous_track(self):
+    async def previous_track(self) -> None:
         """Send PREVIOUS TRACK command to BluOS player."""
         await self.client.back()
         self._set_polling_dynamic()
         self.update_state()
 
-    async def seek(self, position) -> None:
+    async def seek(self, position: int) -> None:
         """Send PLAY command to BluOS player."""
         play_state = await self.client.play(seek=position, timeout=1)
         if play_state in ("stream", "play"):
@@ -215,7 +216,10 @@ class BluesoundPlayer(Player):
             return
 
         def player_id_to_paired_player(player_id: str) -> PairedPlayer:
-            client = self.mass.players.get_player(player_id, raise_unavailable=True)
+            client = cast(
+                "BluesoundPlayer",
+                self.mass.players.get_player(player_id, raise_unavailable=True),
+            )
             return PairedPlayer(client.ip_address, client.port)
 
         if player_ids_to_remove:
@@ -230,7 +234,7 @@ class BluesoundPlayer(Player):
                     continue
                 removed_player = self.mass.players.get_player(player_id)
                 if removed_player:
-                    removed_player._set_polling_dynamic()
+                    cast("BluesoundPlayer", removed_player)._set_polling_dynamic()
                     removed_player._attr_current_media = None
                     removed_player.update_state()
 
@@ -245,7 +249,7 @@ class BluesoundPlayer(Player):
                 self._attr_group_members.append(player_id)
                 added_player = self.mass.players.get_player(player_id)
                 if added_player:
-                    added_player._set_polling_dynamic()
+                    cast("BluesoundPlayer", added_player)._set_polling_dynamic()
                     added_player.update_state()
 
         self._set_polling_dynamic()
@@ -255,8 +259,10 @@ class BluesoundPlayer(Player):
         """Handle UNGROUP command for BluOS player."""
         if not (leader := self.sync_status.leader):
             return
-        leader_player_id = self.provider.player_map.get((leader.ip, leader.port))
-        if leader_player_id and (leader_player := self.mass.players.get_player(leader_player_id)):
+        provider = cast("BluesoundPlayerProvider", self.provider)
+        if (leader_player_id := provider.player_map.get((leader.ip, leader.port))) and (
+            leader_player := self.mass.players.get_player(leader_player_id)
+        ):
             await leader_player.set_members(None, [self.player_id])
 
     async def poll(self) -> None:
@@ -266,7 +272,7 @@ class BluesoundPlayer(Player):
     def _resolve_source(self) -> None:
         """Check  PLAYER_SOURCE_MAP for known sources, otherwise create a new source."""
 
-        def resolve_analog_digital_source(source_name) -> PlayerMedia:
+        def resolve_analog_digital_source(source_name: str) -> PlayerSource:
             """Resolve Analog/Digital Source here, avoid duplicate entries in PLAYER_SOURCE_MAP."""
             return PlayerSource(
                 id=source_name,
@@ -281,13 +287,13 @@ class BluesoundPlayer(Player):
         mass_url = self.mass.streams.base_url
         if self.status.stream_url and mass_url in self.status.stream_url:
             self._attr_active_source = None
-        elif player_source := PLAYER_SOURCE_MAP.get(self.status.input_id):
+        elif player_source := PLAYER_SOURCE_MAP.get(cast("str", self.status.input_id)):
             self._attr_active_source = self.status.input_id
             self._attr_source_list.append(player_source)
-        elif player_source := PLAYER_SOURCE_MAP.get(self.status.service):
+        elif player_source := PLAYER_SOURCE_MAP.get(cast("str", self.status.service)):
             self._attr_active_source = self.status.service
             self._attr_source_list.append(player_source)
-        elif player_source := PLAYER_SOURCE_MAP.get(self.status.name):
+        elif player_source := PLAYER_SOURCE_MAP.get(cast("str", self.status.name)):
             self._attr_active_source = self.status.name
             self._attr_source_list.append(player_source)
         elif (name := self.status.name) and ("Analog Input" in name or "Digital Input" in name):
@@ -299,8 +305,8 @@ class BluesoundPlayer(Player):
             self.logger.debug("Appending new PlayerSource")
             self._attr_source_list.append(
                 PlayerSource(
-                    id=self.status.input_id,
-                    name=self.status.input_id,
+                    id=cast("str", self.status.input_id),
+                    name=cast("str", self.status.input_id),
                     passive=True,
                     can_play_pause=True,
                     can_seek=self.status.can_seek,
@@ -317,12 +323,13 @@ class BluesoundPlayer(Player):
             image_url = None
 
         self._attr_current_media = PlayerMedia(
-            uri=self.status.stream_url or self.status.name,
+            uri=cast("str", self.status.stream_url or self.status.name),
             title=self.status.name,
             artist=self.status.artist,
             album=self.status.album,
             image_url=image_url,
-            duration=self.status.total_seconds or None,
+            # keep float as-is; int() here would change the stored precision
+            duration=cast("int | None", self.status.total_seconds or None),
         )
 
     async def update_attributes(self) -> None:
@@ -379,13 +386,14 @@ class BluesoundPlayer(Player):
             f"Volume from sync_status: {self.sync_status.volume}, from status: {self.status.volume}"
         )
 
+        provider = cast("BluesoundPlayerProvider", self.provider)
         if not self.sync_status.leader:
             # Player not grouped or player is group leader
             if self.sync_status.followers:
                 self._attr_group_members = [
-                    self.provider.player_map[f.ip, f.port]
+                    provider.player_map[f.ip, f.port]
                     for f in self.sync_status.followers
-                    if (f.ip, f.port) in self.provider.player_map
+                    if (f.ip, f.port) in provider.player_map
                 ]
             else:
                 self._attr_group_members.clear()
@@ -396,7 +404,7 @@ class BluesoundPlayer(Player):
             # Player has group leader
             self._attr_group_members.clear()
             leader = self.sync_status.leader
-            leader_player_id = self.provider.player_map.get((leader.ip, leader.port), None)
+            leader_player_id = provider.player_map.get((leader.ip, leader.port), None)
             self._attr_active_source = leader_player_id
 
         self.update_state()
@@ -411,19 +419,19 @@ class BluesoundPlayer(Player):
         """
         source_type, source_id = source.split("-", 1)
         if source_type == "preset":
-            await self.client.load_preset(preset_id=source_id)
+            await self.client.load_preset(preset_id=int(source_id))
         elif source_type == "input":
             await self.client.play_url(source_id)
         self._set_polling_dynamic()
         self.update_state()
 
-    async def _get_bluesound_sources(self, timeout: float | None = None) -> None:
+    async def _get_bluesound_sources(self, timeout: float | None = None) -> list[PlayerSource]:
         """Resolve Bluesound presets and inputs to MA PlayerSource.
 
         :param timeout: The timeout for getting inputs and presets.
         """
 
-        def _preset_to_ma_source(preset: Preset):
+        def _preset_to_ma_source(preset: Preset) -> PlayerSource:
             return PlayerSource(
                 id=f"preset-{preset.id}",
                 name=f"Preset {preset.id:02d}: {preset.name}",
@@ -433,7 +441,7 @@ class BluesoundPlayer(Player):
                 can_next_previous=True,
             )
 
-        def _input_to_ma_source(bluos_input: Input):
+        def _input_to_ma_source(bluos_input: Input) -> PlayerSource:
             return PlayerSource(
                 id=f"input-{bluos_input.url}",
                 name=f"Input: {bluos_input.text}",
@@ -448,10 +456,11 @@ class BluesoundPlayer(Player):
         inputs_as_sources = [_input_to_ma_source(bluos_input) for bluos_input in inputs]
         return [_preset_to_ma_source(preset) for preset in presets] + inputs_as_sources
 
-    def _set_polling_dynamic(self, poll_count: int = 6, poll_interval: float = 0.5):
+    def _set_polling_dynamic(self, poll_count: int = 6, poll_interval: float = 0.5) -> None:
         self.poll_state = POLL_STATE_DYNAMIC
         self.dynamic_poll_count = poll_count
-        self._attr_poll_interval = poll_interval
+        # sub-second interval for dynamic polling; base attr is typed int
+        self._attr_poll_interval = poll_interval  # type: ignore[assignment]
 
     @property
     def synced_to(self) -> str | None:
@@ -464,5 +473,7 @@ class BluesoundPlayer(Player):
         """
         if self.sync_status.leader:
             leader = self.sync_status.leader
-            return self.provider.player_map.get((leader.ip, leader.port), None)
+            return cast("BluesoundPlayerProvider", self.provider).player_map.get(
+                (leader.ip, leader.port), None
+            )
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,6 @@ exclude = [
   '^music_assistant/controllers/music.py$',
   '^music_assistant/helpers/app_vars.py',
   '^music_assistant/providers/apple_music/.*$',
-  '^music_assistant/providers/bluesound/player.py',
   '^music_assistant/providers/plex/.*$',
   '^music_assistant/providers/plex_connect/.*$',
   '^music_assistant/providers/sonic_analysis/vendored_clap/.*$',


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Last set of typing fixes

Points to note

  - `cast("str", …)` on a few pyblu fields. pyblu types these as `str | None`. The casts keep the existing behaviour exactly (these values were already used as-is); for the `dict.get(...)` keys a `None `is harmless. Whether those fields can actually be None mid-playback is a pre-existing question, not something introduced here but happy to follow up separately if you'd prefer real guards.
  - `int(source_id)` in `select_source`. pyblu's `load_preset` is typed `preset_id: int`.  `source_id` is the numeric string form of `preset.id` so this produces an identical HTTP request
  - duration cast keeps the float as-is (an inline comment notes that `int()` would change precision).
  - Two `# type: ignore` remain, both commented inline: `close()` (pyblu upstream lacks a `-> None` return annotation) and the sub-second `poll_interval = 0.5` assignment (base attr is typed int).


Upstream PR for pyblu is here https://github.com/LouisChrist/pyblu/pull/75

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
