### PR TITLE
Fix track titles with multiple bracketed sections being parsed incorrectly

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -316,6 +316,7 @@ def parse_title_and_version(
         return title, version
 
     # Standard version parsing
+    version_part: str | None = None
     for regex in (r"\(.*?\)", r"\[.*?\]", r" - .*"):
         for title_part in re.findall(regex, title):
             # Extract the content without brackets/dashes for checking
@@ -344,13 +345,17 @@ def parse_title_and_version(
             if should_ignore:
                 continue
 
-            # Check if this part is a version
-            for version_str in VERSION_PARTS:
-                if version_str in clean_part:
-                    # Preserve original casing for output
-                    version = title_part.strip("()[]- ").strip()
-                    title = title.replace(title_part, "").strip()
-                    return title, version
+            # Remember this part if it looks like a version; the last match wins so
+            # trailing markers like "(Mixed)" take precedence over earlier ones.
+            if any(version_str in clean_part for version_str in VERSION_PARTS):
+                version_part = title_part
+
+    if version_part is not None:
+        # Preserve original casing for output
+        version = version_part.strip("()[]- ").strip()
+        title = title.replace(version_part, "").strip()
+    # Collapse spaces left behind by removed segments
+    title = re.sub(r"\s{2,}", " ", title).strip()
     return title, version
 
 

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -61,6 +61,20 @@ def test_version_extract() -> None:
     assert version == "Mosquito Chillout mix"
 
 
+def test_version_extract_multiple_brackets() -> None:
+    """Test version extraction when several bracketed segments match version keywords."""
+    # The trailing segment is the version; earlier version-like segments
+    # (remix attribution) stay in the title.
+    test_str = "Fiji (Oliver Smith Remix) (Mixed)"
+    title, version = util.parse_title_and_version(test_str)
+    assert title == "Fiji (Oliver Smith Remix)"
+    assert version == "Mixed"
+    test_str = "Heaven Scent (Above & Beyond Remix) (Mixed)"
+    title, version = util.parse_title_and_version(test_str)
+    assert title == "Heaven Scent (Above & Beyond Remix)"
+    assert version == "Mixed"
+
+
 def test_with_handling_in_titles() -> None:
     """Test 'with' handling - preserved in title, stripped as featuring credit."""
     # 'with you' (preserved as title word)


### PR DESCRIPTION
# What does this implement/fix?

Tracks whose title contains multiple bracketed sections were parsed incorrectly. For a title like `Fiji (Oliver Smith Remix) (Mixed)`, `parse_title_and_version` returned on the first bracket containing a version keyword — extracting `Oliver Smith Remix` as the version and leaving `(Mixed)` stranded in the title, which then rendered as a mangled name.

The trailing segment should be treated as the version, while earlier version-like segments (e.g. remix attribution) remain part of the title.

- Scan all bracketed/dash segments and keep the **last** version match instead of returning on the first.
- Collapse leftover whitespace from removed segments.
- Add a regression test covering multi-bracket titles.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
