### PR TITLE
Alexa: Fix restore saved session after aiohttp update

### DIFF
--- a/music_assistant/providers/alexa/__init__.py
+++ b/music_assistant/providers/alexa/__init__.py
@@ -262,6 +262,31 @@ async def delete_cookie(cookiefile: str) -> None:
         _LOGGER.debug("Cookie file %s does not exist, nothing to delete.", cookiefile)
 
 
+async def load_cookie(login: AlexaLogin) -> dict[str, str] | None:
+    """
+    Restore a previously saved Alexa session into the login's aiohttp session.
+
+    :param login: The AlexaLogin whose session cookie jar should be populated.
+    """
+    cookiefile = login._cookiefile[0] if login._cookiefile else None
+    if not cookiefile or not await asyncio.to_thread(os.path.exists, cookiefile):
+        return None
+    if login._session is None:
+        login._create_session()
+    # aiohttp 3.14 saves the cookie jar as JSON, which alexapy's own load_cookie()
+    # cannot parse. Load it with aiohttp's loader into the session jar (preserving
+    # the cookie domains required for auth) and return the cookies for login().
+    cookie_jar = login._session.cookie_jar
+    assert isinstance(cookie_jar, aiohttp.CookieJar)
+    try:
+        await asyncio.to_thread(cookie_jar.load, cookiefile)
+    except (OSError, EOFError, TypeError, ValueError, AttributeError) as ex:
+        _LOGGER.debug("Error loading cookie from %s: %s", cookiefile, ex)
+        return None
+    cookies = login._get_cookies_from_session()
+    return cast("dict[str, str]", cookies) if cookies else None
+
+
 async def _request_with_session(
     session: aiohttp.ClientSession,
     method: str,
@@ -536,7 +561,7 @@ class AlexaProvider(PlayerProvider):
         )
         self.login._cookiefile = [self.login._outputpath(cookie_path)]
 
-        await self.login.login(cookies=await self.login.load_cookie())
+        await self.login.login(cookies=await load_cookie(self.login))
 
         devices = await AlexaAPI.get_devices(self.login)
 


### PR DESCRIPTION
Since the update from aiohttp 3.13 -> 3.14 the cooking loading broke claude made this which made it work again for me.

claude said it works with the pre 3.14 files and converts them on first load. I haven't confirmed.

this was the error:

```
 [alexapy.alexalogin] Cookie /data/.alexa/alexa_media.<email>.pickle is truncated:
     An exception of type LoadError occurred. Arguments:
     ("'/data/.alexa/alexa_media.<email>.pickle' does not look like a Netscape format cookies file",)
  [alexapy.alexalogin] Using credentials to log in

  The resulting failure — device fetch gets the signin page, not JSON:
  [alexapy.helpers] Failed (URL: https://www.amazon.de/ap/signin?...openid.return_to=https://alexa.amazon.de/api/devices-v2/device...)
     to parse JSON for 'devices' (status 200): Expecting value: line 1 column 1 (char 0)

  [alexapy.helpers] alexaapi.get_devices((<alexapy.alexalogin.AlexaLogin object ...>,), {}):
     A connection error occurred: An exception of type KeyError occurred. Arguments:
    File ".../alexapy/helpers.py", line 146, in wrapper
    File ".../alexapy/alexaapi.py", line 1479, in get_devices
      devices if devices else AlexaAPI.devices[login.email]
    File ".../music_assistant/providers/alexa/__init__.py", line 537, in loaded_in_mass
      devices = await AlexaAPI.get_devices(self.login)
    File ".../alexapy/helpers.py", line 156, in wrapper
      raise AlexapyConnectionError from ex
  alexapy.errors.AlexapyConnectionError
```

The Alexa provider saves the login session via aiohttp.CookieJar.save() but restored it through AlexaLogin.load_cookie(), which only understands pickle/Netscape cookie files. aiohttp 3.14 switched CookieJar.save() to JSON, so load_cookie() can no longer parse the file ("does not look like a Netscape format cookies file"). The session is then discarded on every load and the credential fallback fails, so get_devices() hits the signin page and no Alexa devices are loaded.

Load the cookie file with aiohttp's own CookieJar.load() (JSON first, pickle fallback) into the login's session jar so cookie domains/paths are preserved, then pass the session cookies to AlexaLogin.login(). Mirrors alexapy's own aiohttp-cookie restore path; works on aiohttp 3.13 and 3.14.

# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
