### PR TITLE
Improve smart crossfade audio quality: true frequency sweep and equal-power curves

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -212,7 +212,11 @@ class CrossfadeFilter(Filter):
 
     def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
         """Apply the acrossfade filter."""
-        return [f"{input_fadeout_label}{input_fadein_label}acrossfade=d={self.crossfade_duration}"]
+        # equal-power qsin curves; the default tri/tri dips ~3dB mid-fade on uncorrelated material
+        return [
+            f"{input_fadeout_label}{input_fadein_label}"
+            f"acrossfade=d={self.crossfade_duration}:c1=qsin:c2=qsin"
+        ]
 
     def __repr__(self) -> str:
         """Return string representation of CrossfadeFilter."""

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -86,10 +86,16 @@ class TrimFilter(Filter):
 
 
 class FrequencySweepFilter(Filter):
-    """Filter that creates frequency sweep effects (lowpass/highpass transitions)."""
+    """Filter that sweeps a lowpass/highpass cutoff frequency over time."""
 
     output_fadeout_label: str = "frequency_sweep"
     output_fadein_label: str = "frequency_sweep"
+
+    # cutoff at which the filter is perceptually transparent
+    lowpass_open_freq: int = 20000
+    highpass_open_freq: int = 20
+    # seconds between cutoff updates; small enough to be perceived as continuous
+    step_interval: float = 0.1
 
     def __init__(
         self,
@@ -103,17 +109,17 @@ class FrequencySweepFilter(Filter):
         curve_type: str,
         stream_type: str = "fadeout",
     ):
-        """Initialize frequency sweep filter.
+        """
+        Initialize frequency sweep filter.
 
-        Args:
-            sweep_type: 'lowpass' or 'highpass'
-            target_freq: Target frequency for the filter
-            duration: Duration of the sweep in seconds
-            start_time: When to start the sweep
-            sweep_direction: 'fade_in' (unfiltered->filtered) or 'fade_out' (filtered->unfiltered)
-            poles: Number of poles for the filter
-            curve_type: 'linear', 'exponential', or 'logarithmic'
-            stream_type: 'fadeout' or 'fadein' - which stream to process
+        :param sweep_type: 'lowpass' or 'highpass'.
+        :param target_freq: Target cutoff frequency for the filter.
+        :param duration: Duration of the sweep in seconds.
+        :param start_time: When to start the sweep.
+        :param sweep_direction: 'fade_in' (open -> target) or 'fade_out' (target -> open).
+        :param poles: Number of poles for the filter.
+        :param curve_type: 'linear', 'exponential', or 'logarithmic'.
+        :param stream_type: 'fadeout' or 'fadein' - which stream to process.
         """
         self.sweep_type = sweep_type
         self.target_freq = target_freq
@@ -134,26 +140,8 @@ class FrequencySweepFilter(Filter):
 
         super().__init__(logger)
 
-    def _generate_volume_expr(self, start: float, dur: float, direction: str, curve: str) -> str:
-        t_expr = f"t-{start}"  # Time relative to start
-        norm_t = f"min(max({t_expr},0),{dur})/{dur}"  # Normalized 0-1
-
-        if curve == "exponential":
-            # Exponential curve for smoother transitions
-            if direction == "up":
-                return f"'pow({norm_t},2)':eval=frame"
-            return f"'1-pow({norm_t},2)':eval=frame"
-        if curve == "logarithmic":
-            # Logarithmic curve for more aggressive initial change
-            if direction == "up":
-                return f"'sqrt({norm_t})':eval=frame"
-            return f"'1-sqrt({norm_t})':eval=frame"
-        if direction == "up":
-            return f"'{norm_t}':eval=frame"
-        return f"'1-{norm_t}':eval=frame"
-
     def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
-        """Generate FFmpeg filters for frequency sweep effect."""
+        """Generate FFmpeg filters for the frequency sweep effect."""
         # Select the correct input based on stream type
         if self.stream_type == "fadeout":
             input_label = input_fadeout_label
@@ -166,48 +154,49 @@ class FrequencySweepFilter(Filter):
             passthrough_label = self.output_fadeout_label
             passthrough_input = input_fadeout_label
 
-        orig_label = f"{output_label}_orig"
-        filter_label = f"{output_label}_to{self.sweep_type[:2]}"
-        filtered_label = f"{output_label}_filtered"
-        orig_faded_label = f"{output_label}_orig_faded"
-        filtered_faded_label = f"{output_label}_filtered_faded"
-
-        # Determine volume ramp directions based on sweep direction
-        if self.sweep_direction == "fade_in":
-            # Fade from dry to wet (unfiltered to filtered)
-            orig_direction = "down"
-            filter_direction = "up"
-        else:  # fade_out
-            # Fade from wet to dry (filtered to unfiltered)
-            orig_direction = "up"
-            filter_direction = "down"
-
-        # Build filter chain
-        orig_volume_expr = self._generate_volume_expr(
-            self.start_time, self.duration, orig_direction, self.curve_type
-        )
-        filtered_volume_expr = self._generate_volume_expr(
-            self.start_time, self.duration, filter_direction, self.curve_type
-        )
+        # instance name is scoped per stream type so both asendcmd command
+        # sequences address their own filter only
+        instance = f"{self.sweep_type}@sweep_{self.stream_type}"
+        steps = self._compute_sweep_steps()
+        cmd_string = "; ".join(f"{ts:.3f} {instance} f {freq:.1f}" for ts, freq in steps)
+        initial_freq = steps[0][1]
 
         return [
             # Pass through the other stream unchanged
             f"{passthrough_input}anull[{passthrough_label}]",  # codespell:ignore anull
-            # Split input into two paths
-            f"{input_label}asplit=2[{orig_label}][{filter_label}]",
-            # Apply frequency filter to one path
-            f"[{filter_label}]{self.sweep_type}=f={self.target_freq}:poles={self.poles}[{filtered_label}]",
-            # Apply time-varying volume to original path
-            f"[{orig_label}]volume={orig_volume_expr}[{orig_faded_label}]",
-            # Apply time-varying volume to filtered path
-            f"[{filtered_label}]volume={filtered_volume_expr}[{filtered_faded_label}]",
-            # Mix the two paths together
-            f"[{orig_faded_label}][{filtered_faded_label}]amix=inputs=2:duration=longest:normalize=0[{output_label}]",
+            f"{input_label}asendcmd=c='{cmd_string}',"
+            f"{instance}=f={initial_freq:.1f}:poles={self.poles}[{output_label}]",
         ]
 
     def __repr__(self) -> str:
         """Return string representation of FrequencySweepFilter."""
-        return f"FreqSweep({self.sweep_type}@{self.target_freq}Hz)"
+        return f"FreqSweep({self.sweep_type}@{self.target_freq}Hz, poles={self.poles})"
+
+    def _compute_sweep_steps(self) -> list[tuple[float, float]]:
+        """Compute the (timestamp, cutoff frequency) steps of the sweep."""
+        open_freq = (
+            self.lowpass_open_freq if self.sweep_type == "lowpass" else self.highpass_open_freq
+        )
+        if self.sweep_direction == "fade_in":
+            freq_start, freq_end = float(open_freq), float(self.target_freq)
+        else:
+            freq_start, freq_end = float(self.target_freq), float(open_freq)
+
+        n_steps = max(2, int(self.duration / self.step_interval))
+        steps: list[tuple[float, float]] = []
+        for i in range(n_steps + 1):
+            progress = i / n_steps
+            # exponential delays the cutoff movement, logarithmic front-loads it
+            # (same perceived pacing as the volume curves this sweep replaced)
+            if self.curve_type == "exponential":
+                progress = progress**2
+            elif self.curve_type == "logarithmic":
+                progress = progress**0.5
+            timestamp = self.start_time + (i / n_steps) * self.duration
+            # interpolate in log-frequency space so the sweep is perceptually linear
+            freq = freq_start * (freq_end / freq_start) ** progress
+            steps.append((timestamp, freq))
+        return steps
 
 
 class CrossfadeFilter(Filter):

--- a/tests/controllers/streams/smart_fades/__init__.py
+++ b/tests/controllers/streams/smart_fades/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the smart fades implementation."""

--- a/tests/controllers/streams/smart_fades/test_filters.py
+++ b/tests/controllers/streams/smart_fades/test_filters.py
@@ -1,0 +1,174 @@
+"""Tests for the smart fades FFmpeg filter builders.
+
+The FrequencySweepFilter must produce a true frequency sweep: an ``asendcmd``
+command sequence that moves the lowpass/highpass cutoff frequency over time,
+rather than blending a fixed-cutoff wet path against the dry signal.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from music_assistant.controllers.streams.smart_fades.filters import FrequencySweepFilter
+
+LOGGER = logging.getLogger(__name__)
+
+# matches "<timestamp> <filter>@<instance> f <frequency>" entries inside asendcmd
+CMD_RE = re.compile(r"(\d+\.\d+) ((?:low|high)pass@\w+) f (\d+(?:\.\d+)?)")
+
+
+def _make_filter(
+    *,
+    sweep_type: str = "lowpass",
+    target_freq: int = 2000,
+    duration: float = 10.0,
+    start_time: float = 5.0,
+    sweep_direction: str = "fade_in",
+    poles: int = 1,
+    curve_type: str = "linear",
+    stream_type: str = "fadeout",
+) -> FrequencySweepFilter:
+    """Return a FrequencySweepFilter with sensible defaults for tests."""
+    return FrequencySweepFilter(
+        logger=LOGGER,
+        sweep_type=sweep_type,
+        target_freq=target_freq,
+        duration=duration,
+        start_time=start_time,
+        sweep_direction=sweep_direction,
+        poles=poles,
+        curve_type=curve_type,
+        stream_type=stream_type,
+    )
+
+
+def _parse_sweep(filter_strings: list[str]) -> tuple[str, list[tuple[float, float]]]:
+    """Extract (sweep_chain, [(timestamp, frequency), ...]) from the filter strings."""
+    sweep_chains = [f for f in filter_strings if "asendcmd" in f]
+    assert len(sweep_chains) == 1, f"expected exactly one asendcmd chain in {filter_strings}"
+    chain = sweep_chains[0]
+    steps = [(float(ts), float(freq)) for ts, _, freq in CMD_RE.findall(chain)]
+    assert steps, f"no frequency commands found in {chain}"
+    return chain, steps
+
+
+def test_lowpass_fade_in_sweeps_from_open_to_target() -> None:
+    """Applying a lowpass sweeps the cutoff from fully open down to the target."""
+    sweep = _make_filter(sweep_type="lowpass", sweep_direction="fade_in", target_freq=2000)
+    chain, steps = _parse_sweep(sweep.apply("[fadein]", "[fadeout]"))
+
+    freqs = [freq for _, freq in steps]
+    assert freqs[0] >= 18000, "sweep must start with the filter effectively open"
+    assert freqs[-1] == pytest.approx(2000, rel=0.01)
+    assert freqs == sorted(freqs, reverse=True), "cutoff must move monotonically down"
+    # the initial filter cutoff must match the first command so there is no jump
+    assert f"=f={int(freqs[0])}" in chain
+
+
+def test_highpass_fade_out_sweeps_from_target_to_open() -> None:
+    """Removing a highpass sweeps the cutoff from the target down until open."""
+    sweep = _make_filter(
+        sweep_type="highpass",
+        sweep_direction="fade_out",
+        target_freq=2000,
+        start_time=0.0,
+        stream_type="fadein",
+    )
+    _, steps = _parse_sweep(sweep.apply("[fadein]", "[fadeout]"))
+
+    freqs = [freq for _, freq in steps]
+    assert freqs[0] == pytest.approx(2000, rel=0.01)
+    assert freqs[-1] <= 30, "sweep must end with the highpass effectively open"
+    assert freqs == sorted(freqs, reverse=True), "cutoff must move monotonically down"
+
+
+def test_sweep_commands_cover_the_configured_window() -> None:
+    """Command timestamps span [start_time, start_time + duration]."""
+    sweep = _make_filter(start_time=5.0, duration=10.0)
+    _, steps = _parse_sweep(sweep.apply("[fadein]", "[fadeout]"))
+
+    timestamps = [ts for ts, _ in steps]
+    assert timestamps[0] == pytest.approx(5.0, abs=0.01)
+    assert timestamps[-1] == pytest.approx(15.0, abs=0.01)
+    assert timestamps == sorted(timestamps)
+    # fine-grained enough to be perceived as continuous
+    assert len(timestamps) >= 50
+
+
+def test_logarithmic_curve_sweeps_faster_initially_than_linear() -> None:
+    """The logarithmic curve must reach a lower cutoff at mid-sweep than linear."""
+
+    def freq_at_midpoint(curve_type: str) -> float:
+        sweep = _make_filter(curve_type=curve_type, start_time=0.0, duration=10.0)
+        _, steps = _parse_sweep(sweep.apply("[fadein]", "[fadeout]"))
+        return min(freq for ts, freq in steps if ts <= 5.0)
+
+    assert freq_at_midpoint("logarithmic") < freq_at_midpoint("linear")
+
+
+def test_exponential_curve_sweeps_slower_initially_than_linear() -> None:
+    """The exponential curve must keep a higher cutoff at mid-sweep than linear."""
+
+    def freq_at_midpoint(curve_type: str) -> float:
+        sweep = _make_filter(curve_type=curve_type, start_time=0.0, duration=10.0)
+        _, steps = _parse_sweep(sweep.apply("[fadein]", "[fadeout]"))
+        return min(freq for ts, freq in steps if ts <= 5.0)
+
+    assert freq_at_midpoint("exponential") > freq_at_midpoint("linear")
+
+
+def test_poles_are_passed_through() -> None:
+    """The poles option must end up in the generated filter chain."""
+    sweep = _make_filter(poles=2)
+    chain, _ = _parse_sweep(sweep.apply("[fadein]", "[fadeout]"))
+    assert "poles=2" in chain
+
+
+def test_fadeout_stream_labels_and_passthrough() -> None:
+    """Processing the fadeout stream passes the fadein stream through untouched."""
+    sweep = _make_filter(stream_type="fadeout")
+    filter_strings = sweep.apply("[fadein]", "[fadeout]")
+
+    assert sweep.output_fadeout_label == "fadeout_lowpass"
+    assert sweep.output_fadein_label == "fadein_passthrough"
+    passthrough = next(f for f in filter_strings if "anull" in f)  # codespell:ignore anull
+    assert passthrough.startswith("[fadein]")
+    assert passthrough.endswith("[fadein_passthrough]")
+    sweep_chain, _ = _parse_sweep(filter_strings)
+    assert sweep_chain.startswith("[fadeout]")
+    assert sweep_chain.endswith("[fadeout_lowpass]")
+
+
+def test_fadein_stream_labels_and_passthrough() -> None:
+    """Processing the fadein stream passes the fadeout stream through untouched."""
+    sweep = _make_filter(
+        sweep_type="highpass", sweep_direction="fade_out", stream_type="fadein", start_time=0.0
+    )
+    filter_strings = sweep.apply("[fadein]", "[fadeout]")
+
+    assert sweep.output_fadeout_label == "fadeout_passthrough"
+    assert sweep.output_fadein_label == "fadein_highpass"
+    passthrough = next(f for f in filter_strings if "anull" in f)  # codespell:ignore anull
+    assert passthrough.startswith("[fadeout]")
+    assert passthrough.endswith("[fadeout_passthrough]")
+    sweep_chain, _ = _parse_sweep(filter_strings)
+    assert sweep_chain.startswith("[fadein]")
+    assert sweep_chain.endswith("[fadein_highpass]")
+
+
+def test_sweep_instances_are_unique_per_stream_type() -> None:
+    """Both stream types must use distinct filter instance names for asendcmd."""
+    fadeout_sweep = _make_filter(stream_type="fadeout")
+    fadein_sweep = _make_filter(
+        sweep_type="highpass", sweep_direction="fade_out", stream_type="fadein"
+    )
+    out_chain, _ = _parse_sweep(fadeout_sweep.apply("[fadein]", "[fadeout]"))
+    in_chain, _ = _parse_sweep(fadein_sweep.apply("[fadein]", "[fadeout]"))
+    out_match = CMD_RE.search(out_chain)
+    in_match = CMD_RE.search(in_chain)
+    assert out_match is not None
+    assert in_match is not None
+    assert out_match.group(2) != in_match.group(2)

--- a/tests/controllers/streams/smart_fades/test_filters.py
+++ b/tests/controllers/streams/smart_fades/test_filters.py
@@ -12,7 +12,10 @@ import re
 
 import pytest
 
-from music_assistant.controllers.streams.smart_fades.filters import FrequencySweepFilter
+from music_assistant.controllers.streams.smart_fades.filters import (
+    CrossfadeFilter,
+    FrequencySweepFilter,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -172,3 +175,10 @@ def test_sweep_instances_are_unique_per_stream_type() -> None:
     assert out_match is not None
     assert in_match is not None
     assert out_match.group(2) != in_match.group(2)
+
+
+def test_crossfade_uses_equal_power_curves() -> None:
+    """The level crossfade must use equal-power curves, not ffmpeg's default tri/tri."""
+    crossfade = CrossfadeFilter(logger=LOGGER, crossfade_duration=12.5)
+    filter_strings = crossfade.apply("[fadein]", "[fadeout]")
+    assert filter_strings == ["[fadeout][fadein]acrossfade=d=12.5:c1=qsin:c2=qsin"]

--- a/tests/providers/hue_entertainment/test_analyzer.py
+++ b/tests/providers/hue_entertainment/test_analyzer.py
@@ -281,4 +281,4 @@ class TestScheduledBeatModel:
 
 def _channel_sum(command: LightColorCommand) -> int:
     """Total 16-bit energy across a command's RGB channels."""
-    return command.red + command.green + command.blue
+    return int(command.red + command.green + command.blue)


### PR DESCRIPTION
# What does this implement/fix?

Two audio-quality improvements to the smart crossfade, both validated with A/B renders on real library tracks:

**True frequency sweep for the EQ transitions.** The lowpass/highpass transitions did not actually sweep the filter cutoff: they applied a fixed-cutoff filter and volume-crossfaded the filtered path against the dry signal. That caps attenuation at the blend ratio (at the halfway point nothing is attenuated more than ~6 dB regardless of frequency) and the dry+filtered sum suffers phase interaction around the cutoff. Now an `asendcmd` command sequence moves the cutoff over time — the same mechanism the gradual time stretch already uses to drive rubberband.

**Equal-power crossfade curves.** `acrossfade` was used with its default `tri/tri` (equal-gain) curves, which sag ~3 dB in loudness mid-fade on uncorrelated program material — measured at 3.0–3.4 dB on all 10 test pairs with 17–26s fades. Switched to `qsin/qsin` (equal-power), for both smart and standard crossfade. The potential +3 dB mid-fade sum on hot un-normalized masters is caught by the default output limiter (`alimiter` at -2 dB) at the F32→int conversion.

- `FrequencySweepFilter.apply()` now emits a 2-node `asendcmd,lowpass/highpass` chain (was 6 nodes: asplit + lowpass + 2× per-frame volume + amix); cutoff steps every 100 ms, interpolated in log-frequency space so the sweep is perceptually linear; the existing `curve_type` values keep their pacing semantics
- `CrossfadeFilter` (also used by `StandardCrossFade`) emits `acrossfade=d=X:c1=qsin:c2=qsin`
- No changes outside the filter classes: same constructors, same labels, same call sites in `fades.py`
- Added unit tests for the generated filter chains; verified end-to-end on real library tracks (A/B renders of 10 fade-compatible pairs)
- Includes a one-line mypy fix in the hue_entertainment analyzer test that was blocking the repo-wide mypy hook

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
