### PR TITLE
Plex: fix bugs, remove dead code and reduce repetition

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -21,7 +21,6 @@ from music_assistant_models.config_entries import (
 from music_assistant_models.enums import (
     ConfigEntryType,
     ContentType,
-    ImageType,
     MediaType,
     ProviderFeature,
     StreamType,
@@ -38,13 +37,11 @@ from music_assistant_models.media_items import (
     AudioFormat,
     ItemMapping,
     MediaItem,
-    MediaItemImage,
     Playlist,
     ProviderMapping,
     RecommendationFolder,
     SearchResults,
     Track,
-    UniqueList,
 )
 from music_assistant_models.streamdetails import StreamDetails
 from plexapi.audio import Album as PlexAlbum
@@ -61,7 +58,44 @@ from music_assistant.helpers.auth import AuthenticationHelper
 from music_assistant.helpers.tags import async_parse_tags
 from music_assistant.helpers.util import parse_title_and_version
 from music_assistant.models.music_provider import MusicProvider
-from music_assistant.providers.plex.helpers import discover_local_servers, get_libraries
+from music_assistant.providers.plex.constants import (
+    AUTH_TOKEN_UNAUTH,
+    COLLECTION_ID_PREFIX,
+    CONF_ACTION_AUTH_LOCAL,
+    CONF_ACTION_AUTH_MYPLEX,
+    CONF_ACTION_CLEAR_AUTH,
+    CONF_ACTION_GDM,
+    CONF_ACTION_LIBRARY,
+    CONF_AUTH_TOKEN,
+    CONF_COLLECTION_PREFIX,
+    CONF_HUB_ITEMS_LIMIT,
+    CONF_IMPORT_COLLECTIONS,
+    CONF_LIBRARY_ID,
+    CONF_LOCAL_SERVER_IP,
+    CONF_LOCAL_SERVER_PORT,
+    CONF_LOCAL_SERVER_SSL,
+    CONF_LOCAL_SERVER_VERIFY_CERT,
+    CONF_PLEX_FAVORITE_THRESHOLD,
+    CONF_PLEX_LIKE_RATING,
+    CONF_PLEX_UNLIKE_RATING,
+    ERR_ARTIST_INVALID_ID,
+    ERR_ARTIST_NOT_FOUND,
+    ERR_AUTH_FAILED,
+    ERR_INVALID_CREDENTIALS,
+    ERR_ITEM_NOT_FOUND,
+    ERR_MYPLEX_AUTH_FAILED,
+    ERR_MYPLEX_TOKEN_NOT_RECEIVED,
+    ERR_NO_ARTIST_FOR_TRACK,
+    ERR_NO_LIBRARIES,
+    ERR_TRACK_NOT_FOUND,
+    FAKE_ARTIST_PREFIX,
+)
+from music_assistant.providers.plex.helpers import (
+    discover_local_servers,
+    get_favorite_from_rating,
+    get_libraries,
+    get_thumbnail_images,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable, Coroutine
@@ -75,29 +109,6 @@ if TYPE_CHECKING:
 
     from music_assistant.mass import MusicAssistant
     from music_assistant.models import ProviderInstanceType
-
-CONF_ACTION_AUTH_MYPLEX = "auth_myplex"
-CONF_ACTION_AUTH_LOCAL = "auth_local"
-CONF_ACTION_CLEAR_AUTH = "auth"
-CONF_ACTION_LIBRARY = "library"
-CONF_ACTION_GDM = "gdm"
-
-CONF_AUTH_TOKEN = "token"
-CONF_LIBRARY_ID = "library_id"
-CONF_LOCAL_SERVER_IP = "local_server_ip"
-CONF_LOCAL_SERVER_PORT = "local_server_port"
-CONF_LOCAL_SERVER_SSL = "local_server_ssl"
-CONF_LOCAL_SERVER_VERIFY_CERT = "local_server_verify_cert"
-CONF_IMPORT_COLLECTIONS = "import_collections"
-CONF_COLLECTION_PREFIX = "collection_prefix"
-CONF_PLEX_LIKE_RATING = "plex_like_rating"
-CONF_PLEX_FAVORITE_THRESHOLD = "plex_favorite_threshold"
-CONF_PLEX_UNLIKE_RATING = "plex_unlike_rating"
-CONF_HUB_ITEMS_LIMIT = "hub_items_limit"
-
-FAKE_ARTIST_PREFIX = "_fake://"
-
-AUTH_TOKEN_UNAUTH = "local_auth"
 
 SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_ARTISTS,
@@ -120,8 +131,7 @@ async def setup(
 ) -> ProviderInstanceType:
     """Initialize provider(instance) with given configuration."""
     if not config.get_value(CONF_AUTH_TOKEN):
-        msg = "Invalid login credentials"
-        raise LoginFailed(msg)
+        raise LoginFailed(ERR_INVALID_CREDENTIALS)
 
     return PlexProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
@@ -183,11 +193,9 @@ async def get_config_entries(  # noqa: PLR0915
                 await asyncio.sleep(0.1 * (2**attempt))
             else:
                 # token still not available
-                msg = "Authentication to MyPlex failed: token not received"
-                raise LoginFailed(msg)
+                raise LoginFailed(ERR_MYPLEX_TOKEN_NOT_RECEIVED)
             if not plex_auth.token:
-                msg = "Authentication to MyPlex failed"
-                raise LoginFailed(msg)
+                raise LoginFailed(ERR_MYPLEX_AUTH_FAILED)
             # set the retrieved token on the values object to pass along
             values[CONF_AUTH_TOKEN] = plex_auth.token
 
@@ -294,8 +302,7 @@ async def get_config_entries(  # noqa: PLR0915
                     instance_id,
                 )
             ):
-                msg = "Unable to retrieve Servers and/or Music Libraries"
-                raise LoginFailed(msg)
+                raise LoginFailed(ERR_NO_LIBRARIES)
             conf_libraries.options = [
                 # use the same value for both the value and the title
                 # until we find out what plex uses as stable identifiers
@@ -495,8 +502,7 @@ class PlexProvider(MusicProvider):
                             self.instance_id, CONF_AUTH_TOKEN
                         ),
                     )
-                    msg = "Authentication failed"
-                    raise LoginFailed(msg)
+                    raise LoginFailed(ERR_AUTH_FAILED)
                 raise LoginFailed from err
             return plex_server
 
@@ -536,8 +542,11 @@ class PlexProvider(MusicProvider):
         await self.get_myplex_account_and_refresh_token(str(self.config.get_value(CONF_AUTH_TOKEN)))
         return await asyncio.to_thread(call, *args, **kwargs)
 
-    async def _get_data(self, key: str, cls: type[PlexObjectT]) -> PlexObjectT:
-        results = await self._run_async(self._plex_library.fetchItem, key, cls)
+    async def _get_data(self, key: str, cls: type[PlexObjectT] | None = None) -> PlexObjectT:
+        try:
+            results = await self._run_async(self._plex_library.fetchItem, key, cls)
+        except plexapi.exceptions.NotFound as err:
+            raise MediaNotFoundError(ERR_ITEM_NOT_FOUND.format(item_id=key)) from err
         return cast("PlexObjectT", results)
 
     def _get_item_mapping(self, media_type: MediaType, key: str, name: str) -> ItemMapping:
@@ -602,7 +611,7 @@ class PlexProvider(MusicProvider):
             return await self._parse_playlist(plex_media)
         return None
 
-    async def _search_track(self, search_query: str | None, limit: int) -> list[PlexTrack]:
+    async def _search_track(self, search_query: str, limit: int) -> list[PlexTrack]:
         return cast(
             "list[PlexTrack]",
             await self._run_async(self._plex_library.searchTracks, title=search_query, limit=limit),
@@ -626,30 +635,6 @@ class PlexProvider(MusicProvider):
         return cast(
             "list[PlexPlaylist]",
             await self._run_async(self._plex_library.playlists, title=search_query, limit=limit),
-        )
-
-    async def _search_track_advanced(self, limit: int, **kwargs: Any) -> list[PlexTrack]:
-        return cast(
-            "list[PlexTrack]",
-            await self._run_async(self._plex_library.searchTracks, filters=kwargs, limit=limit),
-        )
-
-    async def _search_album_advanced(self, limit: int, **kwargs: Any) -> list[PlexAlbum]:
-        return cast(
-            "list[PlexAlbum]",
-            await self._run_async(self._plex_library.searchAlbums, filters=kwargs, limit=limit),
-        )
-
-    async def _search_artist_advanced(self, limit: int, **kwargs: Any) -> list[PlexArtist]:
-        return cast(
-            "list[PlexArtist]",
-            await self._run_async(self._plex_library.searchArtists, filters=kwargs, limit=limit),
-        )
-
-    async def _search_playlist_advanced(self, limit: int, **kwargs: Any) -> list[PlexPlaylist]:
-        return cast(
-            "list[PlexPlaylist]",
-            await self._run_async(self._plex_library.playlists, filters=kwargs, limit=limit),
         )
 
     async def _search_and_parse(
@@ -686,23 +671,13 @@ class PlexProvider(MusicProvider):
         )
         # Check if album rating meets the configured threshold for favorites
         favorite_threshold = cast("float", self.config.get_value(CONF_PLEX_FAVORITE_THRESHOLD))
-        # Try to get the user rating - Plex stores ratings as 0.0-10.0
-        if hasattr(plex_album, "userRating") and plex_album.userRating is not None:
-            album.favorite = float(plex_album.userRating) >= favorite_threshold
+        if (favorite := get_favorite_from_rating(plex_album, favorite_threshold)) is not None:
+            album.favorite = favorite
 
         if plex_album.year:
             album.year = plex_album.year
-        if thumb := plex_album.firstAttr("thumb", "parentThumb", "grandparentThumb"):
-            album.metadata.images = UniqueList(
-                [
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=thumb,
-                        provider=self.instance_id,
-                        remotely_accessible=False,
-                    )
-                ]
-            )
+        if images := get_thumbnail_images(plex_album, self.instance_id):
+            album.metadata.images = images
         if plex_album.summary:
             album.metadata.description = plex_album.summary
 
@@ -719,8 +694,7 @@ class PlexProvider(MusicProvider):
         """Parse a Plex Artist response to Artist model object."""
         artist_id = plex_artist.key
         if not artist_id:
-            msg = "Artist does not have a valid ID"
-            raise InvalidDataError(msg)
+            raise InvalidDataError(ERR_ARTIST_INVALID_ID)
         artist = Artist(
             item_id=artist_id,
             name=plex_artist.title or UNKNOWN_ARTIST,
@@ -736,17 +710,8 @@ class PlexProvider(MusicProvider):
         )
         if plex_artist.summary:
             artist.metadata.description = plex_artist.summary
-        if thumb := plex_artist.firstAttr("thumb", "parentThumb", "grandparentThumb"):
-            artist.metadata.images = UniqueList(
-                [
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=thumb,
-                        provider=self.instance_id,
-                        remotely_accessible=False,
-                    )
-                ]
-            )
+        if images := get_thumbnail_images(plex_artist, self.instance_id):
+            artist.metadata.images = images
         return artist
 
     async def _parse_playlist(self, plex_playlist: PlexPlaylist) -> Playlist:
@@ -766,17 +731,8 @@ class PlexProvider(MusicProvider):
         )
         if plex_playlist.summary:
             playlist.metadata.description = plex_playlist.summary
-        if thumb := plex_playlist.firstAttr("thumb", "parentThumb", "grandparentThumb"):
-            playlist.metadata.images = UniqueList(
-                [
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=thumb,
-                        provider=self.instance_id,
-                        remotely_accessible=False,
-                    )
-                ]
-            )
+        if images := get_thumbnail_images(plex_playlist, self.instance_id):
+            playlist.metadata.images = images
         playlist.is_editable = not plex_playlist.smart
         return playlist
 
@@ -787,44 +743,29 @@ class PlexProvider(MusicProvider):
 
         # Collections are imported as playlists with the configured prefix
         playlist = Playlist(
-            item_id=f"collection:{plex_collection.key}",
+            item_id=f"{COLLECTION_ID_PREFIX}{plex_collection.key}",
             provider=self.instance_id,
             name=f"{collection_prefix}{plex_collection.title}",
             provider_mappings={
                 ProviderMapping(
-                    item_id=f"collection:{plex_collection.key}",
+                    item_id=f"{COLLECTION_ID_PREFIX}{plex_collection.key}",
                     provider_domain=self.domain,
                     provider_instance=self.instance_id,
                 )
             },
         )
         # Add collection poster/thumbnail if available
-        if thumb := plex_collection.firstAttr("thumb", "composite"):
-            playlist.metadata.images = UniqueList(
-                [
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=thumb,
-                        provider=self.instance_id,
-                        remotely_accessible=False,
-                    )
-                ]
-            )
+        if images := get_thumbnail_images(
+            plex_collection, self.instance_id, ("thumb", "composite")
+        ):
+            playlist.metadata.images = images
         # Collections are not editable in Music Assistant
         playlist.is_editable = False
         return playlist
 
     async def _parse_track(self, plex_track: PlexTrack) -> Track:
         """Parse a Plex Track response to a Track model object."""
-        if plex_track.media:
-            available = True
-            content = plex_track.media[0].container
-        else:
-            # For Plex (local library provider), assume tracks are available by default
-            # even if media attribute is not populated in the initial response.
-            # This prevents tracks from being skipped during library sync.
-            available = True
-            content = None
+        content = plex_track.media[0].container if plex_track.media else None
         track = Track(
             item_id=plex_track.key,
             provider=self.instance_id,
@@ -834,7 +775,10 @@ class PlexProvider(MusicProvider):
                     item_id=plex_track.key,
                     provider_domain=self.domain,
                     provider_instance=self.instance_id,
-                    available=available,
+                    # For Plex (local library provider), assume tracks are available by default
+                    # even if media attribute is not populated in the initial response.
+                    # This prevents tracks from being skipped during library sync.
+                    available=True,
                     audio_format=AudioFormat(
                         content_type=(
                             ContentType.try_parse(content) if content else ContentType.UNKNOWN
@@ -848,9 +792,8 @@ class PlexProvider(MusicProvider):
         )
         # Check if track rating meets the configured threshold for favorites
         favorite_threshold = cast("float", self.config.get_value(CONF_PLEX_FAVORITE_THRESHOLD))
-        # Try to get the user rating - Plex stores ratings as 0.0-10.0
-        if hasattr(plex_track, "userRating") and plex_track.userRating is not None:
-            track.favorite = float(plex_track.userRating) >= favorite_threshold
+        if (favorite := get_favorite_from_rating(plex_track, favorite_threshold)) is not None:
+            track.favorite = favorite
 
         if plex_track.originalTitle and plex_track.originalTitle != plex_track.grandparentTitle:
             # The artist of the track if different from the album's artist.
@@ -868,28 +811,16 @@ class PlexProvider(MusicProvider):
                 )
             )
         else:
-            msg = "No artist was found for track"
-            raise InvalidDataError(msg)
+            raise InvalidDataError(ERR_NO_ARTIST_FOR_TRACK)
 
-        if thumb := plex_track.firstAttr("thumb", "parentThumb", "grandparentThumb"):
-            track.metadata.images = UniqueList(
-                [
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=thumb,
-                        provider=self.instance_id,
-                        remotely_accessible=False,
-                    )
-                ]
-            )
+        if images := get_thumbnail_images(plex_track, self.instance_id):
+            track.metadata.images = images
         if plex_track.parentKey:
             track.album = self._get_item_mapping(
                 MediaType.ALBUM, plex_track.parentKey, plex_track.parentTitle
             )
         if plex_track.duration:
             track.duration = int(plex_track.duration / 1000)
-        if plex_track.chapters:
-            pass  # TODO!
 
         return track
 
@@ -1004,10 +935,8 @@ class PlexProvider(MusicProvider):
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_album(self, prov_album_id: str) -> Album:
         """Get full album details by id."""
-        if plex_album := await self._get_data(prov_album_id, PlexAlbum):
-            return await self._parse_album(plex_album)
-        msg = f"Item {prov_album_id} not found"
-        raise MediaNotFoundError(msg)
+        plex_album = await self._get_data(prov_album_id, PlexAlbum)
+        return await self._parse_album(plex_album)
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
@@ -1031,41 +960,28 @@ class PlexProvider(MusicProvider):
                 prov_artist_id, self.instance_id
             ):
                 return db_artist
-            msg = f"Artist not found: {prov_artist_id}"
-            raise MediaNotFoundError(msg)
+            raise MediaNotFoundError(ERR_ARTIST_NOT_FOUND.format(item_id=prov_artist_id))
 
-        if plex_artist := await self._get_data(prov_artist_id, PlexArtist):
-            return await self._parse_artist(plex_artist)
-        msg = f"Item {prov_artist_id} not found"
-        raise MediaNotFoundError(msg)
+        plex_artist = await self._get_data(prov_artist_id, PlexArtist)
+        return await self._parse_artist(plex_artist)
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_track(self, prov_track_id: str) -> Track:
         """Get full track details by id."""
-        if plex_track := await self._get_data(prov_track_id, PlexTrack):
-            return await self._parse_track(plex_track)
-        msg = f"Item {prov_track_id} not found"
-        raise MediaNotFoundError(msg)
+        plex_track = await self._get_data(prov_track_id, PlexTrack)
+        return await self._parse_track(plex_track)
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
         """Get full playlist details by id."""
         # Check if this is a collection (collections have the format "collection:<key>")
-        if prov_playlist_id.startswith("collection:"):
-            # Extract the collection key
-            collection_key = prov_playlist_id.replace("collection:", "")
-            # Fetch the collection
-            if plex_collection := await self._run_async(
-                self._plex_library.fetchItem, collection_key
-            ):
-                return await self._parse_collection(plex_collection)
-            msg = f"Collection {prov_playlist_id} not found"
-            raise MediaNotFoundError(msg)
+        if prov_playlist_id.startswith(COLLECTION_ID_PREFIX):
+            collection_key = prov_playlist_id.removeprefix(COLLECTION_ID_PREFIX)
+            plex_collection: PlexObject = await self._get_data(collection_key)
+            return await self._parse_collection(plex_collection)
 
-        if plex_playlist := await self._get_data(prov_playlist_id, PlexPlaylist):
-            return await self._parse_playlist(plex_playlist)
-        msg = f"Item {prov_playlist_id} not found"
-        raise MediaNotFoundError(msg)
+        plex_playlist = await self._get_data(prov_playlist_id, PlexPlaylist)
+        return await self._parse_playlist(plex_playlist)
 
     @use_cache(3600 * 3)  # Cache for 3 hours
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
@@ -1076,14 +992,9 @@ class PlexProvider(MusicProvider):
             return []
 
         # Check if this is a collection (collections have the format "collection:<key>")
-        if prov_playlist_id.startswith("collection:"):
-            # Extract the collection key
-            collection_key = prov_playlist_id.replace("collection:", "")
-            # Fetch the collection
-            plex_collection = await self._run_async(self._plex_library.fetchItem, collection_key)
-            if not plex_collection:
-                msg = f"Collection {prov_playlist_id} not found"
-                raise MediaNotFoundError(msg)
+        if prov_playlist_id.startswith(COLLECTION_ID_PREFIX):
+            collection_key = prov_playlist_id.removeprefix(COLLECTION_ID_PREFIX)
+            plex_collection: PlexObject = await self._get_data(collection_key)
             if not (collection_items := await self._run_async(plex_collection.items)):
                 return result
             # Collections can contain tracks, albums, or artists - we only want tracks
@@ -1221,17 +1132,7 @@ class PlexProvider(MusicProvider):
                             )
                             continue
 
-                        # Parse item based on its type
-                        if item.type == "track":
-                            folder.items.append(await self._parse_track(item))
-                        elif item.type == "album":
-                            folder.items.append(await self._parse_album(item))
-                        elif item.type == "artist":
-                            folder.items.append(await self._parse_artist(item))
-                        elif item.type == "playlist":
-                            folder.items.append(await self._parse_playlist(item))
-                        # Try to parse other types generically
-                        elif parsed_item := await self._parse(item):
+                        if parsed_item := await self._parse(item):
                             folder.items.append(parsed_item)  # type: ignore[arg-type]
                         else:
                             self.logger.debug(
@@ -1274,9 +1175,8 @@ class PlexProvider(MusicProvider):
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Get streamdetails for a track."""
         plex_track = await self._get_data(item_id, PlexTrack)
-        if not plex_track or not plex_track.media:
-            msg = f"track {item_id} not found"
-            raise MediaNotFoundError(msg)
+        if not plex_track.media:
+            raise MediaNotFoundError(ERR_TRACK_NOT_FOUND.format(item_id=item_id))
 
         media: PlexMedia = plex_track.media[0]
 
@@ -1295,7 +1195,8 @@ class PlexProvider(MusicProvider):
                 channels=media.audioChannels,
             ),
             stream_type=StreamType.HTTP,
-            duration=plex_track.duration,
+            # plex reports duration in milliseconds, streamdetails expect seconds
+            duration=int(plex_track.duration / 1000) if plex_track.duration else None,
             data=plex_track,
             can_seek=True,
             allow_seek=True,
@@ -1344,20 +1245,16 @@ class PlexProvider(MusicProvider):
             rating = cast("float", self.config.get_value(CONF_PLEX_UNLIKE_RATING))
 
         if media_type == MediaType.TRACK:
-            plex_track = await self._get_data(prov_item_id, PlexTrack)
-            await self._run_async(plex_track.rate, rating)
-            self.logger.debug(
-                "Set Plex rating to %s for track with ID %s (ratingKey: %s)",
-                rating,
-                prov_item_id,
-                plex_track.ratingKey,
-            )
+            plex_item: PlexTrack | PlexAlbum = await self._get_data(prov_item_id, PlexTrack)
         elif media_type == MediaType.ALBUM:
-            plex_album = await self._get_data(prov_item_id, PlexAlbum)
-            await self._run_async(plex_album.rate, rating)
-            self.logger.debug(
-                "Set Plex rating to %s for album with ID %s (ratingKey: %s)",
-                rating,
-                prov_item_id,
-                plex_album.ratingKey,
-            )
+            plex_item = await self._get_data(prov_item_id, PlexAlbum)
+        else:
+            return
+        await self._run_async(plex_item.rate, rating)
+        self.logger.debug(
+            "Set Plex rating to %s for %s with ID %s (ratingKey: %s)",
+            rating,
+            media_type.value,
+            prov_item_id,
+            plex_item.ratingKey,
+        )

--- a/music_assistant/providers/plex/constants.py
+++ b/music_assistant/providers/plex/constants.py
@@ -1,0 +1,42 @@
+"""Constants for the Plex Music Provider."""
+
+from __future__ import annotations
+
+CONF_ACTION_AUTH_MYPLEX = "auth_myplex"
+CONF_ACTION_AUTH_LOCAL = "auth_local"
+CONF_ACTION_CLEAR_AUTH = "auth"
+CONF_ACTION_LIBRARY = "library"
+CONF_ACTION_GDM = "gdm"
+
+CONF_AUTH_TOKEN = "token"
+CONF_LIBRARY_ID = "library_id"
+CONF_LOCAL_SERVER_IP = "local_server_ip"
+CONF_LOCAL_SERVER_PORT = "local_server_port"
+CONF_LOCAL_SERVER_SSL = "local_server_ssl"
+CONF_LOCAL_SERVER_VERIFY_CERT = "local_server_verify_cert"
+CONF_IMPORT_COLLECTIONS = "import_collections"
+CONF_COLLECTION_PREFIX = "collection_prefix"
+CONF_PLEX_LIKE_RATING = "plex_like_rating"
+CONF_PLEX_FAVORITE_THRESHOLD = "plex_favorite_threshold"
+CONF_PLEX_UNLIKE_RATING = "plex_unlike_rating"
+CONF_HUB_ITEMS_LIMIT = "hub_items_limit"
+
+FAKE_ARTIST_PREFIX = "_fake://"
+
+# sentinel token value for local (unauthenticated) connections, not via plex.tv
+AUTH_TOKEN_UNAUTH = "local_auth"
+
+# item_id prefix used for Plex collections imported as playlists
+COLLECTION_ID_PREFIX = "collection:"
+
+# error messages (templates use str.format)
+ERR_INVALID_CREDENTIALS = "Invalid login credentials"
+ERR_AUTH_FAILED = "Authentication failed"
+ERR_MYPLEX_AUTH_FAILED = "Authentication to MyPlex failed"
+ERR_MYPLEX_TOKEN_NOT_RECEIVED = "Authentication to MyPlex failed: token not received"
+ERR_NO_LIBRARIES = "Unable to retrieve Servers and/or Music Libraries"
+ERR_ITEM_NOT_FOUND = "Item {item_id} not found"
+ERR_ARTIST_NOT_FOUND = "Artist not found: {item_id}"
+ERR_TRACK_NOT_FOUND = "Track {item_id} not found"
+ERR_ARTIST_INVALID_ID = "Artist does not have a valid ID"
+ERR_NO_ARTIST_FOR_TRACK = "No artist was found for track"

--- a/music_assistant/providers/plex/helpers.py
+++ b/music_assistant/providers/plex/helpers.py
@@ -6,12 +6,18 @@ import asyncio
 from typing import TYPE_CHECKING, cast
 
 import requests
+from music_assistant_models.enums import ImageType
+from music_assistant_models.media_items import MediaItemImage, UniqueList
 from plexapi.gdm import GDM
 from plexapi.library import LibrarySection as PlexLibrarySection
 from plexapi.library import MusicSection as PlexMusicSection
 from plexapi.server import PlexServer
 
+from music_assistant.providers.plex.constants import AUTH_TOKEN_UNAUTH
+
 if TYPE_CHECKING:
+    from plexapi.base import PlexObject
+
     from music_assistant.mass import MusicAssistant
 
 
@@ -38,6 +44,7 @@ async def get_libraries(
     :param instance_id: Provider instance ID to use for cache isolation.
     """
     cache_key = "plex_libraries"
+    cache_provider = instance_id or local_server_ip
 
     def _get_libraries() -> list[str]:
         # create a listing of available music libraries on all servers
@@ -45,17 +52,12 @@ async def get_libraries(
         session = requests.Session()
         session.verify = local_server_verify_cert
         local_server_protocol = "https" if local_server_ssl else "http"
-        plex_server: PlexServer
-        if auth_token is None:
-            plex_server = PlexServer(
-                f"{local_server_protocol}://{local_server_ip}:{local_server_port}"
-            )
+        plex_url = f"{local_server_protocol}://{local_server_ip}:{local_server_port}"
+        if not auth_token or auth_token == AUTH_TOKEN_UNAUTH:
+            # local (unauthenticated) connection, not via plex.tv
+            plex_server = PlexServer(plex_url, session=session)
         else:
-            plex_server = PlexServer(
-                f"{local_server_protocol}://{local_server_ip}:{local_server_port}",
-                auth_token,
-                session=session,
-            )
+            plex_server = PlexServer(plex_url, auth_token, session=session)
         for media_section in cast("list[PlexLibrarySection]", plex_server.library.sections()):
             if media_section.type != PlexMusicSection.TYPE:
                 continue
@@ -63,9 +65,7 @@ async def get_libraries(
             all_libraries.append(f"{plex_server.friendlyName} / {media_section.title}")
         return all_libraries
 
-    if cache := await mass.cache.get(
-        cache_key, checksum=auth_token, provider=instance_id or local_server_ip
-    ):
+    if cache := await mass.cache.get(cache_key, checksum=auth_token, provider=cache_provider):
         return cast("list[str]", cache)
 
     result = await asyncio.to_thread(_get_libraries)
@@ -75,7 +75,7 @@ async def get_libraries(
         result,
         checksum=auth_token,
         expiration=3600,
-        provider=instance_id or "default",
+        provider=cache_provider,
     )
     return result
 
@@ -95,3 +95,44 @@ async def discover_local_servers() -> tuple[str, int] | tuple[None, None]:
         return None, None
 
     return await asyncio.to_thread(_discover_local_servers)
+
+
+def get_thumbnail_images(
+    plex_media: PlexObject,
+    provider_instance_id: str,
+    attrs: tuple[str, ...] = ("thumb", "parentThumb", "grandparentThumb"),
+) -> UniqueList[MediaItemImage] | None:
+    """
+    Get the thumbnail of a Plex object as MA image list, if available.
+
+    :param plex_media: The Plex object to extract the thumbnail from.
+    :param provider_instance_id: The provider instance id to set on the image.
+    :param attrs: Plex attributes to check (in order) for a thumbnail.
+    """
+    if thumb := plex_media.firstAttr(*attrs):
+        return UniqueList(
+            [
+                MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=thumb,
+                    provider=provider_instance_id,
+                    remotely_accessible=False,
+                )
+            ]
+        )
+    return None
+
+
+def get_favorite_from_rating(plex_media: PlexObject, threshold: float) -> bool | None:
+    """
+    Derive favorite status from the user rating of a Plex object.
+
+    Returns None if the object has no user rating.
+
+    :param plex_media: The Plex object to read the user rating from.
+    :param threshold: Minimum rating (0.0-10.0) to consider the item a favorite.
+    """
+    rating = getattr(plex_media, "userRating", None)
+    if rating is None:
+        return None
+    return float(rating) >= threshold


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
- Fix StreamDetails duration being passed in milliseconds instead of seconds
- Translate plexapi NotFound into MediaNotFoundError instead of leaking it
- Fix library-list cache key mismatch between read and write
- Don't send the local-auth sentinel as a real token; honor verify-cert in unauthenticated connections during config flow
- Use removeprefix for collection ids instead of str.replace
- Remove unused _search_*_advanced methods, dead chapters/availability code and the redundant type dispatch in recommendations()
- Add constants.py (config keys, sentinels, error messages)
- Add get_thumbnail_images/get_favorite_from_rating helpers to deduplicate the parsers


## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
