### PR TITLE
Typing fixes for the music controller - stage 1

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -2361,18 +2361,18 @@ class MusicController(CoreController):
                 DB_TABLE_PODCASTS,
             ):
                 try:
-                    await self._database.execute(
+                    await self.database.execute(
                         f"ALTER TABLE {table} ADD COLUMN search_name TEXT DEFAULT '' NOT NULL"
                     )
-                    await self._database.execute(
+                    await self.database.execute(
                         f"ALTER TABLE {table} ADD COLUMN search_sort_name TEXT DEFAULT '' NOT NULL"
                     )
                 except Exception as err:
                     if "duplicate column" not in str(err):
                         raise
                 # migrate all existing values
-                async for db_row in self._database.iter_items(table):
-                    await self._database.update(
+                async for db_row in self.database.iter_items(table):
+                    await self.database.update(
                         table,
                         {"item_id": db_row["item_id"]},
                         {
@@ -2389,7 +2389,7 @@ class MusicController(CoreController):
                 DB_TABLE_AUDIOBOOKS,
                 DB_TABLE_PODCASTS,
             ):
-                async for db_row in self._database.iter_items(table):
+                async for db_row in self.database.iter_items(table):
                     if '"release_date":null' in db_row["metadata"]:
                         continue
                     metadata = json_loads(db_row["metadata"])
@@ -2398,7 +2398,7 @@ class MusicController(CoreController):
                     except (KeyError, ValueError):
                         # this is not a valid date, so we set it to None
                         metadata["release_date"] = None
-                        await self._database.update(
+                        await self.database.update(
                             table,
                             {"item_id": db_row["item_id"]},
                             {
@@ -2418,16 +2418,16 @@ class MusicController(CoreController):
                 "audiobooks",
                 "podcasts",
             ):
-                await self._database.execute(f"DROP TRIGGER IF EXISTS update_{db_table}_timestamp;")
+                await self.database.execute(f"DROP TRIGGER IF EXISTS update_{db_table}_timestamp;")
 
         if prev_version <= 18:
             # add in_library column to provider_mappings table
-            await self._database.execute(
+            await self.database.execute(
                 f"ALTER TABLE {DB_TABLE_PROVIDER_MAPPINGS} ADD COLUMN in_library "
                 "BOOLEAN NOT NULL DEFAULT 0;"
             )
             # migrate existing entries in provider_mappings which are filesystem
-            await self._database.execute(
+            await self.database.execute(
                 f"UPDATE {DB_TABLE_PROVIDER_MAPPINGS} SET in_library = 1 "
                 "WHERE provider_domain in ('filesystem_local', 'filesystem_smb');"
             )
@@ -2436,7 +2436,7 @@ class MusicController(CoreController):
             # drop column cache_checksum from playlists table
             # this is no longer used and is a leftover from previous designs
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_PLAYLISTS} DROP COLUMN cache_checksum"
                 )
             except Exception as err:
@@ -2445,13 +2445,13 @@ class MusicController(CoreController):
 
         if prev_version <= 21:
             # drop table for smart fades analysis - it will be recreated with needed columns
-            await self._database.execute("DROP TABLE IF EXISTS smart_fades_analysis")
+            await self.database.execute("DROP TABLE IF EXISTS smart_fades_analysis")
             await self.__create_database_tables()
 
         if prev_version <= 22:
             # add userid column to playlog table
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_PLAYLOG} ADD COLUMN userid TEXT"
                 )
             except Exception as err:
@@ -2461,8 +2461,8 @@ class MusicController(CoreController):
             # The UNIQUE constraint will be updated when the table is recreated
             # For now, we'll keep the old constraint and add a new one via unique index
             try:
-                await self._database.execute(f"DROP INDEX IF EXISTS {DB_TABLE_PLAYLOG}_unique_idx")
-                await self._database.execute(
+                await self.database.execute(f"DROP INDEX IF EXISTS {DB_TABLE_PLAYLOG}_unique_idx")
+                await self.database.execute(
                     f"CREATE UNIQUE INDEX {DB_TABLE_PLAYLOG}_unique_idx "
                     f"ON {DB_TABLE_PLAYLOG}(item_id,provider,media_type,userid)"
                 )
@@ -2473,7 +2473,7 @@ class MusicController(CoreController):
         if prev_version <= 23:
             # add is_unique column to provider_mappings table
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_PROVIDER_MAPPINGS} ADD COLUMN is_unique BOOLEAN"
                 )
             except Exception as err:
@@ -2483,14 +2483,14 @@ class MusicController(CoreController):
         if prev_version <= 24:
             # add queue_id and user_initiated columns to playlog table
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_PLAYLOG} ADD COLUMN queue_id TEXT"
                 )
             except Exception as err:
                 if "duplicate column" not in str(err):
                     raise
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_PLAYLOG} "
                     "ADD COLUMN user_initiated BOOLEAN NOT NULL DEFAULT 1"
                 )
@@ -2501,18 +2501,18 @@ class MusicController(CoreController):
         if prev_version <= 26:
             # force in_library=True for provider mappings from non-streaming providers
             # streaming providers will be automatically added to library when synced
-            await self._database.execute(
+            await self.database.execute(
                 f"UPDATE {DB_TABLE_PROVIDER_MAPPINGS} SET in_library = 1 "
                 "WHERE provider_domain NOT IN "
                 "('spotify', 'deezer', 'tidal', 'qobuz', 'apple_music', 'ytmusic');"
             )
             # also set in_library=True for all radio items
-            await self._database.execute(
+            await self.database.execute(
                 f"UPDATE {DB_TABLE_PROVIDER_MAPPINGS} SET in_library = 1 "
                 "WHERE media_type = 'radio';"
             )
             # remove invalid playlist provider mappings for playlists which are not in library
-            await self._database.execute(
+            await self.database.execute(
                 f"DELETE FROM {DB_TABLE_PROVIDER_MAPPINGS} "
                 "WHERE media_type = 'playlist' AND in_library = 0;"
             )
@@ -2521,7 +2521,7 @@ class MusicController(CoreController):
             # set streaming provider mappings to in_library=True, but only for items
             # that do not already have any mapping with in_library=True
             # (to avoid overwriting explicit values in multi-instance setups)
-            await self._database.execute(
+            await self.database.execute(
                 f"UPDATE {DB_TABLE_PROVIDER_MAPPINGS} SET in_library = 1 "
                 "WHERE provider_domain NOT IN "
                 "('filesystem_local', 'builtin', 'test', 'jellyfin', 'emby', "
@@ -2538,7 +2538,7 @@ class MusicController(CoreController):
             await self.__create_database_tables()
 
             # Use raw aiosqlite connection for bulk operations.
-            db = self._database._db
+            db = self.database._db
 
             empty_metadata = serialize_to_json({})
             empty_external_ids = serialize_to_json(set())
@@ -2746,13 +2746,13 @@ class MusicController(CoreController):
             # so beat timestamps are misaligned with the unstripped buffers now passed
             # to the crossfade mixer. Truncate the table so all analyses are re-computed.
             with suppress(Exception):
-                await self._database.execute("DELETE FROM smart_fades_analysis")
+                await self.database.execute("DELETE FROM smart_fades_analysis")
 
         if prev_version <= 30:
             # add supported_mediatypes column to playlist table, and make {MediaType.TRACK},
             # i.e. ["track"] the default, as this was the only media type supported.
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_PLAYLISTS} ADD COLUMN supported_mediatypes"
                     " json DEFAULT '[\"track\"]' NOT NULL"
                 )
@@ -2762,7 +2762,7 @@ class MusicController(CoreController):
 
         if prev_version <= 31:
             # create the genre_media_item_exclusion table (new in schema 31)
-            await self._database.execute(
+            await self.database.execute(
                 f"""
                 CREATE TABLE IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(
                 [genre_id] INTEGER NOT NULL,
@@ -2772,11 +2772,11 @@ class MusicController(CoreController):
                 UNIQUE(genre_id, media_id, media_type)
                 );"""
             )
-            await self._database.execute(
+            await self.database.execute(
                 f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}_media_idx "
                 f"on {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(media_id,media_type);"
             )
-            await self._database.execute(
+            await self.database.execute(
                 f"CREATE INDEX IF NOT EXISTS {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}_genre_idx "
                 f"on {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}(genre_id);"
             )
@@ -2784,11 +2784,11 @@ class MusicController(CoreController):
         if prev_version <= 32:
             # recreate genre_media_item_mapping with nullable alias and is_derived column
             # (new in schema 33 to support propagated genre mappings from tracks)
-            await self._database.execute(
+            await self.database.execute(
                 f"ALTER TABLE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
                 f"RENAME TO {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}_old;"
             )
-            await self._database.execute(
+            await self.database.execute(
                 f"""
                 CREATE TABLE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}(
                 [genre_id] INTEGER NOT NULL,
@@ -2800,18 +2800,18 @@ class MusicController(CoreController):
                 UNIQUE(genre_id, media_id, media_type)
                 );"""
             )
-            await self._database.execute(
+            await self.database.execute(
                 f"INSERT INTO {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
                 f"(genre_id, media_id, media_type, alias) "
                 f"SELECT genre_id, media_id, media_type, alias "
                 f"FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}_old;"
             )
-            await self._database.execute(f"DROP TABLE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}_old;")
+            await self.database.execute(f"DROP TABLE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING}_old;")
 
         if prev_version <= 33:
             # add is_excluded column to genres table (new in schema 34)
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_GENRES} "
                     "ADD COLUMN [is_excluded] BOOLEAN NOT NULL DEFAULT 0;"
                 )
@@ -2819,10 +2819,10 @@ class MusicController(CoreController):
                 if "duplicate column" not in str(err):
                     raise
             # drop the old genre_global_exclusion table (replaced by is_excluded column)
-            await self._database.execute("DROP TABLE IF EXISTS genre_global_exclusion;")
+            await self.database.execute("DROP TABLE IF EXISTS genre_global_exclusion;")
             # add is_default column to genres table (new in schema 34)
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_GENRES} "
                     "ADD COLUMN [is_default] BOOLEAN NOT NULL DEFAULT 0;"
                 )
@@ -2830,12 +2830,12 @@ class MusicController(CoreController):
                 if "duplicate column" not in str(err):
                     raise
             # mark all existing genres with a translation_key as default
-            await self._database.execute(
+            await self.database.execute(
                 f"UPDATE {DB_TABLE_GENRES} SET is_default = 1 WHERE translation_key IS NOT NULL;"
             )
         if prev_version <= 34:
             # fix filesystem playlists missing in_library flag
-            await self._database.execute(
+            await self.database.execute(
                 f"UPDATE {DB_TABLE_PROVIDER_MAPPINGS} SET in_library = 1 "
                 "WHERE media_type = 'playlist' "
                 "AND provider_domain IN ('filesystem_local', 'filesystem_smb', 'filesystem_nfs');"
@@ -2844,7 +2844,7 @@ class MusicController(CoreController):
         if prev_version <= 35:
             # add is_dynamic column to playlist table
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_PLAYLISTS} ADD COLUMN is_dynamic"
                     " BOOLEAN NOT NULL DEFAULT 0"
                 )
@@ -2852,7 +2852,7 @@ class MusicController(CoreController):
                 if "duplicate column" not in str(err):
                     raise
             # backfill is_dynamic for existing Apple Music station playlists
-            await self._database.execute(
+            await self.database.execute(
                 f"UPDATE {DB_TABLE_PLAYLISTS} SET is_dynamic = 1 "
                 f"WHERE item_id IN ("
                 f"  SELECT item_id FROM {DB_TABLE_PROVIDER_MAPPINGS} "
@@ -2865,17 +2865,17 @@ class MusicController(CoreController):
         if prev_version <= 36:
             # drop legacy smart_fades_analysis table — analysis is now handled by
             # audio analysis providers and stored in the audio_analysis table.
-            await self._database.execute("DROP TABLE IF EXISTS smart_fades_analysis")
+            await self.database.execute("DROP TABLE IF EXISTS smart_fades_analysis")
 
         if prev_version <= 37:
             # purge unreliable loudness measurements persisted by earlier versions
             # (ebur128 reports ~-70 LUFS on near-silence / early-cancelled streams,
             # which caused huge gain corrections on subsequent plays)
-            await self._database.execute(
+            await self.database.execute(
                 f"DELETE FROM {DB_TABLE_LOUDNESS_MEASUREMENTS} "
                 f"WHERE loudness <= {LOUDNESS_MEASUREMENT_MIN_LUFS}"
             )
-            await self._database.execute(
+            await self.database.execute(
                 f"UPDATE {DB_TABLE_LOUDNESS_MEASUREMENTS} "
                 f"SET loudness_album = NULL "
                 f"WHERE loudness_album <= {LOUDNESS_MEASUREMENT_MIN_LUFS}"
@@ -2885,7 +2885,7 @@ class MusicController(CoreController):
             # migrate loudness measurements to the unified audio_analysis table
             # under the new builtin loudness_analysis provider, then drop the
             # legacy table. album loudness rides along when present.
-            await self._database.execute(
+            await self.database.execute(
                 f"INSERT OR IGNORE INTO {DB_TABLE_AUDIO_ANALYSIS} "
                 f"(media_type, item_id, provider, aa_provider_domain, "
                 f" analysis_data, analysis_version) "
@@ -2898,12 +2898,12 @@ class MusicController(CoreController):
                 f"WHERE loudness IS NOT NULL "
                 f"  AND loudness > {LOUDNESS_MEASUREMENT_MIN_LUFS}"
             )
-            await self._database.execute(f"DROP TABLE IF EXISTS {DB_TABLE_LOUDNESS_MEASUREMENTS}")
+            await self.database.execute(f"DROP TABLE IF EXISTS {DB_TABLE_LOUDNESS_MEASUREMENTS}")
 
         if prev_version <= 39:
             # add is_manual column to genre_media_item_mapping
             try:
-                await self._database.execute(
+                await self.database.execute(
                     f"ALTER TABLE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
                     "ADD COLUMN [is_manual] BOOLEAN NOT NULL DEFAULT 0;"
                 )
@@ -2945,7 +2945,7 @@ class MusicController(CoreController):
                     )
 
         # save changes
-        await self._database.commit()
+        await self.database.commit()
 
         # always clear the cache after a db migration
         await self.mass.cache.clear()

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -168,7 +168,7 @@ class MusicController(CoreController):
         values: dict[str, ConfigValueType] | None = None,
     ) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
-        entries = (
+        entries: tuple[ConfigEntry, ...] = (
             ConfigEntry(
                 key=CONF_RESET_DB,
                 type=ConfigEntryType.ACTION,
@@ -656,10 +656,10 @@ class MusicController(CoreController):
             isinstance(prov, PluginProvider)
             and ProviderFeature.AUDIO_SOURCE in prov.supported_features
         ):
-            initiable: list[MediaItemType | BrowseFolder] = [
+            initiable_items: list[MediaItemType | BrowseFolder] = [
                 source for source in await prov.get_audio_sources() if source.can_initiate
             ]
-            return [*prepend_items, *initiable]
+            return [*prepend_items, *initiable_items]
         # limit -1 to account for the prepended items
         prov_items = await prov.browse(path=path)
         return prepend_items + prov_items
@@ -2184,9 +2184,9 @@ class MusicController(CoreController):
         # on top of the list.
         safe_title_str = create_safe_string(search_query)
         if " - " in search_query:
-            artist, title_alt = search_query.split(" - ", 1)
+            artist_name, title_alt = search_query.split(" - ", 1)
             safe_title_alt = create_safe_string(title_alt)
-            safe_artist_str = create_safe_string(artist)
+            safe_artist_str = create_safe_string(artist_name)
         else:
             safe_artist_str = None
             safe_title_alt = None

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -200,8 +200,9 @@ class MusicController(CoreController):
         # setup library database
         await self._setup_database()
         # make sure to finish any removal jobs
-        for removed_provider in self.mass.config.get_raw_core_config_value(
-            self.domain, CONF_DELETED_PROVIDERS, []
+        for removed_provider in cast(
+            "list[str]",
+            self.mass.config.get_raw_core_config_value(self.domain, CONF_DELETED_PROVIDERS, []),
         ):
             await self.cleanup_provider(removed_provider)
 
@@ -278,7 +279,7 @@ class MusicController(CoreController):
                     continue
                 # handle mediatype specific sync config
                 conf_key = f"library_sync_{media_type}s"
-                sync_conf = await self.mass.config.get_provider_config_value(
+                sync_conf: ConfigValueType = await self.mass.config.get_provider_config_value(
                     provider.instance_id, conf_key
                 )
                 if not sync_conf:
@@ -343,7 +344,7 @@ class MusicController(CoreController):
             category=CACHE_CATEGORY_SEARCH_RESULTS,
             base_class=SearchResults,
         ):
-            return cache
+            return cast("SearchResults", cache)
         if not media_types:
             media_types = MediaType.ALL
         # Check if the search query is a streaming provider public shareable URL
@@ -2217,7 +2218,9 @@ class MusicController(CoreController):
         """Schedule Library sync for given provider and media type."""
         # handle mediatype specific sync config
         conf_key = f"library_sync_{media_type}s"
-        sync_conf = await self.mass.config.get_provider_config_value(provider.instance_id, conf_key)
+        sync_conf: ConfigValueType = await self.mass.config.get_provider_config_value(
+            provider.instance_id, conf_key
+        )
         if not sync_conf:
             self.mass.tasks.unregister_scheduled_task(self._get_sync_task_id(provider, media_type))
             return
@@ -2588,12 +2591,12 @@ class MusicController(CoreController):
                 )
                 if row_id and row_id[0]:
                     genre_cache[search_name] = row_id[0]
-                    return row_id[0]
+                    return cast("int", row_id[0])
                 async with db.execute(genre_select_sql, (search_name,)) as cursor:
                     row = await cursor.fetchone()
                     if row:
                         genre_cache[search_name] = row[0]
-                        return row[0]
+                        return cast("int", row[0])
                 return 0
 
             # Phase 1: Seed DEFAULT_GENRE_MAPPING — create genres with aliases.


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Stage 1 of 3 of typing foxes for the music controller

Point to note:

- `self._database` changes to `self.database` in `__migrate_database`. The database property returns the same non-Optional connection (raises `RuntimeError `if uninitialised, which can't happen mid-migration). Behaviour-identical; scoped to the migration method only, leaving raw `_database` where it can legitimately be `None` (declaration, close-guard, _setup_database). 

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
