### PR TITLE
Enable WiiM and Last.fm Recommendations by default

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -1092,8 +1092,10 @@ DEFAULT_PROVIDERS: Final[set[tuple[str, bool, Callable[[], bool]]]] = {
     ("sonos", True, lambda: True),
     ("bluesound", True, lambda: True),
     ("heos", True, lambda: True),
+    ("wiim", True, lambda: True),
     ("party", False, lambda: True),
     ("smart_fades", False, lambda: (os.cpu_count() or 1) > 1),
+    ("lastfm_recommendations", False, lambda: True),
 }
 
 EXTERNAL_SOURCES: Final[set[str]] = {


### PR DESCRIPTION
# What does this implement/fix?

Enables two existing providers by default so users get them out of the box:

- **WiiM** is now set up automatically once WiiM mDNS traffic (`_linkplay._tcp.local.`) is detected on the network, matching the behaviour of Sonos/Bluesound/HEOS.
- **Last.fm Recommendations** is now set up by default on every install (no mDNS gate). All of its config entries are optional and it ships with a built-in API key, so no user configuration is required.

Both remain fully removable/disable-able, and the one-time default setup is tracked so a removed provider is not re-added.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
