### PR TITLE
Fix None handling in music controller track/resume lookups

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1537,14 +1537,15 @@ class MusicController(CoreController):
                         # no artist match found: abort
                         continue
                 # check optional album
-                if (
-                    album_name
-                    and is_track
-                    and not compare_strings(album_name, search_track.album.name, False)
-                ):
-                    # no album match found: abort
-                    continue
-                    # if we reach this, we found a match
+                if album_name and is_track:
+                    track_album = search_track.album
+                    # a track without album info can never match a requested album
+                    if track_album is None or not compare_strings(
+                        album_name, track_album.name, False
+                    ):
+                        # no album match found: abort
+                        continue
+                # if we reach this, we found a match
                 if not isinstance(search_track, Track):
                     # ensure we return an actual Track object
                     return await self.mass.music.tracks.get(
@@ -1656,7 +1657,8 @@ class MusicController(CoreController):
             params["userid"] = user.user_id
         if db_entry := await self.database.get_row(DB_TABLE_PLAYLOG, params):
             ma_position_ms = db_entry["seconds_played"] * 1000 if db_entry["seconds_played"] else 0
-            ma_fully_played = parse_optional_bool(db_entry["fully_played"])
+            # fully_played is a nullable column; treat an unknown (NULL) value as not played
+            ma_fully_played = parse_optional_bool(db_entry["fully_played"]) or False
             ma_timestamp = from_utc_timestamp(db_entry["timestamp"])
 
         if provider_timestamp is not None and provider_timestamp > ma_timestamp:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

While doing the typing fixes I came across two edge case bugs that need to be resolved separately, so I've pulled them into this dedicated PR. 

1. `get_track_by_name` could crash on tracks with no album. It read the album's name without checking the track actually had one, so an album-filtered lookup hit an `AttributeError` for singles/untagged files. Now a track with no album is simply treated as a non-match.

2. `get_resume_position` could return a non-boolean "fully played" value. The `fully_played` playlog column is nullable, so a `None` could leak out of a method declared to return true/false. Now an unknown (NULL) value is treated as "not played".

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
