### PR TITLE
Fix genre icons disappearing after install path changes

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -61,8 +61,10 @@ VARIOUS_ARTISTS_MBID: Final[str] = "89ad4ac3-39f7-470e-963a-56509c546377"
 RESOURCES_DIR: Final[pathlib.Path] = (
     pathlib.Path(__file__).parent.resolve().joinpath("helpers/resources")
 )
-GENRE_ICONS_DIR: Final[pathlib.Path] = RESOURCES_DIR.joinpath("genres")
-GENRE_MAPPING_FILE: Final[pathlib.Path] = GENRE_ICONS_DIR.joinpath("genre_mapping.json")
+GENRE_ICONS_DIR_NAME: Final[str] = "genres"
+GENRE_MAPPING_FILE: Final[pathlib.Path] = RESOURCES_DIR.joinpath(
+    GENRE_ICONS_DIR_NAME, "genre_mapping.json"
+)
 
 ANNOUNCE_ALERT_FILE: Final[str] = str(RESOURCES_DIR.joinpath("announce.mp3"))
 SILENCE_FILE: Final[str] = str(RESOURCES_DIR.joinpath("silence.mp3"))

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -38,7 +38,8 @@ from music_assistant.constants import (
     DB_TABLE_TRACK_ARTISTS,
     DB_TABLE_TRACKS,
     DEFAULT_GENRE_MAPPING,
-    GENRE_ICONS_DIR,
+    GENRE_ICONS_DIR_NAME,
+    RESOURCES_DIR,
 )
 from music_assistant.controllers.tasks.context import update_current_task_progress_text
 from music_assistant.helpers.compare import create_safe_string
@@ -196,12 +197,12 @@ class GenreController(MediaControllerBase[Genre]):
         """
         if not translation_key:
             return None
-        icon_path = GENRE_ICONS_DIR / f"{translation_key}.svg"
+        icon_path = RESOURCES_DIR.joinpath(GENRE_ICONS_DIR_NAME, f"{translation_key}.svg")
         if not icon_path.is_file():
             return None
         image = MediaItemImage(
             type=ImageType.THUMB,
-            path=str(icon_path),
+            path=f"{GENRE_ICONS_DIR_NAME}/{translation_key}.svg",
             provider="builtin",
         )
         return MediaItemMetadata(images=UniqueList([image]))

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -71,6 +71,7 @@ from music_assistant.constants import (
     DB_TABLE_TRACK_ARTISTS,
     DB_TABLE_TRACKS,
     DEFAULT_GENRE_MAPPING,
+    GENRE_ICONS_DIR_NAME,
     LOUDNESS_MEASUREMENT_MIN_LUFS,
     PROVIDERS_WITH_SHAREABLE_URLS,
 )
@@ -116,7 +117,7 @@ CONF_RESET_DB = "reset_db"
 DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
-DB_SCHEMA_VERSION: Final[int] = 40
+DB_SCHEMA_VERSION: Final[int] = 41
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60
 _DYNAMIC_RADIO_BASE_SAMPLE_SIZE: Final[int] = 5
@@ -2900,6 +2901,39 @@ class MusicController(CoreController):
             except Exception as err:
                 if "duplicate column" not in str(err):
                     raise
+
+        if prev_version <= 40:
+            # genre icons were previously stored with an absolute filesystem path to
+            # the builtin SVG, which is install-location dependent. after a runtime
+            # upgrade or relocation (e.g. the python3.13 -> python3.14 site-packages
+            # move) that path no longer existed, so genre icons 404'd via imageproxy.
+            # rewrite them to the install-independent "<GENRE_ICONS_DIR_NAME>/<file>"
+            # form; the builtin provider resolves that against RESOURCES_DIR at serve
+            # time.
+            genre_dir_marker = f"/resources/{GENRE_ICONS_DIR_NAME}/"
+            async for db_row in self._database.iter_items(DB_TABLE_GENRES):
+                raw_metadata = db_row["metadata"]
+                if not raw_metadata:
+                    continue
+                metadata = json_loads(raw_metadata)
+                images = metadata.get("images")
+                if not images:
+                    continue
+                changed = False
+                for image in images:
+                    path = image.get("path")
+                    if not (image.get("provider") == "builtin" and isinstance(path, str)):
+                        continue
+                    norm = path.replace("\\", "/")
+                    if genre_dir_marker in norm and norm.endswith(".svg"):
+                        image["path"] = f"{GENRE_ICONS_DIR_NAME}/{norm.rsplit('/', 1)[-1]}"
+                        changed = True
+                if changed:
+                    await self._database.update(
+                        DB_TABLE_GENRES,
+                        {"item_id": db_row["item_id"]},
+                        {"metadata": serialize_to_json(metadata)},
+                    )
 
         # save changes
         await self._database.commit()

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -41,8 +41,10 @@ from music_assistant_models.media_items import (
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import (
+    GENRE_ICONS_DIR_NAME,
     MASS_LOGO,
     PLAYLIST_MEDIA_TYPES,
+    RESOURCES_DIR,
     VARIOUS_ARTISTS_FANART,
     PlaylistPlayableItem,
 )
@@ -67,6 +69,7 @@ from music_assistant.helpers.playlists import (
     parse_m3u_playlist_image,
     parse_m3u_playlist_name,
 )
+from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.tags import AudioTags, async_parse_tags
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.music_provider import MusicProvider
@@ -993,6 +996,10 @@ class BuiltinProvider(MusicProvider):
             return MASS_LOGO
         if path in ("fanart.jpg", "fallback_fanart.jpeg"):
             return VARIOUS_ARTISTS_FANART
+        if path.startswith(f"{GENRE_ICONS_DIR_NAME}/"):
+            icon_name = path[len(GENRE_ICONS_DIR_NAME) + 1 :]
+            if is_safe_name(icon_name):
+                return str(RESOURCES_DIR.joinpath(GENRE_ICONS_DIR_NAME, icon_name))
         return path
 
     async def _resolve_url(self, url: str) -> str:

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -998,8 +998,9 @@ class BuiltinProvider(MusicProvider):
             return VARIOUS_ARTISTS_FANART
         if path.startswith(f"{GENRE_ICONS_DIR_NAME}/"):
             icon_name = path[len(GENRE_ICONS_DIR_NAME) + 1 :]
-            if is_safe_name(icon_name):
-                return str(RESOURCES_DIR.joinpath(GENRE_ICONS_DIR_NAME, icon_name))
+            if not is_safe_name(icon_name):
+                raise FileNotFoundError(f"Invalid genre icon reference: {path}")
+            return str(RESOURCES_DIR.joinpath(GENRE_ICONS_DIR_NAME, icon_name))
         return path
 
     async def _resolve_url(self, url: str) -> str:


### PR DESCRIPTION
# What does this implement/fix?

Genre icons were stored in the `genres` DB table with an **absolute filesystem path** to the builtin SVG (e.g. `/usr/local/lib/python3.13/site-packages/music_assistant/helpers/resources/genres/metal.svg`). That path is derived from the install location, so after a runtime upgrade or relocation — most notably the **python3.13 → python3.14 site-packages move** — the stored path no longer exists on disk. The imageproxy then returns `404` for every genre icon (the `FileNotFoundError` is logged only at verbose level, so nothing obvious shows in the logs), while the genres themselves still load fine. The only known workaround was a full genre restore, which wipes customizations.

This is the same class of issue that `logo.png` / `fanart.jpg` already avoid by storing a bare reference and resolving it at serve time — genre icons were the only builtin image persisting an absolute path.

**Changes:**
- Store genre icons as an install-independent `genres/<translation_key>.svg` reference instead of an absolute path.
- Resolve that reference against the current `RESOURCES_DIR` in the builtin provider's `resolve_image` at serve time (guarded by `is_safe_name`).
- Introduce a `GENRE_ICONS_DIR_NAME` constant used both as the stored prefix and to build the resources dir, replacing `GENRE_ICONS_DIR`.
- Add a schema migration (v40 → v41) that rewrites existing absolute genre image paths to the new form. The migration is idempotent.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.