### PR TITLE
Prevent out-of-memory crash when compacting the library database

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -187,6 +187,9 @@ DB_TABLE_GENRES: Final[str] = "genres"
 DB_TABLE_GENRE_MEDIA_ITEM_MAPPING: Final[str] = "genre_media_item_mapping"
 DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION: Final[str] = "genre_media_item_exclusion"
 
+# Min fraction of a database file reclaimable before a startup VACUUM is worth running.
+VACUUM_MIN_RECLAIM_RATIO: Final[float] = 0.2
+
 # Loudness measurements at or below this value are considered unreliable:
 # ebur128 reports ~-70 LUFS when it receives near-silence or very little
 # audio (e.g. when a stream was cancelled early).

--- a/music_assistant/controllers/cache/constants.py
+++ b/music_assistant/controllers/cache/constants.py
@@ -13,8 +13,6 @@ CONF_CLEAR_CACHE = "clear_cache"
 DEFAULT_CACHE_EXPIRATION = 86400 * 30  # 30 days
 DB_SCHEMA_VERSION = 8
 MAX_CACHE_DB_SIZE_MB = 2048
-# Min fraction of the db file reclaimable before the startup VACUUM is worth running.
-VACUUM_MIN_RECLAIM_RATIO = 0.2
 CACHE_DATABASE_CLEANUP_TASK_ID = "cache_database_cleanup"
 
 BYPASS_CACHE: ContextVar[bool] = ContextVar("BYPASS_CACHE", default=False)

--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -14,7 +14,11 @@ from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType
 
-from music_assistant.constants import DB_TABLE_CACHE, DB_TABLE_SETTINGS
+from music_assistant.constants import (
+    DB_TABLE_CACHE,
+    DB_TABLE_SETTINGS,
+    VACUUM_MIN_RECLAIM_RATIO,
+)
 from music_assistant.controllers.cache.constants import (
     BYPASS_CACHE,
     CACHE_DATABASE_CLEANUP_TASK_ID,
@@ -23,7 +27,6 @@ from music_assistant.controllers.cache.constants import (
     DEFAULT_CACHE_EXPIRATION,
     LOGGER,
     MAX_CACHE_DB_SIZE_MB,
-    VACUUM_MIN_RECLAIM_RATIO,
     SerializableType,
 )
 from music_assistant.controllers.tasks.context import (

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -75,6 +75,7 @@ from music_assistant.constants import (
     GENRE_ICONS_DIR_NAME,
     LOUDNESS_MEASUREMENT_MIN_LUFS,
     PROVIDERS_WITH_SHAREABLE_URLS,
+    VACUUM_MIN_RECLAIM_RATIO,
 )
 from music_assistant.controllers.tasks.context import update_current_task_progress_text
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
@@ -2417,14 +2418,22 @@ class MusicController(CoreController):
         if prev_version == 0:
             # fresh install - populate default genres
             await self.genres.restore_default_genres()
-        # compact db
-        self.logger.debug("Compacting database...")
+        # compact db - skip the full rebuild unless a meaningful share is reclaimable
         try:
-            await self._database.vacuum()
+            reclaimable_ratio = await self._database.get_reclaimable_ratio()
+            if reclaimable_ratio < VACUUM_MIN_RECLAIM_RATIO:
+                self.logger.debug(
+                    "Skipping database compaction (only %.1f%% reclaimable)",
+                    reclaimable_ratio * 100,
+                )
+            else:
+                self.logger.debug(
+                    "Compacting database (%.1f%% reclaimable)...", reclaimable_ratio * 100
+                )
+                await self._database.vacuum()
+                self.logger.debug("Compacting database done")
         except Exception as err:
             self.logger.warning("Database vacuum failed: %s", str(err))
-        else:
-            self.logger.debug("Compacting database done")
 
     async def __migrate_database(self, prev_version: int) -> None:  # noqa: PLR0915
         """Perform a database migration."""

--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -337,8 +337,15 @@ class DatabaseConnection:
 
     async def vacuum(self) -> None:
         """Run vacuum command on database."""
-        await self._db.execute("VACUUM")
-        await self._db.commit()
+        # VACUUM rebuilds the whole database in temp storage; with temp_store=memory that
+        # copy lives entirely in RAM and OOMs memory constrained devices on large databases,
+        # so spill it to a temp file (located at SQLITE_TMPDIR) for the duration.
+        await self._db.execute("PRAGMA temp_store=FILE;")
+        try:
+            await self._db.execute("VACUUM")
+            await self._db.commit()
+        finally:
+            await self._db.execute("PRAGMA temp_store=memory;")
 
     async def _get_pragma_int(self, pragma: str) -> int:
         """Return the integer value of a single-value sqlite PRAGMA."""

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -125,6 +125,9 @@ class MusicAssistant:
         self._state = CoreState.STARTING
         self.storage_path = storage_path
         self.cache_path = cache_path
+        # Sqlite spills temp files (sort scratch, the VACUUM rebuild copy) to /tmp by
+        # default, which is a RAM-backed tmpfs on HAOS - redirect to the data volume.
+        os.environ.setdefault("SQLITE_TMPDIR", storage_path)
         self.safe_mode = safe_mode
         # we dynamically register command handlers which can be consumed by the apis
         self.command_handlers: dict[str, APICommandHandler] = {}

--- a/tests/core/test_cache_controller.py
+++ b/tests/core/test_cache_controller.py
@@ -9,9 +9,8 @@ from unittest.mock import AsyncMock, patch
 import aiofiles
 import pytest
 
-from music_assistant.constants import DB_TABLE_CACHE
+from music_assistant.constants import DB_TABLE_CACHE, VACUUM_MIN_RECLAIM_RATIO
 from music_assistant.controllers.cache import MAX_CACHE_DB_SIZE_MB, CacheController
-from music_assistant.controllers.cache.constants import VACUUM_MIN_RECLAIM_RATIO
 from music_assistant.helpers.database import DatabaseConnection
 from music_assistant.mass import MusicAssistant
 

--- a/tests/core/test_database_connection.py
+++ b/tests/core/test_database_connection.py
@@ -1,0 +1,68 @@
+"""Tests for the DatabaseConnection helper."""
+
+import pathlib
+from collections.abc import AsyncGenerator
+from sqlite3 import OperationalError
+from typing import Any
+
+import pytest
+
+from music_assistant.helpers.database import DatabaseConnection
+
+# PRAGMA temp_store integer values (sqlite docs)
+TEMP_STORE_FILE = 1
+TEMP_STORE_MEMORY = 2
+
+
+@pytest.fixture
+async def db_connection(tmp_path: pathlib.Path) -> AsyncGenerator[DatabaseConnection]:
+    """Return an initialized DatabaseConnection backed by a temp file."""
+    db = DatabaseConnection(str(tmp_path / "test.db"))
+    await db.setup()
+    yield db
+    await db.close()
+
+
+async def _get_temp_store(db: DatabaseConnection) -> int:
+    async with db._db.execute("PRAGMA temp_store") as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+async def test_vacuum_spills_temp_storage_to_disk(db_connection: DatabaseConnection) -> None:
+    """Test that vacuum runs with temp_store=FILE and restores temp_store=memory after."""
+    executed: list[str] = []
+    original_execute = db_connection._db.execute
+
+    def record(sql: str, *args: Any, **kwargs: Any) -> Any:
+        executed.append(sql)
+        return original_execute(sql, *args, **kwargs)
+
+    db_connection._db.execute = record  # type: ignore[method-assign]
+    await db_connection.vacuum()
+    db_connection._db.execute = original_execute  # type: ignore[method-assign]
+
+    vacuum_idx = executed.index("VACUUM")
+    assert any("temp_store=FILE" in sql for sql in executed[:vacuum_idx])
+    assert any("temp_store=memory" in sql for sql in executed[vacuum_idx:])
+    assert await _get_temp_store(db_connection) == TEMP_STORE_MEMORY
+
+
+async def test_vacuum_restores_temp_store_on_failure(
+    db_connection: DatabaseConnection,
+) -> None:
+    """Test that temp_store is restored to memory even when the vacuum itself fails."""
+    original_execute = db_connection._db.execute
+
+    def explode(sql: str, *args: Any, **kwargs: Any) -> Any:
+        if sql == "VACUUM":
+            raise OperationalError("database or disk is full")
+        return original_execute(sql, *args, **kwargs)
+
+    db_connection._db.execute = explode  # type: ignore[method-assign]
+    with pytest.raises(OperationalError):
+        await db_connection.vacuum()
+    db_connection._db.execute = original_execute  # type: ignore[method-assign]
+
+    assert await _get_temp_store(db_connection) == TEMP_STORE_MEMORY

--- a/tests/core/test_database_connection.py
+++ b/tests/core/test_database_connection.py
@@ -1,5 +1,6 @@
 """Tests for the DatabaseConnection helper."""
 
+import os
 import pathlib
 from collections.abc import AsyncGenerator
 from sqlite3 import OperationalError
@@ -8,6 +9,7 @@ from typing import Any
 import pytest
 
 from music_assistant.helpers.database import DatabaseConnection
+from music_assistant.mass import MusicAssistant
 
 # PRAGMA temp_store integer values (sqlite docs)
 TEMP_STORE_FILE = 1
@@ -66,3 +68,25 @@ async def test_vacuum_restores_temp_store_on_failure(
     db_connection._db.execute = original_execute  # type: ignore[method-assign]
 
     assert await _get_temp_store(db_connection) == TEMP_STORE_MEMORY
+
+
+def test_sqlite_tmpdir_defaults_to_storage_path(tmp_path: pathlib.Path) -> None:
+    """Test that SQLITE_TMPDIR is pointed at the storage path on server init."""
+    original = os.environ.pop("SQLITE_TMPDIR", None)
+    try:
+        MusicAssistant(str(tmp_path / "data"), str(tmp_path / "cache"))
+        assert os.environ.get("SQLITE_TMPDIR") == str(tmp_path / "data")
+    finally:
+        if original is None:
+            os.environ.pop("SQLITE_TMPDIR", None)
+        else:
+            os.environ["SQLITE_TMPDIR"] = original
+
+
+def test_sqlite_tmpdir_respects_existing_value(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that a user-provided SQLITE_TMPDIR is not overwritten."""
+    monkeypatch.setenv("SQLITE_TMPDIR", "/custom/tmp")
+    MusicAssistant(str(tmp_path / "data"), str(tmp_path / "cache"))
+    assert os.environ["SQLITE_TMPDIR"] == "/custom/tmp"

--- a/tests/core/test_music_controller.py
+++ b/tests/core/test_music_controller.py
@@ -1,0 +1,50 @@
+"""Tests for the music controller."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from music_assistant.constants import VACUUM_MIN_RECLAIM_RATIO
+from music_assistant.controllers.music import MusicController
+from music_assistant.helpers.database import DatabaseConnection
+from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture
+async def music(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicController]:
+    """Return a music controller attached to the minimal mass instance."""
+    controller = MusicController(mass_minimal)
+    mass_minimal.music = controller
+    yield controller
+    # close the db connection so its worker thread does not outlive the test
+    if controller._database:
+        await controller._database.close()
+
+
+async def test_setup_skips_vacuum_when_little_reclaimable(music: MusicController) -> None:
+    """Test that the library db startup vacuum is skipped when little can be reclaimed."""
+    with (
+        patch.object(
+            DatabaseConnection,
+            "get_reclaimable_ratio",
+            AsyncMock(return_value=VACUUM_MIN_RECLAIM_RATIO / 2),
+        ),
+        patch.object(DatabaseConnection, "vacuum", AsyncMock()) as mock_vacuum,
+    ):
+        await music._setup_database()
+    mock_vacuum.assert_not_called()
+
+
+async def test_setup_runs_vacuum_when_reclaimable(music: MusicController) -> None:
+    """Test that the library db startup vacuum runs when enough space can be reclaimed."""
+    with (
+        patch.object(
+            DatabaseConnection,
+            "get_reclaimable_ratio",
+            AsyncMock(return_value=VACUUM_MIN_RECLAIM_RATIO + 0.1),
+        ),
+        patch.object(DatabaseConnection, "vacuum", AsyncMock()) as mock_vacuum,
+    ):
+        await music._setup_database()
+    mock_vacuum.assert_awaited_once_with()


### PR DESCRIPTION
# What does this implement/fix?

On memory constrained devices (HAOS), the startup `VACUUM` of `library.db` builds the entire rebuilt database in RAM (`temp_store=memory`), which OOM-kills the server on large libraries and causes a restart loop. Observed on 2.9.0rc5 with a ~4 GB library (kernel killed the process at ~4.1 GB anon-rss). Large libraries are becoming the norm now that audio analysis stores per-track data.

- `DatabaseConnection.vacuum()` now runs with `temp_store=FILE` (restored afterwards), so the vacuum's rebuild copy spills to a temp file instead of RAM - applies to both the cache and library db
- `SQLITE_TMPDIR` is pointed at the storage path on startup so sqlite temp files land on the data volume instead of `/tmp` (RAM-backed tmpfs on HAOS); an externally provided value is respected
- The library db startup vacuum is now skipped unless ≥20% of the file is reclaimable, mirroring the existing cache db gate from #4156 (`VACUUM_MIN_RECLAIM_RATIO` moved to shared constants)
- Added tests for the bounded vacuum, the env var default and the library vacuum gate

**Related issue (if applicable):**

- related issue N/A (user report on 2.9.0rc5)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
