### PR TITLE
Send Sendspin album artwork for radio and Spotify Connect streams

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -829,23 +829,15 @@ class SendspinPlayer(SendspinBasePlayer):
                     f.cancel()
         # self.group_members will be updated by the group event callback
 
-    async def _send_album_artwork(
-        self, current_media: PlayerMedia, queue_item: QueueItem | None
-    ) -> str | None:
+    async def _send_album_artwork(self, current_media: PlayerMedia) -> str | None:
         """
         Send album artwork to the sendspin group.
 
         Args:
             current_media: The current player media.
-            queue_item: The current queue item, or None for raw streams
-                (radio, Spotify Connect) with no resolved MA queue item.
         """
-        # PlayerMedia.image_url is synthesized from stream_metadata.image_url
-        # by the players controller, so it carries radio / Spotify Connect art.
+        # image_url is resolved per-source upstream (radio / Spotify Connect / queue items).
         artwork_url = current_media.image_url
-        if artwork_url is None and queue_item is not None and queue_item.image is not None:
-            artwork_url = self.mass.metadata.get_image_url(queue_item.image)
-
         if artwork_url != self.last_sent_artwork_url:
             self.last_sent_artwork_url = artwork_url
             image_data: bytes | None = None
@@ -994,7 +986,7 @@ class SendspinPlayer(SendspinBasePlayer):
             )
 
         # Runs even without a queue item so radio / Spotify Connect streams still get art.
-        await self._send_album_artwork(current_media, queue_item)
+        await self._send_album_artwork(current_media)
         if queue_item:
             await self._send_artist_artwork(queue_item)
 

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -829,29 +829,36 @@ class SendspinPlayer(SendspinBasePlayer):
                     f.cancel()
         # self.group_members will be updated by the group event callback
 
-    async def _send_album_artwork(self, current_item: QueueItem) -> str | None:
+    async def _send_album_artwork(
+        self, current_media: PlayerMedia, queue_item: QueueItem | None
+    ) -> str | None:
         """
         Send album artwork to the sendspin group.
 
         Args:
-            current_item: The current queue item.
+            current_media: The current player media.
+            queue_item: The current queue item, or None for raw streams
+                (radio, Spotify Connect) with no resolved MA queue item.
         """
-        artwork_url = None
-        if current_item.image is not None:
-            artwork_url = self.mass.metadata.get_image_url(current_item.image)
+        # PlayerMedia.image_url is synthesized from stream_metadata.image_url
+        # by the players controller, so it carries radio / Spotify Connect art.
+        artwork_url = current_media.image_url
+        if artwork_url is None and queue_item is not None and queue_item.image is not None:
+            artwork_url = self.mass.metadata.get_image_url(queue_item.image)
 
         if artwork_url != self.last_sent_artwork_url:
-            # Image changed, resend the artwork
             self.last_sent_artwork_url = artwork_url
-            if artwork_url is not None and current_item.media_item is not None:
-                image_data = await self.mass.metadata.get_image_data_for_item(
-                    current_item.media_item
-                )
-                if image_data is not None:
-                    image = await asyncio.to_thread(Image.open, BytesIO(image_data))
-                    if (artwork_role := self._artwork_role) is not None:
-                        await artwork_role.set_album_artwork(image)
-            # Clear artwork if none available
+            image_data: bytes | None = None
+            if artwork_url is not None:
+                # Fetch from the resolved URL so the bytes match artwork_url, even when
+                # radio now-playing art differs from the queue item's own image.
+                fetched = await self.mass.metadata.get_thumbnail(artwork_url, provider="builtin")
+                if isinstance(fetched, bytes):
+                    image_data = fetched
+            if image_data is not None:
+                image = await asyncio.to_thread(Image.open, BytesIO(image_data))
+                if (artwork_role := self._artwork_role) is not None:
+                    await artwork_role.set_album_artwork(image)
             elif (artwork_role := self._artwork_role) is not None:
                 await artwork_role.set_album_artwork(None)
 
@@ -986,9 +993,9 @@ class SendspinPlayer(SendspinBasePlayer):
                 current_media.source_id, current_media.queue_item_id
             )
 
-        # Send album and artist artwork
+        # Runs even without a queue item so radio / Spotify Connect streams still get art.
+        await self._send_album_artwork(current_media, queue_item)
         if queue_item:
-            await self._send_album_artwork(queue_item)
             await self._send_artist_artwork(queue_item)
 
         track_number: int | None = None


### PR DESCRIPTION
Album artwork was only sent inside the `queue_item` branch, so radio and Spotify Connect streams never updated it. Instead it is now sent based on `current_media.image_url`, so radio shows the now-playing cover instead of the static station logo.