### PR TITLE
Reconcile smart playlist library entries on load to recover after DB reset

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -145,6 +145,8 @@ class SmartPlaylistProvider(PluginProvider):
         self.logger.info(
             "Smart Playlist provider loaded with %d stored playlists", len(self._rules_store)
         )
+        # Re-add playlists missing from the library (e.g. after a DB reset).
+        self.mass.create_task(self._reconcile_library())
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
@@ -152,10 +154,7 @@ class SmartPlaylistProvider(PluginProvider):
             unregister()
         self._unregister_handles.clear()
         if is_removed:
-            # Smart playlists only exist as long as this provider is installed.
-            # When the provider is removed, the playlists must be explicitly removed
-            # from the MA library — otherwise orphaned entries remain, because MA
-            # has no other mechanism to clean up provider-owned playlists on removal.
+            # Remove all library entries — MA has no other mechanism to clean them up on removal.
             for playlist_id in list(self._rules_store):
                 try:
                     library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
@@ -250,6 +249,21 @@ class SmartPlaylistProvider(PluginProvider):
         return await self._evaluate_rules(
             sample_rules, list(user_provider_filter) if user_provider_filter else None
         )
+
+    async def _reconcile_library(self) -> None:
+        """Re-add smart playlists that are missing from the library (e.g. after a DB reset)."""
+        for playlist_id, rules in list(self._rules_store.items()):
+            existing = await self.mass.music.playlists.get_library_item_by_prov_id(
+                playlist_id, self.instance_id
+            )
+            if existing is not None:
+                continue
+            self.logger.info("Re-adding missing smart playlist '%s' to library", playlist_id)
+            try:
+                playlist = self._build_playlist(playlist_id, rules)
+                await self.mass.music.playlists.add_item_to_library(playlist)
+            except Exception as exc:
+                self.logger.warning("Could not re-add smart playlist %s: %s", playlist_id, exc)
 
     async def _on_media_item_deleted(self, event: MassEvent) -> None:
         """Remove the rules for a deleted smart playlist."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -253,13 +253,13 @@ class SmartPlaylistProvider(PluginProvider):
     async def _reconcile_library(self) -> None:
         """Re-add smart playlists that are missing from the library (e.g. after a DB reset)."""
         for playlist_id, rules in list(self._rules_store.items()):
-            existing = await self.mass.music.playlists.get_library_item_by_prov_id(
-                playlist_id, self.instance_id
-            )
-            if existing is not None:
-                continue
-            self.logger.info("Re-adding missing smart playlist '%s' to library", playlist_id)
             try:
+                existing = await self.mass.music.playlists.get_library_item_by_prov_id(
+                    playlist_id, self.instance_id
+                )
+                if existing is not None:
+                    continue
+                self.logger.info("Re-adding missing smart playlist '%s' to library", playlist_id)
                 playlist = self._build_playlist(playlist_id, rules)
                 await self.mass.music.playlists.add_item_to_library(playlist)
             except Exception as exc:


### PR DESCRIPTION
## What does this implement/fix?

After a database reset, smart playlists stored on disk (under `$HOME/.musicassistant/smart_playlists/`) were no longer present in the library DB. Any attempt to interact with them (e.g. "Remove from Library") crashed with:

```
ValueError: invalid literal for int() with base 10: 'b054...'
```

because the remove path called `int(item_id)` on the provider-side UUID string instead of the library integer PK.

**Root cause:** `loaded_in_mass()` had no reconciliation step. After a DB reset the rules exist on disk but the library DB is empty.

**Fix:** A background task `_reconcile_library()` is run at startup. It iterates over all stored playlists, checks whether each one already has a library entry via `get_library_item_by_prov_id()`, and calls `add_item_to_library()` for any that are missing. The provider-side UUID remains stable across resets; the library DB auto-assigns a new integer PK.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.