### PR TITLE
Restore 'ignore volume reports' setting for AirPlay players

### DIFF
--- a/music_assistant/providers/airplay/player.py
+++ b/music_assistant/providers/airplay/player.py
@@ -309,6 +309,21 @@ class AirPlayPlayer(Player):
                 advanced=True,
             ),
             ConfigEntry(
+                key=CONF_IGNORE_VOLUME,
+                type=ConfigEntryType.BOOLEAN,
+                default_value=False,
+                label="Ignore volume reports sent by the device itself",
+                description=(
+                    "The AirPlay protocol allows devices to report their own volume "
+                    "level. \n"
+                    "For some devices this is not reliable and can cause unexpected "
+                    "volume changes. \n"
+                    "Enable this option to ignore these reports."
+                ),
+                category="protocol_generic",
+                advanced=True,
+            ),
+            ConfigEntry(
                 key=CONF_RAOP_LATENCY,
                 type=ConfigEntryType.INTEGER,
                 default_value=AIRPLAY_OUTPUT_BUFFER_DEFAULT_DURATION_MS,

--- a/tests/providers/airplay/test_player.py
+++ b/tests/providers/airplay/test_player.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from music_assistant.providers.airplay.constants import StreamingProtocol
+from music_assistant.providers.airplay.constants import CONF_IGNORE_VOLUME, StreamingProtocol
 from music_assistant.providers.airplay.player import AirPlayPlayer
 
 
@@ -138,6 +138,13 @@ async def test_start_pairing__pin_decision(flags: bytes, pin_call_expected: bool
         pairing_instance.start_pin_pairing.assert_called_once()
     else:
         pairing_instance.start_pin_pairing.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_config_entries_include_ignore_volume(airplay_player: AirPlayPlayer) -> None:
+    """The ignore_volume setting must be offered in the player config entries."""
+    entries = await airplay_player.get_config_entries()
+    assert any(entry.key == CONF_IGNORE_VOLUME for entry in entries)
 
 
 # --- Volume and Mute tests ---


### PR DESCRIPTION
# What does this implement/fix?

PR #3210 accidentally replaced the "Ignore volume reports sent by the device itself" config entry with the new latency entry in `get_config_entries`, so the setting disappeared from the UI while the backend still honors it. This restores the config entry (advanced, generic protocol category).

- Restore the `ignore_volume` ConfigEntry with its original label/description
- The entry is no longer RAOP-only: the original TODO to drop the `depends_on` once AirPlay2 gained DACP support is now fulfilled, and volume feedback reaches `update_volume_from_device` for both protocols
- Add a regression test asserting the entry is present in the player config entries

Related issue: https://github.com/music-assistant/support/issues/5603

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.