### PR TITLE
Fix release notes for minor releases skipping most changes

### DIFF
--- a/.github/actions/generate-release-notes/generate_notes.py
+++ b/.github/actions/generate-release-notes/generate_notes.py
@@ -39,9 +39,29 @@ def get_tag_date(repo, tag_name):
         return None
 
 
+def get_released_pr_numbers(repo, merge_base_sha, previous_tag):
+    """Get PR numbers that already shipped on the previous tag's (diverged) branch."""
+    merge_pattern = re.compile(r"Merge pull request #(\d+)")
+    squash_pattern = re.compile(r"\(#(\d+)\)\s*$")
+    released = set()
+    comparison = repo.compare(merge_base_sha, previous_tag)
+    for commit in comparison.commits:
+        # Only the first line (squash/merge commit title) identifies the released
+        # PR; the body may reference unrelated PRs/issues.
+        title = commit.commit.message.split("\n", 1)[0]
+        match = merge_pattern.search(title) or squash_pattern.search(title)
+        if match:
+            released.add(int(match.group(1)))
+    return released
+
+
 def get_prs_between_tags(repo, previous_tag, current_branch):
     """Get all merged PRs between the previous tag and current HEAD."""
-    tag_date = None
+    pr_pattern = re.compile(r"#(\d+)")
+    merge_pattern = re.compile(r"Merge pull request #(\d+)")
+
+    cutoff_date = None
+    released_pr_numbers = set()
     if not previous_tag:
         print("No previous tag specified, will include all PRs from branch history")  # noqa: T201
         # Get the first commit on the branch
@@ -50,17 +70,33 @@ def get_prs_between_tags(repo, previous_tag, current_branch):
         commits = commits[:100]
     else:
         print(f"Finding PRs between {previous_tag} and {current_branch}")  # noqa: T201
-        tag_date = get_tag_date(repo, previous_tag)
-        if tag_date:
-            print(f"Previous tag date: {tag_date}")  # noqa: T201
         comparison = repo.compare(previous_tag, current_branch)
         commits = comparison.commits
         print(f"Found {comparison.total_commits} commits")  # noqa: T201
+        if comparison.behind_by:
+            # The previous tag lives on a diverged branch: a minor release (e.g. 2.9.0)
+            # compares against the latest patch tag (2.8.9) on the old stable branch.
+            # That tag's date lies *after* most of this release's content was merged to
+            # dev, so cut off at the merge base (the old branch point) instead, and
+            # drop PRs that already shipped in the patch releases on the old branch.
+            merge_base = comparison.merge_base_commit
+            cutoff_date = merge_base.commit.committer.date
+            print(  # noqa: T201
+                f"Previous tag {previous_tag} has diverged from {current_branch}, "
+                f"using merge base date {cutoff_date} as cutoff"
+            )
+            released_pr_numbers = get_released_pr_numbers(repo, merge_base.sha, previous_tag)
+            print(  # noqa: T201
+                f"Found {len(released_pr_numbers)} PRs already released "
+                f"in patch releases up to {previous_tag}"
+            )
+        else:
+            cutoff_date = get_tag_date(repo, previous_tag)
+            if cutoff_date:
+                print(f"Previous tag date: {cutoff_date}")  # noqa: T201
 
     # Extract PR numbers from commit messages
     pr_numbers = set()
-    pr_pattern = re.compile(r"#(\d+)")
-    merge_pattern = re.compile(r"Merge pull request #(\d+)")
 
     for commit in commits:
         message = commit.commit.message
@@ -75,17 +111,24 @@ def get_prs_between_tags(repo, previous_tag, current_branch):
 
     print(f"Found {len(pr_numbers)} unique PRs")  # noqa: T201
 
-    # Fetch the actual PR objects, filtering out PRs merged before the previous tag
+    # Fetch the actual PR objects, filtering out PRs merged before the cutoff date
+    # and PRs that already shipped in patch releases on the previous (stable) branch
     prs = []
     skipped = 0
     for pr_num in sorted(pr_numbers):
+        if pr_num in released_pr_numbers:
+            skipped += 1
+            print(  # noqa: T201
+                f"  Skipping PR #{pr_num}: already released in a patch release"
+            )
+            continue
         try:
             pr = repo.get_pull(pr_num)
             if pr.merged:
-                if tag_date and pr.merged_at and pr.merged_at <= tag_date:
+                if cutoff_date and pr.merged_at and pr.merged_at <= cutoff_date:
                     skipped += 1
                     print(  # noqa: T201
-                        f"  Skipping PR #{pr_num}: merged at {pr.merged_at}, before tag date {tag_date}"
+                        f"  Skipping PR #{pr_num}: merged at {pr.merged_at}, before cutoff {cutoff_date}"
                     )
                     continue
                 prs.append(pr)
@@ -93,7 +136,7 @@ def get_prs_between_tags(repo, previous_tag, current_branch):
             print(f"Warning: Could not fetch PR #{pr_num}: {e}")  # noqa: T201
 
     if skipped:
-        print(f"Filtered out {skipped} PRs merged before {previous_tag}")  # noqa: T201
+        print(f"Filtered out {skipped} PRs already released before/in {previous_tag}")  # noqa: T201
 
     return prs
 

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -1,0 +1,189 @@
+"""Tests for the generate-release-notes GitHub action script."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from datetime import UTC, datetime
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).parent.parent
+    / ".github"
+    / "actions"
+    / "generate-release-notes"
+    / "generate_notes.py"
+)
+
+# The action script depends on PyGithub and PyYAML, which are installed ad hoc in
+# the GitHub action and not part of the project's (test) dependencies.
+if "github" not in sys.modules:
+    github_stub = types.ModuleType("github")
+    github_stub.Github = object  # type: ignore[attr-defined]
+    github_stub.GithubException = type("GithubException", (Exception,), {})  # type: ignore[attr-defined]
+    sys.modules["github"] = github_stub
+try:
+    import yaml  # noqa: F401
+except ImportError:
+    sys.modules["yaml"] = types.ModuleType("yaml")
+
+
+def load_generate_notes_module() -> types.ModuleType:
+    """Load the action script as a module."""
+    spec = importlib.util.spec_from_file_location("generate_notes", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeCommit:
+    """Mimics PyGithub Commit (.sha and .commit.message/.commit.committer.date)."""
+
+    def __init__(self, sha: str, message: str, date: datetime | None = None) -> None:
+        """Initialize fake commit."""
+        self.sha = sha
+        self.commit = types.SimpleNamespace(
+            message=message,
+            committer=types.SimpleNamespace(date=date),
+        )
+
+
+class FakeComparison:
+    """Mimics PyGithub Comparison."""
+
+    def __init__(
+        self,
+        commits: list[FakeCommit],
+        behind_by: int = 0,
+        merge_base_commit: FakeCommit | None = None,
+    ) -> None:
+        """Initialize fake comparison."""
+        self.commits = commits
+        self.total_commits = len(commits)
+        self.behind_by = behind_by
+        self.merge_base_commit = merge_base_commit
+
+
+class FakePR:
+    """Mimics PyGithub PullRequest."""
+
+    def __init__(self, number: int, merged_at: datetime) -> None:
+        """Initialize fake pull request."""
+        self.number = number
+        self.merged = True
+        self.merged_at = merged_at
+
+
+class FakeRepo:
+    """Mimics the PyGithub Repository calls used by get_prs_between_tags."""
+
+    def __init__(
+        self,
+        comparisons: dict[tuple[str, str], FakeComparison],
+        pulls: dict[int, FakePR],
+        tag_commits: dict[str, FakeCommit] | None = None,
+    ) -> None:
+        """Initialize fake repository."""
+        self.comparisons = comparisons
+        self.pulls = pulls
+        self.tag_commits = tag_commits or {}
+        self.fetched_pulls: list[int] = []
+
+    def compare(self, base: str, head: str) -> FakeComparison:
+        """Return the preset comparison for the given base/head refs."""
+        return self.comparisons[(base, head)]
+
+    def get_pull(self, number: int) -> FakePR:
+        """Return the preset pull request with the given number."""
+        self.fetched_pulls.append(number)
+        return self.pulls[number]
+
+    def get_git_ref(self, ref: str) -> types.SimpleNamespace:
+        """Return a lightweight tag ref pointing at the preset tag commit."""
+        tag_name = ref.removeprefix("tags/")
+        commit = self.tag_commits[tag_name]
+        return types.SimpleNamespace(object=types.SimpleNamespace(type="commit", sha=commit.sha))
+
+    def get_commit(self, sha: str) -> FakeCommit:
+        """Return the preset commit with the given sha."""
+        for commit in self.tag_commits.values():
+            if commit.sha == sha:
+                return commit
+        raise KeyError(sha)
+
+
+def test_linear_release_filters_prs_merged_before_previous_tag() -> None:
+    """Beta/nightly/patch releases: previous tag is an ancestor of the branch."""
+    generate_notes = load_generate_notes_module()
+    tag_commit = FakeCommit("tagsha", "2.9.0b1 release", datetime(2026, 6, 1, tzinfo=UTC))
+    comparison = FakeComparison(
+        commits=[
+            FakeCommit("aaa", "Add feature (#200)"),
+            FakeCommit("bbb", "Improve thing\n\nfixes #150"),
+        ],
+    )
+    repo = FakeRepo(
+        comparisons={("2.9.0b1", "dev"): comparison},
+        pulls={
+            200: FakePR(200, datetime(2026, 6, 5, tzinfo=UTC)),
+            150: FakePR(150, datetime(2026, 1, 10, tzinfo=UTC)),
+        },
+        tag_commits={"2.9.0b1": tag_commit},
+    )
+
+    prs = generate_notes.get_prs_between_tags(repo, "2.9.0b1", "dev")
+
+    assert [pr.number for pr in prs] == [200]
+
+
+def test_minor_release_with_diverged_previous_tag() -> None:
+    """
+    Generate notes for a minor release whose previous tag diverged.
+
+    For a minor release (e.g. 2.9.0) the previous stable tag (2.8.9) lives on the
+    old stable branch, which diverged from dev at the 2.8.0 branch point. The notes
+    must include everything merged to dev since the branch point, except PRs that
+    already shipped in the 2.8.x patch releases.
+    """
+    generate_notes = load_generate_notes_module()
+    merge_base = FakeCommit("mbsha", "2.8.0 release", datetime(2026, 3, 25, tzinfo=UTC))
+    head_comparison = FakeComparison(
+        commits=[
+            # Merged to dev well before the 2.8.9 tag date: must be included
+            FakeCommit("aaa", "Add feature X (#100)"),
+            # Cherry-picked to stable and released as a 2.8.x patch: must be excluded
+            FakeCommit("bbb", "Fix bug Y (#50)"),
+            # Body references an old PR merged before the branch point: must be excluded
+            FakeCommit("ccc", "Improve Z (#120)\n\nfixes #10"),
+        ],
+        behind_by=3,
+        merge_base_commit=merge_base,
+    )
+    base_comparison = FakeComparison(
+        commits=[
+            # Body mentions #120 but only the first line identifies the released PR
+            FakeCommit("ddd", "Fix bug Y (#50)\n\nRelates to #120"),
+        ],
+    )
+    # 2.8.9 was tagged long after most of the 2.9.0 content was merged to dev
+    tag_commit = FakeCommit("tagsha", "2.8.9 release", datetime(2026, 6, 3, tzinfo=UTC))
+    repo = FakeRepo(
+        comparisons={
+            ("2.8.9", "stable"): head_comparison,
+            ("mbsha", "2.8.9"): base_comparison,
+        },
+        pulls={
+            100: FakePR(100, datetime(2026, 4, 20, tzinfo=UTC)),
+            50: FakePR(50, datetime(2026, 5, 1, tzinfo=UTC)),
+            120: FakePR(120, datetime(2026, 6, 5, tzinfo=UTC)),
+            10: FakePR(10, datetime(2026, 1, 1, tzinfo=UTC)),
+        },
+        tag_commits={"2.8.9": tag_commit},
+    )
+
+    prs = generate_notes.get_prs_between_tags(repo, "2.8.9", "stable")
+
+    assert [pr.number for pr in prs] == [100, 120]

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -8,6 +8,8 @@ import types
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 SCRIPT_PATH = (
     Path(__file__).parent.parent
     / ".github"
@@ -16,21 +18,18 @@ SCRIPT_PATH = (
     / "generate_notes.py"
 )
 
-# The action script depends on PyGithub and PyYAML, which are installed ad hoc in
-# the GitHub action and not part of the project's (test) dependencies.
-if "github" not in sys.modules:
+
+@pytest.fixture
+def generate_notes(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    """Load the action script with its action-only dependencies stubbed."""
+    # The action script depends on PyGithub and PyYAML, which are installed ad hoc
+    # in the GitHub action and not part of the project's (test) dependencies.
     github_stub = types.ModuleType("github")
     github_stub.Github = object  # type: ignore[attr-defined]
     github_stub.GithubException = type("GithubException", (Exception,), {})  # type: ignore[attr-defined]
-    sys.modules["github"] = github_stub
-try:
-    import yaml  # noqa: F401
-except ImportError:
-    sys.modules["yaml"] = types.ModuleType("yaml")
-
-
-def load_generate_notes_module() -> types.ModuleType:
-    """Load the action script as a module."""
+    monkeypatch.setitem(sys.modules, "github", github_stub)
+    if importlib.util.find_spec("yaml") is None:
+        monkeypatch.setitem(sys.modules, "yaml", types.ModuleType("yaml"))
     spec = importlib.util.spec_from_file_location("generate_notes", SCRIPT_PATH)
     assert spec is not None
     assert spec.loader is not None
@@ -115,9 +114,10 @@ class FakeRepo:
         raise KeyError(sha)
 
 
-def test_linear_release_filters_prs_merged_before_previous_tag() -> None:
+def test_linear_release_filters_prs_merged_before_previous_tag(
+    generate_notes: types.ModuleType,
+) -> None:
     """Beta/nightly/patch releases: previous tag is an ancestor of the branch."""
-    generate_notes = load_generate_notes_module()
     tag_commit = FakeCommit("tagsha", "2.9.0b1 release", datetime(2026, 6, 1, tzinfo=UTC))
     comparison = FakeComparison(
         commits=[
@@ -139,7 +139,9 @@ def test_linear_release_filters_prs_merged_before_previous_tag() -> None:
     assert [pr.number for pr in prs] == [200]
 
 
-def test_minor_release_with_diverged_previous_tag() -> None:
+def test_minor_release_with_diverged_previous_tag(
+    generate_notes: types.ModuleType,
+) -> None:
     """
     Generate notes for a minor release whose previous tag diverged.
 
@@ -148,7 +150,6 @@ def test_minor_release_with_diverged_previous_tag() -> None:
     must include everything merged to dev since the branch point, except PRs that
     already shipped in the 2.8.x patch releases.
     """
-    generate_notes = load_generate_notes_module()
     merge_base = FakeCommit("mbsha", "2.8.0 release", datetime(2026, 3, 25, tzinfo=UTC))
     head_comparison = FakeComparison(
         commits=[


### PR DESCRIPTION
# What does this implement/fix?

Release notes for minor releases (e.g. 2.9.0) only contained the PRs merged after the last patch release (2.8.9), dropping months of changes.

The previous stable tag lives on the old stable branch, which diverged from dev at the previous minor's branch point. Filtering PRs on that tag's date discarded everything merged to dev before it — almost the entire release.

- For a diverged previous tag (`comparison.behind_by > 0`), use the merge base (branch point) date as the merged-at cutoff instead of the tag date
- Exclude PRs that already shipped in the patch releases on the old stable branch (extracted from the squash/merge commit titles on that branch)
- Linear releases (beta, nightly, RC, stable patch) keep the exact same code path; dry runs against the published 2.8.9 and 2.9.0b16 notes reproduce them byte-identical
- Add regression tests for both the diverged and linear scenarios

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
