### PR TITLE
Avoid event loop block in YouTube Music recommendations and skip SoundCloud default avatar

### DIFF
--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -499,8 +499,9 @@ class SoundcloudMusicProvider(MusicProvider):
         )
         if artist_obj.get("description"):
             artist.metadata.description = artist_obj["description"]
-        if artist_obj.get("avatar_url"):
-            img_url = self._transform_artwork_url(artist_obj["avatar_url"])
+        # skip default_avatar placeholder; it has no high-res variant and 404s after transform
+        if (avatar_url := artist_obj.get("avatar_url")) and "default_avatar" not in avatar_url:
+            img_url = self._transform_artwork_url(avatar_url)
             artist.metadata.images = UniqueList(
                 [
                     MediaItemImage(

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -685,42 +685,50 @@ class YoutubeMusicProvider(MusicProvider):
     async def recommendations(self) -> list[RecommendationFolder]:
         """Get available recommendations."""
         recommendations = await get_home(self._headers, self.language, user=self._yt_user)
-        folders = []
-        for section in recommendations:
-            folder = RecommendationFolder(
-                name=section["title"],
-                item_id=f"{self.instance_id}_{section['title']}",
-                provider=self.instance_id,
-                icon=determine_recommendation_icon(section["title"]),
-            )
-            for recommended_item in section.get("contents", []):
-                if not recommended_item:
-                    continue  # yeah this seems to happen sometimes ?!
-                if recommended_item.get("videoId"):
-                    # Probably a track
-                    try:
-                        track = self._parse_track(recommended_item)
-                        folder.items.append(track)
-                    except InvalidDataError:
-                        self.logger.debug("Invalid track in recommendations: %s", recommended_item)
+
+        def _parse_sections() -> list[RecommendationFolder]:
+            # building model objects from the raw payload is CPU-bound; run off the event loop
+            folders: list[RecommendationFolder] = []
+            for section in recommendations:
+                folder = RecommendationFolder(
+                    name=section["title"],
+                    item_id=f"{self.instance_id}_{section['title']}",
+                    provider=self.instance_id,
+                    icon=determine_recommendation_icon(section["title"]),
+                )
+                for recommended_item in section.get("contents", []):
+                    if not recommended_item:
+                        continue  # yeah this seems to happen sometimes ?!
+                    if recommended_item.get("videoId"):
+                        # Probably a track
+                        try:
+                            track = self._parse_track(recommended_item)
+                            folder.items.append(track)
+                        except InvalidDataError:
+                            self.logger.debug(
+                                "Invalid track in recommendations: %s", recommended_item
+                            )
+                            continue
+                    elif recommended_item.get("playlistId"):
+                        # Probably a playlist
+                        recommended_item["id"] = recommended_item["playlistId"]
+                        del recommended_item["playlistId"]
+                        folder.items.append(self._parse_playlist(recommended_item))
+                    elif recommended_item.get("browseId"):
+                        # Probably an album
+                        folder.items.append(self._parse_album(recommended_item))
+                    elif recommended_item.get("subscribers"):
+                        # Probably artist
+                        folder.items.append(self._parse_album(recommended_item))
+                    else:
+                        self.logger.warning(
+                            "Unknown item type in recommendation folder: %s", recommended_item
+                        )
                         continue
-                elif recommended_item.get("playlistId"):
-                    # Probably a playlist
-                    recommended_item["id"] = recommended_item["playlistId"]
-                    del recommended_item["playlistId"]
-                    folder.items.append(self._parse_playlist(recommended_item))
-                elif recommended_item.get("browseId"):
-                    # Probably an album
-                    folder.items.append(self._parse_album(recommended_item))
-                elif recommended_item.get("subscribers"):
-                    # Probably artist
-                    folder.items.append(self._parse_album(recommended_item))
-                else:
-                    self.logger.warning(
-                        "Unknown item type in recommendation folder: %s", recommended_item
-                    )
-                    continue
-            folders.append(folder)
+                folders.append(folder)
+            return folders
+
+        folders = await asyncio.to_thread(_parse_sections)
         # Also add personalized mixes if available
         mixed_for_you_folder = RecommendationFolder(
             name="Mixed for you",


### PR DESCRIPTION
# What does this implement/fix?

Two small unrelated cleanups surfaced by a recent log triage:

- YouTube Music's `recommendations()` was blocking the event loop for up to ~0.4s while parsing the raw home/recommendations payload into model objects on the main thread (the network call was already off-loop, the parse was not).
- The SoundCloud parser blindly applied its `large` → `t500x500` artwork transform to the generic `default_avatar_*.png` placeholder, which has no high-res variant and 404s on fetch — producing repeated fetch errors and tracebacks for artists without an avatar.

**Related issue (if applicable):**

- n/a

## Changes

- Wrap the YouTube Music recommendations parse loop in `asyncio.to_thread`, matching the existing offload of `get_home()`.
- Skip storing an image when the SoundCloud `avatar_url` is the `default_avatar` placeholder.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.