### PR TITLE
Fix 30s delay when grouping some Sendspin devices

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin[server]==6.0.4", "av==16.1.0"],
+  "requirements": ["aiosendspin[server]==6.0.5", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ aiohttp-socks==0.11.0
 aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
-aiosendspin[server]==6.0.4
+aiosendspin[server]==6.0.5
 aioslimproto==3.1.8
 aiosonos==0.1.12
 aiosqlite==0.22.1


### PR DESCRIPTION
# What does this implement/fix?

Bumps `aiosendspin[server]` to 6.0.5, which fixes a bug where, in some scenarios, grouping Sendspin players started playing audio only after 30s of silence.

Full release notes: https://github.com/Sendspin/aiosendspin/releases/tag/6.0.5

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — \`bugfix\`
- [ ] New feature (non-breaking change which adds functionality) — \`new-feature\`
- [ ] Enhancement to an existing feature — \`enhancement\`
- [ ] New music/player/metadata/plugin provider — \`new-provider\`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — \`breaking-change\`
- [ ] Refactor (no behaviour change) — \`refactor\`
- [ ] Documentation only — \`documentation\`
- [ ] Maintenance / chore — \`maintenance\`
- [ ] CI / workflow change — \`ci\`
- [ ] Dependencies bump — \`dependencies\`

## Checklist

- [x] The code change is tested and works locally.
- [x] \`pre-commit run --all-files\` passes.
- [x] \`pytest\` passes, and tests have been added/updated under \`tests/\` where applicable.
- [ ] For changes to shared models, the companion PR in \`music-assistant/models\` is linked.
- [ ] For changes affecting the UI, the companion PR in \`music-assistant/frontend\` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.