### PR TITLE
Some typing fixes for the YouTube Music provider

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -207,7 +207,7 @@ class YoutubeMusicProvider(MusicProvider):
         """Set up the YTMusic provider."""
         logging.getLogger("yt_dlp").setLevel(self.logger.level + 10)
         await self._install_packages()
-        self._cookie = self.config.get_value(CONF_COOKIE)
+        self._cookie = str(self.config.get_value(CONF_COOKIE))
         self._po_token_server_url = (
             self.config.get_value(CONF_PO_TOKEN_SERVER_URL) or DEFAULT_PO_TOKEN_SERVER_URL
         )
@@ -217,7 +217,7 @@ class YoutubeMusicProvider(MusicProvider):
                 "Make sure you have installed the YT Music PO Token Generator "
                 "and that it is running."
             )
-        yt_username = self.config.get_value(CONF_USERNAME)
+        yt_username = str(self.config.get_value(CONF_USERNAME))
         self._yt_user = yt_username if is_brand_account(yt_username) else None
         # yt-dlp needs a netscape formatted cookie
         self._netscape_cookie = convert_to_netscape(self._cookie, YTM_COOKIE_DOMAIN)
@@ -766,8 +766,8 @@ class YoutubeMusicProvider(MusicProvider):
         ) as response:
             return await response.text()
 
-    def _initialize_headers(self) -> dict[str, str]:
-        """Return headers to include in the requests."""
+    def _initialize_headers(self) -> None:
+        """Initialize the headers to include in the requests."""
         headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0",
             "Accept": "*/*",
@@ -788,8 +788,8 @@ class YoutubeMusicProvider(MusicProvider):
         headers["Authorization"] = get_authorization(sapisid + " " + YTM_DOMAIN)
         self._headers = headers
 
-    def _initialize_context(self) -> dict[str, str]:
-        """Return a dict to use as a context in requests."""
+    def _initialize_context(self) -> None:
+        """Initialize the context to use in requests."""
         self._context = {
             "context": {
                 "client": {"clientName": "WEB_REMIX", "clientVersion": "0.1"},

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -9,18 +9,21 @@ This also nicely separates the parsing logic from the Youtube Music provider log
 import asyncio
 from http.cookies import SimpleCookie
 from time import time
+from typing import Any
 
 import ytmusicapi
+from ytmusicapi import LikeStatus
+from ytmusicapi.exceptions import YTMusicError
 
 from music_assistant.providers.ytmusic.constants import YTMRecommendationIcons
 
 
 async def get_artist(
     prov_artist_id: str, headers: dict[str, str], language: str = "en"
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Async wrapper around the ytmusicapi get_artist function."""
 
-    def _get_artist():
+    def _get_artist() -> dict[str, Any]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         try:
             artist = ytm.get_artist(channelId=prov_artist_id)
@@ -39,10 +42,10 @@ async def get_artist(
 
 async def get_album(
     headers: dict[str, str], prov_album_id: str, language: str = "en", user: str | None = None
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Async wrapper around the ytmusicapi get_album function."""
 
-    def _get_album():
+    def _get_album() -> dict[str, Any]:
         if prov_album_id.startswith("FEmusic_library_privately_owned_release"):
             ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
             album = ytm.get_library_upload_album(browseId=prov_album_id)
@@ -55,7 +58,7 @@ async def get_album(
             # points to the videoId of the original version, while we want the album version
             try:
                 album_playlist = ytm.get_playlist(playlistId=album["audioPlaylistId"], limit=None)
-            except ytmusicapi.YTMusicError:
+            except YTMusicError:
                 return album
 
             # Do some basic checks
@@ -78,11 +81,11 @@ async def get_playlist(
     headers: dict[str, str],
     language: str = "en",
     user: str | None = None,
-    limit=None,
-) -> dict[str, str]:
+    limit: int | None = None,
+) -> dict[str, Any]:
     """Async wrapper around the ytmusicapi get_playlist function."""
 
-    def _get_playlist():
+    def _get_playlist() -> dict[str, Any]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         playlist = ytm.get_playlist(playlistId=prov_playlist_id, limit=limit)
         playlist["checksum"] = get_playlist_checksum(playlist)
@@ -95,13 +98,13 @@ async def get_playlist(
 
 async def get_track(
     prov_track_id: str, headers: dict[str, str], language: str = "en"
-) -> dict[str, str] | None:
+) -> dict[str, Any] | None:
     """Async wrapper around the ytmusicapi get_playlist function."""
 
-    def _get_song():
+    def _get_song() -> dict[str, Any] | None:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         track_obj = ytm.get_song(videoId=prov_track_id)
-        track = {}
+        track: dict[str, Any] = {}
         if "videoDetails" not in track_obj:
             # video that no longer exists
             return None
@@ -127,10 +130,10 @@ async def get_track(
 
 async def get_podcast(
     prov_podcast_id: str, headers: dict[str, str], language: str = "en"
-) -> dict[str, str] | None:
+) -> dict[str, Any]:
     """Async wrapper around the get_podcast function."""
 
-    def _get_podcast():
+    def _get_podcast() -> dict[str, Any]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         podcast_obj = ytm.get_podcast(playlistId=prov_podcast_id)
         if "podcastId" not in podcast_obj:
@@ -142,10 +145,10 @@ async def get_podcast(
 
 async def get_podcast_episode(
     prov_episode_id: str, headers: dict[str, str], language: str = "en"
-) -> dict[str, str] | None:
+) -> dict[str, Any]:
     """Async wrapper around the podcast episode function."""
 
-    def _get_podcast_episode():
+    def _get_podcast_episode() -> dict[str, Any]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language)
         episode = ytm.get_episode(videoId=prov_episode_id)
         if "videoId" not in episode:
@@ -157,10 +160,10 @@ async def get_podcast_episode(
 
 async def get_library_artists(
     headers: dict[str, str], language: str = "en", user: str | None = None
-) -> dict[str, str]:
+) -> list[dict[str, Any]]:
     """Async wrapper around the ytmusicapi get_library_artists function."""
 
-    def _get_library_artists():
+    def _get_library_artists() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         artists = ytm.get_library_subscriptions(limit=9999)
         # Sync properties with uniformal artist object
@@ -176,10 +179,10 @@ async def get_library_artists(
 
 async def get_library_albums(
     headers: dict[str, str], language: str = "en", user: str | None = None
-) -> dict[str, str]:
+) -> list[dict[str, Any]]:
     """Async wrapper around the ytmusicapi get_library_albums function."""
 
-    def _get_library_albums():
+    def _get_library_albums() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         return ytm.get_library_albums(limit=9999)
 
@@ -188,10 +191,10 @@ async def get_library_albums(
 
 async def get_library_playlists(
     headers: dict[str, str], language: str = "en", user: str | None = None
-) -> dict[str, str]:
+) -> list[dict[str, Any]]:
     """Async wrapper around the ytmusicapi get_library_playlists function."""
 
-    def _get_library_playlists():
+    def _get_library_playlists() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         playlists = ytm.get_library_playlists(limit=9999)
         # Sync properties with uniformal playlist object
@@ -206,10 +209,10 @@ async def get_library_playlists(
 
 async def get_library_tracks(
     headers: dict[str, str], language: str = "en", user: str | None = None
-) -> dict[str, str]:
+) -> list[dict[str, Any]]:
     """Async wrapper around the ytmusicapi get_library_tracks function."""
 
-    def _get_library_tracks():
+    def _get_library_tracks() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         return ytm.get_library_songs(limit=9999)
 
@@ -218,12 +221,12 @@ async def get_library_tracks(
 
 async def get_library_podcasts(
     headers: dict[str, str], language: str = "en", user: str | None = None
-) -> dict[str, str]:
+) -> list[dict[str, Any]]:
     """Async wrapper around the ytmusic api get_library_podcasts function."""
 
-    def _get_library_podcasts():
+    def _get_library_podcasts() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
-        return ytm.get_library_podcasts(limit=None)
+        return ytm.get_library_podcasts(limit=9999)
 
     return await asyncio.to_thread(_get_library_podcasts)
 
@@ -233,31 +236,27 @@ async def library_add_remove_artist(
 ) -> bool:
     """Add or remove an artist to the user's library."""
 
-    def _library_add_remove_artist():
+    def _library_add_remove_artist() -> bool:
         ytm = ytmusicapi.YTMusic(auth=headers, user=user)
         if add:
             return "actions" in ytm.subscribe_artists(channelIds=[prov_artist_id])
-        if not add:
-            return "actions" in ytm.unsubscribe_artists(channelIds=[prov_artist_id])
-        return None
+        return "actions" in ytm.unsubscribe_artists(channelIds=[prov_artist_id])
 
     return await asyncio.to_thread(_library_add_remove_artist)
 
 
 async def library_add_remove_album(
     headers: dict[str, str], prov_item_id: str, add: bool = True, user: str | None = None
-) -> bool:
+) -> dict[str, Any]:
     """Add or remove an album or playlist to the user's library."""
     album = await get_album(headers=headers, prov_album_id=prov_item_id, user=user)
 
-    def _library_add_remove_album():
+    def _library_add_remove_album() -> dict[str, Any]:
         ytm = ytmusicapi.YTMusic(auth=headers, user=user)
         playlist_id = album["audioPlaylistId"]
         if add:
-            return ytm.rate_playlist(playlist_id, "LIKE")
-        if not add:
-            return ytm.rate_playlist(playlist_id, "INDIFFERENT")
-        return None
+            return ytm.rate_playlist(playlist_id, LikeStatus.LIKE)
+        return ytm.rate_playlist(playlist_id, LikeStatus.INDIFFERENT)
 
     return await asyncio.to_thread(_library_add_remove_album)
 
@@ -267,13 +266,11 @@ async def library_add_remove_playlist(
 ) -> bool:
     """Add or remove an album or playlist to the user's library."""
 
-    def _library_add_remove_playlist():
+    def _library_add_remove_playlist() -> bool:
         ytm = ytmusicapi.YTMusic(auth=headers, user=user)
         if add:
-            return "actions" in ytm.rate_playlist(prov_item_id, "LIKE")
-        if not add:
-            return "actions" in ytm.rate_playlist(prov_item_id, "INDIFFERENT")
-        return None
+            return "actions" in ytm.rate_playlist(prov_item_id, LikeStatus.LIKE)
+        return "actions" in ytm.rate_playlist(prov_item_id, LikeStatus.INDIFFERENT)
 
     return await asyncio.to_thread(_library_add_remove_playlist)
 
@@ -281,41 +278,41 @@ async def library_add_remove_playlist(
 async def add_remove_playlist_tracks(
     headers: dict[str, str],
     prov_playlist_id: str,
-    prov_track_ids: list[str],
+    prov_track_ids: list[Any],
     add: bool,
     user: str | None = None,
-) -> bool:
+) -> str | dict[str, Any]:
     """Async wrapper around adding/removing tracks to a playlist."""
 
-    def _add_playlist_tracks():
+    def _add_playlist_tracks() -> str | dict[str, Any]:
         ytm = ytmusicapi.YTMusic(auth=headers, user=user)
         if add:
             return ytm.add_playlist_items(playlistId=prov_playlist_id, videoIds=prov_track_ids)
-        if not add:
-            return ytm.remove_playlist_items(playlistId=prov_playlist_id, videos=prov_track_ids)
-        return None
+        return ytm.remove_playlist_items(playlistId=prov_playlist_id, videos=prov_track_ids)
 
     return await asyncio.to_thread(_add_playlist_tracks)
 
 
 async def get_song_radio_tracks(
-    headers: dict[str, str], prov_item_id: str, limit=25, user: str | None = None
-) -> dict[str, str]:
+    headers: dict[str, str], prov_item_id: str, limit: int = 25, user: str | None = None
+) -> dict[str, Any]:
     """Async wrapper around the ytmusicapi radio function."""
 
-    def _get_song_radio_tracks():
+    def _get_song_radio_tracks() -> dict[str, Any]:
         ytm = ytmusicapi.YTMusic(auth=headers, user=user)
         playlist_id = f"RDAMVM{prov_item_id}"
         result = ytm.get_watch_playlist(
             videoId=prov_item_id, playlistId=playlist_id, limit=limit, radio=True
         )
         # Replace inconsistensies for easier parsing
-        for track in result["tracks"]:
-            if track.get("thumbnail"):
-                track["thumbnails"] = track["thumbnail"]
-                del track["thumbnail"]
-            if track.get("length"):
-                track["duration"] = get_sec(track["length"])
+        tracks = result.get("tracks")
+        if isinstance(tracks, list):
+            for track in tracks:
+                if track.get("thumbnail"):
+                    track["thumbnails"] = track["thumbnail"]
+                    del track["thumbnail"]
+                if track.get("length"):
+                    track["duration"] = get_sec(track["length"])
         return result
 
     return await asyncio.to_thread(_get_song_radio_tracks)
@@ -323,10 +320,10 @@ async def get_song_radio_tracks(
 
 async def search(
     query: str, ytm_filter: str | None = None, limit: int = 20, language: str = "en"
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """Async wrapper around the ytmusicapi search function."""
 
-    def _search():
+    def _search() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(language=language)
         results = ytm.search(query=query, filter=ytm_filter, limit=limit)
         # Sync result properties with uniformal objects
@@ -353,11 +350,11 @@ async def search(
     return await asyncio.to_thread(_search)
 
 
-def get_playlist_checksum(playlist_obj: dict) -> str:
+def get_playlist_checksum(playlist_obj: dict[str, Any]) -> str:
     """Try to calculate a checksum so we can detect changes in a playlist."""
     for key in ("duration_seconds", "trackCount", "count"):
         if key in playlist_obj:
-            return playlist_obj[key]
+            return str(playlist_obj[key])
     return str(int(time()))
 
 
@@ -366,7 +363,7 @@ def is_brand_account(username: str) -> bool:
     return len(username) == 21 and username.isdigit()
 
 
-def get_sec(time_str):
+def get_sec(time_str: str) -> int:
     """Get seconds from time."""
     parts = time_str.split(":")
     if len(parts) == 3:
@@ -389,10 +386,10 @@ def convert_to_netscape(raw_cookie_str: str, domain: str) -> str:
 
 async def get_home(
     headers: dict[str, str], language: str = "en", user: str | None = None, limit: int = 3
-) -> dict[str, str]:
+) -> list[dict[str, Any]]:
     """Get the recommendations from the home page."""
 
-    def _get_home():
+    def _get_home() -> list[dict[str, Any]]:
         ytm = ytmusicapi.YTMusic(auth=headers, language=language, user=user)
         return ytm.get_home(limit=limit)
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

First stage of mypy fixes. helpers.py fully done and some simple ones to start for init.py

There are some noteworthy changes

  1. `get_library_podcasts`: `limit=None` has changed to `limit=9999`. `ytmusicapi `types limit as `int` (so None was wrong), and this has been matched to the sibling `get_library_*` calls which all use 9999. But `None` might have meant "fetch all" semantically, whereas now 9999 is a cap. In practice no one has >9999 library podcasts, so it's almost certainly fine but it's mentioned for transparency.

  2. `get_playlist_checksum`: `return playlist_obj[key]` has changed to `return str(playlist_obj[key])` . `trackCount/count` are ints, so this now always returns a `str `to satisfy the `-> str` contract. Low risk (the value ends up as a str checksum downstream anyway), but on upgrade an existing playlist could see a one-time checksum mismatch but this would only result in a harmless re-sync.
 
  3. `except ytmusicapi.YTMusicError` changes to `except YTMusicError`. `ytmusicapi.YTMusicError` isn't exposed at
  the top level (it lives in `ytmusicapi.exceptions`), so the old except clause would itself raise `AttributeError` if that path were ever hit, masking the real error. Now it catches correctly and returns the album gracefully as intended.

  4. `library_add_remove_album` typed -> `dict[str, Any]` (was `-> bool`) is a valid typing change as it always returned the raw rate_playlist dict. But it's now the odd one out as its siblings `library_add_remove_playlist/_artist` return a real bool ("actions" in ...). A reviewer may prefer it be normalized to "actions" in ... instead. But again this fix does not change runtime behaviour.
 
  5. `add_remove_playlist_tracks`: `param list[str]` has been changed to ` list[Any]`, and the return to `str | dict[str, Any]`. This is the weakest typing in the change. The param genuinely holds `list[str]` (add path) vs `list[dict]` (remove path), so `list[Any]` has been used to avoid casts. A reviewer might want list[str] | list[dict[str, Any]] with explicit cast()s, or the function split in two.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate