### PR TITLE
Fix Sendspin grouping with Cast devices

### DIFF
--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -416,6 +416,7 @@ class SendspinChromecastBridge:
             fut.set_result(None)
         else:
             fut.set_exception(error)
+            fut.exception()
 
     def on_cast_status_changed(self, app_id: str | None) -> None:
         """Handle Cast app id change / connection loss (called from socket thread).

--- a/music_assistant/providers/chromecast/sendspin_bridge.py
+++ b/music_assistant/providers/chromecast/sendspin_bridge.py
@@ -466,7 +466,10 @@ class SendspinChromecastBridge:
         )
         self.ensure_cast_app_ready()
         if not self.cast_player.available:
-            self.logger.warning("Cannot start Sendspin stream for %s: player not available")
+            self.logger.warning(
+                "Cannot start Sendspin stream for %s: player not available",
+                self.cast_player.display_name,
+            )
             return
         # Cancel any previous launch task
         if self._launch_task and not self._launch_task.done():

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -798,6 +798,7 @@ class SendspinPlayer(SendspinBasePlayer):
             await self.api.group.remove_client(member_player.api)
         # Cast-only: reset futures before add so a fatal error on a Cast-bridged
         # member (e.g. AudioContext unsupported) raises PlayerCommandFailed.
+        # Only track readiness while streaming, only then add_client launches the app.
         bridge_manager = self._get_cast_bridge_manager()
         pending_cast: list[tuple[SendspinPlayer, asyncio.Future[None]]] = []
         try:
@@ -805,7 +806,11 @@ class SendspinPlayer(SendspinBasePlayer):
                 member_player = cast(
                     "SendspinPlayer", self.mass.players.get_player(player_id, True)
                 )
-                if bridge_manager and (bridge := bridge_manager.get_bridge_by_client_id(player_id)):
+                if (
+                    self.api.group.has_active_stream
+                    and bridge_manager
+                    and (bridge := bridge_manager.get_bridge_by_client_id(player_id))
+                ):
                     pending_cast.append((member_player, bridge.reset_cast_app_ready()))
                 await self.api.group.add_client(member_player.api)
 


### PR DESCRIPTION
# What does this implement/fix?

The Cast receiver app is only launched while the Sendspin group is actively streaming, but `set_members` always waited for it to report ready. Grouping via an idle group (e.g. the playing device on native Cast) therefore always timed out after 30s. The wait is now skipped while no stream is active, the app launches once playback starts the stream.

Also fixes a `logger.warning` call in the Cast bridge missing its format argument.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5609

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.