### PR TITLE
Fix disappearing Sendspin Visualizer clients

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin[server]==6.0.2", "av==16.1.0"],
+  "requirements": ["aiosendspin[server]==6.0.3", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ aiohttp-socks==0.11.0
 aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
-aiosendspin[server]==6.0.2
+aiosendspin[server]==6.0.3
 aioslimproto==3.1.8
 aiosonos==0.1.12
 aiosqlite==0.22.1


### PR DESCRIPTION
Visualizer clients previously disappeared after the player grouped with them.
This PR bumps `aiosendspin` to fix this by stopping groups with only visualizers in them, making them show up in the frontend again.