### PR TITLE
Speed up YouTube Music recommendations loading

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -736,17 +736,18 @@ class YoutubeMusicProvider(MusicProvider):
 
         folders = await asyncio.to_thread(_parse_sections)
         # Also add personalized mixes if available
-        if mixed_for_you_folder := await self._get_mixed_for_you_folder():
+        mixed_for_you_folder = await self._get_mixed_for_you_folder()
+        if mixed_for_you_folder.items:
             folders.append(mixed_for_you_folder)
 
         return folders
 
     @use_cache(3600 * 24, allow_expired_cache=True)  # Cache for 24 hours
-    async def _get_mixed_for_you_folder(self) -> RecommendationFolder | None:
+    async def _get_mixed_for_you_folder(self) -> RecommendationFolder:
         """
         Build the "Mixed for you" recommendation folder from the user's personal mixes.
 
-        :return: The folder, or None when none of the personal mixes are available.
+        :return: The folder, which has no items when no personal mixes are available.
         """
         mixed_for_you_folder = RecommendationFolder(
             name="Mixed for you",
@@ -780,8 +781,6 @@ class YoutubeMusicProvider(MusicProvider):
         mixed_for_you_folder.items.extend(
             preview for preview in playlist_previews if preview is not None
         )
-        if not mixed_for_you_folder.items:
-            return None
         return mixed_for_you_folder
 
     async def _post_data(self, endpoint: str, data: dict[str, str], **kwargs: Any) -> Any:

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -718,6 +718,14 @@ class YoutubeMusicProvider(MusicProvider):
                     elif recommended_item.get("subscribers"):
                         # Probably artist
                         folder.items.append(self._parse_album(recommended_item))
+                    elif recommended_item.get("videoType") == "MUSIC_VIDEO_TYPE_PODCAST_EPISODE":
+                        # Podcast episodes show up here without a videoId/browseId,
+                        # so there is no playable item to build from them
+                        self.logger.debug(
+                            "Skipping podcast episode in recommendation folder: %s",
+                            recommended_item.get("title"),
+                        )
+                        continue
                     else:
                         self.logger.warning(
                             "Unknown item type in recommendation folder: %s", recommended_item
@@ -728,6 +736,18 @@ class YoutubeMusicProvider(MusicProvider):
 
         folders = await asyncio.to_thread(_parse_sections)
         # Also add personalized mixes if available
+        if mixed_for_you_folder := await self._get_mixed_for_you_folder():
+            folders.append(mixed_for_you_folder)
+
+        return folders
+
+    @use_cache(3600 * 24, allow_expired_cache=True)  # Cache for 24 hours
+    async def _get_mixed_for_you_folder(self) -> RecommendationFolder | None:
+        """
+        Build the "Mixed for you" recommendation folder from the user's personal mixes.
+
+        :return: The folder, or None when none of the personal mixes are available.
+        """
         mixed_for_you_folder = RecommendationFolder(
             name="Mixed for you",
             item_id=f"{self.instance_id}_mixed_for_you",
@@ -760,10 +780,9 @@ class YoutubeMusicProvider(MusicProvider):
         mixed_for_you_folder.items.extend(
             preview for preview in playlist_previews if preview is not None
         )
-        if mixed_for_you_folder.items:
-            folders.append(mixed_for_you_folder)
-
-        return folders
+        if not mixed_for_you_folder.items:
+            return None
+        return mixed_for_you_folder
 
     async def _post_data(self, endpoint: str, data: dict[str, str], **kwargs: Any) -> Any:
         """Post data to the given endpoint."""


### PR DESCRIPTION
# What does this implement/fix?

Loading YouTube Music recommendations stalled for several seconds whenever the cache expired. The "Mixed for you" folder refetches ~12 personal mixes on every refresh — each a blocking request — which dominated the call (~2.5s of ~3.5s measured). Those mixes change rarely, so they don't need to sit on the recommendations critical path. While in there, this also stops recurring warning spam from podcast-episode items that can't become playable entries.

- Cache the "Mixed for you" personal mixes for 24h with `allow_expired_cache=True` (stale-while-revalidate): after the first fetch they are served instantly and refreshed in the background.
- Extract the personal-mix fetching into `_get_mixed_for_you_folder` so it can be cached independently of the hourly recommendations cache.
- Skip recommendation items of type `MUSIC_VIDEO_TYPE_PODCAST_EPISODE` (they arrive without a playable id) instead of logging an "Unknown item type" warning.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
