### PR TITLE
Spread metadata maintenance schedule across the day

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1427,8 +1427,39 @@ class ConfigController:
                 )
                 changed = True
 
+        # Drop the persisted schedule for the metadata maintenance tasks that were hardcoded
+        # to run at 04:00 local. They are now registered under new ("_v2") task ids with a
+        # randomized full-day schedule (to avoid spiking the shared musicbrainz mirror), so the
+        # old persisted state is orphaned and can be removed.
+        # TODO: remove after 2.10 release
+        if self._migrate_metadata_maintenance_schedule():
+            changed = True
+
         if changed:
             await self._async_save()
+
+    def _migrate_metadata_maintenance_schedule(self) -> bool:
+        """Remove the orphaned persisted state for the pre-randomization metadata task ids."""
+        core_config = self._data.get(CONF_CORE)
+        if not isinstance(core_config, dict):
+            return False
+        tasks_config = core_config.get("tasks")
+        if not isinstance(tasks_config, dict):
+            return False
+        task_states = tasks_config.get("scheduled_task_states")
+        if not isinstance(task_states, dict):
+            return False
+        legacy_task_ids = (
+            "metadata_missing_artist_metadata_scan",
+            "metadata_playlist_metadata_scan",
+            "metadata_thumb_cache_cleanup",
+        )
+        removed = [task_id for task_id in legacy_task_ids if task_id in task_states]
+        for task_id in removed:
+            del task_states[task_id]
+        if removed:
+            LOGGER.info("Removed orphaned metadata maintenance schedule state for %s", removed)
+        return bool(removed)
 
     def _migrate_fully_kiosk_multi_instance(self) -> bool:
         """Collapse legacy multi-instance Fully Kiosk configs into a single provider instance."""

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1431,7 +1431,7 @@ class ConfigController:
         # to run at 04:00 local. They are now registered under new ("_v2") task ids with a
         # randomized full-day schedule (to avoid spiking the shared musicbrainz mirror), so the
         # old persisted state is orphaned and can be removed.
-        # TODO: remove after 2.10 release
+        # TODO: remove after 2.9 release
         if self._migrate_metadata_maintenance_schedule():
             changed = True
 

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1429,7 +1429,7 @@ class ConfigController:
 
         # Drop the persisted schedule for the metadata maintenance tasks that were hardcoded
         # to run at 04:00 local. They are now registered under new ("_v2") task ids with a
-        # randomized full-day schedule (to avoid spiking the shared musicbrainz mirror), so the
+        # randomized full-day schedule (to avoid spiking the shared MusicBrainz mirror), so the
         # old persisted state is orphaned and can be removed.
         # TODO: remove after 2.9 release
         if self._migrate_metadata_maintenance_schedule():

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -71,7 +71,6 @@ from music_assistant.controllers.tasks.context import (
 )
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.compare import compare_strings
-from music_assistant.helpers.datetime import local_clock_time_to_utc
 from music_assistant.helpers.images import (
     cleanup_thumb_cache,
     create_collage,
@@ -219,9 +218,10 @@ REFRESH_INTERVAL = 60 * 60 * 24 * 90  # 90 days
 CONF_ENABLE_ONLINE_METADATA = "enable_online_metadata"
 CONF_PREFER_LOCAL_GENRES = "prefer_local_genres"
 CONF_ENABLE_RADIO_METADATA_LOOKUP = "enable_radio_metadata_lookup"
-MISSING_ARTIST_METADATA_SCAN_TASK_ID = "metadata_missing_artist_metadata_scan"
-PLAYLIST_METADATA_SCAN_TASK_ID = "metadata_playlist_metadata_scan"
-THUMB_CACHE_CLEANUP_TASK_ID = "metadata_thumb_cache_cleanup"
+# "_v2" ids drop the legacy 04:00 schedule on existing installs (see ConfigController._migrate).
+MISSING_ARTIST_METADATA_SCAN_TASK_ID = "metadata_missing_artist_metadata_scan_v2"
+PLAYLIST_METADATA_SCAN_TASK_ID = "metadata_playlist_metadata_scan_v2"
+THUMB_CACHE_CLEANUP_TASK_ID = "metadata_thumb_cache_cleanup_v2"
 METADATA_LOOKUP_TASK_ID_PREFIX = "metadata_lookup"
 METADATA_SCAN_BATCH_SIZE = 5
 CONF_THUMB_CACHE_MAX_SIZE = "thumb_cache_max_size"
@@ -1948,11 +1948,9 @@ class MetaDataController(CoreController):
 
     def _register_maintenance_tasks(self) -> None:
         """Register the recurring metadata maintenance background tasks."""
-        # Pick a random minute within a 3-hour window (02:00-05:00 local time) so that
-        # instances across the globe don't all hit the shared musicbrainz mirror at the
-        # exact same moment, spreading out the load and avoiding a request spike.
-        local_hour, local_minute = divmod(2 * 60 + random.randint(0, 3 * 60 - 1), 60)
-        utc_hour, utc_minute = local_clock_time_to_utc(local_hour, local_minute)
+        # Spread across the full day so instances don't all hit the shared musicbrainz mirror
+        # at once; persisted on first registration so it stays stable across restarts.
+        utc_hour, utc_minute = divmod(random.randint(0, 24 * 60 - 1), 60)
         desired_schedule = TaskSchedule.daily(hour=utc_hour, minute=utc_minute)
         self.mass.tasks.register_scheduled_task(
             task_id=MISSING_ARTIST_METADATA_SCAN_TASK_ID,

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -1948,7 +1948,7 @@ class MetaDataController(CoreController):
 
     def _register_maintenance_tasks(self) -> None:
         """Register the recurring metadata maintenance background tasks."""
-        # Spread across the full day so instances don't all hit the shared musicbrainz mirror at once
+        # Spread across the full day so instances don't all hit the shared MusicBrainz mirror at once
         utc_hour, utc_minute = divmod(random.randint(0, 24 * 60 - 1), 60)
         desired_schedule = TaskSchedule.daily(hour=utc_hour, minute=utc_minute)
         self.mass.tasks.register_scheduled_task(

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -1948,8 +1948,7 @@ class MetaDataController(CoreController):
 
     def _register_maintenance_tasks(self) -> None:
         """Register the recurring metadata maintenance background tasks."""
-        # Spread across the full day so instances don't all hit the shared musicbrainz mirror
-        # at once; persisted on first registration so it stays stable across restarts.
+        # Spread across the full day so instances don't all hit the shared musicbrainz mirror at once
         utc_hour, utc_minute = divmod(random.randint(0, 24 * 60 - 1), 60)
         desired_schedule = TaskSchedule.daily(hour=utc_hour, minute=utc_minute)
         self.mass.tasks.register_scheduled_task(

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -1948,7 +1948,11 @@ class MetaDataController(CoreController):
 
     def _register_maintenance_tasks(self) -> None:
         """Register the recurring metadata maintenance background tasks."""
-        utc_hour, utc_minute = local_clock_time_to_utc(4, 0)
+        # Pick a random minute within a 3-hour window (02:00-05:00 local time) so that
+        # instances across the globe don't all hit the shared musicbrainz mirror at the
+        # exact same moment, spreading out the load and avoiding a request spike.
+        local_hour, local_minute = divmod(2 * 60 + random.randint(0, 3 * 60 - 1), 60)
+        utc_hour, utc_minute = local_clock_time_to_utc(local_hour, local_minute)
         desired_schedule = TaskSchedule.daily(hour=utc_hour, minute=utc_minute)
         self.mass.tasks.register_scheduled_task(
             task_id=MISSING_ARTIST_METADATA_SCAN_TASK_ID,

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -218,7 +218,6 @@ REFRESH_INTERVAL = 60 * 60 * 24 * 90  # 90 days
 CONF_ENABLE_ONLINE_METADATA = "enable_online_metadata"
 CONF_PREFER_LOCAL_GENRES = "prefer_local_genres"
 CONF_ENABLE_RADIO_METADATA_LOOKUP = "enable_radio_metadata_lookup"
-# "_v2" ids drop the legacy 04:00 schedule on existing installs (see ConfigController._migrate).
 MISSING_ARTIST_METADATA_SCAN_TASK_ID = "metadata_missing_artist_metadata_scan_v2"
 PLAYLIST_METADATA_SCAN_TASK_ID = "metadata_playlist_metadata_scan_v2"
 THUMB_CACHE_CLEANUP_TASK_ID = "metadata_thumb_cache_cleanup_v2"

--- a/tests/core/test_background_tasks.py
+++ b/tests/core/test_background_tasks.py
@@ -31,6 +31,7 @@ from music_assistant.controllers.media.playlists import PlaylistController
 from music_assistant.controllers.metadata import (
     MISSING_ARTIST_METADATA_SCAN_TASK_ID,
     PLAYLIST_METADATA_SCAN_TASK_ID,
+    THUMB_CACHE_CLEANUP_TASK_ID,
     MetaDataController,
 )
 from music_assistant.controllers.music import MusicController
@@ -438,6 +439,7 @@ async def test_core_maintenance_tasks_register_nightly_schedules(
     cache_task = tasks_controller.get_task("cache_database_cleanup")
     artist_scan_task = tasks_controller.get_task(MISSING_ARTIST_METADATA_SCAN_TASK_ID)
     playlist_scan_task = tasks_controller.get_task(PLAYLIST_METADATA_SCAN_TASK_ID)
+    thumb_cleanup_task = tasks_controller.get_task(THUMB_CACHE_CLEANUP_TASK_ID)
 
     assert cache_task.translation_key == "background_task.cache_database_cleanup"
     assert cache_task.schedule == maintenance_schedule
@@ -460,12 +462,15 @@ async def test_core_maintenance_tasks_register_nightly_schedules(
     assert playlist_scan_task.metadata == {"task_domain": "metadata_playlist_metadata_scan"}
 
     # Metadata maintenance tasks pick a random time spread across the full day (instead of a
-    # fixed 04:00) to avoid spiking the shared musicbrainz mirror, but share one time per instance.
+    # fixed 04:00) to avoid spiking the shared MusicBrainz mirror, but share one time per instance.
     assert artist_scan_task.schedule is not None
     assert artist_scan_task.schedule.type == TaskScheduleType.DAILY
-    assert 0 <= (artist_scan_task.schedule.hour or 0) <= 23
-    assert 0 <= (artist_scan_task.schedule.minute or 0) <= 59
+    assert artist_scan_task.schedule.hour is not None
+    assert artist_scan_task.schedule.minute is not None
+    assert 0 <= artist_scan_task.schedule.hour <= 23
+    assert 0 <= artist_scan_task.schedule.minute <= 59
     assert artist_scan_task.schedule == playlist_scan_task.schedule
+    assert thumb_cleanup_task.schedule == artist_scan_task.schedule
 
 
 async def test_music_sync_completion_queues_database_cleanup_background_task(

--- a/tests/core/test_background_tasks.py
+++ b/tests/core/test_background_tasks.py
@@ -461,8 +461,8 @@ async def test_core_maintenance_tasks_register_nightly_schedules(
     assert playlist_scan_task.translation_key == "background_task.refresh_playlist_metadata"
     assert playlist_scan_task.metadata == {"task_domain": "metadata_playlist_metadata_scan"}
 
-    # Metadata maintenance tasks pick a random time spread across the full day (instead of a
-    # fixed 04:00) to avoid spiking the shared MusicBrainz mirror, but share one time per instance.
+    # Metadata maintenance tasks pick a random time spread across the full day
+    # to avoid spiking the shared MusicBrainz mirror, but share one time per instance.
     assert artist_scan_task.schedule is not None
     assert artist_scan_task.schedule.type == TaskScheduleType.DAILY
     assert artist_scan_task.schedule.hour is not None

--- a/tests/core/test_background_tasks.py
+++ b/tests/core/test_background_tasks.py
@@ -25,9 +25,14 @@ from music_assistant_models.provider import ProviderManifest
 
 import music_assistant.controllers.media.playlists as playlists_module
 from music_assistant.controllers.cache import CacheController
+from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.media.genres import GenreController
 from music_assistant.controllers.media.playlists import PlaylistController
-from music_assistant.controllers.metadata import MetaDataController
+from music_assistant.controllers.metadata import (
+    MISSING_ARTIST_METADATA_SCAN_TASK_ID,
+    PLAYLIST_METADATA_SCAN_TASK_ID,
+    MetaDataController,
+)
 from music_assistant.controllers.music import MusicController
 from music_assistant.controllers.tasks import (
     TasksController,
@@ -65,7 +70,7 @@ async def _wait_for_task_status(
 
 
 @pytest.fixture
-async def tasks_controller(mass_minimal: MusicAssistant) -> AsyncGenerator[TasksController, None]:
+async def tasks_controller(mass_minimal: MusicAssistant) -> AsyncGenerator[TasksController]:
     """Set up the background tasks controller on a minimal Music Assistant instance."""
     controller = TasksController(mass_minimal)
     mass_minimal.tasks = controller
@@ -431,8 +436,8 @@ async def test_core_maintenance_tasks_register_nightly_schedules(
     metadata._register_maintenance_tasks()
 
     cache_task = tasks_controller.get_task("cache_database_cleanup")
-    artist_scan_task = tasks_controller.get_task("metadata_missing_artist_metadata_scan")
-    playlist_scan_task = tasks_controller.get_task("metadata_playlist_metadata_scan")
+    artist_scan_task = tasks_controller.get_task(MISSING_ARTIST_METADATA_SCAN_TASK_ID)
+    playlist_scan_task = tasks_controller.get_task(PLAYLIST_METADATA_SCAN_TASK_ID)
 
     assert cache_task.translation_key == "background_task.cache_database_cleanup"
     assert cache_task.schedule == maintenance_schedule
@@ -449,12 +454,18 @@ async def test_core_maintenance_tasks_register_nightly_schedules(
     assert genre_scan_task.schedule == maintenance_schedule
 
     assert artist_scan_task.translation_key == "background_task.scan_missing_artist_metadata"
-    assert artist_scan_task.schedule == maintenance_schedule
     assert artist_scan_task.metadata == {"task_domain": "metadata_missing_artist_metadata_scan"}
 
     assert playlist_scan_task.translation_key == "background_task.refresh_playlist_metadata"
-    assert playlist_scan_task.schedule == maintenance_schedule
     assert playlist_scan_task.metadata == {"task_domain": "metadata_playlist_metadata_scan"}
+
+    # Metadata maintenance tasks pick a random time spread across the full day (instead of a
+    # fixed 04:00) to avoid spiking the shared musicbrainz mirror, but share one time per instance.
+    assert artist_scan_task.schedule is not None
+    assert artist_scan_task.schedule.type == TaskScheduleType.DAILY
+    assert 0 <= (artist_scan_task.schedule.hour or 0) <= 23
+    assert 0 <= (artist_scan_task.schedule.minute or 0) <= 59
+    assert artist_scan_task.schedule == playlist_scan_task.schedule
 
 
 async def test_music_sync_completion_queues_database_cleanup_background_task(
@@ -587,3 +598,59 @@ async def test_schedule_update_metadata_uses_managed_background_task(
         await asyncio.sleep(0.01)
     else:
         raise AssertionError("Metadata lookup task did not finish successfully")
+
+
+def _legacy_maintenance_schedule_state() -> dict[str, Any]:
+    """Build a persisted core/tasks config holding the legacy 04:00 metadata schedules."""
+    return {
+        "tasks": {
+            "domain": "tasks",
+            "scheduled_task_states": {
+                "metadata_missing_artist_metadata_scan": {
+                    "status": "idle",
+                    "schedule": {"type": "daily", "enabled": True, "hour": 4, "minute": 0},
+                },
+                "metadata_playlist_metadata_scan": {
+                    "status": "idle",
+                    "schedule": {"type": "daily", "enabled": True, "hour": 4, "minute": 0},
+                },
+                "metadata_thumb_cache_cleanup": {
+                    "status": "idle",
+                    "schedule": {"type": "daily", "enabled": True, "hour": 4, "minute": 0},
+                },
+                "music_database_cleanup": {
+                    "status": "idle",
+                    "schedule": {"type": "daily", "enabled": True, "hour": 5, "minute": 0},
+                },
+            },
+        }
+    }
+
+
+async def test_metadata_maintenance_schedule_migration_drops_legacy_state(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """The config migration should remove only the orphaned legacy metadata task state."""
+    config = ConfigController(mass_minimal)
+    config._data = {"core": _legacy_maintenance_schedule_state()}
+
+    assert config._migrate_metadata_maintenance_schedule() is True
+
+    task_states = config._data["core"]["tasks"]["scheduled_task_states"]
+    assert "metadata_missing_artist_metadata_scan" not in task_states
+    assert "metadata_playlist_metadata_scan" not in task_states
+    assert "metadata_thumb_cache_cleanup" not in task_states
+    # Unrelated scheduled tasks must be left untouched.
+    assert "music_database_cleanup" in task_states
+
+    # Migration is idempotent: a second pass finds nothing left to remove.
+    assert config._migrate_metadata_maintenance_schedule() is False
+
+
+async def test_metadata_maintenance_schedule_migration_noop_without_state(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """The migration should be a no-op when no persisted task state exists."""
+    config = ConfigController(mass_minimal)
+    config._data = {}
+    assert config._migrate_metadata_maintenance_schedule() is False


### PR DESCRIPTION
# What does this implement/fix?

The daily metadata maintenance tasks were hard-scheduled at 04:00 local time. The
"scan missing artist metadata" task queries the shared MusicBrainz mirror
(`musicbrainz-mirror.music-assistant.io`), so every instance firing at the same
wall-clock minute caused a request spike on the mirror.

This spreads the schedule across the full day using a per-instance random time.
Since the schedule is persisted and restored on boot, existing installs are
migrated rather than left stuck on their old 04:00 time.

- Pick a random daily time across the full 24h instead of a fixed 04:00
- Register the maintenance tasks under new (`_v2`) ids so existing installs drop
  the persisted 04:00 schedule and pick up the randomized one
- Clean up the orphaned legacy task state in `ConfigController._migrate`
- Add/update tests

**Related issue (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
