### PR TITLE
Remove local providers without wiping the entire library

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -7,6 +7,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from contextlib import suppress
+from contextvars import ContextVar
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypeVar, cast, final
 
@@ -25,9 +26,11 @@ from music_assistant_models.errors import (
 from music_assistant_models.media_items import (
     AudioFormat,
     ItemMapping,
+    MediaItemMetadata,
     MediaItemType,
     ProviderMapping,
     Track,
+    UniqueList,
 )
 
 from music_assistant.constants import (
@@ -65,6 +68,13 @@ JSON_KEYS = (
     "authors",
     "genre_aliases",
     "supported_mediatypes",
+)
+
+# When set (task-local), per-item MEDIA_ITEM_UPDATED events are suppressed.
+# Used by bulk operations such as provider cleanup, where emitting an event for every
+# touched item would flood subscribers; consumers refresh in bulk afterwards instead.
+SUPPRESS_MEDIA_ITEM_UPDATES: ContextVar[bool] = ContextVar(
+    "SUPPRESS_MEDIA_ITEM_UPDATES", default=False
 )
 
 SORT_KEYS = {
@@ -803,13 +813,22 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             if not (x.provider_instance == provider_instance_id and x.item_id == provider_item_id)
         }
         if library_item.provider_mappings:
+            # if this was the last mapping for the provider instance, strip any artwork
+            # that belonged to it (e.g. local file paths that are no longer resolvable)
+            images_changed = not any(
+                x.provider_instance == provider_instance_id for x in library_item.provider_mappings
+            ) and await self._remove_provider_images(db_id, provider_instance_id)
             self.logger.debug(
                 "removed provider_mapping %s/%s from item id %s",
                 provider_instance_id,
                 provider_item_id,
                 db_id,
             )
-            self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
+            if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
+                if images_changed:
+                    # re-fetch so the event payload reflects the stripped images
+                    library_item = await self.get_library_item(db_id)
+                self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
         else:
             # remove item if it has no more providers
             with suppress(AssertionError):
@@ -840,12 +859,20 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             x for x in library_item.provider_mappings if x.provider_instance != provider_instance_id
         }
         if library_item.provider_mappings:
+            # the item is kept (it still has other providers), but it may carry artwork
+            # that belonged to the removed provider (e.g. local file paths that are no
+            # longer resolvable), so strip those images from the stored metadata
+            images_changed = await self._remove_provider_images(db_id, provider_instance_id)
             self.logger.debug(
                 "removed all provider mappings for provider %s from item id %s",
                 provider_instance_id,
                 db_id,
             )
-            self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
+            if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
+                if images_changed:
+                    # re-fetch so the event payload reflects the stripped images
+                    library_item = await self.get_library_item(db_id)
+                self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
         else:
             # remove item if it has no more providers
             with suppress(AssertionError):
@@ -1252,3 +1279,34 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         # fallback to first mapping
         mapping = next(iter(library_item.provider_mappings))
         return (mapping.provider_instance, mapping.item_id)
+
+    async def _remove_provider_images(self, db_id: int, provider_instance_id: str) -> bool:
+        """
+        Remove images belonging to a provider from a library item's stored metadata.
+
+        :param db_id: The library (database) id of the item.
+        :param provider_instance_id: The provider instance whose images should be removed.
+        :return: True if any images were removed and the db record was updated.
+        """
+        # read the raw metadata straight from the db (instead of via get_library_item)
+        # to avoid persisting any images that are only injected at read time (such as
+        # the album thumb that gets merged into a track's images)
+        db_row = await self.mass.music.database.get_row(self.db_table, {"item_id": db_id})
+        if not db_row or not (raw_metadata := db_row["metadata"]):
+            return False
+        metadata = MediaItemMetadata.from_dict(json_loads(raw_metadata))
+        if not metadata.images:
+            return False
+        remaining = UniqueList(
+            img for img in metadata.images if img.provider != provider_instance_id
+        )
+        if len(remaining) == len(metadata.images):
+            # nothing belonged to this provider
+            return False
+        metadata.images = remaining or None
+        await self.mass.music.database.update(
+            self.db_table,
+            {"item_id": db_id},
+            {"metadata": serialize_to_json(metadata)},
+        )
+        return True

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -824,11 +824,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 provider_item_id,
                 db_id,
             )
+            # the removed provider mapping is itself a change to the item, so always notify
+            # (unless suppressed during a bulk cleanup); re-fetch first when images were
+            # stripped so the event payload stays accurate
             if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
-                if images_changed:
-                    # re-fetch so the event payload reflects the stripped images
-                    library_item = await self.get_library_item(db_id)
-                self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
+                event_item = await self.get_library_item(db_id) if images_changed else library_item
+                self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, event_item.uri, event_item)
         else:
             # remove item if it has no more providers
             with suppress(AssertionError):
@@ -868,11 +869,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 provider_instance_id,
                 db_id,
             )
+            # the removed provider mapping(s) are themselves a change to the item, so
+            # always notify (unless suppressed during a bulk cleanup); re-fetch first when
+            # images were stripped so the event payload stays accurate
             if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
-                if images_changed:
-                    # re-fetch so the event payload reflects the stripped images
-                    library_item = await self.get_library_item(db_id)
-                self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, library_item.uri, library_item)
+                event_item = await self.get_library_item(db_id) if images_changed else library_item
+                self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, event_item.uri, event_item)
         else:
             # remove item if it has no more providers
             with suppress(AssertionError):

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -98,6 +98,7 @@ from music_assistant.models.plugin import PluginProvider
 from .media.albums import AlbumsController
 from .media.artists import ArtistsController
 from .media.audiobooks import AudiobooksController
+from .media.base import SUPPRESS_MEDIA_ITEM_UPDATES
 from .media.genres import GenreController
 from .media.playlists import PlaylistController
 from .media.podcasts import PodcastsController
@@ -1796,16 +1797,6 @@ class MusicController(CoreController):
 
     async def cleanup_provider(self, provider_instance: str) -> None:
         """Cleanup provider records from the database."""
-        if provider_instance.startswith(("filesystem", "jellyfin", "plex", "opensubsonic")):
-            # removal of a local provider can become messy very fast due to the relations
-            # such as images pointing at the files etc. so we just reset the whole db
-            # TODO: Handle this more gracefully in the future where we remove the provider
-            # and traverse the database to also remove all related items.
-            self.logger.warning(
-                "Removal of local provider detected, issuing full database reset..."
-            )
-            await self._reset_database()
-            return
         deleted_providers = self.mass.config.get_raw_core_config_value(
             self.domain, CONF_DELETED_PROVIDERS, []
         )
@@ -1827,38 +1818,44 @@ class MusicController(CoreController):
             provider_instance,
         )
         errors = 0
-        for ctrl in (
-            # order is important here to recursively cleanup bottom up
-            self.mass.music.radio,
-            self.mass.music.playlists,
-            self.mass.music.tracks,
-            self.mass.music.albums,
-            self.mass.music.artists,
-            self.mass.music.podcasts,
-            self.mass.music.audiobooks,
-            # run main controllers twice to rule out relations
-            self.mass.music.tracks,
-            self.mass.music.albums,
-            self.mass.music.artists,
-        ):
-            query = (
-                f"SELECT item_id FROM {DB_TABLE_PROVIDER_MAPPINGS} "
-                f"WHERE media_type = '{ctrl.media_type}' "
-                f"AND provider_instance = '{provider_instance}'"
-            )
-            for db_row in await self.database.get_rows_from_query(query, limit=100000):
-                try:
-                    await ctrl.remove_provider_mappings(db_row["item_id"], provider_instance)
-                except Exception as err:
-                    # we dont want the whole removal process to stall on one item
-                    # so in case of an unexpected error, we log and move on.
-                    self.logger.warning(
-                        "Error while removing %s: %s",
-                        db_row["item_id"],
-                        str(err),
-                        exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
-                    )
-                    errors += 1
+        # suppress the per-item MEDIA_ITEM_UPDATED events during this bulk removal so we
+        # don't flood subscribers; they refresh once via the PROVIDERS_UPDATED event
+        token = SUPPRESS_MEDIA_ITEM_UPDATES.set(True)
+        try:
+            for ctrl in (
+                # order is important here to recursively cleanup bottom up
+                self.mass.music.radio,
+                self.mass.music.playlists,
+                self.mass.music.tracks,
+                self.mass.music.albums,
+                self.mass.music.artists,
+                self.mass.music.podcasts,
+                self.mass.music.audiobooks,
+                # run main controllers twice to rule out relations
+                self.mass.music.tracks,
+                self.mass.music.albums,
+                self.mass.music.artists,
+            ):
+                query = (
+                    f"SELECT item_id FROM {DB_TABLE_PROVIDER_MAPPINGS} "
+                    f"WHERE media_type = '{ctrl.media_type}' "
+                    f"AND provider_instance = '{provider_instance}'"
+                )
+                for db_row in await self.database.get_rows_from_query(query, limit=100000):
+                    try:
+                        await ctrl.remove_provider_mappings(db_row["item_id"], provider_instance)
+                    except Exception as err:
+                        # we dont want the whole removal process to stall on one item
+                        # so in case of an unexpected error, we log and move on.
+                        self.logger.warning(
+                            "Error while removing %s: %s",
+                            db_row["item_id"],
+                            str(err),
+                            exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
+                        )
+                        errors += 1
+        finally:
+            SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
 
         # remove all orphaned items (not in provider mappings table anymore)
         query = (

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1838,10 +1838,14 @@ class MusicController(CoreController):
             ):
                 query = (
                     f"SELECT item_id FROM {DB_TABLE_PROVIDER_MAPPINGS} "
-                    f"WHERE media_type = '{ctrl.media_type}' "
-                    f"AND provider_instance = '{provider_instance}'"
+                    "WHERE media_type = :media_type "
+                    "AND provider_instance = :provider_instance"
                 )
-                for db_row in await self.database.get_rows_from_query(query, limit=100000):
+                params = {
+                    "media_type": ctrl.media_type.value,
+                    "provider_instance": provider_instance,
+                }
+                for db_row in await self.database.get_rows_from_query(query, params, limit=100000):
                     try:
                         await ctrl.remove_provider_mappings(db_row["item_id"], provider_instance)
                     except Exception as err:

--- a/tests/core/test_provider_cleanup.py
+++ b/tests/core/test_provider_cleanup.py
@@ -1,0 +1,197 @@
+"""Tests for cleanup of library items/images when a provider is removed."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from music_assistant_models.enums import EventType, ImageType
+from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.media_items import (
+    Artist,
+    MediaItemImage,
+    ProviderMapping,
+    UniqueList,
+)
+
+from music_assistant.mass import MusicAssistant
+
+FS_INSTANCE = "filesystem_local--AbCd"
+STREAM_INSTANCE = "spotify--EfGh"
+
+
+def _artist_with_two_providers(name: str) -> Artist:
+    """Build an artist that exists on both a filesystem and a streaming provider."""
+    artist = Artist(
+        item_id="fs1",
+        provider=FS_INSTANCE,
+        name=name,
+        provider_mappings={
+            ProviderMapping(
+                item_id="fs1", provider_domain="filesystem_local", provider_instance=FS_INSTANCE
+            ),
+            ProviderMapping(
+                item_id="sp1", provider_domain="spotify", provider_instance=STREAM_INSTANCE
+            ),
+        },
+    )
+    artist.metadata.images = UniqueList(
+        [
+            # local file path image: unresolvable once the filesystem provider is gone
+            MediaItemImage(
+                type=ImageType.THUMB,
+                path="Artist/folder.jpg",
+                provider=FS_INSTANCE,
+                remotely_accessible=False,
+            ),
+            # streaming image: stays valid, must be kept
+            MediaItemImage(
+                type=ImageType.THUMB,
+                path="https://i.scdn.co/image/abc",
+                provider=STREAM_INSTANCE,
+                remotely_accessible=True,
+            ),
+        ]
+    )
+    return artist
+
+
+async def test_remove_provider_mappings_strips_provider_images(mass: MusicAssistant) -> None:
+    """Removing a provider's mappings keeps the item but drops only that provider's images."""
+    artists = mass.music.artists
+    db_artist = await artists.add_item_to_library(_artist_with_two_providers("Two Provider Artist"))
+    db_id = int(db_artist.item_id)
+    assert db_artist.metadata.images is not None
+    assert len(db_artist.metadata.images) == 2
+
+    await artists.remove_provider_mappings(db_id, FS_INSTANCE)
+
+    # the item survives (it still has the streaming provider mapping)
+    updated = await artists.get_library_item(db_id)
+    assert {pm.provider_instance for pm in updated.provider_mappings} == {STREAM_INSTANCE}
+    # only the streaming image remains; the (now unresolvable) filesystem image is gone
+    assert updated.metadata.images is not None
+    assert [img.provider for img in updated.metadata.images] == [STREAM_INSTANCE]
+
+
+async def test_cleanup_filesystem_provider_does_not_reset_database(mass: MusicAssistant) -> None:
+    """Removing a local (filesystem) provider cleans up its items without wiping the db."""
+    artists = mass.music.artists
+    # an artist that only exists on the filesystem provider (should be removed entirely)
+    fs_only = Artist(
+        item_id="fsonly",
+        provider=FS_INSTANCE,
+        name="Filesystem Only Artist",
+        provider_mappings={
+            ProviderMapping(
+                item_id="fsonly",
+                provider_domain="filesystem_local",
+                provider_instance=FS_INSTANCE,
+            )
+        },
+    )
+    db_fs_only = await artists.add_item_to_library(fs_only)
+    # an artist from an unrelated provider that must survive the cleanup
+    survivor = Artist(
+        item_id="sp2",
+        provider=STREAM_INSTANCE,
+        name="Surviving Artist",
+        provider_mappings={
+            ProviderMapping(
+                item_id="sp2", provider_domain="spotify", provider_instance=STREAM_INSTANCE
+            )
+        },
+    )
+    db_survivor = await artists.add_item_to_library(survivor)
+
+    with patch.object(mass.music, "_reset_database", AsyncMock()) as mock_reset:
+        await mass.music.cleanup_provider(FS_INSTANCE)
+
+    # the whole database must NOT be wiped for a local provider anymore
+    mock_reset.assert_not_called()
+    # the filesystem-only item is gone, the unrelated item survives
+    with pytest.raises(MediaNotFoundError):
+        await artists.get_library_item(int(db_fs_only.item_id))
+    assert await artists.get_library_item(int(db_survivor.item_id))
+
+
+async def test_remove_single_provider_mapping_strips_provider_images(mass: MusicAssistant) -> None:
+    """Removing the last mapping of a provider instance also strips its images."""
+    artists = mass.music.artists
+    db_artist = await artists.add_item_to_library(
+        _artist_with_two_providers("Single Mapping Artist")
+    )
+    db_id = int(db_artist.item_id)
+
+    await artists.remove_provider_mapping(db_id, FS_INSTANCE, "fs1")
+
+    updated = await artists.get_library_item(db_id)
+    assert {pm.provider_instance for pm in updated.provider_mappings} == {STREAM_INSTANCE}
+    assert updated.metadata.images is not None
+    assert [img.provider for img in updated.metadata.images] == [STREAM_INSTANCE]
+
+
+async def test_remove_single_provider_mapping_keeps_images_if_instance_remains(
+    mass: MusicAssistant,
+) -> None:
+    """A provider's images are kept while another mapping of that same instance remains."""
+    artists = mass.music.artists
+    artist = Artist(
+        item_id="fs1",
+        provider=FS_INSTANCE,
+        name="Duplicate Mapping Artist",
+        provider_mappings={
+            ProviderMapping(
+                item_id="fs1", provider_domain="filesystem_local", provider_instance=FS_INSTANCE
+            ),
+            ProviderMapping(
+                item_id="fs2", provider_domain="filesystem_local", provider_instance=FS_INSTANCE
+            ),
+        },
+    )
+    artist.metadata.images = UniqueList(
+        [
+            MediaItemImage(
+                type=ImageType.THUMB,
+                path="Artist/folder.jpg",
+                provider=FS_INSTANCE,
+                remotely_accessible=False,
+            )
+        ]
+    )
+    db_artist = await artists.add_item_to_library(artist)
+    db_id = int(db_artist.item_id)
+
+    # remove only one of the two mappings for the same provider instance
+    await artists.remove_provider_mapping(db_id, FS_INSTANCE, "fs1")
+
+    # the instance still maps the item (via fs2), so its image must be kept
+    updated = await artists.get_library_item(db_id)
+    assert {pm.item_id for pm in updated.provider_mappings} == {"fs2"}
+    assert updated.metadata.images is not None
+    assert [img.provider for img in updated.metadata.images] == [FS_INSTANCE]
+
+
+async def test_cleanup_suppresses_media_item_updated_events(mass: MusicAssistant) -> None:
+    """A surviving item must not emit MEDIA_ITEM_UPDATED during bulk provider cleanup."""
+    artists = mass.music.artists
+    db_artist = await artists.add_item_to_library(_artist_with_two_providers("Suppressed Artist"))
+    db_id = int(db_artist.item_id)
+
+    updated_object_ids: list[str | None] = []
+    real_signal_event = mass.signal_event
+
+    def _spy(event: EventType, object_id: str | None = None, data: object = None) -> None:
+        if event == EventType.MEDIA_ITEM_UPDATED:
+            updated_object_ids.append(object_id)
+        real_signal_event(event, object_id, data)
+
+    with patch.object(mass, "signal_event", side_effect=_spy):
+        await mass.music.cleanup_provider(FS_INSTANCE)
+
+    # no per-item update event was emitted during the bulk cleanup
+    assert updated_object_ids == []
+    # but the cleanup work still happened: the filesystem image was stripped, item kept
+    updated = await artists.get_library_item(db_id)
+    assert {pm.provider_instance for pm in updated.provider_mappings} == {STREAM_INSTANCE}
+    assert [img.provider for img in (updated.metadata.images or [])] == [STREAM_INSTANCE]

--- a/tests/core/test_provider_cleanup.py
+++ b/tests/core/test_provider_cleanup.py
@@ -195,3 +195,42 @@ async def test_cleanup_suppresses_media_item_updated_events(mass: MusicAssistant
     updated = await artists.get_library_item(db_id)
     assert {pm.provider_instance for pm in updated.provider_mappings} == {STREAM_INSTANCE}
     assert [img.provider for img in (updated.metadata.images or [])] == [STREAM_INSTANCE]
+
+
+async def test_remove_provider_mappings_emits_event_without_image_changes(
+    mass: MusicAssistant,
+) -> None:
+    """Removing mappings emits an update event even when no images were stripped."""
+    artists = mass.music.artists
+    # artist on two providers but without any images, so nothing gets stripped
+    artist = Artist(
+        item_id="fs1",
+        provider=FS_INSTANCE,
+        name="No Image Artist",
+        provider_mappings={
+            ProviderMapping(
+                item_id="fs1", provider_domain="filesystem_local", provider_instance=FS_INSTANCE
+            ),
+            ProviderMapping(
+                item_id="sp1", provider_domain="spotify", provider_instance=STREAM_INSTANCE
+            ),
+        },
+    )
+    db_artist = await artists.add_item_to_library(artist)
+    db_id = int(db_artist.item_id)
+
+    events: list[Artist] = []
+    real_signal_event = mass.signal_event
+
+    def _spy(event: EventType, object_id: str | None = None, data: object = None) -> None:
+        if event == EventType.MEDIA_ITEM_UPDATED and isinstance(data, Artist):
+            events.append(data)
+        real_signal_event(event, object_id, data)
+
+    with patch.object(mass, "signal_event", side_effect=_spy):
+        await artists.remove_provider_mappings(db_id, FS_INSTANCE)
+
+    # the update event fires purely because a provider mapping was removed, and its
+    # payload reflects the removed mapping
+    assert len(events) == 1
+    assert {pm.provider_instance for pm in events[0].provider_mappings} == {STREAM_INSTANCE}


### PR DESCRIPTION
# What does this implement/fix?

Removing a local provider (filesystem, Jellyfin, Plex, OpenSubsonic) wiped the **entire** library database — every item, favorite and playlist from all other providers along with it. This was a deliberate shortcut: local providers store their images as on-disk file paths, and cleaning those references up on removal was non-trivial, so the whole library was reset instead.

Local providers are now removed gracefully, exactly like streaming providers: provider mappings are stripped recursively, items left without any provider are deleted, and images that belonged to the removed provider are removed from the metadata of the items that are kept.

## Changes

- Drop the full database reset that ran when removing a filesystem/jellyfin/plex/opensubsonic provider.
- When a provider mapping is removed but the item is kept, strip the removed provider's images from its stored metadata (operates on the raw metadata so images injected at read time aren't accidentally persisted).
- Apply the same image cleanup to the single-mapping removal path, guarded so a provider's images are only dropped once it no longer maps the item.
- Suppress the per-item `MEDIA_ITEM_UPDATED` events during the bulk cleanup to avoid flooding subscribers; `MEDIA_ITEM_DELETED` is left intact.
- Add tests covering the cleanup and event-suppression behaviour.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
