### PR TITLE
Fix Universal Group Player producing no audio on some members

### DIFF
--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -583,12 +583,15 @@ class UniversalGroupPlayer(Player):
         # use each member's own config to support mixed members (e.g. a chunked
         # Chromecast alongside an HTTP/1.0 Squeezelite). Fall back to the group config
         # when the request has no player_id.
+        http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
         if child_player_id:
-            http_profile = await self.mass.config.get_player_config_value(
-                child_player_id, CONF_HTTP_PROFILE, default="default", return_type=str
-            )
-        else:
-            http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
+            try:
+                http_profile = await self.mass.config.get_player_config_value(
+                    child_player_id, CONF_HTTP_PROFILE, default=http_profile, return_type=str
+                )
+            except KeyError:
+                # player_id may be stale/invalid; fall back to the group profile
+                pass
         if http_profile == "chunked" and request.version < HttpVersion11:
             # chunked encoding is not allowed on HTTP/1.0; fall back to
             # connection-close streaming to avoid raising in resp.prepare()

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from time import time
 from typing import TYPE_CHECKING, cast
 
-from aiohttp import web
+from aiohttp import HttpVersion11, web
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.constants import PLAYER_CONTROL_FAKE, PLAYER_CONTROL_NONE
 from music_assistant_models.enums import (
@@ -580,6 +580,17 @@ class UniversalGroupPlayer(Player):
         }
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
         http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
+        if http_profile == "chunked" and request.version < HttpVersion11:
+            # chunked transfer-encoding is forbidden for HTTP/1.0 clients (e.g. some
+            # Squeezelite and older Chromecast firmware). Unlike the per-player flow
+            # stream, every UGP member shares the group's single http_profile, so an
+            # HTTP/1.0 member would otherwise crash on resp.prepare() and get no audio.
+            # Fall back to connection-close streaming so these members still play.
+            self.logger.debug(
+                "Disabling chunked encoding for UGP stream to HTTP/1.0 client %s",
+                child_player_id or request.remote,
+            )
+            http_profile = "no_content_length"
         if http_profile == "forced_content_length":
             # some clients (notably older Chromecast firmware) refuse to play unless
             # they see a Content-Length header up front

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -581,6 +581,7 @@ class UniversalGroupPlayer(Player):
         }
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
         http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
+        # prefer the child (protocol) player configuration
         if child_player_id:
             # player_id may be stale/invalid; fall back to the group profile
             with contextlib.suppress(KeyError):

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -580,10 +580,6 @@ class UniversalGroupPlayer(Player):
             "Content-Type": get_mime_type(output_format_str),
         }
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
-        # http_profile is per-connection, not part of the shared encoded stream, so
-        # use each member's own config to support mixed members (e.g. a chunked
-        # Chromecast alongside an HTTP/1.0 Squeezelite). Fall back to the group config
-        # when the request has no player_id.
         http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
         if child_player_id:
             # player_id may be stale/invalid; fall back to the group profile

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -579,13 +579,19 @@ class UniversalGroupPlayer(Player):
             "Content-Type": get_mime_type(output_format_str),
         }
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
-        http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
+        # http_profile is per-connection, not part of the shared encoded stream, so
+        # use each member's own config to support mixed members (e.g. a chunked
+        # Chromecast alongside an HTTP/1.0 Squeezelite). Fall back to the group config
+        # when the request has no player_id.
+        if child_player_id:
+            http_profile = await self.mass.config.get_player_config_value(
+                child_player_id, CONF_HTTP_PROFILE, default="default", return_type=str
+            )
+        else:
+            http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
         if http_profile == "chunked" and request.version < HttpVersion11:
-            # chunked transfer-encoding is forbidden for HTTP/1.0 clients (e.g. some
-            # Squeezelite and older Chromecast firmware). Unlike the per-player flow
-            # stream, every UGP member shares the group's single http_profile, so an
-            # HTTP/1.0 member would otherwise crash on resp.prepare() and get no audio.
-            # Fall back to connection-close streaming so these members still play.
+            # chunked encoding is not allowed on HTTP/1.0; fall back to
+            # connection-close streaming to avoid raising in resp.prepare()
             self.logger.debug(
                 "Disabling chunked encoding for UGP stream to HTTP/1.0 client %s",
                 child_player_id or request.remote,

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from copy import deepcopy
 from time import time
 from typing import TYPE_CHECKING, cast
@@ -585,13 +586,11 @@ class UniversalGroupPlayer(Player):
         # when the request has no player_id.
         http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
         if child_player_id:
-            try:
+            # player_id may be stale/invalid; fall back to the group profile
+            with contextlib.suppress(KeyError):
                 http_profile = await self.mass.config.get_player_config_value(
                     child_player_id, CONF_HTTP_PROFILE, default=http_profile, return_type=str
                 )
-            except KeyError:
-                # player_id may be stale/invalid; fall back to the group profile
-                pass
         if http_profile == "chunked" and request.version < HttpVersion11:
             # chunked encoding is not allowed on HTTP/1.0; fall back to
             # connection-close streaming to avoid raising in resp.prepare()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

When playing to a Universal Group, members that can't use chunked streaming (e.g. Squeezelite, some older Chromecast firmware) got no sound. Universal groups always streamed using chunked encoding to every member, regardless of each member's own configured streaming style so any member that couldn't handle chunked failed silently, and the whole group then stopped after a few seconds.

Each member already fetches the audio over its own connection, so the streaming style can safely differ per member. We now pick it from each member's own player settings — the same one it uses for normal (non-group) playback — instead of forcing chunked on everyone. We also guard against the specific crash that left HTTP/1.0 members silent.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5214

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
