### PR TITLE
Align MusicBrainz throttler with mirror rate limit

### DIFF
--- a/music_assistant/providers/musicbrainz/__init__.py
+++ b/music_assistant/providers/musicbrainz/__init__.py
@@ -275,7 +275,7 @@ class MusicBrainzRecording(DataClassDictMixin):
 class MusicbrainzProvider(MetadataProvider):
     """The Musicbrainz Metadata provider."""
 
-    throttler = ThrottlerManager(rate_limit=5, period=1)
+    throttler = ThrottlerManager(rate_limit=10, period=10)
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""


### PR DESCRIPTION
# What does this implement/fix?

The MusicBrainz provider's client-side throttler was configured at `rate_limit=5, period=1` (up to 5 req/s, ~50 requests per 10s). Our self-hosted MusicBrainz mirror enforces 10 requests / 10s at the Cloudflare edge, so the provider would burst past that budget almost immediately during library scans, trip the rate-limit rule, and get served `429`s with a long `Retry-After`. Users saw effective throughput collapse to ~1 request per 10 minutes.

This aligns the throttler to the mirror's actual budget so MA paces itself within the rule instead of tripping it.

- Change MusicBrainz throttler from `rate_limit=5, period=1` to `rate_limit=10, period=10`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.