### PR TITLE
Audio analysis: re-scan stale-version tracks in background scan

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -598,7 +598,9 @@ class AudioAnalysisController:
             raise ProviderUnavailableError(f"{aa_domain} is not available")
 
         analyzed = await self.get_audio_analysis_count(aa_domain)
-        pending = await self._count_candidates_missing_analysis(aa_domain)
+        pending = await self._count_candidates_missing_analysis(
+            aa_domain, provider.analysis_version
+        )
         # NULL analysis_version (pre-versioning rows) is treated as stale: SQLite
         # evaluates `NULL < N` as NULL (falsy), so it must be matched explicitly.
         stale_query = (
@@ -912,8 +914,14 @@ class AudioAnalysisController:
             )
         return results
 
-    async def _count_candidates_missing_analysis(self, aa_domain: str) -> int:
-        """Count filesystem candidate tracks with no analysis row for aa_domain."""
+    async def _count_candidates_missing_analysis(
+        self, aa_domain: str, current_version: int
+    ) -> int:
+        """Count filesystem candidate tracks needing (re)analysis for aa_domain.
+
+        A track is counted when it has no analysis row for the domain, or when
+        its stored analysis_version is NULL or less than current_version.
+        """
         filesystem_domains = self._available_filesystem_domains()
         if not filesystem_domains:
             return 0
@@ -927,12 +935,18 @@ class AudioAnalysisController:
             f"    WHERE aa.item_id = pm.provider_item_id "
             f"      AND aa.provider = pm.provider_instance "
             f"      AND aa.aa_provider_domain = :aa_domain "
-            f"      AND aa.media_type = :media_type"
+            f"      AND aa.media_type = :media_type "
+            f"      AND aa.analysis_version IS NOT NULL "
+            f"      AND aa.analysis_version >= :current_version"
             f"  )"
         )
         return await self.mass.music.database.get_count_from_query(
             query,
-            {"media_type": MediaType.TRACK.value, "aa_domain": aa_domain},
+            {
+                "media_type": MediaType.TRACK.value,
+                "aa_domain": aa_domain,
+                "current_version": current_version,
+            },
         )
 
     async def _start_analysis_on_providers(

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -628,8 +628,8 @@ class AudioAnalysisController:
         if not providers:
             return
 
-        domains = [p.domain for p in providers]
-        candidates = await self._find_candidates_missing_analysis(domains, limit=0)
+        provider_versions = {p.domain: p.analysis_version for p in providers}
+        candidates = await self._find_candidates_missing_analysis(provider_versions, limit=0)
         if not candidates:
             return
 
@@ -836,27 +836,48 @@ class AudioAnalysisController:
 
     async def _find_candidates_missing_analysis(
         self,
-        aa_provider_domains: list[str],
+        aa_provider_versions: Mapping[str, int],
         limit: int,
     ) -> list[dict[str, Any]]:
-        """Return rows {item_id, provider_instance, missing_domains} for tracks lacking analysis."""
-        if not aa_provider_domains:
+        """
+        Return tracks that need (re)analysis for one or more AA providers.
+
+        A track is a candidate for a given AA provider domain when it has no
+        analysis row for that domain, or when its stored row predates the
+        provider's current analysis_version (a NULL stored version, from
+        pre-versioning rows, is also treated as stale). This mirrors the
+        per-track version gate in AudioAnalysisProvider.start_analysis so a
+        provider bumping its analysis_version triggers a background re-scan.
+
+        :param aa_provider_versions: Mapping of AA provider domain to the
+            provider's current analysis_version.
+        :param limit: Maximum number of candidate rows to return (0 for no limit).
+        :returns: Rows {item_id, provider_instance, missing_domains} where
+            missing_domains lists the AA provider domains needing analysis.
+        """
+        if not aa_provider_versions:
             return []
 
         filesystem_domains = self._available_filesystem_domains()
         if not filesystem_domains:
             return []
 
-        # CROSS JOIN (track x possible domain), keep pairs with no analysis row,
-        # GROUP_CONCAT the missing domains per track.
+        # CROSS JOIN (track x possible domain), keep pairs with no up-to-date analysis
+        # row, GROUP_CONCAT the missing domains per track.
+        aa_domains = list(aa_provider_versions)
         fs_inline = ", ".join(f"'{d}'" for d in filesystem_domains)
         aa_select_terms = " UNION ALL ".join(
-            f"SELECT :aa_{i} AS aa_provider_domain" for i in range(len(aa_provider_domains))
+            f"SELECT :aa_{i} AS aa_provider_domain, :ver_{i} AS current_version"
+            for i in range(len(aa_domains))
         )
         params: dict[str, Any] = {
             "media_type": MediaType.TRACK.value,
-            **{f"aa_{i}": d for i, d in enumerate(aa_provider_domains)},
+            **{f"aa_{i}": d for i, d in enumerate(aa_domains)},
+            **{f"ver_{i}": aa_provider_versions[d] for i, d in enumerate(aa_domains)},
         }
+        # The NOT EXISTS gate only counts an analysis row as up-to-date when its
+        # analysis_version is non-NULL and >= the provider's current version, so
+        # missing rows and stale-version rows both surface as candidates.
         query = (
             f"SELECT pm.provider_item_id AS item_id, "
             f"       pm.provider_instance AS provider_instance, "
@@ -870,7 +891,9 @@ class AudioAnalysisController:
             f"    WHERE aa.item_id = pm.provider_item_id "
             f"      AND aa.provider = pm.provider_instance "
             f"      AND aa.aa_provider_domain = possible.aa_provider_domain "
-            f"      AND aa.media_type = :media_type"
+            f"      AND aa.media_type = :media_type "
+            f"      AND aa.analysis_version IS NOT NULL "
+            f"      AND aa.analysis_version >= possible.current_version"
             f"  ) "
             f"GROUP BY pm.provider_item_id, pm.provider_instance"
         )

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -914,9 +914,7 @@ class AudioAnalysisController:
             )
         return results
 
-    async def _count_candidates_missing_analysis(
-        self, aa_domain: str, current_version: int
-    ) -> int:
+    async def _count_candidates_missing_analysis(self, aa_domain: str, current_version: int) -> int:
         """Count filesystem candidate tracks needing (re)analysis for aa_domain.
 
         A track is counted when it has no analysis row for the domain, or when

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -366,11 +366,54 @@ async def test_find_candidates_handles_sqlite_row_without_get(
     ]
     controller.mass.music.database.get_rows_from_query = AsyncMock(return_value=rows)  # type: ignore[method-assign]
 
-    result = await controller._find_candidates_missing_analysis(["loudness_analysis"], 100)
+    result = await controller._find_candidates_missing_analysis({"loudness_analysis": 1}, 100)
 
     assert len(result) == 1
     assert result[0]["item_id"] == "track-1"
     assert result[0]["missing_domains"] == ["loudness_analysis"]
+
+
+@pytest.mark.asyncio
+async def test_find_candidates_query_gates_on_current_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The candidate query must treat stale-version rows as needing re-analysis.
+
+    The NOT EXISTS gate may only count a stored analysis row as up-to-date when
+    its analysis_version is non-NULL and >= the provider's current version, so a
+    provider bumping analysis_version re-surfaces previously analyzed tracks.
+    """
+    controller = _make_controller()
+    p1 = _make_aa_provider("prov-1", available=True)
+    p1.domain = "sonic_analysis"
+    monkeypatch.setattr(
+        controller.__class__,
+        "providers",
+        property(lambda _self: [p1]),
+    )
+
+    fs_prov = MagicMock()
+    fs_prov.domain = "filesystem_local"
+    fs_prov.available = True
+    controller.mass.get_providers = MagicMock(return_value=[fs_prov])  # type: ignore[method-assign]
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(query: str, params: dict[str, Any], limit: int) -> list[Any]:  # noqa: ARG001
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    controller.mass.music.database.get_rows_from_query = AsyncMock(side_effect=_capture)  # type: ignore[method-assign]
+
+    await controller._find_candidates_missing_analysis({"sonic_analysis": 3}, 0)
+
+    sql = captured["query"]
+    assert "aa.analysis_version IS NOT NULL" in sql
+    assert "aa.analysis_version >= possible.current_version" in sql
+    assert captured["params"]["ver_0"] == 3
+    assert captured["params"]["aa_0"] == "sonic_analysis"
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -1075,7 +1075,7 @@ async def test_count_candidates_missing_analysis_zero_without_filesystem() -> No
     c, _ = _stub_controller()
     c.mass.get_providers = MagicMock(return_value=[])  # type: ignore[method-assign]
 
-    assert await c._count_candidates_missing_analysis("sonic_analysis") == 0
+    assert await c._count_candidates_missing_analysis("sonic_analysis", 1) == 0
 
 
 @pytest.mark.asyncio
@@ -1088,14 +1088,20 @@ async def test_count_candidates_missing_analysis_queries_with_available_filesyst
     fs_prov.available = True
     c.mass.get_providers = MagicMock(return_value=[fs_prov])  # type: ignore[method-assign]
 
-    result = await c._count_candidates_missing_analysis("sonic_analysis")
+    result = await c._count_candidates_missing_analysis("sonic_analysis", 2)
 
     assert result == 7
     db.get_count_from_query.assert_awaited_once()
     sql, params = db.get_count_from_query.await_args.args
     assert "NOT EXISTS" in sql
+    assert "aa.analysis_version IS NOT NULL" in sql
+    assert "aa.analysis_version >= :current_version" in sql
     assert f"'{domain}'" in sql
-    assert params == {"media_type": MediaType.TRACK.value, "aa_domain": "sonic_analysis"}
+    assert params == {
+        "media_type": MediaType.TRACK.value,
+        "aa_domain": "sonic_analysis",
+        "current_version": 2,
+    }
 
 
 def test_controller_has_no_provider_specific_extra_data_keys() -> None:


### PR DESCRIPTION
The nightly background scan only surfaced tracks with no analysis row at all, treating any existing row as done regardless of analysis_version. So when an AA provider bumped its analysis_version, only live playback (via the base-class start_analysis version gate) re-analyzed old tracks; the background scan never picked them up.

(H/T @OzGav)

The candidate query now passes each provider's current analysis_version and only counts a stored row as up-to-date when its analysis_version is non-NULL and >= the current version, so missing rows, stale-version rows and pre-versioning NULL rows all surface for re-analysis.

**Related issue (if applicable):**

[- related issue <link to issue>](https://github.com/music-assistant/server/pull/4070)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
