### PR TITLE
Add get_artist_toptracks to lastfm recommendations provider

### DIFF
--- a/music_assistant/providers/lastfm_recommendations/__init__.py
+++ b/music_assistant/providers/lastfm_recommendations/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.config_entries import (
@@ -18,11 +18,14 @@ from music_assistant_models.errors import (
     MusicAssistantError,
     ResourceTemporarilyUnavailable,
 )
+from music_assistant_models.media_items import Track
 
 from music_assistant.constants import CONF_USERNAME
 from music_assistant.models.metadata_provider import MetadataProvider
 from music_assistant.providers.lastfm_recommendations.api_client import LastFMAPIClient
 from music_assistant.providers.lastfm_recommendations.constants import (
+    CACHE_CATEGORY_RESOLVED_ITEMS,
+    CACHE_EXPIRATION_SECONDS,
     CONF_ACTION_CLEAR_CACHE,
     CONF_API_KEY,
     CONF_ENABLE_GENRE,
@@ -39,7 +42,7 @@ from music_assistant.providers.lastfm_recommendations.recommendations import (
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ProviderConfig
-    from music_assistant_models.media_items import Artist, RecommendationFolder, Track
+    from music_assistant_models.media_items import Artist, RecommendationFolder
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.mass import MusicAssistant
@@ -49,6 +52,7 @@ SUPPORTED_FEATURES = {
     ProviderFeature.RECOMMENDATIONS,
     ProviderFeature.SIMILAR_ARTISTS,
     ProviderFeature.SIMILAR_TRACKS,
+    ProviderFeature.ARTIST_TOPTRACKS,
 }
 
 
@@ -249,3 +253,50 @@ class LastFMRecommendationsProvider(MetadataProvider):
             *[self.recommendations_manager.get_or_resolve_track(raw) for raw in similar_raw]
         )
         return [t for t in resolved if t is not None]
+
+    async def get_artist_toptracks(self, artist: Artist, limit: int = 25) -> list[Track]:
+        """Retrieve an artist's top tracks from Last.fm.
+
+        :param artist: The reference artist.
+        :param limit: Maximum number of top tracks to return.
+        """
+        artist_mbid = artist.get_external_id(ExternalID.MB_ARTIST)
+        cache_key = f"toptracks.{artist.name}.{artist_mbid or ''}.{limit}"
+        # Resolving every track hits MusicBrainz/streaming providers, so serve a cached
+        # listing where we have one (shares the category the "Clear Cache" action flushes).
+        if cached := await self.mass.cache.get(
+            key=cache_key,
+            category=CACHE_CATEGORY_RESOLVED_ITEMS,
+            provider=self.instance_id,
+            base_class=Track,
+        ):
+            return cast("list[Track]", cached)
+
+        top_raw = await self.api.get_artist_top_tracks(artist.name, artist_mbid, limit)
+        if not top_raw:
+            return []
+
+        # Tolerate individual resolution failures (e.g. a rate-limited lookup) so one bad
+        # track can't sink the whole listing.
+        resolved = await asyncio.gather(
+            *[self.recommendations_manager.get_or_resolve_track(raw) for raw in top_raw],
+            return_exceptions=True,
+        )
+        tracks = [t for t in resolved if isinstance(t, Track)]
+        self.logger.debug(
+            "Resolved %d/%d top tracks to playable items for '%s'",
+            len(tracks),
+            len(top_raw),
+            artist.name,
+        )
+
+        # Only cache a non-empty result so a transient resolution failure isn't persisted.
+        if tracks:
+            await self.mass.cache.set(
+                cache_key,
+                [track.to_dict() for track in tracks],
+                category=CACHE_CATEGORY_RESOLVED_ITEMS,
+                provider=self.instance_id,
+                expiration=CACHE_EXPIRATION_SECONDS,
+            )
+        return tracks

--- a/music_assistant/providers/lastfm_recommendations/__init__.py
+++ b/music_assistant/providers/lastfm_recommendations/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.config_entries import (
@@ -21,6 +21,7 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import Track
 
 from music_assistant.constants import CONF_USERNAME
+from music_assistant.controllers.cache import use_cache
 from music_assistant.models.metadata_provider import MetadataProvider
 from music_assistant.providers.lastfm_recommendations.api_client import LastFMAPIClient
 from music_assistant.providers.lastfm_recommendations.constants import (
@@ -261,18 +262,18 @@ class LastFMRecommendationsProvider(MetadataProvider):
         :param limit: Maximum number of top tracks to return.
         """
         artist_mbid = artist.get_external_id(ExternalID.MB_ARTIST)
-        cache_key = f"toptracks.{artist.name}.{artist_mbid or ''}.{limit}"
-        # Resolving every track hits MusicBrainz/streaming providers, so serve a cached
-        # listing where we have one (shares the category the "Clear Cache" action flushes).
-        if cached := await self.mass.cache.get(
-            key=cache_key,
-            category=CACHE_CATEGORY_RESOLVED_ITEMS,
-            provider=self.instance_id,
-            base_class=Track,
-        ):
-            return cast("list[Track]", cached)
+        return await self._get_artist_toptracks(artist.name, artist_mbid, limit)
 
-        top_raw = await self.api.get_artist_top_tracks(artist.name, artist_mbid, limit)
+    @use_cache(
+        CACHE_EXPIRATION_SECONDS,
+        category=CACHE_CATEGORY_RESOLVED_ITEMS,
+        allow_expired_cache=True,
+    )
+    async def _get_artist_toptracks(
+        self, artist_name: str, artist_mbid: str | None, limit: int
+    ) -> list[Track]:
+        """Fetch and resolve an artist's top tracks, keyed by name/mbid for caching."""
+        top_raw = await self.api.get_artist_top_tracks(artist_name, artist_mbid, limit)
         if not top_raw:
             return []
 
@@ -287,16 +288,6 @@ class LastFMRecommendationsProvider(MetadataProvider):
             "Resolved %d/%d top tracks to playable items for '%s'",
             len(tracks),
             len(top_raw),
-            artist.name,
+            artist_name,
         )
-
-        # Only cache a non-empty result so a transient resolution failure isn't persisted.
-        if tracks:
-            await self.mass.cache.set(
-                cache_key,
-                [track.to_dict() for track in tracks],
-                category=CACHE_CATEGORY_RESOLVED_ITEMS,
-                provider=self.instance_id,
-                expiration=CACHE_EXPIRATION_SECONDS,
-            )
         return tracks

--- a/music_assistant/providers/lastfm_recommendations/api_client.py
+++ b/music_assistant/providers/lastfm_recommendations/api_client.py
@@ -169,6 +169,44 @@ class LastFMAPIClient:
 
         return similar_tracks
 
+    async def get_artist_top_tracks(
+        self, artist_name: str, artist_mbid: str | None = None, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        """
+        Get an artist's top tracks from Last.fm, ordered by popularity.
+
+        :param artist_name: Name of the artist.
+        :param artist_mbid: Optional MusicBrainz ID for more accurate matching.
+        :param limit: Maximum number of top tracks to return.
+        """
+        params: dict[str, Any] = {"limit": limit}
+
+        # Prefer MBID for more accurate matching; fall back to name with autocorrect.
+        if artist_mbid:
+            params["mbid"] = artist_mbid
+        else:
+            params["artist"] = artist_name
+            params["autocorrect"] = 1
+
+        self.logger.debug(
+            "Fetching top tracks for artist: %s (MBID: %s)",
+            artist_name,
+            artist_mbid or "none",
+        )
+        try:
+            data = await self._get_data("artist.getTopTracks", **params)
+        except (TimeoutError, ClientError, InvalidDataError) as err:
+            self.logger.debug("Artist top tracks request failed: %s", err)
+            return []
+
+        tracks: list[dict[str, Any]] | dict[str, Any] = data.get("toptracks", {}).get("track", [])
+
+        # Last.fm returns a single dict when only one result is present.
+        if isinstance(tracks, dict):
+            return [tracks]
+
+        return tracks
+
     async def get_chart_top_artists(self, limit: int = 10) -> list[dict[str, Any]]:
         """
         Get global top artists chart from Last.fm.


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

With the change to the artist view it is advantageous for this provider to be able to provide artist_toptracks

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
