### PR TITLE
fix(alexa): include track metadata in the initial play_media push

### DIFF
--- a/music_assistant/providers/alexa/__init__.py
+++ b/music_assistant/providers/alexa/__init__.py
@@ -423,6 +423,10 @@ class AlexaPlayer(Player):
 
         payload = {
             "streamUrl": stream_url,
+            "title": media.title,
+            "artist": media.artist,
+            "album": media.album,
+            "imageUrl": media.image_url,
         }
 
         await api_request(


### PR DESCRIPTION
## The problem

The Alexa player provider pushes playback to the companion skill (`music-assistant-alexa-skill-prototype`) in two separate steps:

1. `play_media()` POSTs only `{"streamUrl": ...}` to the skill's `/ma/push-url` endpoint, then triggers playback via a voice command.
2. `_on_player_media_updated()` later POSTs the track metadata (title / artist / album / imageUrl) in a **separate** `/ma/push-url` call.

The skill reads `/ma/latest-url` at the moment playback starts, which creates a race: on track changes / skips it frequently reads the URL-only push (step 1) **before** the metadata push (step 2) arrives. The Echo then plays the audio but shows an empty *Now Playing* (no cover art, no title) until the next track.

## The fix

Include the track metadata directly in the `play_media()` push, so the skill always has it available when playback starts. `PlayerMedia` already exposes `title`, `artist`, `album` and `image_url` (the same fields used by `_on_player_media_updated`). The separate `_on_player_media_updated()` call is left unchanged and still handles later metadata refreshes.

## Testing

Tested on Echo Dot and Echo Show: cover art, title and artist now display correctly and persist across skips / track changes.
