### PR TITLE
Add unofficial-integration disclaimer to streaming provider settings

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -742,6 +742,16 @@ CONF_ENTRY_WARN_PREVIEW = ConfigEntry(
     required=False,
 )
 
+CONF_ENTRY_UNOFFICIAL_PROVIDER = ConfigEntry(
+    key="unofficial_provider_note",
+    type=ConfigEntryType.ALERT,
+    label="This is an unofficial integration that is not affiliated with, supported by, "
+    "or endorsed by the music service. It relies on interfaces that are not officially "
+    "supported and may stop working at any time. Use of this provider may also be subject "
+    "to the service's terms of use.",
+    required=False,
+)
+
 CONF_ENTRY_MANUAL_DISCOVERY_IPS = ConfigEntry(
     key="manual_discovery_ip_addresses",
     type=ConfigEntryType.STRING,

--- a/music_assistant/providers/apple_music/__init__.py
+++ b/music_assistant/providers/apple_music/__init__.py
@@ -25,6 +25,7 @@ from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType
 from music_assistant_models.errors import LoginFailed
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.helpers.auth import AuthenticationHelper
 
 from .constants import (
@@ -158,6 +159,7 @@ async def get_config_entries(
 
     # ruff: noqa: ARG001
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_MUSIC_APP_TOKEN,
             type=ConfigEntryType.SECURE_STRING,

--- a/music_assistant/providers/audible/__init__.py
+++ b/music_assistant/providers/audible/__init__.py
@@ -21,6 +21,7 @@ from music_assistant_models.enums import ConfigEntryType, EventType, MediaType, 
 from music_assistant_models.errors import LoginFailed, MediaNotFoundError
 from music_assistant_models.media_items import BrowseFolder, ItemMapping
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.providers.audible.audible_helper import (
     AudibleHelper,
@@ -154,6 +155,7 @@ async def get_config_entries(
             raise LoginFailed(f"Verification failed: {e}") from e
 
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key="label_text",
             type=ConfigEntryType.LABEL,

--- a/music_assistant/providers/bandcamp/__init__.py
+++ b/music_assistant/providers/bandcamp/__init__.py
@@ -55,6 +55,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
 from music_assistant.mass import MusicAssistant
@@ -95,6 +96,7 @@ async def get_config_entries(
 ) -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_IDENTITY,
             type=ConfigEntryType.SECURE_STRING,

--- a/music_assistant/providers/bbc_sounds/__init__.py
+++ b/music_assistant/providers/bbc_sounds/__init__.py
@@ -41,7 +41,11 @@ from music_assistant_models.streamdetails import StreamMetadata
 from music_assistant_models.unique_list import UniqueList
 
 import music_assistant.helpers.datetime as dt
-from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.constants import (
+    CONF_ENTRY_UNOFFICIAL_PROVIDER,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.datetime import LOCAL_TIMEZONE
 from music_assistant.models.music_provider import MusicProvider
@@ -106,6 +110,7 @@ async def get_config_entries(
     # ruff: noqa: ARG001
 
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=_Constants.CONF_INTRO,
             type=ConfigEntryType.LABEL,

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -49,6 +49,7 @@ from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant import MusicAssistant
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
 from music_assistant.helpers.auth import AuthenticationHelper
@@ -175,6 +176,7 @@ async def get_config_entries(
             )
 
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_ACCESS_TOKEN,
             type=ConfigEntryType.SECURE_STRING,

--- a/music_assistant/providers/kion_music/__init__.py
+++ b/music_assistant/providers/kion_music/__init__.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, cast
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
+
 from .constants import (
     CONF_ACTION_CLEAR_AUTH,
     CONF_BASE_URL,
@@ -77,6 +79,7 @@ async def get_config_entries(
     is_authenticated = bool(values.get(CONF_TOKEN))
 
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         # Authentication
         ConfigEntry(
             key=CONF_TOKEN,

--- a/music_assistant/providers/musicme/__init__.py
+++ b/music_assistant/providers/musicme/__init__.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType
 
-from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.constants import (
+    CONF_ENTRY_UNOFFICIAL_PROVIDER,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
 
 from .constants import SUPPORTED_FEATURES
 from .provider import MusicMeProvider
@@ -42,6 +46,7 @@ async def get_config_entries(
     """
     # ruff: noqa: ARG001
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_USERNAME,
             type=ConfigEntryType.STRING,

--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -48,6 +48,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.controllers.cache import use_cache
 from music_assistant.models.music_provider import MusicProvider
 
@@ -689,7 +690,7 @@ async def get_config_entries(
             await _check_qr_auth(mass, values)
     except ResourceTemporarilyUnavailable as err:
         raise InvalidDataError(str(err)) from err
-    return _build_config_entries(values)
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER, *_build_config_entries(values))
 
 
 class NeteaseCloudMusicProvider(MusicProvider):

--- a/music_assistant/providers/nicovideo/config/factory.py
+++ b/music_assistant/providers/nicovideo/config/factory.py
@@ -8,6 +8,8 @@ from typing import overload
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
+
 from .descriptor import ConfigDescriptor
 
 # Global registry for all config entries
@@ -195,4 +197,4 @@ class ConfigFactory:
 async def get_config_entries_impl() -> tuple[ConfigEntry, ...]:
     """Return Config entries to setup this provider."""
     # Combine entries from logical categories
-    return tuple(_registry)
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER, *_registry)

--- a/music_assistant/providers/nugs/__init__.py
+++ b/music_assistant/providers/nugs/__init__.py
@@ -38,7 +38,11 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.streamdetails import StreamDetails
 
-from music_assistant.constants import CONF_PASSWORD, CONF_USERNAME
+from music_assistant.constants import (
+    CONF_ENTRY_UNOFFICIAL_PROVIDER,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.util import infer_album_type, parse_title_and_version
@@ -83,6 +87,7 @@ async def get_config_entries(
     """
     # ruff: noqa: ARG001
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_USERNAME,
             type=ConfigEntryType.STRING,

--- a/music_assistant/providers/pandora/__init__.py
+++ b/music_assistant/providers/pandora/__init__.py
@@ -8,7 +8,12 @@ from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError
 
-from music_assistant.constants import CONF_PASSWORD, CONF_SOCKS_URL, CONF_USERNAME
+from music_assistant.constants import (
+    CONF_ENTRY_UNOFFICIAL_PROVIDER,
+    CONF_PASSWORD,
+    CONF_SOCKS_URL,
+    CONF_USERNAME,
+)
 
 from .constants import CONF_QUALITY, CONF_TAKEOVER_ACTION, QUALITY_HIGH, QUALITY_STANDARD
 from .provider import PandoraProvider
@@ -62,6 +67,7 @@ async def get_config_entries(
             await provider.takeover_stream()
 
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_USERNAME,
             type=ConfigEntryType.STRING,

--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -43,6 +43,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import (
+    CONF_ENTRY_UNOFFICIAL_PROVIDER,
     CONF_PASSWORD,
     CONF_USERNAME,
     VARIOUS_ARTISTS_MBID,
@@ -118,6 +119,7 @@ async def get_config_entries(
     """
     # ruff: noqa: ARG001
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_USERNAME,
             type=ConfigEntryType.STRING,

--- a/music_assistant/providers/qqmusic/__init__.py
+++ b/music_assistant/providers/qqmusic/__init__.py
@@ -80,6 +80,7 @@ from qqmusic_api.utils.session import (
     set_session as qq_set_session,
 )
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.controllers.cache import use_cache
 from music_assistant.models.music_provider import MusicProvider
 
@@ -505,7 +506,7 @@ async def get_config_entries(
         await _start_qr_auth(mass, values, qq_login_mod.QRLoginType.WX)
     elif action == CONF_ACTION_CHECK_QR_AUTH:
         await _check_qr_auth(values)
-    return _build_config_entries(values)
+    return (CONF_ENTRY_UNOFFICIAL_PROVIDER, *_build_config_entries(values))
 
 
 class QQMusicProvider(MusicProvider):

--- a/music_assistant/providers/siriusxm/__init__.py
+++ b/music_assistant/providers/siriusxm/__init__.py
@@ -31,6 +31,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.streamdetails import StreamDetails
 from tenacity import RetryError
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.util import select_free_port
 from music_assistant.helpers.webserver import Webserver
@@ -80,6 +81,7 @@ async def get_config_entries(
     """
     # ruff: noqa: ARG001
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_SXM_USERNAME,
             type=ConfigEntryType.STRING,

--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -31,6 +31,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.streamdetails import StreamDetails
 from soundcloudpy import SoundcloudAsyncAPI
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.util import parse_title_and_version
 from music_assistant.models.music_provider import MusicProvider
@@ -90,6 +91,7 @@ async def get_config_entries(
     """
     # ruff: noqa: ARG001
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_CLIENT_ID,
             type=ConfigEntryType.SECURE_STRING,

--- a/music_assistant/providers/spotify/__init__.py
+++ b/music_assistant/providers/spotify/__init__.py
@@ -8,6 +8,7 @@ from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError, LoginFailed
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
 
 from .constants import (
@@ -137,6 +138,7 @@ async def get_config_entries(
         )
 
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         # Global authentication section
         ConfigEntry(
             key="label_text",

--- a/music_assistant/providers/tidal/__init__.py
+++ b/music_assistant/providers/tidal/__init__.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, cast
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
+
 from .auth_manager import ManualAuthenticationHelper, TidalAuthManager
 from .constants import (
     CONF_ACTION_CLEAR_AUTH,
@@ -208,6 +210,7 @@ async def get_config_entries(
 
     # return the auth_data config entry
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         *auth_entries,
         ConfigEntry(
             key=CONF_AUTH_TOKEN,

--- a/music_assistant/providers/yandex_music/__init__.py
+++ b/music_assistant/providers/yandex_music/__init__.py
@@ -9,6 +9,8 @@ from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
+
 from .auth import perform_device_auth, perform_qr_auth
 from .constants import (
     CONF_ACTION_AUTH_DEVICE,
@@ -334,6 +336,7 @@ async def get_config_entries(
         label_text = "Authenticated to Yandex Music."
 
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         # Status label
         ConfigEntry(
             key="label_text",

--- a/music_assistant/providers/yousee/__init__.py
+++ b/music_assistant/providers/yousee/__init__.py
@@ -11,6 +11,7 @@ from music_assistant_models.enums import (
 )
 
 from music_assistant.constants import (
+    CONF_ENTRY_UNOFFICIAL_PROVIDER,
     CONF_PASSWORD,
     CONF_USERNAME,
 )
@@ -71,6 +72,7 @@ async def get_config_entries(
     """
     # ruff: noqa: ARG001
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_USERNAME,
             type=ConfigEntryType.STRING,

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -53,7 +53,11 @@ from ytmusicapi.constants import SUPPORTED_LANGUAGES
 from ytmusicapi.exceptions import YTMusicServerError
 from ytmusicapi.helpers import get_authorization, sapisid_from_cookie
 
-from music_assistant.constants import CONF_USERNAME, VERBOSE_LOG_LEVEL
+from music_assistant.constants import (
+    CONF_ENTRY_UNOFFICIAL_PROVIDER,
+    CONF_USERNAME,
+    VERBOSE_LOG_LEVEL,
+)
 from music_assistant.controllers.cache import use_cache
 from music_assistant.helpers.util import infer_album_type, install_package, parse_title_and_version
 from music_assistant.models.music_provider import MusicProvider
@@ -167,6 +171,7 @@ async def get_config_entries(
     values: the (intermediate) raw values for config entries sent with the action.
     """
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_USERNAME, type=ConfigEntryType.STRING, label="Username", required=True
         ),

--- a/music_assistant/providers/zvuk_music/__init__.py
+++ b/music_assistant/providers/zvuk_music/__init__.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, cast
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
+
 from .constants import (
     CONF_ACTION_CLEAR_AUTH,
     CONF_QUALITY,
@@ -71,6 +73,7 @@ async def get_config_entries(
     is_authenticated = bool(values.get(CONF_TOKEN))
 
     return (
+        CONF_ENTRY_UNOFFICIAL_PROVIDER,
         ConfigEntry(
             key=CONF_TOKEN,
             type=ConfigEntryType.SECURE_STRING,


### PR DESCRIPTION
# What does this implement/fix?

Many of our music providers integrate with commercial streaming services through unofficial or reverse-engineered interfaces (often using app credentials extracted from the official clients). These integrations are not affiliated with, supported by, or endorsed by those services, and may stop working whenever a service changes — but nothing in the UI tells the user that.

This adds a clear disclaimer alert at the top of the settings for those providers.

- Add a shared `CONF_ENTRY_UNOFFICIAL_PROVIDER` alert entry in `constants.py`.
- Surface it as the first config entry for the affected providers: Spotify, Tidal, Deezer, Qobuz, Apple Music, YouTube Music, SoundCloud, Pandora, SiriusXM, Audible, Bandcamp, Nugs, BBC Sounds, QQ Music, NetEase Cloud Music, Yandex Music, KION, Zvuk, niconico, MusicMe and YouSee.
- Local/self-hosted, free public-radio, open/official-API, RSS and public-broadcaster providers are intentionally left untouched.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
