### PR TITLE
Improve playlog for artists and albums

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1335,7 +1335,7 @@ class MusicController(CoreController):
         self,
         artists: Iterable[Artist | ItemMapping],
         *,
-        timestamp: int,
+        timestamp: float,
         user_ids: list[str],
         queue_id: str | None,
         user_initiated: bool,

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1346,12 +1346,16 @@ class MusicController(CoreController):
             db_artist = await self.artists.get_library_item_by_prov_id(
                 artist.item_id, artist.provider
             )
-            if db_artist is None or db_artist.item_id in skip_ids:
+            if db_artist is None:
+                continue
+            if db_artist.item_id in skip_ids:
+                self.logger.debug("Skipping already-credited artist '%s'", db_artist.name)
                 continue
             await self.database.execute(
                 f"UPDATE {self.artists.db_table} SET play_count = play_count + 1, "
                 f"last_played = {timestamp} WHERE item_id = {db_artist.item_id}"
             )
+            self.logger.debug("Credited play for artist '%s'", db_artist.name)
             playlog_entry: dict[str, Any] = {
                 "item_id": db_artist.item_id,
                 "provider": "library",

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1320,9 +1320,11 @@ class MusicController(CoreController):
                 f"UPDATE {ctrl.db_table} SET play_count = play_count + 1, "
                 f"last_played = {timestamp} WHERE item_id = {db_item.item_id}"
             )
-            self.logger.debug(
-                "Credited play for %s '%s'", media_item.media_type.value, media_item.name
-            )
+            if not isinstance(media_item, Album):
+                # albums are already logged with their trigger context by the queue controller
+                self.logger.debug(
+                    "Credited play for %s '%s'", media_item.media_type.value, media_item.name
+                )
         if isinstance(media_item, Track | Album):
             await self._credit_artist_plays(
                 media_item.artists,

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1320,6 +1320,9 @@ class MusicController(CoreController):
                 f"UPDATE {ctrl.db_table} SET play_count = play_count + 1, "
                 f"last_played = {timestamp} WHERE item_id = {db_item.item_id}"
             )
+            self.logger.debug(
+                "Credited play for %s '%s'", media_item.media_type.value, media_item.name
+            )
         if isinstance(media_item, Track | Album):
             await self._credit_artist_plays(
                 media_item.artists,

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1210,6 +1210,7 @@ class MusicController(CoreController):
         userid: str | None = None,
         queue_id: str | None = None,
         user_initiated: bool = True,
+        skip_artist_ids: list[str] | None = None,
     ) -> None:
         """
         Mark item as played in playlog.
@@ -1221,6 +1222,7 @@ class MusicController(CoreController):
         :param userid: The user ID to mark the item as played for (instead of the current user).
         :param queue_id: The queue ID where the item was played.
         :param user_initiated: If True, the playback was initiated by the user (e.g. enqueued).
+        :param skip_artist_ids: Library artist ids to skip when crediting an album's artists.
         """
         timestamp = utc_timestamp()
         if (
@@ -1318,34 +1320,64 @@ class MusicController(CoreController):
                 f"UPDATE {ctrl.db_table} SET play_count = play_count + 1, "
                 f"last_played = {timestamp} WHERE item_id = {db_item.item_id}"
             )
-        if isinstance(media_item, Track) and media_item.artists:
-            primary_artist = media_item.artists[0]
-            db_artist = await self.artists.get_library_item_by_prov_id(
-                primary_artist.item_id, primary_artist.provider
+        if isinstance(media_item, Track | Album):
+            await self._credit_artist_plays(
+                media_item.artists,
+                timestamp=timestamp,
+                user_ids=user_ids,
+                queue_id=queue_id,
+                user_initiated=user_initiated,
+                skip_ids=set(skip_artist_ids or ()),
             )
-            if db_artist:
-                await self.database.execute(
-                    f"UPDATE {self.artists.db_table} SET play_count = play_count + 1, "
-                    f"last_played = {timestamp} WHERE item_id = {db_artist.item_id}"
-                )
-                artist_params = {
-                    "item_id": db_artist.item_id,
-                    "provider": "library",
-                    "media_type": MediaType.ARTIST.value,
-                    "name": db_artist.name,
-                    "image": serialize_to_json(db_artist.image.to_dict())
-                    if db_artist.image
-                    else None,
-                    "fully_played": fully_played,
-                    "seconds_played": seconds_played,
-                    "timestamp": timestamp,
-                    "queue_id": queue_id,
-                    "user_initiated": user_initiated,
-                }
-                for user_id in user_ids:
-                    artist_params["userid"] = user_id
-                    await self.database.insert(DB_TABLE_PLAYLOG, artist_params, allow_replace=True)
         await self.database.commit()
+
+    async def _credit_artist_plays(
+        self,
+        artists: Iterable[Artist | ItemMapping],
+        *,
+        timestamp: int,
+        user_ids: list[str],
+        queue_id: str | None,
+        user_initiated: bool,
+        skip_ids: set[str],
+    ) -> None:
+        """Credit each (library-resolvable) artist with a play, skipping skip_ids."""
+        for artist in artists:
+            db_artist = await self.artists.get_library_item_by_prov_id(
+                artist.item_id, artist.provider
+            )
+            if db_artist is None or db_artist.item_id in skip_ids:
+                continue
+            await self.database.execute(
+                f"UPDATE {self.artists.db_table} SET play_count = play_count + 1, "
+                f"last_played = {timestamp} WHERE item_id = {db_artist.item_id}"
+            )
+            playlog_entry: dict[str, Any] = {
+                "item_id": db_artist.item_id,
+                "provider": "library",
+                "media_type": MediaType.ARTIST.value,
+                "name": db_artist.name,
+                "image": serialize_to_json(db_artist.image.to_dict()) if db_artist.image else None,
+                "fully_played": True,
+                "seconds_played": None,
+                "timestamp": timestamp,
+                "queue_id": queue_id,
+                "user_initiated": user_initiated,
+            }
+            for user_id in user_ids:
+                playlog_entry["userid"] = user_id
+                await self.database.insert(DB_TABLE_PLAYLOG, playlog_entry, allow_replace=True)
+
+    async def resolve_library_artist_ids(self, artists: Iterable[Artist | ItemMapping]) -> set[str]:
+        """Resolve the given artist references to their library item ids (when present)."""
+        ids: set[str] = set()
+        for artist in artists:
+            db_artist = await self.artists.get_library_item_by_prov_id(
+                artist.item_id, artist.provider
+            )
+            if db_artist is not None:
+                ids.add(db_artist.item_id)
+        return ids
 
     @api_command("music/mark_unplayed")
     async def mark_item_unplayed(

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1320,11 +1320,8 @@ class MusicController(CoreController):
                 f"UPDATE {ctrl.db_table} SET play_count = play_count + 1, "
                 f"last_played = {timestamp} WHERE item_id = {db_item.item_id}"
             )
-            if not isinstance(media_item, Album):
-                # albums are already logged with their trigger context by the queue controller
-                self.logger.debug(
-                    "Credited play for %s '%s'", media_item.media_type.value, media_item.name
-                )
+            if isinstance(media_item, Track):
+                self.logger.debug("Credited play for track '%s'", media_item.name)
         if isinstance(media_item, Track | Album):
             await self._credit_artist_plays(
                 media_item.artists,

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1336,47 +1336,6 @@ class MusicController(CoreController):
             )
         await self.database.commit()
 
-    async def _credit_artist_plays(
-        self,
-        artists: Iterable[Artist | ItemMapping],
-        *,
-        timestamp: float,
-        user_ids: list[str],
-        queue_id: str | None,
-        user_initiated: bool,
-        skip_ids: set[str],
-    ) -> None:
-        """Credit each (library-resolvable) artist with a play, skipping skip_ids."""
-        for artist in artists:
-            db_artist = await self.artists.get_library_item_by_prov_id(
-                artist.item_id, artist.provider
-            )
-            if db_artist is None:
-                continue
-            if db_artist.item_id in skip_ids:
-                self.logger.debug("Skipping already-credited artist '%s'", db_artist.name)
-                continue
-            await self.database.execute(
-                f"UPDATE {self.artists.db_table} SET play_count = play_count + 1, "
-                f"last_played = {timestamp} WHERE item_id = {db_artist.item_id}"
-            )
-            self.logger.debug("Credited play for artist '%s'", db_artist.name)
-            playlog_entry: dict[str, Any] = {
-                "item_id": db_artist.item_id,
-                "provider": "library",
-                "media_type": MediaType.ARTIST.value,
-                "name": db_artist.name,
-                "image": serialize_to_json(db_artist.image.to_dict()) if db_artist.image else None,
-                "fully_played": True,
-                "seconds_played": None,
-                "timestamp": timestamp,
-                "queue_id": queue_id,
-                "user_initiated": user_initiated,
-            }
-            for user_id in user_ids:
-                playlog_entry["userid"] = user_id
-                await self.database.insert(DB_TABLE_PLAYLOG, playlog_entry, allow_replace=True)
-
     async def resolve_library_artist_ids(self, artists: Iterable[Artist | ItemMapping]) -> set[str]:
         """Resolve the given artist references to their library item ids (when present)."""
         ids: set[str] = set()
@@ -3407,3 +3366,44 @@ class MusicController(CoreController):
             CONF_ENTRY_LIBRARY_SYNC_BACK.key, CONF_ENTRY_LIBRARY_SYNC_BACK.default_value
         )
         return bool(conf_value)
+
+    async def _credit_artist_plays(
+        self,
+        artists: Iterable[Artist | ItemMapping],
+        *,
+        timestamp: float,
+        user_ids: list[str],
+        queue_id: str | None,
+        user_initiated: bool,
+        skip_ids: set[str],
+    ) -> None:
+        """Credit each (library-resolvable) artist with a play, skipping skip_ids."""
+        for artist in artists:
+            db_artist = await self.artists.get_library_item_by_prov_id(
+                artist.item_id, artist.provider
+            )
+            if db_artist is None:
+                continue
+            if db_artist.item_id in skip_ids:
+                self.logger.debug("Skipping already-credited artist '%s'", db_artist.name)
+                continue
+            await self.database.execute(
+                f"UPDATE {self.artists.db_table} SET play_count = play_count + 1, "
+                f"last_played = {timestamp} WHERE item_id = {db_artist.item_id}"
+            )
+            self.logger.debug("Credited play for artist '%s'", db_artist.name)
+            playlog_entry: dict[str, Any] = {
+                "item_id": db_artist.item_id,
+                "provider": "library",
+                "media_type": MediaType.ARTIST.value,
+                "name": db_artist.name,
+                "image": serialize_to_json(db_artist.image.to_dict()) if db_artist.image else None,
+                "fully_played": True,
+                "seconds_played": None,
+                "timestamp": timestamp,
+                "queue_id": queue_id,
+                "user_initiated": user_initiated,
+            }
+            for user_id in user_ids:
+                playlog_entry["userid"] = user_id
+                await self.database.insert(DB_TABLE_PLAYLOG, playlog_entry, allow_replace=True)

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1318,6 +1318,33 @@ class MusicController(CoreController):
                 f"UPDATE {ctrl.db_table} SET play_count = play_count + 1, "
                 f"last_played = {timestamp} WHERE item_id = {db_item.item_id}"
             )
+        if isinstance(media_item, Track) and media_item.artists:
+            primary_artist = media_item.artists[0]
+            db_artist = await self.artists.get_library_item_by_prov_id(
+                primary_artist.item_id, primary_artist.provider
+            )
+            if db_artist:
+                await self.database.execute(
+                    f"UPDATE {self.artists.db_table} SET play_count = play_count + 1, "
+                    f"last_played = {timestamp} WHERE item_id = {db_artist.item_id}"
+                )
+                artist_params = {
+                    "item_id": db_artist.item_id,
+                    "provider": "library",
+                    "media_type": MediaType.ARTIST.value,
+                    "name": db_artist.name,
+                    "image": serialize_to_json(db_artist.image.to_dict())
+                    if db_artist.image
+                    else None,
+                    "fully_played": fully_played,
+                    "seconds_played": seconds_played,
+                    "timestamp": timestamp,
+                    "queue_id": queue_id,
+                    "user_initiated": user_initiated,
+                }
+                for user_id in user_ids:
+                    artist_params["userid"] = user_id
+                    await self.database.insert(DB_TABLE_PLAYLOG, artist_params, allow_replace=True)
         await self.database.commit()
 
     @api_command("music/mark_unplayed")

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2484,19 +2484,9 @@ class PlayerQueuesController(CoreController):
             return list(await self.get_playlist_tracks(media_item, start_item, sort_by=sort_by))
         if media_item.media_type == MediaType.ARTIST:
             media_item = cast("Artist", media_item)
-            self.mass.create_task(
-                self.mass.music.mark_item_played(
-                    media_item, userid=userid, queue_id=queue_id, user_initiated=True
-                )
-            )
             return list(await self.get_artist_tracks(media_item))
         if media_item.media_type == MediaType.ALBUM:
             media_item = cast("Album", media_item)
-            self.mass.create_task(
-                self.mass.music.mark_item_played(
-                    media_item, userid=userid, queue_id=queue_id, user_initiated=True
-                )
-            )
             return list(await self.get_album_tracks(media_item, start_item, sort_by=sort_by))
         if media_item.media_type == MediaType.GENRE:
             media_item = cast("Genre", media_item)
@@ -3287,6 +3277,9 @@ class PlayerQueuesController(CoreController):
                 user_initiated=False,
             )
         )
+        if fully_played and not is_playing:
+            if credit_album := self._enqueued_album_for_track(queue, item_to_report, media_item):
+                self.mass.create_task(self._mark_album_played(credit_album, media_item, queue))
 
         album: Album | ItemMapping | None = getattr(media_item, "album", None)
         # signal 'media item played' event,
@@ -3329,6 +3322,53 @@ class PlayerQueuesController(CoreController):
                 userid=queue.userid,
                 player_id=queue.queue_id,
             ),
+        )
+
+    def _enqueued_album_for_track(
+        self, queue: PlayerQueue, item_to_report: QueueItem, media_item: MediaItemType
+    ) -> Album | None:
+        """Return the album to credit for this played track, or None.
+
+        Only an album the user explicitly enqueued is eligible, and only on the first
+        track of a contiguous run of its tracks (the previous queue item must belong to
+        a different album), so a single album play is credited once.
+        """
+        album = getattr(media_item, "album", None)
+        if album is None:
+            return None
+        enqueued = next(
+            (
+                item
+                for item in queue.enqueued_media_items
+                if isinstance(item, Album) and item == album
+            ),
+            None,
+        )
+        if enqueued is None:
+            return None
+        index = self.index_by_id(queue.queue_id, item_to_report.queue_item_id)
+        if index:
+            prev_item = self.get_item(queue.queue_id, index - 1)
+            prev_album = (
+                getattr(prev_item.media_item, "album", None)
+                if prev_item and prev_item.media_item
+                else None
+            )
+            if prev_album == album:
+                return None
+        return enqueued
+
+    async def _mark_album_played(
+        self, album: Album, track: MediaItemType, queue: PlayerQueue
+    ) -> None:
+        """Mark an enqueued album played, skipping artists already credited via its track."""
+        skip = await self.mass.music.resolve_library_artist_ids(getattr(track, "artists", []))
+        await self.mass.music.mark_item_played(
+            album,
+            userid=queue.userid,
+            queue_id=queue.queue_id,
+            user_initiated=False,
+            skip_artist_ids=list(skip),
         )
 
     async def _cleanup_stale_queue_buffers(self, queue_id: str, current_index: int) -> None:

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -3363,7 +3363,7 @@ class PlayerQueuesController(CoreController):
     ) -> None:
         """Mark an enqueued album played, skipping artists already credited via its track."""
         self.logger.debug(
-            "Crediting album '%s' as played (triggered by track '%s')", album.name, track.name
+            "Credited album '%s' as played (triggered by track '%s')", album.name, track.name
         )
         skip = await self.mass.music.resolve_library_artist_ids(getattr(track, "artists", []))
         await self.mass.music.mark_item_played(

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -3327,7 +3327,8 @@ class PlayerQueuesController(CoreController):
     def _enqueued_album_for_track(
         self, queue: PlayerQueue, item_to_report: QueueItem, media_item: MediaItemType
     ) -> Album | None:
-        """Return the album to credit for this played track, or None.
+        """
+        Return the album to credit for this played track, or None.
 
         Only an album the user explicitly enqueued is eligible, and only on the first
         track of a contiguous run of its tracks (the previous queue item must belong to

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -3362,6 +3362,9 @@ class PlayerQueuesController(CoreController):
         self, album: Album, track: MediaItemType, queue: PlayerQueue
     ) -> None:
         """Mark an enqueued album played, skipping artists already credited via its track."""
+        self.logger.debug(
+            "Crediting album '%s' as played (triggered by track '%s')", album.name, track.name
+        )
         skip = await self.mass.music.resolve_library_artist_ids(getattr(track, "artists", []))
         await self.mass.music.mark_item_played(
             album,

--- a/tests/core/test_artist_play_credit.py
+++ b/tests/core/test_artist_play_credit.py
@@ -1,0 +1,100 @@
+"""Integration tests: a fully played track credits its primary artist.
+
+Uses the ``mass`` fixture from ``tests/conftest.py`` which creates a full
+MusicAssistant instance with a real SQLite database in a temporary directory.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Artist, ProviderMapping, Track
+from music_assistant_models.unique_list import UniqueList
+
+from music_assistant.constants import DB_TABLE_ARTISTS, DB_TABLE_PLAYLOG
+from music_assistant.mass import MusicAssistant
+
+
+def _library_mapping() -> set[ProviderMapping]:
+    """Create a single library provider mapping with a unique provider item id."""
+    return {
+        ProviderMapping(
+            item_id=uuid4().hex,
+            provider_domain="library",
+            provider_instance="library",
+            in_library=True,
+        )
+    }
+
+
+async def _add_artist(mass: MusicAssistant, name: str) -> Artist:
+    """Add a minimal artist to the library and return the stored item."""
+    artist = Artist(
+        item_id="0",
+        provider="library",
+        name=name,
+        provider_mappings=_library_mapping(),
+    )
+    return await mass.music.artists.add_item_to_library(artist)
+
+
+async def _add_track(mass: MusicAssistant, name: str, artists: list[Artist]) -> Track:
+    """Add a minimal track with the given artists and return the stored item."""
+    track = Track(
+        item_id="0",
+        provider="library",
+        name=name,
+        provider_mappings=_library_mapping(),
+        artists=UniqueList(artists),
+    )
+    added = await mass.music.tracks.add_item_to_library(track)
+    return await mass.music.tracks.get_library_item(added.item_id)
+
+
+async def test_played_track_credits_primary_artist(mass: MusicAssistant) -> None:
+    """Marking a track fully played bumps its primary artist and logs an artist play."""
+    user = await mass.webserver.auth.create_user("playcredit")
+    artist = await _add_artist(mass, "Primary Artist")
+    track = await _add_track(mass, "Some Track", [artist])
+
+    before = await mass.music.database.get_row(DB_TABLE_ARTISTS, {"item_id": artist.item_id})
+    assert before is not None
+    assert before["play_count"] == 0
+
+    await mass.music.mark_item_played(
+        track, fully_played=True, user_initiated=True, userid=user.user_id
+    )
+
+    after = await mass.music.database.get_row(DB_TABLE_ARTISTS, {"item_id": artist.item_id})
+    assert after is not None
+    assert after["play_count"] == 1
+    assert after["last_played"] > 0
+
+    playlog = await mass.music.database.get_rows(
+        DB_TABLE_PLAYLOG,
+        {
+            "media_type": MediaType.ARTIST.value,
+            "item_id": artist.item_id,
+            "userid": user.user_id,
+        },
+    )
+    assert len(playlog) == 1
+
+
+async def test_played_track_does_not_credit_featured_artist(mass: MusicAssistant) -> None:
+    """Only the primary artist (artists[0]) is credited; featured artists are not."""
+    primary = await _add_artist(mass, "Primary")
+    featured = await _add_artist(mass, "Featured")
+    track = await _add_track(mass, "Collab Track", [primary, featured])
+
+    await mass.music.mark_item_played(track, fully_played=True, user_initiated=True)
+
+    primary_row = await mass.music.database.get_row(DB_TABLE_ARTISTS, {"item_id": primary.item_id})
+    featured_row = await mass.music.database.get_row(
+        DB_TABLE_ARTISTS, {"item_id": featured.item_id}
+    )
+    assert primary_row is not None
+    assert featured_row is not None
+    assert primary_row["play_count"] == 1
+    assert featured_row["play_count"] == 0

--- a/tests/core/test_artist_play_credit.py
+++ b/tests/core/test_artist_play_credit.py
@@ -1,4 +1,5 @@
-"""Tests for crediting artists and albums from track plays.
+"""
+Tests for crediting artists and albums from track plays.
 
 The integration tests use the ``mass`` fixture from ``tests/conftest.py`` which
 creates a full MusicAssistant instance with a real SQLite database in a

--- a/tests/core/test_artist_play_credit.py
+++ b/tests/core/test_artist_play_credit.py
@@ -1,19 +1,27 @@
-"""Integration tests: a fully played track credits its primary artist.
+"""Tests for crediting artists and albums from track plays.
 
-Uses the ``mass`` fixture from ``tests/conftest.py`` which creates a full
-MusicAssistant instance with a real SQLite database in a temporary directory.
+The integration tests use the ``mass`` fixture from ``tests/conftest.py`` which
+creates a full MusicAssistant instance with a real SQLite database in a
+temporary directory. The decision helper is covered by a plain unit test.
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+from unittest.mock import Mock
 from uuid import uuid4
 
-from music_assistant_models.enums import MediaType
-from music_assistant_models.media_items import Artist, ProviderMapping, Track
+from music_assistant_models.enums import AlbumType, MediaType
+from music_assistant_models.media_items import Album, Artist, ProviderMapping, Track
+from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.unique_list import UniqueList
 
-from music_assistant.constants import DB_TABLE_ARTISTS, DB_TABLE_PLAYLOG
+from music_assistant.constants import DB_TABLE_ALBUMS, DB_TABLE_ARTISTS, DB_TABLE_PLAYLOG
+from music_assistant.controllers.player_queues import PlayerQueuesController
 from music_assistant.mass import MusicAssistant
+
+if TYPE_CHECKING:
+    from music_assistant_models.player_queue import PlayerQueue
 
 
 def _library_mapping() -> set[ProviderMapping]:
@@ -30,71 +38,115 @@ def _library_mapping() -> set[ProviderMapping]:
 
 async def _add_artist(mass: MusicAssistant, name: str) -> Artist:
     """Add a minimal artist to the library and return the stored item."""
-    artist = Artist(
-        item_id="0",
-        provider="library",
-        name=name,
-        provider_mappings=_library_mapping(),
+    return await mass.music.artists.add_item_to_library(
+        Artist(item_id="0", provider="library", name=name, provider_mappings=_library_mapping())
     )
-    return await mass.music.artists.add_item_to_library(artist)
 
 
 async def _add_track(mass: MusicAssistant, name: str, artists: list[Artist]) -> Track:
-    """Add a minimal track with the given artists and return the stored item."""
-    track = Track(
-        item_id="0",
-        provider="library",
-        name=name,
-        provider_mappings=_library_mapping(),
-        artists=UniqueList(artists),
+    """Add a minimal track with the given artists and return the (re-fetched) stored item."""
+    added = await mass.music.tracks.add_item_to_library(
+        Track(
+            item_id="0",
+            provider="library",
+            name=name,
+            provider_mappings=_library_mapping(),
+            artists=UniqueList(artists),
+        )
     )
-    added = await mass.music.tracks.add_item_to_library(track)
     return await mass.music.tracks.get_library_item(added.item_id)
 
 
-async def test_played_track_credits_primary_artist(mass: MusicAssistant) -> None:
-    """Marking a track fully played bumps its primary artist and logs an artist play."""
-    user = await mass.webserver.auth.create_user("playcredit")
-    artist = await _add_artist(mass, "Primary Artist")
-    track = await _add_track(mass, "Some Track", [artist])
+async def _add_album(mass: MusicAssistant, name: str, artists: list[Artist]) -> Album:
+    """Add a minimal album with the given album artists and return the (re-fetched) stored item."""
+    added = await mass.music.albums.add_item_to_library(
+        Album(
+            item_id="0",
+            provider="library",
+            name=name,
+            provider_mappings=_library_mapping(),
+            album_type=AlbumType.ALBUM,
+            artists=UniqueList(artists),
+        )
+    )
+    return await mass.music.albums.get_library_item(added.item_id)
 
-    before = await mass.music.database.get_row(DB_TABLE_ARTISTS, {"item_id": artist.item_id})
-    assert before is not None
-    assert before["play_count"] == 0
+
+async def _play_count(mass: MusicAssistant, table: str, item_id: str) -> int:
+    """Read the play_count for a library item directly from the database."""
+    row = await mass.music.database.get_row(table, {"item_id": item_id})
+    assert row is not None
+    return int(row["play_count"])
+
+
+async def test_played_track_credits_all_track_artists(mass: MusicAssistant) -> None:
+    """A fully played track credits every one of its artists (not just the primary)."""
+    user = await mass.webserver.auth.create_user("trackcredit")
+    primary = await _add_artist(mass, "Primary")
+    featured = await _add_artist(mass, "Featured")
+    track = await _add_track(mass, "Collab", [primary, featured])
 
     await mass.music.mark_item_played(
         track, fully_played=True, user_initiated=True, userid=user.user_id
     )
 
-    after = await mass.music.database.get_row(DB_TABLE_ARTISTS, {"item_id": artist.item_id})
-    assert after is not None
-    assert after["play_count"] == 1
-    assert after["last_played"] > 0
+    assert await _play_count(mass, DB_TABLE_ARTISTS, primary.item_id) == 1
+    assert await _play_count(mass, DB_TABLE_ARTISTS, featured.item_id) == 1
+    for artist in (primary, featured):
+        rows = await mass.music.database.get_rows(
+            DB_TABLE_PLAYLOG,
+            {
+                "media_type": MediaType.ARTIST.value,
+                "item_id": artist.item_id,
+                "userid": user.user_id,
+            },
+        )
+        assert len(rows) == 1
 
-    playlog = await mass.music.database.get_rows(
-        DB_TABLE_PLAYLOG,
-        {
-            "media_type": MediaType.ARTIST.value,
-            "item_id": artist.item_id,
-            "userid": user.user_id,
-        },
+
+async def test_album_play_credits_album_artists_with_dedup(mass: MusicAssistant) -> None:
+    """Marking an album played credits its album artists, skipping any in skip_artist_ids."""
+    kept = await _add_artist(mass, "Kept Artist")
+    skipped = await _add_artist(mass, "Skipped Artist")
+    album = await _add_album(mass, "An Album", [kept, skipped])
+
+    await mass.music.mark_item_played(
+        album, fully_played=True, user_initiated=True, skip_artist_ids=[skipped.item_id]
     )
-    assert len(playlog) == 1
+
+    assert await _play_count(mass, DB_TABLE_ALBUMS, album.item_id) == 1
+    assert await _play_count(mass, DB_TABLE_ARTISTS, kept.item_id) == 1
+    assert await _play_count(mass, DB_TABLE_ARTISTS, skipped.item_id) == 0
 
 
-async def test_played_track_does_not_credit_featured_artist(mass: MusicAssistant) -> None:
-    """Only the primary artist (artists[0]) is credited; featured artists are not."""
-    primary = await _add_artist(mass, "Primary")
-    featured = await _add_artist(mass, "Featured")
-    track = await _add_track(mass, "Collab Track", [primary, featured])
-
-    await mass.music.mark_item_played(track, fully_played=True, user_initiated=True)
-
-    primary_row = await mass.music.database.get_row(DB_TABLE_ARTISTS, {"item_id": primary.item_id})
-    featured_row = await mass.music.database.get_row(
-        DB_TABLE_ARTISTS, {"item_id": featured.item_id}
+def test_enqueued_album_decision() -> None:
+    """An album is credited only when enqueued and only on the first track of its run."""
+    album_x = Album(
+        item_id="ax",
+        provider="library",
+        name="X",
+        provider_mappings=set(),
+        album_type=AlbumType.ALBUM,
     )
-    assert primary_row is not None
-    assert featured_row is not None
-    assert primary_row["play_count"] == 1
-    assert featured_row["play_count"] == 0
+    album_y = Album(
+        item_id="ay",
+        provider="library",
+        name="Y",
+        provider_mappings=set(),
+        album_type=AlbumType.ALBUM,
+    )
+    t1 = Track(item_id="t1", provider="library", name="T1", provider_mappings=set(), album=album_x)
+    t2 = Track(item_id="t2", provider="library", name="T2", provider_mappings=set(), album=album_x)
+    t3 = Track(item_id="t3", provider="library", name="T3", provider_mappings=set(), album=album_y)
+    items = [QueueItem.from_media_item("q1", track) for track in (t1, t2, t3)]
+
+    ctrl = PlayerQueuesController.__new__(PlayerQueuesController)
+    ctrl._queue_items = {"q1": items}
+    queue = cast("PlayerQueue", Mock(queue_id="q1", enqueued_media_items=[album_x]))
+
+    # first track of the enqueued album -> credit it
+    assert ctrl._enqueued_album_for_track(queue, items[0], t1) is album_x
+    # second track shares the previous queue item's album -> already handled
+    assert ctrl._enqueued_album_for_track(queue, items[1], t2) is None
+    # a track whose album was never enqueued -> not credited
+    assert ctrl._enqueued_album_for_track(queue, items[2], t3) is None


### PR DESCRIPTION
# What does this implement/fix?

- Enqueuing an artist or album no longer marks it played. Enqueue-time marking is kept for playlists, genres and podcasts (there's no better signal for those yet).

- When a track is fully played, every one of its artists is credited — not just the primary/album artist. "Credited" means play_count +1, last_played updated, and a playlog entry.
- When a fully-played track's album is one you enqueued, the album is credited too — once per album, on the first track of its run in the queue. The rest of the album's tracks don't re-credit it.
- Crediting an album also credits its album artist(s), skipping any already credited as that track's artist, so the same artist isn't double-counted for one track.

## How it works
The crediting itself (resolve each artist/album reference → bump counters + write the playlog row) lives in MusicController.mark_item_played, so it's centralized and also applies when items are marked played via the API.

The queue-specific decision — was this track's album enqueued, and is this its first track? — lives in the player-queues controller, where the queue and previous-track context exist. It runs in a background task, off the playback path, so audio isn't affected.

## limitations/issues
Interleaved shuffle: if you shuffle several enqueued albums together so one album's tracks aren't contiguous, that album can be credited more than once. A single shuffled album is still credited once (its tracks stay contiguous, just reordered).
Cross-provider album match: the "did you enqueue this album?" check matches by URI, so enqueueing a streaming album whose tracks resolve to your library album won't match. The common cases (library, or same-provider streaming) work.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
