### PR TITLE
Fix Apple Music library-only album artwork by caching blobstore URLs

### DIFF
--- a/music_assistant/providers/apple_music/constants.py
+++ b/music_assistant/providers/apple_music/constants.py
@@ -37,3 +37,4 @@ CONF_MUSIC_USER_MANUAL_TOKEN = "music_user_manual_token"
 CONF_MUSIC_USER_TOKEN_TIMESTAMP = "music_user_token_timestamp"
 CACHE_CATEGORY_DECRYPT_KEY = 1
 MAX_ARTWORK_DIMENSION = 1000
+BLOBSTORE_DOMAIN = "blobstore.apple.com"

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
 
 from music_assistant_models.enums import AlbumType, ContentType, ExternalID, ImageType, MediaType
 from music_assistant_models.media_items import (
@@ -23,11 +24,25 @@ from music_assistant.helpers.util import (
     parse_title_and_version,
 )
 
-from .constants import MAX_ARTWORK_DIMENSION, UNKNOWN_PLAYLIST_NAME
+from .constants import BLOBSTORE_DOMAIN, MAX_ARTWORK_DIMENSION, UNKNOWN_PLAYLIST_NAME
 from .helpers.utils import is_library_id
 
 if TYPE_CHECKING:
     from .provider import AppleMusicProvider
+
+
+def is_remotely_accessible_artwork_url(url: str) -> bool:
+    """
+    Check if artwork URL is remotely accessible without caching.
+
+    Blobstore URLs have AWS signatures that expire after 24h, so they must be cached immediately.
+    mzstatic.com URLs are permanent CDN URLs that can be used directly.
+
+    :param url: The artwork URL to check.
+    :return: True if the URL is remotely accessible (permanent), False if it needs caching.
+    """
+    hostname = urlparse(url).hostname or ""
+    return BLOBSTORE_DOMAIN not in hostname
 
 
 def parse_artist(provider: AppleMusicProvider, artist_obj: dict[str, Any]) -> Artist | ItemMapping:
@@ -76,7 +91,7 @@ def parse_artist(provider: AppleMusicProvider, artist_obj: dict[str, Any]) -> Ar
                 provider=provider.instance_id,
                 type=ImageType.THUMB,
                 path=url,
-                remotely_accessible=True,
+                remotely_accessible=is_remotely_accessible_artwork_url(url),
             )
         )
     if genres := attributes.get("genreNames"):
@@ -154,7 +169,7 @@ def parse_album(
                 provider=provider.instance_id,
                 type=ImageType.THUMB,
                 path=url,
-                remotely_accessible=True,
+                remotely_accessible=is_remotely_accessible_artwork_url(url),
             )
         )
     if album_copyright := attributes.get("copyright"):
@@ -266,7 +281,7 @@ def parse_track(
                 provider=provider.instance_id,
                 type=ImageType.THUMB,
                 path=url,
-                remotely_accessible=True,
+                remotely_accessible=is_remotely_accessible_artwork_url(url),
             )
         )
     if genres := attributes.get("genreNames"):


### PR DESCRIPTION
# What does this implement/fix?

Fixes an issue where Apple Music library-only albums (custom uploaded albums with `l.` prefix IDs) display no artwork in the album list view, though artwork appears correctly in the detail view.

**Root cause:**
- Apple Music uses two types of artwork URLs:
  - `mzstatic.com`: Permanent CDN URLs for catalog items
  - `blobstore.apple.com`: Temporary AWS-signed URLs (24h expiration) for library-only content
- MA's remotely_accessible flag was set to `True` for all artwork, meaning blobstore URLs were stored directly in the database
- When cached metadata was reused days later, the AWS signatures had expired, causing HTTP 400 Bad Request errors

**Solution:**
- Detect blobstore URLs via domain check: `BLOBSTORE_DOMAIN not in url`
- Set `remotely_accessible = False` for blobstore URLs to force immediate local caching (within the 24h validity window)
- Keep `remotely_accessible = True` for permanent mzstatic.com URLs
- Applies consistently to artists, albums, and tracks

This follows the same pattern as other providers (OpenSubsonic, Tidal, Jellyfin) that distinguish between permanent and temporary/auth-protected image URLs.

**Related issue (if applicable):**

- Fixes music-assistant/support#5456

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.