### PR TITLE
Apple Music: Intelligent fallback for deprecated catalog tracks

### DIFF
--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -322,15 +322,15 @@ class AppleMusicLibraryManager:
                 if not any(a.name.lower() == artist_name_lower for a in track.artists):
                     continue
 
-                # If we have album info, verify album match too
-                if album_name_lower and track.album:
-                    if track.album.name.lower() != album_name_lower:
-                        # Album mismatch - might be a different version/remaster
+                # If we have album info, require album match
+                if album_name_lower:
+                    if not track.album or track.album.name.lower() != album_name_lower:
+                        # Album mismatch or missing - might be a different version/remaster
                         continue
 
                 # Found a match! Update favorite status and return
                 track.favorite = is_favourite or False
-                self.logger.info(
+                self.logger.debug(
                     "Found replacement catalog track %s for deprecated library track %s",
                     track.item_id,
                     library_item.get("id"),
@@ -345,6 +345,7 @@ class AppleMusicLibraryManager:
                 track_name,
                 artist_name,
                 err,
+                exc_info=True,
             )
             return None
 

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -256,7 +256,7 @@ class AppleMusicLibraryManager:
             yield parsed_track
         # Handle deprecated catalog IDs: search replacement with per-window limit
         search_attempts = 0
-        for missing_catalog_id in set(catalog_ids) - returned_catalog_ids:
+        for missing_catalog_id in (cid for cid in catalog_ids if cid not in returned_catalog_ids):
             if library_item := library_items_by_catalog_id.get(missing_catalog_id):
                 library_item_id = library_item.get("id")
                 is_favourite = rating_response.get(missing_catalog_id)

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -25,6 +25,9 @@ _TRACK_PAGE_SIZE = 30
 # bounds the in-flight window, keeping a ~100k library from being materialized at once.
 _TRACK_SYNC_WINDOW = 150
 
+# Limit search fallback attempts per window to avoid rate limits/latency when many IDs are deprecated.
+_MAX_SEARCH_FALLBACK_PER_WINDOW = 10
+
 
 class AppleMusicLibraryManager:
     """Manages Apple Music library operations."""
@@ -251,11 +254,29 @@ class AppleMusicLibraryManager:
                 ):
                     parsed_track.album = parsed_library_track.album
             yield parsed_track
-        # Some library items may not resolve on the catalog endpoint anymore.
-        # Try intelligent fallback: search -> unavailable
+        # Handle deprecated catalog IDs: search replacement with per-window limit
+        search_attempts = 0
         for missing_catalog_id in set(catalog_ids) - returned_catalog_ids:
             if library_item := library_items_by_catalog_id.get(missing_catalog_id):
+                library_item_id = library_item.get("id")
                 is_favourite = rating_response.get(missing_catalog_id)
+
+                # Limit search attempts per window to avoid API rate limits
+                if search_attempts >= _MAX_SEARCH_FALLBACK_PER_WINDOW:
+                    # Mark remaining as unavailable without attempting search
+                    parsed_track = parse_track(self.provider, library_item, is_favourite)
+                    for mapping in parsed_track.provider_mappings:
+                        if mapping.provider_instance == self.provider.instance_id:
+                            mapping.available = False
+                    self.logger.debug(
+                        "Skipping search fallback for %s (reached window limit of %d searches)",
+                        library_item_id,
+                        _MAX_SEARCH_FALLBACK_PER_WINDOW,
+                    )
+                    yield parsed_track
+                    continue
+
+                search_attempts += 1
 
                 # Try to find current catalog version via search
                 replacement_track = await self._try_search_replacement_for_deprecated_track(
@@ -273,7 +294,7 @@ class AppleMusicLibraryManager:
                             mapping.available = False
                     self.logger.debug(
                         "Library track %s references deprecated catalog ID %s - marked unavailable",
-                        library_item.get("id"),
+                        library_item_id,
                         missing_catalog_id,
                     )
                     yield parsed_track

--- a/music_assistant/providers/apple_music/library.py
+++ b/music_assistant/providers/apple_music/library.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.media_items import Track
 
 from .helpers.utils import is_catalog_id, is_library_id, translate_media_type_to_apple_type
 from .parsers import parse_album, parse_artist, parse_playlist, parse_track
@@ -13,7 +14,7 @@ from .parsers import parse_album, parse_artist, parse_playlist, parse_track
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-    from music_assistant_models.media_items import Album, Artist, MediaItemType, Playlist, Track
+    from music_assistant_models.media_items import Album, Artist, MediaItemType, Playlist
 
     from .provider import AppleMusicProvider
 
@@ -251,10 +252,101 @@ class AppleMusicLibraryManager:
                     parsed_track.album = parsed_library_track.album
             yield parsed_track
         # Some library items may not resolve on the catalog endpoint anymore.
+        # Try intelligent fallback: search -> unavailable
         for missing_catalog_id in set(catalog_ids) - returned_catalog_ids:
             if library_item := library_items_by_catalog_id.get(missing_catalog_id):
                 is_favourite = rating_response.get(missing_catalog_id)
-                yield parse_track(self.provider, library_item, is_favourite)
+
+                # Try to find current catalog version via search
+                replacement_track = await self._try_search_replacement_for_deprecated_track(
+                    library_item, is_favourite
+                )
+
+                if replacement_track:
+                    yield replacement_track
+                else:
+                    # No replacement found - yield library-only track but mark unavailable
+                    # (these often have corrupt streams from Apple's deprecated catalog versions)
+                    parsed_track = parse_track(self.provider, library_item, is_favourite)
+                    for mapping in parsed_track.provider_mappings:
+                        if mapping.provider_instance == self.provider.instance_id:
+                            mapping.available = False
+                    self.logger.debug(
+                        "Library track %s references deprecated catalog ID %s - marked unavailable",
+                        library_item.get("id"),
+                        missing_catalog_id,
+                    )
+                    yield parsed_track
+
+    async def _try_search_replacement_for_deprecated_track(
+        self, library_item: dict[str, Any], is_favourite: bool | None
+    ) -> Track | None:
+        """
+        Try to find a current catalog version for a deprecated library track via search.
+
+        Returns the replacement track if found, None otherwise.
+        """
+        attributes = library_item.get("attributes", {})
+        track_name = attributes.get("name")
+        artist_name = attributes.get("artistName")
+        album_name = attributes.get("albumName")
+
+        if not track_name or not artist_name:
+            return None
+
+        # Search for track: "Artist Track"
+        search_query = f"{artist_name} {track_name}"
+        try:
+            search_results = await self.provider.media_manager.search(
+                search_query, [MediaType.TRACK], limit=10
+            )
+
+            if not search_results.tracks:
+                return None
+
+            # Try to find exact match (case-insensitive)
+            track_name_lower = track_name.lower()
+            artist_name_lower = artist_name.lower()
+            album_name_lower = album_name.lower() if album_name else None
+
+            for track in search_results.tracks:
+                # Skip ItemMapping entries (only interested in full Track objects)
+                if not isinstance(track, Track):
+                    continue
+
+                # Check track name match
+                if track.name.lower() != track_name_lower:
+                    continue
+
+                # Check artist match
+                if not any(a.name.lower() == artist_name_lower for a in track.artists):
+                    continue
+
+                # If we have album info, verify album match too
+                if album_name_lower and track.album:
+                    if track.album.name.lower() != album_name_lower:
+                        # Album mismatch - might be a different version/remaster
+                        continue
+
+                # Found a match! Update favorite status and return
+                track.favorite = is_favourite or False
+                self.logger.info(
+                    "Found replacement catalog track %s for deprecated library track %s",
+                    track.item_id,
+                    library_item.get("id"),
+                )
+                return track
+
+            return None
+
+        except Exception as err:
+            self.logger.debug(
+                "Search fallback failed for track '%s' by '%s': %s",
+                track_name,
+                artist_name,
+                err,
+            )
+            return None
 
     async def _flush_library_only_tracks(
         self, library_only_items: list[dict[str, Any]]

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -278,7 +278,7 @@ async def test_search_replacement_album_mismatch_skipped() -> None:
         "attributes": {
             "name": "Test Track",
             "artistName": "Test Artist",
-            "albumName": "Test Artist",
+            "albumName": "Test Album",
         },
     }
 
@@ -375,4 +375,38 @@ async def test_search_replacement_missing_metadata() -> None:
 
     result = await manager._try_search_replacement_for_deprecated_track(library_item, False)
 
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_search_replacement_skips_item_mappings() -> None:
+    """Search replacement skips ItemMapping entries and only processes Track objects."""
+    provider = _make_test_provider()
+
+    library_item = {
+        "id": "i.123",
+        "attributes": {
+            "name": "Test Track",
+            "artistName": "Test Artist",
+            "albumName": "Test Album",
+        },
+    }
+
+    # Create an ItemMapping instead of a Track
+    item_mapping = ItemMapping(
+        media_type=MediaType.TRACK,
+        item_id="999",
+        provider="apple_music",
+        name="Test Track",
+    )
+
+    search_results = MagicMock()
+    search_results.tracks = [item_mapping]  # Only ItemMapping, no Track objects
+
+    provider.media_manager.search = AsyncMock(return_value=search_results)
+
+    manager = AppleMusicLibraryManager(provider)
+    result = await manager._try_search_replacement_for_deprecated_track(library_item, False)
+
+    # Should return None since ItemMapping should be skipped
     assert result is None

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import MediaType
-from music_assistant_models.media_items import Track
+from music_assistant_models.media_items import Album, Artist, ProviderMapping, Track, UniqueList
 
 from music_assistant.providers.apple_music.library import (
     _TRACK_SYNC_WINDOW,
@@ -107,19 +107,47 @@ async def test_search_replacement_finds_exact_match() -> None:
         },
     }
 
-    # Mock search result with matching track
-    mock_artist = MagicMock()
-    mock_artist.name = "Test Artist"
-
-    mock_album = MagicMock()
-    mock_album.name = "Test Album"
-
-    mock_track = MagicMock(spec=Track)
-    mock_track.name = "Test Track"
-    mock_track.item_id = "999"
-    mock_track.artists = [mock_artist]
-    mock_track.album = mock_album
-    mock_track.favorite = False
+    # Create real Track instance for proper isinstance() check
+    mock_track = Track(
+        provider="apple_music",
+        item_id="999",
+        name="Test Track",
+        artists=UniqueList(
+            [
+                Artist(
+                    provider="apple_music",
+                    item_id="456",
+                    name="Test Artist",
+                    provider_mappings={
+                        ProviderMapping(
+                            item_id="456",
+                            provider_domain="apple_music",
+                            provider_instance="apple_music--test",
+                        )
+                    },
+                )
+            ]
+        ),
+        album=Album(
+            provider="apple_music",
+            item_id="789",
+            name="Test Album",
+            provider_mappings={
+                ProviderMapping(
+                    item_id="789",
+                    provider_domain="apple_music",
+                    provider_instance="apple_music--test",
+                )
+            },
+        ),
+        provider_mappings={
+            ProviderMapping(
+                item_id="999",
+                provider_domain="apple_music",
+                provider_instance="apple_music--test",
+            )
+        },
+    )
 
     search_results = MagicMock()
     search_results.tracks = [mock_track]
@@ -154,12 +182,34 @@ async def test_search_replacement_no_match_wrong_track_name() -> None:
         },
     }
 
-    mock_artist = MagicMock()
-    mock_artist.name = "Test Artist"
-
-    mock_track = MagicMock(spec=Track)
-    mock_track.name = "Different Song"  # Wrong name
-    mock_track.artists = [mock_artist]
+    mock_track = Track(
+        provider="apple_music",
+        item_id="999",
+        name="Different Song",  # Wrong name
+        artists=UniqueList(
+            [
+                Artist(
+                    provider="apple_music",
+                    item_id="456",
+                    name="Test Artist",
+                    provider_mappings={
+                        ProviderMapping(
+                            item_id="456",
+                            provider_domain="apple_music",
+                            provider_instance="apple_music--test",
+                        )
+                    },
+                )
+            ]
+        ),
+        provider_mappings={
+            ProviderMapping(
+                item_id="999",
+                provider_domain="apple_music",
+                provider_instance="apple_music--test",
+            )
+        },
+    )
 
     search_results = MagicMock()
     search_results.tracks = [mock_track]
@@ -187,12 +237,34 @@ async def test_search_replacement_no_match_wrong_artist() -> None:
         },
     }
 
-    mock_artist = MagicMock()
-    mock_artist.name = "Different Artist"
-
-    mock_track = MagicMock(spec=Track)
-    mock_track.name = "Test Track"
-    mock_track.artists = [mock_artist]
+    mock_track = Track(
+        provider="apple_music",
+        item_id="999",
+        name="Test Track",
+        artists=UniqueList(
+            [
+                Artist(
+                    provider="apple_music",
+                    item_id="456",
+                    name="Different Artist",
+                    provider_mappings={
+                        ProviderMapping(
+                            item_id="456",
+                            provider_domain="apple_music",
+                            provider_instance="apple_music--test",
+                        )
+                    },
+                )
+            ]
+        ),
+        provider_mappings={
+            ProviderMapping(
+                item_id="999",
+                provider_domain="apple_music",
+                provider_instance="apple_music--test",
+            )
+        },
+    )
 
     search_results = MagicMock()
     search_results.tracks = [mock_track]
@@ -221,16 +293,46 @@ async def test_search_replacement_album_mismatch_skipped() -> None:
         },
     }
 
-    mock_artist = MagicMock()
-    mock_artist.name = "Test Artist"
-
-    mock_album = MagicMock()
-    mock_album.name = "Different Album"  # Wrong album
-
-    mock_track = MagicMock(spec=Track)
-    mock_track.name = "Test Track"
-    mock_track.artists = [mock_artist]
-    mock_track.album = mock_album
+    mock_track = Track(
+        provider="apple_music",
+        item_id="999",
+        name="Test Track",
+        artists=UniqueList(
+            [
+                Artist(
+                    provider="apple_music",
+                    item_id="456",
+                    name="Test Artist",
+                    provider_mappings={
+                        ProviderMapping(
+                            item_id="456",
+                            provider_domain="apple_music",
+                            provider_instance="apple_music--test",
+                        )
+                    },
+                )
+            ]
+        ),
+        album=Album(
+            provider="apple_music",
+            item_id="789",
+            name="Different Album",  # Wrong album
+            provider_mappings={
+                ProviderMapping(
+                    item_id="789",
+                    provider_domain="apple_music",
+                    provider_instance="apple_music--test",
+                )
+            },
+        ),
+        provider_mappings={
+            ProviderMapping(
+                item_id="999",
+                provider_domain="apple_music",
+                provider_instance="apple_music--test",
+            )
+        },
+    )
 
     search_results = MagicMock()
     search_results.tracks = [mock_track]

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -1,11 +1,18 @@
 """Unit tests for Apple Music library track streaming and windowed enrichment."""
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import MediaType
-from music_assistant_models.media_items import Album, Artist, ProviderMapping, Track, UniqueList
+from music_assistant_models.media_items import (
+    Album,
+    Artist,
+    ItemMapping,
+    ProviderMapping,
+    Track,
+    UniqueList,
+)
 
 from music_assistant.providers.apple_music.library import (
     _TRACK_SYNC_WINDOW,
@@ -32,6 +39,72 @@ def _catalog_song(catalog_id: str) -> dict[str, Any]:
         "type": "songs",
         "attributes": {"name": f"Catalog {catalog_id}", "playParams": {"id": catalog_id}},
     }
+
+
+def _make_test_track(
+    track_id: str,
+    track_name: str,
+    artist_id: str,
+    artist_name: str,
+    album_id: str | None = None,
+    album_name: str | None = None,
+    instance_id: str = "apple_music--test",
+) -> Track:
+    """Build a real Track instance with Artist and optional Album for testing."""
+    artists = UniqueList(
+        [
+            Artist(
+                provider="apple_music",
+                item_id=artist_id,
+                name=artist_name,
+                provider_mappings={
+                    ProviderMapping(
+                        item_id=artist_id,
+                        provider_domain="apple_music",
+                        provider_instance=instance_id,
+                    )
+                },
+            )
+        ]
+    )
+
+    album = None
+    if album_id and album_name:
+        album = Album(
+            provider="apple_music",
+            item_id=album_id,
+            name=album_name,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=album_id,
+                    provider_domain="apple_music",
+                    provider_instance=instance_id,
+                )
+            },
+        )
+
+    return Track(
+        provider="apple_music",
+        item_id=track_id,
+        name=track_name,
+        artists=cast("UniqueList[Artist | ItemMapping]", artists),
+        album=album,
+        provider_mappings={
+            ProviderMapping(
+                item_id=track_id,
+                provider_domain="apple_music",
+                provider_instance=instance_id,
+            )
+        },
+    )
+
+
+def _make_test_provider() -> MagicMock:
+    """Build a mock provider for search replacement tests."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+    return provider
 
 
 def _make_manager(
@@ -93,9 +166,7 @@ async def test_enriches_before_listing_completes() -> None:
 @pytest.mark.asyncio
 async def test_search_replacement_finds_exact_match() -> None:
     """Search replacement finds exact match when deprecated catalog ID no longer exists."""
-    provider = MagicMock()
-    provider.domain = "apple_music"
-    provider.instance_id = "apple_music--test"
+    provider = _make_test_provider()
 
     # Mock library item with track metadata
     library_item = {
@@ -108,45 +179,13 @@ async def test_search_replacement_finds_exact_match() -> None:
     }
 
     # Create real Track instance for proper isinstance() check
-    mock_track = Track(
-        provider="apple_music",
-        item_id="999",
-        name="Test Track",
-        artists=UniqueList(
-            [
-                Artist(
-                    provider="apple_music",
-                    item_id="456",
-                    name="Test Artist",
-                    provider_mappings={
-                        ProviderMapping(
-                            item_id="456",
-                            provider_domain="apple_music",
-                            provider_instance="apple_music--test",
-                        )
-                    },
-                )
-            ]
-        ),
-        album=Album(
-            provider="apple_music",
-            item_id="789",
-            name="Test Album",
-            provider_mappings={
-                ProviderMapping(
-                    item_id="789",
-                    provider_domain="apple_music",
-                    provider_instance="apple_music--test",
-                )
-            },
-        ),
-        provider_mappings={
-            ProviderMapping(
-                item_id="999",
-                provider_domain="apple_music",
-                provider_instance="apple_music--test",
-            )
-        },
+    mock_track = _make_test_track(
+        track_id="999",
+        track_name="Test Track",
+        artist_id="456",
+        artist_name="Test Artist",
+        album_id="789",
+        album_name="Test Album",
     )
 
     search_results = MagicMock()
@@ -170,9 +209,7 @@ async def test_search_replacement_finds_exact_match() -> None:
 @pytest.mark.asyncio
 async def test_search_replacement_no_match_wrong_track_name() -> None:
     """Search replacement returns None when track name doesn't match."""
-    provider = MagicMock()
-    provider.domain = "apple_music"
-    provider.instance_id = "apple_music--test"
+    provider = _make_test_provider()
 
     library_item = {
         "id": "i.123",
@@ -182,33 +219,11 @@ async def test_search_replacement_no_match_wrong_track_name() -> None:
         },
     }
 
-    mock_track = Track(
-        provider="apple_music",
-        item_id="999",
-        name="Different Song",  # Wrong name
-        artists=UniqueList(
-            [
-                Artist(
-                    provider="apple_music",
-                    item_id="456",
-                    name="Test Artist",
-                    provider_mappings={
-                        ProviderMapping(
-                            item_id="456",
-                            provider_domain="apple_music",
-                            provider_instance="apple_music--test",
-                        )
-                    },
-                )
-            ]
-        ),
-        provider_mappings={
-            ProviderMapping(
-                item_id="999",
-                provider_domain="apple_music",
-                provider_instance="apple_music--test",
-            )
-        },
+    mock_track = _make_test_track(
+        track_id="999",
+        track_name="Different Song",  # Wrong name
+        artist_id="456",
+        artist_name="Test Artist",
     )
 
     search_results = MagicMock()
@@ -225,9 +240,7 @@ async def test_search_replacement_no_match_wrong_track_name() -> None:
 @pytest.mark.asyncio
 async def test_search_replacement_no_match_wrong_artist() -> None:
     """Search replacement returns None when artist name doesn't match."""
-    provider = MagicMock()
-    provider.domain = "apple_music"
-    provider.instance_id = "apple_music--test"
+    provider = _make_test_provider()
 
     library_item = {
         "id": "i.123",
@@ -237,33 +250,11 @@ async def test_search_replacement_no_match_wrong_artist() -> None:
         },
     }
 
-    mock_track = Track(
-        provider="apple_music",
-        item_id="999",
-        name="Test Track",
-        artists=UniqueList(
-            [
-                Artist(
-                    provider="apple_music",
-                    item_id="456",
-                    name="Different Artist",
-                    provider_mappings={
-                        ProviderMapping(
-                            item_id="456",
-                            provider_domain="apple_music",
-                            provider_instance="apple_music--test",
-                        )
-                    },
-                )
-            ]
-        ),
-        provider_mappings={
-            ProviderMapping(
-                item_id="999",
-                provider_domain="apple_music",
-                provider_instance="apple_music--test",
-            )
-        },
+    mock_track = _make_test_track(
+        track_id="999",
+        track_name="Test Track",
+        artist_id="456",
+        artist_name="Different Artist",  # Wrong artist
     )
 
     search_results = MagicMock()
@@ -280,9 +271,7 @@ async def test_search_replacement_no_match_wrong_artist() -> None:
 @pytest.mark.asyncio
 async def test_search_replacement_album_mismatch_skipped() -> None:
     """Search replacement skips tracks with mismatched album when album info available."""
-    provider = MagicMock()
-    provider.domain = "apple_music"
-    provider.instance_id = "apple_music--test"
+    provider = _make_test_provider()
 
     library_item = {
         "id": "i.123",
@@ -293,45 +282,13 @@ async def test_search_replacement_album_mismatch_skipped() -> None:
         },
     }
 
-    mock_track = Track(
-        provider="apple_music",
-        item_id="999",
-        name="Test Track",
-        artists=UniqueList(
-            [
-                Artist(
-                    provider="apple_music",
-                    item_id="456",
-                    name="Test Artist",
-                    provider_mappings={
-                        ProviderMapping(
-                            item_id="456",
-                            provider_domain="apple_music",
-                            provider_instance="apple_music--test",
-                        )
-                    },
-                )
-            ]
-        ),
-        album=Album(
-            provider="apple_music",
-            item_id="789",
-            name="Different Album",  # Wrong album
-            provider_mappings={
-                ProviderMapping(
-                    item_id="789",
-                    provider_domain="apple_music",
-                    provider_instance="apple_music--test",
-                )
-            },
-        ),
-        provider_mappings={
-            ProviderMapping(
-                item_id="999",
-                provider_domain="apple_music",
-                provider_instance="apple_music--test",
-            )
-        },
+    mock_track = _make_test_track(
+        track_id="999",
+        track_name="Test Track",
+        artist_id="456",
+        artist_name="Test Artist",
+        album_id="789",
+        album_name="Different Album",  # Wrong album
     )
 
     search_results = MagicMock()
@@ -348,9 +305,7 @@ async def test_search_replacement_album_mismatch_skipped() -> None:
 @pytest.mark.asyncio
 async def test_search_replacement_no_results() -> None:
     """Search replacement returns None when search yields no results."""
-    provider = MagicMock()
-    provider.domain = "apple_music"
-    provider.instance_id = "apple_music--test"
+    provider = _make_test_provider()
 
     library_item = {
         "id": "i.123",
@@ -374,9 +329,7 @@ async def test_search_replacement_no_results() -> None:
 @pytest.mark.asyncio
 async def test_search_replacement_handles_exceptions() -> None:
     """Search replacement returns None and logs when search raises exception."""
-    provider = MagicMock()
-    provider.domain = "apple_music"
-    provider.instance_id = "apple_music--test"
+    provider = _make_test_provider()
 
     library_item = {
         "id": "i.123",
@@ -397,9 +350,7 @@ async def test_search_replacement_handles_exceptions() -> None:
 @pytest.mark.asyncio
 async def test_search_replacement_missing_metadata() -> None:
     """Search replacement returns None when library item lacks required metadata."""
-    provider = MagicMock()
-    provider.domain = "apple_music"
-    provider.instance_id = "apple_music--test"
+    provider = _make_test_provider()
 
     # Missing track name
     library_item = {

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -15,6 +15,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.providers.apple_music.library import (
+    _MAX_SEARCH_FALLBACK_PER_WINDOW,
     _TRACK_SYNC_WINDOW,
     AppleMusicLibraryManager,
 )
@@ -29,6 +30,31 @@ def _library_song(idx: int, *, catalog_id: str | None) -> dict[str, Any]:
         "id": f"i.{idx}",
         "type": "library-songs",
         "attributes": {"name": f"Track {idx}", "playParams": play_params},
+    }
+
+
+def _library_song_with_metadata(
+    idx: int,
+    *,
+    catalog_id: str | None,
+    artist_name: str | None = None,
+    album_name: str | None = None,
+) -> dict[str, Any]:
+    """Build a library song item with artist/album metadata."""
+    play_params: dict[str, Any] = {"id": f"i.{idx}"}
+    if catalog_id is not None:
+        play_params["catalogId"] = catalog_id
+
+    attributes: dict[str, Any] = {"name": f"Track {idx}", "playParams": play_params}
+    if artist_name:
+        attributes["artistName"] = artist_name
+    if album_name:
+        attributes["albumName"] = album_name
+
+    return {
+        "id": f"i.{idx}",
+        "type": "library-songs",
+        "attributes": attributes,
     }
 
 
@@ -161,6 +187,68 @@ async def test_enriches_before_listing_completes() -> None:
     manager, _, state = _make_manager(items)
     [track async for track in manager.get_library_tracks()]
     assert state["first_enrich_at"] == _TRACK_SYNC_WINDOW
+
+
+@pytest.mark.asyncio
+async def test_per_window_search_limit_enforced() -> None:
+    """Only first N deprecated tracks per window trigger search fallback; rest marked unavailable."""
+    # Create library items with missing catalog IDs and full metadata
+    missing_count = _MAX_SEARCH_FALLBACK_PER_WINDOW + 5
+    library_items = [
+        _library_song_with_metadata(
+            i, catalog_id=f"c{i}", artist_name=f"Artist {i}", album_name=f"Album {i}"
+        )
+        for i in range(missing_count)
+    ]
+
+    # Setup provider similar to _make_manager
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+    provider._storefront = "us"
+
+    # Setup API client
+    api = provider.api_client
+
+    async def _iter(*_args: Any, **_kwargs: Any) -> Any:
+        for item in library_items:
+            yield item
+
+    api.iter_all_items = _iter
+    # Return empty data (all catalog IDs "missing")
+    api.get_data = AsyncMock(return_value={"data": []})
+    api.get_ratings = AsyncMock(return_value={})
+
+    # Track search attempts
+    search_call_count = 0
+
+    async def mock_search(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal search_call_count
+        search_call_count += 1
+        results = MagicMock()
+        results.tracks = []
+        return results
+
+    # Mock media_manager with search method
+    provider.media_manager.search = AsyncMock(side_effect=mock_search)
+
+    manager = AppleMusicLibraryManager(provider)
+    tracks = [track async for track in manager.get_library_tracks()]
+
+    # All tracks should be returned
+    assert len(tracks) == missing_count
+
+    # Only first _MAX_SEARCH_FALLBACK_PER_WINDOW should trigger search
+    assert search_call_count == _MAX_SEARCH_FALLBACK_PER_WINDOW
+
+    # All tracks should be marked unavailable
+    for track in tracks:
+        provider_mapping = next(
+            (m for m in track.provider_mappings if m.provider_instance == provider.instance_id),
+            None,
+        )
+        assert provider_mapping is not None
+        assert provider_mapping.available is False
 
 
 @pytest.mark.asyncio

--- a/tests/providers/apple_music/test_library.py
+++ b/tests/providers/apple_music/test_library.py
@@ -4,6 +4,8 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Track
 
 from music_assistant.providers.apple_music.library import (
     _TRACK_SYNC_WINDOW,
@@ -86,3 +88,238 @@ async def test_enriches_before_listing_completes() -> None:
     manager, _, state = _make_manager(items)
     [track async for track in manager.get_library_tracks()]
     assert state["first_enrich_at"] == _TRACK_SYNC_WINDOW
+
+
+@pytest.mark.asyncio
+async def test_search_replacement_finds_exact_match() -> None:
+    """Search replacement finds exact match when deprecated catalog ID no longer exists."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+
+    # Mock library item with track metadata
+    library_item = {
+        "id": "i.123",
+        "attributes": {
+            "name": "Test Track",
+            "artistName": "Test Artist",
+            "albumName": "Test Album",
+        },
+    }
+
+    # Mock search result with matching track
+    mock_artist = MagicMock()
+    mock_artist.name = "Test Artist"
+
+    mock_album = MagicMock()
+    mock_album.name = "Test Album"
+
+    mock_track = MagicMock(spec=Track)
+    mock_track.name = "Test Track"
+    mock_track.item_id = "999"
+    mock_track.artists = [mock_artist]
+    mock_track.album = mock_album
+    mock_track.favorite = False
+
+    search_results = MagicMock()
+    search_results.tracks = [mock_track]
+
+    provider.media_manager.search = AsyncMock(return_value=search_results)
+
+    manager = AppleMusicLibraryManager(provider)
+
+    # Test search replacement
+    result = await manager._try_search_replacement_for_deprecated_track(library_item, True)
+
+    assert result is not None
+    assert result.name == "Test Track"
+    assert result.favorite is True
+    provider.media_manager.search.assert_called_once_with(
+        "Test Artist Test Track", [MediaType.TRACK], limit=10
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_replacement_no_match_wrong_track_name() -> None:
+    """Search replacement returns None when track name doesn't match."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+
+    library_item = {
+        "id": "i.123",
+        "attributes": {
+            "name": "Test Track",
+            "artistName": "Test Artist",
+        },
+    }
+
+    mock_artist = MagicMock()
+    mock_artist.name = "Test Artist"
+
+    mock_track = MagicMock(spec=Track)
+    mock_track.name = "Different Song"  # Wrong name
+    mock_track.artists = [mock_artist]
+
+    search_results = MagicMock()
+    search_results.tracks = [mock_track]
+
+    provider.media_manager.search = AsyncMock(return_value=search_results)
+
+    manager = AppleMusicLibraryManager(provider)
+    result = await manager._try_search_replacement_for_deprecated_track(library_item, False)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_search_replacement_no_match_wrong_artist() -> None:
+    """Search replacement returns None when artist name doesn't match."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+
+    library_item = {
+        "id": "i.123",
+        "attributes": {
+            "name": "Test Track",
+            "artistName": "Test Artist",
+        },
+    }
+
+    mock_artist = MagicMock()
+    mock_artist.name = "Different Artist"
+
+    mock_track = MagicMock(spec=Track)
+    mock_track.name = "Test Track"
+    mock_track.artists = [mock_artist]
+
+    search_results = MagicMock()
+    search_results.tracks = [mock_track]
+
+    provider.media_manager.search = AsyncMock(return_value=search_results)
+
+    manager = AppleMusicLibraryManager(provider)
+    result = await manager._try_search_replacement_for_deprecated_track(library_item, False)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_search_replacement_album_mismatch_skipped() -> None:
+    """Search replacement skips tracks with mismatched album when album info available."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+
+    library_item = {
+        "id": "i.123",
+        "attributes": {
+            "name": "Test Track",
+            "artistName": "Test Artist",
+            "albumName": "Test Artist",
+        },
+    }
+
+    mock_artist = MagicMock()
+    mock_artist.name = "Test Artist"
+
+    mock_album = MagicMock()
+    mock_album.name = "Different Album"  # Wrong album
+
+    mock_track = MagicMock(spec=Track)
+    mock_track.name = "Test Track"
+    mock_track.artists = [mock_artist]
+    mock_track.album = mock_album
+
+    search_results = MagicMock()
+    search_results.tracks = [mock_track]
+
+    provider.media_manager.search = AsyncMock(return_value=search_results)
+
+    manager = AppleMusicLibraryManager(provider)
+    result = await manager._try_search_replacement_for_deprecated_track(library_item, False)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_search_replacement_no_results() -> None:
+    """Search replacement returns None when search yields no results."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+
+    library_item = {
+        "id": "i.123",
+        "attributes": {
+            "name": "Test Track",
+            "artistName": "Test Artist",
+        },
+    }
+
+    search_results = MagicMock()
+    search_results.tracks = []  # Empty results
+
+    provider.media_manager.search = AsyncMock(return_value=search_results)
+
+    manager = AppleMusicLibraryManager(provider)
+    result = await manager._try_search_replacement_for_deprecated_track(library_item, False)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_search_replacement_handles_exceptions() -> None:
+    """Search replacement returns None and logs when search raises exception."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+
+    library_item = {
+        "id": "i.123",
+        "attributes": {
+            "name": "Test Track",
+            "artistName": "Test Artist",
+        },
+    }
+
+    provider.media_manager.search = AsyncMock(side_effect=Exception("Network error"))
+
+    manager = AppleMusicLibraryManager(provider)
+    result = await manager._try_search_replacement_for_deprecated_track(library_item, False)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_search_replacement_missing_metadata() -> None:
+    """Search replacement returns None when library item lacks required metadata."""
+    provider = MagicMock()
+    provider.domain = "apple_music"
+    provider.instance_id = "apple_music--test"
+
+    # Missing track name
+    library_item = {
+        "id": "i.123",
+        "attributes": {
+            "artistName": "Test Artist",
+        },
+    }
+
+    manager = AppleMusicLibraryManager(provider)
+    result = await manager._try_search_replacement_for_deprecated_track(library_item, False)
+
+    assert result is None
+
+    # Missing artist name
+    library_item = {
+        "id": "i.123",
+        "attributes": {
+            "name": "Test Track",
+        },
+    }
+
+    result = await manager._try_search_replacement_for_deprecated_track(library_item, False)
+
+    assert result is None


### PR DESCRIPTION
# What does this implement/fix?

This PR implements an intelligent fallback system for Apple Music library tracks that reference deprecated catalog IDs. When Apple removes old album versions from their catalog (e.g., when uploading remasters or re-releases), library references persist but point to non-existent or corrupt streams, causing playback failures.

**How it works:**
1. **Search-based replacement**: When a catalog ID lookup fails, MA automatically searches for the current catalog version using exact matching on track name, artist, and album
2. **Automatic linking**: If found, the track uses the new catalog version seamlessly
3. **Safe degradation**: If no replacement exists, the track is marked as unavailable (preventing corrupt stream usage)

**Related issue:**

- Fixes #5456

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

## Technical Details

### Changes to `library.py`:
- Added `_try_search_replacement_for_deprecated_track()` method
- Modified `_flush_catalog_tracks()` to implement intelligent fallback
- Added `Track` import for runtime `isinstance()` checks

### Test Coverage (`test_library.py`):
- ✅ Successful exact match (track, artist, album)
- ✅ No match with wrong track name
- ✅ No match with wrong artist
- ✅ Album mismatch detection
- ✅ No search results handling
- ✅ Exception handling
- ✅ Missing metadata handling

All tests pass with generic test data to avoid codespell issues.