### PR TITLE
Type-check plex and plex_connect providers, treat plexapi as untyped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,6 @@ enable_error_code = [
 exclude = [
   '^music_assistant/controllers/music.py$',
   '^music_assistant/helpers/app_vars.py',
-  '^music_assistant/providers/plex/.*$',
   '^music_assistant/providers/plex_connect/.*$',
   '^music_assistant/providers/sonic_analysis/vendored_clap/.*$',
   '^music_assistant/providers/ytmusic/.*$',
@@ -173,6 +172,13 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
+
+# plexapi ships a py.typed marker but its annotations are incomplete (unannotated
+# methods, attributes declared as None and only set dynamically). Treat it as an
+# untyped dependency rather than trusting its type info.
+[[tool.mypy.overrides]]
+module = ["plexapi", "plexapi.*"]
+follow_imports = "skip"
 
 [tool.ruff.format]
 # Force Linux/macOS line endings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,6 @@ enable_error_code = [
 exclude = [
   '^music_assistant/controllers/music.py$',
   '^music_assistant/helpers/app_vars.py',
-  '^music_assistant/providers/plex_connect/.*$',
   '^music_assistant/providers/sonic_analysis/vendored_clap/.*$',
   '^music_assistant/providers/ytmusic/.*$',
 ]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Enable mypy type-checking on the Plex provider by removing it from the exclude list and adding a follow_imports = "skip" override for plexapi, whose incomplete py.typed annotations were the sole source of the provider's type errors

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
