### PR TITLE
Last.fm provider search bug fixes

### DIFF
--- a/music_assistant/providers/lastfm_recommendations/api_client.py
+++ b/music_assistant/providers/lastfm_recommendations/api_client.py
@@ -88,6 +88,49 @@ class LastFMAPIClient:
 
         return data
 
+    async def _get_list(
+        self,
+        method: str,
+        container: str,
+        item_key: str,
+        log_label: str,
+        primary_params: dict[str, Any],
+        fallback_params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Fetch a list-type Last.fm response, retrying with the fallback params when empty.
+
+        :param method: Last.fm API method to call.
+        :param container: Top-level response key wrapping the result list.
+        :param item_key: Key of the result list within the container.
+        :param log_label: Human-readable label used in debug logging.
+        :param primary_params: Preferred request params (MBID when available).
+        :param fallback_params: Name-based params to retry with, or None for no retry.
+        """
+        # Last.fm's MBID index is sparse (recording MBIDs especially), so a missing MBID
+        # is retried by name rather than treated as "no similar items exist".
+        attempts = [primary_params]
+        if fallback_params is not None:
+            attempts.append(fallback_params)
+
+        for index, params in enumerate(attempts):
+            if index:
+                self.logger.debug("%s: MBID lookup empty, retrying by name", log_label)
+            try:
+                data = await self._get_data(method, **params)
+            except (TimeoutError, ClientError, InvalidDataError) as err:
+                self.logger.debug("%s request failed: %s", log_label, err)
+                continue
+
+            items: list[dict[str, Any]] | dict[str, Any] = data.get(container, {}).get(item_key, [])
+            # Last.fm returns a single dict when only one result is present.
+            if isinstance(items, dict):
+                return [items]
+            if items:
+                return items
+
+        return []
+
     async def get_similar_artists(
         self, artist_name: str, artist_mbid: str | None = None, limit: int = 10
     ) -> list[dict[str, Any]]:
@@ -98,35 +141,35 @@ class LastFMAPIClient:
         :param artist_mbid: Optional MusicBrainz ID for more accurate matching.
         :param limit: Maximum number of similar artists to return.
         """
-        params: dict[str, Any] = {"limit": limit}
-
-        # Prefer MBID for more accurate matching; fall back to name with autocorrect.
-        if artist_mbid:
-            params["mbid"] = artist_mbid
-        else:
-            params["artist"] = artist_name
-            params["autocorrect"] = 1
-
         self.logger.debug(
             "Fetching similar artists for: %s (MBID: %s)",
             artist_name,
             artist_mbid or "none",
         )
-        try:
-            data = await self._get_data("artist.getSimilar", **params)
-        except (TimeoutError, ClientError, InvalidDataError) as err:
-            self.logger.debug("Similar artists request failed: %s", err)
+        name_params: dict[str, Any] | None = (
+            {"limit": limit, "artist": artist_name, "autocorrect": 1} if artist_name else None
+        )
+        primary_params: dict[str, Any] | None
+        fallback_params: dict[str, Any] | None
+        # Lead with the MBID (exact when Last.fm has it), fall back to the name lookup.
+        if artist_mbid:
+            primary_params = {"limit": limit, "mbid": artist_mbid}
+            fallback_params = name_params
+        else:
+            primary_params = name_params
+            fallback_params = None
+
+        if primary_params is None:
             return []
 
-        similar_artists: list[dict[str, Any]] | dict[str, Any] = data.get("similarartists", {}).get(
-            "artist", []
+        return await self._get_list(
+            "artist.getSimilar",
+            "similarartists",
+            "artist",
+            "Similar artists",
+            primary_params,
+            fallback_params,
         )
-
-        # Last.fm returns a single dict when only one result is present.
-        if isinstance(similar_artists, dict):
-            return [similar_artists]
-
-        return similar_artists
 
     async def get_similar_tracks(
         self,
@@ -143,37 +186,38 @@ class LastFMAPIClient:
         :param track_mbid: Optional MusicBrainz ID for more accurate matching.
         :param limit: Maximum number of similar tracks to return.
         """
-        params: dict[str, Any] = {"limit": limit}
-
-        # Prefer MBID for more accurate matching; fall back to name with autocorrect.
-        if track_mbid:
-            params["mbid"] = track_mbid
-        else:
-            params["artist"] = artist_name
-            params["track"] = track_name
-            params["autocorrect"] = 1
-
         self.logger.debug(
             "Fetching similar tracks for: %s - %s (MBID: %s)",
             artist_name,
             track_name,
             track_mbid or "none",
         )
-        try:
-            data = await self._get_data("track.getSimilar", **params)
-        except (TimeoutError, ClientError, InvalidDataError) as err:
-            self.logger.debug("Similar tracks request failed: %s", err)
+        name_params: dict[str, Any] | None = (
+            {"limit": limit, "artist": artist_name, "track": track_name, "autocorrect": 1}
+            if artist_name and track_name
+            else None
+        )
+        primary_params: dict[str, Any] | None
+        fallback_params: dict[str, Any] | None
+        # Lead with the MBID (exact when Last.fm has it), fall back to the name lookup.
+        if track_mbid:
+            primary_params = {"limit": limit, "mbid": track_mbid}
+            fallback_params = name_params
+        else:
+            primary_params = name_params
+            fallback_params = None
+
+        if primary_params is None:
             return []
 
-        similar_tracks: list[dict[str, Any]] | dict[str, Any] = data.get("similartracks", {}).get(
-            "track", []
+        return await self._get_list(
+            "track.getSimilar",
+            "similartracks",
+            "track",
+            "Similar tracks",
+            primary_params,
+            fallback_params,
         )
-
-        # Last.fm returns a single dict when only one result is present.
-        if isinstance(similar_tracks, dict):
-            return [similar_tracks]
-
-        return similar_tracks
 
     async def get_artist_top_tracks(
         self, artist_name: str, artist_mbid: str | None = None, limit: int = 10
@@ -185,33 +229,35 @@ class LastFMAPIClient:
         :param artist_mbid: Optional MusicBrainz ID for more accurate matching.
         :param limit: Maximum number of top tracks to return.
         """
-        params: dict[str, Any] = {"limit": limit}
-
-        # Prefer MBID for more accurate matching; fall back to name with autocorrect.
-        if artist_mbid:
-            params["mbid"] = artist_mbid
-        else:
-            params["artist"] = artist_name
-            params["autocorrect"] = 1
-
         self.logger.debug(
             "Fetching top tracks for artist: %s (MBID: %s)",
             artist_name,
             artist_mbid or "none",
         )
-        try:
-            data = await self._get_data("artist.getTopTracks", **params)
-        except (TimeoutError, ClientError, InvalidDataError) as err:
-            self.logger.debug("Artist top tracks request failed: %s", err)
+        name_params: dict[str, Any] | None = (
+            {"limit": limit, "artist": artist_name, "autocorrect": 1} if artist_name else None
+        )
+        primary_params: dict[str, Any] | None
+        fallback_params: dict[str, Any] | None
+        # Lead with the MBID (exact when Last.fm has it), fall back to the name lookup.
+        if artist_mbid:
+            primary_params = {"limit": limit, "mbid": artist_mbid}
+            fallback_params = name_params
+        else:
+            primary_params = name_params
+            fallback_params = None
+
+        if primary_params is None:
             return []
 
-        tracks: list[dict[str, Any]] | dict[str, Any] = data.get("toptracks", {}).get("track", [])
-
-        # Last.fm returns a single dict when only one result is present.
-        if isinstance(tracks, dict):
-            return [tracks]
-
-        return tracks
+        return await self._get_list(
+            "artist.getTopTracks",
+            "toptracks",
+            "track",
+            "Artist top tracks",
+            primary_params,
+            fallback_params,
+        )
 
     async def get_chart_top_artists(self, limit: int = 10) -> list[dict[str, Any]]:
         """

--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -49,6 +49,11 @@ LIBRARY_MATCH_SCAN_LIMIT = 5
 # Number of similar items to fetch before filtering to target count
 SIMILAR_ITEMS_BUFFER = 12
 
+# Number of similar tracks to resolve before filtering to target count. Larger than the
+# artist buffer to absorb this row's extra attrition: stricter ISRC matching and the
+# exclusion of tracks that resolve to the user's own library copy.
+SIMILAR_TRACKS_BUFFER = 15
+
 # Number of similar items to fetch for each seed artist/track
 SIMILAR_ITEMS_PER_SEED = 5
 

--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -42,6 +42,10 @@ RESOLUTION_BUFFER_LARGE = 60
 # Number of top items to always include when sampling (before random selection)
 TOP_ITEMS_TO_TAKE = 3
 
+# Number of library search hits scanned when verifying an item is already in the library.
+# A small window so a genuine match ranked behind a fuzzier one is still caught.
+LIBRARY_MATCH_SCAN_LIMIT = 5
+
 # Number of similar items to fetch before filtering to target count
 SIMILAR_ITEMS_BUFFER = 12
 

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -6,7 +6,7 @@ import asyncio
 import datetime
 import random
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from music_assistant_models.enums import ExternalID, MediaType
 from music_assistant_models.media_items import (
@@ -33,6 +33,7 @@ from music_assistant.providers.lastfm_recommendations.constants import (
     RESOLUTION_BUFFER_SMALL,
     SIMILAR_ITEMS_BUFFER,
     SIMILAR_ITEMS_PER_SEED,
+    SIMILAR_TRACKS_BUFFER,
     TARGET_ITEM_COUNT,
     TOP_ARTISTS_LIMIT,
     TOP_ITEMS_TO_TAKE,
@@ -49,6 +50,8 @@ if TYPE_CHECKING:
     import logging
 
     from music_assistant.providers.lastfm_recommendations import LastFMRecommendationsProvider
+
+_MediaItemT = TypeVar("_MediaItemT", Artist, Album, Track)
 
 
 class LastFMRecommendationManager:
@@ -213,6 +216,17 @@ class LastFMRecommendationManager:
                     return True
 
         return False
+
+    @staticmethod
+    def _exclude_owned(items: list[_MediaItemT]) -> list[_MediaItemT]:
+        """
+        Drop items that resolved to the user's own library copy from a discovery row.
+
+        :param items: Resolved discovery items to filter.
+        """
+        # Resolution returns the library copy when a recommendation matches on ISRC/MBID,
+        # which the cheaper pre-filter can miss; exclude those so Discover rows stay discovery.
+        return [item for item in items if item.provider != "library"]
 
     def _sample_items(
         self, items: list[dict[str, Any]], seed_suffix: str, target_count: int = TARGET_ITEM_COUNT
@@ -501,7 +515,7 @@ class LastFMRecommendationManager:
             resolved_artists = await asyncio.gather(
                 *[self.get_or_resolve_artist(artist_data) for artist_data in sampled_artists_raw]
             )
-            all_resolved = [a for a in resolved_artists if a is not None]
+            all_resolved = self._exclude_owned([a for a in resolved_artists if a is not None])
             genre_artists = list(UniqueList(all_resolved))[:TARGET_ITEM_COUNT]
 
             if genre_artists:
@@ -533,7 +547,9 @@ class LastFMRecommendationManager:
             resolved_albums = await asyncio.gather(
                 *[self._get_or_resolve_album(album_data) for album_data in sampled_albums_raw]
             )
-            all_resolved_albums = [album for album in resolved_albums if album is not None]
+            all_resolved_albums = self._exclude_owned(
+                [album for album in resolved_albums if album is not None]
+            )
             genre_albums = list(UniqueList(all_resolved_albums))[:TARGET_ITEM_COUNT]
 
             if genre_albums:
@@ -565,7 +581,9 @@ class LastFMRecommendationManager:
             resolved_tracks = await asyncio.gather(
                 *[self.get_or_resolve_track(track_data) for track_data in sampled_tracks_raw]
             )
-            all_resolved_genre_tracks = [track for track in resolved_tracks if track is not None]
+            all_resolved_genre_tracks = self._exclude_owned(
+                [track for track in resolved_tracks if track is not None]
+            )
             genre_tracks = list(UniqueList(all_resolved_genre_tracks))[:TARGET_ITEM_COUNT]
 
             if genre_tracks:
@@ -713,7 +731,7 @@ class LastFMRecommendationManager:
                 for artist_data in unique_similar[:SIMILAR_ITEMS_BUFFER]
             ]
         )
-        return [artist for artist in resolved_artists if artist is not None]
+        return self._exclude_owned([artist for artist in resolved_artists if artist is not None])
 
     async def _get_similar_tracks_from_seeds(self, seed_tracks: list[Track]) -> list[Track]:
         """
@@ -782,10 +800,11 @@ class LastFMRecommendationManager:
 
         unique_similar.sort(key=lambda x: float(x.get("match", 0)), reverse=True)
 
-        # Only resolve ISRCs for the top results to avoid unnecessary MusicBrainz lookups.
-        top_tracks_data = unique_similar[:TARGET_ITEM_COUNT]
+        # Resolve a small buffer beyond the target so resolution failures and owned-copy
+        # exclusion still leave enough to fill the row, while capping MusicBrainz ISRC lookups.
+        top_tracks_data = unique_similar[:SIMILAR_TRACKS_BUFFER]
 
         resolved_tracks = await asyncio.gather(
             *[self.get_or_resolve_track(track_data) for track_data in top_tracks_data]
         )
-        return [track for track in resolved_tracks if track is not None]
+        return self._exclude_owned([track for track in resolved_tracks if track is not None])

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -18,6 +18,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.constants import CONF_USERNAME
+from music_assistant.helpers.compare import compare_strings
 from music_assistant.providers.lastfm_recommendations.constants import (
     CACHE_CATEGORY_RESOLVED_ITEMS,
     CACHE_EXPIRATION_SECONDS,
@@ -26,6 +27,7 @@ from music_assistant.providers.lastfm_recommendations.constants import (
     CONF_ENABLE_GLOBAL_CHARTS,
     CONF_ENABLE_PERSONALIZED,
     CONF_GEO_COUNTRY,
+    LIBRARY_MATCH_SCAN_LIMIT,
     RECENT_TRACKS_SCAN_LIMIT,
     RESOLUTION_BUFFER_LARGE,
     RESOLUTION_BUFFER_SMALL,
@@ -144,21 +146,36 @@ class LastFMRecommendationManager:
                     self.logger.debug("Filtered track '%s' (MBID match: %s)", name, mbid)
                     return True
 
+        # Library search is fuzzy and always returns a best-effort row, so verify the hit's
+        # name actually matches before treating the item as owned. Lenient (strict=False) so
+        # tagging variants still count, erring towards filtering over showing owned items.
         if media_type == MediaType.ARTIST:
             if name:
-                artist_results = await self.mass.music.artists.library_items(search=name, limit=1)
-                if artist_results:
+                artist_results = await self.mass.music.artists.library_items(
+                    search=name, limit=LIBRARY_MATCH_SCAN_LIMIT
+                )
+                artist_match = next(
+                    (a for a in artist_results if compare_strings(name, a.name, strict=False)),
+                    None,
+                )
+                if artist_match:
                     self.logger.debug(
-                        "Filtered artist '%s' (name match: '%s')", name, artist_results[0].name
+                        "Filtered artist '%s' (name match: '%s')", name, artist_match.name
                     )
                     return True
 
         elif media_type == MediaType.ALBUM:
             if name:
-                album_results = await self.mass.music.albums.library_items(search=name, limit=1)
-                if album_results:
+                album_results = await self.mass.music.albums.library_items(
+                    search=name, limit=LIBRARY_MATCH_SCAN_LIMIT
+                )
+                album_match = next(
+                    (a for a in album_results if compare_strings(name, a.name, strict=False)),
+                    None,
+                )
+                if album_match:
                     self.logger.debug(
-                        "Filtered album '%s' (name match: '%s')", name, album_results[0].name
+                        "Filtered album '%s' (name match: '%s')", name, album_match.name
                     )
                     return True
 
@@ -170,14 +187,28 @@ class LastFMRecommendationManager:
             if name and artist_name:
                 search_query = f"{artist_name} {name}"
                 track_results = await self.mass.music.tracks.library_items(
-                    search=search_query, limit=1
+                    search=search_query, limit=LIBRARY_MATCH_SCAN_LIMIT
                 )
-                if track_results:
+                # Match both title and artist; a title-only check would treat a same-named
+                # track by a different artist as owned.
+                track_match = next(
+                    (
+                        track
+                        for track in track_results
+                        if compare_strings(name, track.name, strict=False)
+                        and any(
+                            compare_strings(artist_name, track_artist.name, strict=False)
+                            for track_artist in track.artists
+                        )
+                    ),
+                    None,
+                )
+                if track_match:
                     self.logger.debug(
                         "Filtered track '%s - %s' (name match: '%s')",
                         artist_name,
                         name,
-                        track_results[0].name,
+                        track_match.name,
                     )
                     return True
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

I was looking through the debug logs and noticed 3 problems.

When the provider asks Last.fm for tracks similar to my favourites, it only identified each of my tracks by its MusicBrainz ID. The trouble is that Last.fm's catalogue often doesn't recognise those IDs, even for very well-known songs. So most of my top tracks came back as "not found" and contributed nothing, while a couple of unusual ones that happened to be recognised ended up dominating the whole row. The result was a row that didn't reflect my actual listens.

There was supposed to be a fallback to using the artist and track name instead but that wasn't working but now it is. The same improvement applies to the similar-artists and artist-top-tracks lookups, which had the same problem.

Before showing recommendations, the provider removes anything already in my library so it doesn't suggest things I own. But the "do I already have this?" check was too loose and it would accept a vaguely similar name as a match. So it was discarding good suggestions by mistake.

The check now confirms the name genuinely matches before deciding I already own something (and for tracks, it checks the artist too, not just the title). It still allows for minor differences in spelling or tagging, deliberately erring on the side of filtering rather than risking showing me something I already have.

Even with that filtering, I was still occasionally seeing a track in a "Discover" row that I already own. The cause is that there are two separate "do I own this?" checks that look a track up in different ways: the quick up-front filter only knows my copy by one kind of ID, but the later step that fetches the actual playable track can match my library copy by a different ID (an ISRC) and quietly hand back my own copy. So a track I own slips into a discovery row.

Now, once the playable track has been fetched, anything that turns out to be my own library copy is dropped from the Discover rows (the worldwide and country "Top" chart rows are left alone, since owning something there is expected). Because dropping items can leave a row short, the similar-tracks list now resolves a few extra candidates so it can still fill a full row.

On the size of the diff — it's mostly restructuring and repetition, not much new logic:

1. api_client.py — extracted a shared helper. Previously each of the three lookup methods (get_similar_artists, get_similar_tracks, get_artist_top_tracks) had its own copy of the same boilerplate: build params, call the API, catch errors, and normalize Last.fm's "single result comes back as a dict instead of a list" quirk. I pulled all of that into one private method (_get_list) that also owns the new retry loop. So each public method shrank to just "assemble the MBID params and the name-fallback params, then delegate." The behavioural change is tiny (try the fallback params when the first call returns nothing), but because all three methods were rewritten to route through the helper and the duplicated normalization moved out of each, the line count churns more than the logic does.

2. recommendations.py — the same small edit applied to parallel branches. The library-ownership check has three branches (artist / album / track); each changed from "if,the fuzzy search returned any row, treat as owned" to "scan the top few rows and only treat as owned if a name actually verifies." The owned-from-Discover exclusion is likewise a one-line helper applied at the end of each of the five Discover rows. Lots of near-identical touch points, plus a couple of new constants and imports, is what makes it look bigger than it is.

The only genuinely new behaviour is (a) the empty-result retry in _get_list, (b) the compare_strings verification gate in each _is_in_library branch, and (c) dropping items that resolve to a library copy from the Discover rows. Everything else is moving existing code around or repeating the same change across parallel branches.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
