### PR TITLE
Lastfm improvements

### DIFF
--- a/music_assistant/providers/lastfm_recommendations/api_client.py
+++ b/music_assistant/providers/lastfm_recommendations/api_client.py
@@ -21,6 +21,8 @@ from music_assistant.providers.lastfm_recommendations.constants import CONF_API_
 _DEFAULT_API_KEY: str = app_var(12)
 
 if TYPE_CHECKING:
+    import logging
+
     from aiohttp import ClientSession
 
     from music_assistant.providers.lastfm_recommendations import LastFMRecommendationsProvider
@@ -48,8 +50,12 @@ class LastFMAPIClient:
         :param provider: The Last.fm recommendations provider instance.
         """
         self.provider = provider
-        self.logger = provider.logger
         self.http_session: ClientSession = provider.mass.http_session
+
+    @property
+    def logger(self) -> logging.Logger:
+        """Return the provider's active logger."""
+        return self.provider.logger
 
     async def _get_data(self, method: str, **params: Any) -> dict[str, Any]:
         """

--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -49,11 +49,11 @@ TOP_ARTISTS_LIMIT = 5
 # Number of recently played tracks to scan when ranking top artists by appearances
 RECENT_TRACKS_SCAN_LIMIT = 200
 
-# Number of top tracks to use as seeds for personalized recommendations
-TOP_TRACKS_LIMIT = 5
+# Number of top tracks fetched as seeds; over-fetched so enough are recognised by Last.fm
+TOP_TRACKS_LIMIT = 10
 
-# Number of top tags to fetch for genre-based recommendations
-TOP_TAGS_LIMIT = 1
+# Number of top genre tags fetched; the genre rows cycle through them daily
+TOP_TAGS_LIMIT = 3
 
 # API search settings
 # Search limit for provider API calls (workaround for Spotify API bug with limit=1)

--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -46,6 +46,9 @@ SIMILAR_ITEMS_PER_SEED = 5
 # Number of top artists to use as seeds for personalized recommendations
 TOP_ARTISTS_LIMIT = 5
 
+# Number of recently played tracks to scan when ranking top artists by appearances
+RECENT_TRACKS_SCAN_LIMIT = 200
+
 # Number of top tracks to use as seeds for personalized recommendations
 TOP_TRACKS_LIMIT = 5
 

--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -31,8 +31,8 @@ TARGET_ITEM_COUNT = 10
 # Number of items to fetch when we expect some resolution failures (small buffer)
 RESOLUTION_BUFFER_SMALL = 15
 
-# Number of items to fetch when we expect many resolution failures (large buffer)
-RESOLUTION_BUFFER_LARGE = 40
+# Genre chart pool (single fetch); sized so the hourly rotation surfaces more of the genre per day
+RESOLUTION_BUFFER_LARGE = 60
 
 # Number of top items to always include when sampling (before random selection)
 TOP_ITEMS_TO_TAKE = 3

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -363,6 +363,9 @@ class LastFMRecommendationManager:
         top_tracks = await self.mass.music.tracks.library_items(
             limit=TOP_TRACKS_LIMIT, order_by="play_count_desc"
         )
+        # only seed from tracks actually played, so a new library of unplayed tracks
+        # doesn't produce a row from arbitrary zero-play seeds
+        top_tracks = [track for track in top_tracks if track.last_played]
 
         if top_tracks:
             similar_tracks = await self._get_similar_tracks_from_seeds(top_tracks)
@@ -439,7 +442,9 @@ class LastFMRecommendationManager:
         if not top_tags:
             return
 
-        tag_name = top_tags[0].get("name")
+        # cycle through the user's top genres day by day so the genre rows vary
+        day_index = datetime.datetime.now(tz=datetime.UTC).date().toordinal()
+        tag_name = top_tags[day_index % len(top_tags)].get("name")
         if not tag_name:
             return
 

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -26,6 +26,7 @@ from music_assistant.providers.lastfm_recommendations.constants import (
     CONF_ENABLE_GLOBAL_CHARTS,
     CONF_ENABLE_PERSONALIZED,
     CONF_GEO_COUNTRY,
+    RECENT_TRACKS_SCAN_LIMIT,
     RESOLUTION_BUFFER_LARGE,
     RESOLUTION_BUFFER_SMALL,
     SIMILAR_ITEMS_BUFFER,
@@ -336,12 +337,7 @@ class LastFMRecommendationManager:
         if not self.provider.config.get_value(CONF_ENABLE_PERSONALIZED):
             return
 
-        # TODO: evaluate recent play history (e.g. last_played, last 7 days) instead of all-time
-        # play_count, possibly weighted. Needs user feedback.
-
-        top_artists = await self.mass.music.artists.library_items(
-            limit=TOP_ARTISTS_LIMIT, order_by="play_count_desc"
-        )
+        top_artists = await self._get_top_artists_by_track_plays()
 
         if top_artists:
             similar_artists = await self._get_similar_artists_from_seeds(top_artists)
@@ -583,6 +579,34 @@ class LastFMRecommendationManager:
                     subtitle=f"Most popular tracks in {country}",
                     icon="mdi-earth",
                 )
+
+    async def _get_top_artists_by_track_plays(self) -> list[Artist]:
+        """
+        Return the user's most listened library artists to seed recommendations.
+
+        :return: Up to TOP_ARTISTS_LIMIT artists, most listened first.
+        """
+        # Artist play_count only increments when an artist is played as a unit, so rank by
+        # appearances across the user's most recently played tracks instead. Ordering happens
+        # in the DB; ties fall to the more recently played artist via insertion order.
+        recent_tracks = await self.mass.music.tracks.library_items(
+            limit=RECENT_TRACKS_SCAN_LIMIT, order_by="last_played_desc"
+        )
+        counts: dict[str | int, int] = {}
+        for track in recent_tracks:
+            if not track.last_played:
+                continue
+            for artist in track.artists:
+                counts[artist.item_id] = counts.get(artist.item_id, 0) + 1
+
+        top_artist_ids = sorted(counts, key=lambda item_id: counts[item_id], reverse=True)[
+            :TOP_ARTISTS_LIMIT
+        ]
+        resolved = await asyncio.gather(
+            *[self.mass.music.artists.get_library_item(item_id) for item_id in top_artist_ids],
+            return_exceptions=True,
+        )
+        return [artist for artist in resolved if isinstance(artist, Artist)]
 
     async def _get_similar_artists_from_seeds(self, seed_artists: list[Artist]) -> list[Artist]:
         """

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -187,7 +187,7 @@ class LastFMRecommendationManager:
         self, items: list[dict[str, Any]], seed_suffix: str, target_count: int = TARGET_ITEM_COUNT
     ) -> list[dict[str, Any]]:
         """
-        Sample items using a 'top N + random remainder' strategy with a daily seed.
+        Sample items using a 'top N + random remainder' strategy with an hourly seed.
 
         :param items: List of items to sample from (already filtered).
         :param seed_suffix: Unique suffix for random seed (to vary between recommendation types).
@@ -201,8 +201,9 @@ class LastFMRecommendationManager:
         remaining = items[TOP_ITEMS_TO_TAKE:]
         random_count = target_count - TOP_ITEMS_TO_TAKE
 
-        # Daily seed keeps recommendations stable within the day and rotates them overnight.
-        seed = f"{datetime.datetime.now(tz=datetime.UTC).date().isoformat()}_{seed_suffix}"
+        # Hourly seed keeps the sampled remainder stable within the hour and rotates it each hour.
+        now = datetime.datetime.now(tz=datetime.UTC)
+        seed = f"{now.date().isoformat()}_{now.hour}_{seed_suffix}"
         rng = random.Random(seed)
         random_items = rng.sample(remaining, min(random_count, len(remaining)))
 

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -44,6 +44,8 @@ from music_assistant.providers.lastfm_recommendations.parsers import (
 )
 
 if TYPE_CHECKING:
+    import logging
+
     from music_assistant.providers.lastfm_recommendations import LastFMRecommendationsProvider
 
 
@@ -58,11 +60,15 @@ class LastFMRecommendationManager:
         """
         self.provider = provider
         self.api = provider.api
-        self.logger = provider.logger
         self.mass = provider.mass
 
         # Resolved items keyed by MBID (preferred) or name to avoid re-resolving.
         self._resolved_cache: dict[str, Artist | Album | Track] = {}
+
+    @property
+    def logger(self) -> logging.Logger:
+        """Return the provider's active logger."""
+        return self.provider.logger
 
     async def clear_cache(self) -> None:
         """Clear in-memory and persistent recommendation caches."""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The "Discover Similar Tracks" row seeds from your most-played tracks, but niche tracks silently fail Last.fm's `track.getSimilar`, so the row quietly collapses onto whichever one or two seeds Last.fm actually recognises and ignores the rest of your listening. So we now fetch more seeds (top 5 → 10) so enough survive to build a representative row. The same seeds are now also filtered to tracks that have actually been played, so a brand-new library full of unplayed tracks doesn't produce a row from arbitrary zero-play seeds.

The genre rows were seeded by date, so they only changed once a day no matter how often recommendations rebuilt. They're now seeded by date + hour, so the sampled items rotate each hour. In-library items are still filtered out before the expensive resolution step, so the extra rotation only ever resolves genuinely external items, which then cache so no wasted lookups and no bigger burst of API calls per rebuild.

With that rotation in place we can also widen the genre chart pool (40 → 60). It's still a single fetch and the same number resolved per rebuild, so the extra items are resolved gradually across the day's rotations and cached, surfacing more of the genre over time for no extra API cost at row build time.

Finally, the genre rows only ever used your single top genre. They now pull your top 3 and cycle through them day by day, so the genre on offer varies instead of being fixed to one tag.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
