### PR TITLE
Fix cache cleanup missing most records and skip needless startup vacuum

### DIFF
--- a/music_assistant/controllers/cache/constants.py
+++ b/music_assistant/controllers/cache/constants.py
@@ -13,6 +13,8 @@ CONF_CLEAR_CACHE = "clear_cache"
 DEFAULT_CACHE_EXPIRATION = 86400 * 30  # 30 days
 DB_SCHEMA_VERSION = 8
 MAX_CACHE_DB_SIZE_MB = 2048
+# Min fraction of the db file reclaimable before the startup VACUUM is worth running.
+VACUUM_MIN_RECLAIM_RATIO = 0.2
 CACHE_DATABASE_CLEANUP_TASK_ID = "cache_database_cleanup"
 
 BYPASS_CACHE: ContextVar[bool] = ContextVar("BYPASS_CACHE", default=False)

--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -260,7 +260,8 @@ class CacheController(CoreController):
         self.logger.debug("Running automatic cleanup...")
         update_current_task_progress_text("Removing expired cache records")
         cur_timestamp = int(time.time())
-        # Single DELETE (no blob loads); allow_expired_cache survives for stale-while-revalidate.
+        # clean up db cache object only if expired; entries marked with
+        # allow_expired_cache are kept as fallback for stale-while-revalidate
         cursor = await self.database.execute(
             f"DELETE FROM {DB_TABLE_CACHE} WHERE expires < :timestamp AND allow_expired_cache = 0",
             {"timestamp": cur_timestamp},

--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -23,10 +23,10 @@ from music_assistant.controllers.cache.constants import (
     DEFAULT_CACHE_EXPIRATION,
     LOGGER,
     MAX_CACHE_DB_SIZE_MB,
+    VACUUM_MIN_RECLAIM_RATIO,
     SerializableType,
 )
 from music_assistant.controllers.tasks.context import (
-    update_current_task_progress_from_index,
     update_current_task_progress_text,
 )
 from music_assistant.helpers.database import DatabaseConnection
@@ -258,22 +258,15 @@ class CacheController(CoreController):
         """Run scheduled auto cleanup task."""
         assert self.database is not None
         self.logger.debug("Running automatic cleanup...")
-        update_current_task_progress_text("Loading cache records")
+        update_current_task_progress_text("Removing expired cache records")
         cur_timestamp = int(time.time())
-        cleaned_records = 0
-        db_rows = await self.database.get_rows(DB_TABLE_CACHE)
-        for index, db_row in enumerate(db_rows, 1):
-            update_current_task_progress_from_index(
-                index,
-                len(db_rows),
-                f"Scanning cache record {index}/{len(db_rows)}",
-            )
-            # clean up db cache object only if expired; entries marked with
-            # allow_expired_cache are kept as fallback for stale-while-revalidate
-            if db_row["expires"] < cur_timestamp and not db_row["allow_expired_cache"]:
-                await self.database.delete(DB_TABLE_CACHE, {"id": db_row["id"]})
-                cleaned_records += 1
-            await asyncio.sleep(0)  # yield to eventloop
+        # Single DELETE (no blob loads); allow_expired_cache survives for stale-while-revalidate.
+        cursor = await self.database.execute(
+            f"DELETE FROM {DB_TABLE_CACHE} WHERE expires < :timestamp AND allow_expired_cache = 0",
+            {"timestamp": cur_timestamp},
+        )
+        await self.database.commit()
+        cleaned_records = cursor.rowcount
         update_current_task_progress_text(f"Cleaned up {cleaned_records} expired cache record(s)")
         self.logger.debug("Automatic cleanup finished (cleaned up %s records)", cleaned_records)
 
@@ -345,14 +338,22 @@ class CacheController(CoreController):
         )
         await self.__create_database_indexes()
 
-        # compact db (vacuum) at startup
-        self.logger.debug("Compacting database...")
+        # Skip the full rebuild unless a meaningful share of the file can be reclaimed.
         try:
-            await self.database.vacuum()
+            reclaimable_ratio = await self.database.get_reclaimable_ratio()
+            if reclaimable_ratio < VACUUM_MIN_RECLAIM_RATIO:
+                self.logger.debug(
+                    "Skipping database compaction (only %.1f%% reclaimable)",
+                    reclaimable_ratio * 100,
+                )
+            else:
+                self.logger.debug(
+                    "Compacting database (%.1f%% reclaimable)...", reclaimable_ratio * 100
+                )
+                await self.database.vacuum()
+                self.logger.debug("Compacting database done")
         except Exception as err:
             self.logger.warning("Database vacuum failed: %s", str(err))
-        else:
-            self.logger.debug("Compacting database done")
 
     async def __create_database_tables(self) -> None:
         """Create database table(s)."""

--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -322,7 +322,26 @@ class DatabaseConnection:
             await asyncio.sleep(0)  # yield to eventloop
             offset += limit
 
+    async def get_reclaimable_ratio(self) -> float:
+        """
+        Return the fraction (0..1) of the database file that a VACUUM would reclaim.
+
+        This is the share of pages on the free list and is a cheap way to decide
+        whether a (potentially expensive) VACUUM is actually worthwhile.
+        """
+        page_count = await self._get_pragma_int("page_count")
+        if page_count <= 0:
+            return 0.0
+        freelist_count = await self._get_pragma_int("freelist_count")
+        return freelist_count / page_count
+
     async def vacuum(self) -> None:
         """Run vacuum command on database."""
         await self._db.execute("VACUUM")
         await self._db.commit()
+
+    async def _get_pragma_int(self, pragma: str) -> int:
+        """Return the integer value of a single-value sqlite PRAGMA."""
+        async with self._db.execute(f"PRAGMA {pragma}") as cursor:
+            row = await cursor.fetchone()
+            return int(row[0]) if row else 0

--- a/tests/core/test_cache_controller.py
+++ b/tests/core/test_cache_controller.py
@@ -9,7 +9,10 @@ from unittest.mock import AsyncMock, patch
 import aiofiles
 import pytest
 
+from music_assistant.constants import DB_TABLE_CACHE
 from music_assistant.controllers.cache import MAX_CACHE_DB_SIZE_MB, CacheController
+from music_assistant.controllers.cache.constants import VACUUM_MIN_RECLAIM_RATIO
+from music_assistant.helpers.database import DatabaseConnection
 from music_assistant.mass import MusicAssistant
 
 
@@ -401,3 +404,59 @@ async def test_auto_cleanup_keeps_fresh_entries(cache: CacheController) -> None:
     await cache.set("alive", "data", provider="test", expiration=3600)
     await cache.auto_cleanup()
     assert await cache.get("alive", provider="test") == "data"
+
+
+async def test_auto_cleanup_scans_all_records(cache: CacheController) -> None:
+    """
+    Test that auto_cleanup removes expired entries beyond the row-fetch page size.
+
+    Regression test: cleanup previously fetched rows via the default 500-row limit,
+    so large caches kept most of their expired entries forever.
+    """
+    expired_count = 1200
+    for i in range(expired_count):
+        await cache.set(f"expired_{i}", "data", provider="test", expiration=-1)
+    await cache.set("fresh", "data", provider="test", expiration=3600)
+
+    await cache.auto_cleanup()
+
+    assert cache.database is not None
+    assert await cache.database.get_count(DB_TABLE_CACHE) == 1
+    assert await cache.get("fresh", provider="test") == "data"
+
+
+# --- Startup vacuum ---
+
+
+async def test_setup_skips_vacuum_when_little_reclaimable(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """Test that the startup vacuum is skipped when little space can be reclaimed."""
+    cache = mass_minimal.cache
+    with (
+        patch.object(
+            DatabaseConnection,
+            "get_reclaimable_ratio",
+            AsyncMock(return_value=VACUUM_MIN_RECLAIM_RATIO / 2),
+        ),
+        patch.object(DatabaseConnection, "vacuum", AsyncMock()) as mock_vacuum,
+    ):
+        await cache._setup_database()
+    mock_vacuum.assert_not_called()
+
+
+async def test_setup_runs_vacuum_when_reclaimable(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """Test that the startup vacuum runs when enough space can be reclaimed."""
+    cache = mass_minimal.cache
+    with (
+        patch.object(
+            DatabaseConnection,
+            "get_reclaimable_ratio",
+            AsyncMock(return_value=VACUUM_MIN_RECLAIM_RATIO + 0.1),
+        ),
+        patch.object(DatabaseConnection, "vacuum", AsyncMock()) as mock_vacuum,
+    ):
+        await cache._setup_database()
+    mock_vacuum.assert_awaited_once_with()


### PR DESCRIPTION
# What does this implement/fix?

Users with very large libraries hit out-of-memory errors during cache database compaction, and most expired cache entries were never cleaned up — so the cache kept growing.

Two issues:

- **Cleanup only scanned the first 500 records.** `auto_cleanup` fetched rows via `get_rows`, which defaults to `limit=500`, so on large caches the vast majority of expired entries were never deleted and accumulated indefinitely. It now deletes expired entries in a single set-based `DELETE` statement, which also avoids materializing the (potentially huge) cached data blobs in memory. Entries marked `allow_expired_cache` are still preserved for stale-while-revalidate.
- **Startup VACUUM ran unconditionally.** A full vacuum rebuilds the whole database, which is wasteful (and memory-hungry) when little space is actually free. The startup vacuum now runs only when at least 20% of the database file can be reclaimed (a cheap freelist check), so it no longer does a full rebuild for negligible gain.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
