### PR TITLE
Smart crossfade: transition on audible content instead of silent outros

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1901,13 +1901,13 @@ class StreamsAudio:
                         fade_in_bytes_consumed += len(chunk)
                         yield chunk
 
-                smart_fade = await self.smart_fades_mixer.build(
+                smart_fade, mix_fade_out_data = await self.smart_fades_mixer.build(
                     fade_in_streamdetails=cast("StreamDetails", next_queue_item.streamdetails),
                     fade_out_streamdetails=streamdetails,
                     pcm_format=pcm_format,
                     standard_crossfade_duration=standard_crossfade_duration,
                     mode=smart_fades_mode,
-                    fade_out_bytes_len=len(fade_out_data),
+                    fade_out_data=fade_out_data,
                     fade_in_bytes_len=crossfade_buffer_size,
                 )
                 crossfade_timing = smart_fade.timing_info
@@ -1922,7 +1922,7 @@ class StreamsAudio:
                 async for mix_chunk in self.smart_fades_mixer.mix(
                     smart_fade,
                     fade_in_part=_limited_fade_in(),
-                    fade_out_part=fade_out_data,
+                    fade_out_part=mix_fade_out_data,
                     pcm_format=pcm_format,
                 ):
                     if first_part_written < fadeout_share_bytes:
@@ -2160,19 +2160,20 @@ class StreamsAudio:
             # Build eagerly so seek_position is set before PlayLogEntry is appended —
             # consumer-paced mix() would otherwise let the queue briefly report 0.
             crossfade_smart_fade: SmartFade | None = None
+            mix_fadeout_part: bytes = b""
             if (
                 last_fadeout_part
                 and last_streamdetails
                 and crossfade_buffer_size > 0
                 and smart_fades_mode != SmartFadesMode.DISABLED
             ):
-                crossfade_smart_fade = await self.smart_fades_mixer.build(
+                crossfade_smart_fade, mix_fadeout_part = await self.smart_fades_mixer.build(
                     fade_in_streamdetails=queue_track.streamdetails,
                     fade_out_streamdetails=last_streamdetails,
                     pcm_format=pcm_format,
                     standard_crossfade_duration=standard_crossfade_duration,
                     mode=smart_fades_mode,
-                    fade_out_bytes_len=len(last_fadeout_part),
+                    fade_out_data=last_fadeout_part,
                     fade_in_bytes_len=crossfade_buffer_size,
                 )
                 timing_info = crossfade_smart_fade.timing_info
@@ -2251,7 +2252,7 @@ class StreamsAudio:
                         async for mix_chunk in self.smart_fades_mixer.mix(
                             crossfade_smart_fade,
                             fade_in_part=fadein_part,
-                            fade_out_part=last_fadeout_part,
+                            fade_out_part=mix_fadeout_part,
                             pcm_format=pcm_format,
                         ):
                             yield mix_chunk

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1875,6 +1875,9 @@ class StreamsAudio:
             # the remaining buffer is the fade-out tail of the current track
             fade_out_data = bytes(buffer)
             buffer = bytearray()
+            # initialized before the try block — the except handler reads these
+            first_part_written = 0
+            second_part_buf = bytearray()
             try:
                 # wrap the next track's stream in a counting generator that caps
                 # at crossfade_buffer_size and tracks how many bytes were consumed
@@ -1917,8 +1920,6 @@ class StreamsAudio:
                     * pcm_format.pcm_sample_size
                 )
                 fadeout_share_bytes = (fadeout_share_bytes // frame_size) * frame_size
-                first_part_written = 0
-                second_part_buf = bytearray()
                 async for mix_chunk in self.smart_fades_mixer.mix(
                     smart_fade,
                     fade_in_part=_limited_fade_in(),

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1904,7 +1904,7 @@ class StreamsAudio:
                         fade_in_bytes_consumed += len(chunk)
                         yield chunk
 
-                smart_fade, mix_fade_out_data = await self.smart_fades_mixer.build(
+                smart_fade = await self.smart_fades_mixer.build(
                     fade_in_streamdetails=cast("StreamDetails", next_queue_item.streamdetails),
                     fade_out_streamdetails=streamdetails,
                     pcm_format=pcm_format,
@@ -1923,7 +1923,7 @@ class StreamsAudio:
                 async for mix_chunk in self.smart_fades_mixer.mix(
                     smart_fade,
                     fade_in_part=_limited_fade_in(),
-                    fade_out_part=mix_fade_out_data,
+                    fade_out_part=fade_out_data,
                     pcm_format=pcm_format,
                 ):
                     if first_part_written < fadeout_share_bytes:
@@ -2161,14 +2161,13 @@ class StreamsAudio:
             # Build eagerly so seek_position is set before PlayLogEntry is appended —
             # consumer-paced mix() would otherwise let the queue briefly report 0.
             crossfade_smart_fade: SmartFade | None = None
-            mix_fadeout_part: bytes = b""
             if (
                 last_fadeout_part
                 and last_streamdetails
                 and crossfade_buffer_size > 0
                 and smart_fades_mode != SmartFadesMode.DISABLED
             ):
-                crossfade_smart_fade, mix_fadeout_part = await self.smart_fades_mixer.build(
+                crossfade_smart_fade = await self.smart_fades_mixer.build(
                     fade_in_streamdetails=queue_track.streamdetails,
                     fade_out_streamdetails=last_streamdetails,
                     pcm_format=pcm_format,
@@ -2253,7 +2252,7 @@ class StreamsAudio:
                         async for mix_chunk in self.smart_fades_mixer.mix(
                             crossfade_smart_fade,
                             fade_in_part=fadein_part,
-                            fade_out_part=mix_fadeout_part,
+                            fade_out_part=last_fadeout_part,
                             pcm_format=pcm_format,
                         ):
                             yield mix_chunk

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -29,11 +29,7 @@ from music_assistant.controllers.streams.smart_fades.helpers import (
     extrapolate_downbeats,
     generate_synthetic_timestamps,
 )
-from music_assistant.helpers.audio import (
-    align_audio_to_frame_boundary,
-    iter_pcm_slices,
-    strip_silence,
-)
+from music_assistant.helpers.audio import iter_pcm_slices
 from music_assistant.helpers.process import AsyncProcess
 from music_assistant.helpers.util import remove_file
 from music_assistant.models.audio_analysis import AudioAnalysisData
@@ -682,8 +678,6 @@ class StandardCrossFade(SmartFade):
 
         Only the overlapping portions are crossfaded, not the full buffers.
         """
-        fade_out_part = await strip_silence(fade_out_part, pcm_format=pcm_format, reverse=True)
-        fade_out_part = align_audio_to_frame_boundary(fade_out_part, pcm_format)
         crossfade_size = int(pcm_format.pcm_sample_size * self.crossfade_duration)
         # Pre-crossfade: outgoing track minus the crossfaded portion
         pre_crossfade = fade_out_part[:-crossfade_size]

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -350,11 +350,15 @@ class SmartCrossFade(SmartFade):
         crossfade_duration = self._adjust_crossfade_to_downbeats(
             crossfade_duration=crossfade_duration,
             fadein_start_pos=fadein_start_pos,
-            min_downbeat_pos=crossfade_start if is_stretched else 0.0,
+            # only consider downbeats after the stretch window when stretching is active,
+            # so the CF starts where the track has already reached the target tempo
+            min_downbeat_pos=crossfade_start if self.tempo_steps else 0.0,
         )
 
         # Compensate crossfade duration for time-stretch compression.
-        if is_stretched:
+        # Gate on tempo_steps (not is_stretched) so a guard-skipped stretch doesn't
+        # apply a compensation for a stretch that never ran.
+        if self.tempo_steps:
             crossfade_duration = crossfade_duration / bpm_ratio
 
         # 90 BPM -> 1500Hz, 140 BPM -> 2500Hz
@@ -380,7 +384,13 @@ class SmartCrossFade(SmartFade):
         # Extended lowpass effect to gradually remove bass frequencies
         fadeout_eq_duration = min(max(crossfade_duration * 2.5, 8.0), self.effective_end)
         # The crossfade always happens at the END of the audible tail
-        fadeout_eq_start = max(0, self.effective_end - fadeout_eq_duration)
+        fadeout_eq_start = max(0.0, self.effective_end - fadeout_eq_duration)
+        if self.tempo_steps:
+            # post-rubberband filters run on OUTPUT time: remap the schedule so the
+            # sweep still completes exactly when the rendered tail ends
+            rendered_end = self.effective_end - self._stretch_savings_until(self.effective_end)
+            fadeout_eq_start -= self._stretch_savings_until(fadeout_eq_start)
+            fadeout_eq_duration = max(rendered_end - fadeout_eq_start, 1.0)
         fadeout_sweep = FrequencySweepFilter(
             logger=self.logger,
             sweep_type="lowpass",
@@ -416,7 +426,7 @@ class SmartCrossFade(SmartFade):
         )
         self.filters.append(crossfade_filter)
 
-        fade_out_seconds = self.effective_end
+        fade_out_seconds = self.effective_end - self._stretch_savings_until(self.effective_end)
         fade_in_seconds = fade_in_bytes_len / pcm_format.pcm_sample_size
         # clamp CF to fit shorter inputs (defensive — normally full buffers)
         self.timing_info.crossfade_duration = min(
@@ -532,6 +542,7 @@ class SmartCrossFade(SmartFade):
         # Shift timestamps back to buffer-relative coordinates for FFmpeg
         tempo_steps = [(ts + stretch_start, ratio) for ts, ratio in tempo_steps]
 
+        self.tempo_steps = tempo_steps
         self.filters.append(GradualTimeStretchFilter(self.logger, tempo_steps))
 
     def _calculate_crossfade_duration(self, crossfade_bars: int) -> float:
@@ -704,6 +715,20 @@ class SmartCrossFade(SmartFade):
             crossfade_duration,
         )
         return crossfade_duration
+
+    def _stretch_savings_until(self, t: float) -> float:
+        """
+        Seconds removed from the rendered stream by the piecewise stretch up to input time t.
+
+        :param t: Input-time position (seconds) up to which to integrate savings.
+        """
+        savings = 0.0
+        for i, (ts, ratio) in enumerate(self.tempo_steps):
+            if ts >= t:
+                break
+            seg_end = min(self.tempo_steps[i + 1][0] if i + 1 < len(self.tempo_steps) else t, t)
+            savings += (seg_end - ts) * (1.0 - 1.0 / ratio)
+        return savings
 
 
 class StandardCrossFade(SmartFade):

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -319,11 +319,11 @@ class SmartCrossFade(SmartFade):
         crossfade_duration = self._calculate_crossfade_duration(crossfade_bars=crossfade_bars)
 
         # Add gradual time stretch filter if needed
-        is_stretched = (
+        stretch_eligible = (
             0.1 < bpm_diff_percent <= self.time_stretch_bpm_percentage_threshold
             and crossfade_bars > 4
         )
-        if is_stretched:
+        if stretch_eligible:
             self._apply_gradual_time_stretch(bpm_ratio, bpm_diff_percent, crossfade_duration)
 
         if (
@@ -356,8 +356,8 @@ class SmartCrossFade(SmartFade):
         )
 
         # Compensate crossfade duration for time-stretch compression.
-        # Gate on tempo_steps (not is_stretched) so a guard-skipped stretch doesn't
-        # apply a compensation for a stretch that never ran.
+        # Gate on tempo_steps (not stretch_eligible) so a guard-skipped stretch
+        # doesn't apply a compensation for a stretch that never ran.
         if self.tempo_steps:
             crossfade_duration = crossfade_duration / bpm_ratio
 
@@ -390,6 +390,8 @@ class SmartCrossFade(SmartFade):
             # sweep still completes exactly when the rendered tail ends
             rendered_end = self.effective_end - self._stretch_savings_until(self.effective_end)
             fadeout_eq_start -= self._stretch_savings_until(fadeout_eq_start)
+            # defensive floor keeping the sweep non-degenerate; cannot bind given
+            # the 5% stretch cap and the 10s minimum audible tail
             fadeout_eq_duration = max(rendered_end - fadeout_eq_start, 1.0)
         fadeout_sweep = FrequencySweepFilter(
             logger=self.logger,
@@ -719,6 +721,8 @@ class SmartCrossFade(SmartFade):
     def _stretch_savings_until(self, t: float) -> float:
         """
         Seconds removed from the rendered stream by the piecewise stretch up to input time t.
+
+        Negative when the stretch slows the tail down (the rendered stream is lengthened).
 
         :param t: Input-time position (seconds) up to which to integrate savings.
         """

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -19,13 +19,16 @@ from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.smart_fades.filters import (
     CrossfadeFilter,
     FadeInTrimFilter,
+    FadeOutTrimFilter,
     Filter,
     FrequencySweepFilter,
     GradualTimeStretchFilter,
 )
 from music_assistant.controllers.streams.smart_fades.helpers import (
+    MIN_EFFECTIVE_FADE_BUFFER,
     SMART_CROSSFADE_DURATION,
     compute_gradual_tempo_steps,
+    detect_effective_audio_end,
     extrapolate_downbeats,
     generate_synthetic_timestamps,
 )
@@ -268,6 +271,13 @@ class SmartCrossFade(SmartFade):
             if fade_out_analysis.downbeats is not None
             else np.array([], dtype=np.float32)
         )
+        # Only beats within the buffered head are usable for alignment decisions
+        self.fade_in_beats = self.fade_in_beats[self.fade_in_beats <= SMART_CROSSFADE_DURATION]
+        self.fade_in_downbeats = self.fade_in_downbeats[
+            self.fade_in_downbeats <= SMART_CROSSFADE_DURATION
+        ]
+        self.effective_end: float = SMART_CROSSFADE_DURATION
+        self.tempo_steps: list[tuple[float, float]] = []
         super().__init__(logger)
 
     def _build(
@@ -278,6 +288,8 @@ class SmartCrossFade(SmartFade):
     ) -> None:
         """Build the smart fades filter chain and assign ``self.timing_info``."""
         self.timing_info = CrossfadeTimingInfo()
+        self._setup_fadeout_window(fade_out_bytes_len, pcm_format)
+
         # Calculate tempo factor for time stretching
         bpm_ratio = self.fade_in_bpm / self.fade_out_bpm
         bpm_diff_percent = abs(1.0 - bpm_ratio) * 100
@@ -285,6 +297,7 @@ class SmartCrossFade(SmartFade):
         # Extrapolate downbeats for better bar calculation
         self.extrapolated_fadeout_downbeats = extrapolate_downbeats(
             self.fade_out_downbeats,
+            buffer_size=self.effective_end,
             bpm=self.fade_out_bpm,
         )
 
@@ -333,7 +346,7 @@ class SmartCrossFade(SmartFade):
         # Adjust crossfade duration to align with outgoing track's downbeats.
         # When stretching, only consider downbeats after the stretch window
         # to ensure the outgoing track has reached the target tempo.
-        crossfade_start = SMART_CROSSFADE_DURATION - crossfade_duration
+        crossfade_start = self.effective_end - crossfade_duration
         crossfade_duration = self._adjust_crossfade_to_downbeats(
             crossfade_duration=crossfade_duration,
             fadein_start_pos=fadein_start_pos,
@@ -365,9 +378,9 @@ class SmartCrossFade(SmartFade):
 
         # Create lowpass filter on the outgoing track (unfiltered → low-pass)
         # Extended lowpass effect to gradually remove bass frequencies
-        fadeout_eq_duration = min(max(crossfade_duration * 2.5, 8.0), SMART_CROSSFADE_DURATION)
-        # The crossfade always happens at the END of the buffer
-        fadeout_eq_start = max(0, SMART_CROSSFADE_DURATION - fadeout_eq_duration)
+        fadeout_eq_duration = min(max(crossfade_duration * 2.5, 8.0), self.effective_end)
+        # The crossfade always happens at the END of the audible tail
+        fadeout_eq_start = max(0, self.effective_end - fadeout_eq_duration)
         fadeout_sweep = FrequencySweepFilter(
             logger=self.logger,
             sweep_type="lowpass",
@@ -403,7 +416,7 @@ class SmartCrossFade(SmartFade):
         )
         self.filters.append(crossfade_filter)
 
-        fade_out_seconds = fade_out_bytes_len / pcm_format.pcm_sample_size
+        fade_out_seconds = self.effective_end
         fade_in_seconds = fade_in_bytes_len / pcm_format.pcm_sample_size
         # clamp CF to fit shorter inputs (defensive — normally full buffers)
         self.timing_info.crossfade_duration = min(
@@ -421,6 +434,48 @@ class SmartCrossFade(SmartFade):
             - self.timing_info.crossfade_duration,
         )
 
+    def _setup_fadeout_window(
+        self,
+        fade_out_bytes_len: int,
+        pcm_format: AudioFormat,
+    ) -> None:
+        """
+        Compute the effective audio end of the fade-out tail and prepare the filter chain.
+
+        Sets ``self.effective_end``, optionally prepends a ``FadeOutTrimFilter``,
+        and masks ``self.fade_out_beats`` / ``self.fade_out_downbeats`` to the
+        audible window.  Raises ``ValueError`` when the tail is too short to be
+        useful so the caller can fall back to a standard crossfade.
+
+        :param fade_out_bytes_len: Raw byte count of the fade-out holdback buffer.
+        :param pcm_format: PCM format used to convert bytes to seconds.
+        """
+        buffer_duration = min(
+            float(SMART_CROSSFADE_DURATION),
+            fade_out_bytes_len / pcm_format.pcm_sample_size,
+        )
+        self.effective_end = detect_effective_audio_end(
+            self.fade_out_analysis.rms_energy,
+            self.fade_out_analysis.duration,
+            buffer_duration,
+        )
+        if self.effective_end < MIN_EFFECTIVE_FADE_BUFFER:
+            raise ValueError(
+                f"Outgoing tail is mostly silent ({self.effective_end:.1f}s audible) - "
+                "smart crossfade not applicable"
+            )
+        if self.effective_end < buffer_duration - 0.5:
+            self.filters.append(
+                FadeOutTrimFilter(logger=self.logger, fadeout_end_pos=self.effective_end)
+            )
+
+        # Mask fade-out beats to the audible buffer window; negative timestamps are
+        # beats before the buffer, beats past effective_end sit in the silent tail
+        beat_mask = (self.fade_out_beats >= 0.0) & (self.fade_out_beats <= self.effective_end)
+        self.fade_out_beats = self.fade_out_beats[beat_mask]
+        db_mask = (self.fade_out_downbeats >= 0.0) & (self.fade_out_downbeats <= self.effective_end)
+        self.fade_out_downbeats = self.fade_out_downbeats[db_mask]
+
     def _apply_gradual_time_stretch(
         self,
         bpm_ratio: float,
@@ -429,7 +484,7 @@ class SmartCrossFade(SmartFade):
     ) -> None:
         """Apply gradual time stretch in the 10s window before the crossfade."""
         stretch_duration = 10.0
-        crossfade_start = SMART_CROSSFADE_DURATION - crossfade_duration
+        crossfade_start = self.effective_end - crossfade_duration
         stretch_start = max(0.0, crossfade_start - stretch_duration)
         stretch_end = crossfade_start
 
@@ -575,15 +630,15 @@ class SmartCrossFade(SmartFade):
             return crossfade_duration
 
         # Calculate where the crossfade would start in the buffer
-        ideal_start_pos = SMART_CROSSFADE_DURATION - crossfade_duration
+        ideal_start_pos = self.effective_end - crossfade_duration
 
         # Debug logging
         self.logger.log(
             VERBOSE_LOG_LEVEL,
-            "Downbeat adjustment - ideal_start=%.2fs (buffer=%.1fs - crossfade=%.2fs), "
+            "Downbeat adjustment - ideal_start=%.2fs (effective_end=%.1fs - crossfade=%.2fs), "
             "fadein_start=%.2fs",
             ideal_start_pos,
-            SMART_CROSSFADE_DURATION,
+            self.effective_end,
             crossfade_duration,
             fadein_start_pos,
         )
@@ -603,7 +658,7 @@ class SmartCrossFade(SmartFade):
 
         # Try earlier downbeat first (longer crossfade)
         if earlier_downbeat is not None:
-            adjusted_duration = float(SMART_CROSSFADE_DURATION - earlier_downbeat)
+            adjusted_duration = float(self.effective_end - earlier_downbeat)
             if fadein_start_pos + adjusted_duration <= SMART_CROSSFADE_DURATION:
                 if abs(adjusted_duration - crossfade_duration) > 0.1:
                     self.logger.log(
@@ -618,7 +673,7 @@ class SmartCrossFade(SmartFade):
 
         # Try later downbeat (shorter crossfade)
         if later_downbeat is not None:
-            adjusted_duration = float(SMART_CROSSFADE_DURATION - later_downbeat)
+            adjusted_duration = float(self.effective_end - later_downbeat)
             if fadein_start_pos + adjusted_duration <= SMART_CROSSFADE_DURATION:
                 if abs(adjusted_duration - crossfade_duration) > 0.1:
                     self.logger.log(

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -653,9 +653,6 @@ class StandardCrossFade(SmartFade):
         pcm_format: AudioFormat,
     ) -> None:
         """Build the standard crossfade filter chain and assign ``self.timing_info``."""
-        self.filters = [
-            CrossfadeFilter(logger=self.logger, crossfade_duration=self.crossfade_duration),
-        ]
         fade_out_seconds = fade_out_bytes_len / pcm_format.pcm_sample_size
         fade_in_seconds = fade_in_bytes_len / pcm_format.pcm_sample_size
         # clamp CF to fit shorter inputs (defensive — normally full buffers)
@@ -666,6 +663,9 @@ class StandardCrossFade(SmartFade):
             fadein_trimmed_duration=0.0,
             post_crossfade_duration=max(0.0, fade_in_seconds - effective_cf),
         )
+        self.filters = [
+            CrossfadeFilter(logger=self.logger, crossfade_duration=effective_cf),
+        ]
 
     async def apply(
         self,
@@ -678,7 +678,9 @@ class StandardCrossFade(SmartFade):
 
         Only the overlapping portions are crossfaded, not the full buffers.
         """
-        crossfade_size = int(pcm_format.pcm_sample_size * self.crossfade_duration)
+        frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+        crossfade_size = int(pcm_format.pcm_sample_size * self.timing_info.crossfade_duration)
+        crossfade_size = (crossfade_size // frame_size) * frame_size
         # Pre-crossfade: outgoing track minus the crossfaded portion
         pre_crossfade = fade_out_part[:-crossfade_size]
         adjusted_fade_out_part = fade_out_part[-crossfade_size:]

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -263,11 +263,11 @@ class SmartCrossFade(SmartFade):
             if fade_in_analysis.downbeats is not None
             else fade_in_analysis.beats
         )
-        # Shift fade-out beats from full-track to buffer-local coordinates
-        buffer_offset = max(0.0, (fade_out_analysis.duration or 0.0) - SMART_CROSSFADE_DURATION)
-        self.fade_out_beats: npt.NDArray[np.float32] = fade_out_analysis.beats - buffer_offset
+        # Store raw full-track beat grids; the shift to buffer-local coordinates
+        # happens in _setup_fadeout_window where the actual buffer length is known
+        self.fade_out_beats: npt.NDArray[np.float32] = fade_out_analysis.beats
         self.fade_out_downbeats: npt.NDArray[np.float32] = (
-            fade_out_analysis.downbeats - buffer_offset
+            fade_out_analysis.downbeats
             if fade_out_analysis.downbeats is not None
             else np.array([], dtype=np.float32)
         )
@@ -456,9 +456,11 @@ class SmartCrossFade(SmartFade):
 
         Sets ``self.effective_end``, optionally appends a ``FadeOutTrimFilter``
         (first in the chain, since this runs before any other filter is added),
-        and masks ``self.fade_out_beats`` / ``self.fade_out_downbeats`` to the
-        audible window.  Raises ``ValueError`` when the tail is too short to be
-        useful so the caller can fall back to a standard crossfade.
+        converts ``self.fade_out_beats`` / ``self.fade_out_downbeats`` from
+        full-track to buffer-local coordinates using the actual buffer length,
+        and masks them to the audible window.  Raises ``ValueError`` when the
+        tail is too short to be useful so the caller can fall back to a standard
+        crossfade.
 
         :param fade_out_bytes_len: Raw byte count of the fade-out holdback buffer.
         :param pcm_format: PCM format used to convert bytes to seconds.
@@ -487,6 +489,14 @@ class SmartCrossFade(SmartFade):
             # Without the trim the rendered stream still ends at buffer_duration,
             # so the anchor must follow it or every schedule lands early
             self.effective_end = buffer_duration
+
+        # Shift fade-out beats from full-track to buffer-local coordinates using the
+        # ACTUAL buffer length: the holdback yield loop leaves up to ~1s less than the
+        # constant 45s depending on chunk boundaries, and effective_end above is in real
+        # buffer coordinates — a constant-45 shift would misalign every beat by the difference
+        buffer_offset = max(0.0, (self.fade_out_analysis.duration or 0.0) - buffer_duration)
+        self.fade_out_beats = self.fade_out_beats - buffer_offset
+        self.fade_out_downbeats = self.fade_out_downbeats - buffer_offset
 
         # Mask fade-out beats to the audible buffer window; negative timestamps are
         # beats before the buffer, beats past effective_end sit in the silent tail

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -41,6 +41,10 @@ if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat
 
 
+class SmartFadeNotApplicable(Exception):
+    """Raised when the tracks cannot yield a smart crossfade and the caller should fall back."""
+
+
 @dataclass(slots=True)
 class CrossfadeTimingInfo:
     """Timing breakdown of a crossfade mix output: PRE | CF | POST."""
@@ -475,9 +479,8 @@ class SmartCrossFade(SmartFade):
             buffer_duration,
         )
         if self.effective_end < MIN_EFFECTIVE_FADE_BUFFER:
-            raise ValueError(
-                f"Outgoing tail is mostly silent ({self.effective_end:.1f}s audible) - "
-                "smart crossfade not applicable"
+            raise SmartFadeNotApplicable(
+                f"outgoing tail is mostly silent ({self.effective_end:.1f}s audible)"
             )
         # Sub-half-second slack is not worth trimming: RMS bin granularity is
         # ~0.1-0.2s for typical track lengths, so finer precision is illusory
@@ -803,6 +806,18 @@ class StandardCrossFade(SmartFade):
         frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
         crossfade_size = int(pcm_format.pcm_sample_size * self.timing_info.crossfade_duration)
         crossfade_size = (crossfade_size // frame_size) * frame_size
+        if crossfade_size == 0:
+            # nothing to blend — concatenate without spawning ffmpeg
+            for pcm_slice in iter_pcm_slices(fade_out_part, pcm_format, 1000):
+                yield pcm_slice
+            if isinstance(fade_in_part, bytes):
+                for pcm_slice in iter_pcm_slices(fade_in_part, pcm_format, 1000):
+                    yield pcm_slice
+            else:
+                async for chunk in fade_in_part:
+                    for pcm_slice in iter_pcm_slices(chunk, pcm_format, 1000):
+                        yield pcm_slice
+            return
         # Pre-crossfade: outgoing track minus the crossfaded portion
         split = len(fade_out_part) - crossfade_size
         pre_crossfade = fade_out_part[:split]

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -485,6 +485,10 @@ class SmartCrossFade(SmartFade):
         """Apply gradual time stretch in the 10s window before the crossfade."""
         stretch_duration = 10.0
         crossfade_start = self.effective_end - crossfade_duration
+        # A crossfade consuming the whole audible tail leaves no room for a
+        # pre-fade tempo ramp
+        if crossfade_start <= 0:
+            return
         stretch_start = max(0.0, crossfade_start - stretch_duration)
         stretch_end = crossfade_start
 
@@ -531,11 +535,12 @@ class SmartCrossFade(SmartFade):
         seconds_per_beat = 60.0 / self.fade_in_bpm
         musical_duration = crossfade_bars * beats_per_bar * seconds_per_beat
 
-        # Apply buffer constraint
-        actual_duration = min(musical_duration, SMART_CROSSFADE_DURATION)
+        # Cap at the audible fade-out room so crossfade_start never goes negative
+        # downstream (effective_end <= SMART_CROSSFADE_DURATION always)
+        actual_duration = min(musical_duration, SMART_CROSSFADE_DURATION, self.effective_end)
 
         # Log if we had to constrain the duration
-        if musical_duration > SMART_CROSSFADE_DURATION:
+        if musical_duration > actual_duration:
             self.logger.log(
                 VERBOSE_LOG_LEVEL,
                 "Constraining crossfade duration from %.1fs to %.1fs (buffer limit)",

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -483,7 +483,11 @@ class SmartCrossFade(SmartFade):
         # ~0.1-0.2s for typical track lengths, so finer precision is illusory
         if self.effective_end < buffer_duration - 0.5:
             self.filters.append(
-                FadeOutTrimFilter(logger=self.logger, fadeout_end_pos=self.effective_end)
+                FadeOutTrimFilter(
+                    logger=self.logger,
+                    fadeout_end_pos=self.effective_end,
+                    trimmed_seconds=buffer_duration - self.effective_end,
+                )
             )
         else:
             # Without the trim the rendered stream still ends at buffer_duration,

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -454,7 +454,8 @@ class SmartCrossFade(SmartFade):
         """
         Compute the effective audio end of the fade-out tail and prepare the filter chain.
 
-        Sets ``self.effective_end``, optionally prepends a ``FadeOutTrimFilter``,
+        Sets ``self.effective_end``, optionally appends a ``FadeOutTrimFilter``
+        (first in the chain, since this runs before any other filter is added),
         and masks ``self.fade_out_beats`` / ``self.fade_out_downbeats`` to the
         audible window.  Raises ``ValueError`` when the tail is too short to be
         useful so the caller can fall back to a standard crossfade.
@@ -727,6 +728,13 @@ class SmartCrossFade(SmartFade):
         :param t: Input-time position (seconds) up to which to integrate savings.
         """
         savings = 0.0
+        # rubberband is initialized at the FIRST step's ratio from t=0, so the
+        # span before the first step already runs stretched (no-op for multi-step
+        # ramps, whose first step has ratio 1.0)
+        if self.tempo_steps and self.tempo_steps[0][0] > 0.0:
+            first_ts, first_ratio = self.tempo_steps[0]
+            span_end = min(first_ts, t)
+            savings += span_end * (1.0 - 1.0 / first_ratio)
         for i, (ts, ratio) in enumerate(self.tempo_steps):
             if ts >= t:
                 break

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -18,10 +18,10 @@ import shortuuid
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.smart_fades.filters import (
     CrossfadeFilter,
+    FadeInTrimFilter,
     Filter,
     FrequencySweepFilter,
     GradualTimeStretchFilter,
-    TrimFilter,
 )
 from music_assistant.controllers.streams.smart_fades.helpers import (
     SMART_CROSSFADE_DURATION,
@@ -317,7 +317,9 @@ class SmartCrossFade(SmartFade):
             fadein_start_pos is not None
             and fadein_start_pos + crossfade_duration <= SMART_CROSSFADE_DURATION
         ):
-            self.filters.append(TrimFilter(logger=self.logger, fadein_start_pos=fadein_start_pos))
+            self.filters.append(
+                FadeInTrimFilter(logger=self.logger, fadein_start_pos=fadein_start_pos)
+            )
             self.timing_info.fadein_trimmed_duration = fadein_start_pos
         else:
             self.logger.log(

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -682,8 +682,9 @@ class StandardCrossFade(SmartFade):
         crossfade_size = int(pcm_format.pcm_sample_size * self.timing_info.crossfade_duration)
         crossfade_size = (crossfade_size // frame_size) * frame_size
         # Pre-crossfade: outgoing track minus the crossfaded portion
-        pre_crossfade = fade_out_part[:-crossfade_size]
-        adjusted_fade_out_part = fade_out_part[-crossfade_size:]
+        split = len(fade_out_part) - crossfade_size
+        pre_crossfade = fade_out_part[:split]
+        adjusted_fade_out_part = fade_out_part[split:]
 
         # Collect only the crossfade portion from fade_in, keep the rest as a generator
         if isinstance(fade_in_part, bytes):

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -750,6 +750,7 @@ class StandardCrossFade(SmartFade):
         """Initialize StandardCrossFade with crossfade duration."""
         super().__init__(logger)
         self.crossfade_duration = crossfade_duration
+        self.trailing_silence_bytes: int = 0
 
     def _build(
         self,
@@ -783,6 +784,8 @@ class StandardCrossFade(SmartFade):
 
         Only the overlapping portions are crossfaded, not the full buffers.
         """
+        if self.trailing_silence_bytes:
+            fade_out_part = fade_out_part[: len(fade_out_part) - self.trailing_silence_bytes]
         frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
         crossfade_size = int(pcm_format.pcm_sample_size * self.timing_info.crossfade_duration)
         crossfade_size = (crossfade_size // frame_size) * frame_size

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -464,10 +464,16 @@ class SmartCrossFade(SmartFade):
                 f"Outgoing tail is mostly silent ({self.effective_end:.1f}s audible) - "
                 "smart crossfade not applicable"
             )
+        # Sub-half-second slack is not worth trimming: RMS bin granularity is
+        # ~0.1-0.2s for typical track lengths, so finer precision is illusory
         if self.effective_end < buffer_duration - 0.5:
             self.filters.append(
                 FadeOutTrimFilter(logger=self.logger, fadeout_end_pos=self.effective_end)
             )
+        else:
+            # Without the trim the rendered stream still ends at buffer_duration,
+            # so the anchor must follow it or every schedule lands early
+            self.effective_end = buffer_duration
 
         # Mask fade-out beats to the audible buffer window; negative timestamps are
         # beats before the buffer, beats past effective_end sit in the silent tail
@@ -537,13 +543,13 @@ class SmartCrossFade(SmartFade):
 
         # Cap at the audible fade-out room so crossfade_start never goes negative
         # downstream (effective_end <= SMART_CROSSFADE_DURATION always)
-        actual_duration = min(musical_duration, SMART_CROSSFADE_DURATION, self.effective_end)
+        actual_duration = min(musical_duration, self.effective_end)
 
         # Log if we had to constrain the duration
         if musical_duration > actual_duration:
             self.logger.log(
                 VERBOSE_LOG_LEVEL,
-                "Constraining crossfade duration from %.1fs to %.1fs (buffer limit)",
+                "Constraining crossfade duration from %.1fs to %.1fs (audible tail limit)",
                 musical_duration,
                 actual_duration,
             )

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -91,7 +91,7 @@ class FadeOutTrimFilter(Filter):
     output_fadeout_label: str = "fadeout_tailtrim"
     output_fadein_label: str = "fadein_tailtrim"
 
-    def __init__(self, logger: logging.Logger, fadeout_end_pos: float):
+    def __init__(self, logger: logging.Logger, fadeout_end_pos: float, trimmed_seconds: float):
         """
         Initialize fade-out trim filter.
 
@@ -99,8 +99,11 @@ class FadeOutTrimFilter(Filter):
             audible content ends; everything after it is dropped.
             Measured on the untrimmed input timeline, so this filter must precede
             any time-stretching filter in the chain.
+        :param trimmed_seconds: Amount of trailing audio in seconds that the trim
+            drops, for logging/debugging purposes.
         """
         self.fadeout_end_pos = fadeout_end_pos
+        self.trimmed_seconds = trimmed_seconds
         super().__init__(logger)
 
     def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
@@ -113,7 +116,7 @@ class FadeOutTrimFilter(Filter):
 
     def __repr__(self) -> str:
         """Return string representation of FadeOutTrimFilter."""
-        return f"FadeOutTrim(end={self.fadeout_end_pos:.2f}s)"
+        return f"FadeOutTrim(end={self.fadeout_end_pos:.2f}s, trimmed={self.trimmed_seconds:.2f}s)"
 
 
 class FrequencySweepFilter(Filter):

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -58,17 +58,17 @@ class GradualTimeStretchFilter(Filter):
         return f"GradualTimeStretch(steps={n}, {start:.4f}->{end:.4f})"
 
 
-class TrimFilter(Filter):
+class FadeInTrimFilter(Filter):
     """Filter that trims incoming track to align with downbeats."""
 
     output_fadeout_label: str = "fadeout_beatalign"
     output_fadein_label: str = "fadein_beatalign"
 
     def __init__(self, logger: logging.Logger, fadein_start_pos: float):
-        """Initialize beat align filter.
+        """
+        Initialize beat align filter.
 
-        Args:
-            fadein_start_pos: Position in seconds to trim the incoming track to
+        :param fadein_start_pos: Position in seconds to trim the incoming track to.
         """
         self.fadein_start_pos = fadein_start_pos
         super().__init__(logger)
@@ -81,8 +81,37 @@ class TrimFilter(Filter):
         ]
 
     def __repr__(self) -> str:
-        """Return string representation of TrimFilter."""
-        return f"Trim(trim={self.fadein_start_pos:.2f}s)"
+        """Return string representation of FadeInTrimFilter."""
+        return f"FadeInTrim(start={self.fadein_start_pos:.2f}s)"
+
+
+class FadeOutTrimFilter(Filter):
+    """Filter that trims trailing (silent) audio off the outgoing track's tail."""
+
+    output_fadeout_label: str = "fadeout_tailtrim"
+    output_fadein_label: str = "fadein_tailtrim"
+
+    def __init__(self, logger: logging.Logger, fadeout_end_pos: float):
+        """
+        Initialize fade-out trim filter.
+
+        :param fadeout_end_pos: Position in seconds where the outgoing track's
+            audible content ends; everything after it is dropped.
+        """
+        self.fadeout_end_pos = fadeout_end_pos
+        super().__init__(logger)
+
+    def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
+        """Trim the outgoing track's tail at the effective audio end."""
+        return [
+            f"{input_fadeout_label}atrim=end={self.fadeout_end_pos:.3f},"
+            f"asetpts=PTS-STARTPTS[{self.output_fadeout_label}]",
+            f"{input_fadein_label}anull[{self.output_fadein_label}]",  # codespell:ignore anull
+        ]
+
+    def __repr__(self) -> str:
+        """Return string representation of FadeOutTrimFilter."""
+        return f"FadeOutTrim(end={self.fadeout_end_pos:.2f}s)"
 
 
 class FrequencySweepFilter(Filter):

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -97,6 +97,8 @@ class FadeOutTrimFilter(Filter):
 
         :param fadeout_end_pos: Position in seconds where the outgoing track's
             audible content ends; everything after it is dropped.
+            Measured on the untrimmed input timeline, so this filter must precede
+            any time-stretching filter in the chain.
         """
         self.fadeout_end_pos = fadeout_end_pos
         super().__init__(logger)

--- a/music_assistant/controllers/streams/smart_fades/helpers.py
+++ b/music_assistant/controllers/streams/smart_fades/helpers.py
@@ -28,7 +28,12 @@ def detect_effective_audio_end(
     :param track_duration: Full track duration in seconds.
     :param buffer_duration: Length in seconds of the fade-out holdback buffer.
     """
-    if rms_energy is None or not track_duration or len(rms_energy) < 2:
+    if (
+        rms_energy is None
+        or not track_duration
+        or len(rms_energy) < 2
+        or not np.any(np.isfinite(rms_energy))
+    ):
         return buffer_duration
     bin_duration = track_duration / len(rms_energy)
     start_bin = max(0, int((track_duration - buffer_duration) / bin_duration))
@@ -40,7 +45,11 @@ def detect_effective_audio_end(
     audible = np.nonzero(tail > floor)[0]
     if len(audible) == 0:
         return 0.0
-    return min(float((audible[-1] + 1) * bin_duration), buffer_duration)
+    return min(
+        float((start_bin + audible[-1] + 1) * bin_duration)
+        - max(0.0, track_duration - buffer_duration),
+        buffer_duration,
+    )
 
 
 def extrapolate_downbeats(

--- a/music_assistant/controllers/streams/smart_fades/helpers.py
+++ b/music_assistant/controllers/streams/smart_fades/helpers.py
@@ -8,6 +8,40 @@ import numpy.typing as npt
 # Buffer size in seconds for crossfade analysis
 SMART_CROSSFADE_DURATION = 45
 
+# Below this many seconds of audible tail, a smart crossfade is pointless;
+# the caller should fall back to a standard fade (which strips silence).
+MIN_EFFECTIVE_FADE_BUFFER = 10.0
+
+
+def detect_effective_audio_end(
+    rms_energy: npt.NDArray[np.float32] | None,
+    track_duration: float | None,
+    buffer_duration: float,
+) -> float:
+    """
+    Return the buffer-local time where the outgoing track's audible content ends.
+
+    Returns ``buffer_duration`` when no usable energy data exists or there is no
+    trailing silence, and ``0.0`` when the entire tail is silent.
+
+    :param rms_energy: Peak-normalized RMS energy bins spanning the full track.
+    :param track_duration: Full track duration in seconds.
+    :param buffer_duration: Length in seconds of the fade-out holdback buffer.
+    """
+    if rms_energy is None or not track_duration or len(rms_energy) < 2:
+        return buffer_duration
+    bin_duration = track_duration / len(rms_energy)
+    start_bin = max(0, int((track_duration - buffer_duration) / bin_duration))
+    tail = rms_energy[start_bin:]
+    # floor relative to sustained track energy, so hiss/noise tails count as
+    # silence but intentionally quiet outros do not
+    sustained = rms_energy[rms_energy > 0.01]
+    floor = max(0.02, 0.05 * float(np.median(sustained))) if len(sustained) else 0.02
+    audible = np.nonzero(tail > floor)[0]
+    if len(audible) == 0:
+        return 0.0
+    return min(float((audible[-1] + 1) * bin_duration), buffer_duration)
+
 
 def extrapolate_downbeats(
     downbeats: npt.NDArray[np.float32],

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -11,6 +11,7 @@ from music_assistant.controllers.streams.smart_fades.fades import (
     SmartFade,
     StandardCrossFade,
 )
+from music_assistant.helpers.audio import align_audio_to_frame_boundary, strip_silence
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.smart_fades import SmartFadesMode
 
@@ -36,17 +37,25 @@ class SmartFadesMixer:
         pcm_format: AudioFormat,
         standard_crossfade_duration: int,
         mode: SmartFadesMode,
-        fade_out_bytes_len: int,
+        fade_out_data: bytes,
         fade_in_bytes_len: int,
-    ) -> SmartFade:
-        """Pick the SmartFade implementation, prime its filters, return it.
+    ) -> tuple[SmartFade, bytes]:
+        """
+        Pick the SmartFade implementation, prime its filters, return it with the mix input.
+
+        Returns a tuple of the built SmartFade and the fade-out bytes to feed into
+        ``mix()``. For the standard crossfade path (explicit mode or smart-crossfade
+        fallback) trailing silence is stripped from those bytes BEFORE timing is
+        computed, so ``timing_info`` always describes the audio that will actually be
+        rendered. Callers must keep their original buffer for failure fallbacks and
+        play-log corrections.
 
         :param fade_in_streamdetails: Stream details for the incoming track.
         :param fade_out_streamdetails: Stream details for the outgoing track.
         :param pcm_format: Audio format of both input buffers (and mix output).
         :param standard_crossfade_duration: Duration in seconds for standard crossfade.
         :param mode: Smart fades mode (SMART_CROSSFADE or STANDARD_CROSSFADE).
-        :param fade_out_bytes_len: Expected length in bytes of the fade-out input.
+        :param fade_out_data: PCM buffer of the outgoing track's tail.
         :param fade_in_bytes_len: Expected length in bytes of the fade-in input.
         """
         smart_fade: SmartFade | None = None
@@ -54,17 +63,22 @@ class SmartFadesMixer:
             smart_fade = await self._build_smart_crossfade(
                 fade_in_streamdetails=fade_in_streamdetails,
                 fade_out_streamdetails=fade_out_streamdetails,
-                fade_out_bytes_len=fade_out_bytes_len,
+                fade_out_bytes_len=len(fade_out_data),
                 fade_in_bytes_len=fade_in_bytes_len,
                 pcm_format=pcm_format,
             )
         if smart_fade is None:
+            # standard path — explicit mode AND smart-crossfade fallback land here
+            fade_out_data = align_audio_to_frame_boundary(
+                await strip_silence(fade_out_data, pcm_format=pcm_format, reverse=True),
+                pcm_format,
+            )
             smart_fade = StandardCrossFade(
                 logger=self.logger,
                 crossfade_duration=standard_crossfade_duration,
             )
-            smart_fade._build(fade_out_bytes_len, fade_in_bytes_len, pcm_format)
-        return smart_fade
+            smart_fade._build(len(fade_out_data), fade_in_bytes_len, pcm_format)
+        return smart_fade, fade_out_data
 
     async def mix(
         self,

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -69,10 +69,15 @@ class SmartFadesMixer:
             )
         if smart_fade is None:
             # standard path — explicit mode AND smart-crossfade fallback land here
-            fade_out_data = align_audio_to_frame_boundary(
-                await strip_silence(fade_out_data, pcm_format=pcm_format, reverse=True),
-                pcm_format,
-            )
+            try:
+                fade_out_data = align_audio_to_frame_boundary(
+                    await strip_silence(fade_out_data, pcm_format=pcm_format, reverse=True),
+                    pcm_format,
+                )
+            except Exception as err:
+                # degrade to the unstripped tail (late-boundary bookkeeping)
+                # rather than killing the stream
+                self.logger.warning("Stripping trailing silence failed: %s", err)
             smart_fade = StandardCrossFade(
                 logger=self.logger,
                 crossfade_duration=standard_crossfade_duration,

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -39,16 +39,14 @@ class SmartFadesMixer:
         mode: SmartFadesMode,
         fade_out_data: bytes,
         fade_in_bytes_len: int,
-    ) -> tuple[SmartFade, bytes]:
+    ) -> SmartFade:
         """
-        Pick the SmartFade implementation, prime its filters, return it with the mix input.
+        Pick the SmartFade implementation, prime its filters, and return it.
 
-        Returns a tuple of the built SmartFade and the fade-out bytes to feed into
-        ``mix()``. For the standard crossfade path (explicit mode or smart-crossfade
-        fallback) trailing silence is stripped from those bytes BEFORE timing is
-        computed, so ``timing_info`` always describes the audio that will actually be
-        rendered. Callers must keep their original buffer for failure fallbacks and
-        play-log corrections.
+        For the standard crossfade path (explicit mode or smart-crossfade fallback)
+        the trailing silence in ``fade_out_data`` is measured so that ``timing_info``
+        reflects the audio that will actually be rendered.  The trim itself is deferred
+        to ``apply()``, which executes it as a plain slice — no bytes are modified here.
 
         :param fade_in_streamdetails: Stream details for the incoming track.
         :param fade_out_streamdetails: Stream details for the outgoing track.
@@ -68,22 +66,29 @@ class SmartFadesMixer:
                 pcm_format=pcm_format,
             )
         if smart_fade is None:
-            # standard path — explicit mode AND smart-crossfade fallback land here
+            # standard path — explicit mode AND smart-crossfade fallback land here.
+            # Measure the trailing silence here so timing_info reflects the audio that
+            # will actually be rendered; apply() executes the cut as a plain slice.
+            trailing_silence_bytes = 0
             try:
-                fade_out_data = align_audio_to_frame_boundary(
+                stripped = align_audio_to_frame_boundary(
                     await strip_silence(fade_out_data, pcm_format=pcm_format, reverse=True),
                     pcm_format,
                 )
+                trailing_silence_bytes = len(fade_out_data) - len(stripped)
             except Exception as err:
-                # degrade to the unstripped tail (late-boundary bookkeeping)
-                # rather than killing the stream
-                self.logger.warning("Stripping trailing silence failed: %s", err)
+                # a failed measurement degrades to the old late-boundary bookkeeping
+                # instead of killing the stream
+                self.logger.warning("Measuring trailing silence failed: %s", err)
             smart_fade = StandardCrossFade(
                 logger=self.logger,
                 crossfade_duration=standard_crossfade_duration,
             )
-            smart_fade._build(len(fade_out_data), fade_in_bytes_len, pcm_format)
-        return smart_fade, fade_out_data
+            smart_fade.trailing_silence_bytes = trailing_silence_bytes
+            smart_fade._build(
+                len(fade_out_data) - trailing_silence_bytes, fade_in_bytes_len, pcm_format
+            )
+        return smart_fade
 
     async def mix(
         self,

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -75,7 +75,7 @@ class SmartFadesMixer:
                     await strip_silence(fade_out_data, pcm_format=pcm_format, reverse=True),
                     pcm_format,
                 )
-                trailing_silence_bytes = len(fade_out_data) - len(stripped)
+                trailing_silence_bytes = max(0, len(fade_out_data) - len(stripped))
             except Exception as err:
                 # a failed measurement degrades to the old late-boundary bookkeeping
                 # instead of killing the stream

--- a/music_assistant/controllers/streams/smart_fades/mixer.py
+++ b/music_assistant/controllers/streams/smart_fades/mixer.py
@@ -9,6 +9,7 @@ from music_assistant.controllers.streams.audio_analysis import SMART_FADES_ANALY
 from music_assistant.controllers.streams.smart_fades.fades import (
     SmartCrossFade,
     SmartFade,
+    SmartFadeNotApplicable,
     StandardCrossFade,
 )
 from music_assistant.helpers.audio import align_audio_to_frame_boundary, strip_silence
@@ -140,6 +141,9 @@ class SmartFadesMixer:
                 fade_in_analysis=fade_in_analysis,
             )
             smart_fade._build(fade_out_bytes_len, fade_in_bytes_len, pcm_format)
+        except SmartFadeNotApplicable as e:
+            self.logger.debug("Smart crossfade not applicable: %s - using standard crossfade", e)
+            return None
         except Exception as e:
             self.logger.warning(
                 "Smart crossfade build failed: %s, falling back to standard crossfade", e

--- a/tests/controllers/streams/smart_fades/test_filters.py
+++ b/tests/controllers/streams/smart_fades/test_filters.py
@@ -180,9 +180,10 @@ def test_sweep_instances_are_unique_per_stream_type() -> None:
 
 def test_fadeout_trim_trims_fadeout_and_passes_fadein_through() -> None:
     """The fadeout stream is end-trimmed; the fadein stream is untouched."""
-    fadeout_trim = FadeOutTrimFilter(logger=LOGGER, fadeout_end_pos=35.0)
+    fadeout_trim = FadeOutTrimFilter(logger=LOGGER, fadeout_end_pos=35.0, trimmed_seconds=10.0)
     filter_strings = fadeout_trim.apply("[fadein]", "[fadeout]")
     assert len(filter_strings) == 2
+    assert repr(fadeout_trim) == "FadeOutTrim(end=35.00s, trimmed=10.00s)"
 
     trim_chain = next(f for f in filter_strings if "atrim" in f)
     assert trim_chain.startswith("[fadeout]")

--- a/tests/controllers/streams/smart_fades/test_filters.py
+++ b/tests/controllers/streams/smart_fades/test_filters.py
@@ -14,6 +14,7 @@ import pytest
 
 from music_assistant.controllers.streams.smart_fades.filters import (
     CrossfadeFilter,
+    FadeOutTrimFilter,
     FrequencySweepFilter,
 )
 
@@ -175,6 +176,22 @@ def test_sweep_instances_are_unique_per_stream_type() -> None:
     assert out_match is not None
     assert in_match is not None
     assert out_match.group(2) != in_match.group(2)
+
+
+def test_fadeout_trim_trims_fadeout_and_passes_fadein_through() -> None:
+    """The fadeout stream is end-trimmed; the fadein stream is untouched."""
+    fadeout_trim = FadeOutTrimFilter(logger=LOGGER, fadeout_end_pos=35.0)
+    filter_strings = fadeout_trim.apply("[fadein]", "[fadeout]")
+
+    trim_chain = next(f for f in filter_strings if "atrim" in f)
+    assert trim_chain.startswith("[fadeout]")
+    assert "atrim=end=35.000" in trim_chain
+    assert "asetpts=PTS-STARTPTS" in trim_chain
+    assert trim_chain.endswith(f"[{fadeout_trim.output_fadeout_label}]")
+
+    passthrough = next(f for f in filter_strings if "anull" in f)  # codespell:ignore anull
+    assert passthrough.startswith("[fadein]")
+    assert passthrough.endswith(f"[{fadeout_trim.output_fadein_label}]")
 
 
 def test_crossfade_uses_equal_power_curves() -> None:

--- a/tests/controllers/streams/smart_fades/test_filters.py
+++ b/tests/controllers/streams/smart_fades/test_filters.py
@@ -182,6 +182,7 @@ def test_fadeout_trim_trims_fadeout_and_passes_fadein_through() -> None:
     """The fadeout stream is end-trimmed; the fadein stream is untouched."""
     fadeout_trim = FadeOutTrimFilter(logger=LOGGER, fadeout_end_pos=35.0)
     filter_strings = fadeout_trim.apply("[fadein]", "[fadeout]")
+    assert len(filter_strings) == 2
 
     trim_chain = next(f for f in filter_strings if "atrim" in f)
     assert trim_chain.startswith("[fadeout]")

--- a/tests/controllers/streams/smart_fades/test_helpers.py
+++ b/tests/controllers/streams/smart_fades/test_helpers.py
@@ -51,3 +51,27 @@ def test_quiet_but_musical_outro_is_kept() -> None:
     bins[-300:] = 0.15
     end = detect_effective_audio_end(bins, 240.0, 45.0)
     assert end == pytest.approx(45.0, abs=0.2)
+
+
+def test_hiss_tail_on_loud_track_counts_as_silence() -> None:
+    """On a loud track the floor scales up, so a hiss tail counts as silence."""
+    # sustained level 0.9 -> floor 0.045; the 0.03 hiss tail falls below it
+    bins = _rms(240.0, silent_tail=0.0, level=0.9)
+    bins[-75:] = 0.03
+    end = detect_effective_audio_end(bins, 240.0, 45.0)
+    assert end == pytest.approx(35.0, abs=0.3)
+
+
+def test_absolute_floor_applies_on_quiet_track() -> None:
+    """On a quiet track the absolute 0.02 floor still flags a near-silent tail."""
+    # sustained level 0.2 -> relative floor 0.01, clamped to absolute 0.02
+    bins = _rms(240.0, silent_tail=0.0, level=0.2)
+    bins[-75:] = 0.015
+    end = detect_effective_audio_end(bins, 240.0, 45.0)
+    assert end == pytest.approx(35.0, abs=0.3)
+
+
+def test_all_nan_rms_returns_buffer_duration() -> None:
+    """RMS data without any finite values fails open to the buffer duration."""
+    bins = np.full(1800, np.nan, dtype=np.float32)
+    assert detect_effective_audio_end(bins, 240.0, 45.0) == 45.0

--- a/tests/controllers/streams/smart_fades/test_helpers.py
+++ b/tests/controllers/streams/smart_fades/test_helpers.py
@@ -1,0 +1,53 @@
+"""Tests for smart fades helper functions."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from music_assistant.controllers.streams.smart_fades.helpers import (
+    detect_effective_audio_end,
+)
+
+
+def _rms(track_duration: float, silent_tail: float, level: float = 0.5) -> np.ndarray:
+    """Build a 1800-bin peak-normalized rms array with a silent tail."""
+    bins = np.full(1800, level, dtype=np.float32)
+    bins[0] = 1.0  # peak normalization reference
+    if silent_tail > 0:
+        silent_bins = int(silent_tail / track_duration * 1800)
+        bins[-silent_bins:] = 0.001
+    return bins
+
+
+def test_no_rms_data_returns_buffer_duration() -> None:
+    """When no RMS data is provided, return the buffer duration."""
+    assert detect_effective_audio_end(None, 240.0, 45.0) == 45.0
+
+
+def test_no_trailing_silence_returns_buffer_duration() -> None:
+    """When there is no trailing silence, return the full buffer duration."""
+    end = detect_effective_audio_end(_rms(240.0, silent_tail=0.0), 240.0, 45.0)
+    assert end == pytest.approx(45.0, abs=0.2)
+
+
+def test_silent_tail_is_excluded() -> None:
+    """Trailing silence is excluded from the effective audio end."""
+    # 10s of silence at the end of a 240s track: audible content ends at 35s buffer-local
+    end = detect_effective_audio_end(_rms(240.0, silent_tail=10.0), 240.0, 45.0)
+    assert end == pytest.approx(35.0, abs=0.3)
+
+
+def test_fully_silent_tail_returns_zero() -> None:
+    """When the entire tail is silent, return 0.0."""
+    end = detect_effective_audio_end(_rms(240.0, silent_tail=50.0), 240.0, 45.0)
+    assert end == 0.0
+
+
+def test_quiet_but_musical_outro_is_kept() -> None:
+    """Quiet but intentional outros above the floor are not treated as silence."""
+    # outro at 30% of sustained level stays well above the silence floor
+    bins = _rms(240.0, silent_tail=0.0)
+    bins[-300:] = 0.15
+    end = detect_effective_audio_end(bins, 240.0, 45.0)
+    assert end == pytest.approx(45.0, abs=0.2)

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -472,3 +472,53 @@ class TestMixerBuild:
         )
         assert isinstance(smart_fade, StandardCrossFade)
         assert len(mix_data) == _seconds(40)
+
+    @pytest.mark.asyncio
+    async def test_standard_mode_fully_silent_tail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A fully silent tail strips to nothing — timing collapses to zero, mix input is empty."""
+
+        async def fake_strip(_audio_data: bytes, **_kwargs: object) -> bytes:
+            return b""
+
+        monkeypatch.setattr(mixer_module, "strip_silence", fake_strip)
+        mixer = _make_mixer()
+        smart_fade, mix_data = await mixer.build(
+            fade_in_streamdetails=_streamdetails("b"),
+            fade_out_streamdetails=_streamdetails("a"),
+            pcm_format=PCM,
+            standard_crossfade_duration=10,
+            mode=SmartFadesMode.STANDARD_CROSSFADE,
+            fade_out_data=b"\x00" * _seconds(45),
+            fade_in_bytes_len=_seconds(45),
+        )
+        assert isinstance(smart_fade, StandardCrossFade)
+        assert mix_data == b""
+        timing = smart_fade.timing_info
+        assert timing.pre_crossfade_duration == 0.0
+        assert timing.crossfade_duration == 0.0
+
+    @pytest.mark.asyncio
+    async def test_standard_mode_strip_failure_keeps_unstripped_bytes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A strip_silence failure must not propagate — build degrades to the unstripped tail."""
+
+        async def broken_strip(*_args: object, **_kwargs: object) -> bytes:
+            raise OSError("ffmpeg spawn failed")
+
+        monkeypatch.setattr(mixer_module, "strip_silence", broken_strip)
+        mixer = _make_mixer()
+        fade_out_data = b"\x00" * _seconds(45)
+        smart_fade, mix_data = await mixer.build(
+            fade_in_streamdetails=_streamdetails("b"),
+            fade_out_streamdetails=_streamdetails("a"),
+            pcm_format=PCM,
+            standard_crossfade_duration=10,
+            mode=SmartFadesMode.STANDARD_CROSSFADE,
+            fade_out_data=fade_out_data,
+            fade_in_bytes_len=_seconds(45),
+        )
+        assert isinstance(smart_fade, StandardCrossFade)
+        assert mix_data is fade_out_data
+        timing = smart_fade.timing_info
+        assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(45.0)

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -596,8 +596,6 @@ class TestMixerBuild:
 
 LOGGER = logging.getLogger(__name__)
 
-PCM_FORMAT = PCM
-
 
 def _rms_with_silent_tail(track_duration: float, silent_tail: float) -> np.ndarray:
     bins = np.full(1800, 0.5, dtype=np.float32)
@@ -621,7 +619,7 @@ class TestSilenceAwareAnchoring:
             ),
             fade_in_analysis=_analysis(bpm=120.0, duration=duration),
         )
-        fade._build(_seconds(45), _seconds(45), PCM_FORMAT)
+        fade._build(_seconds(45), _seconds(45), PCM)
         return fade
 
     def test_silent_tail_moves_the_anchor(self) -> None:
@@ -641,6 +639,12 @@ class TestSilenceAwareAnchoring:
         """Without silence, effective_end equals the full buffer and no trim filter is added."""
         fade = self._build_fade(silent_tail=0.0)
         assert fade.effective_end == pytest.approx(45.0, abs=0.3)
+        assert not any(isinstance(f, FadeOutTrimFilter) for f in fade.filters)
+
+    def test_sub_tolerance_silent_tail_snaps_anchor_to_buffer_end(self) -> None:
+        """A silent tail below the trim tolerance keeps the anchor at the rendered buffer end."""
+        fade = self._build_fade(silent_tail=0.4)
+        assert fade.effective_end == pytest.approx(45.0)
         assert not any(isinstance(f, FadeOutTrimFilter) for f in fade.filters)
 
     def test_mostly_silent_tail_raises_for_fallback(self) -> None:
@@ -667,8 +671,10 @@ class TestSilenceAwareAnchoring:
             # 115 vs 120 BPM is within the stretch threshold, so the tempo ramp is active
             fade_in_analysis=_analysis(bpm=115.0, duration=duration),
         )
-        fade._build(_seconds(45), _seconds(45), PCM_FORMAT)
+        fade._build(_seconds(45), _seconds(45), PCM)
         assert fade.timing_info.crossfade_duration <= fade.effective_end + 1e-6
+        # the capped crossfade consumes the whole audible tail, so the stretch is skipped
+        assert not any(isinstance(f, GradualTimeStretchFilter) for f in fade.filters)
         for stretch_filter in fade.filters:
             if isinstance(stretch_filter, GradualTimeStretchFilter):
                 assert all(ts >= 0 for ts, _ in stretch_filter.tempo_steps)

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -701,6 +701,13 @@ class TestStretchSavings:
         fade._build(_seconds(45), _seconds(45), PCM)
         return fade
 
+    def _fadeout_sweep(self, fade: SmartCrossFade) -> FrequencySweepFilter:
+        return next(
+            f
+            for f in fade.filters
+            if isinstance(f, FrequencySweepFilter) and f.stream_type == "fadeout"
+        )
+
     def test_savings_until_integrates_piecewise(self) -> None:
         """_stretch_savings_until integrates savings piecewise over the step list."""
         fade = SmartCrossFade(
@@ -758,12 +765,55 @@ class TestStretchSavings:
     def test_sweep_schedule_ends_at_rendered_end(self) -> None:
         """Fade-out sweep schedule ends exactly at the rendered (output-time) tail end."""
         fade = self._stretched_fade()
-        sweep = next(
-            f
-            for f in fade.filters
-            if isinstance(f, FrequencySweepFilter) and f.stream_type == "fadeout"
-        )
+        sweep = self._fadeout_sweep(fade)
         rendered_end = fade.effective_end - fade._stretch_savings_until(fade.effective_end)
+        assert sweep.start_time + sweep.duration == pytest.approx(rendered_end, abs=0.05)
+
+    def test_sweep_start_is_remapped_to_output_time(self) -> None:
+        """The sweep start itself shifts left by the savings at its input-time position."""
+        # The standard fixture cannot pin the start remap: its EQ window begins
+        # before the stretch window, so the shift there is zero. A short (6-bar)
+        # crossfade — high BPM plus late fade-in downbeats — pushes the EQ start
+        # inside the stretch window where the remap actually binds.
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(bpm=230.0, duration=240.0),
+            fade_in_analysis=_analysis(bpm=239.2, beats_start=38.0, duration=240.0),
+        )
+        fade._build(_seconds(45), _seconds(45), PCM)
+        assert fade.tempo_steps, "test requires the stretch to be active"
+        sweep = self._fadeout_sweep(fade)
+        timing = fade.timing_info
+        input_duration = min(max(timing.crossfade_duration * 2.5, 8.0), fade.effective_end)
+        input_start = max(0.0, fade.effective_end - input_duration)
+        start_shift = fade._stretch_savings_until(input_start)
+        assert start_shift > 0.0, "fixture must place the EQ start inside the stretch window"
+        assert sweep.start_time == pytest.approx(input_start - start_shift, abs=1e-9)
+        rendered_end = fade.effective_end - fade._stretch_savings_until(fade.effective_end)
+        assert sweep.start_time + sweep.duration == pytest.approx(rendered_end, abs=0.05)
+
+    def test_trim_and_stretch_combined(self) -> None:
+        """A trimmed silent tail and an active stretch compose: both anchor on the rendered end."""
+        duration = 240.0
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(
+                bpm=120.0,
+                duration=duration,
+                rms_energy=_rms_with_silent_tail(duration, 10.0),
+            ),
+            fade_in_analysis=_analysis(bpm=124.8, duration=duration),
+        )
+        fade._build(_seconds(45), _seconds(45), PCM)
+        # tail trim must come first so every later schedule sees the trimmed stream
+        assert isinstance(fade.filters[0], FadeOutTrimFilter)
+        assert fade.tempo_steps, "test requires the stretch to be active"
+        rendered_end = fade.effective_end - fade._stretch_savings_until(fade.effective_end)
+        timing = fade.timing_info
+        assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(
+            rendered_end, abs=0.05
+        )
+        sweep = self._fadeout_sweep(fade)
         assert sweep.start_time + sweep.duration == pytest.approx(rendered_end, abs=0.05)
 
     def test_unstretched_fade_has_zero_savings(self) -> None:

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -35,6 +35,7 @@ from music_assistant.controllers.streams.smart_fades.fades import (
 from music_assistant.controllers.streams.smart_fades.filters import (
     CrossfadeFilter,
     FadeOutTrimFilter,
+    FrequencySweepFilter,
     GradualTimeStretchFilter,
 )
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
@@ -378,12 +379,16 @@ class TestMixerBuild:
         assert timing.fadein_trimmed_duration > 0
         assert timing.crossfade_duration > 0
         # Invariants the flow loop depends on:
-        #   PRE + CF == fade_out_seconds  (A's audio fully accounted for)
-        #   TRIM + CF + POST == fade_in_seconds  (B's audio fully accounted for)
-        fade_out_seconds = float(SMART_CROSSFADE_DURATION)
+        #   PRE + CF == rendered_fade_out_seconds  (A's audio fully accounted for)
+        #   TRIM + CF + POST == fade_in_seconds    (B's audio fully accounted for)
+        # When time-stretch is active, rendered_fade_out_seconds < buffer_duration because
+        # rubberband compresses the tail; savings are computed via _stretch_savings_until.
+        rendered_fade_out_seconds = fade.effective_end - fade._stretch_savings_until(
+            fade.effective_end
+        )
         fade_in_seconds = float(SMART_CROSSFADE_DURATION)
         assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(
-            fade_out_seconds, abs=0.01
+            rendered_fade_out_seconds, abs=0.05
         )
         assert (
             timing.fadein_trimmed_duration
@@ -675,6 +680,73 @@ class TestSilenceAwareAnchoring:
         assert fade.timing_info.crossfade_duration <= fade.effective_end + 1e-6
         # the capped crossfade consumes the whole audible tail, so the stretch is skipped
         assert not any(isinstance(f, GradualTimeStretchFilter) for f in fade.filters)
-        for stretch_filter in fade.filters:
-            if isinstance(stretch_filter, GradualTimeStretchFilter):
-                assert all(ts >= 0 for ts, _ in stretch_filter.tempo_steps)
+
+
+# ---------------------------------------------------------------------------
+# SmartCrossFade — rubberband stretch savings compensation
+# ---------------------------------------------------------------------------
+
+
+class TestStretchSavings:
+    """Rendered-time savings from the stretch must reach timing and the sweep."""
+
+    def _stretched_fade(self) -> SmartCrossFade:
+        duration = 240.0
+        # 4% BPM difference with >4 bars available -> stretch is applied
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(bpm=120.0, duration=duration),
+            fade_in_analysis=_analysis(bpm=124.8, duration=duration),
+        )
+        fade._build(_seconds(45), _seconds(45), PCM)
+        return fade
+
+    def test_savings_until_integrates_piecewise(self) -> None:
+        """_stretch_savings_until integrates savings piecewise over the step list."""
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(bpm=120.0),
+            fade_in_analysis=_analysis(bpm=120.0),
+        )
+        fade.tempo_steps = [(35.0, 1.0), (40.0, 1.05)]
+        assert fade._stretch_savings_until(35.0) == 0.0
+        assert fade._stretch_savings_until(40.0) == 0.0  # ratio 1.0 segment saves nothing
+        expected = 5.0 * (1.0 - 1.0 / 1.05)
+        assert fade._stretch_savings_until(45.0) == pytest.approx(expected)
+
+    def test_pre_plus_cf_equals_rendered_tail(self) -> None:
+        """PRE + CF equals the rendered tail duration (buffer minus stretch savings)."""
+        fade = self._stretched_fade()
+        assert fade.tempo_steps, "test requires the stretch to be active"
+        total_savings = fade._stretch_savings_until(fade.effective_end)
+        assert total_savings > 0.0
+        timing = fade.timing_info
+        assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(
+            fade.effective_end - total_savings, abs=0.05
+        )
+
+    def test_sweep_schedule_ends_at_rendered_end(self) -> None:
+        """Fade-out sweep schedule ends exactly at the rendered (output-time) tail end."""
+        fade = self._stretched_fade()
+        sweep = next(
+            f
+            for f in fade.filters
+            if isinstance(f, FrequencySweepFilter) and f.stream_type == "fadeout"
+        )
+        rendered_end = fade.effective_end - fade._stretch_savings_until(fade.effective_end)
+        assert sweep.start_time + sweep.duration == pytest.approx(rendered_end, abs=0.05)
+
+    def test_unstretched_fade_has_zero_savings(self) -> None:
+        """Without a stretch, savings are zero and PRE + CF equals effective_end exactly."""
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(bpm=120.0, duration=240.0),
+            fade_in_analysis=_analysis(bpm=120.0, duration=240.0),
+        )
+        fade._build(_seconds(45), _seconds(45), PCM)
+        assert fade.tempo_steps == []
+        assert fade._stretch_savings_until(fade.effective_end) == 0.0
+        timing = fade.timing_info
+        assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(
+            fade.effective_end, abs=0.05
+        )

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -24,6 +24,7 @@ from music_assistant_models.enums import ContentType, MediaType, StreamType
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
+import music_assistant.controllers.streams.smart_fades.mixer as mixer_module
 from music_assistant.controllers.streams.smart_fades.fades import (
     CrossfadeTimingInfo,
     SmartCrossFade,
@@ -259,16 +260,23 @@ class TestMixerBuild:
     """build() resolves smart vs standard, primes filters, and returns a SmartFade."""
 
     @pytest.mark.asyncio
-    async def test_standard_mode_returns_standard_crossfade(self) -> None:
+    async def test_standard_mode_returns_standard_crossfade(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Standard mode always builds a StandardCrossFade with the configured duration."""
+
+        async def identity_strip(audio_data: bytes, **_kwargs: object) -> bytes:
+            return audio_data  # no stripping — test pure timing math
+
+        monkeypatch.setattr(mixer_module, "strip_silence", identity_strip)
         mixer = _make_mixer()
-        fade = await mixer.build(
+        fade, _mix_data = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
             standard_crossfade_duration=8,
             mode=SmartFadesMode.STANDARD_CROSSFADE,
-            fade_out_bytes_len=_seconds(20),
+            fade_out_data=b"\x00" * _seconds(20),
             fade_in_bytes_len=_seconds(20),
         )
         assert isinstance(fade, StandardCrossFade)
@@ -286,16 +294,19 @@ class TestMixerBuild:
         analysis_out = _analysis(120.0)
         analysis_in = _analysis(124.0, beats_start=0.4)
         mixer = _make_mixer({"out": analysis_out, "in": analysis_in})
-        fade = await mixer.build(
+        fade_out_data = b"\x00" * _seconds(SMART_CROSSFADE_DURATION)
+        fade, mix_data = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
             standard_crossfade_duration=10,
             mode=SmartFadesMode.SMART_CROSSFADE,
-            fade_out_bytes_len=_seconds(SMART_CROSSFADE_DURATION),
+            fade_out_data=fade_out_data,
             fade_in_bytes_len=_seconds(SMART_CROSSFADE_DURATION),
         )
         assert isinstance(fade, SmartCrossFade)
+        # smart path must not strip — beat coordinates map onto the full buffer
+        assert mix_data is fade_out_data
         timing = fade.timing_info
         # SmartCrossFade applies a beat-aligned trim, so TRIM is non-zero.
         assert timing.fadein_trimmed_duration > 0
@@ -316,16 +327,23 @@ class TestMixerBuild:
         )
 
     @pytest.mark.asyncio
-    async def test_smart_mode_falls_back_when_no_analysis(self) -> None:
+    async def test_smart_mode_falls_back_when_no_analysis(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """No audio analysis -> build() falls back to StandardCrossFade."""
+
+        async def identity_strip(audio_data: bytes, **_kwargs: object) -> bytes:
+            return audio_data  # no stripping — test pure timing math
+
+        monkeypatch.setattr(mixer_module, "strip_silence", identity_strip)
         mixer = _make_mixer()
-        fade = await mixer.build(
+        fade, _mix_data = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
             standard_crossfade_duration=10,
             mode=SmartFadesMode.SMART_CROSSFADE,
-            fade_out_bytes_len=_seconds(45),
+            fade_out_data=b"\x00" * _seconds(45),
             fade_in_bytes_len=_seconds(45),
         )
         assert isinstance(fade, StandardCrossFade)
@@ -336,33 +354,121 @@ class TestMixerBuild:
         assert timing.post_crossfade_duration == pytest.approx(35.0)
 
     @pytest.mark.asyncio
-    async def test_smart_mode_falls_back_when_analysis_missing_bpm(self) -> None:
+    async def test_smart_mode_falls_back_when_analysis_missing_bpm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Analysis present but missing bpm/beats -> falls back to standard."""
+
+        async def identity_strip(audio_data: bytes, **_kwargs: object) -> bytes:
+            return audio_data
+
+        monkeypatch.setattr(mixer_module, "strip_silence", identity_strip)
         incomplete = AudioAnalysisData(duration=180.0, bpm=None, beats=None)
         mixer = _make_mixer({"out": incomplete, "in": incomplete})
-        fade = await mixer.build(
+        fade, _mix_data = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
             standard_crossfade_duration=10,
             mode=SmartFadesMode.SMART_CROSSFADE,
-            fade_out_bytes_len=_seconds(30),
+            fade_out_data=b"\x00" * _seconds(30),
             fade_in_bytes_len=_seconds(30),
         )
         assert isinstance(fade, StandardCrossFade)
         assert fade.timing_info.fadein_trimmed_duration == 0.0
 
     @pytest.mark.asyncio
-    async def test_build_returns_fade_with_timing_info_readable(self) -> None:
+    async def test_build_returns_fade_with_timing_info_readable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """timing_info is queryable immediately after build() — no apply() needed."""
+
+        async def identity_strip(audio_data: bytes, **_kwargs: object) -> bytes:
+            return audio_data
+
+        monkeypatch.setattr(mixer_module, "strip_silence", identity_strip)
         mixer = _make_mixer()
-        fade = await mixer.build(
+        fade, _mix_data = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
             standard_crossfade_duration=10,
             mode=SmartFadesMode.STANDARD_CROSSFADE,
-            fade_out_bytes_len=_seconds(15),
+            fade_out_data=b"\x00" * _seconds(15),
             fade_in_bytes_len=_seconds(15),
         )
         assert isinstance(fade.timing_info, CrossfadeTimingInfo)
+
+    @pytest.mark.asyncio
+    async def test_standard_mode_strips_trailing_silence_before_timing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Timing must be computed from the stripped length, and the stripped bytes returned."""
+
+        async def fake_strip(
+            audio_data: bytes, *, reverse: bool = False, **_kwargs: object
+        ) -> bytes:
+            assert reverse is True
+            return audio_data[: -_seconds(3)]  # pretend 3s of trailing silence
+
+        monkeypatch.setattr(mixer_module, "strip_silence", fake_strip)
+        mixer = _make_mixer()
+        fade_out_data = b"\x00" * _seconds(45)
+        smart_fade, mix_data = await mixer.build(
+            fade_in_streamdetails=_streamdetails("b"),
+            fade_out_streamdetails=_streamdetails("a"),
+            pcm_format=PCM,
+            standard_crossfade_duration=10,
+            mode=SmartFadesMode.STANDARD_CROSSFADE,
+            fade_out_data=fade_out_data,
+            fade_in_bytes_len=_seconds(45),
+        )
+        assert isinstance(smart_fade, StandardCrossFade)
+        assert len(mix_data) == _seconds(42)
+        timing = smart_fade.timing_info
+        assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(42.0)
+
+    @pytest.mark.asyncio
+    async def test_smart_mode_returns_original_bytes_unstripped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The smart path must never strip — beat coordinates map onto the full buffer."""
+
+        async def fail_strip(*_args: object, **_kwargs: object) -> bytes:
+            raise AssertionError("strip_silence must not be called on the smart path")
+
+        monkeypatch.setattr(mixer_module, "strip_silence", fail_strip)
+        mixer = _make_mixer(analysis_for={"a": _analysis(bpm=120.0), "b": _analysis(bpm=120.0)})
+        fade_out_data = b"\x00" * _seconds(45)
+        smart_fade, mix_data = await mixer.build(
+            fade_in_streamdetails=_streamdetails("b"),
+            fade_out_streamdetails=_streamdetails("a"),
+            pcm_format=PCM,
+            standard_crossfade_duration=10,
+            mode=SmartFadesMode.SMART_CROSSFADE,
+            fade_out_data=fade_out_data,
+            fade_in_bytes_len=_seconds(45),
+        )
+        assert isinstance(smart_fade, SmartCrossFade)
+        assert mix_data is fade_out_data
+
+    @pytest.mark.asyncio
+    async def test_smart_fallback_to_standard_strips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Smart mode without analysis falls back to standard — which must strip."""
+
+        async def fake_strip(audio_data: bytes, **_kwargs: object) -> bytes:
+            return audio_data[: -_seconds(5)]
+
+        monkeypatch.setattr(mixer_module, "strip_silence", fake_strip)
+        mixer = _make_mixer(analysis_for={})  # no analysis available
+        smart_fade, mix_data = await mixer.build(
+            fade_in_streamdetails=_streamdetails("b"),
+            fade_out_streamdetails=_streamdetails("a"),
+            pcm_format=PCM,
+            standard_crossfade_duration=10,
+            mode=SmartFadesMode.SMART_CROSSFADE,
+            fade_out_data=b"\x00" * _seconds(45),
+            fade_in_bytes_len=_seconds(45),
+        )
+        assert isinstance(smart_fade, StandardCrossFade)
+        assert len(mix_data) == _seconds(40)

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -733,6 +733,21 @@ class TestStretchSavings:
         assert expected < 0.0
         assert fade._stretch_savings_until(45.0) == pytest.approx(expected)
 
+    def test_savings_counts_pre_step_span_at_first_ratio(self) -> None:
+        """The span before the first step runs at the first step's ratio, not 1.0."""
+        # rubberband is initialized at tempo_steps[0][1] from t=0, so a single
+        # step at ts>0 with ratio != 1 stretches the whole stream from the start
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(bpm=120.0),
+            fade_in_analysis=_analysis(bpm=120.0),
+        )
+        fade.tempo_steps = [(20.0, 1.004)]
+        assert fade._stretch_savings_until(45.0) == pytest.approx(
+            20.0 * (1.0 - 1.0 / 1.004) + 25.0 * (1.0 - 1.0 / 1.004)
+        )
+        assert fade._stretch_savings_until(10.0) == pytest.approx(10.0 * (1.0 - 1.0 / 1.004))
+
     def test_pre_plus_cf_equals_rendered_tail(self) -> None:
         """PRE + CF equals the rendered tail duration (buffer minus stretch savings)."""
         fade = self._stretched_fade()

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -31,6 +31,7 @@ from music_assistant.controllers.streams.smart_fades.fades import (
     SmartFade,
     StandardCrossFade,
 )
+from music_assistant.controllers.streams.smart_fades.filters import CrossfadeFilter
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 from music_assistant.controllers.streams.smart_fades.mixer import SmartFadesMixer
 from music_assistant.models.audio_analysis import AudioAnalysisData
@@ -189,6 +190,16 @@ class TestStandardCrossFadeBuild:
         assert timing.crossfade_duration == pytest.approx(3.0)
         assert timing.pre_crossfade_duration == pytest.approx(0.0)
         assert timing.post_crossfade_duration == pytest.approx(17.0)
+
+    def test_filter_duration_matches_clamped_timing(self) -> None:
+        """The acrossfade filter must use the clamped duration, not the configured one."""
+        fade = StandardCrossFade(logger=logging.getLogger(), crossfade_duration=10.0)
+        # only 6s of (stripped) fade-out audio available
+        fade._build(_seconds(6), _seconds(45), PCM)
+        assert fade.timing_info.crossfade_duration == pytest.approx(6.0)
+        crossfade_filter = fade.filters[0]
+        assert isinstance(crossfade_filter, CrossfadeFilter)
+        assert crossfade_filter.crossfade_duration == pytest.approx(6.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -35,6 +35,7 @@ from music_assistant.controllers.streams.smart_fades.fades import (
 from music_assistant.controllers.streams.smart_fades.filters import (
     CrossfadeFilter,
     FadeOutTrimFilter,
+    GradualTimeStretchFilter,
 )
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 from music_assistant.controllers.streams.smart_fades.mixer import SmartFadesMixer
@@ -652,3 +653,22 @@ class TestSilenceAwareAnchoring:
         fade = self._build_fade(silent_tail=10.0)
         assert fade.fade_out_beats.min() >= 0.0
         assert fade.fade_out_beats.max() <= fade.effective_end + 0.01
+
+    def test_short_audible_tail_keeps_crossfade_inside_it(self) -> None:
+        """A crossfade longer than the audible tail is capped so no schedule goes negative."""
+        duration = 240.0
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(
+                bpm=120.0,
+                duration=duration,
+                rms_energy=_rms_with_silent_tail(duration, 33.0),
+            ),
+            # 115 vs 120 BPM is within the stretch threshold, so the tempo ramp is active
+            fade_in_analysis=_analysis(bpm=115.0, duration=duration),
+        )
+        fade._build(_seconds(45), _seconds(45), PCM_FORMAT)
+        assert fade.timing_info.crossfade_duration <= fade.effective_end + 1e-6
+        for stretch_filter in fade.filters:
+            if isinstance(stretch_filter, GradualTimeStretchFilter):
+                assert all(ts >= 0 for ts, _ in stretch_filter.tempo_steps)

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -337,7 +337,7 @@ class TestMixerBuild:
 
         monkeypatch.setattr(mixer_module, "strip_silence", identity_strip)
         mixer = _make_mixer()
-        fade, _mix_data = await mixer.build(
+        fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
@@ -362,7 +362,7 @@ class TestMixerBuild:
         analysis_in = _analysis(124.0, beats_start=0.4)
         mixer = _make_mixer({"out": analysis_out, "in": analysis_in})
         fade_out_data = b"\x00" * _seconds(SMART_CROSSFADE_DURATION)
-        fade, mix_data = await mixer.build(
+        fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
@@ -372,8 +372,6 @@ class TestMixerBuild:
             fade_in_bytes_len=_seconds(SMART_CROSSFADE_DURATION),
         )
         assert isinstance(fade, SmartCrossFade)
-        # smart path must not strip — beat coordinates map onto the full buffer
-        assert mix_data is fade_out_data
         timing = fade.timing_info
         # SmartCrossFade applies a beat-aligned trim, so TRIM is non-zero.
         assert timing.fadein_trimmed_duration > 0
@@ -408,7 +406,7 @@ class TestMixerBuild:
 
         monkeypatch.setattr(mixer_module, "strip_silence", identity_strip)
         mixer = _make_mixer()
-        fade, _mix_data = await mixer.build(
+        fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
@@ -436,7 +434,7 @@ class TestMixerBuild:
         monkeypatch.setattr(mixer_module, "strip_silence", identity_strip)
         incomplete = AudioAnalysisData(duration=180.0, bpm=None, beats=None)
         mixer = _make_mixer({"out": incomplete, "in": incomplete})
-        fade, _mix_data = await mixer.build(
+        fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
@@ -459,7 +457,7 @@ class TestMixerBuild:
 
         monkeypatch.setattr(mixer_module, "strip_silence", identity_strip)
         mixer = _make_mixer()
-        fade, _mix_data = await mixer.build(
+        fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("in"),
             fade_out_streamdetails=_streamdetails("out"),
             pcm_format=PCM,
@@ -474,7 +472,7 @@ class TestMixerBuild:
     async def test_standard_mode_strips_trailing_silence_before_timing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Timing must be computed from the stripped length, and the stripped bytes returned."""
+        """Timing must be computed from the stripped length; the plan is stored on the fade."""
 
         async def fake_strip(
             audio_data: bytes, *, reverse: bool = False, **_kwargs: object
@@ -485,7 +483,7 @@ class TestMixerBuild:
         monkeypatch.setattr(mixer_module, "strip_silence", fake_strip)
         mixer = _make_mixer()
         fade_out_data = b"\x00" * _seconds(45)
-        smart_fade, mix_data = await mixer.build(
+        smart_fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("b"),
             fade_out_streamdetails=_streamdetails("a"),
             pcm_format=PCM,
@@ -495,15 +493,13 @@ class TestMixerBuild:
             fade_in_bytes_len=_seconds(45),
         )
         assert isinstance(smart_fade, StandardCrossFade)
-        assert len(mix_data) == _seconds(42)
+        assert smart_fade.trailing_silence_bytes == _seconds(3)
         timing = smart_fade.timing_info
         assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(42.0)
 
     @pytest.mark.asyncio
-    async def test_smart_mode_returns_original_bytes_unstripped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The smart path must never strip — beat coordinates map onto the full buffer."""
+    async def test_smart_mode_never_measures_silence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The smart path must never call strip_silence — beat coordinates map onto the full buffer."""
 
         async def fail_strip(*_args: object, **_kwargs: object) -> bytes:
             raise AssertionError("strip_silence must not be called on the smart path")
@@ -511,7 +507,7 @@ class TestMixerBuild:
         monkeypatch.setattr(mixer_module, "strip_silence", fail_strip)
         mixer = _make_mixer(analysis_for={"a": _analysis(bpm=120.0), "b": _analysis(bpm=120.0)})
         fade_out_data = b"\x00" * _seconds(45)
-        smart_fade, mix_data = await mixer.build(
+        smart_fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("b"),
             fade_out_streamdetails=_streamdetails("a"),
             pcm_format=PCM,
@@ -521,18 +517,17 @@ class TestMixerBuild:
             fade_in_bytes_len=_seconds(45),
         )
         assert isinstance(smart_fade, SmartCrossFade)
-        assert mix_data is fade_out_data
 
     @pytest.mark.asyncio
     async def test_smart_fallback_to_standard_strips(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Smart mode without analysis falls back to standard — which must strip."""
+        """Smart mode without analysis falls back to standard — which must measure silence."""
 
         async def fake_strip(audio_data: bytes, **_kwargs: object) -> bytes:
             return audio_data[: -_seconds(5)]
 
         monkeypatch.setattr(mixer_module, "strip_silence", fake_strip)
         mixer = _make_mixer(analysis_for={})  # no analysis available
-        smart_fade, mix_data = await mixer.build(
+        smart_fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("b"),
             fade_out_streamdetails=_streamdetails("a"),
             pcm_format=PCM,
@@ -542,18 +537,18 @@ class TestMixerBuild:
             fade_in_bytes_len=_seconds(45),
         )
         assert isinstance(smart_fade, StandardCrossFade)
-        assert len(mix_data) == _seconds(40)
+        assert smart_fade.trailing_silence_bytes == _seconds(5)
 
     @pytest.mark.asyncio
     async def test_standard_mode_fully_silent_tail(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A fully silent tail strips to nothing — timing collapses to zero, mix input is empty."""
+        """A fully silent tail — timing collapses to zero; trailing_silence_bytes is the full input."""
 
         async def fake_strip(_audio_data: bytes, **_kwargs: object) -> bytes:
             return b""
 
         monkeypatch.setattr(mixer_module, "strip_silence", fake_strip)
         mixer = _make_mixer()
-        smart_fade, mix_data = await mixer.build(
+        smart_fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("b"),
             fade_out_streamdetails=_streamdetails("a"),
             pcm_format=PCM,
@@ -563,16 +558,16 @@ class TestMixerBuild:
             fade_in_bytes_len=_seconds(45),
         )
         assert isinstance(smart_fade, StandardCrossFade)
-        assert mix_data == b""
+        assert smart_fade.trailing_silence_bytes == _seconds(45)
         timing = smart_fade.timing_info
         assert timing.pre_crossfade_duration == 0.0
         assert timing.crossfade_duration == 0.0
 
     @pytest.mark.asyncio
-    async def test_standard_mode_strip_failure_keeps_unstripped_bytes(
+    async def test_standard_mode_measurement_failure_degrades_gracefully(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A strip_silence failure must not propagate — build degrades to the unstripped tail."""
+        """A strip_silence failure must not propagate — build degrades with trailing_silence_bytes=0."""
 
         async def broken_strip(*_args: object, **_kwargs: object) -> bytes:
             raise OSError("ffmpeg spawn failed")
@@ -580,7 +575,7 @@ class TestMixerBuild:
         monkeypatch.setattr(mixer_module, "strip_silence", broken_strip)
         mixer = _make_mixer()
         fade_out_data = b"\x00" * _seconds(45)
-        smart_fade, mix_data = await mixer.build(
+        smart_fade = await mixer.build(
             fade_in_streamdetails=_streamdetails("b"),
             fade_out_streamdetails=_streamdetails("a"),
             pcm_format=PCM,
@@ -590,9 +585,61 @@ class TestMixerBuild:
             fade_in_bytes_len=_seconds(45),
         )
         assert isinstance(smart_fade, StandardCrossFade)
-        assert mix_data is fade_out_data
+        assert smart_fade.trailing_silence_bytes == 0
         timing = smart_fade.timing_info
         assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(45.0)
+
+    @pytest.mark.asyncio
+    async def test_apply_executes_silence_trim_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """apply() must slice out trailing_silence_bytes before crossfading."""
+
+        async def fake_strip(audio_data: bytes, **_kwargs: object) -> bytes:
+            return audio_data[: -_seconds(3)]  # pretend 3s of trailing silence
+
+        monkeypatch.setattr(mixer_module, "strip_silence", fake_strip)
+
+        captured: dict[str, bytes] = {}
+
+        async def fake_base_apply(
+            _self: SmartFade,
+            fade_out_part: bytes,
+            _fade_in_part: bytes | AsyncGenerator[bytes],
+            _pcm_format: AudioFormat,
+        ) -> AsyncGenerator[bytes]:
+            captured["fade_out"] = fade_out_part
+            yield b"crossfade-output"
+
+        monkeypatch.setattr(SmartFade, "apply", fake_base_apply)
+
+        mixer = _make_mixer()
+        fade_out_data = b"\x00" * _seconds(45)
+        smart_fade = await mixer.build(
+            fade_in_streamdetails=_streamdetails("b"),
+            fade_out_streamdetails=_streamdetails("a"),
+            pcm_format=PCM,
+            standard_crossfade_duration=10,
+            mode=SmartFadesMode.STANDARD_CROSSFADE,
+            fade_out_data=fade_out_data,
+            fade_in_bytes_len=_seconds(45),
+        )
+        assert isinstance(smart_fade, StandardCrossFade)
+
+        # consume the generator to trigger apply(); chunks not inspected here
+        _ = [
+            chunk
+            async for chunk in smart_fade.apply(
+                fade_out_part=fade_out_data,
+                fade_in_part=b"\x00" * _seconds(45),
+                pcm_format=PCM,
+            )
+        ]
+
+        # The pre-crossfade slice (32s) plus the captured CF slice must equal 42s total.
+        # The CF is clamped to min(10, 42, 45) = 10s, so pre = 42 - 10 = 32s.
+        cf_size = _seconds(10)
+        assert len(captured["fade_out"]) == cf_size
+        total_pre_and_cf = _seconds(42)
+        assert _seconds(32) + cf_size == total_pre_and_cf
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -32,7 +32,10 @@ from music_assistant.controllers.streams.smart_fades.fades import (
     SmartFade,
     StandardCrossFade,
 )
-from music_assistant.controllers.streams.smart_fades.filters import CrossfadeFilter
+from music_assistant.controllers.streams.smart_fades.filters import (
+    CrossfadeFilter,
+    FadeOutTrimFilter,
+)
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 from music_assistant.controllers.streams.smart_fades.mixer import SmartFadesMixer
 from music_assistant.models.audio_analysis import AudioAnalysisData
@@ -82,16 +85,30 @@ def _beats(start: float, count: int, interval: float) -> np.ndarray:
     return np.arange(count, dtype=np.float32) * interval + start
 
 
-def _analysis(bpm: float, beats_start: float = 0.0, beats_count: int = 200) -> AudioAnalysisData:
+def _analysis(
+    bpm: float,
+    beats_start: float = 0.0,
+    beats_count: int = 200,
+    duration: float | None = None,
+    rms_energy: np.ndarray | None = None,
+) -> AudioAnalysisData:
     """Synthetic analysis data with enough beats for SmartCrossFade._build() to succeed."""
     interval = 60.0 / bpm  # seconds per beat
-    beats = _beats(beats_start, beats_count, interval)
+    # When an explicit duration is given, generate beats spanning the full track so the
+    # buffer-local shift (duration - 45s) leaves real beats inside the 45s window.
+    if duration is not None:
+        count = max(beats_count, int(duration / interval) + 1)
+        beats = _beats(beats_start, count, interval)
+    else:
+        beats = _beats(beats_start, beats_count, interval)
+        duration = float(beats[-1] + interval)
     downbeats = beats[::4]  # 4/4 time signature
     return AudioAnalysisData(
-        duration=beats[-1] + interval,
+        duration=duration,
         bpm=bpm,
         beats=beats,
         downbeats=downbeats,
+        rms_energy=rms_energy,
     )
 
 
@@ -570,3 +587,68 @@ class TestMixerBuild:
         assert mix_data is fade_out_data
         timing = smart_fade.timing_info
         assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(45.0)
+
+
+# ---------------------------------------------------------------------------
+# SmartCrossFade — silence-aware fade-out anchoring
+# ---------------------------------------------------------------------------
+
+LOGGER = logging.getLogger(__name__)
+
+PCM_FORMAT = PCM
+
+
+def _rms_with_silent_tail(track_duration: float, silent_tail: float) -> np.ndarray:
+    bins = np.full(1800, 0.5, dtype=np.float32)
+    bins[0] = 1.0
+    if silent_tail > 0:
+        bins[-int(silent_tail / track_duration * 1800) :] = 0.001
+    return bins
+
+
+class TestSilenceAwareAnchoring:
+    """SmartCrossFade must anchor the fade where audible content ends."""
+
+    def _build_fade(self, silent_tail: float) -> SmartCrossFade:
+        duration = 240.0
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(
+                bpm=120.0,
+                duration=duration,
+                rms_energy=_rms_with_silent_tail(duration, silent_tail),
+            ),
+            fade_in_analysis=_analysis(bpm=120.0, duration=duration),
+        )
+        fade._build(_seconds(45), _seconds(45), PCM_FORMAT)
+        return fade
+
+    def test_silent_tail_moves_the_anchor(self) -> None:
+        """A 10s silent tail shortens the audible anchor to ~35s and inserts FadeOutTrimFilter."""
+        fade = self._build_fade(silent_tail=10.0)
+        assert fade.effective_end == pytest.approx(35.0, abs=0.3)
+        # the rendered fade-out covers only the audible region
+        timing = fade.timing_info
+        assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(
+            fade.effective_end, abs=0.05
+        )
+        # tail trim is the FIRST filter so later schedules see the trimmed stream
+        assert isinstance(fade.filters[0], FadeOutTrimFilter)
+        assert fade.filters[0].fadeout_end_pos == pytest.approx(fade.effective_end)
+
+    def test_no_silence_keeps_buffer_end_anchor(self) -> None:
+        """Without silence, effective_end equals the full buffer and no trim filter is added."""
+        fade = self._build_fade(silent_tail=0.0)
+        assert fade.effective_end == pytest.approx(45.0, abs=0.3)
+        assert not any(isinstance(f, FadeOutTrimFilter) for f in fade.filters)
+
+    def test_mostly_silent_tail_raises_for_fallback(self) -> None:
+        """A tail with only ~5s of audible content raises ValueError so the caller falls back."""
+        with pytest.raises(ValueError, match="silent"):
+            self._build_fade(silent_tail=40.0)
+
+    def test_fadeout_beats_are_masked_to_effective_end(self) -> None:
+        """Beats in the silent tail are dropped so no downbeat sits beyond effective_end."""
+        fade = self._build_fade(silent_tail=10.0)
+        assert fade.fade_out_beats.min() >= 0.0
+        assert fade.fade_out_beats.max() <= fade.effective_end + 0.01

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -30,6 +30,7 @@ from music_assistant.controllers.streams.smart_fades.fades import (
     CrossfadeTimingInfo,
     SmartCrossFade,
     SmartFade,
+    SmartFadeNotApplicable,
     StandardCrossFade,
 )
 from music_assistant.controllers.streams.smart_fades.filters import (
@@ -256,6 +257,38 @@ class TestStandardCrossFadeApplySlicing:
         assert len(captured["fade_out"]) == _seconds(6)
         # nothing precedes the crossfade — the 6s buffer is consumed entirely by the overlap
         assert chunks[0] == crossfade_marker
+
+    @pytest.mark.asyncio
+    async def test_zero_crossfade_skips_ffmpeg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When crossfade_duration == 0, apply() must concatenate without calling ffmpeg."""
+        base_apply_invoked: list[bool] = []
+
+        async def _base_apply_sentinel(
+            _self: SmartFade,
+            _fade_out_part: bytes,
+            _fade_in_part: bytes | AsyncGenerator[bytes],
+            _pcm_format: AudioFormat,
+        ) -> AsyncGenerator[bytes]:
+            base_apply_invoked.append(True)
+            yield b""
+
+        monkeypatch.setattr(SmartFade, "apply", _base_apply_sentinel)
+
+        fade = StandardCrossFade(logger=logging.getLogger(), crossfade_duration=10.0)
+        # fade_out_bytes_len=0 → effective_cf = min(10, 0, 45) = 0 → crossfade_duration == 0
+        fade._build(0, _seconds(45), PCM)
+        assert fade.timing_info.crossfade_duration == 0.0
+
+        fade_out_data = b"\x00" * _seconds(5)
+        fade_in_data = b"\x11" * _seconds(5)
+        chunks = [chunk async for chunk in fade.apply(fade_out_data, fade_in_data, PCM)]
+        combined = b"".join(chunks)
+        assert len(combined) == _seconds(10), f"Expected {_seconds(10)} bytes, got {len(combined)}"
+        assert combined[0:1] == b"\x00", "fade_out bytes should come first"
+        assert combined[-1:] == b"\x11", "fade_in bytes should come last"
+        assert not base_apply_invoked, (
+            "SmartFade.apply (ffmpeg path) must not be called for zero-length crossfade"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -701,8 +734,8 @@ class TestSilenceAwareAnchoring:
         assert not any(isinstance(f, FadeOutTrimFilter) for f in fade.filters)
 
     def test_mostly_silent_tail_raises_for_fallback(self) -> None:
-        """A tail with only ~5s of audible content raises ValueError so the caller falls back."""
-        with pytest.raises(ValueError, match="silent"):
+        """A tail with only ~5s of audible content raises SmartFadeNotApplicable so the caller falls back."""
+        with pytest.raises(SmartFadeNotApplicable, match="silent"):
             self._build_fade(silent_tail=40.0)
 
     def test_partial_buffer_keeps_beats_aligned(self) -> None:

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -599,6 +599,7 @@ class TestMixerBuild:
         monkeypatch.setattr(mixer_module, "strip_silence", fake_strip)
 
         captured: dict[str, bytes] = {}
+        crossfade_marker = b"crossfade-output"
 
         async def fake_base_apply(
             _self: SmartFade,
@@ -607,7 +608,7 @@ class TestMixerBuild:
             _pcm_format: AudioFormat,
         ) -> AsyncGenerator[bytes]:
             captured["fade_out"] = fade_out_part
-            yield b"crossfade-output"
+            yield crossfade_marker
 
         monkeypatch.setattr(SmartFade, "apply", fake_base_apply)
 
@@ -624,8 +625,7 @@ class TestMixerBuild:
         )
         assert isinstance(smart_fade, StandardCrossFade)
 
-        # consume the generator to trigger apply(); chunks not inspected here
-        _ = [
+        chunks = [
             chunk
             async for chunk in smart_fade.apply(
                 fade_out_part=fade_out_data,
@@ -634,12 +634,13 @@ class TestMixerBuild:
             )
         ]
 
-        # The pre-crossfade slice (32s) plus the captured CF slice must equal 42s total.
-        # The CF is clamped to min(10, 42, 45) = 10s, so pre = 42 - 10 = 32s.
-        cf_size = _seconds(10)
-        assert len(captured["fade_out"]) == cf_size
-        total_pre_and_cf = _seconds(42)
-        assert _seconds(32) + cf_size == total_pre_and_cf
+        # The yielded pre-crossfade bytes are where the trim actually lands:
+        # 45s input - 3s measured silence - 10s clamped CF = 32s. Without the
+        # trim apply() would yield 35s here.
+        marker_idx = chunks.index(crossfade_marker)
+        pre_crossfade_bytes = sum(len(chunk) for chunk in chunks[:marker_idx])
+        assert pre_crossfade_bytes == _seconds(32)
+        assert len(captured["fade_out"]) == _seconds(10)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -705,6 +705,43 @@ class TestSilenceAwareAnchoring:
         with pytest.raises(ValueError, match="silent"):
             self._build_fade(silent_tail=40.0)
 
+    def test_partial_buffer_keeps_beats_aligned(self) -> None:
+        """
+        The live holdback buffer is rarely exactly 45s.
+
+        Beat coordinates must use the actual buffer length or every downbeat snap
+        is off by the difference.
+        """
+        duration = 240.0
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(bpm=120.0, duration=duration),
+            fade_in_analysis=_analysis(bpm=120.0, duration=duration),
+        )
+        # 44.3s buffer: 0.7s short of the constant, like a real partial final chunk
+        partial_bytes = int(PCM.pcm_sample_size * 44.3)
+        frame_size = (PCM.bit_depth // 8) * PCM.channels
+        partial_bytes = (partial_bytes // frame_size) * frame_size
+        fade._build(partial_bytes, _seconds(45), PCM)
+        buffer_duration = partial_bytes / PCM.pcm_sample_size
+        # beats are on a strict 0.5s grid from t=0 in the analysis fixture;
+        # in real buffer coordinates each beat must satisfy
+        # (beat + duration - buffer_duration) % 0.5 == 0
+        offset = duration - buffer_duration
+        for beat in fade.fade_out_beats[:8]:
+            track_pos = beat + offset
+            assert abs(track_pos % 0.5) < 1e-3 or abs(track_pos % 0.5 - 0.5) < 1e-3, (
+                f"beat {beat:.4f} maps to track_pos {track_pos:.4f}, "
+                f"not on 0.5s grid (offset={offset:.4f})"
+            )
+        # the snapped crossfade start must land on a real downbeat (2s grid), not 0.7s off
+        crossfade_start = fade.effective_end - fade.timing_info.crossfade_duration
+        start_track_pos = crossfade_start + offset
+        assert abs(start_track_pos % 2.0) < 0.02 or abs(start_track_pos % 2.0 - 2.0) < 0.02, (
+            f"crossfade start {crossfade_start:.4f} maps to track_pos {start_track_pos:.4f}, "
+            f"not on 2s downbeat grid (offset={offset:.4f})"
+        )
+
     def test_fadeout_beats_are_masked_to_effective_end(self) -> None:
         """Beats in the silent tail are dropped so no downbeat sits beyond effective_end."""
         fade = self._build_fade(silent_tail=10.0)

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -714,12 +714,42 @@ class TestStretchSavings:
         expected = 5.0 * (1.0 - 1.0 / 1.05)
         assert fade._stretch_savings_until(45.0) == pytest.approx(expected)
 
+    def test_savings_until_handles_slowdown(self) -> None:
+        """A ratio below 1.0 lengthens the rendered stream, so savings go negative."""
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(bpm=120.0),
+            fade_in_analysis=_analysis(bpm=120.0),
+        )
+        fade.tempo_steps = [(35.0, 1.0), (40.0, 0.95)]
+        expected = 5.0 * (1.0 - 1.0 / 0.95)
+        assert expected < 0.0
+        assert fade._stretch_savings_until(45.0) == pytest.approx(expected)
+
     def test_pre_plus_cf_equals_rendered_tail(self) -> None:
         """PRE + CF equals the rendered tail duration (buffer minus stretch savings)."""
         fade = self._stretched_fade()
         assert fade.tempo_steps, "test requires the stretch to be active"
         total_savings = fade._stretch_savings_until(fade.effective_end)
         assert total_savings > 0.0
+        timing = fade.timing_info
+        assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(
+            fade.effective_end - total_savings, abs=0.05
+        )
+
+    def test_pre_plus_cf_equals_rendered_tail_when_slowing_down(self) -> None:
+        """A slower incoming track lengthens the rendered tail — PRE + CF exceeds effective_end."""
+        duration = 240.0
+        # ~3.8% BPM difference downwards -> stretch slows the outgoing track
+        fade = SmartCrossFade(
+            logger=LOGGER,
+            fade_out_analysis=_analysis(bpm=120.0, duration=duration),
+            fade_in_analysis=_analysis(bpm=115.4, duration=duration),
+        )
+        fade._build(_seconds(45), _seconds(45), PCM)
+        assert fade.tempo_steps, "test requires the stretch to be active"
+        total_savings = fade._stretch_savings_until(fade.effective_end)
+        assert total_savings < 0.0
         timing = fade.timing_info
         assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(
             fade.effective_end - total_savings, abs=0.05

--- a/tests/core/test_smartfade_transition_timings.py
+++ b/tests/core/test_smartfade_transition_timings.py
@@ -16,6 +16,7 @@ timing in its ``_build``. Smart/standard end-to-end behavior is exercised throug
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -200,6 +201,42 @@ class TestStandardCrossFadeBuild:
         crossfade_filter = fade.filters[0]
         assert isinstance(crossfade_filter, CrossfadeFilter)
         assert crossfade_filter.crossfade_duration == pytest.approx(6.0)
+
+
+# ---------------------------------------------------------------------------
+# StandardCrossFade.apply — byte slicing must follow the clamped timing
+# ---------------------------------------------------------------------------
+
+
+class TestStandardCrossFadeApplySlicing:
+    """apply() must slice the fade-out buffer by the clamped duration, not the configured one."""
+
+    @pytest.mark.asyncio
+    async def test_apply_slices_with_clamped_duration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 6s fade-out with a 10s configured CF must hand the base mixer all 6s, no more."""
+        captured: dict[str, bytes] = {}
+        crossfade_marker = b"crossfade-output"
+
+        async def fake_base_apply(
+            _self: SmartFade,
+            fade_out_part: bytes,
+            _fade_in_part: bytes | AsyncGenerator[bytes],
+            _pcm_format: AudioFormat,
+        ) -> AsyncGenerator[bytes]:
+            captured["fade_out"] = fade_out_part
+            yield crossfade_marker
+
+        monkeypatch.setattr(SmartFade, "apply", fake_base_apply)
+        fade = StandardCrossFade(logger=logging.getLogger(), crossfade_duration=10.0)
+        fade._build(_seconds(6), _seconds(45), PCM)
+        chunks = [
+            chunk async for chunk in fade.apply(b"\x00" * _seconds(6), b"\x00" * _seconds(45), PCM)
+        ]
+        assert len(captured["fade_out"]) == _seconds(6)
+        # nothing precedes the crossfade — the 6s buffer is consumed entirely by the overlap
+        assert chunks[0] == crossfade_marker
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Smart crossfades were blind to what is actually in the outgoing track's tail: a mastered fade-out or digital silence got "crossfaded" against dead air — a gap-like energy hole with beat alignment confidently extrapolated into silence. On top of that, two timing bugs made the track-change boundary land late: the standard crossfade stripped trailing silence *after* timing was computed, and rubberband time-stretching changes the rendered tail length without the timing math (or the EQ sweep schedule) knowing.

- Trailing silence is now *measured* in `mixer.build()` so `timing_info` reflects the audio that will actually be rendered (also covers the smart→standard fallback path); `apply()` executes the cut as a plain slice — build stays side-effect free and never touches audio bytes, and measurement failures degrade gracefully
- `StandardCrossFade`'s acrossfade filter and byte slicing now use the clamped crossfade duration, so short/stripped tails can't drift from `timing_info`
- New `detect_effective_audio_end()` finds where audible content ends from the stored RMS energy; `SmartCrossFade` anchors the whole fade there: silent tails are trimmed off the stream (`FadeOutTrimFilter`), beats in the silent region are masked out, and mostly-silent tails (<10s audible) fall back to a standard fade
- Crossfade duration is capped at the audible tail length; sub-half-second slack skips the trim and keeps the buffer-end anchor
- Rubberband stretch savings are compensated in `timing_info` and the fade-out EQ sweep schedule (post-rubberband filters run on output time — verified against real ffmpeg renders, timing now matches within ~20ms in both stretch directions); the tempo compensation only applies when the stretch actually runs
- `TrimFilter` renamed to `FadeInTrimFilter` for symmetry with the new `FadeOutTrimFilter`

Validated with A/B renders on real library tracks: 9 of the 10 reference pairs had 1–8s of dead tail that the fade previously blended into — silent outros are the common case, not the edge case.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

