### PR TITLE
Add explicit filter to smart playlist rules

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -604,12 +604,12 @@ class SmartPlaylistProvider(PluginProvider):
                     and t.metadata.popularity >= rules.min_popularity
                 ]
 
-            if rules.explicit_only is True:
+            if rules.explicit is True:
                 # Only include tracks explicitly marked as explicit
                 tracks = [
                     t for t in tracks if t.metadata is not None and t.metadata.explicit is True
                 ]
-            elif rules.explicit_only is False:
+            elif rules.explicit is False:
                 # Exclude tracks explicitly marked as explicit; pass through unknown
                 tracks = [
                     t for t in tracks if t.metadata is None or t.metadata.explicit is not True
@@ -685,9 +685,9 @@ class SmartPlaylistProvider(PluginProvider):
             ]
         if rules.favorites_only:
             tracks = [t for t in tracks if t.favorite]
-        if rules.explicit_only is True:
+        if rules.explicit is True:
             tracks = [t for t in tracks if t.metadata is not None and t.metadata.explicit is True]
-        elif rules.explicit_only is False:
+        elif rules.explicit is False:
             tracks = [t for t in tracks if t.metadata is None or t.metadata.explicit is not True]
         if has_genre_filter and rules.logic == LOGIC_AND:
             # Best-effort genre filter: resolve names then match against track genre metadata.

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -107,7 +107,8 @@ async def get_config_entries(
 
 
 def _filter_by_explicit(tracks: list[Track], explicit_rule: bool | None) -> list[Track]:
-    """Filter tracks based on the explicit content rule.
+    """
+    Filter tracks based on the explicit content rule.
 
     :param tracks: List of tracks to filter.
     :param explicit_rule: True = only explicit tracks, False = exclude explicit tracks,

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -106,6 +106,23 @@ async def get_config_entries(
     )
 
 
+def _filter_by_explicit(tracks: list[Track], explicit_rule: bool | None) -> list[Track]:
+    """Filter tracks based on the explicit content rule.
+
+    :param tracks: List of tracks to filter.
+    :param explicit_rule: True = only explicit tracks, False = exclude explicit tracks,
+                          None = no filter.
+    :return: Filtered list of tracks.
+    """
+    if explicit_rule is True:
+        # Only include tracks explicitly marked as explicit
+        return [t for t in tracks if t.metadata is not None and t.metadata.explicit is True]
+    if explicit_rule is False:
+        # Exclude tracks explicitly marked as explicit; pass through unknown
+        return [t for t in tracks if t.metadata is None or t.metadata.explicit is not True]
+    return tracks
+
+
 class SmartPlaylistProvider(PluginProvider):
     """Smart Playlist plugin provider for Music Assistant."""
 
@@ -604,16 +621,7 @@ class SmartPlaylistProvider(PluginProvider):
                     and t.metadata.popularity >= rules.min_popularity
                 ]
 
-            if rules.explicit is True:
-                # Only include tracks explicitly marked as explicit
-                tracks = [
-                    t for t in tracks if t.metadata is not None and t.metadata.explicit is True
-                ]
-            elif rules.explicit is False:
-                # Exclude tracks explicitly marked as explicit; pass through unknown
-                tracks = [
-                    t for t in tracks if t.metadata is None or t.metadata.explicit is not True
-                ]
+            tracks = _filter_by_explicit(tracks, rules.explicit)
 
             if rules.year_from is not None or rules.year_to is not None:
                 tracks = [
@@ -685,10 +693,7 @@ class SmartPlaylistProvider(PluginProvider):
             ]
         if rules.favorites_only:
             tracks = [t for t in tracks if t.favorite]
-        if rules.explicit is True:
-            tracks = [t for t in tracks if t.metadata is not None and t.metadata.explicit is True]
-        elif rules.explicit is False:
-            tracks = [t for t in tracks if t.metadata is None or t.metadata.explicit is not True]
+        tracks = _filter_by_explicit(tracks, rules.explicit)
         if has_genre_filter and rules.logic == LOGIC_AND:
             # Best-effort genre filter: resolve names then match against track genre metadata.
             # Tracks without genre metadata are kept (don't exclude for missing data).

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -116,10 +116,10 @@ def _filter_by_explicit(tracks: list[Track], explicit_rule: bool | None) -> list
     """
     if explicit_rule is True:
         # Only include tracks explicitly marked as explicit
-        return [t for t in tracks if t.metadata is not None and t.metadata.explicit is True]
+        return [t for t in tracks if t.metadata.explicit is True]
     if explicit_rule is False:
         # Exclude tracks explicitly marked as explicit; pass through unknown
-        return [t for t in tracks if t.metadata is None or t.metadata.explicit is not True]
+        return [t for t in tracks if t.metadata.explicit is not True]
     return tracks
 
 
@@ -621,6 +621,7 @@ class SmartPlaylistProvider(PluginProvider):
                     and t.metadata.popularity >= rules.min_popularity
                 ]
 
+            # Apply explicit filter in library mode
             tracks = _filter_by_explicit(tracks, rules.explicit)
 
             if rules.year_from is not None or rules.year_to is not None:
@@ -693,6 +694,7 @@ class SmartPlaylistProvider(PluginProvider):
             ]
         if rules.favorites_only:
             tracks = [t for t in tracks if t.favorite]
+        # Apply explicit filter in seed/discover mode post-filtering
         tracks = _filter_by_explicit(tracks, rules.explicit)
         if has_genre_filter and rules.logic == LOGIC_AND:
             # Best-effort genre filter: resolve names then match against track genre metadata.

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -604,6 +604,17 @@ class SmartPlaylistProvider(PluginProvider):
                     and t.metadata.popularity >= rules.min_popularity
                 ]
 
+            if rules.explicit_only is True:
+                # Only include tracks explicitly marked as explicit
+                tracks = [
+                    t for t in tracks if t.metadata is not None and t.metadata.explicit is True
+                ]
+            elif rules.explicit_only is False:
+                # Exclude tracks explicitly marked as explicit; pass through unknown
+                tracks = [
+                    t for t in tracks if t.metadata is None or t.metadata.explicit is not True
+                ]
+
             if rules.year_from is not None or rules.year_to is not None:
                 tracks = [
                     t
@@ -674,6 +685,10 @@ class SmartPlaylistProvider(PluginProvider):
             ]
         if rules.favorites_only:
             tracks = [t for t in tracks if t.favorite]
+        if rules.explicit_only is True:
+            tracks = [t for t in tracks if t.metadata is not None and t.metadata.explicit is True]
+        elif rules.explicit_only is False:
+            tracks = [t for t in tracks if t.metadata is None or t.metadata.explicit is not True]
         if has_genre_filter and rules.logic == LOGIC_AND:
             # Best-effort genre filter: resolve names then match against track genre metadata.
             # Tracks without genre metadata are kept (don't exclude for missing data).

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -117,6 +117,7 @@ class SmartPlaylistRules:
     dedup_hours: int | None = None
     album_types: list[str] = field(default_factory=list)
     excluded_album_types: list[str] = field(default_factory=list)
+    explicit_only: bool | None = None
 
     def all_seed_uris(self) -> list[str]:
         """Return every seed URI across the four seed lists, deduplicated, original order."""
@@ -164,6 +165,7 @@ class SmartPlaylistRules:
             "dedup_hours": self.dedup_hours,
             "album_types": self.album_types,
             "excluded_album_types": self.excluded_album_types,
+            "explicit_only": self.explicit_only,
         }
 
     @classmethod
@@ -216,6 +218,7 @@ class SmartPlaylistRules:
             excluded_album_types=_coerce_str_list(
                 data.get("excluded_album_types"), "excluded_album_types"
             ),
+            explicit_only=data.get("explicit_only"),
         )
 
     def human_readable(self) -> str:
@@ -223,6 +226,10 @@ class SmartPlaylistRules:
         parts: list[str] = []
         if self.favorites_only:
             parts.append("Favorites only")
+        if self.explicit_only is True:
+            parts.append("Explicit only")
+        elif self.explicit_only is False:
+            parts.append("No explicit content")
         if self.genre_ids:
             names = [self.genre_names.get(gid, str(gid)) for gid in self.genre_ids]
             parts.append(f"Genres: {', '.join(names)}")

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -37,8 +37,8 @@ def _coerce_optional_int(value: Any, field_name: str) -> int | None:
         raise InvalidDataError(f"Invalid value for {field_name}: {value!r}") from err
 
 
-def _validate_optional_bool(value: Any, field_name: str) -> bool | None:
-    """Validate a value is bool | None, raising InvalidDataError on bad input."""
+def _coerce_optional_bool(value: Any, field_name: str) -> bool | None:
+    """Coerce a value to bool | None, raising InvalidDataError on bad input."""
     if value is None:
         return None
     if isinstance(value, bool):
@@ -229,7 +229,7 @@ class SmartPlaylistRules:
             excluded_album_types=_coerce_str_list(
                 data.get("excluded_album_types"), "excluded_album_types"
             ),
-            explicit=_validate_optional_bool(data.get("explicit"), "explicit"),
+            explicit=_coerce_optional_bool(data.get("explicit"), "explicit"),
         )
 
     def human_readable(self) -> str:

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -37,8 +37,8 @@ def _coerce_optional_int(value: Any, field_name: str) -> int | None:
         raise InvalidDataError(f"Invalid value for {field_name}: {value!r}") from err
 
 
-def _coerce_optional_bool(value: Any, field_name: str) -> bool | None:
-    """Coerce a value to bool | None, raising InvalidDataError on bad input."""
+def _validate_optional_bool(value: Any, field_name: str) -> bool | None:
+    """Validate a value is bool | None, raising InvalidDataError on bad input."""
     if value is None:
         return None
     if isinstance(value, bool):
@@ -229,7 +229,7 @@ class SmartPlaylistRules:
             excluded_album_types=_coerce_str_list(
                 data.get("excluded_album_types"), "excluded_album_types"
             ),
-            explicit=_coerce_optional_bool(data.get("explicit"), "explicit"),
+            explicit=_validate_optional_bool(data.get("explicit"), "explicit"),
         )
 
     def human_readable(self) -> str:

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -37,6 +37,17 @@ def _coerce_optional_int(value: Any, field_name: str) -> int | None:
         raise InvalidDataError(f"Invalid value for {field_name}: {value!r}") from err
 
 
+def _coerce_optional_bool(value: Any, field_name: str) -> bool | None:
+    """Coerce a value to bool | None, raising InvalidDataError on bad input."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise InvalidDataError(
+        f"Invalid value for {field_name}: {value!r}. Expected True, False, or None."
+    )
+
+
 def _coerce_id_list(value: Any, field_name: str) -> list[int]:
     """Coerce a value to a list of ints, raising InvalidDataError on bad input."""
     if value is None:
@@ -218,7 +229,7 @@ class SmartPlaylistRules:
             excluded_album_types=_coerce_str_list(
                 data.get("excluded_album_types"), "excluded_album_types"
             ),
-            explicit=data.get("explicit"),
+            explicit=_coerce_optional_bool(data.get("explicit"), "explicit"),
         )
 
     def human_readable(self) -> str:

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -117,7 +117,7 @@ class SmartPlaylistRules:
     dedup_hours: int | None = None
     album_types: list[str] = field(default_factory=list)
     excluded_album_types: list[str] = field(default_factory=list)
-    explicit_only: bool | None = None
+    explicit: bool | None = None
 
     def all_seed_uris(self) -> list[str]:
         """Return every seed URI across the four seed lists, deduplicated, original order."""
@@ -165,7 +165,7 @@ class SmartPlaylistRules:
             "dedup_hours": self.dedup_hours,
             "album_types": self.album_types,
             "excluded_album_types": self.excluded_album_types,
-            "explicit_only": self.explicit_only,
+            "explicit": self.explicit,
         }
 
     @classmethod
@@ -218,7 +218,7 @@ class SmartPlaylistRules:
             excluded_album_types=_coerce_str_list(
                 data.get("excluded_album_types"), "excluded_album_types"
             ),
-            explicit_only=data.get("explicit_only"),
+            explicit=data.get("explicit"),
         )
 
     def human_readable(self) -> str:
@@ -226,9 +226,9 @@ class SmartPlaylistRules:
         parts: list[str] = []
         if self.favorites_only:
             parts.append("Favorites only")
-        if self.explicit_only is True:
+        if self.explicit is True:
             parts.append("Explicit only")
-        elif self.explicit_only is False:
+        elif self.explicit is False:
             parts.append("No explicit content")
         if self.genre_ids:
             names = [self.genre_names.get(gid, str(gid)) for gid in self.genre_ids]


### PR DESCRIPTION
# What does this implement/fix?

Adds an `explicit` filter to smart playlist rules. Users can set the filter to:
- **Explicit only** — only include tracks explicitly marked as explicit (true)
- **Not allowed** — exclude tracks marked as explicit (false)
- **Allowed** — no restriction, shows all tracks (null, same as not adding the filter)

The filter is tri-state where `null` and `undefined` are treated identically on the backend (no restriction).

**Related issue (if applicable):**

- Companion frontend PR: music-assistant/frontend#1865
- Addresses feedback from @marcelveldt in review comments (renamed from `explicit_only` to `explicit`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.