### PR TITLE
Re-add configurable output buffer for AirPlay 1 (RAOP) players

### DIFF
--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -40,9 +40,8 @@ DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 AIRPLAY_DEFAULT_SESSION_DELAY_MS: Final[int] = 900
 # Read ahead buffer for cliraop. Default output buffer duration.
 AIRPLAY_OUTPUT_BUFFER_DEFAULT_DURATION_MS: Final[int] = 1000
-# Minimum output buffer duration permitted.
+# RAOP buffer settings
 RAOP_OUTPUT_BUFFER_MIN_DURATION_MS: Final[int] = 250
-# Maximum output buffer duration permitted.
 RAOP_OUTPUT_BUFFER_MAX_DURATION_MS: Final[int] = 5000
 # Default session establishment latency i.e. expected duration to pair with AirPlay device and negotiate session
 AIRPLAY_SESSION_ESTABLISHMENT_LATENCY_DEFAULT_MS: Final[int] = 500
@@ -58,7 +57,8 @@ RAOP_CONNECT_TIME_MS: Final[int] = 1500  # Time in ms to allow RAOP device to co
 # Per-protocol credential storage keys
 CONF_RAOP_CREDENTIALS: Final[str] = "raop_credentials"
 CONF_AIRPLAY_CREDENTIALS: Final[str] = "airplay_credentials"
-# Keep the stored key as "airplay_latency" for backwards compatibility with pre-2.9 configs.
+
+# Some RAOP models require a higher than default 1000ms buffer to prevent stuttering
 CONF_RAOP_LATENCY: Final[str] = "airplay_latency"
 
 # Legacy credential key (for migration)

--- a/music_assistant/providers/airplay/constants.py
+++ b/music_assistant/providers/airplay/constants.py
@@ -40,6 +40,10 @@ DACP_DISCOVERY_TYPE: Final[str] = "_dacp._tcp.local."
 AIRPLAY_DEFAULT_SESSION_DELAY_MS: Final[int] = 900
 # Read ahead buffer for cliraop. Default output buffer duration.
 AIRPLAY_OUTPUT_BUFFER_DEFAULT_DURATION_MS: Final[int] = 1000
+# Minimum output buffer duration permitted.
+RAOP_OUTPUT_BUFFER_MIN_DURATION_MS: Final[int] = 250
+# Maximum output buffer duration permitted.
+RAOP_OUTPUT_BUFFER_MAX_DURATION_MS: Final[int] = 5000
 # Default session establishment latency i.e. expected duration to pair with AirPlay device and negotiate session
 AIRPLAY_SESSION_ESTABLISHMENT_LATENCY_DEFAULT_MS: Final[int] = 500
 AIRPLAY_SESSION_ESTABLISHMENT_LATENCY_MIN_MS: Final[int] = (
@@ -54,7 +58,8 @@ RAOP_CONNECT_TIME_MS: Final[int] = 1500  # Time in ms to allow RAOP device to co
 # Per-protocol credential storage keys
 CONF_RAOP_CREDENTIALS: Final[str] = "raop_credentials"
 CONF_AIRPLAY_CREDENTIALS: Final[str] = "airplay_credentials"
-CONF_AIRPLAY_LATENCY: Final[str] = "airplay_latency"
+# Keep the stored key as "airplay_latency" for backwards compatibility with pre-2.9 configs.
+CONF_RAOP_LATENCY: Final[str] = "airplay_latency"
 
 # Legacy credential key (for migration)
 CONF_AP_CREDENTIALS: Final[str] = "ap_credentials"

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -44,6 +44,7 @@ from .constants import (
     CONF_PAIRING_PIN,
     CONF_PASSWORD,
     CONF_RAOP_CREDENTIALS,
+    CONF_RAOP_LATENCY,
     CONF_SESSION_ESTABLISHMENT_LATENCY,
     CONF_STORED_VOLUME,
     FALLBACK_VOLUME,
@@ -52,6 +53,8 @@ from .constants import (
     PIN_REQUIRED,
     RAOP_CONNECT_TIME_MS,
     RAOP_DISCOVERY_TYPE,
+    RAOP_OUTPUT_BUFFER_MAX_DURATION_MS,
+    RAOP_OUTPUT_BUFFER_MIN_DURATION_MS,
     StreamingProtocol,
 )
 from .helpers import (
@@ -174,6 +177,13 @@ class AirPlayPlayer(Player):
     @property
     def output_buffer_duration_ms(self) -> int:
         """Get the output buffer duration in milliseconds."""
+        # Only the RAOP (AirPlay 1) path exposes a configurable read-ahead buffer;
+        # AirPlay 2 uses the fixed default to avoid interfering with sync.
+        if self.protocol == StreamingProtocol.RAOP:
+            return cast(
+                "int",
+                self.config.get_value(CONF_RAOP_LATENCY, AIRPLAY_OUTPUT_BUFFER_DEFAULT_DURATION_MS),
+            )
         return AIRPLAY_OUTPUT_BUFFER_DEFAULT_DURATION_MS
 
     @property
@@ -288,6 +298,27 @@ class AirPlayPlayer(Player):
                 required=False,
                 label="Device password",
                 description="Some devices require a password to connect/play.",
+                depends_on=CONF_AIRPLAY_PROTOCOL,
+                depends_on_value=StreamingProtocol.RAOP.value,
+                hidden=not is_raop,
+                category="protocol_generic",
+                advanced=True,
+            ),
+            ConfigEntry(
+                key=CONF_RAOP_LATENCY,
+                type=ConfigEntryType.INTEGER,
+                default_value=AIRPLAY_OUTPUT_BUFFER_DEFAULT_DURATION_MS,
+                range=(
+                    RAOP_OUTPUT_BUFFER_MIN_DURATION_MS,
+                    RAOP_OUTPUT_BUFFER_MAX_DURATION_MS,
+                ),
+                label="Milliseconds of data to buffer",
+                description=(
+                    "The number of milliseconds of data to buffer\n"
+                    "NOTE: This adds to the latency experienced for commencement "
+                    "of playback. \n"
+                    "Try increasing value if playback is unreliable."
+                ),
                 depends_on=CONF_AIRPLAY_PROTOCOL,
                 depends_on_value=StreamingProtocol.RAOP.value,
                 hidden=not is_raop,


### PR DESCRIPTION
# What does this implement/fix?

The advanced AirPlay output buffer setting was removed during the 2.9 beta cycle (commit b6691d4, PR #3776) to address AirPlay 2 sync behaviour. That setting also controlled the RAOP (AirPlay 1) read-ahead buffer passed to `cliraop`, so AirPlay 1 devices that need a larger buffer lost their only reliability knob and are now pinned to the 1000ms default. Affected devices (e.g. Aether Cone) play back garbled/stuttered audio with no workaround.

This re-adds the buffer setting, but scoped to RAOP only so it cannot reintroduce the AirPlay 2 sync fragility.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5591

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Changes

- Re-add the per-player "Milliseconds of data to buffer" advanced config entry, gated to AirPlay 1 (RAOP) via `depends_on`/`hidden`; it stays hidden for AirPlay 2.
- `output_buffer_duration_ms` reads the configured value for RAOP and keeps the fixed default for AirPlay 2.
- Restore the `RAOP_OUTPUT_BUFFER_MIN/MAX_DURATION_MS` bounds (250–5000ms) and rename the now RAOP-only config constant to `CONF_RAOP_LATENCY`, keeping the stored key `airplay_latency` for backwards compatibility with pre-2.9 configs.

## Checklist

- [x] `pre-commit run --all-files` passes.
