### PR TITLE
Fix radio station logos rendering as black or failing to load

### DIFF
--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -659,36 +659,14 @@ class MetaDataController(CoreController):
         flatten_transparency: bool = False,
     ) -> bytes | str:
         """Get/create thumbnail image for path (image url or local path)."""
-        if not self.mass.get_provider(provider) and not path.startswith("http"):
-            raise ProviderUnavailableError
         if image_format is None:
             image_format = _detect_image_format(path)
-        if provider == "builtin" and path.startswith("/collage/"):
-            # special case for collage images
-            collage_rel = path.rsplit("/collage/", maxsplit=1)[-1]
-            if not is_safe_path(collage_rel):
-                raise FileNotFoundError("Invalid collage path")
-            path = os.path.join(self._collage_images_dir, collage_rel)
-        if image_format == "svg":
-            svg_bytes = await get_image_data(self.mass, path, provider)
-            if base64:
-                enc_image = b64encode(svg_bytes).decode()
-                return f"data:image/svg+xml;base64,{enc_image}"
-            return svg_bytes
-        thumbnail_bytes = await get_image_thumb(
-            self.mass,
-            path,
-            size=size,
-            provider=provider,
-            image_format=image_format,
-            flatten_transparency=flatten_transparency,
+        thumbnail_bytes, content_format = await self._resolve_thumbnail(
+            path, provider, size, image_format, flatten_transparency
         )
         if base64:
             enc_image = b64encode(thumbnail_bytes).decode()
-            # output format may differ from the request (e.g. PNG kept for
-            # transparency), so derive the mime from the bytes
-            sniffed = detect_image_content_format(thumbnail_bytes) or image_format
-            return f"data:{_IMAGEPROXY_CONTENT_TYPES.get(sniffed, f'image/{sniffed}')};base64,{enc_image}"
+            return f"data:{_IMAGEPROXY_CONTENT_TYPES[content_format]};base64,{enc_image}"
         return thumbnail_bytes
 
     async def handle_imageproxy(self, request: web.Request) -> web.Response:
@@ -765,6 +743,47 @@ class MetaDataController(CoreController):
             return web.Response(status=404)
         return await self._serve_thumbnail(path, provider, size, image_format)
 
+    async def _resolve_thumbnail(
+        self,
+        path: str,
+        provider: str,
+        size: int | None,
+        image_format: str,
+        flatten_transparency: bool,
+    ) -> tuple[bytes, str]:
+        """
+        Fetch image bytes and return them with their resolved content format.
+
+        The served format can differ from the requested one (SVG is passed
+        through unchanged and transparent sources may be kept as PNG), so the
+        actual format is determined once here and reused by every caller.
+
+        :param path: Image url or local path.
+        :param provider: Provider identifier for the image source.
+        :param size: Target thumbnail size (square), or None for original.
+        :param image_format: Requested output format (jpg/jpeg/png/svg).
+        :param flatten_transparency: Composite alpha onto white and keep JPEG when True.
+        """
+        if not self.mass.get_provider(provider) and not path.startswith("http"):
+            raise ProviderUnavailableError
+        if provider == "builtin" and path.startswith("/collage/"):
+            # special case for collage images
+            collage_rel = path.rsplit("/collage/", maxsplit=1)[-1]
+            if not is_safe_path(collage_rel):
+                raise FileNotFoundError("Invalid collage path")
+            path = os.path.join(self._collage_images_dir, collage_rel)
+        if image_format == "svg":
+            return await get_image_data(self.mass, path, provider), "svg"
+        thumbnail_bytes = await get_image_thumb(
+            self.mass,
+            path,
+            size=size,
+            provider=provider,
+            image_format=image_format,
+            flatten_transparency=flatten_transparency,
+        )
+        return thumbnail_bytes, detect_image_content_format(thumbnail_bytes) or image_format
+
     async def _serve_thumbnail(
         self, path: str, provider: str, size: int, image_format: str
     ) -> web.Response:
@@ -775,12 +794,8 @@ class MetaDataController(CoreController):
         # default (app/UI) instead keeps transparency as PNG.
         flatten_transparency = image_format == "jpeg"
         try:
-            image_data = await self.get_thumbnail(
-                path,
-                size=size,
-                provider=provider,
-                image_format=image_format,
-                flatten_transparency=flatten_transparency,
+            image_data, content_format = await self._resolve_thumbnail(
+                path, provider, size, image_format, flatten_transparency
             )
         except Exception as err:
             # broadly catch all exceptions here to ensure we dont crash the request handler
@@ -794,16 +809,10 @@ class MetaDataController(CoreController):
                     exc_info=err if self.logger.isEnabledFor(10) else None,
                 )
             return web.Response(status=404)
-        content_type = _IMAGEPROXY_CONTENT_TYPES[image_format]
-        if isinstance(image_data, (bytes, bytearray)):
-            # output may differ from the requested fmt (passed-through SVG, or
-            # PNG kept for transparency), so set the type from the actual bytes
-            if sniffed := detect_image_content_format(image_data):
-                content_type = _IMAGEPROXY_CONTENT_TYPES[sniffed]
         return web.Response(
             body=image_data,
             headers={"Cache-Control": "max-age=31536000", "Access-Control-Allow-Origin": "*"},
-            content_type=content_type,
+            content_type=_IMAGEPROXY_CONTENT_TYPES[content_format],
         )
 
     def _maybe_log_legacy_imageproxy(self, request: web.Request) -> None:

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -809,9 +809,20 @@ class MetaDataController(CoreController):
                     exc_info=err if self.logger.isEnabledFor(10) else None,
                 )
             return web.Response(status=404)
+        response_headers = {
+            "Cache-Control": "max-age=31536000",
+            "Access-Control-Allow-Origin": "*",
+        }
+        if content_format == "svg":
+            # Sniffed SVGs from attacker-influenceable sources (radio favicons) are
+            # served same-origin; without a CSP an embedded <script> would run.
+            response_headers["Content-Security-Policy"] = (
+                "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+            )
+            response_headers["X-Content-Type-Options"] = "nosniff"
         return web.Response(
             body=image_data,
-            headers={"Cache-Control": "max-age=31536000", "Access-Control-Allow-Origin": "*"},
+            headers=response_headers,
             content_type=_IMAGEPROXY_CONTENT_TYPES[content_format],
         )
 

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -76,9 +76,9 @@ from music_assistant.helpers.images import (
     cleanup_thumb_cache,
     create_collage,
     create_thumb_hash,
+    detect_image_content_format,
     get_image_data,
     get_image_thumb,
-    is_svg_data,
 )
 from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.tags import split_artists
@@ -656,6 +656,7 @@ class MetaDataController(CoreController):
         size: int | None = None,
         base64: bool = False,
         image_format: str | None = None,
+        flatten_transparency: bool = False,
     ) -> bytes | str:
         """Get/create thumbnail image for path (image url or local path)."""
         if not self.mass.get_provider(provider) and not path.startswith("http"):
@@ -675,11 +676,19 @@ class MetaDataController(CoreController):
                 return f"data:image/svg+xml;base64,{enc_image}"
             return svg_bytes
         thumbnail_bytes = await get_image_thumb(
-            self.mass, path, size=size, provider=provider, image_format=image_format
+            self.mass,
+            path,
+            size=size,
+            provider=provider,
+            image_format=image_format,
+            flatten_transparency=flatten_transparency,
         )
         if base64:
             enc_image = b64encode(thumbnail_bytes).decode()
-            return f"data:image/{image_format};base64,{enc_image}"
+            # output format may differ from the request (e.g. PNG kept for
+            # transparency), so derive the mime from the bytes
+            sniffed = detect_image_content_format(thumbnail_bytes) or image_format
+            return f"data:{_IMAGEPROXY_CONTENT_TYPES.get(sniffed, f'image/{sniffed}')};base64,{enc_image}"
         return thumbnail_bytes
 
     async def handle_imageproxy(self, request: web.Request) -> web.Response:
@@ -760,9 +769,18 @@ class MetaDataController(CoreController):
         self, path: str, provider: str, size: int, image_format: str
     ) -> web.Response:
         """Fetch (or render+cache) the thumbnail and produce an HTTP response."""
+        # `fmt=jpeg` is the explicit player-media request: players are sent a
+        # JPEG for maximum compatibility, and since JPEG has no alpha channel we
+        # composite transparency onto white. The auto-detected `fmt=jpg`/`png`
+        # default (app/UI) instead keeps transparency as PNG.
+        flatten_transparency = image_format == "jpeg"
         try:
             image_data = await self.get_thumbnail(
-                path, size=size, provider=provider, image_format=image_format
+                path,
+                size=size,
+                provider=provider,
+                image_format=image_format,
+                flatten_transparency=flatten_transparency,
             )
         except Exception as err:
             # broadly catch all exceptions here to ensure we dont crash the request handler
@@ -777,11 +795,11 @@ class MetaDataController(CoreController):
                 )
             return web.Response(status=404)
         content_type = _IMAGEPROXY_CONTENT_TYPES[image_format]
-        if isinstance(image_data, (bytes, bytearray)) and is_svg_data(image_data):
-            # Some sources (e.g. radio station favicons) serve SVG from URLs
-            # without a `.svg` suffix, so the requested fmt may be jpg/png even
-            # though the bytes are SVG. Report the correct content type instead.
-            content_type = _IMAGEPROXY_CONTENT_TYPES["svg"]
+        if isinstance(image_data, (bytes, bytearray)):
+            # output may differ from the requested fmt (passed-through SVG, or
+            # PNG kept for transparency), so set the type from the actual bytes
+            if sniffed := detect_image_content_format(image_data):
+                content_type = _IMAGEPROXY_CONTENT_TYPES[sniffed]
         return web.Response(
             body=image_data,
             headers={"Cache-Control": "max-age=31536000", "Access-Control-Allow-Origin": "*"},

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -78,6 +78,7 @@ from music_assistant.helpers.images import (
     create_thumb_hash,
     get_image_data,
     get_image_thumb,
+    is_svg_data,
 )
 from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.tags import split_artists
@@ -775,10 +776,16 @@ class MetaDataController(CoreController):
                     exc_info=err if self.logger.isEnabledFor(10) else None,
                 )
             return web.Response(status=404)
+        content_type = _IMAGEPROXY_CONTENT_TYPES[image_format]
+        if isinstance(image_data, (bytes, bytearray)) and is_svg_data(image_data):
+            # Some sources (e.g. radio station favicons) serve SVG from URLs
+            # without a `.svg` suffix, so the requested fmt may be jpg/png even
+            # though the bytes are SVG. Report the correct content type instead.
+            content_type = _IMAGEPROXY_CONTENT_TYPES["svg"]
         return web.Response(
             body=image_data,
             headers={"Cache-Control": "max-age=31536000", "Access-Control-Allow-Origin": "*"},
-            content_type=_IMAGEPROXY_CONTENT_TYPES[image_format],
+            content_type=content_type,
         )
 
     def _maybe_log_legacy_imageproxy(self, request: web.Request) -> None:

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1929,7 +1929,7 @@ class PlayerQueuesController(CoreController):
                 # we prefer the imageproxy on the streamserver here because this request is sent
                 # to the player itself which may not be able to reach the regular webserver
                 media.image_url = self.mass.metadata.get_image_url(
-                    queue_item.image, size=512, prefer_stream_server=True
+                    queue_item.image, size=512, image_format="jpeg", prefer_stream_server=True
                 )
         return media
 

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -38,35 +38,47 @@ _THUMB_CACHE_DIR = "thumbnails"
 _THUMB_MEMORY_CACHE_MAX = 50
 _ALLOWED_THUMB_FORMATS: frozenset[str] = frozenset({"PNG", "JPEG"})
 
-# By construction the filename is `<sha256>_<int>.(jpg|png)`; the regex is an
-# explicit sanitizer that also lets CodeQL prove the value is safe to join
-# into a filesystem path.
-_THUMB_FILENAME_RE = re.compile(r"^[0-9a-f]{64}_\d+\.(?:jpg|png)$")
+# By construction the filename is `<sha256>_<int>[_flat].(jpg|png)`; the regex
+# is an explicit sanitizer that also lets CodeQL prove the value is safe to
+# join into a filesystem path. The `_flat` marker separates the flattened and
+# transparency-preserving cache variants.
+_THUMB_FILENAME_RE = re.compile(r"^[0-9a-f]{64}_\d+(?:_flat)?\.(?:jpg|png)$")
 
 _thumb_memory_cache: OrderedDict[str, bytes] = OrderedDict()
 
 _MAX_IMAGEPROXY_RECURSION_DEPTH = 5
 
+# Leading magic bytes used to sniff raster image formats from their content.
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_JPEG_MAGIC = b"\xff\xd8\xff"
+
 
 def is_svg_data(data: bytes) -> bool:
-    """
-    Return True when the given bytes appear to be an SVG image.
-
-    Detection is content based (not extension based) so SVG artwork served
-    from URLs without a `.svg` suffix is still recognised. SVG is a vector
-    (XML/text) format that Pillow cannot decode, so callers use this to avoid
-    feeding it to PIL and to serve it with the correct content type.
-
-    :param data: Raw image bytes to inspect.
-    """
+    """Return True when the given bytes appear to be an SVG image."""
     if not data:
         return False
-    # An SVG document may open with an XML declaration, a doctype or a comment
-    # before the root <svg> element, so look for the element within the head.
+    # the root <svg> may be preceded by an xml declaration, doctype or comment
     sample = data[:1024].lstrip()
     if not sample[:64].lower().startswith((b"<?xml", b"<svg", b"<!--", b"<!doctype")):
         return False
     return b"<svg" in sample.lower()
+
+
+def detect_image_content_format(data: bytes) -> str | None:
+    """
+    Return the sniffed image format (`png`, `jpg` or `svg`), or None if unknown.
+
+    :param data: Raw image bytes to inspect.
+    """
+    if not data:
+        return None
+    if data.startswith(_PNG_MAGIC):
+        return "png"
+    if data.startswith(_JPEG_MAGIC):
+        return "jpg"
+    if is_svg_data(data):
+        return "svg"
+    return None
 
 
 def create_thumb_hash(provider: str, path_or_url: str) -> str:
@@ -75,12 +87,15 @@ def create_thumb_hash(provider: str, path_or_url: str) -> str:
     return hashlib.sha256(raw.encode(), usedforsecurity=False).hexdigest()
 
 
-def _thumb_cache_filename(thumb_hash: str, size: int | None, image_format: str) -> str:
+def _thumb_cache_filename(
+    thumb_hash: str, size: int | None, image_format: str, flatten_transparency: bool = False
+) -> str:
     """Build the cache filename for a thumbnail."""
     ext = image_format.lower()
     if ext == "jpeg":
         ext = "jpg"
-    return f"{thumb_hash}_{size or 0}.{ext}"
+    suffix = "_flat" if flatten_transparency else ""
+    return f"{thumb_hash}_{size or 0}{suffix}.{ext}"
 
 
 def _get_from_memory_cache(key: str) -> bytes | None:
@@ -97,6 +112,17 @@ def _put_in_memory_cache(key: str, data: bytes) -> None:
     _thumb_memory_cache.move_to_end(key)
     while len(_thumb_memory_cache) > _THUMB_MEMORY_CACHE_MAX:
         _thumb_memory_cache.popitem(last=False)
+
+
+def _has_alpha(img: ImageClass) -> bool:
+    """Return True if the image actually uses transparency."""
+    if img.mode == "P":
+        return "transparency" in img.info
+    if img.mode in ("RGBA", "LA", "PA"):
+        # an alpha channel may still be fully opaque; only treat it as
+        # transparent when some pixel is not fully opaque
+        return img.getchannel("A").getextrema()[0] < 255
+    return False
 
 
 _IMAGEPROXY_V2_PREFIX = "/imageproxy/"
@@ -248,6 +274,7 @@ async def get_image_thumb(
     size: int | None,
     provider: str,
     image_format: str = "PNG",
+    flatten_transparency: bool = False,
 ) -> bytes:
     """Get (optimized) thumbnail from image url.
 
@@ -261,6 +288,8 @@ async def get_image_thumb(
     :param size: Target thumbnail size (square), or None for original.
     :param provider: Provider identifier for the image source.
     :param image_format: Output format (PNG or JPEG/JPG).
+    :param flatten_transparency: When True, alpha is composited onto white and
+        kept as JPEG; when False, transparent sources are emitted as PNG.
     """
     image_format = image_format.upper()
     if image_format == "JPG":
@@ -270,7 +299,7 @@ async def get_image_thumb(
         raise ValueError(msg)
 
     thumb_hash = create_thumb_hash(provider, path_or_url)
-    cache_filename = _thumb_cache_filename(thumb_hash, size, image_format)
+    cache_filename = _thumb_cache_filename(thumb_hash, size, image_format, flatten_transparency)
     if not _THUMB_FILENAME_RE.fullmatch(cache_filename):
         # cache_filename is built from a sha256 + int + fixed extension, so this
         # is unreachable in practice — it is here so a future change to either
@@ -303,6 +332,7 @@ async def get_image_thumb(
         provider,
         image_format,
         cache_filepath,
+        flatten_transparency,
         task_id=f"thumb.{cache_filename}",
         abort_existing=False,
     )
@@ -318,6 +348,7 @@ async def _generate_and_cache_thumb(
     provider: str,
     image_format: str,
     cache_filepath: str,
+    flatten_transparency: bool = False,
 ) -> bytes:
     """Generate a thumbnail, persist it on disk, and return the bytes.
 
@@ -327,15 +358,15 @@ async def _generate_and_cache_thumb(
     :param provider: Provider identifier for the image source.
     :param image_format: Normalized output format (PNG or JPEG).
     :param cache_filepath: Absolute path where the thumbnail will be stored.
+    :param flatten_transparency: When True, alpha is composited onto white and
+        kept as JPEG; when False, transparent sources are emitted as PNG.
     """
     img_data = await get_image_data(mass, path_or_url, provider)
     if not img_data or not isinstance(img_data, bytes):
         raise FileNotFoundError(f"Image not found: {path_or_url}")
 
     if is_svg_data(img_data):
-        # SVG is a vector format Pillow can't rasterize; serve it untouched
-        # (it scales without resizing). The imageproxy sniffs the bytes to
-        # report image/svg+xml regardless of the requested fmt.
+        # Pillow can't decode SVG; pass it through unchanged.
         thumb_data = img_data
     elif not size and image_format.encode() in img_data:
         thumb_data = img_data
@@ -349,11 +380,20 @@ async def _generate_and_cache_thumb(
                 raise FileNotFoundError(f"Invalid image: {path_or_url}")
             if size:
                 img.thumbnail((size, size), Image.Resampling.LANCZOS)
-            mode = "RGBA" if image_format == "PNG" else "RGB"
-            if image_format == "JPEG":
-                img.convert(mode).save(data, image_format, quality=95, optimize=False)
+            target_format = image_format
+            if target_format == "JPEG" and _has_alpha(img):
+                if flatten_transparency:
+                    # composite onto white, else the alpha would flatten to black
+                    background = Image.new("RGBA", img.size, (255, 255, 255, 255))
+                    background.alpha_composite(img.convert("RGBA"))
+                    img = background
+                else:
+                    target_format = "PNG"
+            mode = "RGBA" if target_format == "PNG" else "RGB"
+            if target_format == "JPEG":
+                img.convert(mode).save(data, target_format, quality=95, optimize=False)
             else:
-                img.convert(mode).save(data, image_format, optimize=False)
+                img.convert(mode).save(data, target_format, optimize=False)
             return data.getvalue()
 
         thumb_data = await asyncio.to_thread(_create_image)

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -48,6 +48,27 @@ _thumb_memory_cache: OrderedDict[str, bytes] = OrderedDict()
 _MAX_IMAGEPROXY_RECURSION_DEPTH = 5
 
 
+def is_svg_data(data: bytes) -> bool:
+    """
+    Return True when the given bytes appear to be an SVG image.
+
+    Detection is content based (not extension based) so SVG artwork served
+    from URLs without a `.svg` suffix is still recognised. SVG is a vector
+    (XML/text) format that Pillow cannot decode, so callers use this to avoid
+    feeding it to PIL and to serve it with the correct content type.
+
+    :param data: Raw image bytes to inspect.
+    """
+    if not data:
+        return False
+    # An SVG document may open with an XML declaration, a doctype or a comment
+    # before the root <svg> element, so look for the element within the head.
+    sample = data[:1024].lstrip()
+    if not sample[:64].lower().startswith((b"<?xml", b"<svg", b"<!--", b"<!doctype")):
+        return False
+    return b"<svg" in sample.lower()
+
+
 def create_thumb_hash(provider: str, path_or_url: str) -> str:
     """Create a safe filesystem hash from provider and image path."""
     raw = f"{provider}/{path_or_url}"
@@ -311,7 +332,12 @@ async def _generate_and_cache_thumb(
     if not img_data or not isinstance(img_data, bytes):
         raise FileNotFoundError(f"Image not found: {path_or_url}")
 
-    if not size and image_format.encode() in img_data:
+    if is_svg_data(img_data):
+        # SVG is a vector format Pillow can't rasterize; serve it untouched
+        # (it scales without resizing). The imageproxy sniffs the bytes to
+        # report image/svg+xml regardless of the requested fmt.
+        thumb_data = img_data
+    elif not size and image_format.encode() in img_data:
         thumb_data = img_data
     else:
 

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -121,7 +121,8 @@ def _has_alpha(img: ImageClass) -> bool:
     if img.mode in ("RGBA", "LA", "PA"):
         # an alpha channel may still be fully opaque; only treat it as
         # transparent when some pixel is not fully opaque
-        return img.getchannel("A").getextrema()[0] < 255
+        # single-band getextrema() returns a (min, max) numeric tuple
+        return cast("tuple[float, float]", img.getchannel("A").getextrema())[0] < 255
     return False
 
 
@@ -375,7 +376,7 @@ async def _generate_and_cache_thumb(
         def _create_image() -> bytes:
             data = BytesIO()
             try:
-                img = Image.open(BytesIO(img_data))
+                img: ImageClass = Image.open(BytesIO(img_data))
             except UnidentifiedImageError:
                 raise FileNotFoundError(f"Invalid image: {path_or_url}")
             if size:

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -38,11 +38,15 @@ _THUMB_CACHE_DIR = "thumbnails"
 _THUMB_MEMORY_CACHE_MAX = 50
 _ALLOWED_THUMB_FORMATS: frozenset[str] = frozenset({"PNG", "JPEG"})
 
-# By construction the filename is `<sha256>_<int>[_flat].(jpg|png)`; the regex
-# is an explicit sanitizer that also lets CodeQL prove the value is safe to
-# join into a filesystem path. The `_flat` marker separates the flattened and
-# transparency-preserving cache variants.
-_THUMB_FILENAME_RE = re.compile(r"^[0-9a-f]{64}_\d+(?:_flat)?\.(?:jpg|png)$")
+# Bump on encoding-rule changes so stale entries (e.g. old black-bg JPEGs for
+# transparent logos) aren't served from a colliding filename after upgrade.
+_THUMB_CACHE_VERSION = 2
+
+# By construction the filename is `<sha256>_<int>_v<int>[_flat].(jpg|png)`; the
+# regex is an explicit sanitizer that also lets CodeQL prove the value is safe
+# to join into a filesystem path. The `_flat` marker separates the flattened
+# and transparency-preserving cache variants.
+_THUMB_FILENAME_RE = re.compile(r"^[0-9a-f]{64}_\d+_v\d+(?:_flat)?\.(?:jpg|png)$")
 
 _thumb_memory_cache: OrderedDict[str, bytes] = OrderedDict()
 
@@ -95,7 +99,7 @@ def _thumb_cache_filename(
     if ext == "jpeg":
         ext = "jpg"
     suffix = "_flat" if flatten_transparency else ""
-    return f"{thumb_hash}_{size or 0}{suffix}.{ext}"
+    return f"{thumb_hash}_{size or 0}_v{_THUMB_CACHE_VERSION}{suffix}.{ext}"
 
 
 def _get_from_memory_cache(key: str) -> bytes | None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -57,7 +57,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 
 from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALYSIS_DOMAIN
 from music_assistant.helpers.util import is_valid_mac_address
@@ -848,8 +848,8 @@ class SendspinPlayer(SendspinBasePlayer):
                     current_item.media_item
                 )
                 if image_data is not None:
-                    image = await asyncio.to_thread(Image.open, BytesIO(image_data))
-                    if (artwork_role := self._artwork_role) is not None:
+                    image = await self._decode_artwork(image_data)
+                    if image is not None and (artwork_role := self._artwork_role) is not None:
                         await artwork_role.set_album_artwork(image)
             # Clear artwork if none available
             elif (artwork_role := self._artwork_role) is not None:
@@ -884,11 +884,29 @@ class SendspinPlayer(SendspinBasePlayer):
                     artist_artwork_url, provider="builtin"
                 )
                 if isinstance(artist_image_data, bytes):
-                    artist_image = await asyncio.to_thread(Image.open, BytesIO(artist_image_data))
-                    if (artwork_role := self._artwork_role) is not None:
+                    artist_image = await self._decode_artwork(artist_image_data)
+                    if (
+                        artist_image is not None
+                        and (artwork_role := self._artwork_role) is not None
+                    ):
                         await artwork_role.set_artist_artwork(artist_image)
             elif (artwork_role := self._artwork_role) is not None:
                 await artwork_role.set_artist_artwork(None)
+
+    async def _decode_artwork(self, image_data: bytes) -> Image.Image | None:
+        """
+        Decode raw artwork bytes into a Pillow image, or None if unsupported.
+
+        Sendspin clients need a raster image; vector (SVG) or otherwise
+        undecodable artwork is skipped rather than crashing the metadata push.
+
+        :param image_data: Raw image bytes to decode.
+        """
+        try:
+            return await asyncio.to_thread(Image.open, BytesIO(image_data))
+        except UnidentifiedImageError:
+            self.logger.debug("Skipping unsupported artwork format")
+            return None
 
     def _on_player_media_updated(self) -> None:
         """Handle callback when the current media of the player is updated."""

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -57,7 +57,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import PlayerCommandFailed
 from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
-from PIL import Image, UnidentifiedImageError
+from PIL import Image
 
 from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALYSIS_DOMAIN
 from music_assistant.helpers.util import is_valid_mac_address
@@ -899,10 +899,16 @@ class SendspinPlayer(SendspinBasePlayer):
 
         :param image_data: Raw image bytes to decode.
         """
+
+        def _open() -> Image.Image:
+            img = Image.open(BytesIO(image_data))
+            img.load()
+            return img
+
         try:
-            return await asyncio.to_thread(Image.open, BytesIO(image_data))
-        except UnidentifiedImageError:
-            self.logger.debug("Skipping unsupported artwork format")
+            return await asyncio.to_thread(_open)
+        except OSError as err:
+            self.logger.debug("Skipping undecodable artwork: %s", err)
             return None
 
     def _on_player_media_updated(self) -> None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -895,10 +895,7 @@ class SendspinPlayer(SendspinBasePlayer):
 
     async def _decode_artwork(self, image_data: bytes) -> Image.Image | None:
         """
-        Decode raw artwork bytes into a Pillow image, or None if unsupported.
-
-        Sendspin clients need a raster image; vector (SVG) or otherwise
-        undecodable artwork is skipped rather than crashing the metadata push.
+        Decode artwork bytes into a Pillow image, returning None if undecodable.
 
         :param image_data: Raw image bytes to decode.
         """

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -13,7 +13,11 @@ from music_assistant.controllers.metadata import (
     _is_safe_imageproxy_request_path,
     _normalize_imageproxy_format,
 )
-from music_assistant.helpers.images import _extract_imageproxy_id, create_thumb_hash
+from music_assistant.helpers.images import (
+    _extract_imageproxy_id,
+    create_thumb_hash,
+    is_svg_data,
+)
 from music_assistant.mass import MusicAssistant
 
 
@@ -243,3 +247,22 @@ async def test_handle_imageproxy_rejects_extra_path_segments(
     # double slash after the prefix must not be accepted either
     bad = await metadata_controller.handle_imageproxy(_fake_request(f"/imageproxy//{image_id}"))
     assert bad.status == 400
+
+
+def test_is_svg_data() -> None:
+    """SVG bytes are detected by content, regardless of file extension."""
+    # plain root element
+    assert is_svg_data(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+    # XML declaration before the root element
+    assert is_svg_data(b'<?xml version="1.0"?>\n<svg viewBox="0 0 10 10"></svg>')
+    # leading whitespace and a comment before the root element
+    assert is_svg_data(b"  \n<!-- a logo -->\n<svg></svg>")
+    # doctype before the root element
+    assert is_svg_data(b'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN">\n<svg></svg>')
+    # raster formats and arbitrary data are not SVG
+    assert not is_svg_data(b"\xff\xd8\xff\xe0JFIF")  # jpeg magic
+    assert not is_svg_data(b"\x89PNG\r\n\x1a\n")  # png magic
+    assert not is_svg_data(b"")
+    assert not is_svg_data(b"<html><body>not svg</body></html>")
+    # an XML document that never declares an <svg> element is not SVG
+    assert not is_svg_data(b'<?xml version="1.0"?><rss></rss>')

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -5,6 +5,7 @@ import hashlib
 from unittest.mock import MagicMock
 
 import pytest
+from PIL import Image
 
 from music_assistant.controllers.metadata import (
     _IMAGEPROXY_CONTENT_TYPES,
@@ -15,7 +16,10 @@ from music_assistant.controllers.metadata import (
 )
 from music_assistant.helpers.images import (
     _extract_imageproxy_id,
+    _has_alpha,
+    _thumb_cache_filename,
     create_thumb_hash,
+    detect_image_content_format,
     is_svg_data,
 )
 from music_assistant.mass import MusicAssistant
@@ -266,3 +270,42 @@ def test_is_svg_data() -> None:
     assert not is_svg_data(b"<html><body>not svg</body></html>")
     # an XML document that never declares an <svg> element is not SVG
     assert not is_svg_data(b'<?xml version="1.0"?><rss></rss>')
+
+
+def test_detect_image_content_format() -> None:
+    """Image format is sniffed from leading magic bytes (png/jpg/svg)."""
+    assert detect_image_content_format(b"\x89PNG\r\n\x1a\n....") == "png"
+    assert detect_image_content_format(b"\xff\xd8\xff\xe0JFIF") == "jpg"
+    assert detect_image_content_format(b'<svg xmlns="http://www.w3.org/2000/svg"></svg>') == "svg"
+    assert detect_image_content_format(b"") is None
+    assert detect_image_content_format(b"GIF89a") is None
+    # every sniffed value must map to a known content type
+    for fmt in ("png", "jpg", "svg"):
+        assert fmt in _IMAGEPROXY_CONTENT_TYPES
+
+
+def test_thumb_cache_filename_separates_flatten_variants() -> None:
+    """Flattened (player-compat) and transparency-preserving variants differ."""
+    thumb_hash = "a" * 64
+    plain = _thumb_cache_filename(thumb_hash, 512, "jpeg", flatten_transparency=False)
+    flat = _thumb_cache_filename(thumb_hash, 512, "jpeg", flatten_transparency=True)
+    assert plain == f"{thumb_hash}_512.jpg"
+    assert flat == f"{thumb_hash}_512_flat.jpg"
+    assert plain != flat
+    # png requests keep their own extension/bucket
+    assert _thumb_cache_filename(thumb_hash, 0, "png") == f"{thumb_hash}_0.png"
+
+
+def test_has_alpha() -> None:
+    """Only images that actually use transparency are detected."""
+    assert _has_alpha(Image.new("RGBA", (4, 4), (0, 0, 0, 0)))
+    assert _has_alpha(Image.new("LA", (4, 4)))
+    palette_img = Image.new("P", (4, 4))
+    palette_img.info["transparency"] = 0
+    assert _has_alpha(palette_img)
+    # a fully-opaque alpha channel does not count as transparent
+    assert not _has_alpha(Image.new("RGBA", (4, 4), (1, 2, 3, 255)))
+    # opaque modes have no alpha
+    assert not _has_alpha(Image.new("RGB", (4, 4), (10, 20, 30)))
+    assert not _has_alpha(Image.new("L", (4, 4)))
+    assert not _has_alpha(Image.new("P", (4, 4)))

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -15,6 +15,8 @@ from music_assistant.controllers.metadata import (
     _normalize_imageproxy_format,
 )
 from music_assistant.helpers.images import (
+    _THUMB_CACHE_VERSION,
+    _THUMB_FILENAME_RE,
     _extract_imageproxy_id,
     _has_alpha,
     _thumb_cache_filename,
@@ -289,11 +291,12 @@ def test_thumb_cache_filename_separates_flatten_variants() -> None:
     thumb_hash = "a" * 64
     plain = _thumb_cache_filename(thumb_hash, 512, "jpeg", flatten_transparency=False)
     flat = _thumb_cache_filename(thumb_hash, 512, "jpeg", flatten_transparency=True)
-    assert plain == f"{thumb_hash}_512.jpg"
-    assert flat == f"{thumb_hash}_512_flat.jpg"
+    assert plain == f"{thumb_hash}_512_v{_THUMB_CACHE_VERSION}.jpg"
+    assert flat == f"{thumb_hash}_512_v{_THUMB_CACHE_VERSION}_flat.jpg"
     assert plain != flat
     # png requests keep their own extension/bucket
-    assert _thumb_cache_filename(thumb_hash, 0, "png") == f"{thumb_hash}_0.png"
+    png_name = _thumb_cache_filename(thumb_hash, 0, "png")
+    assert png_name == f"{thumb_hash}_0_v{_THUMB_CACHE_VERSION}.png"
 
 
 def test_has_alpha() -> None:
@@ -309,3 +312,40 @@ def test_has_alpha() -> None:
     assert not _has_alpha(Image.new("RGB", (4, 4), (10, 20, 30)))
     assert not _has_alpha(Image.new("L", (4, 4)))
     assert not _has_alpha(Image.new("P", (4, 4)))
+
+
+def test_thumb_cache_filename_includes_cache_version() -> None:
+    """The version is in the filename so pre-upgrade thumbnails can't be reused."""
+    thumb_hash = "a" * 64
+    name = _thumb_cache_filename(thumb_hash, 512, "jpeg")
+    assert f"_v{_THUMB_CACHE_VERSION}" in name
+    # the unversioned (pre-PR) filename must not collide with the current one
+    assert name != f"{thumb_hash}_512.jpg"
+    # the sanitizer must accept the versioned shape it now produces
+    assert _THUMB_FILENAME_RE.fullmatch(name)
+    assert _THUMB_FILENAME_RE.fullmatch(
+        _thumb_cache_filename(thumb_hash, 0, "png", flatten_transparency=True)
+    )
+
+
+async def test_serve_thumbnail_sets_csp_for_svg(
+    metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SVG responses carry a script-blocking CSP; raster responses do not."""
+    served: dict[str, tuple[bytes, str]] = {"value": (b"<svg></svg>", "svg")}
+
+    async def _fake_resolve(*_args: object, **_kwargs: object) -> tuple[bytes, str]:
+        return served["value"]
+
+    monkeypatch.setattr(metadata_controller, "_resolve_thumbnail", _fake_resolve)
+
+    svg_resp = await metadata_controller._serve_thumbnail("p", "builtin", 0, "svg")
+    assert svg_resp.headers["Content-Security-Policy"] == (
+        "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+    )
+    assert svg_resp.headers["X-Content-Type-Options"] == "nosniff"
+
+    served["value"] = (b"\xff\xd8\xff", "jpg")
+    jpg_resp = await metadata_controller._serve_thumbnail("p", "builtin", 256, "jpeg")
+    assert "Content-Security-Policy" not in jpg_resp.headers
+    assert "X-Content-Type-Options" not in jpg_resp.headers

--- a/tests/providers/sendspin/test_decode_artwork.py
+++ b/tests/providers/sendspin/test_decode_artwork.py
@@ -1,0 +1,42 @@
+"""Tests for Sendspin artwork decoding resilience."""
+
+from __future__ import annotations
+
+import logging
+from io import BytesIO
+from types import SimpleNamespace
+from typing import cast
+
+from PIL import Image
+
+from music_assistant.providers.sendspin.player import SendspinPlayer
+
+
+def _fake_player() -> SendspinPlayer:
+    return cast("SendspinPlayer", SimpleNamespace(logger=logging.getLogger("test")))
+
+
+def _png_bytes(size: tuple[int, int] = (4, 4)) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", size, (1, 2, 3)).save(buf, "PNG")
+    return buf.getvalue()
+
+
+async def test_decode_artwork_valid_image() -> None:
+    """A valid raster image decodes to a Pillow image."""
+    img = await SendspinPlayer._decode_artwork(_fake_player(), _png_bytes())
+    assert img is not None
+    assert img.size == (4, 4)
+
+
+async def test_decode_artwork_returns_none_for_unidentifiable() -> None:
+    """SVG / arbitrary / empty bytes return None instead of raising."""
+    assert await SendspinPlayer._decode_artwork(_fake_player(), b"<svg></svg>") is None
+    assert await SendspinPlayer._decode_artwork(_fake_player(), b"") is None
+
+
+async def test_decode_artwork_returns_none_for_truncated_image() -> None:
+    """Truncated data opens lazily but fails on decode; it must be caught, not raised."""
+    full = _png_bytes((64, 64))
+    truncated = full[: len(full) // 2]
+    assert await SendspinPlayer._decode_artwork(_fake_player(), truncated) is None


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Some image sources (notably radio station favicons) serve SVG or transparent PNG logos, and the image proxy mishandled both:

- SVGs served from URLs without a .svg extension were treated as JPEGs, failed to convert, and returned a 404 — so the logo never appeared. They're now detected by their content and passed through correctly.
- Transparent PNGs were converted to JPEG with the transparent areas turned black. They're now handled based on where the image is going:
    - Images sent to playback devices stay JPEG (for hardware compatibility) but transparent areas are filled with white instead of black.
    - Images shown in the app/UI keep their transparency (served as PNG).

Also fixed a crash in the Sendspin player, which threw an error whenever it received an image it couldn't decode (such as an SVG); it now skips that artwork instead.

Opaque images and normal album art are unaffected — they behave exactly as before.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5107 and https://github.com/music-assistant/support/issues/5580

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
