### PR TITLE
Type throttle_with_retries via Protocol instead of Provider bound

### DIFF
--- a/music_assistant/helpers/throttle_retry.py
+++ b/music_assistant/helpers/throttle_retry.py
@@ -12,7 +12,7 @@ from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from email.utils import parsedate_to_datetime
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Concatenate
+from typing import Any, Concatenate, Protocol
 
 from music_assistant_models.errors import (
     RateLimited,
@@ -21,9 +21,6 @@ from music_assistant_models.errors import (
 )
 
 from music_assistant.constants import MASS_LOGGER_NAME
-
-if TYPE_CHECKING:
-    from music_assistant.models.provider import Provider
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.throttle_retry")
 
@@ -140,7 +137,17 @@ class ThrottlerManager:
             BYPASS_THROTTLER.reset(token)
 
 
-def throttle_with_retries[ProviderT: "Provider", **P, R](
+class _Throttleable(Protocol):
+    """Protocol for objects that can use the @throttle_with_retries decorator."""
+
+    @property
+    def logger(self) -> logging.Logger: ...
+
+    @property
+    def throttler(self) -> ThrottlerManager: ...
+
+
+def throttle_with_retries[ProviderT: _Throttleable, **P, R](
     func: Callable[Concatenate[ProviderT, P], Awaitable[R]],
 ) -> Callable[Concatenate[ProviderT, P], Coroutine[Any, Any, R]]:
     """Call async function using the throttler with retries."""
@@ -148,8 +155,7 @@ def throttle_with_retries[ProviderT: "Provider", **P, R](
     @functools.wraps(func)
     async def wrapper(self: ProviderT, *args: P.args, **kwargs: P.kwargs) -> R:
         """Call async function using the throttler with retries."""
-        # the throttler attribute must be present on the class
-        throttler: ThrottlerManager = self.throttler  # type: ignore[attr-defined]
+        throttler = self.throttler
         exp_backoff = throttler.initial_backoff
         async with throttler.acquire() as delay:
             if delay != 0:

--- a/music_assistant/providers/tidal/api_client.py
+++ b/music_assistant/providers/tidal/api_client.py
@@ -91,7 +91,7 @@ class TidalAPIClient:
         kwargs["json"] = data
         return cast("dict[str, Any]", await self._request("DELETE", endpoint, **kwargs))
 
-    @throttle_with_retries  # type: ignore[type-var]
+    @throttle_with_retries
     async def _request(
         self, method: str, endpoint: str, **kwargs: Any
     ) -> dict[str, Any] | tuple[dict[str, Any], str]:

--- a/music_assistant/providers/yousee/api_client.py
+++ b/music_assistant/providers/yousee/api_client.py
@@ -45,7 +45,7 @@ class YouSeeAPIClient:
         self.logger = provider.logger
         self.mass = provider.mass
 
-    @throttle_with_retries  # type: ignore[type-var]
+    @throttle_with_retries
     async def post_graphql(
         self, query: str, variables: JsonLike, _headers: JsonLike | None = None
     ) -> JsonLike:

--- a/tests/core/test_throttle_retry.py
+++ b/tests/core/test_throttle_retry.py
@@ -42,7 +42,7 @@ class FakeProvider:
         self._side_effects = list(effects)
         self.call_count = 0
 
-    @throttle_with_retries  # type: ignore[type-var]
+    @throttle_with_retries
     async def api_call(self, value: str) -> str:
         """Simulate an API call."""
         self.call_count += 1


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Inline with the recent typing changes to the cache decorator (`@use_cache`, which uses a structural `_Cacheable` Protocol), this applies the same treatment to `throttle_with_retries`.

The decorator only ever touches` self.logger` and `self.throttler`, but it bounded its type var to the nominal Provider class. Helper API-client classes that hold a throttler without subclassing Provider (apple_music, tidal, yousee) therefore couldn't satisfy the bound and needed `# type: ignore[type-var]` on every decorated method. The decorator itself also needed a `# type: ignore[attr-defined]` on `self.throttler`, because Provider doesn't actually declare a throttler attribute.

This replaces the Provider bound with a structural `_Throttleable` Protocol (logger + throttler), so any duck-typed class with those two attributes satisfies it directly

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
