### PR TITLE
Fix invalid scope error when adding a custom Spotify client ID

### DIFF
--- a/music_assistant/providers/spotify/constants.py
+++ b/music_assistant/providers/spotify/constants.py
@@ -16,7 +16,6 @@ CONF_SYNC_AUDIOBOOK_PROGRESS = "sync_audiobook_progress"
 
 # OAuth Settings
 SCOPE = [
-    "playlist-read",
     "playlist-read-private",
     "playlist-read-collaborative",
     "playlist-modify-public",
@@ -33,8 +32,6 @@ SCOPE = [
     "user-read-playback-state",
     "user-modify-playback-state",
     "user-read-currently-playing",
-    "user-modify-private",
-    "user-modify",
     "user-read-playback-position",
     "user-read-recently-played",
 ]


### PR DESCRIPTION
# What does this implement/fix?

Adding a custom Spotify client ID (developer token) fails during authorization with an `invalid scope` error. The requested OAuth scope list contained three strings that are not valid Spotify scopes: `playlist-read`, `user-modify-private` and `user-modify`. Spotify historically ignored unknown scopes, so this went unnoticed — but newly created [Development Mode client IDs (Feb 2026 platform changes)](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide) now strictly validate scopes and reject the whole authorization request. Music Assistant's built-in client ID is unaffected, which is why only users supplying their own (recently created) client ID hit this.

No functionality is lost — the valid scopes covering the same access (`playlist-read-private`, `playlist-read-collaborative`, `user-modify-playback-state`) were already being requested.

**Changes:**

- Remove the invalid scopes `playlist-read`, `user-modify-private` and `user-modify` from the Spotify OAuth scope list.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
