### PR TITLE
AirPlay: Skip PIN pairing for legacy RAOP devices without HAP public key

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -389,7 +389,16 @@ class AirPlayPlayer(Player):
 
         Adapted from pyatv.protocols.airplay.utils.get_pairing_requirement.
         """
-        return bool(self._get_flags() & (LEGACY_PAIRING_BIT | PIN_REQUIRED))
+        if not (self._get_flags() & (LEGACY_PAIRING_BIT | PIN_REQUIRED)):
+            return False
+        # Only devices advertising a public key ('pk') support HAP/SRP PIN pairing.
+        # Legacy RAOP-only devices (e.g. AirPort Express) may set PIN_REQUIRED when a
+        # speaker password is enabled but don't implement /pair-setup-pin — they use
+        # simple password authentication via the CONF_PASSWORD setting instead.
+        return any(
+            di.decoded_properties.get("pk")
+            for di in filter(None, [self.raop_discovery_info, self.airplay_discovery_info])
+        )
 
     def _requires_password_pairing(self) -> bool:
         """Check if this device requires password authentication.

--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -391,10 +391,7 @@ class AirPlayPlayer(Player):
         """
         if not (self._get_flags() & (LEGACY_PAIRING_BIT | PIN_REQUIRED)):
             return False
-        # Only devices advertising a public key ('pk') support HAP/SRP PIN pairing.
-        # Legacy RAOP-only devices (e.g. AirPort Express) may set PIN_REQUIRED when a
-        # speaker password is enabled but don't implement /pair-setup-pin — they use
-        # simple password authentication via the CONF_PASSWORD setting instead.
+        # Devices without 'pk' in their mDNS use password auth, not HAP/SRP PIN pairing.
         return any(
             di.decoded_properties.get("pk")
             for di in filter(None, [self.raop_discovery_info, self.airplay_discovery_info])


### PR DESCRIPTION
<!-- This PR was auto-triaged from support issue https://github.com/music-assistant/support/issues/5594 -->

# What does this implement/fix?

Devices like AirPort Express (Gen1/Gen2) may advertise `PIN_REQUIRED` in their mDNS `sf` flags when a speaker password is enabled. Music Assistant interpreted this as requiring HAP/SRP PIN pairing, marked the player as needing setup (unavailable), and then failed the pairing process with HTTP 404 because the AirPort Express does not implement the `/pair-setup-pin` endpoint — it uses simple password authentication instead.

The fix gates PIN pairing on whether the device advertises a public key (`pk`) in its discovery properties. Only HAP/HomeKit-capable devices (Apple TV, HomePod) carry `pk`; legacy RAOP-only devices do not, and should use simple password authentication via the **Device password** player setting (`CONF_PASSWORD`) instead.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5594

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShMXh6raz5Qj57aiY1sr5a)_