### PR TITLE
Don't enqueue next track onto a stopped queue

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -683,6 +683,10 @@ class PlayerQueuesController(CoreController):
         self._check_player_permission(queue_id)
         # cancel any pending play_index calls for this queue to prevent conflicts
         self.mass.cancel_timer(f"queue_play_index_{queue_id}")
+        # cancel in-flight preload/enqueue-next so it can't enqueue after stop
+        self.mass.cancel_task(f"preload_next_item_{queue_id}")
+        self.mass.cancel_timer(f"enqueue_next_item_{queue_id}")
+        self.mass.cancel_task(f"enqueue_next_item_{queue_id}")
         self._transitioning_players.discard(queue_id)
         queue_player = self.mass.players.get_player(queue_id, True)
         if queue_player is None:
@@ -2351,7 +2355,11 @@ class PlayerQueuesController(CoreController):
             return
 
         async def _enqueue_next_item_on_player(next_item: QueueItem) -> None:
-            if not queue.active or queue.session_id != session_id:
+            if (
+                not queue.active
+                or queue.session_id != session_id
+                or queue.state != PlaybackState.PLAYING
+            ):
                 # queue is not active anymore or session_id does not match, so we bail out
                 return
             await self.mass.players.enqueue_next_media(


### PR DESCRIPTION
# What does this implement/fix?

Fixes playback resuming by itself a while after the user stops or pauses, observed on WiiM (LinkPlay) players.

A next-track preload — notably Smart Fades crossfade/beat analysis, which can take tens of seconds — can finish well after the queue was stopped or paused. The enqueue-next guard only checked `queue.active` and `session_id`, neither of which a stop/pause changes, so it still called `enqueue_next_media`. On WiiM/LinkPlay players, issuing `SetNextAVTransportURI` on a stopped device makes the device start playing, so playback resumed on its own seconds-to-minutes after the user stopped/paused. (Per the UPnP AVTransport spec, staging a next URI should not start playback — this is firmware behaviour, but MA should not be enqueuing onto a non-playing queue regardless.)

Fix (defense in depth):
- Skip enqueue-next when the queue is no longer playing (`queue.state != PLAYING`).
- Cancel the in-flight preload/enqueue-next tasks in `stop()` so a slow preload finishing after stop can't enqueue.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
