### PR TITLE
Smart playlists: optional AI-generated descriptions

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -347,7 +347,7 @@ class SmartPlaylistProvider(PluginProvider):
         playlist = self._build_playlist(playlist_id, parsed_rules)
         library_playlist = await self.mass.music.playlists.add_item_to_library(playlist)
         self.mass.metadata.schedule_update_metadata(library_playlist)
-        self.mass.create_task(self._refresh_ai_description(playlist_id))
+        self._schedule_ai_description_refresh(playlist_id)
         return library_playlist
 
     async def generate_playlist(
@@ -439,7 +439,7 @@ class SmartPlaylistProvider(PluginProvider):
             await self._update_playlist_description(
                 library_item.item_id, self._description_for(prov_id, parsed_rules)
             )
-        self.mass.create_task(self._refresh_ai_description(prov_id))
+        self._schedule_ai_description_refresh(prov_id)
 
     async def list_smart_playlists(self) -> list[dict[str, Any]]:
         """Return list of all smart playlist IDs and their rule summaries."""
@@ -1021,10 +1021,20 @@ class SmartPlaylistProvider(PluginProvider):
             self.logger.debug("Could not update description for %s: %s", library_item_id, exc)
 
     def _description_for(self, playlist_id: str, rules: SmartPlaylistRules) -> str:
-        """Return the stored AI description, or the rules summary as fallback."""
-        if stored := self._descriptions_store.get(playlist_id):
+        """Return the stored AI description when enabled, else the rules summary."""
+        if self.config.get_value(CONF_AI_DESCRIPTIONS) and (
+            stored := self._descriptions_store.get(playlist_id)
+        ):
             return stored
         return f"{DESCRIPTION_PREFIX}{rules.human_readable()}"
+
+    def _schedule_ai_description_refresh(self, playlist_id: str) -> None:
+        """Schedule a background AI description refresh, deduped per playlist."""
+        self.mass.create_task(
+            self._refresh_ai_description(playlist_id),
+            task_id=f"smart_playlist_ai_desc_{playlist_id}",
+            abort_existing=True,
+        )
 
     async def _refresh_ai_description(self, playlist_id: str) -> None:
         """Regenerate and persist the AI description for a playlist, updating the library item."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1048,11 +1048,13 @@ class SmartPlaylistProvider(PluginProvider):
             return
         name = self._names_store.get(playlist_id, playlist_id)
         description = await self._generate_ai_description(name, rules)
+        previous = self._descriptions_store.get(playlist_id)
         if description:
             self._descriptions_store[playlist_id] = description
         else:
             self._descriptions_store.pop(playlist_id, None)
-        await self._flush_rules_to_disk()
+        if self._descriptions_store.get(playlist_id) != previous:
+            await self._flush_rules_to_disk()
         library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
             playlist_id, self.instance_id
         )

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -427,8 +427,10 @@ class SmartPlaylistProvider(PluginProvider):
         if existing is not None:
             parsed_rules.is_dynamic = existing.is_dynamic
         self._validate_rules(parsed_rules)
-        await self._save_rules(prov_id, parsed_rules)
+        # Drop the stale AI description before saving so it is invalidated on disk in the
+        # same flush as the rule change, not left behind until the background refresh runs.
         self._descriptions_store.pop(prov_id, None)
+        await self._save_rules(prov_id, parsed_rules)
 
         library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
             prov_id, self.instance_id

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1054,21 +1054,23 @@ class SmartPlaylistProvider(PluginProvider):
         """
         if not self.config.get_value(CONF_AI_DESCRIPTIONS):
             return None
+        locale = self.mass.metadata.locale
         for provider in self.mass.get_providers_supporting_feature(ProviderFeature.AI_QUERY):
             if not isinstance(provider, PluginProvider):
                 continue
             try:
-                response = await provider.ai_query(self._build_ai_prompt(name, rules))
+                response = await provider.ai_query(self._build_ai_prompt(name, rules, locale))
             except Exception as exc:
                 self.logger.debug("AI description generation failed for '%s': %s", name, exc)
                 return None
             return response.strip() or None
         return None
 
-    def _build_ai_prompt(self, name: str, rules: SmartPlaylistRules) -> str:
+    def _build_ai_prompt(self, name: str, rules: SmartPlaylistRules, locale: str) -> str:
         """Build the prompt asking an AI provider to describe the smart playlist."""
         return (
             "Write a short, friendly description (one or two sentences) for a music playlist. "
+            f"Write it in the language matching the locale '{locale}'. "
             "Reply with only the description, no quotes or preamble.\n"
             f"Playlist name: {name}\n"
             f"It contains tracks matching these rules: {rules.human_readable()}"

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1030,6 +1030,8 @@ class SmartPlaylistProvider(PluginProvider):
 
     def _schedule_ai_description_refresh(self, playlist_id: str) -> None:
         """Schedule a background AI description refresh, deduped per playlist."""
+        if not self.config.get_value(CONF_AI_DESCRIPTIONS):
+            return
         self.mass.create_task(
             self._refresh_ai_description(playlist_id),
             task_id=f"smart_playlist_ai_desc_{playlist_id}",
@@ -1058,7 +1060,7 @@ class SmartPlaylistProvider(PluginProvider):
 
     async def _generate_ai_description(self, name: str, rules: SmartPlaylistRules) -> str | None:
         """
-        Generate a natural-language description via the first available AI provider.
+        Generate a natural-language description via the first AI provider that responds.
 
         :param name: The playlist name, included in the prompt for context.
         :param rules: The rules whose summary the description should reflect.
@@ -1074,8 +1076,9 @@ class SmartPlaylistProvider(PluginProvider):
                 response = await provider.ai_query(self._build_ai_prompt(name, rules, locale))
             except Exception as exc:
                 self.logger.debug("AI description generation failed for '%s': %s", name, exc)
-                return None
-            return response.strip() or None
+                continue
+            if cleaned := response.strip():
+                return cleaned
         return None
 
     def _build_ai_prompt(self, name: str, rules: SmartPlaylistRules, locale: str) -> str:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1012,6 +1012,9 @@ class SmartPlaylistProvider(PluginProvider):
         """Update the library playlist description with the given text."""
         try:
             playlist = await self.mass.music.playlists.get_library_item(library_item_id)
+            if playlist.metadata and playlist.metadata.description == description:
+                # Already up to date; skip the redundant write and update event.
+                return
             updated = Playlist.from_dict(playlist.to_dict())
             updated.metadata.description = description
             await self.mass.music.playlists.update_item_in_library(

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -21,7 +21,15 @@ from dataclasses import replace as dc_replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.enums import AlbumType, EventType, ImageType, MediaType, ProviderFeature
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import (
+    AlbumType,
+    ConfigEntryType,
+    EventType,
+    ImageType,
+    MediaType,
+    ProviderFeature,
+)
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
     BrowseFolder,
@@ -54,7 +62,7 @@ from music_assistant.providers.smart_playlist.helpers import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+    from music_assistant_models.config_entries import ConfigValueType, ProviderConfig
     from music_assistant_models.event import MassEvent
     from music_assistant_models.provider import ProviderManifest
 
@@ -64,6 +72,9 @@ if TYPE_CHECKING:
 FETCH_LIMIT = 2000
 CACHE_CATEGORY_DYNAMIC_SAMPLE = 0
 DYNAMIC_SAMPLE_CACHE_EXPIRATION = 24 * 3600  # 24h; stale entries are still served via SWR
+
+CONF_AI_DESCRIPTIONS = "ai_descriptions"
+DESCRIPTION_PREFIX = "[Smart Playlist] "
 
 SUPPORTED_FEATURES: set[ProviderFeature] = {
     ProviderFeature.BROWSE,
@@ -85,7 +96,18 @@ async def get_config_entries(
     values: dict[str, ConfigValueType] | None = None,  # noqa: ARG001
 ) -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
-    return ()
+    return (
+        ConfigEntry(
+            key=CONF_AI_DESCRIPTIONS,
+            type=ConfigEntryType.BOOLEAN,
+            label="Generate descriptions with AI",
+            description="When a provider with AI support is available, use it to write a "
+            "natural-language description for each smart playlist. Falls back to a plain "
+            "rules summary when no AI provider is available.",
+            required=False,
+            default_value=True,
+        ),
+    )
 
 
 class SmartPlaylistProvider(PluginProvider):
@@ -94,6 +116,7 @@ class SmartPlaylistProvider(PluginProvider):
     _rules_dir: str
     _rules_store: dict[str, SmartPlaylistRules]
     _names_store: dict[str, str]
+    _descriptions_store: dict[str, str]
     _unregister_handles: list[Callable[[], None]]
     _flush_lock: asyncio.Lock
 
@@ -101,6 +124,7 @@ class SmartPlaylistProvider(PluginProvider):
         """Handle async initialization."""
         self._rules_store = {}
         self._names_store = {}
+        self._descriptions_store = {}
         self._unregister_handles = []
         self._flush_lock = asyncio.Lock()
         self._rules_dir = os.path.join(self.mass.storage_path, "smart_playlists")
@@ -275,6 +299,7 @@ class SmartPlaylistProvider(PluginProvider):
                 prov_id = mapping.item_id
                 self._rules_store.pop(prov_id, None)
                 self._names_store.pop(prov_id, None)
+                self._descriptions_store.pop(prov_id, None)
                 await self._invalidate_dynamic_sample_cache(prov_id)
                 await self._flush_rules_to_disk()
                 break
@@ -322,6 +347,7 @@ class SmartPlaylistProvider(PluginProvider):
         playlist = self._build_playlist(playlist_id, parsed_rules)
         library_playlist = await self.mass.music.playlists.add_item_to_library(playlist)
         self.mass.metadata.schedule_update_metadata(library_playlist)
+        self.mass.create_task(self._refresh_ai_description(playlist_id))
         return library_playlist
 
     async def generate_playlist(
@@ -402,12 +428,16 @@ class SmartPlaylistProvider(PluginProvider):
             parsed_rules.is_dynamic = existing.is_dynamic
         self._validate_rules(parsed_rules)
         await self._save_rules(prov_id, parsed_rules)
+        self._descriptions_store.pop(prov_id, None)
 
         library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
             prov_id, self.instance_id
         )
         if library_item:
-            await self._update_playlist_description(library_item.item_id, parsed_rules)
+            await self._update_playlist_description(
+                library_item.item_id, self._description_for(prov_id, parsed_rules)
+            )
+        self.mass.create_task(self._refresh_ai_description(prov_id))
 
     async def list_smart_playlists(self) -> list[dict[str, Any]]:
         """Return list of all smart playlist IDs and their rule summaries."""
@@ -513,7 +543,7 @@ class SmartPlaylistProvider(PluginProvider):
         )
         playlist.is_dynamic = rules.is_dynamic
         playlist.metadata = MediaItemMetadata(
-            description=f"[Smart Playlist] {rules.human_readable()}",
+            description=self._description_for(playlist_id, rules),
             images=UniqueList(
                 [
                     MediaItemImage(
@@ -975,18 +1005,74 @@ class SmartPlaylistProvider(PluginProvider):
             return []
 
     async def _update_playlist_description(
-        self, library_item_id: int | str, rules: SmartPlaylistRules
+        self, library_item_id: int | str, description: str
     ) -> None:
-        """Update the library playlist description with the rules summary."""
+        """Update the library playlist description with the given text."""
         try:
             playlist = await self.mass.music.playlists.get_library_item(library_item_id)
             updated = Playlist.from_dict(playlist.to_dict())
-            updated.metadata.description = f"[Smart Playlist] {rules.human_readable()}"
+            updated.metadata.description = description
             await self.mass.music.playlists.update_item_in_library(
                 library_item_id, updated, overwrite=True
             )
         except Exception as exc:
             self.logger.debug("Could not update description for %s: %s", library_item_id, exc)
+
+    def _description_for(self, playlist_id: str, rules: SmartPlaylistRules) -> str:
+        """Return the stored AI description, or the rules summary as fallback."""
+        if stored := self._descriptions_store.get(playlist_id):
+            return stored
+        return f"{DESCRIPTION_PREFIX}{rules.human_readable()}"
+
+    async def _refresh_ai_description(self, playlist_id: str) -> None:
+        """Regenerate and persist the AI description for a playlist, updating the library item."""
+        rules = self._rules_store.get(playlist_id)
+        if rules is None:
+            return
+        name = self._names_store.get(playlist_id, playlist_id)
+        description = await self._generate_ai_description(name, rules)
+        if description:
+            self._descriptions_store[playlist_id] = description
+        else:
+            self._descriptions_store.pop(playlist_id, None)
+        await self._flush_rules_to_disk()
+        library_item = await self.mass.music.playlists.get_library_item_by_prov_id(
+            playlist_id, self.instance_id
+        )
+        if library_item:
+            await self._update_playlist_description(
+                library_item.item_id, self._description_for(playlist_id, rules)
+            )
+
+    async def _generate_ai_description(self, name: str, rules: SmartPlaylistRules) -> str | None:
+        """
+        Generate a natural-language description via the first available AI provider.
+
+        :param name: The playlist name, included in the prompt for context.
+        :param rules: The rules whose summary the description should reflect.
+        :return: The AI-generated description, or None when disabled, unavailable, or on error.
+        """
+        if not self.config.get_value(CONF_AI_DESCRIPTIONS):
+            return None
+        for provider in self.mass.get_providers_supporting_feature(ProviderFeature.AI_QUERY):
+            if not isinstance(provider, PluginProvider):
+                continue
+            try:
+                response = await provider.ai_query(self._build_ai_prompt(name, rules))
+            except Exception as exc:
+                self.logger.debug("AI description generation failed for '%s': %s", name, exc)
+                return None
+            return response.strip() or None
+        return None
+
+    def _build_ai_prompt(self, name: str, rules: SmartPlaylistRules) -> str:
+        """Build the prompt asking an AI provider to describe the smart playlist."""
+        return (
+            "Write a short, friendly description (one or two sentences) for a music playlist. "
+            "Reply with only the description, no quotes or preamble.\n"
+            f"Playlist name: {name}\n"
+            f"It contains tracks matching these rules: {rules.human_readable()}"
+        )
 
     async def _load_rules_from_disk(self) -> None:
         """Load all persisted rules from the rules directory."""
@@ -998,6 +1084,8 @@ class SmartPlaylistProvider(PluginProvider):
             for playlist_id, entry in data.items():
                 self._rules_store[playlist_id] = SmartPlaylistRules.from_dict(entry["rules"])
                 self._names_store[playlist_id] = entry.get("name", playlist_id)
+                if description := entry.get("ai_description"):
+                    self._descriptions_store[playlist_id] = description
         except Exception as exc:
             self.logger.warning("Failed to load smart playlist rules: %s", exc)
 
@@ -1020,7 +1108,11 @@ class SmartPlaylistProvider(PluginProvider):
         async with self._flush_lock:
             rules_file = os.path.join(self._rules_dir, RULES_FILENAME)
             data = {
-                pid: {"name": self._names_store.get(pid, pid), "rules": r.to_dict()}
+                pid: {
+                    "name": self._names_store.get(pid, pid),
+                    "rules": r.to_dict(),
+                    "ai_description": self._descriptions_store.get(pid),
+                }
                 for pid, r in self._rules_store.items()
             }
             await write_json(rules_file, data)

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 from contextlib import suppress
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, cast
 
 import aiofiles
@@ -326,12 +327,15 @@ async def write_json(path: str, data: dict[str, Any]) -> None:
     # write+rename so an interrupted write (e.g. task cancellation) can't truncate it.
     payload = json_dumps(data, indent=True)
     tmp_path = f"{path}.tmp"
-    async with aiofiles.open(tmp_path, "w", encoding="utf-8") as fh:
-        await fh.write(payload)
+    replaced = False
     try:
+        async with aiofiles.open(tmp_path, "w", encoding="utf-8") as fh:
+            await fh.write(payload)
         await asyncio.to_thread(os.replace, tmp_path, path)
-    except OSError:
-        # Don't leave a stray temp file behind to accumulate on repeated failures.
-        with suppress(OSError):
-            await asyncio.to_thread(os.remove, tmp_path)
-        raise
+        replaced = True
+    finally:
+        # On any failure or cancellation before the rename completed, don't leave a stray
+        # temp file behind to accumulate over time.
+        if not replaced:
+            with suppress(OSError):
+                Path(tmp_path).unlink(missing_ok=True)

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -327,4 +328,10 @@ async def write_json(path: str, data: dict[str, Any]) -> None:
     tmp_path = f"{path}.tmp"
     async with aiofiles.open(tmp_path, "w", encoding="utf-8") as fh:
         await fh.write(payload)
-    await asyncio.to_thread(os.replace, tmp_path, path)
+    try:
+        await asyncio.to_thread(os.replace, tmp_path, path)
+    except OSError:
+        # Don't leave a stray temp file behind to accumulate on repeated failures.
+        with suppress(OSError):
+            await asyncio.to_thread(os.remove, tmp_path)
+        raise

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -321,21 +320,25 @@ async def read_json(path: str) -> dict[str, Any]:
         return cast("dict[str, Any]", json_loads(await fh.read()))
 
 
-async def write_json(path: str, data: dict[str, Any]) -> None:
-    """Write data as JSON to a file atomically (write to a temp file, then replace)."""
-    # Serialize first so a serialization error never touches the destination file, then
-    # write+rename so an interrupted write (e.g. task cancellation) can't truncate it.
-    payload = json_dumps(data, indent=True)
-    tmp_path = f"{path}.tmp"
+def _atomic_write(path: str, payload: str) -> None:
+    """Write payload to a temp file and atomically replace path, cleaning up on failure."""
+    tmp = Path(f"{path}.tmp")
     replaced = False
     try:
-        async with aiofiles.open(tmp_path, "w", encoding="utf-8") as fh:
-            await fh.write(payload)
-        await asyncio.to_thread(os.replace, tmp_path, path)
+        with tmp.open("w", encoding="utf-8") as fh:
+            fh.write(payload)
+        tmp.replace(path)
         replaced = True
     finally:
-        # On any failure or cancellation before the rename completed, don't leave a stray
-        # temp file behind to accumulate over time.
+        # On any failure mid-write, don't leave a stray temp file behind to accumulate.
         if not replaced:
             with suppress(OSError):
-                Path(tmp_path).unlink(missing_ok=True)
+                tmp.unlink(missing_ok=True)
+
+
+async def write_json(path: str, data: dict[str, Any]) -> None:
+    """Write data as JSON to a file atomically (temp file + replace, off the event loop)."""
+    # The whole write+rename+cleanup runs in one thread so a cancelled await can't race the
+    # rename against cleanup; the rename itself is atomic, so the destination is never truncated.
+    payload = json_dumps(data, indent=True)
+    await asyncio.to_thread(_atomic_write, path, payload)

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -318,6 +320,11 @@ async def read_json(path: str) -> dict[str, Any]:
 
 
 async def write_json(path: str, data: dict[str, Any]) -> None:
-    """Write data as JSON to a file."""
-    async with aiofiles.open(path, "w", encoding="utf-8") as fh:
-        await fh.write(json_dumps(data, indent=True))
+    """Write data as JSON to a file atomically (write to a temp file, then replace)."""
+    # Serialize first so a serialization error never touches the destination file, then
+    # write+rename so an interrupted write (e.g. task cancellation) can't truncate it.
+    payload = json_dumps(data, indent=True)
+    tmp_path = f"{path}.tmp"
+    async with aiofiles.open(tmp_path, "w", encoding="utf-8") as fh:
+        await fh.write(payload)
+    await asyncio.to_thread(os.replace, tmp_path, path)

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -1334,6 +1334,20 @@ async def test_build_playlist_uses_stored_ai_description(tmp_path: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_build_playlist_ignores_stored_description_when_disabled(tmp_path: Any) -> None:
+    """With the toggle off, a stored AI description is ignored in favour of the summary."""
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=False)
+    await plugin.handle_async_init()
+    plugin._names_store["abc"] = "My List"
+    plugin._descriptions_store["abc"] = "Old AI text."
+    rules = SmartPlaylistRules(favorites_only=True)
+
+    playlist = plugin._build_playlist("abc", rules)
+
+    assert playlist.metadata.description == f"[Smart Playlist] {rules.human_readable()}"
+
+
+@pytest.mark.asyncio
 async def test_build_playlist_falls_back_to_human_readable(tmp_path: Any) -> None:
     """Without a stored AI description, _build_playlist uses the mechanical summary."""
     plugin = _make_ai_plugin(tmp_path)
@@ -1383,6 +1397,10 @@ async def test_create_smart_playlist_schedules_ai_generation(tmp_path: Any) -> N
     await plugin.create_smart_playlist("Evening Chill", {"favorites_only": True})
 
     assert scheduled == ["_refresh_ai_description"]
+    # Deduped per playlist so rapid calls don't run concurrent refreshes.
+    kwargs = mass.create_task.call_args.kwargs
+    assert kwargs["task_id"].startswith("smart_playlist_ai_desc_")
+    assert kwargs["abort_existing"] is True
 
 
 @pytest.mark.asyncio
@@ -1411,6 +1429,10 @@ async def test_update_rules_drops_stale_and_schedules_regeneration(tmp_path: Any
     scheduled_desc = cast("Any", plugin)._update_playlist_description.await_args.args[1]
     assert scheduled_desc.startswith("[Smart Playlist]")
     assert scheduled == ["_refresh_ai_description"]
+    assert mass.create_task.call_args.kwargs == {
+        "task_id": "smart_playlist_ai_desc_abc",
+        "abort_existing": True,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -22,6 +22,7 @@ from music_assistant.providers.smart_playlist.helpers import (
     LOGIC_OR,
     RULES_FILENAME,
     SmartPlaylistRules,
+    write_json,
 )
 
 # ---------------------------------------------------------------------------
@@ -1311,6 +1312,37 @@ async def test_generate_ai_description_provider_error_returns_none(tmp_path: Any
 
 
 @pytest.mark.asyncio
+async def test_generate_ai_description_falls_back_to_next_provider(tmp_path: Any) -> None:
+    """If the first provider errors, the next available provider is tried."""
+    bad = MagicMock(spec=PluginProvider)
+    bad.ai_query = AsyncMock(side_effect=Exception("boom"))
+    good = _make_ai_provider("Second provider result.")
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True)
+    cast("Any", plugin.mass).get_providers_supporting_feature = MagicMock(return_value=[bad, good])
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
+
+    assert result == "Second provider result."
+    bad.ai_query.assert_awaited_once()
+    good.ai_query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disabled_toggle_does_not_schedule_refresh(tmp_path: Any) -> None:
+    """With the toggle off, creating a playlist schedules no background AI refresh."""
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=False)
+    await plugin.handle_async_init()
+    mass = cast("Any", plugin.mass)
+    mass.music.playlists.add_item_to_library = AsyncMock(return_value=MagicMock())
+    scheduled: list[str] = []
+    mass.create_task = MagicMock(side_effect=_capture_scheduled(scheduled))
+
+    await plugin.create_smart_playlist("Evening Chill", {"favorites_only": True})
+
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
 async def test_generate_ai_description_blank_response_returns_none(tmp_path: Any) -> None:
     """A blank/whitespace AI response is treated as no description."""
     plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=_make_ai_provider("   "))
@@ -1382,6 +1414,24 @@ async def test_ai_description_persists_to_disk(tmp_path: Any) -> None:
     await plugin2._load_rules_from_disk()
 
     assert plugin2._descriptions_store.get("42") == "Persisted AI text."
+
+
+@pytest.mark.asyncio
+async def test_write_json_preserves_original_on_failure(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed atomic replace must leave the existing file intact, never truncated."""
+    target = tmp_path / "rules.json"
+    await write_json(str(target), {"value": "original"})
+
+    def _boom(*_: Any, **__: Any) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr("music_assistant.providers.smart_playlist.helpers.os.replace", _boom)
+    with pytest.raises(OSError, match="replace failed"):
+        await write_json(str(target), {"value": "new"})
+
+    assert json.loads(target.read_text()) == {"value": "original"}
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -1429,7 +1429,7 @@ async def test_write_json_preserves_original_on_failure(
     def _boom(*_: Any, **__: Any) -> None:
         raise OSError("replace failed")
 
-    monkeypatch.setattr("music_assistant.providers.smart_playlist.helpers.os.replace", _boom)
+    monkeypatch.setattr("music_assistant.providers.smart_playlist.helpers.Path.replace", _boom)
     with pytest.raises(OSError, match="replace failed"):
         await write_json(str(target), {"value": "new"})
 
@@ -1449,7 +1449,7 @@ async def test_write_json_cleans_temp_on_cancellation(
     def _cancel(*_: Any, **__: Any) -> None:
         raise asyncio.CancelledError
 
-    monkeypatch.setattr("music_assistant.providers.smart_playlist.helpers.os.replace", _cancel)
+    monkeypatch.setattr("music_assistant.providers.smart_playlist.helpers.Path.replace", _cancel)
     with pytest.raises(asyncio.CancelledError):
         await write_json(str(target), {"value": "new"})
 

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -1589,3 +1589,21 @@ async def test_refresh_ai_description_no_provider_uses_fallback(tmp_path: Any) -
     assert "abc" not in plugin._descriptions_store
     written = cast("Any", plugin)._update_playlist_description.await_args.args[1]
     assert written == f"[Smart Playlist] {rules.human_readable()}"
+
+
+@pytest.mark.asyncio
+async def test_refresh_ai_description_skips_flush_when_unchanged(tmp_path: Any) -> None:
+    """No rules-file flush when the stored description doesn't change (e.g. no AI provider)."""
+    plugin = _make_ai_plugin(tmp_path, ai_provider=None)
+    await plugin.handle_async_init()
+    plugin._rules_store["abc"] = SmartPlaylistRules(favorites_only=True)
+    plugin._names_store["abc"] = "Name"  # no stored description to begin with
+    cast("Any", plugin)._flush_rules_to_disk = AsyncMock()
+    cast("Any", plugin)._update_playlist_description = AsyncMock()
+    cast("Any", plugin.mass).music.playlists.get_library_item_by_prov_id = AsyncMock(
+        return_value=_make_library_item(plugin, "abc")
+    )
+
+    await plugin._refresh_ai_description("abc")
+
+    cast("Any", plugin)._flush_rules_to_disk.assert_not_awaited()

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -19,6 +20,7 @@ from music_assistant.providers.smart_playlist import (
 from music_assistant.providers.smart_playlist.helpers import (
     LOGIC_AND,
     LOGIC_OR,
+    RULES_FILENAME,
     SmartPlaylistRules,
 )
 
@@ -1402,6 +1404,10 @@ async def test_update_rules_drops_stale_and_schedules_regeneration(tmp_path: Any
     await plugin.update_smart_playlist_rules("abc", {"genre_ids": [1]})
 
     assert "abc" not in plugin._descriptions_store
+    # The stale description must also be invalidated on disk, not just in memory, so it
+    # cannot be reloaded after a restart before the background refresh runs.
+    persisted = json.loads((tmp_path / "smart_playlists" / RULES_FILENAME).read_text())
+    assert persisted["abc"]["ai_description"] is None
     scheduled_desc = cast("Any", plugin)._update_playlist_description.await_args.args[1]
     assert scheduled_desc.startswith("[Smart Playlist]")
     assert scheduled == ["_refresh_ai_description"]

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -1434,6 +1435,25 @@ async def test_write_json_preserves_original_on_failure(
 
     assert json.loads(target.read_text()) == {"value": "original"}
     # The temp file must be cleaned up so it can't accumulate on repeated failures.
+    assert not (tmp_path / "rules.json.tmp").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_json_cleans_temp_on_cancellation(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cancellation during the write must not leave a temp file behind or corrupt the original."""
+    target = tmp_path / "rules.json"
+    await write_json(str(target), {"value": "original"})
+
+    def _cancel(*_: Any, **__: Any) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr("music_assistant.providers.smart_playlist.helpers.os.replace", _cancel)
+    with pytest.raises(asyncio.CancelledError):
+        await write_json(str(target), {"value": "new"})
+
+    assert json.loads(target.read_text()) == {"value": "original"}
     assert not (tmp_path / "rules.json.tmp").exists()
 
 

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -1209,6 +1209,7 @@ def _make_ai_plugin(
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
     mass.cache.clear = AsyncMock()
+    mass.metadata.locale = "en_US"
     providers = [ai_provider] if ai_provider is not None else []
     mass.get_providers_supporting_feature = MagicMock(return_value=providers)
     manifest = MagicMock()
@@ -1255,6 +1256,19 @@ async def test_generate_ai_description_uses_provider(tmp_path: Any) -> None:
     prompt = ai_provider.ai_query.await_args.args[0]
     assert "Evening Chill" in prompt
     assert "Favorites only" in prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_includes_locale(tmp_path: Any) -> None:
+    """The configured locale is passed to the provider so it answers in that language."""
+    ai_provider = _make_ai_provider("Een rustige mix voor de avond.")
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=ai_provider)
+    cast("Any", plugin.mass).metadata.locale = "nl_NL"
+
+    await plugin._generate_ai_description("Avond Chill", SmartPlaylistRules(favorites_only=True))
+
+    prompt = ai_provider.ai_query.await_args.args[0]
+    assert "nl_NL" in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -9,7 +9,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from music_assistant_models.enums import AlbumType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError
-from music_assistant_models.media_items import ProviderMapping, Track
+from music_assistant_models.media_items import Playlist, ProviderMapping, Track
+from music_assistant_models.media_items.metadata import MediaItemMetadata
 
 from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
 from music_assistant.models.plugin import PluginProvider
@@ -1432,6 +1433,49 @@ async def test_write_json_preserves_original_on_failure(
         await write_json(str(target), {"value": "new"})
 
     assert json.loads(target.read_text()) == {"value": "original"}
+    # The temp file must be cleaned up so it can't accumulate on repeated failures.
+    assert not (tmp_path / "rules.json.tmp").exists()
+
+
+@pytest.mark.asyncio
+async def test_update_playlist_description_skips_when_unchanged(tmp_path: Any) -> None:
+    """No library write/event when the description already matches."""
+    plugin = _make_ai_plugin(tmp_path)
+    await plugin.handle_async_init()
+    existing = MagicMock()
+    existing.metadata.description = "Same text."
+    mass = cast("Any", plugin.mass)
+    mass.music.playlists.get_library_item = AsyncMock(return_value=existing)
+    mass.music.playlists.update_item_in_library = AsyncMock()
+
+    await plugin._update_playlist_description(7, "Same text.")
+
+    mass.music.playlists.update_item_in_library.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_playlist_description_writes_when_changed(tmp_path: Any) -> None:
+    """The library item is rewritten only when the description actually differs."""
+    plugin = _make_ai_plugin(tmp_path)
+    await plugin.handle_async_init()
+    existing = Playlist(
+        item_id="1",
+        provider="library",
+        name="P",
+        provider_mappings={
+            ProviderMapping(item_id="1", provider_domain="library", provider_instance="library")
+        },
+    )
+    existing.metadata = MediaItemMetadata(description="Old text.")
+    mass = cast("Any", plugin.mass)
+    mass.music.playlists.get_library_item = AsyncMock(return_value=existing)
+    mass.music.playlists.update_item_in_library = AsyncMock()
+
+    await plugin._update_playlist_description(7, "New text.")
+
+    mass.music.playlists.update_item_in_library.assert_awaited_once()
+    written = mass.music.playlists.update_item_in_library.await_args.args[1]
+    assert written.metadata.description == "New text."
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_smart_playlist.py
+++ b/tests/providers/test_smart_playlist.py
@@ -6,12 +6,14 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.enums import AlbumType
+from music_assistant_models.enums import AlbumType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import ProviderMapping, Track
 
 from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
+from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.smart_playlist import (
+    CONF_AI_DESCRIPTIONS,
     SmartPlaylistProvider,
 )
 from music_assistant.providers.smart_playlist.helpers import (
@@ -1183,3 +1185,251 @@ async def test_seed_mode_album_types_filter_is_applied() -> None:
     uris = [t.uri for t in result]
     assert "library://track/1" in uris  # album → kept
     assert "library://track/2" not in uris  # single → filtered out by _apply_seed_post_filters
+
+
+# ---------------------------------------------------------------------------
+# AI-generated description tests
+# ---------------------------------------------------------------------------
+
+
+def _make_ai_provider(response: str = "A mellow mix for the evening.") -> MagicMock:
+    """Build a mock plugin provider that supports ai_query and returns the given response."""
+    provider = MagicMock(spec=PluginProvider)
+    provider.ai_query = AsyncMock(return_value=response)
+    return provider
+
+
+def _make_ai_plugin(
+    tmp_path: Any,
+    *,
+    ai_enabled: bool = True,
+    ai_provider: Any = None,
+) -> SmartPlaylistProvider:
+    """Build a SmartPlaylistProvider wired for AI-description tests."""
+    mass = MagicMock()
+    mass.storage_path = str(tmp_path)
+    mass.cache.clear = AsyncMock()
+    providers = [ai_provider] if ai_provider is not None else []
+    mass.get_providers_supporting_feature = MagicMock(return_value=providers)
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.side_effect = lambda key, *_args: (
+        ai_enabled if key == CONF_AI_DESCRIPTIONS else "GLOBAL"
+    )
+    return SmartPlaylistProvider(mass, manifest, config, set())
+
+
+def _make_library_item(plugin: SmartPlaylistProvider, prov_id: str, db_id: int = 7) -> MagicMock:
+    """Build a mock library playlist item mapped back to the given provider id."""
+    mapping = MagicMock()
+    mapping.provider_instance = plugin.instance_id
+    mapping.item_id = prov_id
+    library_item = MagicMock()
+    library_item.item_id = db_id
+    library_item.provider_mappings = [mapping]
+    return library_item
+
+
+def _capture_scheduled(names: list[str]) -> Any:
+    """Return a create_task side-effect that records scheduled coroutine names and closes them."""
+
+    def _side_effect(coro: Any, **_: Any) -> None:
+        names.append(coro.cr_code.co_name)
+        coro.close()
+
+    return _side_effect
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_uses_provider(tmp_path: Any) -> None:
+    """When enabled and a provider is available, the AI response is returned."""
+    ai_provider = _make_ai_provider("Chill evening vibes.")
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=ai_provider)
+
+    rules = SmartPlaylistRules(favorites_only=True)
+    result = await plugin._generate_ai_description("Evening Chill", rules)
+
+    assert result == "Chill evening vibes."
+    ai_provider.ai_query.assert_awaited_once()
+    prompt = ai_provider.ai_query.await_args.args[0]
+    assert "Evening Chill" in prompt
+    assert "Favorites only" in prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_disabled_returns_none(tmp_path: Any) -> None:
+    """With the toggle off, the AI provider is never called."""
+    ai_provider = _make_ai_provider()
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=False, ai_provider=ai_provider)
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules())
+
+    assert result is None
+    ai_provider.ai_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_no_provider_returns_none(tmp_path: Any) -> None:
+    """With no AI_QUERY provider available, None is returned."""
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=None)
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules())
+
+    assert result is None
+    cast("Any", plugin.mass).get_providers_supporting_feature.assert_called_once_with(
+        ProviderFeature.AI_QUERY
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_provider_error_returns_none(tmp_path: Any) -> None:
+    """A failing AI provider falls back to None instead of raising."""
+    ai_provider = MagicMock(spec=PluginProvider)
+    ai_provider.ai_query = AsyncMock(side_effect=Exception("boom"))
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=ai_provider)
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_ai_description_blank_response_returns_none(tmp_path: Any) -> None:
+    """A blank/whitespace AI response is treated as no description."""
+    plugin = _make_ai_plugin(tmp_path, ai_enabled=True, ai_provider=_make_ai_provider("   "))
+
+    result = await plugin._generate_ai_description("X", SmartPlaylistRules(favorites_only=True))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_build_playlist_uses_stored_ai_description(tmp_path: Any) -> None:
+    """_build_playlist uses the stored AI description verbatim (no prefix)."""
+    plugin = _make_ai_plugin(tmp_path)
+    await plugin.handle_async_init()
+    plugin._names_store["abc"] = "My List"
+    plugin._descriptions_store["abc"] = "Hand-crafted AI summary."
+
+    playlist = plugin._build_playlist("abc", SmartPlaylistRules(favorites_only=True))
+
+    assert playlist.metadata.description == "Hand-crafted AI summary."
+
+
+@pytest.mark.asyncio
+async def test_build_playlist_falls_back_to_human_readable(tmp_path: Any) -> None:
+    """Without a stored AI description, _build_playlist uses the mechanical summary."""
+    plugin = _make_ai_plugin(tmp_path)
+    await plugin.handle_async_init()
+    plugin._names_store["abc"] = "My List"
+    rules = SmartPlaylistRules(favorites_only=True)
+
+    playlist = plugin._build_playlist("abc", rules)
+
+    assert playlist.metadata.description == f"[Smart Playlist] {rules.human_readable()}"
+
+
+@pytest.mark.asyncio
+async def test_ai_description_persists_to_disk(tmp_path: Any) -> None:
+    """A stored AI description survives a plugin reload."""
+    rules_dir = tmp_path / "smart_playlists"
+    rules_dir.mkdir()
+
+    plugin = _make_ai_plugin(tmp_path)
+    await plugin.handle_async_init()
+    plugin._rules_dir = str(rules_dir)
+    plugin._names_store["42"] = "Name"
+    plugin._descriptions_store["42"] = "Persisted AI text."
+    await plugin._save_rules("42", SmartPlaylistRules(genre_ids=[1]))
+
+    plugin2 = _make_ai_plugin(tmp_path)
+    await plugin2.handle_async_init()
+    plugin2._rules_dir = str(rules_dir)
+    plugin2._rules_store = {}
+    plugin2._names_store = {}
+    plugin2._descriptions_store = {}
+    await plugin2._load_rules_from_disk()
+
+    assert plugin2._descriptions_store.get("42") == "Persisted AI text."
+
+
+@pytest.mark.asyncio
+async def test_create_smart_playlist_schedules_ai_generation(tmp_path: Any) -> None:
+    """Creating a smart playlist schedules background AI description generation."""
+    plugin = _make_ai_plugin(tmp_path)
+    await plugin.handle_async_init()
+    mass = cast("Any", plugin.mass)
+    mass.music.playlists.add_item_to_library = AsyncMock(return_value=MagicMock())
+    scheduled: list[str] = []
+    mass.create_task = MagicMock(side_effect=_capture_scheduled(scheduled))
+
+    await plugin.create_smart_playlist("Evening Chill", {"favorites_only": True})
+
+    assert scheduled == ["_refresh_ai_description"]
+
+
+@pytest.mark.asyncio
+async def test_update_rules_drops_stale_and_schedules_regeneration(tmp_path: Any) -> None:
+    """Updating rules clears the stale AI description, sets the fallback, and regenerates."""
+    plugin = _make_ai_plugin(tmp_path)
+    await plugin.handle_async_init()
+    plugin._rules_store["abc"] = SmartPlaylistRules(favorites_only=True)
+    plugin._names_store["abc"] = "Name"
+    plugin._descriptions_store["abc"] = "Stale AI text."
+    mass = cast("Any", plugin.mass)
+    scheduled: list[str] = []
+    mass.create_task = MagicMock(side_effect=_capture_scheduled(scheduled))
+    mass.music.playlists.get_library_item_by_prov_id = AsyncMock(
+        return_value=_make_library_item(plugin, "abc")
+    )
+    cast("Any", plugin)._update_playlist_description = AsyncMock()
+
+    await plugin.update_smart_playlist_rules("abc", {"genre_ids": [1]})
+
+    assert "abc" not in plugin._descriptions_store
+    scheduled_desc = cast("Any", plugin)._update_playlist_description.await_args.args[1]
+    assert scheduled_desc.startswith("[Smart Playlist]")
+    assert scheduled == ["_refresh_ai_description"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_ai_description_stores_and_updates(tmp_path: Any) -> None:
+    """The background refresh stores the AI text and pushes it to the library item."""
+    plugin = _make_ai_plugin(tmp_path, ai_provider=_make_ai_provider("Fresh AI summary."))
+    await plugin.handle_async_init()
+    plugin._rules_store["abc"] = SmartPlaylistRules(favorites_only=True)
+    plugin._names_store["abc"] = "Name"
+    cast("Any", plugin.mass).music.playlists.get_library_item_by_prov_id = AsyncMock(
+        return_value=_make_library_item(plugin, "abc")
+    )
+    cast("Any", plugin)._update_playlist_description = AsyncMock()
+
+    await plugin._refresh_ai_description("abc")
+
+    assert plugin._descriptions_store["abc"] == "Fresh AI summary."
+    cast("Any", plugin)._update_playlist_description.assert_awaited_once()
+    assert (
+        cast("Any", plugin)._update_playlist_description.await_args.args[1] == "Fresh AI summary."
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_ai_description_no_provider_uses_fallback(tmp_path: Any) -> None:
+    """With no AI available, the refresh drops any stale text and writes the fallback."""
+    plugin = _make_ai_plugin(tmp_path, ai_provider=None)
+    await plugin.handle_async_init()
+    rules = SmartPlaylistRules(favorites_only=True)
+    plugin._rules_store["abc"] = rules
+    plugin._names_store["abc"] = "Name"
+    plugin._descriptions_store["abc"] = "Stale."
+    cast("Any", plugin.mass).music.playlists.get_library_item_by_prov_id = AsyncMock(
+        return_value=_make_library_item(plugin, "abc")
+    )
+    cast("Any", plugin)._update_playlist_description = AsyncMock()
+
+    await plugin._refresh_ai_description("abc")
+
+    assert "abc" not in plugin._descriptions_store
+    written = cast("Any", plugin)._update_playlist_description.await_args.args[1]
+    assert written == f"[Smart Playlist] {rules.human_readable()}"


### PR DESCRIPTION
# What does this implement/fix?

Smart playlist descriptions are currently a plain, mechanical summary of the rules (e.g. `Favorites only AND Genres: Rock`). When a provider exposing the `ai_query` feature is available (such as Home Assistant with an AI Task entity), this lets Music Assistant generate a natural-language description instead, with a graceful fallback to the existing summary.

- Add an `ai_descriptions` provider config toggle (default **on**) to the Smart Playlist provider.
- Generate the description via the first available `AI_QUERY` provider, prompting it with the playlist name and rules summary.
- Persist the generated description per playlist and reuse it; regenerate it when the rules change.
- Ask the AI to write the description in the configured locale (`mass.metadata.locale`).
- Run generation in the background so create/update return immediately, then update the description once ready.
- Fall back to the existing `[Smart Playlist] <summary>` text when the toggle is off, no AI provider is available, or the call fails.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
