### PR TITLE
AirPlay: Ignore mDNS address updates that replace a routable IP with a Docker bridge address

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -901,7 +901,7 @@ class AirPlayPlayer(Player):
                     and ipaddress.ip_address(new_address) in _DOCKER_SUBNET
                     and ipaddress.ip_address(cur_address) not in _DOCKER_SUBNET
                 ):
-                    self.logger.debug(
+                    self.logger.warning(
                         "Ignoring mDNS update from %s to Docker address %s",
                         cur_address,
                         new_address,

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -72,8 +72,7 @@ if TYPE_CHECKING:
     from .protocols.raop import RaopStream
     from .provider import AirPlayProvider
 
-# The 172.16.0.0/12 block is the Docker bridge subnet.
-# Devices running inside containers may incorrectly advertise this address via mDNS.
+# Docker bridge subnet, sometimes wrongly advertised via mDNS by containerized devices.
 _DOCKER_SUBNET = ipaddress.ip_network("172.16.0.0/12")
 
 
@@ -895,19 +894,15 @@ class AirPlayPlayer(Player):
             # should always be set, but guard against None
             return
         if cur_address != new_address:
-            # Ignore mDNS updates that replace a routable LAN address with one in the
-            # Docker bridge subnet (172.16.0.0/12). Devices such as HiFiBerry OS run
-            # Shairport Sync inside a container and can mistakenly advertise the Docker
-            # gateway address rather than their real network address.
+            # Ignore mDNS updates that replace a routable address with a Docker bridge one.
             try:
                 if (
                     cur_address
                     and ipaddress.ip_address(new_address) in _DOCKER_SUBNET
                     and ipaddress.ip_address(cur_address) not in _DOCKER_SUBNET
                 ):
-                    self.logger.warning(
-                        "Ignoring mDNS address update from %s to %s "
-                        "(new address is in Docker bridge subnet 172.16.0.0/12)",
+                    self.logger.debug(
+                        "Ignoring mDNS update from %s to Docker address %s",
                         cur_address,
                         new_address,
                     )

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import ipaddress
 import time
 from typing import TYPE_CHECKING, cast
 
@@ -70,6 +71,10 @@ if TYPE_CHECKING:
     from .protocols.airplay2 import AirPlay2Stream
     from .protocols.raop import RaopStream
     from .provider import AirPlayProvider
+
+# The 172.16.0.0/12 block is the Docker bridge subnet.
+# Devices running inside containers may incorrectly advertise this address via mDNS.
+_DOCKER_SUBNET = ipaddress.ip_network("172.16.0.0/12")
 
 
 class AirPlayPlayer(Player):
@@ -890,6 +895,26 @@ class AirPlayPlayer(Player):
             # should always be set, but guard against None
             return
         if cur_address != new_address:
+            # Ignore mDNS updates that replace a routable LAN address with one in the
+            # Docker bridge subnet (172.16.0.0/12). Devices such as HiFiBerry OS run
+            # Shairport Sync inside a container and can mistakenly advertise the Docker
+            # gateway address rather than their real network address.
+            try:
+                if (
+                    cur_address
+                    and ipaddress.ip_address(new_address) in _DOCKER_SUBNET
+                    and ipaddress.ip_address(cur_address) not in _DOCKER_SUBNET
+                ):
+                    self.logger.warning(
+                        "Ignoring mDNS address update from %s to %s "
+                        "(new address is in Docker bridge subnet 172.16.0.0/12)",
+                        cur_address,
+                        new_address,
+                    )
+                    self.update_state()
+                    return
+            except ValueError:
+                pass
             self.logger.debug("Address updated from %s to %s", cur_address, new_address)
             self._attr_device_info.add_identifier(IdentifierType.IP_ADDRESS, new_address)
             self.address = new_address


### PR DESCRIPTION
# What does this implement/fix?

Devices such as HiFiBerry OS run Shairport Sync inside a Docker container and can mistakenly advertise the Docker gateway address (`172.17.0.1`) via mDNS instead of their actual network address. When Music Assistant accepts this mDNS update it overwrites the working LAN IP, and all subsequent AirPlay connection attempts fail with a timeout.

The fix skips any mDNS address update where the new IP falls inside the Docker bridge subnet (`172.16.0.0/12`) but the current known address does not. A `WARNING` log entry is emitted so the situation is visible in the logs. Devices that legitimately live on a `172.16.0.0/12` network are unaffected because their address is already in that range when first discovered.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5588

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

---
_Generated by [Claude Code](https://claude.ai/code/session_0161kE9bDtvCExBVbgdVJodR)_