### PR TITLE
Cap concurrent MusicBrainz ISRC lookups in Last.fm recommendations

### DIFF
--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -24,6 +24,11 @@ CACHE_EXPIRATION_SECONDS = 60 * 60 * 24 * 90  # 90 days
 # Maximum number of concurrent provider searches to prevent overwhelming APIs
 SEARCH_CONCURRENCY_LIMIT = 5
 
+# Maximum number of concurrent MusicBrainz ISRC lookups. MusicBrainz throttles all
+# callers to a shared global budget, so a wide fan-out just queues behind it while
+# bursting past the mirror's edge limit; cap it to stay within budget with headroom.
+MB_ISRC_CONCURRENCY_LIMIT = 5
+
 # Item counts and limits
 # Target number of items to return in recommendation folders
 TARGET_ITEM_COUNT = 10

--- a/music_assistant/providers/lastfm_recommendations/parsers.py
+++ b/music_assistant/providers/lastfm_recommendations/parsers.py
@@ -13,6 +13,7 @@ from music_assistant_models.media_items import Album, Artist, ItemMapping, Track
 from music_assistant.constants import MASS_LOGGER_NAME
 from music_assistant.helpers.compare import compare_strings
 from music_assistant.providers.lastfm_recommendations.constants import (
+    MB_ISRC_CONCURRENCY_LIMIT,
     PROVIDER_SEARCH_LIMIT,
     SEARCH_CONCURRENCY_LIMIT,
 )
@@ -28,6 +29,10 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.lastfm_recommendations")
 
 # Limit concurrent provider searches to avoid overwhelming their APIs.
 _SEARCH_SEMAPHORE = asyncio.Semaphore(SEARCH_CONCURRENCY_LIMIT)
+
+# Cap concurrent MusicBrainz ISRC lookups so a single artist's top-track fan-out
+# doesn't dump dozens of requests onto the shared MusicBrainz rate-limit budget at once.
+_MB_ISRC_SEMAPHORE = asyncio.Semaphore(MB_ISRC_CONCURRENCY_LIMIT)
 
 
 def _has_matching_external_ids(
@@ -339,7 +344,8 @@ async def parse_track(
         mb_provider = mass.get_provider("musicbrainz")
         if mb_provider:
             LOGGER.debug("Resolving MBID %s to ISRCs via MusicBrainz", mbid)
-            isrcs = await cast("MusicbrainzProvider", mb_provider).get_isrcs_for_recording(mbid)
+            async with _MB_ISRC_SEMAPHORE:
+                isrcs = await cast("MusicbrainzProvider", mb_provider).get_isrcs_for_recording(mbid)
             if isrcs:
                 LOGGER.debug("Found %d ISRCs for MBID %s: %s", len(isrcs), mbid, isrcs)
                 for isrc in isrcs:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
#4146 helped a lot but I was still seeing some rate limiting

Resolving an artist's top tracks fanned out one MusicBrainz ISRC lookup per track (~25) with no concurrency limit, while the streaming-provider search was already capped. So the wide fan-out was still going past the mirror's edge limit and tripping 429s with 60s Retry-After backoffs.

So this puts the ISRC lookups behind a semaphore (MB_ISRC_CONCURRENCY_LIMIT = 5, half the budget so other MusicBrainz callers keep headroom). Throughput is unchanged as it was always bounded by the rate limit, not concurrency but now requests no longer burst past it.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
