### PR TITLE
Only advertise extended ICY headers on flow stream when ICY metadata is requested

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -972,6 +972,7 @@ DEFAULT_STREAM_HEADERS = {
     "Pragma": "no-cache",
     "Accept-Ranges": "none",
     "Connection": "close",
+    "icy-name": APPLICATION_NAME,
 }
 
 # DLNA contentFeatures header values for different stream types.

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -972,7 +972,6 @@ DEFAULT_STREAM_HEADERS = {
     "Pragma": "no-cache",
     "Accept-Ranges": "none",
     "Connection": "close",
-    "icy-name": APPLICATION_NAME,
 }
 
 # DLNA contentFeatures header values for different stream types.

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -875,18 +875,18 @@ class StreamsController(CoreController):
         enable_icy = request.headers.get("Icy-MetaData", "") == "1" and icy_preference != "disabled"
         icy_meta_interval = 256000 if icy_preference == "full" else 16384
 
-        # prepare request, add some DLNA/UPNP compatible headers
+        # prepare request, add some DLNA/UPNP compatible headers.
+        # icy-name (in DEFAULT_STREAM_HEADERS) is always present so players have a
+        # readable stream name; the rest of the ICY/shoutcast metadata headers are
+        # only advertised when the client actually requested ICY metadata, rather
+        # than on every flow response.
         headers = {
             **DEFAULT_STREAM_HEADERS,
+            **(ICY_HEADERS if enable_icy else {}),
             "contentFeatures.dlna.org": DLNA_CONTENT_FEATURES_REALTIME,
             "Content-Type": get_mime_type(output_format.output_format_str),
         }
         if enable_icy:
-            # Only advertise the stream as ICY/shoutcast (icy-name and friends) when
-            # metadata injection is actually enabled. Some players (e.g. AmpliPi/VLC)
-            # react to any icy-* header by opening a second "probe" connection, which
-            # breaks the single-use flow session and aborts playback.
-            headers.update(ICY_HEADERS)
             headers["icy-metaint"] = str(icy_meta_interval)
 
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -886,7 +886,8 @@ class StreamsController(CoreController):
             # metadata injection is actually enabled. Some players (e.g. AmpliPi/VLC)
             # react to any icy-* header by opening a second "probe" connection, which
             # breaks the single-use flow session and aborts playback.
-            headers = {**headers, **ICY_HEADERS, "icy-metaint": str(icy_meta_interval)}
+            headers.update(ICY_HEADERS)
+            headers["icy-metaint"] = str(icy_meta_interval)
 
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
         http_profile = await self.mass.config.get_player_config_value(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -878,12 +878,15 @@ class StreamsController(CoreController):
         # prepare request, add some DLNA/UPNP compatible headers
         headers = {
             **DEFAULT_STREAM_HEADERS,
-            **ICY_HEADERS,
             "contentFeatures.dlna.org": DLNA_CONTENT_FEATURES_REALTIME,
             "Content-Type": get_mime_type(output_format.output_format_str),
         }
         if enable_icy:
-            headers["icy-metaint"] = str(icy_meta_interval)
+            # Only advertise the stream as ICY/shoutcast (icy-name and friends) when
+            # metadata injection is actually enabled. Some players (e.g. AmpliPi/VLC)
+            # react to any icy-* header by opening a second "probe" connection, which
+            # breaks the single-use flow session and aborts playback.
+            headers = {**headers, **ICY_HEADERS, "icy-metaint": str(icy_meta_interval)}
 
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
         http_profile = await self.mass.config.get_player_config_value(


### PR DESCRIPTION
# What does this implement/fix?

The queue flow stream (`serve_queue_flow_stream`) advertised the full ICY/SHOUTcast metadata header set (`icy-description`, `icy-version`, `icy-logo`) on every response by merging `ICY_HEADERS` unconditionally, regardless of whether the client actually requested ICY metadata. (`icy-metaint` was already gated behind `enable_icy`.)

This change merges those extended ICY headers only when the client requests ICY metadata (`Icy-MetaData: 1`). `icy-name` is intentionally left on every flow response (via `DEFAULT_STREAM_HEADERS`) so players still get a readable stream name. When a client does request ICY, the response is unchanged from before.

This is header hygiene — we no longer advertise SHOUTcast metadata we aren't serving on non-ICY responses — not a behavioural fix.

### Background

This started while integrating an AmpliPi player provider, where AmpliPi (via LibVLC) opens a second "probe" connection whenever it sees `icy-*` headers. The original premise was that this double-open broke the flow session and killed playback. Further testing showed that the changes were not needed.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
