### PR TITLE
Fix library-only tracks/albums showing as unavailable in shared playlists

### DIFF
--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -110,6 +110,9 @@ def parse_album(
             name=album_id,
         )
     name, version = parse_title_and_version(attributes["name"])
+    # Check availability: library albums owned by user OR catalog items with playParams
+    is_library_album = is_library_id(album_id) and album_obj.get("type") == "library-albums"
+    has_play_params = attributes.get("playParams", {}).get("id") is not None
     album = Album(
         item_id=album_id,
         provider=provider.domain,
@@ -121,8 +124,7 @@ def parse_album(
                 provider_domain=provider.domain,
                 provider_instance=provider.instance_id,
                 url=attributes.get("url"),
-                available=(is_library_id(album_id) and response_type == "library-albums")
-                or attributes.get("playParams", {}).get("id") is not None,
+                available=is_library_album or has_play_params,
             )
         },
     )
@@ -203,6 +205,9 @@ def parse_track(
         track_id = track_obj["id"]
         attributes = {}
     name, version = parse_title_and_version(attributes.get("name", ""))
+    # Check availability: library tracks owned by user OR catalog items with playParams
+    is_library_track = is_library_id(track_id) and track_obj.get("type") == "library-songs"
+    has_play_params = attributes.get("playParams", {}).get("id") is not None
     track = Track(
         item_id=track_id,
         provider=provider.domain,
@@ -216,8 +221,7 @@ def parse_track(
                 provider_instance=provider.instance_id,
                 audio_format=AudioFormat(content_type=ContentType.AAC),
                 url=attributes.get("url"),
-                available=(is_library_id(track_id) and track_obj.get("type") == "library-songs")
-                or attributes.get("playParams", {}).get("id") is not None,
+                available=is_library_track or has_play_params,
             )
         },
     )

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -121,7 +121,8 @@ def parse_album(
                 provider_domain=provider.domain,
                 provider_instance=provider.instance_id,
                 url=attributes.get("url"),
-                available=attributes.get("playParams", {}).get("id") is not None,
+                available=(is_library_id(album_id) and response_type == "library-albums")
+                or attributes.get("playParams", {}).get("id") is not None,
             )
         },
     )
@@ -215,7 +216,8 @@ def parse_track(
                 provider_instance=provider.instance_id,
                 audio_format=AudioFormat(content_type=ContentType.AAC),
                 url=attributes.get("url"),
-                available=attributes.get("playParams", {}).get("id") is not None,
+                available=(is_library_id(track_id) and track_obj.get("type") == "library-songs")
+                or attributes.get("playParams", {}).get("id") is not None,
             )
         },
     )


### PR DESCRIPTION
# What does this implement/fix?

Fixes library-only tracks and albums showing as unavailable when syncing shared/public Apple Music playlists.

**Problem:**
When subscribing to a shared/public playlist containing library-only tracks (user-uploaded songs), the Apple Music API returns those tracks without `playParams` in the response. The previous logic marked them as unavailable, causing them to be skipped during sync.

However, when the authenticated user adds their OWN library-only tracks to a public playlist, those tracks SHOULD be available for playback (they're in the user's library).

**Solution:**
Refine the availability check to distinguish between:
1. **Owner's library tracks** (`type="library-songs"`) → `available=True`
2. **Other users' library tracks** in shared playlists → `available=False` (no playParams, can't be played)
3. **Catalog tracks** with playParams → `available=True`

**Changes:**
- **For tracks:** Check both `is_library_id(track_id)` AND `track_obj.get("type") == "library-songs"`
- **For albums:** Check both `is_library_id(album_id)` AND `response_type == "library-albums"`

This ensures library-only items are only marked available if they're actually in the authenticated user's library, not just because they have a library ID format.

**Related issue (if applicable):**

- Fixes https://github.com/music-assistant/support/issues/5314

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

## Testing

Tested locally with a library-only track (user-uploaded MP3) added to a playlist. The track now correctly appears as available and can be played.

@Bonjei15 Could you please test this fix? It should now correctly show your library-only tracks as available in your public playlists.