### PR TITLE
Separate Phish.in artist tracks from top tracks

### DIFF
--- a/music_assistant/providers/phishin/__init__.py
+++ b/music_assistant/providers/phishin/__init__.py
@@ -21,6 +21,7 @@ SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_ARTISTS,
     ProviderFeature.LIBRARY_PLAYLISTS,
     ProviderFeature.ARTIST_ALBUMS,
+    ProviderFeature.ARTIST_TRACKS,
     ProviderFeature.ARTIST_TOPTRACKS,
 }
 

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -199,44 +199,56 @@ class PhishInProvider(MusicProvider):
         if prov_artist_id != PHISH_ARTIST_ID:
             raise MediaNotFoundError(f"Artist {prov_artist_id} not found")
 
-        try:
-            all_tracks: list[Track] = []
-            page = 1
-            per_page = 500
-            max_pages = 5  # 2500 tracks max for UI performance
+        # single ranked page, mirroring Phish.in's own top-tracks page
+        tracks_data = await api_request(
+            self,
+            ENDPOINTS["tracks"],
+            params={
+                "page": 1,
+                "per_page": 50,
+                "sort": "likes_count:desc",
+                "audio_status": "complete_or_partial",
+            },
+        )
+        return [track_to_ma_track(self, track_data) for track_data in tracks_data.get("tracks", [])]
 
-            while page <= max_pages:
-                tracks_data = await api_request(
-                    self,
-                    ENDPOINTS["tracks"],
-                    params={
-                        "page": page,
-                        "per_page": per_page,
-                        "sort": "likes_count:desc",
-                        "audio_status": "complete_or_partial",
-                    },
-                )
+    @use_cache(expiration=86400)  # 24 hours - new performances can be added as shows are uploaded
+    async def get_artist_tracks(self, prov_artist_id: str) -> list[Track]:
+        """Get a list of all tracks for the given artist."""
+        if prov_artist_id != PHISH_ARTIST_ID:
+            raise MediaNotFoundError(f"Artist {prov_artist_id} not found")
 
-                tracks_on_page = tracks_data.get("tracks", [])
-                if not tracks_on_page:
-                    break
+        all_tracks: list[Track] = []
+        page = 1
+        per_page = 500
+        max_pages = 5  # cap at 2500 tracks for UI performance
 
-                for track_data in tracks_on_page:
-                    all_tracks.append(track_to_ma_track(self, track_data))
+        while page <= max_pages:
+            tracks_data = await api_request(
+                self,
+                ENDPOINTS["tracks"],
+                params={
+                    "page": page,
+                    "per_page": per_page,
+                    "sort": "likes_count:desc",
+                    "audio_status": "complete_or_partial",
+                },
+            )
 
-                # a short page means we've reached the end
-                if len(tracks_on_page) < per_page:
-                    break
+            tracks_on_page = tracks_data.get("tracks", [])
+            if not tracks_on_page:
+                break
 
-                page += 1
+            for track_data in tracks_on_page:
+                all_tracks.append(track_to_ma_track(self, track_data))
 
-            return all_tracks
+            # short page means the last page was reached
+            if len(tracks_on_page) < per_page:
+                break
 
-        except (MediaNotFoundError, ProviderUnavailableError):
-            raise
-        except Exception as err:
-            self.logger.error("Failed to get artist top tracks: %s", err)
-            raise ProviderUnavailableError(f"Top tracks error: {err}") from err
+            page += 1
+
+        return all_tracks
 
     @use_cache(expiration=2592000)  # 30 days - Show details from specific dates never change
     async def get_album(self, prov_album_id: str) -> Album:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Originally `get_artist_toptracks` was returning 2500 tracks from phish.in. `get_artist_toptracks` now returns a single ranked page (top 50, mirroring Phish.in's own top-tracks page) instead of paging the whole catalogue, so the artist page populates fast. The full listing moves to a new `get_artist_tracks` (ARTIST_TRACKS feature).


**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
