### PR TITLE
Add translation_key to builtin playlists

### DIFF
--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -253,6 +253,7 @@ class BuiltinProvider(MusicProvider):
                 item_id=prov_playlist_id,
                 provider=self.instance_id,
                 name=BUILTIN_PLAYLISTS[prov_playlist_id],
+                translation_key=f"builtin_playlist.{prov_playlist_id}",
                 provider_mappings={
                     ProviderMapping(
                         item_id=prov_playlist_id,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Adds more translation keys. The English label remains as the fallback `name`, matching the pattern already used by recommendation folders in the music controller.

Related frontend PR https://github.com/music-assistant/frontend/pull/1876

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [X] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
