### PR TITLE
Cache recommendations() for sonic_similarity and audiobookshelf

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -96,6 +96,7 @@ from music_assistant_models.media_items.media_item import RecommendationFolder
 from music_assistant_models.streamdetails import MultiPartPath, StreamDetails
 
 from music_assistant.constants import PLAYBACK_REPORT_INTERVAL_SECONDS, PlaylistPlayableItem
+from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.datetime import from_utc_timestamp
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.audiobookshelf.parsers import (
@@ -996,6 +997,7 @@ for more details.
             timestamp,
         )
 
+    @use_cache(3600, base_class=RecommendationFolder, allow_expired_cache=True)
     @handle_refresh_token
     async def recommendations(self) -> list[RecommendationFolder]:
         """Get recommendations."""

--- a/music_assistant/providers/sonic_similarity/provider.py
+++ b/music_assistant/providers/sonic_similarity/provider.py
@@ -24,6 +24,7 @@ from music_assistant_models.media_items import Album, RecommendationFolder, Sear
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import DB_TABLE_AUDIO_ANALYSIS
+from music_assistant.controllers.cache import use_cache
 from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALYSIS_DOMAIN
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.sonic_similarity.clap_index import ClapIndex
@@ -690,6 +691,7 @@ class SonicSimilarityPlugin(PluginProvider):
                     return pm.item_id, None
         return None, None
 
+    @use_cache(60, base_class=RecommendationFolder, allow_expired_cache=True)
     async def recommendations(self) -> list[RecommendationFolder]:
         """Yield an 'Inspired by recently played' folder for the discover page.
 

--- a/tests/providers/sonic_similarity/conftest.py
+++ b/tests/providers/sonic_similarity/conftest.py
@@ -51,6 +51,9 @@ def mock_mass(tmp_path: Path) -> MagicMock:
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
     mass.cache = MagicMock()
+    # @use_cache on recommendations() awaits cache.get; return a miss so the
+    # wrapped method runs. cache.set is fire-and-forget via create_task (mocked).
+    mass.cache.get = AsyncMock(return_value=None)
     mass.create_task = MagicMock()  # fire-and-forget; we assert it was called
     mass.get_provider = MagicMock(return_value=None)
 


### PR DESCRIPTION
# What does this implement/fix?

The home view refetches `music/recommendations` on every `MEDIA_ITEM_PLAYED` (`is_playing=False`) event, multiplied by the number of connected clients. In nightly logs this produced bursts of dozens of `music/recommendations` calls, `Discover row` debug spam, and multi-second event-loop stalls.

Most providers already cache `recommendations()` — either directly (`ytmusic`, `deezer`, `tidal`, `plex`, …) or via internal `@use_cache` helpers (`apple_music`, `kion_music`, `yandex_music`, `itunes_podcasts`, `neteasecloudmusic`, `qqmusic`). Two of the remaining ones hit on-device compute / a remote API on every call:

- `sonic_similarity` — on-device similarity compute (the source of the `Discover row` spam and the `_resolve_candidate_tracks` stalls)
- `audiobookshelf`

Each now gets `@use_cache(..., allow_expired_cache=True)`, matching the existing per-provider precedent. With stale-while-revalidate, a burst of concurrent calls is served from cache and collapses to a single deduplicated background refresh per TTL window.

TTLs reflect each provider's data volatility:

| Provider | TTL |
|---|---|
| `sonic_similarity` | 60s (recently-played seeded) |
| `audiobookshelf` | 1h |

Note: this caps server-side cost regardless of client behaviour, but does not reduce the request *volume* — a companion frontend change to debounce the home-view refetch is still worthwhile.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes. <!-- ran on the changed files; Ruff lint/format + mypy pass -->
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.