### PR TITLE
AirPlay: Fix mDNS cross-matching when one device name is a substring of another

### DIFF
--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -148,10 +148,11 @@ class DiscoveryController(CoreController):
     async def async_find_mdns_service(
         self, service_type: str, name_filter: str, timeout: float = 3.0
     ) -> AsyncServiceInfo | None:
-        """Find an mDNS service by partial name match, checking cache first then waiting.
+        """Find an mDNS service by name, checking cache first then waiting.
 
         :param service_type: The mDNS service type (e.g., "_raop._tcp.local.").
-        :param name_filter: Substring that must appear in the service name.
+        :param name_filter: The device display name to match; must equal the first DNS label
+            or the part after '@' in RAOP-style names (e.g. ``MAC@Name``).
         :param timeout: Maximum time to wait in seconds.
         """
         deadline = asyncio.get_event_loop().time() + timeout
@@ -166,9 +167,14 @@ class DiscoveryController(CoreController):
                 event.clear()
                 # Check cache for a matching entry
                 for mdns_name in set(self.aiozc.zeroconf.cache.cache):
+                    # Use exact label matching to avoid false positives when one device name
+                    # is a substring of another (e.g. "Kelder" matching "ATV Kelder")
                     if (
                         service_type_lower in mdns_name
-                        and name_filter_lower in mdns_name
+                        and (
+                            mdns_name.startswith(name_filter_lower + ".")
+                            or ("@" + name_filter_lower + ".") in mdns_name
+                        )
                         and mdns_name != service_type_lower
                     ):
                         info = AsyncServiceInfo(service_type, mdns_name)


### PR DESCRIPTION
## What does this implement/fix?

When discovering a device's counterpart mDNS service (e.g. looking up the AirPlay service for a RAOP device), the previous implementation used a plain substring search. This caused false positives when one device's display name is contained within another's — for example, a Denon AVR named "Kelder" would incorrectly match the Apple TV named "ATV Kelder". The Denon would then inherit the Apple TV's model properties (`am=AppleTV6,2`), appear as "Apple TV 4K" in the player list, and demand PIN pairing.

The fix changes the cache lookup from substring matching to exact DNS-label matching: the `name_filter` must either be the full first DNS label (`name._service._tcp.local.`) or appear as the `@Name` portion of a RAOP-style name (`MAC@Name._raop._tcp.local.`).

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5582

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3h1cPLdax79gxttwx3Dkr)_