### PR TITLE
Fix smart playlist dedup for streaming (non-library) tracks

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -671,6 +671,7 @@ class MusicController(CoreController):
         queue_id: str | None = None,
         fully_played_only: bool = True,
         user_initiated_only: bool = False,
+        played_after_timestamp: int | None = None,
     ) -> list[ItemMapping]:
         """Return a list of the last played items.
 
@@ -680,6 +681,8 @@ class MusicController(CoreController):
         :param queue_id: Filter by specific queue ID.
         :param fully_played_only: If True, only return fully played items.
         :param user_initiated_only: If True, only return items initiated by the user.
+        :param played_after_timestamp: If set, only return items played at or after this
+            epoch-seconds timestamp.
         """
         if media_types is None:
             media_types = MediaType.ALL
@@ -705,6 +708,9 @@ class MusicController(CoreController):
         if queue_id:
             query += "AND queue_id = :queue_id "
             params["queue_id"] = queue_id
+        if played_after_timestamp is not None:
+            query += "AND timestamp >= :played_after_timestamp "
+            params["played_after_timestamp"] = played_after_timestamp
         query += "ORDER BY timestamp DESC"
         db_rows = await self.mass.music.database.get_rows_from_query(
             query, params=params or None, limit=limit

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -3076,6 +3076,15 @@ class PlayerQueuesController(CoreController):
                 )
             if dynamic_playlist is not None:
                 try:
+                    # Restore the queue owner's user context so provider filters and
+                    # per-user logic (e.g. smart playlist dedup) are respected during
+                    # this background refill, mirroring _fill_radio_tracks.
+                    playback_user = (
+                        await self.mass.webserver.auth.get_user(queue.userid)
+                        if queue.userid
+                        else None
+                    )
+                    set_current_user(playback_user)
                     dynamic_tracks = await self.get_playlist_tracks(
                         dynamic_playlist, start_item=None
                     )

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -580,7 +580,9 @@ class SmartPlaylistProvider(PluginProvider):
                 deduped_uris = {t.uri for t in deduped}
                 played_remainder = sorted(
                     (t for t in tracks if t.uri not in deduped_uris),
-                    key=lambda t: t.last_played,
+                    # last_played is 0 for non-library (streaming) tracks; treat 0 as
+                    # "most recent" so just-played streaming tracks aren't filled first.
+                    key=lambda t: t.last_played or float("inf"),
                 )
                 tracks = deduped + played_remainder[: rules.limit - len(deduped)]
             else:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -571,7 +571,7 @@ class SmartPlaylistProvider(PluginProvider):
         tracks = self._apply_exclusions(tracks, rules, excluded_genre_names)
         tracks = self._deduplicate_tracks(tracks)
         if rules.dedup_hours is not None:
-            deduped = self._apply_dedup(tracks, rules.dedup_hours)
+            deduped = await self._apply_dedup(tracks, rules.dedup_hours)
             if len(deduped) >= rules.limit:
                 tracks = deduped
             elif deduped:
@@ -714,11 +714,36 @@ class SmartPlaylistProvider(PluginProvider):
                     genre_id_to_name[genre_id] = genre.name
         return {v.lower() for v in genre_id_to_name.values() if v}
 
-    def _apply_dedup(self, tracks: list[Track], dedup_hours: int) -> list[Track]:
-        """Filter out tracks last played within dedup_hours hours."""
-        cutoff_ts = time.time() - dedup_hours * 3600
-        # last_played is a Unix timestamp (int); 0 means never played.
-        return [t for t in tracks if t.last_played == 0 or t.last_played < cutoff_ts]
+    async def _recently_played_keys(self, dedup_hours: int) -> set[tuple[str, str]]:
+        """
+        Return ``(provider, item_id)`` keys of tracks fully played within dedup_hours.
+
+        Scoped to the current user. ``recently_played`` resolves the user from the active
+        context; during queue refills the player queue restores the queue owner's user
+        context before evaluating, so the dedup window is per user without resolving here.
+        """
+        cutoff = int(time.time()) - dedup_hours * 3600
+        played = await self.mass.music.recently_played(
+            limit=0,
+            media_types=[MediaType.TRACK],
+            fully_played_only=True,
+            played_after_timestamp=cutoff,
+        )
+        return {(item.provider, item.item_id) for item in played}
+
+    async def _apply_dedup(self, tracks: list[Track], dedup_hours: int) -> list[Track]:
+        """Filter out tracks fully played within dedup_hours (scoped to the current user)."""
+        played_keys = await self._recently_played_keys(dedup_hours)
+        if not played_keys:
+            return list(tracks)
+        return [
+            t
+            for t in tracks
+            if not any(
+                (pm.provider_instance, pm.item_id) in played_keys
+                for pm in (t.provider_mappings or ())
+            )
+        ]
 
     async def _evaluate_and(
         self,

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -283,8 +283,9 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
     if total_seeds > MAX_SEEDS:
         msg = f"Too many seeds: {total_seeds} > {MAX_SEEDS}"
         raise InvalidDataError(msg)
-    if rules.dedup_hours is not None and not (1 <= rules.dedup_hours <= 8760):
-        msg = f"dedup_hours must be between 1 and 8760, got {rules.dedup_hours}"
+    if rules.dedup_hours is not None and not (1 <= rules.dedup_hours <= 2160):
+        # 2160h == 90 days, matching the playlog retention window the dedup relies on.
+        msg = f"dedup_hours must be between 1 and 2160, got {rules.dedup_hours}"
         raise InvalidDataError(msg)
 
 

--- a/tests/core/test_recently_played.py
+++ b/tests/core/test_recently_played.py
@@ -1,0 +1,65 @@
+"""Tests for MusicController.recently_played playlog queries."""
+
+from __future__ import annotations
+
+from music_assistant_models.enums import MediaType
+
+from music_assistant.constants import DB_TABLE_PLAYLOG
+from music_assistant.mass import MusicAssistant
+
+
+async def _add_playlog_track(
+    mass: MusicAssistant,
+    item_id: str,
+    timestamp: int,
+    *,
+    fully_played: bool = True,
+    userid: str = "user-a",
+) -> None:
+    """Insert a single track row into the playlog."""
+    await mass.music.database.insert(
+        DB_TABLE_PLAYLOG,
+        {
+            "item_id": item_id,
+            "provider": "library",
+            "media_type": MediaType.TRACK.value,
+            "name": f"Track {item_id}",
+            "timestamp": timestamp,
+            "fully_played": fully_played,
+            "seconds_played": 180,
+            "userid": userid,
+            "user_initiated": True,
+        },
+    )
+
+
+async def test_recently_played_filters_by_played_after_timestamp(mass: MusicAssistant) -> None:
+    """Only entries with timestamp >= played_after_timestamp are returned."""
+    await _add_playlog_track(mass, "recent", timestamp=2000)
+    await _add_playlog_track(mass, "old", timestamp=1000)
+
+    result = await mass.music.recently_played(
+        limit=0,
+        media_types=[MediaType.TRACK],
+        userid="user-a",
+        played_after_timestamp=1500,
+    )
+
+    item_ids = {item.item_id for item in result}
+    assert "recent" in item_ids
+    assert "old" not in item_ids
+
+
+async def test_recently_played_without_timestamp_returns_all(mass: MusicAssistant) -> None:
+    """Existing callers (no played_after_timestamp) still get every entry."""
+    await _add_playlog_track(mass, "recent", timestamp=2000)
+    await _add_playlog_track(mass, "old", timestamp=1000)
+
+    result = await mass.music.recently_played(
+        limit=0,
+        media_types=[MediaType.TRACK],
+        userid="user-a",
+    )
+
+    item_ids = {item.item_id for item in result}
+    assert {"recent", "old"} <= item_ids

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time as _time
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -262,6 +261,7 @@ def _make_mock_track(
     album_id: str | None = None,
     favorite: bool = False,
     popularity: int | None = None,
+    provider_instance: str = "library",
 ) -> MagicMock:
     """Build a minimal mock Track object."""
     track = MagicMock()
@@ -269,6 +269,11 @@ def _make_mock_track(
     track.uri = uri
     track.name = f"Track {item_id}"
     track.favorite = favorite
+
+    mapping = MagicMock()
+    mapping.provider_instance = provider_instance
+    mapping.item_id = item_id
+    track.provider_mappings = [mapping]
 
     artist = MagicMock()
     artist.item_id = (artist_ids or ["100"])[0]
@@ -451,7 +456,7 @@ class TestNewValidation:
         plugin._validate_rules(rules)  # should not raise
 
     def test_dedup_hours_out_of_range_raises(self) -> None:
-        """dedup_hours outside 1-8760 raises InvalidDataError."""
+        """dedup_hours outside 1-2160 raises InvalidDataError."""
         plugin = self._make_plugin()
         with pytest.raises(InvalidDataError, match="dedup_hours"):
             plugin._validate_rules(SmartPlaylistRules(dedup_hours=0))
@@ -459,9 +464,16 @@ class TestNewValidation:
             plugin._validate_rules(SmartPlaylistRules(dedup_hours=9000))
 
     def test_dedup_hours_valid_passes(self) -> None:
-        """dedup_hours within 1-8760 does not raise."""
+        """dedup_hours within 1-2160 does not raise."""
         plugin = self._make_plugin()
         plugin._validate_rules(SmartPlaylistRules(dedup_hours=24))  # should not raise
+
+    def test_dedup_hours_above_retention_raises(self) -> None:
+        """dedup_hours beyond the 90-day (2160h) playlog retention raises."""
+        plugin = self._make_plugin()
+        with pytest.raises(InvalidDataError, match="dedup_hours"):
+            plugin._validate_rules(SmartPlaylistRules(dedup_hours=2161))
+        plugin._validate_rules(SmartPlaylistRules(dedup_hours=2160))  # boundary, should not raise
 
 
 @pytest.mark.asyncio
@@ -532,10 +544,19 @@ async def test_exclusion_filters_out_excluded_uri() -> None:
     assert all(t.uri != "library://track/2" for t in result)
 
 
+def _make_played_mapping(provider: str, item_id: str) -> MagicMock:
+    """Build a minimal mock ItemMapping as returned by recently_played."""
+    mapping = MagicMock()
+    mapping.provider = provider
+    mapping.item_id = item_id
+    return mapping
+
+
 @pytest.mark.asyncio
 async def test_dedup_removes_recently_played() -> None:
-    """Tracks played within dedup_hours are excluded; others are kept."""
+    """Tracks present in the playlog within dedup_hours are excluded; others are kept."""
     mass = MagicMock()
+    mass.music.recently_played = AsyncMock(return_value=[_make_played_mapping("library", "1")])
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
     config = MagicMock()
@@ -543,13 +564,8 @@ async def test_dedup_removes_recently_played() -> None:
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
     recent = _make_mock_track("1", "library://track/1")
-    recent.last_played = int(_time.time() - 60)  # 1 minute ago
-
     old = _make_mock_track("2", "library://track/2")
-    old.last_played = int(_time.time() - 7200)  # 2 hours ago
-
     never = _make_mock_track("3", "library://track/3")
-    never.last_played = 0  # never played
 
     cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[recent, old, never])
 
@@ -562,20 +578,42 @@ async def test_dedup_removes_recently_played() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dedup_fallback_when_pool_exhausted() -> None:
-    """When all tracks were recently played, dedup is ignored and the full pool is returned."""
+async def test_dedup_removes_recently_played_streaming_track() -> None:
+    """A non-library (streaming) track in the playlog is excluded via its provider mapping."""
     mass = MagicMock()
+    mass.music.recently_played = AsyncMock(
+        return_value=[_make_played_mapping("spotify--abc", "s1")]
+    )
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
     config = MagicMock()
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
-    tracks = []
-    for i in range(5):
-        t = _make_mock_track(str(i), f"library://track/{i}")
-        t.last_played = int(_time.time() - 30)  # 30 sec ago
-        tracks.append(t)
+    played = _make_mock_track("s1", "spotify://track/s1", provider_instance="spotify--abc")
+    fresh = _make_mock_track("s2", "spotify://track/s2", provider_instance="spotify--abc")
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[played, fresh])
+
+    rules = SmartPlaylistRules(dedup_hours=1, limit=1)
+    result = await plugin._evaluate_rules(rules)
+    uris = {t.uri for t in result}
+    assert "spotify://track/s1" not in uris
+    assert "spotify://track/s2" in uris
+
+
+@pytest.mark.asyncio
+async def test_dedup_fallback_when_pool_exhausted() -> None:
+    """When all tracks were recently played, dedup is ignored and the full pool is returned."""
+    mass = MagicMock()
+    tracks = [_make_mock_track(str(i), f"library://track/{i}") for i in range(5)]
+    mass.music.recently_played = AsyncMock(
+        return_value=[_make_played_mapping("library", str(i)) for i in range(5)]
+    )
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
     cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
 

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -624,6 +624,41 @@ async def test_dedup_fallback_when_pool_exhausted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dedup_partial_fill_prefers_old_library_over_streaming() -> None:
+    """Partial-exhaustion fill must not rank streaming tracks (last_played=0) as oldest."""
+    mass = MagicMock()
+    mass.music.recently_played = AsyncMock(
+        return_value=[
+            _make_played_mapping("library", "lo"),
+            _make_played_mapping("spotify--abc", "sn"),
+        ]
+    )
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    never = _make_mock_track("n", "library://track/n")  # not in playlog -> survives dedup
+    lib_old = _make_mock_track("lo", "library://track/lo")
+    lib_old.last_played = 100  # genuinely old play
+    stream_new = _make_mock_track("sn", "spotify://track/sn", provider_instance="spotify--abc")
+    stream_new.last_played = 0  # streaming track: no library timestamp
+
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[never, lib_old, stream_new])
+
+    # limit=2: `never` fills one slot, the remaining slot is filled from the
+    # recently-played remainder; the old library track should win over the
+    # just-played streaming track.
+    rules = SmartPlaylistRules(dedup_hours=1, limit=2)
+    result = await plugin._evaluate_rules(rules)
+    uris = {t.uri for t in result}
+    assert "library://track/n" in uris
+    assert "library://track/lo" in uris
+    assert "spotify://track/sn" not in uris
+
+
+@pytest.mark.asyncio
 async def test_evaluate_rules_removes_duplicate_track_uris() -> None:
     """Smart playlist evaluation should not return the same track URI multiple times."""
     mass = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

The smart playlist `dedup_hours` rule ("do not play the same song for X hours") did not work for playlists seeded from a streaming-provider playlist.

`_apply_dedup` filtered candidates using the library `track.last_played` column, which is only written for items that exist in the library. Streaming-seeded tracks are not in the library, so `last_played` stayed `0`, dedup kept everything, and the same song could replay across different smart playlists within the window.

Changes:
- `_apply_dedup` now matches each candidate track's provider mappings against the **playlog** (via `recently_played`), so it covers both library and streaming tracks. It is scoped to the current user and counts only fully-played entries. The user context is already restored by the player queue on refill (`set_current_user`), so no extra user resolution is needed.
- `recently_played` gains an optional `played_after_timestamp` filter for the time window (backward-compatible; existing callers unaffected).
- The `dedup_hours` ceiling is lowered from 8760h to **2160h (90 days)** to match the playlog retention window, so the setting cannot promise more history than the playlog keeps.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked (see below).
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

Companion frontend PR: music-assistant/frontend#1861