### PR TITLE
Enable ruff UP043 and drop unnecessary default type arguments

### DIFF
--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -278,7 +278,7 @@ class CacheController(CoreController):
         self.logger.debug("Automatic cleanup finished (cleaned up %s records)", cleaned_records)
 
     @asynccontextmanager
-    async def handle_refresh(self, bypass: bool) -> AsyncGenerator[None, None]:
+    async def handle_refresh(self, bypass: bool) -> AsyncGenerator[None]:
         """Handle the cache bypass."""
         try:
             token = BYPASS_CACHE.set(bypass)

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -321,7 +321,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         library_items_only: bool = True,
-    ) -> AsyncGenerator[ItemCls, None]:
+    ) -> AsyncGenerator[ItemCls]:
         """Iterate all in-database items."""
         limit: int = 500
         offset: int = 0
@@ -548,7 +548,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         self,
         provider_instance_id_or_domain: str,
         provider_item_id: str | None = None,
-    ) -> AsyncGenerator[ItemCls, None]:
+    ) -> AsyncGenerator[ItemCls]:
         """Iterate all records from database for given provider."""
         limit: int = 500
         offset: int = 0

--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -117,7 +117,7 @@ class PlaylistController(MediaControllerBase[Playlist]):
         provider_instance_id_or_domain: str,
         force_refresh: bool = False,
         allow_dynamic_tracks: bool = False,
-    ) -> AsyncGenerator[PlaylistPlayableItem, None]:
+    ) -> AsyncGenerator[PlaylistPlayableItem]:
         """Return playlist tracks for the given provider playlist id."""
         if provider_instance_id_or_domain == "library":
             library_item = await self.get_library_item(item_id)

--- a/music_assistant/controllers/media/podcasts.py
+++ b/music_assistant/controllers/media/podcasts.py
@@ -101,7 +101,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
         self,
         item_id: str,
         provider_instance_id_or_domain: str,
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    ) -> AsyncGenerator[PodcastEpisode]:
         """Return podcast episodes for the given provider podcast id."""
         # always check if we have a library item for this podcast
         if provider_instance_id_or_domain == "library":
@@ -219,7 +219,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
 
     async def _get_provider_podcast_episodes(
         self, item_id: str, provider_instance_id_or_domain: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    ) -> AsyncGenerator[PodcastEpisode]:
         """Return podcast episodes for the given provider podcast id."""
         prov = self.mass.get_provider(provider_instance_id_or_domain)
         if not isinstance(prov, MusicProvider):

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -426,7 +426,7 @@ class StreamsAudio:
         seek_position: int = 0,
         filter_params: list[str] | None = None,
         chunk_seconds: float = 1.0,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Get audio stream for given media details as raw PCM.
 
@@ -446,7 +446,7 @@ class StreamsAudio:
         extra_input_args = streamdetails.extra_input_args or []
 
         # work out audio source for these streamdetails
-        audio_source: str | AsyncGenerator[bytes, None]
+        audio_source: str | AsyncGenerator[bytes]
         stream_type = streamdetails.stream_type
         if stream_type == StreamType.CUSTOM:
             # MusicProvider and PluginProvider both expose get_audio_stream with the same shape
@@ -779,7 +779,7 @@ class StreamsAudio:
 
     async def get_icy_radio_stream(
         self, url: str, streamdetails: StreamDetails
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Stream radio audio with ICY metadata support.
 
@@ -810,7 +810,7 @@ class StreamsAudio:
                 except asyncio.exceptions.IncompleteReadError:
                     break
 
-    async def get_reconnecting_radio_stream(self, url: str) -> AsyncGenerator[bytes, None]:
+    async def get_reconnecting_radio_stream(self, url: str) -> AsyncGenerator[bytes]:
         """
         Yield continuous radio stream data, automatically reconnecting on disconnect.
 
@@ -914,7 +914,7 @@ class StreamsAudio:
         streamdetails: StreamDetails,
         seek_position: int = 0,
         verify_ssl: bool = True,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Get audio stream from HTTP."""
         mass = self.mass
         self.logger.debug(
@@ -982,7 +982,7 @@ class StreamsAudio:
         filename: str,
         streamdetails: StreamDetails,
         seek_position: int = 0,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Get audio stream from local accessible file."""
         if seek_position:
             assert streamdetails.duration, "Duration required for seek requests"
@@ -1020,7 +1020,7 @@ class StreamsAudio:
         self,
         streamdetails: StreamDetails,
         seek_position: int = 0,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Return audio stream for a concatenation of multiple files.
 
@@ -1355,7 +1355,7 @@ class StreamsAudio:
         queue_item: QueueItem,
         pcm_format: AudioFormat,
         raise_on_error: bool = True,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Get the realtime PCM stream for an AudioSource queue item.
 
@@ -1413,7 +1413,7 @@ class StreamsAudio:
         self,
         streamdetails: StreamDetails,
         pcm_format: AudioFormat,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Yield PCM for an AudioSource, bypassing ffmpeg when formats match."""
         if _pcm_formats_match(streamdetails.audio_format, pcm_format):
             source_gen = self._open_audio_source_generator(streamdetails)
@@ -1429,9 +1429,7 @@ class StreamsAudio:
         ):
             yield chunk
 
-    def _open_audio_source_generator(
-        self, streamdetails: StreamDetails
-    ) -> AsyncGenerator[bytes, None]:
+    def _open_audio_source_generator(self, streamdetails: StreamDetails) -> AsyncGenerator[bytes]:
         """Open the raw PCM generator for an AudioSource (CUSTOM or NAMED_PIPE)."""
         if streamdetails.stream_type == StreamType.CUSTOM:
             provider = self.mass.get_provider(streamdetails.provider)
@@ -1453,7 +1451,7 @@ class StreamsAudio:
         seek_position: int = 0,
         playback_speed: float = 1.0,
         raise_on_error: bool = True,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Get the (PCM) audio stream for a single queue item.
 
@@ -1668,7 +1666,7 @@ class StreamsAudio:
         pcm_format: AudioFormat,
         smart_fades_mode: SmartFadesMode = SmartFadesMode.SMART_CROSSFADE,
         standard_crossfade_duration: int = 10,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Get the audio stream for a single queue item with (smart) crossfade to the next item."""
         queue = self.mass.player_queues.get(queue_item.queue_id)
         if not queue:
@@ -1866,7 +1864,7 @@ class StreamsAudio:
 
                 _next_item = next_queue_item
 
-                async def _limited_fade_in() -> AsyncGenerator[bytes, None]:
+                async def _limited_fade_in() -> AsyncGenerator[bytes]:
                     nonlocal fade_in_bytes_consumed
                     async for chunk in self.get_queue_item_stream(
                         _next_item,
@@ -1982,7 +1980,7 @@ class StreamsAudio:
 
     async def get_queue_flow_stream(
         self, queue: PlayerQueue, start_queue_item: QueueItem, pcm_format: AudioFormat
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Get a flow stream of all tracks in the queue as raw PCM audio.
 
@@ -2473,7 +2471,7 @@ class StreamsAudio:
 
     async def get_shoutcast_stream(
         self, url: str, streamdetails: StreamDetails
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Yield audio from a legacy Shoutcast server, with ICY metadata parsed inline.
 
@@ -2838,7 +2836,7 @@ class StreamsAudio:
         return needs_restart
 
     @asynccontextmanager
-    async def _connect_radio_stream(self, url: str, **kwargs: Any) -> AsyncGenerator[Any, None]:
+    async def _connect_radio_stream(self, url: str, **kwargs: Any) -> AsyncGenerator[Any]:
         """
         Connect to a radio stream URL with fallback for legacy SSL/TLS configurations.
 

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -176,7 +176,7 @@ class AudioBuffer:
         chunks_ahead = seek_chunk - total_chunks
         return chunks_ahead <= SEEK_WAIT_THRESHOLD
 
-    async def get_raw_stream(self, seek_position_ms: int = 0) -> AsyncGenerator[bytes, None]:
+    async def get_raw_stream(self, seek_position_ms: int = 0) -> AsyncGenerator[bytes]:
         """
         Get raw (unprocessed) PCM audio from the buffer.
 
@@ -210,7 +210,7 @@ class AudioBuffer:
         output_format: AudioFormat,
         seek_position_ms: int = 0,
         filter_params: list[str] | None = None,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Get processed audio from the buffer.
 
@@ -236,7 +236,7 @@ class AudioBuffer:
         ):
             yield chunk
 
-    def fill(self, audio_source: AsyncGenerator[bytes, None], source_name: str = "unknown") -> None:
+    def fill(self, audio_source: AsyncGenerator[bytes], source_name: str = "unknown") -> None:
         """
         Start filling the buffer from an async generator of PCM audio chunks.
 

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -124,8 +124,8 @@ def _streaming_wav_header(output_format: AudioFormat) -> bytes:
 
 
 async def _wav_passthrough_stream(
-    audio_input: AsyncGenerator[bytes, None], output_format: AudioFormat
-) -> AsyncGenerator[bytes, None]:
+    audio_input: AsyncGenerator[bytes], output_format: AudioFormat
+) -> AsyncGenerator[bytes]:
     """Yield a WAV header followed by raw PCM bytes from ``audio_input``."""
     yield _streaming_wav_header(output_format)
     async for chunk in audio_input:
@@ -725,7 +725,7 @@ class StreamsController(CoreController):
             # skip the encode ffmpeg entirely and just stream a WAV header
             # followed by the raw PCM bytes — saves an ffmpeg process and the
             # latency of its internal buffer on every realtime stream.
-            audio_bytes: AsyncGenerator[bytes, None]
+            audio_bytes: AsyncGenerator[bytes]
             if (
                 queue_item.media_type == MediaType.AUDIO_SOURCE
                 and output_format.content_type == ContentType.WAV
@@ -1060,7 +1060,7 @@ class StreamsController(CoreController):
         player_id: str | None = None,
         force_flow_mode: bool = False,
         use_flow_stream_buffering: bool = False,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Get a stream of the given media as raw PCM audio.
 
@@ -1175,7 +1175,7 @@ class StreamsController(CoreController):
         provider_instance_id_or_domain: str,
         item_id: str,
         media_type: MediaType = MediaType.TRACK,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Create a 30 seconds preview audioclip for the given media item."""
         if not (music_prov := self.mass.get_provider(provider_instance_id_or_domain)):
             raise ProviderUnavailableError
@@ -1218,7 +1218,7 @@ class StreamsController(CoreController):
         output_format: AudioFormat,
         pre_announce: bool | str = False,
         pre_announce_url: str = ANNOUNCE_ALERT_FILE,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Get the special announcement stream."""
         announcement_data: asyncio.Queue[bytes | None] = asyncio.Queue(10)
         # we are doing announcement in PCM first to avoid multiple encodings
@@ -1257,7 +1257,7 @@ class StreamsController(CoreController):
 
         self.mass.create_task(fetch_announcement())
 
-        async def _announcement_stream() -> AsyncGenerator[bytes, None]:
+        async def _announcement_stream() -> AsyncGenerator[bytes]:
             """Generate the PCM audio stream for the announcement + optional pre-announce."""
             if pre_announce:
                 async for chunk in get_ffmpeg_stream(
@@ -1294,10 +1294,10 @@ class StreamsController(CoreController):
 
     async def _wrap_with_audio_source_lifecycle(
         self,
-        inner: AsyncGenerator[bytes, None],
+        inner: AsyncGenerator[bytes],
         queue_item: QueueItem,
         player_id: str,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Wrap an AudioSource queue item stream with on_source_selected/unselected hooks.
 

--- a/music_assistant/controllers/streams/ogg_handler.py
+++ b/music_assistant/controllers/streams/ogg_handler.py
@@ -408,7 +408,7 @@ async def get_chained_ogg_stream(
     mass: MusicAssistant,
     url: str,
     metadata_callback: Callable[[dict[str, str]], Any] | None = None,
-) -> AsyncGenerator[bytes, None]:
+) -> AsyncGenerator[bytes]:
     """
     Yield continuous OGG data from a chained stream, stitching chain boundaries.
 

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -94,9 +94,9 @@ class SmartFade(ABC):
     async def apply(
         self,
         fade_out_part: bytes,
-        fade_in_part: bytes | AsyncGenerator[bytes, None],
+        fade_in_part: bytes | AsyncGenerator[bytes],
         pcm_format: AudioFormat,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Apply the smart fade, yielding PCM audio chunks as they become available.
 
@@ -669,9 +669,9 @@ class StandardCrossFade(SmartFade):
     async def apply(
         self,
         fade_out_part: bytes,
-        fade_in_part: bytes | AsyncGenerator[bytes, None],
+        fade_in_part: bytes | AsyncGenerator[bytes],
         pcm_format: AudioFormat,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Apply standard crossfade, yielding PCM audio chunks.
 
@@ -687,7 +687,7 @@ class StandardCrossFade(SmartFade):
         # Collect only the crossfade portion from fade_in, keep the rest as a generator
         if isinstance(fade_in_part, bytes):
             adjusted_fade_in_part = fade_in_part[:crossfade_size]
-            post_crossfade: bytes | AsyncGenerator[bytes, None] = fade_in_part[crossfade_size:]
+            post_crossfade: bytes | AsyncGenerator[bytes] = fade_in_part[crossfade_size:]
         else:
             # read exactly crossfade_size bytes from the generator
             buf = bytearray()
@@ -699,7 +699,7 @@ class StandardCrossFade(SmartFade):
             # anything beyond crossfade_size plus the remaining generator is post_crossfade
             leftover = bytes(buf[crossfade_size:])
 
-            async def _post_crossfade() -> AsyncGenerator[bytes, None]:
+            async def _post_crossfade() -> AsyncGenerator[bytes]:
                 if leftover:
                     for pcm_slice in iter_pcm_slices(leftover, pcm_format, 1000):
                         yield pcm_slice

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -69,10 +69,10 @@ class SmartFadesMixer:
     async def mix(
         self,
         smart_fade: SmartFade,
-        fade_in_part: bytes | AsyncGenerator[bytes, None],
+        fade_in_part: bytes | AsyncGenerator[bytes],
         fade_out_part: bytes,
         pcm_format: AudioFormat,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Run the already-built SmartFade and yield mixed PCM audio chunks."""
         async for chunk in smart_fade.apply(fade_out_part, fade_in_part, pcm_format):
             yield chunk

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -325,9 +325,9 @@ def get_parts_from_position(
 
 
 async def realtime_pcm_pacer(
-    inner: AsyncGenerator[bytes, None],
+    inner: AsyncGenerator[bytes],
     pcm_format: AudioFormat,
-) -> AsyncGenerator[bytes, None]:
+) -> AsyncGenerator[bytes]:
     """
     Pace a PCM byte stream at the format's native rate.
 
@@ -357,11 +357,11 @@ async def realtime_pcm_pacer(
 
 
 async def audio_source_silence_keepalive(
-    inner: AsyncGenerator[bytes, None],
+    inner: AsyncGenerator[bytes],
     pcm_format: AudioFormat,
     silence_chunk_ms: int = 100,
     idle_threshold_s: float | None = None,
-) -> AsyncGenerator[bytes, None]:
+) -> AsyncGenerator[bytes]:
     """
     Wrap a live AudioSource PCM stream and emit silence during idle gaps.
 
@@ -442,7 +442,7 @@ async def audio_source_silence_keepalive(
 async def get_silence(
     duration: int,
     output_format: AudioFormat,
-) -> AsyncGenerator[bytes, None]:
+) -> AsyncGenerator[bytes]:
     """Create stream of silence, encoded to format of choice."""
     if output_format.content_type.is_pcm():
         # pcm = just zeros
@@ -482,11 +482,11 @@ async def get_silence(
 
 
 async def resample_pcm_audio(
-    input_audio: bytes | AsyncGenerator[bytes, None],
+    input_audio: bytes | AsyncGenerator[bytes],
     input_format: AudioFormat,
     output_format: AudioFormat,
     chunk_size: int | None = None,
-) -> AsyncGenerator[bytes, None]:
+) -> AsyncGenerator[bytes]:
     """
     Resample PCM audio from input_format to output_format using ffmpeg.
 
@@ -500,7 +500,7 @@ async def resample_pcm_audio(
     if chunk_size is None:
         chunk_size = output_format.pcm_sample_size
 
-    async def _as_generator() -> AsyncGenerator[bytes, None]:
+    async def _as_generator() -> AsyncGenerator[bytes]:
         if isinstance(input_audio, bytes):
             yield input_audio
         else:

--- a/music_assistant/helpers/buffered_generator.py
+++ b/music_assistant/helpers/buffered_generator.py
@@ -22,7 +22,7 @@ _ACTIVE_PRODUCER_TASKS: set[asyncio.Task[Any]] = set()
 
 
 async def _finalize_producer(
-    generator: AsyncGenerator[bytes, None],
+    generator: AsyncGenerator[bytes],
     completed_naturally: bool,
     buffer: asyncio.Queue[bytes | None],
     threshold_reached: asyncio.Event,
@@ -67,10 +67,10 @@ async def _shutdown_producer(
 
 
 async def buffered(
-    generator: AsyncGenerator[bytes, None],
+    generator: AsyncGenerator[bytes],
     buffer_size: int = DEFAULT_BUFFER_SIZE,
     min_buffer_before_yield: int = DEFAULT_MIN_BUFFER_BEFORE_YIELD,
-) -> AsyncGenerator[bytes, None]:
+) -> AsyncGenerator[bytes]:
     """
     Add buffering to an async generator that yields (chunks of) bytes.
 
@@ -168,8 +168,8 @@ def use_buffer(
     buffer_size: int = DEFAULT_BUFFER_SIZE,
     min_buffer_before_yield: int = DEFAULT_MIN_BUFFER_BEFORE_YIELD,
 ) -> Callable[
-    [Callable[_P, AsyncGenerator[bytes, None]]],
-    Callable[_P, AsyncGenerator[bytes, None]],
+    [Callable[_P, AsyncGenerator[bytes]]],
+    Callable[_P, AsyncGenerator[bytes]],
 ]:
     """
     Add buffering to async generator functions that yield bytes (decorator).
@@ -189,10 +189,10 @@ def use_buffer(
     """
 
     def decorator(
-        func: Callable[_P, AsyncGenerator[bytes, None]],
-    ) -> Callable[_P, AsyncGenerator[bytes, None]]:
+        func: Callable[_P, AsyncGenerator[bytes]],
+    ) -> Callable[_P, AsyncGenerator[bytes]]:
         @wraps(func)
-        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> AsyncGenerator[bytes, None]:
+        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> AsyncGenerator[bytes]:
             async for chunk in buffered(
                 func(*args, **kwargs),
                 buffer_size=buffer_size,

--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -304,7 +304,7 @@ class DatabaseConnection:
         self,
         table: str,
         match: dict[str, Any] | None = None,
-    ) -> AsyncGenerator[Mapping[str, Any], None]:
+    ) -> AsyncGenerator[Mapping[str, Any]]:
         """Iterate all items within a table."""
         limit: int = 500
         offset: int = 0

--- a/music_assistant/helpers/ffmpeg.py
+++ b/music_assistant/helpers/ffmpeg.py
@@ -76,7 +76,7 @@ class FFMpeg(AsyncProcess):
 
     def __init__(
         self,
-        audio_input: AsyncGenerator[bytes, None] | str | int,
+        audio_input: AsyncGenerator[bytes] | str | int,
         input_format: AudioFormat,
         output_format: AudioFormat,
         filter_params: list[str] | None = None,
@@ -353,7 +353,7 @@ def parse_ffmpeg_duration(line: str) -> int | None:
 
 
 async def get_ffmpeg_stream(
-    audio_input: AsyncGenerator[bytes, None] | str,
+    audio_input: AsyncGenerator[bytes] | str,
     input_format: AudioFormat,
     output_format: AudioFormat,
     filter_params: list[str] | None = None,
@@ -361,7 +361,7 @@ async def get_ffmpeg_stream(
     chunk_size: int | None = None,
     extra_input_args: list[str] | None = None,
     extra_output_args: list[str] | None = None,
-) -> AsyncGenerator[bytes, None]:
+) -> AsyncGenerator[bytes]:
     """
     Get the ffmpeg audio stream as async generator.
 

--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -126,7 +126,7 @@ class AsyncNamedPipeWriter:
 async def read_named_pipe(
     pipe_path: str,
     chunk_size: int = 4096,
-) -> AsyncGenerator[bytes, None]:
+) -> AsyncGenerator[bytes]:
     """
     Read raw bytes from a named pipe (FIFO) as an async generator.
 

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -128,7 +128,7 @@ class AsyncProcess:
             VERBOSE_LOG_LEVEL, "Process %s started with PID %s", self.name, self.proc.pid
         )
 
-    async def iter_chunked(self, n: int = DEFAULT_CHUNKSIZE) -> AsyncGenerator[bytes, None]:
+    async def iter_chunked(self, n: int = DEFAULT_CHUNKSIZE) -> AsyncGenerator[bytes]:
         """Yield chunks of n size from the process stdout."""
         while True:
             chunk = await self.readexactly(n)
@@ -136,7 +136,7 @@ class AsyncProcess:
                 break
             yield chunk
 
-    async def iter_any(self, n: int = DEFAULT_CHUNKSIZE) -> AsyncGenerator[bytes, None]:
+    async def iter_any(self, n: int = DEFAULT_CHUNKSIZE) -> AsyncGenerator[bytes]:
         """Yield chunks as they come in from process stdout."""
         while True:
             chunk = await self.read(n)
@@ -221,7 +221,7 @@ class AsyncProcess:
                 # raise for all other (value) errors
                 raise
 
-    async def iter_stderr(self) -> AsyncGenerator[str, None]:
+    async def iter_stderr(self) -> AsyncGenerator[str]:
         """Iterate lines from the stderr stream as string."""
         line: str | bytes
         while True:

--- a/music_assistant/helpers/throttle_retry.py
+++ b/music_assistant/helpers/throttle_retry.py
@@ -120,7 +120,7 @@ class ThrottlerManager:
         self.throttler = Throttler(rate_limit, period)
 
     @asynccontextmanager
-    async def acquire(self) -> AsyncGenerator[float, None]:
+    async def acquire(self) -> AsyncGenerator[float]:
         """Acquire a free slot from the Throttler, returns the throttled time."""
         if BYPASS_THROTTLER.get():
             yield 0
@@ -128,7 +128,7 @@ class ThrottlerManager:
             yield await self.throttler.acquire()
 
     @asynccontextmanager
-    async def bypass(self) -> AsyncGenerator[None, None]:
+    async def bypass(self) -> AsyncGenerator[None]:
         """Bypass the throttler."""
         try:
             token = BYPASS_THROTTLER.set(True)

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -901,7 +901,7 @@ def get_zeroconf_args(
     return {"ip_version": ip_version, "interfaces": InterfaceChoice.All}
 
 
-async def close_async_generator(agen: AsyncGenerator[Any, None]) -> None:
+async def close_async_generator(agen: AsyncGenerator[Any]) -> None:
     """Force close an async generator."""
     task = asyncio.create_task(agen.__anext__())
     task.cancel()

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -91,42 +91,42 @@ class MusicProvider(Provider):
             raise NotImplementedError
         return SearchResults()
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from the provider."""
         yield  # type: ignore[misc]
         raise NotImplementedError
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         yield  # type: ignore[misc]
         raise NotImplementedError
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         yield  # type: ignore[misc]
         raise NotImplementedError
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library/subscribed playlists from the provider."""
         yield  # type: ignore[misc]
         raise NotImplementedError
 
-    async def get_library_radios(self) -> AsyncGenerator[Radio, None]:
+    async def get_library_radios(self) -> AsyncGenerator[Radio]:
         """Retrieve library/subscribed radio stations from the provider."""
         yield  # type: ignore[misc]
         raise NotImplementedError
 
-    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook, None]:
+    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
         """Retrieve library/subscribed audiobooks from the provider."""
         yield  # type: ignore[misc]
         raise NotImplementedError
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library/subscribed podcasts from the provider."""
         yield  # type: ignore[misc]
         raise NotImplementedError
 
-    async def get_library_genres(self) -> AsyncGenerator[str, None]:
+    async def get_library_genres(self) -> AsyncGenerator[str]:
         """Retrieve library genres from the provider."""
         yield  # type: ignore[misc]
         raise NotImplementedError
@@ -226,7 +226,7 @@ class MusicProvider(Provider):
     async def get_podcast_episodes(
         self,
         prov_podcast_id: str,
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    ) -> AsyncGenerator[PodcastEpisode]:
         """Get all PodcastEpisodes for given podcast id.
 
         Only called if provider supports ProviderFeature.LIBRARY_PODCASTS.
@@ -429,7 +429,7 @@ class MusicProvider(Provider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Return the (custom) audio stream for the provider item.
 
@@ -1329,7 +1329,7 @@ class MusicProvider(Provider):
     async def iter_playlist_tracks(
         self,
         prov_playlist_id: str,
-    ) -> AsyncGenerator[PlaylistPlayableItem, None]:
+    ) -> AsyncGenerator[PlaylistPlayableItem]:
         """Iterate playlist tracks for the given provider playlist id."""
         page = 0
         while True:
@@ -1343,7 +1343,7 @@ class MusicProvider(Provider):
                 yield track
             page += 1
 
-    def _get_library_gen(self, media_type: MediaType) -> AsyncGenerator[MediaItemType, None]:
+    def _get_library_gen(self, media_type: MediaType) -> AsyncGenerator[MediaItemType]:
         """Return library generator for given media_type."""
         if media_type == MediaType.ARTIST:
             return self.get_library_artists()

--- a/music_assistant/models/plugin.py
+++ b/music_assistant/models/plugin.py
@@ -93,7 +93,7 @@ class PluginProvider(Provider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Return the (custom) audio stream for an AudioSource.
 

--- a/music_assistant/providers/_demo_music_provider/__init__.py
+++ b/music_assistant/providers/_demo_music_provider/__init__.py
@@ -212,7 +212,7 @@ class MyDemoMusicprovider(MusicProvider):
         # in general you should return a list of MediaItems for each media type.
         # For radio, a simple search of the available channel names is acceptable
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from the provider."""
         # OPTIONAL
         # Will only be called if you reported the LIBRARY_ARTISTS feature
@@ -252,7 +252,7 @@ class MyDemoMusicprovider(MusicProvider):
             },
         )
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         # OPTIONAL
         # Will only be called if you reported the LIBRARY_ALBUMS feature
@@ -268,7 +268,7 @@ class MyDemoMusicprovider(MusicProvider):
         # the 'sync_library' method.
         yield  # type: ignore[misc]
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         # OPTIONAL
         # Will only be called if you reported the LIBRARY_TRACKS feature
@@ -284,7 +284,7 @@ class MyDemoMusicprovider(MusicProvider):
         # the 'sync_library' method.
         yield  # type: ignore[misc]
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library/subscribed playlists from the provider."""
         # OPTIONAL
         # Will only be called if you reported the LIBRARY_PLAYLISTS feature
@@ -300,7 +300,7 @@ class MyDemoMusicprovider(MusicProvider):
         # the 'sync_library' method.
         yield  # type: ignore[misc]
 
-    async def get_library_radios(self) -> AsyncGenerator[Radio, None]:
+    async def get_library_radios(self) -> AsyncGenerator[Radio]:
         """Retrieve library/subscribed radio stations from the provider."""
         # OPTIONAL
         # Will only be called if you reported the LIBRARY_RADIOS feature
@@ -520,7 +520,7 @@ class MyDemoMusicprovider(MusicProvider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """
         Return the (custom) audio stream for the provider item.
 

--- a/music_assistant/providers/_demo_plugin_provider/__init__.py
+++ b/music_assistant/providers/_demo_plugin_provider/__init__.py
@@ -273,7 +273,7 @@ class MyDemoPluginprovider(PluginProvider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Yield raw audio bytes for the given streamdetails."""
         # OPTIONAL
         # Will only be called when get_stream_details returned

--- a/music_assistant/providers/airplay/stream_session.py
+++ b/music_assistant/providers/airplay/stream_session.py
@@ -60,7 +60,7 @@ class AirPlayStreamSession:
         self._pcm_buffer = bytearray()
         self._pcm_buffer_max = pcm_format.pcm_sample_size * 5  # 5 seconds
 
-    async def start(self, audio_source: AsyncGenerator[bytes, None]) -> None:
+    async def start(self, audio_source: AsyncGenerator[bytes]) -> None:
         """Initialize stream session for all players."""
         cur_time = time.time()
         wait_start = max(p.wait_start for p in self.sync_clients)
@@ -276,7 +276,7 @@ class AirPlayStreamSession:
                 )
                 await self.remove_client(airplay_player, reason="late joiner connection timeout")
 
-    async def _audio_streamer(self, audio_source: AsyncGenerator[bytes, None]) -> None:
+    async def _audio_streamer(self, audio_source: AsyncGenerator[bytes]) -> None:
         """Stream audio to all players."""
         stream_error: BaseException | None = None
         try:

--- a/music_assistant/providers/apple_music/api_client.py
+++ b/music_assistant/providers/apple_music/api_client.py
@@ -186,7 +186,7 @@ class AppleMusicAPIClient:
 
     async def iter_all_items(
         self, endpoint: str, key: str = "data", page_size: int = _LIBRARY_PAGE_SIZE, **kwargs: Any
-    ) -> AsyncGenerator[dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any]]:
         """
         Yield items from a paged list one page at a time.
 

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -34,7 +34,7 @@ class AppleMusicLibraryManager:
         self.api = provider.api_client
         self.logger = provider.logger
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from the provider."""
         endpoint = "me/library/artists"
         for item in await self.api.get_all_items(
@@ -43,7 +43,7 @@ class AppleMusicLibraryManager:
             if item and item["id"]:
                 yield cast("Artist", parse_artist(self.provider, item))
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         endpoint = "me/library/albums"
         album_items = await self.api.get_all_items(
@@ -74,7 +74,7 @@ class AppleMusicLibraryManager:
                 if album:
                     yield cast("Album", album)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         # Enrich and yield in bounded windows so the full library is never held in memory at once.
         catalog_items: dict[str, dict[str, Any]] = {}
@@ -140,7 +140,7 @@ class AppleMusicLibraryManager:
             return parsed_track
         return detailed_track
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve playlists from the provider."""
         endpoint = "me/library/playlists"
         playlist_items = await self.api.get_all_items(endpoint)
@@ -226,7 +226,7 @@ class AppleMusicLibraryManager:
 
     async def _flush_catalog_tracks(
         self, library_items_by_catalog_id: dict[str, dict[str, Any]]
-    ) -> AsyncGenerator[Track, None]:
+    ) -> AsyncGenerator[Track]:
         """Enrich one window of catalog-backed library tracks with catalog detail and yield them."""
         if not library_items_by_catalog_id:
             return
@@ -258,7 +258,7 @@ class AppleMusicLibraryManager:
 
     async def _flush_library_only_tracks(
         self, library_only_items: list[dict[str, Any]]
-    ) -> AsyncGenerator[Track, None]:
+    ) -> AsyncGenerator[Track]:
         """Enrich one window of library-only tracks (no catalog id) and yield them."""
         if not library_only_items:
             return

--- a/music_assistant/providers/apple_music/provider.py
+++ b/music_assistant/providers/apple_music/provider.py
@@ -163,22 +163,22 @@ class AppleMusicProvider(MusicProvider):
     # Library generators
     # ------------------------------------------------------------------
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from the provider."""
         async for item in self.library_manager.get_library_artists():
             yield item
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         async for item in self.library_manager.get_library_albums():
             yield item
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         async for item in self.library_manager.get_library_tracks():
             yield item
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve playlists from the provider."""
         async for item in self.library_manager.get_library_playlists():
             yield item

--- a/music_assistant/providers/ard_audiothek/__init__.py
+++ b/music_assistant/providers/ard_audiothek/__init__.py
@@ -425,7 +425,7 @@ class ARDAudiothek(MusicProvider):
             prov_radio_id,
         )
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library/subscribed podcasts from the provider.
 
         Minified podcast information is enough.
@@ -479,9 +479,7 @@ class ARDAudiothek(MusicProvider):
             prov_podcast_id,
         )
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get podcast episodes."""
         await self._update_progress()
         depublished_filter = {"isPublished": {"equalTo": True}}

--- a/music_assistant/providers/ariacast_receiver/__init__.py
+++ b/music_assistant/providers/ariacast_receiver/__init__.py
@@ -234,7 +234,7 @@ class AriaCastBridge(PluginProvider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Stream PCM audio frames from the binary's stdout pump."""
         consumer_queue = self._in_use_by_queue
         # Snapshot the active session id so a same-queue reconnect (which

--- a/music_assistant/providers/audible/__init__.py
+++ b/music_assistant/providers/audible/__init__.py
@@ -327,7 +327,7 @@ class Audibleprovider(MusicProvider):
         """Return True if the provider is a streaming provider."""
         return True
 
-    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook, None]:
+    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
         """Get all audiobooks from the library."""
         async for audiobook in self.helper.get_library():
             yield audiobook
@@ -517,7 +517,7 @@ class Audibleprovider(MusicProvider):
         """Return audiobooks from a specific publisher."""
         return await self.helper.get_audiobooks_by_publisher(publisher)
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Get all podcasts from the library."""
         async for podcast in self.helper.get_library_podcasts():
             yield podcast
@@ -526,9 +526,7 @@ class Audibleprovider(MusicProvider):
         """Get full podcast details by id."""
         return await self.helper.get_podcast(asin=prov_podcast_id)
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get all episodes for a podcast."""
         async for episode in self.helper.get_podcast_episodes(prov_podcast_id):
             yield episode

--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -151,7 +151,7 @@ class AudibleHelper:
         self,
         response_groups: str,
         content_types: tuple[str, ...],
-    ) -> AsyncGenerator[dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any]]:
         """Fetch items from the library with pagination."""
         page = 1
         page_size = 50
@@ -231,7 +231,7 @@ class AudibleHelper:
             )
             return None
 
-    async def get_library(self) -> AsyncGenerator[Audiobook, None]:
+    async def get_library(self) -> AsyncGenerator[Audiobook]:
         """Fetch the user's library with pagination."""
         response_groups = [
             "contributors",
@@ -699,7 +699,7 @@ class AudibleHelper:
             )
             return None
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Fetch podcasts from the user's library with pagination."""
         response_groups = [
             "contributors",
@@ -755,7 +755,7 @@ class AudibleHelper:
         )
         return self._parse_podcast(item_data)
 
-    async def get_podcast_episodes(self, podcast_asin: str) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, podcast_asin: str) -> AsyncGenerator[PodcastEpisode]:
         """Fetch all episodes for a podcast.
 
         :param podcast_asin: The ASIN of the parent podcast.

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -458,7 +458,7 @@ for more details.
         user = await self._client.get_my_user()
         await self._set_playlog_from_user(user)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve playlists from abs."""
         for playlist_dict, media_type in zip(
             [
@@ -649,7 +649,7 @@ for more details.
         )
         return False
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library/subscribed podcasts from the provider.
 
         Minified podcast information is enough.
@@ -700,9 +700,7 @@ for more details.
             base_url=str(self.config.get_value(CONF_URL)).rstrip("/"),
         )
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get all podcast episodes of podcast.
 
         Adds progress information.
@@ -766,7 +764,7 @@ for more details.
             episode_cnt += 1
         raise MediaNotFoundError("Episode not found")
 
-    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook, None]:
+    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
         """Get Audiobook libraries.
 
         Need expanded version for chapters.

--- a/music_assistant/providers/bandcamp/__init__.py
+++ b/music_assistant/providers/bandcamp/__init__.py
@@ -274,7 +274,7 @@ class BandcampProvider(MusicProvider):
             older_than_token = page.last_token
         return all_items
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from Bandcamp."""
         if not self._client.identity:  # library requires identity
             return
@@ -304,7 +304,7 @@ class BandcampProvider(MusicProvider):
         except BandcampAPIError as error:
             raise MediaNotFoundError("Failed to get library artists") from error
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from Bandcamp."""
         if not self._client.identity:  # library requires identity
             return
@@ -327,7 +327,7 @@ class BandcampProvider(MusicProvider):
         except BandcampAPIError as error:
             raise MediaNotFoundError("Failed to get library albums") from error
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Bandcamp."""
         if not self._client.identity:  # library requires identity
             return

--- a/music_assistant/providers/bbc_sounds/__init__.py
+++ b/music_assistant/providers/bbc_sounds/__init__.py
@@ -753,7 +753,7 @@ class BBCSoundsProvider(MusicProvider):
     async def get_podcast_episodes(
         self,
         prov_podcast_id: str,
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    ) -> AsyncGenerator[PodcastEpisode]:
         """Get all PodcastEpisodes for given podcast id."""
         podcast_episodes = await self.client.streaming.get_podcast_episodes(prov_podcast_id)
 

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -313,7 +313,7 @@ class BuiltinProvider(MusicProvider):
             metadata=metadata,
         )
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         stored_items: list[StoredItem] = self.mass.config.get(CONF_KEY_TRACKS, [])
         for item in stored_items:
@@ -322,7 +322,7 @@ class BuiltinProvider(MusicProvider):
             except MediaNotFoundError as err:
                 self.logger.warning("Track %s not found: %s", item, err)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library/subscribed playlists from the provider."""
         # return user stored playlists from M3U files on disk
         for filename in await asyncio.to_thread(os.listdir, self._playlists_dir):
@@ -339,7 +339,7 @@ class BuiltinProvider(MusicProvider):
                 continue
             yield await self.get_playlist(item_id)
 
-    async def get_library_radios(self) -> AsyncGenerator[Radio, None]:
+    async def get_library_radios(self) -> AsyncGenerator[Radio]:
         """Retrieve library/subscribed radio stations from the provider."""
         stored_items: list[StoredItem] = self.mass.config.get(CONF_KEY_RADIOS, [])
         for item in stored_items:

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -321,7 +321,7 @@ class DeezerProvider(MusicProvider):
 
         return results
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from Deezer."""
         async for artist in await self.client.get_user_artists():
             item = self.parse_artist(artist=artist)
@@ -329,7 +329,7 @@ class DeezerProvider(MusicProvider):
                 item.date_added = datetime.fromtimestamp(int(time_add), tz=UTC)
             yield item
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve all library albums from Deezer."""
         async for album in await self.client.get_user_albums():
             item = self.parse_album(album=album)
@@ -337,7 +337,7 @@ class DeezerProvider(MusicProvider):
                 item.date_added = datetime.fromtimestamp(int(time_add), tz=UTC)
             yield item
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve all library playlists from Deezer."""
         async for playlist in await self.user.get_playlists():
             item = self.parse_playlist(playlist=playlist)
@@ -345,7 +345,7 @@ class DeezerProvider(MusicProvider):
                 item.date_added = datetime.fromtimestamp(int(time_add), tz=UTC)
             yield item
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve all library tracks from Deezer."""
         async for track in await self.client.get_user_tracks():
             yield self.parse_track(track=track, user_country=self.gw_client.user_country)
@@ -773,7 +773,7 @@ class DeezerProvider(MusicProvider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Return the audio stream for the provider item."""
         blowfish_key = self.get_blowfish_key(streamdetails.data["track_id"])
         chunk_index = 0

--- a/music_assistant/providers/digitally_incorporated/__init__.py
+++ b/music_assistant/providers/digitally_incorporated/__init__.py
@@ -271,7 +271,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
         results.radio = radios
         return results
 
-    async def get_library_radios(self) -> AsyncGenerator[Radio, None]:
+    async def get_library_radios(self) -> AsyncGenerator[Radio]:
         """Retrieve all radio stations from active networks."""
         for network_key in self._get_active_networks():
             try:

--- a/music_assistant/providers/emby/__init__.py
+++ b/music_assistant/providers/emby/__init__.py
@@ -282,7 +282,7 @@ class EmbyProvider(MusicProvider):
             search_results.playlists = playlists.result()
         return search_results
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Yield all artists from the music library."""
         libs = await self._get_music_libraries()
         for lib in libs:
@@ -305,7 +305,7 @@ class EmbyProvider(MusicProvider):
                     yield parse_artist(self.instance_id, self, artist)
                 page += 1
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Yield all albums from the music library."""
         libs = await self._get_music_libraries()
         for lib in libs:
@@ -328,7 +328,7 @@ class EmbyProvider(MusicProvider):
                     yield parse_album(self.instance_id, self, album)
                 page += 1
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Yield all tracks from the music library."""
         libs = await self._get_music_libraries()
         for lib in libs:
@@ -353,7 +353,7 @@ class EmbyProvider(MusicProvider):
                     yield parse_track(self.instance_id, self, track)
                 page += 1
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Yield all playlists from the music library."""
         libs = await self._get_music_libraries()
         for lib in libs:

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -861,9 +861,7 @@ class LocalFileSystemProvider(MusicProvider):
 
         return result
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get podcast episodes for given podcast id."""
         episodes: list[PodcastEpisode] = []
 

--- a/music_assistant/providers/gpodder/__init__.py
+++ b/music_assistant/providers/gpodder/__init__.py
@@ -335,7 +335,7 @@ class GPodder(MusicProvider):
         # While the streams are remote, the user controls what is added.
         return False
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library/subscribed podcasts from the provider."""
         try:
             subscriptions = await self._client.get_subscriptions()
@@ -434,7 +434,7 @@ class GPodder(MusicProvider):
 
     async def get_podcast_episodes(
         self, prov_podcast_id: str, add_progress: bool = True
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    ) -> AsyncGenerator[PodcastEpisode]:
         """Get Podcast episodes. Add progress information."""
         if add_progress:
             episode_actions, timestamp = await self._client.get_episode_actions()

--- a/music_assistant/providers/hass_players/helpers.py
+++ b/music_assistant/providers/hass_players/helpers.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 async def get_hass_media_players(
     hass_prov: HomeAssistantProvider,
-) -> AsyncGenerator[HassState, None]:
+) -> AsyncGenerator[HassState]:
     """Return all HA state objects for (valid) media_player entities."""
     entity_registry = {x["entity_id"]: x for x in await hass_prov.hass.get_entity_registry()}
     for state in await hass_prov.hass.get_states():

--- a/music_assistant/providers/ibroadcast/__init__.py
+++ b/music_assistant/providers/ibroadcast/__init__.py
@@ -118,7 +118,7 @@ class IBroadcastProvider(MusicProvider):
         # temporary call to refresh library until ibroadcast provides a detailed api
         await self._client.refresh_library()
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from ibroadcast."""
         for album in (await self._client.get_albums()).values():
             try:
@@ -133,7 +133,7 @@ class IBroadcastProvider(MusicProvider):
         album_obj = await self._client.get_album(int(prov_album_id))
         return await self._parse_album(album_obj)
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from iBroadcast."""
         for artist in (await self._client.get_artists()).values():
             try:
@@ -177,7 +177,7 @@ class IBroadcastProvider(MusicProvider):
         artist_obj = await self._client.get_artist(int(prov_artist_id))
         return await self._parse_artist(artist_obj)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from iBroadcast."""
         for track in (await self._client.get_tracks()).values():
             try:
@@ -201,7 +201,7 @@ class IBroadcastProvider(MusicProvider):
             name=name,
         )
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve playlists from iBroadcast."""
         for playlist in (await self._client.get_playlists()).values():
             # Skip the auto generated playlist

--- a/music_assistant/providers/internet_archive/provider.py
+++ b/music_assistant/providers/internet_archive/provider.py
@@ -781,7 +781,7 @@ class InternetArchiveProvider(MusicProvider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Get audio stream from Internet Archive."""
         # Use sock_read=None to allow long audiobook chapters to stream fully
         timeout = aiohttp.ClientTimeout(sock_read=None, total=None)
@@ -884,9 +884,7 @@ class InternetArchiveProvider(MusicProvider):
 
         return podcast
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get podcast episodes for given podcast id."""
         metadata = await self._get_metadata(prov_podcast_id)
         item_metadata = metadata.get("metadata", {})

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -230,7 +230,7 @@ class ITunesPodcastsProvider(MusicProvider):
             podcast_list.append(podcast)
         return podcast_list
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Get library podcasts.
 
         We use get_library_podcasts to sync all feeds which have been added to the MA library
@@ -289,9 +289,7 @@ class ITunesPodcastsProvider(MusicProvider):
             domain=self.domain,
         )
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get podcast episodes."""
         podcast = await self._cache_get_podcast(prov_podcast_id)
         podcast_cover = podcast.get("cover_url")

--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -273,7 +273,7 @@ class JellyfinProvider(MusicProvider):
 
         return search_results
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from Jellyfin Music."""
         jellyfin_libraries = await self._get_music_libraries()
         for jellyfin_library in jellyfin_libraries:
@@ -286,7 +286,7 @@ class JellyfinProvider(MusicProvider):
             async for artist in stream:
                 yield parse_artist(self.logger, self.instance_id, self._client, artist)
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve all library albums from Jellyfin Music."""
         jellyfin_libraries = await self._get_music_libraries()
         for jellyfin_library in jellyfin_libraries:
@@ -299,7 +299,7 @@ class JellyfinProvider(MusicProvider):
             async for album in stream:
                 yield parse_album(self.logger, self.instance_id, self._client, album)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Jellyfin Music."""
         jellyfin_libraries = await self._get_music_libraries()
         for jellyfin_library in jellyfin_libraries:
@@ -317,7 +317,7 @@ class JellyfinProvider(MusicProvider):
                     continue
                 yield parse_track(self.logger, self.instance_id, self._client, track)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve all library playlists from the provider."""
         playlist_libraries = await self._get_playlists()
         for playlist_library in playlist_libraries:

--- a/music_assistant/providers/kion_music/provider.py
+++ b/music_assistant/providers/kion_music/provider.py
@@ -2317,7 +2317,7 @@ class KionMusicProvider(MusicProvider):
 
     # Library methods
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from KION Music."""
         artists = await self.client.get_liked_artists()
         for artist in artists:
@@ -2326,7 +2326,7 @@ class KionMusicProvider(MusicProvider):
             except InvalidDataError as err:
                 self.logger.debug("Error parsing library artist: %s", err)
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from KION Music."""
         batch_size = TRACK_BATCH_SIZE
         albums = await self.client.get_liked_albums(batch_size=batch_size)
@@ -2336,7 +2336,7 @@ class KionMusicProvider(MusicProvider):
             except InvalidDataError as err:
                 self.logger.debug("Error parsing library album: %s", err)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from KION Music."""
         track_shorts = await self.client.get_liked_tracks()
         if not track_shorts:
@@ -2354,7 +2354,7 @@ class KionMusicProvider(MusicProvider):
                 except InvalidDataError as err:
                     self.logger.debug("Error parsing library track: %s", err)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library playlists from KION Music.
 
         Includes virtual playlists (My Mix and Liked Tracks if enabled), user-created playlists,
@@ -2441,7 +2441,7 @@ class KionMusicProvider(MusicProvider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Return the audio stream for the provider item.
 
         Uses windowed Range-request streaming to prevent Kion CDN drops.

--- a/music_assistant/providers/kion_music/streaming.py
+++ b/music_assistant/providers/kion_music/streaming.py
@@ -525,7 +525,7 @@ class KionMusicStreamingManager:
         key_bytes: bytes,
         block_size: int,
         bytes_delivered: int,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Decrypt one HTTP response and yield plaintext chunks.
 
         Aligns the AES-CTR counter to the correct block for resumption.
@@ -624,7 +624,7 @@ class KionMusicStreamingManager:
         response: Any,
         bytes_delivered: int,
         block_start: int,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Yield raw (unencrypted) chunks from one HTTP response.
 
         If the server ignored the Range header (200 instead of 206), skips the
@@ -738,7 +738,7 @@ class KionMusicStreamingManager:
 
     async def get_audio_stream(  # noqa: PLR0915
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Return the audio stream via windowed Range requests.
 
         Handles both raw (direct) and encraw (AES-CTR encrypted) transports.

--- a/music_assistant/providers/musicme/provider.py
+++ b/music_assistant/providers/musicme/provider.py
@@ -359,7 +359,7 @@ class MusicMeProvider(MusicProvider):
 
     # ---- library ----
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library playlists from MusicMe."""
         data = await self._api_get('/playlists?resources=home{details:"list"}')
         if not data:

--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -1574,7 +1574,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
 
         return await self._get_playlist_tracks_cached(prov_playlist_id, page)
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve favorite artists from NCM."""
         limit = 200
         offset = 0
@@ -1598,7 +1598,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
             if not has_more and len(artists) < limit:
                 break
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve favorite albums from NCM."""
         limit = 200
         offset = 0
@@ -1622,7 +1622,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
             if not has_more and len(albums) < limit:
                 break
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve liked tracks from NCM."""
         payload = await self._client.get(
             "/likelist",
@@ -1642,7 +1642,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
                 with suppress(InvalidDataError):
                     yield self._parse_track(song_obj)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve user playlists from NCM."""
         payload = await self._client.get(
             "/user/playlist",

--- a/music_assistant/providers/nicovideo/provider_mixins/artist.py
+++ b/music_assistant/providers/nicovideo/provider_mixins/artist.py
@@ -33,7 +33,7 @@ class NicovideoMusicProviderArtistMixin(NicovideoMusicProviderMixinBase):
     @override
     async def get_library_artists(
         self,
-    ) -> AsyncGenerator[Artist, None]:
+    ) -> AsyncGenerator[Artist]:
         """Retrieve library artists from the provider."""
         # Include followed artists if user is logged in
         following_artists = await self.service_manager.user.get_own_followings()

--- a/music_assistant/providers/nicovideo/provider_mixins/playlist.py
+++ b/music_assistant/providers/nicovideo/provider_mixins/playlist.py
@@ -52,7 +52,7 @@ class NicovideoMusicProviderPlaylistMixin(NicovideoMusicProviderMixinBase):
     @override
     async def get_library_playlists(
         self,
-    ) -> AsyncGenerator[Playlist, None]:
+    ) -> AsyncGenerator[Playlist]:
         """Retrieve library playlists from the provider."""
         # Get own mylists (editable playlists)
         own_mylists = await self.service_manager.mylist.get_own_mylists()

--- a/music_assistant/providers/nicovideo/provider_mixins/track.py
+++ b/music_assistant/providers/nicovideo/provider_mixins/track.py
@@ -50,7 +50,7 @@ class NicovideoMusicProviderTrackMixin(NicovideoMusicProviderMixinBase):
     @override
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Get audio stream with dynamic playlist generation for optimized seeking.
 
         Args:

--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -108,21 +108,21 @@ class NugsProvider(MusicProvider):
         """Handle async initialization of the provider."""
         await self.login()
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from nugs.net."""
         artist_data = await self._get_all_items("stash", "artists/favorite/")
         for item in artist_data:
             if item and item["id"]:
                 yield self._parse_artist(item)
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         album_data = await self._get_all_items("stash", "releases/favorite")
         for item in album_data:
             if item and item["id"]:
                 yield self._parse_album(item)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve playlists from the provider."""
         playlist_data = await self._get_all_items("stash", "playlists/")
         for item in playlist_data:

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -277,7 +277,7 @@ class OpenSonicProvider(MusicProvider):
         else:
             await self.conn.unstar(sids=track_ids, album_ids=album_ids, artist_ids=artist_ids)
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Provide a generator for reading all artists."""
         artists = await self.conn.get_artists()
 
@@ -291,7 +291,7 @@ class OpenSonicProvider(MusicProvider):
             for artist in index.artist:
                 yield parse_artist(self.instance_id, artist)
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """
         Provide a generator for reading all artists.
 
@@ -315,13 +315,13 @@ class OpenSonicProvider(MusicProvider):
                 offset=offset,
             )
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Provide a generator for library playlists."""
         results = await self.conn.get_playlists()
         for entry in results:
             yield parse_playlist(self.instance_id, entry)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """
         Provide a generator for library tracks.
 
@@ -491,7 +491,7 @@ class OpenSonicProvider(MusicProvider):
     async def get_podcast_episodes(
         self,
         prov_podcast_id: str,
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    ) -> AsyncGenerator[PodcastEpisode]:
         """Get all Episodes for given podcast id."""
         if not self._enable_podcasts:
             return
@@ -515,7 +515,7 @@ class OpenSonicProvider(MusicProvider):
 
         return parse_podcast(self.instance_id, channels[0])
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library/subscribed podcasts from the provider."""
         if self._enable_podcasts:
             channels = await self.conn.get_podcasts(inc_episodes=True)
@@ -782,7 +782,7 @@ class OpenSonicProvider(MusicProvider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Provide a generator for the stream data."""
         # ignore seek position if the server does not support it
         # in that case we let the core handle seeking

--- a/music_assistant/providers/orf_radiothek/__init__.py
+++ b/music_assistant/providers/orf_radiothek/__init__.py
@@ -730,9 +730,7 @@ class RadiothekProvider(MusicProvider):
 
         raise MediaNotFoundError("Podcast not found.")
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get episodes of a specific podcast."""
         bundle = await self._get_bundle()
 

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -288,7 +288,7 @@ class PandoraProvider(MusicProvider):
             },
         )
 
-    async def get_library_radios(self) -> AsyncGenerator[Radio, None]:
+    async def get_library_radios(self) -> AsyncGenerator[Radio]:
         """Retrieve library/subscribed radio stations from the provider."""
         response = await self._api_request(
             "POST",

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -140,7 +140,7 @@ class PhishInProvider(MusicProvider):
             self.logger.error("Search failed for query '%s': %s", search_query, err)
             raise ProviderUnavailableError(f"Search error: {err}") from err
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from the provider."""
         yield await get_phish_artist(self)
 
@@ -353,7 +353,7 @@ class PhishInProvider(MusicProvider):
             params={"per_page": 20, "sort": "date:desc", "audio_status": "complete_or_partial"},
         )
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library playlists from the provider."""
         try:
             for playlist_data in await self._get_playlists():

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -957,19 +957,19 @@ class PlexProvider(MusicProvider):
 
         return search_results
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from Plex Music."""
         artists_obj = await self._run_async(self._plex_library.all)
         for artist in artists_obj:
             yield await self._parse_artist(artist)
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve all library albums from Plex Music."""
         albums_obj = await self._run_async(self._plex_library.albums)
         for album in albums_obj:
             yield await self._parse_album(album)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve all library playlists from the provider."""
         playlists_obj = await self._run_async(self._plex_library.playlists)
         for playlist in playlists_obj:
@@ -981,7 +981,7 @@ class PlexProvider(MusicProvider):
             for collection in collections_obj:
                 yield await self._parse_collection(collection)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Plex Music."""
         page_size = 500
         offset = 0

--- a/music_assistant/providers/podcast_index/provider.py
+++ b/music_assistant/providers/podcast_index/provider.py
@@ -226,9 +226,7 @@ class PodcastIndexProvider(MusicProvider):
 
         raise MediaNotFoundError(f"Podcast {prov_podcast_id} not found")
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get episodes for a podcast."""
         self.logger.debug("Getting episodes for podcast ID: %s", prov_podcast_id)
 

--- a/music_assistant/providers/podcastfeed/__init__.py
+++ b/music_assistant/providers/podcastfeed/__init__.py
@@ -128,7 +128,7 @@ class PodcastMusicprovider(MusicProvider):
         """Return a (default) instance name postfix for this provider instance."""
         return self.parsed_podcast.get("title")
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library/subscribed podcasts from the provider."""
         """
         Only one podcast per rss feed is supported. The data format of the rss feed supports
@@ -158,7 +158,7 @@ class PodcastMusicprovider(MusicProvider):
     async def get_podcast_episodes(
         self,
         prov_podcast_id: str,
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    ) -> AsyncGenerator[PodcastEpisode]:
         """List all episodes for the podcast."""
         if prov_podcast_id != self.podcast_id:
             raise Exception(f"Podcast id not in provider: {prov_podcast_id}")

--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -222,28 +222,28 @@ class QobuzProvider(MusicProvider):
                 ]
         return result
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from Qobuz."""
         endpoint = "favorite/getUserFavorites"
         for item in await self._get_all_items(endpoint, key="artists", type="artists"):
             if item and item["id"]:
                 yield self._parse_artist(item)
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve all library albums from Qobuz."""
         endpoint = "favorite/getUserFavorites"
         for item in await self._get_all_items(endpoint, key="albums", type="albums"):
             if item and item["id"]:
                 yield await self._parse_album(item)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Qobuz."""
         endpoint = "favorite/getUserFavorites"
         for item in await self._get_all_items(endpoint, key="tracks", type="tracks"):
             if item and item["id"]:
                 yield await self._parse_track(item)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve all library playlists from the provider."""
         endpoint = "playlist/getUserPlaylists"
         for item in await self._get_all_items(endpoint, key="playlists"):

--- a/music_assistant/providers/qqmusic/__init__.py
+++ b/music_assistant/providers/qqmusic/__init__.py
@@ -1174,7 +1174,7 @@ class QQMusicProvider(MusicProvider):
             self.logger.debug("Failed to load QQ Music lyrics for %s: %s", prov_track_id, err)
         return track
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve followed artists from QQ Music."""
         euin = await self._ensure_user_euin()
         page = 1
@@ -1211,7 +1211,7 @@ class QQMusicProvider(MusicProvider):
             page += 1
         self.logger.info("QQ library artists sync yielded %s artist(s)", total_yielded)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from QQ Music."""
         euin = await self._ensure_user_euin()
         page = 1
@@ -1237,7 +1237,7 @@ class QQMusicProvider(MusicProvider):
                 break
             page += 1
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from QQ Music."""
         euin = await self._ensure_user_euin()
         page = 1
@@ -1272,7 +1272,7 @@ class QQMusicProvider(MusicProvider):
             page += 1
         self.logger.info("QQ library albums sync yielded %s album(s)", total_yielded)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve user playlists from QQ Music."""
         euin = await self._ensure_user_euin()
         created = await self._run_with_session(

--- a/music_assistant/providers/siriusxm/__init__.py
+++ b/music_assistant/providers/siriusxm/__init__.py
@@ -202,7 +202,7 @@ class SiriusXMProvider(MusicProvider):
         """
         return True
 
-    async def get_library_radios(self) -> AsyncGenerator[Radio, None]:
+    async def get_library_radios(self) -> AsyncGenerator[Radio]:
         """Retrieve library/subscribed radio stations from the provider."""
         for channel in self._channels_by_id.values():
             if channel.is_favorite:

--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -157,7 +157,7 @@ class SoundcloudMusicProvider(MusicProvider):
 
         return result
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from Soundcloud."""
         time_start = time.time()
 
@@ -173,7 +173,7 @@ class SoundcloudMusicProvider(MusicProvider):
                 self.logger.debug("Parse artist failed: %s", artist, exc_info=error)
                 continue
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve all library playlists from Soundcloud."""
         time_start = time.time()
         async for item in self._soundcloud.get_account_playlists():
@@ -205,7 +205,7 @@ class SoundcloudMusicProvider(MusicProvider):
             round(time.time() - time_start, 2),
         )
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Soundcloud."""
         time_start = time.time()
         async for track in self._soundcloud.get_track_details_liked(self._user_id):

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -162,7 +162,7 @@ class SpotifyProvider(MusicProvider):
         return None
 
     ## Library retrieval methods (generators)
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from spotify."""
         endpoint = "me/following"
         while True:
@@ -180,19 +180,19 @@ class SpotifyProvider(MusicProvider):
             else:
                 break
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         async for item in self._get_all_items("me/albums"):
             if item["album"] and item["album"]["id"]:
                 yield parse_album(item["album"], self)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         async for item in self._get_all_items("me/tracks"):
             if item and item["track"]["id"]:
                 yield parse_track(item["track"], self)
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library podcasts from spotify."""
         async for item in self._get_all_items("me/shows"):
             if item["show"] and item["show"]["id"]:
@@ -203,7 +203,7 @@ class SpotifyProvider(MusicProvider):
                     continue
                 yield parse_podcast(show_obj, self)
 
-    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook, None]:
+    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
         """Retrieve library audiobooks from spotify."""
         if not self.audiobooks_supported:
             return
@@ -215,7 +215,7 @@ class SpotifyProvider(MusicProvider):
                 await self._add_audiobook_chapters(audiobook)
                 yield audiobook
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve playlists from the provider.
 
         Note: We use the global session here because playlists like "Daily Mix"
@@ -424,9 +424,7 @@ class SpotifyProvider(MusicProvider):
 
         return audiobook
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get all podcast episodes."""
         podcast = await self.get_podcast(prov_podcast_id)
 
@@ -794,7 +792,7 @@ class SpotifyProvider(MusicProvider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Get audio stream from Spotify via librespot."""
         if streamdetails.media_type == MediaType.AUDIOBOOK and isinstance(streamdetails.data, dict):
             chapter_uris = streamdetails.data.get("chapters", [])
@@ -1143,7 +1141,7 @@ class SpotifyProvider(MusicProvider):
 
     async def _get_all_items(
         self, endpoint: str, key: str = "items", limit: int = 50, **kwargs: Any
-    ) -> AsyncGenerator[dict[str, Any], None]:
+    ) -> AsyncGenerator[dict[str, Any]]:
         """Get all items from a paged list."""
         offset = 0
         # single request to fetch the etag (used as cache checksum) and total

--- a/music_assistant/providers/spotify/streaming.py
+++ b/music_assistant/providers/spotify/streaming.py
@@ -28,7 +28,7 @@ class LibrespotStreamer:
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Return the audio stream for the provider item."""
         # Regular track/episode streaming - audiobooks are handled in the provider
         media_type = "episode" if streamdetails.media_type == MediaType.PODCAST_EPISODE else "track"
@@ -38,7 +38,7 @@ class LibrespotStreamer:
 
     async def stream_spotify_uri(
         self, spotify_uri: str, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Return the audio stream for the Spotify URI."""
         self.provider.logger.log(
             VERBOSE_LOG_LEVEL, f"Start streaming {spotify_uri} using librespot"

--- a/music_assistant/providers/squeezelite/multi_client_stream.py
+++ b/music_assistant/providers/squeezelite/multi_client_stream.py
@@ -18,7 +18,7 @@ class MultiClientStream:
 
     def __init__(
         self,
-        audio_source: AsyncGenerator[bytes, None],
+        audio_source: AsyncGenerator[bytes],
         audio_format: AudioFormat,
         expected_clients: int = 0,
     ) -> None:
@@ -48,7 +48,7 @@ class MultiClientStream:
         self,
         output_format: AudioFormat,
         filter_params: list[str] | None = None,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Get (client specific encoded) ffmpeg stream."""
         async for chunk in get_ffmpeg_stream(
             audio_input=self.subscribe_raw(),
@@ -58,7 +58,7 @@ class MultiClientStream:
         ):
             yield chunk
 
-    async def subscribe_raw(self) -> AsyncGenerator[bytes, None]:
+    async def subscribe_raw(self) -> AsyncGenerator[bytes]:
         """Subscribe to the raw/unaltered audio stream."""
         queue: asyncio.Queue[bytes] = asyncio.Queue(2)
         try:

--- a/music_assistant/providers/test/__init__.py
+++ b/music_assistant/providers/test/__init__.py
@@ -150,7 +150,7 @@ class TestProvider(MusicProvider):
         """Return True if the provider is a streaming provider."""
         return False
 
-    async def get_library_genres(self) -> AsyncGenerator[str, None]:
+    async def get_library_genres(self) -> AsyncGenerator[str]:
         """Retrieve library genres from the provider."""
         for genre in DEFAULT_GENRES:
             yield genre
@@ -283,14 +283,14 @@ class TestProvider(MusicProvider):
             duration=60,
         )
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from the provider."""
         num_artists = self.config.get_value(CONF_KEY_NUM_ARTISTS)
         assert isinstance(num_artists, int)
         for artist_idx in range(num_artists):
             yield await self.get_artist(str(artist_idx))
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         num_artists = self.config.get_value(CONF_KEY_NUM_ARTISTS) or 5
         assert isinstance(num_artists, int)
@@ -301,7 +301,7 @@ class TestProvider(MusicProvider):
                 album_item_id = f"{artist_idx}_{album_idx}"
                 yield await self.get_album(album_item_id)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         num_artists = self.config.get_value(CONF_KEY_NUM_ARTISTS) or 5
         assert isinstance(num_artists, int)
@@ -315,14 +315,14 @@ class TestProvider(MusicProvider):
                     track_item_id = f"{artist_idx}_{album_idx}_{track_idx}"
                     yield await self.get_track(track_item_id)
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library tracks from the provider."""
         num_podcasts = self.config.get_value(CONF_KEY_NUM_PODCASTS)
         assert isinstance(num_podcasts, int)
         for podcast_idx in range(num_podcasts):
             yield await self.get_podcast(str(podcast_idx))
 
-    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook, None]:
+    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
         """Retrieve library audiobooks from the provider."""
         num_audiobooks = self.config.get_value(CONF_KEY_NUM_AUDIOBOOKS)
         assert isinstance(num_audiobooks, int)
@@ -332,7 +332,7 @@ class TestProvider(MusicProvider):
     async def get_podcast_episodes(
         self,
         prov_podcast_id: str,
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    ) -> AsyncGenerator[PodcastEpisode]:
         """Get all PodcastEpisodes for given podcast id."""
         num_episodes = 25
         for episode_idx in range(num_episodes):

--- a/music_assistant/providers/tidal/api_client.py
+++ b/music_assistant/providers/tidal/api_client.py
@@ -164,7 +164,7 @@ class TidalAPIClient:
         limit: int = 50,
         cursor_based: bool = False,
         **kwargs: Any,
-    ) -> AsyncGenerator[Any, None]:
+    ) -> AsyncGenerator[Any]:
         """Paginate through all items from a Tidal API endpoint."""
         offset = 0
         cursor = None

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -42,28 +42,28 @@ class TidalLibraryManager:
         self.auth = provider.auth
         self.logger = provider.logger
 
-    async def get_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists."""
         path = f"users/{self.auth.user_id}/{FAVORITES_ARTISTS}"
         async for item in self.api.paginate(path):
             if item and item.get("item") and item["item"].get("id"):
                 yield parse_artist(self.provider, item)
 
-    async def get_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums."""
         path = f"users/{self.auth.user_id}/{FAVORITES_ALBUMS}"
         async for item in self.api.paginate(path):
             if item and item.get("item") and item["item"].get("id"):
                 yield parse_album(self.provider, item)
 
-    async def get_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks."""
         path = f"users/{self.auth.user_id}/{FAVORITES_TRACKS}"
         async for item in self.api.paginate(path):
             if item and item.get("item") and item["item"].get("id"):
                 yield parse_track(self.provider, item)
 
-    async def get_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library playlists."""
         # 1. Get favorite mixes
         async for item in self.api.paginate(

--- a/music_assistant/providers/tidal/provider.py
+++ b/music_assistant/providers/tidal/provider.py
@@ -197,22 +197,22 @@ class TidalProvider(MusicProvider):
             name=name,
         )
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from Tidal."""
         async for item in self.library.get_artists():
             yield item
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve all library albums from Tidal."""
         async for item in self.library.get_albums():
             yield item
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Tidal."""
         async for item in self.library.get_tracks():
             yield item
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve all library playlists from the provider."""
         async for item in self.library.get_playlists():
             yield item

--- a/music_assistant/providers/tunein/__init__.py
+++ b/music_assistant/providers/tunein/__init__.py
@@ -199,12 +199,12 @@ class TuneInProvider(MusicProvider):
                         result.append(self._parse_radio_lazy(child))
         return result
 
-    async def get_library_radios(self) -> AsyncGenerator[Radio, None]:
+    async def get_library_radios(self) -> AsyncGenerator[Radio]:
         """Retrieve library/subscribed radio stations from the provider."""
 
         async def parse_items(
             items: list[dict[str, Any]], folder: str | None = None
-        ) -> AsyncGenerator[Radio, None]:
+        ) -> AsyncGenerator[Radio]:
             for item in items:
                 item_type = item.get("type", "")
                 if "unavailable" in item.get("key", ""):

--- a/music_assistant/providers/universal_group/ugp_stream.py
+++ b/music_assistant/providers/universal_group/ugp_stream.py
@@ -35,7 +35,7 @@ class UGPStream:
 
     def __init__(
         self,
-        audio_source: AsyncGenerator[bytes, None],
+        audio_source: AsyncGenerator[bytes],
         audio_format: AudioFormat,
         base_pcm_format: AudioFormat,
     ) -> None:
@@ -62,7 +62,7 @@ class UGPStream:
                 await self._task
         self._done.set()
 
-    async def subscribe_raw(self) -> AsyncGenerator[bytes, None]:
+    async def subscribe_raw(self) -> AsyncGenerator[bytes]:
         """
         Subscribe to the raw/unaltered audio stream.
 
@@ -86,7 +86,7 @@ class UGPStream:
 
     async def get_stream(
         self, output_format: AudioFormat, filter_params: list[str] | None = None
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Subscribe to the client specific audio stream."""
         # start the runner as soon as the (first) client connects
         async for chunk in get_ffmpeg_stream(

--- a/music_assistant/providers/vban_receiver/provider.py
+++ b/music_assistant/providers/vban_receiver/provider.py
@@ -195,7 +195,7 @@ class VBANReceiverProvider(PluginProvider):
 
     async def get_audio_stream(  # noqa: PLR0915
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Yield raw PCM chunks from the VBANIncomingStream queue."""
         assert self._vban_stream  # for type checking
         assert self._udp_socket_fut  # for type checking

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -2093,9 +2093,7 @@ class YandexMusicProvider(MusicProvider):
             raise MediaNotFoundError(f"Podcast {prov_podcast_id} not found")
         return parse_podcast(self, album)
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Iterate podcast episodes for a given podcast (album) ID."""
         album = await self.client.get_album_with_tracks(prov_podcast_id)
         if not album:
@@ -3049,7 +3047,7 @@ class YandexMusicProvider(MusicProvider):
 
     # Library methods
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from Yandex Music."""
         artists = await self.client.get_liked_artists()
         for artist in artists:
@@ -3077,7 +3075,7 @@ class YandexMusicProvider(MusicProvider):
             self._liked_albums_cache = (now, albums)
             return albums
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from Yandex Music.
 
         Excludes entries classified as podcasts or audiobooks so they don't
@@ -3091,7 +3089,7 @@ class YandexMusicProvider(MusicProvider):
             except InvalidDataError as err:
                 self.logger.debug("Error parsing library album: %s", err)
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve library podcasts from Yandex Music (filtered liked albums)."""
         for album in await self._get_liked_albums_cached():
             if classify_album(album) != "podcast":
@@ -3101,7 +3099,7 @@ class YandexMusicProvider(MusicProvider):
             except InvalidDataError as err:
                 self.logger.debug("Error parsing library podcast: %s", err)
 
-    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook, None]:
+    async def get_library_audiobooks(self) -> AsyncGenerator[Audiobook]:
         """Retrieve library audiobooks from Yandex Music (filtered liked albums)."""
         for album in await self._get_liked_albums_cached():
             if classify_album(album) != "audiobook":
@@ -3111,7 +3109,7 @@ class YandexMusicProvider(MusicProvider):
             except InvalidDataError as err:
                 self.logger.debug("Error parsing library audiobook: %s", err)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Yandex Music."""
         track_shorts = await self.client.get_liked_tracks()
         if not track_shorts:
@@ -3129,7 +3127,7 @@ class YandexMusicProvider(MusicProvider):
                 except InvalidDataError as err:
                     self.logger.debug("Error parsing library track: %s", err)
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library playlists from Yandex Music.
 
         Includes virtual playlists (My Wave and Liked Tracks if enabled), user-created playlists,
@@ -3274,7 +3272,7 @@ class YandexMusicProvider(MusicProvider):
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Return the audio stream for the provider item.
 
         For tracks and podcast episodes, streams via windowed Range requests
@@ -3329,7 +3327,7 @@ class YandexMusicProvider(MusicProvider):
 
     async def _stream_audiobook_chapters(
         self, data: dict[str, Any], seek_position: int
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Concatenate per-chapter streams of an audiobook.
 
         Translates ``seek_position`` into (start_chapter, in_chapter_offset) and

--- a/music_assistant/providers/yandex_music/streaming.py
+++ b/music_assistant/providers/yandex_music/streaming.py
@@ -541,7 +541,7 @@ class YandexMusicStreamingManager:
         key_bytes: bytes,
         block_size: int,
         bytes_delivered: int,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Decrypt one HTTP response and yield plaintext chunks.
 
         Aligns the AES-CTR counter to the correct block for resumption.
@@ -640,7 +640,7 @@ class YandexMusicStreamingManager:
         response: Any,
         bytes_delivered: int,
         block_start: int,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Yield raw (unencrypted) chunks from one HTTP response.
 
         If the server ignored the Range header (200 instead of 206), skips the
@@ -738,7 +738,7 @@ class YandexMusicStreamingManager:
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Return the audio stream via windowed Range requests.
 
         Handles both raw (direct) and encraw (AES-CTR encrypted) transports.

--- a/music_assistant/providers/yandex_ynison/protocols.py
+++ b/music_assistant/providers/yandex_ynison/protocols.py
@@ -24,7 +24,7 @@ class YandexMusicProviderLike(Protocol):
         """Resolve stream details for a track."""
         ...
 
-    def get_audio_stream(self, stream_details: StreamDetails) -> AsyncGenerator[bytes, None]:
+    def get_audio_stream(self, stream_details: StreamDetails) -> AsyncGenerator[bytes]:
         """Return async generator of raw audio bytes."""
         ...
 

--- a/music_assistant/providers/yandex_ynison/provider.py
+++ b/music_assistant/providers/yandex_ynison/provider.py
@@ -390,7 +390,7 @@ class YandexYnisonProvider(PluginProvider):
 
     async def get_audio_stream(  # noqa: PLR0915
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Return continuous audio stream following Ynison track changes.
 
         Streams the current track, then waits for track changes and streams
@@ -578,7 +578,7 @@ class YandexYnisonProvider(PluginProvider):
         track_id: str,
         seek_ms: int = 0,
         session_params: dict[str, Any] | None = None,
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         """Stream a single track, normalizing to fixed PCM via per-track ffmpeg.
 
         Every track is decoded through its own ffmpeg process to produce a

--- a/music_assistant/providers/yousee/api_client.py
+++ b/music_assistant/providers/yousee/api_client.py
@@ -81,7 +81,7 @@ class YouSeeAPIClient:
         page_path: list[str],
         variables_first_key: str = "first",
         variables_after_key: str = "after",
-    ) -> AsyncGenerator[JsonLike, None]:
+    ) -> AsyncGenerator[JsonLike]:
         """Paginate GraphQL results."""
         after = None
         has_more = True

--- a/music_assistant/providers/yousee/library.py
+++ b/music_assistant/providers/yousee/library.py
@@ -33,7 +33,7 @@ class YouSeeLibraryManager:
         self.auth = provider.auth
         self.logger = provider.logger
 
-    async def get_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from the provider."""
         query = """
         query favoriteArtists($first: Int!, $after: String, $imageSize: Int = 512) {
@@ -64,7 +64,7 @@ class YouSeeLibraryManager:
             self.logger.log(VERBOSE_LOG_LEVEL, "Parsing artist item: %s", item)
             yield parse_artist(self.provider, item)
 
-    async def get_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         query = """
         query favoriteAlbums($first: Int!, $after: String, $imageSize: Int = 512) {
@@ -99,7 +99,7 @@ class YouSeeLibraryManager:
             self.logger.log(VERBOSE_LOG_LEVEL, "Parsing album item: %s", item)
             yield await parse_album(self.provider, item)
 
-    async def get_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         query = """
             query favoriteTracks($first: Int!, $after: String, $imageSize: Int = 512) {
@@ -150,7 +150,7 @@ class YouSeeLibraryManager:
             self.logger.log(VERBOSE_LOG_LEVEL, "Parsing track item: %s", item)
             yield await parse_track(self.provider, item)
 
-    async def get_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library/subscribed playlists from the provider."""
         query = """
             query favoritePlaylists($first: Int!, $after: String, $imageSize: Int = 512) {

--- a/music_assistant/providers/yousee/provider.py
+++ b/music_assistant/providers/yousee/provider.py
@@ -86,22 +86,22 @@ class YouSeeMusikProvider(MusicProvider):
         """
         return await self.media.search(search_query, media_types, limit)
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from the provider."""
         async for artist in self.library.get_artists():
             yield artist
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from the provider."""
         async for album in self.library.get_albums():
             yield album
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from the provider."""
         async for track in self.library.get_tracks():
             yield track
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library/subscribed playlists from the provider."""
         async for playlist in self.library.get_playlists():
             yield playlist

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -290,7 +290,7 @@ class YoutubeMusicProvider(MusicProvider):
         parsed_results.tracks = tracks
         return parsed_results
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve all library artists from Youtube Music."""
         artists_obj = await get_library_artists(
             headers=self._headers, language=self.language, user=self._yt_user
@@ -298,7 +298,7 @@ class YoutubeMusicProvider(MusicProvider):
         for artist in artists_obj:
             yield self._parse_artist(artist)
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve all library albums from Youtube Music."""
         albums_obj = await get_library_albums(
             headers=self._headers, language=self.language, user=self._yt_user
@@ -306,7 +306,7 @@ class YoutubeMusicProvider(MusicProvider):
         for album in albums_obj:
             yield self._parse_album(album, album["browseId"])
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve all library playlists from the provider."""
         playlists_obj = await get_library_playlists(
             headers=self._headers, language=self.language, user=self._yt_user
@@ -317,7 +317,7 @@ class YoutubeMusicProvider(MusicProvider):
                 continue
             yield self._parse_playlist(playlist)
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Youtube Music."""
         tracks_obj = await get_library_tracks(
             headers=self._headers, language=self.language, user=self._yt_user
@@ -331,7 +331,7 @@ class YoutubeMusicProvider(MusicProvider):
                 full_track = await self.get_track(track["videoId"])
                 yield full_track
 
-    async def get_library_podcasts(self) -> AsyncGenerator[Podcast, None]:
+    async def get_library_podcasts(self) -> AsyncGenerator[Podcast]:
         """Retrieve the library podcasts from Youtube Music."""
         podcasts_obj = await get_library_podcasts(
             headers=self._headers, language=self.language, user=self._yt_user
@@ -502,9 +502,7 @@ class YoutubeMusicProvider(MusicProvider):
         podcast_obj = await get_podcast(prov_podcast_id, headers=self._headers)
         return self._parse_podcast(podcast_obj)
 
-    async def get_podcast_episodes(
-        self, prov_podcast_id: str
-    ) -> AsyncGenerator[PodcastEpisode, None]:
+    async def get_podcast_episodes(self, prov_podcast_id: str) -> AsyncGenerator[PodcastEpisode]:
         """Get all episodes from a podcast."""
         podcast_obj = await get_podcast(prov_podcast_id, headers=self._headers)
         podcast_obj["podcastId"] = prov_podcast_id

--- a/music_assistant/providers/zvuk_music/provider.py
+++ b/music_assistant/providers/zvuk_music/provider.py
@@ -350,7 +350,7 @@ class ZvukMusicProvider(MusicProvider):
         fetcher: Any,
         parser: Any,
         item_type: str,
-    ) -> AsyncGenerator[Any, None]:
+    ) -> AsyncGenerator[Any]:
         """Yield parsed items by fetching ``ids`` in batches of DEFAULT_LIMIT.
 
         :param ids: List of item IDs to fetch.
@@ -367,7 +367,7 @@ class ZvukMusicProvider(MusicProvider):
                 except InvalidDataError as err:
                     self.logger.debug("Error parsing library %s: %s", item_type, err)
 
-    async def get_library_artists(self) -> AsyncGenerator[Artist, None]:
+    async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from Zvuk Music."""
         collection = await self.client.get_collection()
         if not collection or not collection.artists:
@@ -378,7 +378,7 @@ class ZvukMusicProvider(MusicProvider):
         ):
             yield artist
 
-    async def get_library_albums(self) -> AsyncGenerator[Album, None]:
+    async def get_library_albums(self) -> AsyncGenerator[Album]:
         """Retrieve library albums from Zvuk Music."""
         collection = await self.client.get_collection()
         if not collection or not collection.releases:
@@ -387,7 +387,7 @@ class ZvukMusicProvider(MusicProvider):
         async for album in self._iter_batched(ids, self.client.get_releases, parse_album, "album"):
             yield album
 
-    async def get_library_tracks(self) -> AsyncGenerator[Track, None]:
+    async def get_library_tracks(self) -> AsyncGenerator[Track]:
         """Retrieve library tracks from Zvuk Music."""
         collection = await self.client.get_collection()
         if not collection or not collection.tracks:
@@ -396,7 +396,7 @@ class ZvukMusicProvider(MusicProvider):
         async for track in self._iter_batched(ids, self.client.get_tracks, parse_track, "track"):
             yield track
 
-    async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
+    async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
         """Retrieve library playlists from Zvuk Music.
 
         Yields user's own playlists followed by Zvuk's personalized synthesis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,6 @@ ignore = [
   "PLW0108", # Just annoying, not really useful
   "FURB110", # Just annoying, not really useful
   # TEMPORARY DISABLED rules  # The below rules must be enabled later one-by-one !
-  "UP043", # AsyncGenerator[X, None] → AsyncGenerator[X]; to enable later before 2.9 release
   "BLE001",
   "FBT001",
   "FBT002",

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,7 +25,7 @@ def _get_fixture_folder(provider: str | None = None) -> pathlib.Path:
 
 async def get_fixtures_dir(
     subdir: str, provider: str | None = None
-) -> AsyncGenerator[tuple[str, bytes], None]:
+) -> AsyncGenerator[tuple[str, bytes]]:
     """Yield the contents of every fixture in a fixtures folder."""
     dir_path = _get_fixture_folder(provider) / subdir
     for file in await aiofiles.os.listdir(dir_path):
@@ -34,7 +34,7 @@ async def get_fixtures_dir(
 
 
 @contextlib.asynccontextmanager
-async def wait_for_sync_completion(mass: MusicAssistant) -> AsyncGenerator[None, None]:
+async def wait_for_sync_completion(mass: MusicAssistant) -> AsyncGenerator[None]:
     """Wait for a sync to finish."""
     flag = asyncio.Event()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def _create_mock_zeroconf() -> MagicMock:
 
 
 @pytest.fixture
-async def mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant, None]:
+async def mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
     """Start a Music Assistant in test mode.
 
     :param tmp_path: Temporary directory for test data.
@@ -85,7 +85,7 @@ async def mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant, None]:
 
 
 @pytest.fixture
-async def mass_minimal(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant, None]:
+async def mass_minimal(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
     """Create a minimal Music Assistant instance without starting the full server.
 
     Only initializes the event loop and config controller.

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -118,7 +118,7 @@ def _make_stream_mock(chunks: list[bytes]) -> object:
 
     async def _stream(
         _streamdetails: object, _pcm_format: object, **_kwargs: object
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         for chunk in chunks:
             yield chunk
 
@@ -212,7 +212,7 @@ async def test_background_streaming_ffmpeg_startup_failure() -> None:
     p.start_analysis = AsyncMock(return_value=True)
     controller.mass.get_provider = MagicMock(return_value=p)  # type: ignore[method-assign]
 
-    def _failing_stream(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes, None]:
+    def _failing_stream(*_args: object, **_kwargs: object) -> AsyncGenerator[bytes]:
         raise RuntimeError("ffmpeg startup failed")
 
     controller.mass.streams.audio.get_media_stream = _failing_stream  # type: ignore[method-assign]

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -44,7 +44,7 @@ class _FakeFFMpeg:
         # self.input_format.codec_type once it reads the input header.
         self.input_format.codec_type = self._probed_codec_type
 
-    async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes, None]:
+    async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes]:
         yield b"\x00\x01" * 256
 
     async def wait_with_timeout(self, _timeout: float) -> None:
@@ -96,7 +96,7 @@ def _make_streamdetails(
     )
 
 
-async def _drain(gen: AsyncGenerator[bytes, None]) -> None:
+async def _drain(gen: AsyncGenerator[bytes]) -> None:
     async for _ in gen:
         pass
 

--- a/tests/core/test_audio_buffer.py
+++ b/tests/core/test_audio_buffer.py
@@ -38,7 +38,7 @@ def _make_chunk(value: int = 0) -> bytes:
     return bytes([value % 256]) * TEST_PCM_FORMAT.pcm_sample_size
 
 
-async def _make_source(num_chunks: int) -> AsyncGenerator[bytes, None]:
+async def _make_source(num_chunks: int) -> AsyncGenerator[bytes]:
     """Create an async generator that yields numbered chunks."""
     for i in range(num_chunks):
         yield _make_chunk(i)
@@ -184,7 +184,7 @@ async def test_fill_sets_eof() -> None:
 async def test_fill_error_propagation() -> None:
     """When the source errors after producing data, valid chunks are still delivered."""
 
-    async def _failing_source() -> AsyncGenerator[bytes, None]:
+    async def _failing_source() -> AsyncGenerator[bytes]:
         yield ONE_SECOND_CHUNK
         msg = "test error"
         raise RuntimeError(msg)
@@ -207,7 +207,7 @@ async def test_fill_error_propagation() -> None:
 async def test_fill_error_no_data() -> None:
     """When the source errors without producing any data, the error propagates."""
 
-    async def _failing_source() -> AsyncGenerator[bytes, None]:
+    async def _failing_source() -> AsyncGenerator[bytes]:
         msg = "test error"
         raise RuntimeError(msg)
         yield  # type: ignore[unreachable]

--- a/tests/core/test_audio_sources.py
+++ b/tests/core/test_audio_sources.py
@@ -156,7 +156,7 @@ class _FakePluginProvider:
 
     async def get_audio_stream(
         self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncGenerator[bytes]:
         del streamdetails, seek_position
         # Snapshot BOTH the queue id and the session id at stream start. The
         # queue-id-only guard is unsafe for same-queue reconnects: a fresh
@@ -815,7 +815,7 @@ class TestAudioSourceSilenceKeepalive:
             audio_source_silence_keepalive,
         )
 
-        async def _inner() -> AsyncGenerator[bytes, None]:
+        async def _inner() -> AsyncGenerator[bytes]:
             yield b"chunk1"
             yield b"chunk2"
 
@@ -829,7 +829,7 @@ class TestAudioSourceSilenceKeepalive:
             audio_source_silence_keepalive,
         )
 
-        async def _inner() -> AsyncGenerator[bytes, None]:
+        async def _inner() -> AsyncGenerator[bytes]:
             yield b"hello"
             # stall longer than the idle threshold
             await asyncio.sleep(0.25)
@@ -858,7 +858,7 @@ class TestAudioSourceSilenceKeepalive:
             audio_source_silence_keepalive,
         )
 
-        async def _inner() -> AsyncGenerator[bytes, None]:
+        async def _inner() -> AsyncGenerator[bytes]:
             yield b"one"
 
         chunks = [

--- a/tests/core/test_background_tasks.py
+++ b/tests/core/test_background_tasks.py
@@ -65,7 +65,7 @@ async def _wait_for_task_status(
 
 
 @pytest.fixture
-async def tasks_controller(mass_minimal: MusicAssistant) -> AsyncGenerator[TasksController, None]:
+async def tasks_controller(mass_minimal: MusicAssistant) -> AsyncGenerator[TasksController]:
     """Set up the background tasks controller on a minimal Music Assistant instance."""
     controller = TasksController(mass_minimal)
     mass_minimal.tasks = controller

--- a/tests/core/test_genres.py
+++ b/tests/core/test_genres.py
@@ -46,7 +46,7 @@ from music_assistant.mass import MusicAssistant
 
 
 @pytest.fixture(scope="class")
-async def mass(tmp_path_factory: pytest.TempPathFactory) -> AsyncGenerator[MusicAssistant, None]:
+async def mass(tmp_path_factory: pytest.TempPathFactory) -> AsyncGenerator[MusicAssistant]:
     """Class-scoped MusicAssistant instance (one per test class)."""
     tmp_path = tmp_path_factory.mktemp("genre_tests")
     storage_path = tmp_path / "data"

--- a/tests/core/test_ogg_handler.py
+++ b/tests/core/test_ogg_handler.py
@@ -31,7 +31,7 @@ class _FakeAudioStreamController:
     def __init__(self, chunks: list[bytes]) -> None:
         self._chunks = chunks
 
-    async def get_reconnecting_radio_stream(self, url: str) -> AsyncGenerator[bytes, None]:
+    async def get_reconnecting_radio_stream(self, url: str) -> AsyncGenerator[bytes]:
         """Yield the provided Ogg chunks."""
         del url
         for chunk in self._chunks:

--- a/tests/core/test_throttle_retry.py
+++ b/tests/core/test_throttle_retry.py
@@ -60,7 +60,7 @@ def provider() -> FakeProvider:
 
 
 @pytest.fixture
-def mock_sleep() -> Generator[AsyncMock, None, None]:
+def mock_sleep() -> Generator[AsyncMock]:
     """Patch asyncio.sleep to capture sleep times without actually sleeping."""
     with patch(
         "music_assistant.helpers.throttle_retry.asyncio.sleep", new_callable=AsyncMock

--- a/tests/integration/test_background_scan_streaming.py
+++ b/tests/integration/test_background_scan_streaming.py
@@ -30,7 +30,7 @@ FIXTURE_AUDIO = Path(__file__).parent.parent / "fixtures" / "audio" / "short_tes
 
 async def _real_get_media_stream(
     sd: StreamDetails, pcm_format: AudioFormat, **_kwargs: object
-) -> AsyncGenerator[bytes, None]:
+) -> AsyncGenerator[bytes]:
     """Real-ffmpeg stand-in for mass.streams.audio.get_media_stream.
 
     Mirrors the wait-then-close pattern in audio.py:466-528 so close() doesn't

--- a/tests/providers/bandcamp/test_init.py
+++ b/tests/providers/bandcamp/test_init.py
@@ -12,7 +12,7 @@ from tests.common import wait_for_sync_completion
 
 
 @pytest.fixture
-async def bandcamp_provider(mass: MusicAssistant) -> AsyncGenerator[ProviderConfig, None]:
+async def bandcamp_provider(mass: MusicAssistant) -> AsyncGenerator[ProviderConfig]:
     """Configure a Bandcamp test fixture, and add a provider to mass that uses it."""
     # Mock the BandcampAPIClient to avoid real API calls
     with mock.patch("music_assistant.providers.bandcamp.BandcampAPIClient") as mock_client_class:

--- a/tests/providers/bandcamp/test_provider.py
+++ b/tests/providers/bandcamp/test_provider.py
@@ -750,7 +750,7 @@ async def test_get_library_tracks_success(provider: BandcampProvider) -> None:
         patch.object(provider, "get_album_tracks", new_callable=AsyncMock) as mock_get_tracks,
     ):
         # Make get_library_albums an async generator
-        async def mock_albums_gen() -> AsyncGenerator[Mock, None]:
+        async def mock_albums_gen() -> AsyncGenerator[Mock]:
             yield Mock(item_id="123-456")
 
         mock_get_albums.return_value = mock_albums_gen()

--- a/tests/providers/jellyfin/test_init.py
+++ b/tests/providers/jellyfin/test_init.py
@@ -12,7 +12,7 @@ from tests.common import get_fixtures_dir, wait_for_sync_completion
 
 
 @pytest.fixture
-async def jellyfin_provider(mass: MusicAssistant) -> AsyncGenerator[ProviderConfig, None]:
+async def jellyfin_provider(mass: MusicAssistant) -> AsyncGenerator[ProviderConfig]:
     """Configure an aiojellyfin test fixture, and add a provider to mass that uses it."""
     f = FixtureBuilder()
     async for _, artist in get_fixtures_dir("artists", "jellyfin"):

--- a/tests/providers/jellyfin/test_parsers.py
+++ b/tests/providers/jellyfin/test_parsers.py
@@ -35,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture
-async def connection() -> AsyncGenerator[Connection, None]:
+async def connection() -> AsyncGenerator[Connection]:
     """Spin up a dummy connection."""
     async with aiohttp.ClientSession() as session:
         session_config = SessionConfiguration(

--- a/tests/providers/msx_bridge/conftest.py
+++ b/tests/providers/msx_bridge/conftest.py
@@ -15,7 +15,7 @@ from music_assistant.providers.msx_bridge.player import MSXPlayer
 from music_assistant.providers.msx_bridge.provider import MSXBridgeProvider
 
 
-async def _empty_async_gen() -> AsyncGenerator[Any, None]:
+async def _empty_async_gen() -> AsyncGenerator[Any]:
     """Empty async generator for mocking AsyncGenerator return types."""
     return
     yield  # type: ignore[unreachable]  # pragma: no cover — makes it a generator
@@ -134,7 +134,7 @@ def player(provider: MSXBridgeProvider) -> MSXPlayer:
 @pytest.fixture
 async def http_client(
     provider: MSXBridgeProvider,
-) -> AsyncGenerator[TestClient[Any, Any], None]:
+) -> AsyncGenerator[TestClient[Any, Any]]:
     """Return an aiohttp TestClient for the MSX HTTP server."""
     server = MSXHTTPServer(provider, 0)
     client = TestClient(TestServer(server.app))

--- a/tests/providers/msx_bridge/test_http_server.py
+++ b/tests/providers/msx_bridge/test_http_server.py
@@ -563,7 +563,7 @@ async def test_msx_playlist_tracks(provider: MSXBridgeProvider, mass_mock: Mock)
     """GET /msx/playlists/{id}/tracks.json should return tracks with audio actions."""
     track = _make_track_mock()
 
-    async def _mock_playlist_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Any, None]:
+    async def _mock_playlist_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Any]:
         yield track
 
     mass_mock.music.playlists.tracks = Mock(side_effect=lambda *_a, **_k: _mock_playlist_tracks())
@@ -741,7 +741,7 @@ async def test_msx_playlist_playlist_endpoint(provider: MSXBridgeProvider, mass_
     """GET /msx/playlist/playlist/{id}.json should return playlist JSON."""
     track = _make_track_mock()
 
-    async def _mock_playlist_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Any, None]:
+    async def _mock_playlist_tracks(*_args: object, **_kwargs: object) -> AsyncGenerator[Any]:
         yield track
 
     mass_mock.music.playlists.tracks = Mock(side_effect=lambda *_a, **_k: _mock_playlist_tracks())
@@ -813,7 +813,7 @@ def test_format_msx_track_duration_only(provider: MSXBridgeProvider) -> None:
 # --- Async iteration helpers for stream mocking ---
 
 
-async def _async_iter(items: list[Any]) -> AsyncGenerator[Any, None]:
+async def _async_iter(items: list[Any]) -> AsyncGenerator[Any]:
     """Async generator helper for mocking iter_chunked."""
     for item in items:
         yield item

--- a/tests/providers/tidal/test_library.py
+++ b/tests/providers/tidal/test_library.py
@@ -23,7 +23,7 @@ def provider_mock() -> Mock:
     provider.api.paginate = MagicMock()
 
     # Configure async iterator for paginate
-    async def async_iter(*_args: Any, **_kwargs: Any) -> AsyncGenerator[Any, None]:
+    async def async_iter(*_args: Any, **_kwargs: Any) -> AsyncGenerator[Any]:
         for item in provider.api.paginate.return_value:
             yield item
 
@@ -127,9 +127,7 @@ async def test_get_playlists(
     ]
 
     # Configure paginate side effect
-    async def paginate_side_effect(
-        endpoint: str, **_kwargs: Any
-    ) -> AsyncGenerator[dict[str, Any], None]:
+    async def paginate_side_effect(endpoint: str, **_kwargs: Any) -> AsyncGenerator[dict[str, Any]]:
         if "mixes" in endpoint:
             for item in mixes_response:
                 yield item

--- a/tests/providers/tidal/test_provider.py
+++ b/tests/providers/tidal/test_provider.py
@@ -249,7 +249,7 @@ async def test_get_item_mapping(provider: TidalProvider) -> None:
 async def test_get_library_artists_delegates_to_library(provider: TidalProvider) -> None:
     """Test get_library_artists delegates to library manager."""
 
-    async def mock_generator() -> AsyncGenerator[Any, None]:
+    async def mock_generator() -> AsyncGenerator[Any]:
         yield Mock(spec=Artist)
         yield Mock(spec=Artist)
 
@@ -264,7 +264,7 @@ async def test_get_library_artists_delegates_to_library(provider: TidalProvider)
 async def test_get_library_albums_delegates_to_library(provider: TidalProvider) -> None:
     """Test get_library_albums delegates to library manager."""
 
-    async def mock_generator() -> AsyncGenerator[Any, None]:
+    async def mock_generator() -> AsyncGenerator[Any]:
         yield Mock(spec=Album)
 
     with patch.object(provider.library, "get_albums", return_value=mock_generator()):
@@ -278,7 +278,7 @@ async def test_get_library_albums_delegates_to_library(provider: TidalProvider) 
 async def test_get_library_tracks_delegates_to_library(provider: TidalProvider) -> None:
     """Test get_library_tracks delegates to library manager."""
 
-    async def mock_generator() -> AsyncGenerator[Any, None]:
+    async def mock_generator() -> AsyncGenerator[Any]:
         yield Mock(spec=Track)
         yield Mock(spec=Track)
         yield Mock(spec=Track)
@@ -294,7 +294,7 @@ async def test_get_library_tracks_delegates_to_library(provider: TidalProvider) 
 async def test_get_library_playlists_delegates_to_library(provider: TidalProvider) -> None:
     """Test get_library_playlists delegates to library manager."""
 
-    async def mock_generator() -> AsyncGenerator[Any, None]:
+    async def mock_generator() -> AsyncGenerator[Any]:
         yield Mock(spec=Playlist)
 
     with patch.object(provider.library, "get_playlists", return_value=mock_generator()):

--- a/tests/providers/yandex_music/test_auth.py
+++ b/tests/providers/yandex_music/test_auth.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture(autouse=True)
-def skip_grace_sleep() -> Generator[mock.AsyncMock, None, None]:
+def skip_grace_sleep() -> Generator[mock.AsyncMock]:
     """Bypass the post-auth grace ``asyncio.sleep`` so tests run instantly."""
     with mock.patch(
         "music_assistant.providers.yandex_music.auth.asyncio.sleep",

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -26,7 +26,7 @@ from music_assistant.mass import MusicAssistant
 
 
 @pytest.fixture
-async def mass_minimal(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant, None]:
+async def mass_minimal(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
     """Create a minimal Music Assistant instance for auth testing without starting the webserver.
 
     :param tmp_path: Temporary directory for test data.


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Removes UP043 from the temporarily-disabled rule list and applies the autofix tree-wide: AsyncGenerator[X, None] -> AsyncGenerator[X] and Generator[X, None, None] -> Generator[X]. Annotation-only, no behaviour change.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
