### PR TITLE
Phishin Change fallback album image URL

### DIFF
--- a/music_assistant/providers/phishin/constants.py
+++ b/music_assistant/providers/phishin/constants.py
@@ -21,7 +21,7 @@ PHISH_TADB_ID: Final[str] = "112677"
 
 # Fallback image for albums without artwork
 FALLBACK_ALBUM_IMAGE: Final[str] = (
-    "https://raw.githubusercontent.com/music-assistant/music-assistant.io/refs/heads/main/docs/assets/icons/phish-logo.png"
+    "https://raw.githubusercontent.com/music-assistant/music-assistant.io/refs/heads/main/public/assets/icons/phish-logo.png"
 )
 
 # API endpoints


### PR DESCRIPTION
Updated fallback album image URL to point to the public assets.

# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

URL changed with the docs site upgrade

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
