### PR TITLE
AirPlay: fix mDNS cross-match when device name is substring of another device name

### DIFF
--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -7,6 +7,7 @@ import contextlib
 import inspect
 import logging
 import os
+import re
 from collections import defaultdict
 from ipaddress import IPv4Address
 from typing import TYPE_CHECKING, Any
@@ -35,6 +36,10 @@ if TYPE_CHECKING:
     from music_assistant_models.config_entries import CoreConfig
 
     from music_assistant.models import ProviderInstanceType
+
+# RAOP cache keys prefix the device name with the device MAC, e.g. "aabbccddeeff@Kelder".
+# Cache keys are lowercased, so the hex is matched in lowercase.
+RAOP_MAC_PREFIX = re.compile(r"^[0-9a-f]{12}@")
 
 CONF_UPNP_NETWORK_SCAN = "upnp_network_scan"
 UPNP_DISCOVERY_INTERVAL = 300
@@ -171,10 +176,10 @@ class DiscoveryController(CoreController):
                     # Use exact matching on the device name portion to prevent a device named
                     # "Foo" from cross-matching another device named "ATV Foo".
                     # mDNS names are either "MAC@DeviceName.service.local." or "DeviceName.service.local."
+                    # Strip the MAC prefix only when present, so device names that legitimately
+                    # contain "@" are not truncated.
                     device_part = mdns_name.split(".")[0]
-                    device_name = (
-                        device_part.split("@", 1)[1] if "@" in device_part else device_part
-                    )
+                    device_name = RAOP_MAC_PREFIX.sub("", device_part, count=1)
                     if device_name != name_filter_lower:
                         continue
                     info = AsyncServiceInfo(service_type, mdns_name)

--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -148,10 +148,10 @@ class DiscoveryController(CoreController):
     async def async_find_mdns_service(
         self, service_type: str, name_filter: str, timeout: float = 3.0
     ) -> AsyncServiceInfo | None:
-        """Find an mDNS service by partial name match, checking cache first then waiting.
+        """Find an mDNS service by exact device name match, checking cache first then waiting.
 
         :param service_type: The mDNS service type (e.g., "_raop._tcp.local.").
-        :param name_filter: Substring that must appear in the service name.
+        :param name_filter: Device name that must exactly match the service name portion.
         :param timeout: Maximum time to wait in seconds.
         """
         deadline = asyncio.get_event_loop().time() + timeout
@@ -166,14 +166,20 @@ class DiscoveryController(CoreController):
                 event.clear()
                 # Check cache for a matching entry
                 for mdns_name in set(self.aiozc.zeroconf.cache.cache):
-                    if (
-                        service_type_lower in mdns_name
-                        and name_filter_lower in mdns_name
-                        and mdns_name != service_type_lower
-                    ):
-                        info = AsyncServiceInfo(service_type, mdns_name)
-                        if await info.async_request(self.aiozc.zeroconf, 3000):
-                            return info
+                    if service_type_lower not in mdns_name or mdns_name == service_type_lower:
+                        continue
+                    # Use exact matching on the device name portion to prevent a device named
+                    # "Foo" from cross-matching another device named "ATV Foo".
+                    # mDNS names are either "MAC@DeviceName.service.local." or "DeviceName.service.local."
+                    device_part = mdns_name.split(".")[0]
+                    device_name = (
+                        device_part.split("@", 1)[1] if "@" in device_part else device_part
+                    )
+                    if device_name != name_filter_lower:
+                        continue
+                    info = AsyncServiceInfo(service_type, mdns_name)
+                    if await info.async_request(self.aiozc.zeroconf, 3000):
+                        return info
                 remaining = deadline - asyncio.get_event_loop().time()
                 if remaining <= 0:
                     return None

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -634,10 +634,8 @@ class MetaDataController(CoreController):
         prefer_stream_server: bool = False,
     ) -> str:
         """Get (proxied) URL for MediaItemImage."""
-        detected_format = _detect_image_format(image.path)
-        if image_format is None or detected_format == "svg":
-            # Always use the detected format for SVGs — they cannot be converted to JPEG/PNG
-            image_format = detected_format
+        if image_format is None:
+            image_format = _detect_image_format(image.path)
         if image_format == "svg":
             # SVGs don't need resizing
             size = 0

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -634,8 +634,10 @@ class MetaDataController(CoreController):
         prefer_stream_server: bool = False,
     ) -> str:
         """Get (proxied) URL for MediaItemImage."""
-        if image_format is None:
-            image_format = _detect_image_format(image.path)
+        detected_format = _detect_image_format(image.path)
+        if image_format is None or detected_format == "svg":
+            # Always use the detected format for SVGs — they cannot be converted to JPEG/PNG
+            image_format = detected_format
         if image_format == "svg":
             # SVGs don't need resizing
             size = 0

--- a/tests/core/test_discovery.py
+++ b/tests/core/test_discovery.py
@@ -103,3 +103,63 @@ async def test_discovery_controller_owns_async_zeroconf(mass_minimal: MusicAssis
         ip_version=IPVersion.All,
         interfaces=["192.168.1.10", "fd00::1%2"],
     )
+
+
+async def test_async_find_mdns_service_matches_exact_device_name(mass: MusicAssistant) -> None:
+    """A device name must not cross-match another device whose name contains it."""
+    mass.discovery.aiozc.zeroconf.cache.cache = {
+        "aabbccddeeff@kelder._raop._tcp.local.": {},
+        "atv kelder._raop._tcp.local.": {},
+    }
+    mock_info = MagicMock()
+    mock_info.async_request = AsyncMock(return_value=True)
+    with patch(
+        "music_assistant.controllers.discovery.controller.AsyncServiceInfo",
+        return_value=mock_info,
+    ) as mock_service_info:
+        result = await mass.discovery.async_find_mdns_service(
+            "_raop._tcp.local.", "Kelder", timeout=1.0
+        )
+
+    assert result is mock_info
+    # "Kelder" must resolve to its own RAOP entry, never the "ATV Kelder" one.
+    mock_service_info.assert_called_once_with(
+        "_raop._tcp.local.", "aabbccddeeff@kelder._raop._tcp.local."
+    )
+
+
+async def test_async_find_mdns_service_no_substring_match(mass: MusicAssistant) -> None:
+    """Looking up a name that is only a substring of a discovered name should not match."""
+    mass.discovery.aiozc.zeroconf.cache.cache = {
+        "atv kelder._raop._tcp.local.": {},
+    }
+    with patch(
+        "music_assistant.controllers.discovery.controller.AsyncServiceInfo",
+    ) as mock_service_info:
+        result = await mass.discovery.async_find_mdns_service(
+            "_raop._tcp.local.", "Kelder", timeout=0.1
+        )
+
+    assert result is None
+    mock_service_info.assert_not_called()
+
+
+async def test_async_find_mdns_service_preserves_at_sign_in_name(mass: MusicAssistant) -> None:
+    """Only a RAOP MAC prefix is stripped, so device names containing '@' still match."""
+    mass.discovery.aiozc.zeroconf.cache.cache = {
+        "living@home._airplay._tcp.local.": {},
+    }
+    mock_info = MagicMock()
+    mock_info.async_request = AsyncMock(return_value=True)
+    with patch(
+        "music_assistant.controllers.discovery.controller.AsyncServiceInfo",
+        return_value=mock_info,
+    ) as mock_service_info:
+        result = await mass.discovery.async_find_mdns_service(
+            "_airplay._tcp.local.", "Living@Home", timeout=1.0
+        )
+
+    assert result is mock_info
+    mock_service_info.assert_called_once_with(
+        "_airplay._tcp.local.", "living@home._airplay._tcp.local."
+    )


### PR DESCRIPTION
## What does this implement/fix?

`async_find_mdns_service` used substring matching (`name_filter_lower in mdns_name`) to find a counterpart mDNS service when a new AirPlay device is discovered. When one device's name is contained in another's, they cross-match. Real case: a Denon AVR-X1000 named "Kelder" (RAOP-only) and an Apple TV named "ATV Kelder" — looking up the AirPlay service for "Kelder" matched "ATV Kelder", causing the Denon to inherit `am=AppleTV6,2`, show as "Apple TV 4K", and demand PIN pairing.

Fix: extract the device-name portion of the mDNS cache key (before the service-type segment, stripping any `MAC@` prefix) and require an exact case-insensitive match rather than a substring match.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5582

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.