### PR TITLE
Fix sendspin unmute

### DIFF
--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -647,6 +647,10 @@ class SendspinPlayer(SendspinBasePlayer):
         roles = self.api.roles_by_family("player")
         for role in roles:
             role.set_player_mute(muted)
+        # Native clients don't always emit a VolumeChangedEvent in response to a
+        # mute command, so update our state directly to keep MA in sync.
+        self._attr_volume_muted = muted
+        self.update_state()
 
     async def stop(self) -> None:
         """Stop command."""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Fixes Sendspin player unable to be unmuted. I could not reproduce but I had the reporter test this fix using the dev server successfully.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5579

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
