### PR TITLE
Bump `aiosendspin` to 6.0.2 to fix spec conformance issues

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin[server]==6.0.1", "av==16.1.0"],
+  "requirements": ["aiosendspin[server]==6.0.2", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ aiohttp-socks==0.11.0
 aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
-aiosendspin[server]==6.0.1
+aiosendspin[server]==6.0.2
 aioslimproto==3.1.8
 aiosonos==0.1.12
 aiosqlite==0.22.1


### PR DESCRIPTION
Notable fixes pulled in:

- mDNS withdrawal no longer cancels the connection retry task. A transient mDNS drop on a still-online device no longer leaves the client unavailable until the server restarts.
- `client/state` partial updates honor the spec delta merge rule, so `static_delay_ms` / `required_lead_time_ms` / `min_buffer_ms` aren't reset to defaults when omitted.
- `buffer_capacity` is now a real byte cap; oversize chunks wait for the buffer to drain instead of bypassing the limit.
- Sendspin clients with player-only, metadata-only, or artwork-only roles now correctly leave their group when an external source (e.g. another app casting) takes over the leader.
- Ungrouping a client always finalizes its old group instead of leaving stale members behind.
- Unknown spec-versioned role IDs (e.g. `visualizer@v2` on a v1-only server) are ignored and logged instead of crashing deserialization, so newer clients no longer break the server on the announce path.

See https://github.com/Sendspin/aiosendspin/pull/259 and https://github.com/Sendspin/aiosendspin/pull/260 for the full list of changes.