### PR TITLE
Fix transfer_queue losing position when source queue is paused/idle

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1061,7 +1061,14 @@ class PlayerQueuesController(CoreController):
 
         # capture source state before stopping (stop resets these)
         source_items = self._queue_items[source_queue_id]
-        source_resume_pos = int(source_queue.corrected_elapsed_time)
+        if source_queue.state == PlaybackState.PLAYING:
+            # use the live playback clock while actively playing
+            source_resume_pos = int(source_queue.corrected_elapsed_time)
+        else:
+            # when paused/idle the live clock is stale (e.g. the queue was itself
+            # just handed over by a previous transfer and never played), so fall
+            # back to the stored resume position - mirrors the resume() precedence
+            source_resume_pos = int(source_queue.resume_pos or source_queue.elapsed_time or 0)
         source_current_index = source_queue.current_index
         source_current_item = source_queue.current_item
 

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1065,9 +1065,7 @@ class PlayerQueuesController(CoreController):
             # use the live playback clock while actively playing
             source_resume_pos = int(source_queue.corrected_elapsed_time)
         else:
-            # when paused/idle the live clock is stale (e.g. the queue was itself
-            # just handed over by a previous transfer and never played), so fall
-            # back to the stored resume position - mirrors the resume() precedence
+            # when not playing the live clock is stale, so use the stored resume position
             source_resume_pos = int(source_queue.resume_pos or source_queue.elapsed_time or 0)
         source_current_index = source_queue.current_index
         source_current_item = source_queue.current_item


### PR DESCRIPTION
## Problem

Reported here https://github.com/orgs/music-assistant/discussions/5572

`transfer_queue` captures the handover position from `corrected_elapsed_time`, the player's **live** playback clock (`elapsed_time` + time since last update). That's correct when the source queue is actively playing — the normal use case — but it's wrong when the source queue is paused or idle.

The asymmetry that causes data loss:

- When a queue is **transferred onto** a player, the code sets the target's `resume_pos`, `current_index`, and `current_item`, but never touches `elapsed_time` / `elapsed_time_last_updated`. So the target knows where to resume (`resume_pos`), but its live clock stays at ~0 because nothing ever played.
- When that queue is **transferred back** while still paused/idle, `corrected_elapsed_time` reads ~0 and the real position sitting in `resume_pos` is ignored. The position is silently dropped and playback resumes the current track from the start.

This surfaces in chained transfers (e.g. park a queue on a dummy player, then hand it back) where the parked queue was never actually played. The only workaround today is to briefly play the parked queue and pause it, which hydrates the live clock by hand.

## Fix

Prefer the live clock only while actively playing; otherwise fall back to the stored resume position — the same precedence already used in `resume()`:

```python
if source_queue.state == PlaybackState.PLAYING:
    source_resume_pos = int(source_queue.corrected_elapsed_time)
else:
    source_resume_pos = int(source_queue.resume_pos or source_queue.elapsed_time or 0)
```

## Reproduction

1. Start playing a queue partway into a track on player A.
2. Pause A and `transfer_queue` to player B (don't play B).
3. `transfer_queue` back to A.

Before: A resumes the track from 0. After: A resumes at the original position.

https://claude.ai/code/session_01Av7o3gx47YJv8Xa6cC7E7c

---
_Generated by [Claude Code](https://claude.ai/code/session_01Av7o3gx47YJv8Xa6cC7E7c)_