### PR TITLE
Apple Music: stream library tracks and harden transient-error handling

### DIFF
--- a/music_assistant/providers/apple_music/api_client.py
+++ b/music_assistant/providers/apple_music/api_client.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+import functools
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Concatenate, cast
 
-from aiohttp import ClientTimeout
+from aiohttp import ClientConnectionError, ClientPayloadError, ClientTimeout
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import (
     MediaNotFoundError,
-    MusicAssistantError,
     RateLimited,
     ResourceTemporarilyUnavailable,
 )
@@ -23,11 +24,40 @@ if TYPE_CHECKING:
 
 _APPLE_API_BASE = "https://api.music.apple.com/v1"
 
+_LIBRARY_PAGE_SIZE = 50
+
+_PAGE_TRUNCATION_RETRIES = 3
+
+
+def _retry_transient_transport_errors[ClientT, **P, R](
+    func: Callable[Concatenate[ClientT, P], Awaitable[R]],
+) -> Callable[Concatenate[ClientT, P], Awaitable[R]]:
+    """
+    Convert transient aiohttp transport errors into the retryable error type.
+
+    A dropped connection or truncated body raises an ``aiohttp.ClientError`` (or
+    ``TimeoutError``) rather than an HTTP status, so it would otherwise bypass the
+    status-based retry handling. ``ClientResponseError`` (raised by
+    ``raise_for_status`` for genuine 4xx/5xx) is deliberately not caught here.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(self: ClientT, *args: P.args, **kwargs: P.kwargs) -> R:
+        try:
+            return await func(self, *args, **kwargs)
+        except (ClientConnectionError, ClientPayloadError, TimeoutError) as err:
+            raise ResourceTemporarilyUnavailable(
+                f"Transient transport error calling Apple Music: {type(err).__name__}: {err}"
+            ) from err
+
+    return wrapper
+
 
 class AppleMusicAPIClient:
     """Handles all HTTP communication with the Apple Music API."""
 
-    throttler = ThrottlerManager(rate_limit=1, period=2, initial_backoff=15)
+    # period=0.25 -> 4 req/s. Raise it if Apple starts returning 429s.
+    throttler = ThrottlerManager(rate_limit=1, period=0.25, initial_backoff=15)
 
     def __init__(self, provider: AppleMusicProvider) -> None:
         """Initialize the API client."""
@@ -43,6 +73,7 @@ class AppleMusicAPIClient:
         }
 
     @throttle_with_retries
+    @_retry_transient_transport_errors
     async def get_data(self, endpoint: str, **kwargs: Any) -> dict[str, Any]:
         """GET data from the Apple Music API."""
         url = f"{_APPLE_API_BASE}/{endpoint}"
@@ -73,7 +104,10 @@ class AppleMusicAPIClient:
                 )
                 raise RateLimited("Apple Music Rate Limiter")
             if response.status == 500:
-                raise MusicAssistantError("Unexpected server error when calling Apple Music")
+                # Apple 500s are typically transient; retry rather than abort the whole sync.
+                raise ResourceTemporarilyUnavailable(
+                    "Unexpected server error when calling Apple Music"
+                )
             response.raise_for_status()
             return cast("dict[str, Any]", await response.json(loads=json_loads))
 
@@ -150,24 +184,34 @@ class AppleMusicAPIClient:
             response.raise_for_status()
             return cast("dict[str, Any]", await response.json(loads=json_loads))
 
+    async def iter_all_items(
+        self, endpoint: str, key: str = "data", page_size: int = _LIBRARY_PAGE_SIZE, **kwargs: Any
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """
+        Yield items from a paged list one page at a time.
+
+        Unlike :meth:`get_all_items`, this never holds the full result set in memory, so it is
+        safe for very large listings (e.g. a 100k-track Apple Music library).
+        """
+        offset = 0
+        while True:
+            kwargs["limit"] = page_size
+            kwargs["offset"] = offset
+            result = await self._get_page(endpoint, key, offset, kwargs)
+            if key not in result:
+                # offset 0 only: empty collection or 404. _get_page raises on mid-list truncation.
+                break
+            for item in result[key]:
+                yield item
+            if not result.get("next"):
+                break
+            offset += page_size
+
     async def get_all_items(
         self, endpoint: str, key: str = "data", **kwargs: Any
     ) -> list[dict[str, Any]]:
         """Get all items from a paged list."""
-        limit = 50
-        offset = 0
-        all_items: list[dict[str, Any]] = []
-        while True:
-            kwargs["limit"] = limit
-            kwargs["offset"] = offset
-            result = await self.get_data(endpoint, **kwargs)
-            if key not in result:
-                break
-            all_items += result[key]
-            if not result.get("next"):
-                break
-            offset += limit
-        return all_items
+        return [item async for item in self.iter_all_items(endpoint, key, **kwargs)]
 
     async def get_user_storefront(self) -> str:
         """Return the user's storefront identifier."""
@@ -201,3 +245,27 @@ class AppleMusicAPIClient:
                 }
             )
         return results
+
+    async def _get_page(
+        self, endpoint: str, key: str, offset: int, kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Fetch a single page of a paged listing, recovering from transient truncation.
+
+        Apple returns ``{}`` (HTTP 404) for a paged request that yields no payload. On the
+        first page (offset 0) that legitimately means an empty collection. Mid-pagination
+        (offset > 0, reached only after a prior page promised more via ``next``) it means a
+        transient truncation; accepting it would drop still-present items and trigger
+        spurious deletions, so re-fetch the same page a bounded number of times before
+        surfacing the failure.
+        """
+        result = await self.get_data(endpoint, **kwargs)
+        if key in result or offset == 0:
+            return result
+        for _ in range(_PAGE_TRUNCATION_RETRIES):
+            result = await self.get_data(endpoint, **kwargs)
+            if key in result:
+                return result
+        raise ResourceTemporarilyUnavailable(
+            f"Incomplete paged listing for {endpoint} at offset {offset}"
+        )

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -17,6 +17,13 @@ if TYPE_CHECKING:
 
     from .provider import AppleMusicProvider
 
+# Tracks carry heavy includes, so they page smaller than the library default.
+_TRACK_PAGE_SIZE = 30
+
+# Catalog enrichment batch size: 300 (the documented max) returns a 504, so cap at 150. This also
+# bounds the in-flight window, keeping a ~100k library from being materialized at once.
+_TRACK_SYNC_WINDOW = 150
+
 
 class AppleMusicLibraryManager:
     """Manages Apple Music library operations."""
@@ -69,52 +76,29 @@ class AppleMusicLibraryManager:
 
     async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
         """Retrieve library tracks from the provider."""
-        endpoint = "me/library/songs"
-        song_catalog_ids = []
-        library_items_by_catalog_id: dict[str, dict[str, Any]] = {}
-        library_only_tracks = []
-        for item in await self.api.get_all_items(endpoint, include="catalog,albums,artists"):
+        # Enrich and yield in bounded windows so the full library is never held in memory at once.
+        catalog_items: dict[str, dict[str, Any]] = {}
+        library_only_items: list[dict[str, Any]] = []
+        async for item in self.api.iter_all_items(
+            "me/library/songs", include="catalog,albums,artists", page_size=_TRACK_PAGE_SIZE
+        ):
             catalog_id = item.get("attributes", {}).get("playParams", {}).get("catalogId")
             if not catalog_id:
-                library_only_tracks.append(item)
+                library_only_items.append(item)
             else:
-                song_catalog_ids.append(catalog_id)
-                library_items_by_catalog_id[catalog_id] = item
-        # Obtain catalog info per 150 songs; the documented limit of 300 results in a 504 timeout.
-        max_limit = 150
-        for i in range(0, len(song_catalog_ids), max_limit):
-            catalog_ids = song_catalog_ids[i : i + max_limit]
-            catalog_endpoint = f"catalog/{self.provider._storefront}/songs"
-            response = await self.api.get_data(
-                catalog_endpoint, ids=",".join(catalog_ids), include="artists,albums"
-            )
-            rating_response = await self.api.get_ratings(catalog_ids, MediaType.TRACK)
-            returned_catalog_ids: set[str] = set()
-            for item in response["data"]:
-                returned_catalog_ids.add(item["id"])
-                is_favourite = rating_response.get(item["id"])
-                parsed_track = parse_track(self.provider, item, is_favourite)
-                if self._track_has_weak_album_mapping(parsed_track) and (
-                    library_item := library_items_by_catalog_id.get(item["id"])
-                ):
-                    parsed_library_track = parse_track(self.provider, library_item, is_favourite)
-                    if parsed_library_track.album and not self._track_has_weak_album_mapping(
-                        parsed_library_track
-                    ):
-                        parsed_track.album = parsed_library_track.album
-                yield parsed_track
-
-            # Some library items may not resolve on the catalog endpoint anymore.
-            for missing_catalog_id in set(catalog_ids) - returned_catalog_ids:
-                if library_item := library_items_by_catalog_id.get(missing_catalog_id):
-                    is_favourite = rating_response.get(missing_catalog_id)
-                    yield parse_track(self.provider, library_item, is_favourite)
-        library_ids = [item["id"] for item in library_only_tracks if item and item["id"]]
-        library_rating_response = await self.api.get_ratings(library_ids, MediaType.TRACK)
-        for item in library_only_tracks:
-            is_favourite = library_rating_response.get(item["id"])
-            parsed_track = await self._parse_library_track_with_detail_fallback(item, is_favourite)
-            yield parsed_track
+                catalog_items[catalog_id] = item
+            if len(catalog_items) >= _TRACK_SYNC_WINDOW:
+                async for track in self._flush_catalog_tracks(catalog_items):
+                    yield track
+                catalog_items = {}
+            if len(library_only_items) >= _TRACK_SYNC_WINDOW:
+                async for track in self._flush_library_only_tracks(library_only_items):
+                    yield track
+                library_only_items = []
+        async for track in self._flush_catalog_tracks(catalog_items):
+            yield track
+        async for track in self._flush_library_only_tracks(library_only_items):
+            yield track
 
     def _track_has_weak_album_mapping(self, track: Track) -> bool:
         """Return True for missing or name-only album mapping."""
@@ -239,3 +223,47 @@ class AppleMusicLibraryManager:
         else:
             endpoint = f"me/ratings/library-{item_type}/{prov_item_id}"
         await self.api.put_data(endpoint, data=data)
+
+    async def _flush_catalog_tracks(
+        self, library_items_by_catalog_id: dict[str, dict[str, Any]]
+    ) -> AsyncGenerator[Track, None]:
+        """Enrich one window of catalog-backed library tracks with catalog detail and yield them."""
+        if not library_items_by_catalog_id:
+            return
+        catalog_ids = list(library_items_by_catalog_id)
+        catalog_endpoint = f"catalog/{self.provider._storefront}/songs"
+        response = await self.api.get_data(
+            catalog_endpoint, ids=",".join(catalog_ids), include="artists,albums"
+        )
+        rating_response = await self.api.get_ratings(catalog_ids, MediaType.TRACK)
+        returned_catalog_ids: set[str] = set()
+        for item in response.get("data", []):
+            returned_catalog_ids.add(item["id"])
+            is_favourite = rating_response.get(item["id"])
+            parsed_track = parse_track(self.provider, item, is_favourite)
+            if self._track_has_weak_album_mapping(parsed_track) and (
+                library_item := library_items_by_catalog_id.get(item["id"])
+            ):
+                parsed_library_track = parse_track(self.provider, library_item, is_favourite)
+                if parsed_library_track.album and not self._track_has_weak_album_mapping(
+                    parsed_library_track
+                ):
+                    parsed_track.album = parsed_library_track.album
+            yield parsed_track
+        # Some library items may not resolve on the catalog endpoint anymore.
+        for missing_catalog_id in set(catalog_ids) - returned_catalog_ids:
+            if library_item := library_items_by_catalog_id.get(missing_catalog_id):
+                is_favourite = rating_response.get(missing_catalog_id)
+                yield parse_track(self.provider, library_item, is_favourite)
+
+    async def _flush_library_only_tracks(
+        self, library_only_items: list[dict[str, Any]]
+    ) -> AsyncGenerator[Track, None]:
+        """Enrich one window of library-only tracks (no catalog id) and yield them."""
+        if not library_only_items:
+            return
+        library_ids = [item["id"] for item in library_only_items if item and item["id"]]
+        rating_response = await self.api.get_ratings(library_ids, MediaType.TRACK)
+        for item in library_only_items:
+            is_favourite = rating_response.get(item["id"])
+            yield await self._parse_library_track_with_detail_fallback(item, is_favourite)

--- a/tests/providers/apple_music/test_api_client.py
+++ b/tests/providers/apple_music/test_api_client.py
@@ -1,0 +1,259 @@
+"""Unit tests for the Apple Music API client error handling and pagination."""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import ClientPayloadError, ClientResponseError, ServerDisconnectedError
+from aiohttp.client_reqrep import RequestInfo
+from multidict import CIMultiDict, CIMultiDictProxy
+from music_assistant_models.errors import ResourceTemporarilyUnavailable, RetriesExhausted
+from yarl import URL
+
+from music_assistant.providers.apple_music.api_client import (
+    _LIBRARY_PAGE_SIZE,
+    _PAGE_TRUNCATION_RETRIES,
+    AppleMusicAPIClient,
+    _retry_transient_transport_errors,
+)
+
+# Target for patching the backoff/throttle sleep so retries run instantly.
+_SLEEP_TARGET = "music_assistant.helpers.throttle_retry.asyncio.sleep"
+
+
+class _FakeRequestCtx:
+    """Minimal async context manager mimicking aiohttp's request context."""
+
+    def __init__(self, response: MagicMock) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> MagicMock:
+        return self._response
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+def _make_response(
+    status: int = 200,
+    json_data: Any = None,
+    json_exc: BaseException | None = None,
+) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.headers = CIMultiDict()
+    response.content_length = 0
+    response.raise_for_status = MagicMock()
+    if json_exc is not None:
+        response.json = AsyncMock(side_effect=json_exc)
+    else:
+        response.json = AsyncMock(return_value=json_data)
+    return response
+
+
+def _make_client() -> tuple[AppleMusicAPIClient, MagicMock]:
+    """Return an API client together with its mock provider (for session stubbing)."""
+    provider = MagicMock()
+    provider.logger = MagicMock()
+    provider._music_app_token = "app-token"
+    provider._music_user_token = "user-token"
+    return AppleMusicAPIClient(provider), provider
+
+
+def _client_response_error(status: int) -> ClientResponseError:
+    request_info = RequestInfo(
+        url=URL("https://api.music.apple.com/v1/me/library/songs"),
+        method="GET",
+        headers=CIMultiDictProxy(CIMultiDict()),
+        real_url=URL("https://api.music.apple.com/v1/me/library/songs"),
+    )
+    return ClientResponseError(
+        request_info=request_info, history=(), status=status, message="error", headers=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# P1: transient transport errors map to the retryable error type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        ClientPayloadError("Not enough data to satisfy content length header."),
+        ServerDisconnectedError("Server disconnected"),
+        TimeoutError("Read timed out"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_transient_transport_errors_mapped_to_retryable(
+    transport_error: BaseException,
+) -> None:
+    """Transport-level errors are converted to ResourceTemporarilyUnavailable."""
+
+    async def _raise(_self: object) -> None:
+        raise transport_error
+
+    wrapped = _retry_transient_transport_errors(_raise)
+    with pytest.raises(ResourceTemporarilyUnavailable):
+        await wrapped(object())
+
+
+@pytest.mark.asyncio
+async def test_client_response_error_not_mapped() -> None:
+    """HTTP status errors (raise_for_status) must not be silently retried."""
+
+    async def _raise(_self: object) -> None:
+        raise _client_response_error(403)
+
+    wrapped = _retry_transient_transport_errors(_raise)
+    with pytest.raises(ClientResponseError):
+        await wrapped(object())
+
+
+@pytest.mark.asyncio
+async def test_decorator_passes_through_success() -> None:
+    """The decorator returns the wrapped result unchanged on success."""
+
+    async def _ok(_self: object, value: int) -> int:
+        return value
+
+    wrapped: Callable[[object, int], Awaitable[int]] = _retry_transient_transport_errors(_ok)
+    assert await wrapped(object(), 42) == 42
+
+
+@pytest.mark.asyncio
+async def test_get_data_recovers_after_transient_payload_error() -> None:
+    """A truncated body on the first attempt is retried and then succeeds."""
+    client, provider = _make_client()
+    payload = {"data": [{"id": "1"}]}
+    provider.mass.http_session.get = MagicMock(
+        side_effect=[
+            _FakeRequestCtx(_make_response(status=200, json_exc=ClientPayloadError("truncated"))),
+            _FakeRequestCtx(_make_response(status=200, json_data=payload)),
+        ]
+    )
+    with patch(_SLEEP_TARGET, new=AsyncMock()):
+        result = await client.get_data("me/library/songs", limit=50, offset=0)
+    assert result == payload
+    assert provider.mass.http_session.get.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# P2: HTTP 500 is retryable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_data_500_recovers_on_retry() -> None:
+    """A transient 500 is retried and then succeeds."""
+    client, provider = _make_client()
+    payload = {"data": [{"id": "1"}]}
+    provider.mass.http_session.get = MagicMock(
+        side_effect=[
+            _FakeRequestCtx(_make_response(status=500)),
+            _FakeRequestCtx(_make_response(status=200, json_data=payload)),
+        ]
+    )
+    with patch(_SLEEP_TARGET, new=AsyncMock()):
+        result = await client.get_data("me/library/songs", limit=50, offset=0)
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_get_data_persistent_500_exhausts_retries() -> None:
+    """A persistent 500 retries retry_attempts times then raises RetriesExhausted."""
+    client, provider = _make_client()
+    provider.mass.http_session.get = MagicMock(
+        return_value=_FakeRequestCtx(_make_response(status=500))
+    )
+    with patch(_SLEEP_TARGET, new=AsyncMock()), pytest.raises(RetriesExhausted):
+        await client.get_data("me/library/songs", limit=50, offset=0)
+    assert provider.mass.http_session.get.call_count == client.throttler.retry_attempts
+
+
+# ---------------------------------------------------------------------------
+# P3: pagination distinguishes a clean/empty end from a mid-list truncation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_all_items_assembles_pages() -> None:
+    """Pages are concatenated and pagination stops when no `next` is returned."""
+    client, _ = _make_client()
+    client.get_data = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            {"data": [{"id": "a"}, {"id": "b"}], "next": "/v1/me/library/songs?offset=50"},
+            {"data": [{"id": "c"}]},
+        ]
+    )
+    items = await client.get_all_items("me/library/songs")
+    assert [item["id"] for item in items] == ["a", "b", "c"]
+    assert client.get_data.call_args_list[0].kwargs["offset"] == 0
+    assert client.get_data.call_args_list[1].kwargs["offset"] == _LIBRARY_PAGE_SIZE
+
+
+@pytest.mark.asyncio
+async def test_iter_all_items_fetches_pages_lazily() -> None:
+    """iter_all_items yields incrementally and only fetches the next page when needed."""
+    client, _ = _make_client()
+    client.get_data = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            {"data": [{"id": "a"}, {"id": "b"}], "next": "/v1/me/library/songs?offset=50"},
+            {"data": [{"id": "c"}]},
+        ]
+    )
+    gen = client.iter_all_items("me/library/songs")
+    first = await anext(gen)
+    assert first["id"] == "a"
+    # The second page must not have been fetched just to yield the first item.
+    assert client.get_data.call_count == 1
+    rest = [item async for item in gen]
+    assert [item["id"] for item in rest] == ["b", "c"]
+    assert client.get_data.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_all_items_empty_first_page_returns_empty() -> None:
+    """An empty collection (empty data, no `next`) yields an empty list."""
+    client, _ = _make_client()
+    client.get_data = AsyncMock(return_value={"data": []})  # type: ignore[method-assign]
+    assert await client.get_all_items("me/library/songs") == []
+
+
+@pytest.mark.asyncio
+async def test_get_all_items_first_page_404_returns_empty() -> None:
+    """A 404 on the very first page (no prior page) is treated as empty, not an error."""
+    client, _ = _make_client()
+    client.get_data = AsyncMock(return_value={})  # type: ignore[method-assign]
+    assert await client.get_all_items("me/library/songs") == []
+
+
+@pytest.mark.asyncio
+async def test_get_all_items_midlist_truncation_recovers() -> None:
+    """A transient mid-list 404 is retried in place and the listing completes."""
+    client, _ = _make_client()
+    client.get_data = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            {"data": [{"id": "a"}], "next": "/v1/me/library/songs?offset=50"},
+            {},  # transient truncation on the second page
+            {"data": [{"id": "b"}]},  # in-place retry succeeds
+        ]
+    )
+    items = await client.get_all_items("me/library/songs")
+    assert [item["id"] for item in items] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_get_all_items_persistent_truncation_raises() -> None:
+    """A 404 that persists across in-place retries surfaces as a loud failure."""
+    client, _ = _make_client()
+    client.get_data = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            {"data": [{"id": "a"}], "next": "/v1/me/library/songs?offset=50"},
+            *([{}] * (_PAGE_TRUNCATION_RETRIES + 1)),
+        ]
+    )
+    with pytest.raises(ResourceTemporarilyUnavailable):
+        await client.get_all_items("me/library/songs")

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -1,0 +1,88 @@
+"""Unit tests for Apple Music library track streaming and windowed enrichment."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from music_assistant.providers.apple_music.library import (
+    _TRACK_SYNC_WINDOW,
+    AppleMusicLibraryManager,
+)
+
+
+def _library_song(idx: int, *, catalog_id: str | None) -> dict[str, Any]:
+    """Build a minimal me/library/songs listing item, optionally catalog-backed."""
+    play_params: dict[str, Any] = {"id": f"i.{idx}"}
+    if catalog_id is not None:
+        play_params["catalogId"] = catalog_id
+    return {
+        "id": f"i.{idx}",
+        "type": "library-songs",
+        "attributes": {"name": f"Track {idx}", "playParams": play_params},
+    }
+
+
+def _catalog_song(catalog_id: str) -> dict[str, Any]:
+    """Build a minimal catalog/songs response item."""
+    return {
+        "id": catalog_id,
+        "type": "songs",
+        "attributes": {"name": f"Catalog {catalog_id}", "playParams": {"id": catalog_id}},
+    }
+
+
+def _make_manager(
+    stream_items: list[dict[str, Any]],
+) -> tuple[AppleMusicLibraryManager, MagicMock, dict[str, Any]]:
+    """
+    Build a library manager whose api streams ``stream_items`` and echoes catalog enrichment.
+
+    The returned ``state`` dict tracks how many listing items have been streamed and at what
+    point the first enrichment request fired, so tests can assert streaming/windowing behaviour.
+    """
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+    provider._storefront = "us"
+    api = provider.api_client
+    state: dict[str, Any] = {"streamed": 0, "first_enrich_at": None}
+
+    async def _iter(*_args: Any, **_kwargs: Any) -> Any:
+        for item in stream_items:
+            state["streamed"] += 1
+            yield item
+
+    async def _get_data(_endpoint: str, **kwargs: Any) -> dict[str, Any]:
+        if state["first_enrich_at"] is None:
+            state["first_enrich_at"] = state["streamed"]
+        ids = kwargs["ids"].split(",")
+        assert len(ids) <= _TRACK_SYNC_WINDOW  # never exceed the documented catalog batch limit
+        return {"data": [_catalog_song(cid) for cid in ids]}
+
+    api.iter_all_items = _iter
+    api.get_data = AsyncMock(side_effect=_get_data)
+    api.get_ratings = AsyncMock(return_value={})
+    return AppleMusicLibraryManager(provider), api, state
+
+
+@pytest.mark.asyncio
+async def test_catalog_enrichment_is_windowed() -> None:
+    """Catalog enrichment runs in batches capped at the window size, never one giant request."""
+    count = _TRACK_SYNC_WINDOW * 2 + 20
+    items = [_library_song(i, catalog_id=f"c{i}") for i in range(count)]
+    manager, api, _ = _make_manager(items)
+    tracks = [track async for track in manager.get_library_tracks()]
+    assert len(tracks) == count
+    # 320 catalog ids -> ceil(320 / 150) = 3 enrichment requests.
+    assert api.get_data.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_enriches_before_listing_completes() -> None:
+    """A window is enriched and yielded as soon as it fills, not after the whole listing."""
+    count = _TRACK_SYNC_WINDOW * 2
+    items = [_library_song(i, catalog_id=f"c{i}") for i in range(count)]
+    manager, _, state = _make_manager(items)
+    [track async for track in manager.get_library_tracks()]
+    assert state["first_enrich_at"] == _TRACK_SYNC_WINDOW

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -1,13 +1,24 @@
 """Regression tests for Apple Music parser and library fallbacks."""
 
+from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.media_items import Album, ItemMapping
 
-from music_assistant.providers.apple_music.library import AppleMusicLibraryManager
+from music_assistant.providers.apple_music.library import _TRACK_PAGE_SIZE, AppleMusicLibraryManager
 from music_assistant.providers.apple_music.media import AppleMusicMediaManager
 from music_assistant.providers.apple_music.parsers import parse_album, parse_track
+
+
+def _stream(items: list[dict[str, Any]]) -> MagicMock:
+    """Mock api.iter_all_items: a sync callable returning a fresh async iterator over items."""
+
+    async def _gen(*_args: Any, **_kwargs: Any) -> Any:
+        for item in items:
+            yield item
+
+    return MagicMock(side_effect=_gen)
 
 
 def _create_provider_mock() -> MagicMock:
@@ -166,14 +177,14 @@ async def test_library_tracks_request_includes_album_relations() -> None:
     """Library track sync should request catalog/album/artist relations from Apple API."""
     provider = _create_provider_mock()
     provider.api_client = MagicMock()
-    provider.api_client.get_all_items = AsyncMock(return_value=[])
+    provider.api_client.iter_all_items = _stream([])
     provider.api_client.get_ratings = AsyncMock(return_value={})
 
     manager = AppleMusicLibraryManager(provider)
     _ = [track async for track in manager.get_library_tracks()]
 
-    provider.api_client.get_all_items.assert_called_once_with(
-        "me/library/songs", include="catalog,albums,artists"
+    provider.api_client.iter_all_items.assert_called_once_with(
+        "me/library/songs", include="catalog,albums,artists", page_size=_TRACK_PAGE_SIZE
     )
 
 
@@ -182,8 +193,8 @@ async def test_library_tracks_falls_back_to_library_item_when_catalog_missing() 
     """Library sync should still parse track if catalog endpoint omits a catalog ID."""
     provider = _create_provider_mock()
     provider.api_client = MagicMock()
-    provider.api_client.get_all_items = AsyncMock(
-        return_value=[
+    provider.api_client.iter_all_items = _stream(
+        [
             {
                 "id": "i.librarytrack2",
                 "type": "library-songs",
@@ -229,8 +240,8 @@ async def test_library_tracks_replaces_weak_catalog_album_mapping() -> None:
     """A weak catalog albumName mapping should be replaced by library album relation."""
     provider = _create_provider_mock()
     provider.api_client = MagicMock()
-    provider.api_client.get_all_items = AsyncMock(
-        return_value=[
+    provider.api_client.iter_all_items = _stream(
+        [
             {
                 "id": "i.librarytrack5",
                 "type": "library-songs",
@@ -306,8 +317,8 @@ async def test_library_tracks_fetches_detail_when_list_item_has_no_album() -> No
     """Library-only tracks should be reparsed from detail endpoint when album is missing."""
     provider = _create_provider_mock()
     provider.api_client = MagicMock()
-    provider.api_client.get_all_items = AsyncMock(
-        return_value=[
+    provider.api_client.iter_all_items = _stream(
+        [
             {
                 "id": "i.librarytrack3",
                 "type": "library-songs",
@@ -357,8 +368,8 @@ async def test_library_tracks_fetches_detail_for_album_name_only_mapping() -> No
     """List items with only albumName fallback should be upgraded to a resolvable album id."""
     provider = _create_provider_mock()
     provider.api_client = MagicMock()
-    provider.api_client.get_all_items = AsyncMock(
-        return_value=[
+    provider.api_client.iter_all_items = _stream(
+        [
             {
                 "id": "i.librarytrack4",
                 "type": "library-songs",


### PR DESCRIPTION
# What does this implement/fix?

I have an Apple Music library of about 96k tracks, very near their upper-limit of 100k. I've had issues in the past where the 'tracks sync' job times out / 'crashes' / etc., but if I left it alone it would eventually muddle through. However, after https://github.com/music-assistant/server/pull/4006 was merged it started failing completely, which I tracked down to MA being OOMkilled once I hit around 70k tracks through the sync, because the added enrichment + holding all of it in RAM until the end meant my HA's server 8GB was not enough. This PR incorporates the recent changes from #4067, fixes up the retry logic to smooth out Apple Music's rough edges (the "further" you get into your library pagination-wise, the slower the API responses get for instance), and (most importantly for large libraries like mine) writes as it goes so that we don't store the entire library's worth of tracks in RAM in one go (my server now stays flat at 5GB used for the entire three and a half hour run).

For testing, I did 10 full runs with various settings for the number of tracks to return per page, and 30 had the best ratio of "wall clock time" vs. "Retries". I *did* see all of the various errors we handle during my testing, from 429s to timeouts, partial / empty responses, etc., and they are now cleanly handled via retry (with backoff!) or treated as fatal (mostly when we run out of retries, which I did multiple times until lowering the track limit to 30).


The library sync materialized the whole ~100k-track listing in memory with heavy includes (~87KB/track), OOM-killing the server around 70k tracks on 8GB HA/MA hosts. Stream the listing in bounded windows instead, enriching and yielding each window so the full library is never held at once.

Also retry transient Apple API failures with exponential backoff (504/500/429 and dropped-connection/timeout transport errors), and re-fetch mid-pagination truncations rather than dropping items. Page tracks at 30 vs the 50 default to reduce deep-offset 504s.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
