### PR TITLE
Fix persistent MusicBrainz rate limiting during Last.fm recommendation rebuilds

### DIFF
--- a/music_assistant/helpers/throttle_retry.py
+++ b/music_assistant/helpers/throttle_retry.py
@@ -118,14 +118,29 @@ class ThrottlerManager:
         self.retry_attempts = retry_attempts
         self.initial_backoff = initial_backoff
         self.throttler = Throttler(rate_limit, period)
+        self._cooldown_until: float = 0.0
+
+    def set_cooldown(self, seconds: float) -> None:
+        """
+        Pause all (non-bypassed) acquires, e.g. after a rate-limit response.
+
+        :param seconds: Duration of the pause; never shortens an active cooldown.
+        """
+        self._cooldown_until = max(self._cooldown_until, time.monotonic() + seconds)
 
     @asynccontextmanager
     async def acquire(self) -> AsyncGenerator[float]:
         """Acquire a free slot from the Throttler, returns the throttled time."""
         if BYPASS_THROTTLER.get():
             yield 0
-        else:
-            yield await self.throttler.acquire()
+            return
+        delay = 0.0
+        cooldown = self._cooldown_until - time.monotonic()
+        if cooldown > 0:
+            await asyncio.sleep(cooldown)
+            delay += cooldown
+        delay += await self.throttler.acquire()
+        yield delay
 
     @asynccontextmanager
     async def bypass(self) -> AsyncGenerator[None]:
@@ -157,37 +172,41 @@ def throttle_with_retries[ProviderT: _Throttleable, **P, R](
         """Call async function using the throttler with retries."""
         throttler = self.throttler
         exp_backoff = throttler.initial_backoff
-        async with throttler.acquire() as delay:
-            if delay != 0:
-                self.logger.debug(
-                    "%s was delayed for %.3f secs due to throttling", func.__name__, delay
-                )
-            for attempt in range(throttler.retry_attempts):
+        for attempt in range(throttler.retry_attempts):
+            # acquire a slot for every attempt so retries are paced like any
+            # other request instead of firing unthrottled after the backoff
+            async with throttler.acquire() as delay:
+                if delay != 0:
+                    self.logger.debug(
+                        "%s was delayed for %.3f secs due to throttling", func.__name__, delay
+                    )
                 try:
                     return await func(self, *args, **kwargs)
                 except ResourceTemporarilyUnavailable as e:
                     self.logger.info(
                         f"Attempt {attempt + 1}/{throttler.retry_attempts} failed: {e}"
                     )
+                    server_wait = min(max(float(e.backoff_time), 0.0), MAX_RETRY_AFTER)
+                    if isinstance(e, RateLimited):
+                        # Retry-After is a floor, not a target: escalate above it,
+                        # jittering up only so we never retry sooner than asked
+                        base = max(server_wait, min(exp_backoff, MAX_BACKOFF))
+                        sleep_time = base * random.uniform(1.0, 1.1)
+                        exp_backoff = min(exp_backoff * 2, MAX_BACKOFF)
+                        # hold back all other callers too: requests fired during
+                        # the backoff window keep the rate limiter tripped
+                        throttler.set_cooldown(sleep_time)
+                    elif server_wait:
+                        # Server named a recovery time — respect it, with citizen jitter
+                        sleep_time = server_wait * random.uniform(1.0, 1.1)
+                    else:
+                        # No server guidance — exponential backoff with jitter
+                        sleep_time = min(exp_backoff * random.uniform(0.75, 1.25), MAX_BACKOFF)
+                        exp_backoff = min(exp_backoff * 2, MAX_BACKOFF)
                     if attempt < throttler.retry_attempts - 1:
-                        server_wait = min(max(float(e.backoff_time), 0.0), MAX_RETRY_AFTER)
-                        if isinstance(e, RateLimited):
-                            # Retry-After is a floor, not a target: escalate above it,
-                            # jittering up only so we never retry sooner than asked
-                            base = max(server_wait, min(exp_backoff, MAX_BACKOFF))
-                            sleep_time = base * random.uniform(1.0, 1.1)
-                            exp_backoff = min(exp_backoff * 2, MAX_BACKOFF)
-                        elif server_wait:
-                            # Server named a recovery time — respect it, with citizen jitter
-                            sleep_time = server_wait * random.uniform(1.0, 1.1)
-                        else:
-                            # No server guidance — exponential backoff with jitter
-                            sleep_time = min(exp_backoff * random.uniform(0.75, 1.25), MAX_BACKOFF)
-                            exp_backoff = min(exp_backoff * 2, MAX_BACKOFF)
                         self.logger.info(f"Retrying in {sleep_time:.1f} seconds...")
                         await asyncio.sleep(sleep_time)
-            else:  # noqa: PLW0120
-                msg = f"Retries exhausted, failed after {throttler.retry_attempts} attempts"
-                raise RetriesExhausted(msg)
+        msg = f"Retries exhausted, failed after {throttler.retry_attempts} attempts"
+        raise RetriesExhausted(msg)
 
     return wrapper

--- a/music_assistant/providers/musicbrainz/__init__.py
+++ b/music_assistant/providers/musicbrainz/__init__.py
@@ -275,7 +275,10 @@ class MusicBrainzRecording(DataClassDictMixin):
 class MusicbrainzProvider(MetadataProvider):
     """The Musicbrainz Metadata provider."""
 
-    throttler = ThrottlerManager(rate_limit=10, period=10)
+    # the MA-hosted mirror allows 10 req/10s, enforced at the Cloudflare edge
+    # with a sliding-window estimate that over-counts bursts; pace requests
+    # one at a time (same throughput as 8/10s) to stay under it with headroom
+    throttler = ThrottlerManager(rate_limit=1, period=1.25)
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""

--- a/tests/core/test_throttle_retry.py
+++ b/tests/core/test_throttle_retry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Generator, Sequence
 from unittest.mock import AsyncMock, patch
 
@@ -26,10 +27,14 @@ class FakeProvider:
     The decorator requires `self.throttler` and `self.logger`.
     """
 
-    throttler = ThrottlerManager(rate_limit=100, period=0.01, retry_attempts=5, initial_backoff=4)
+    throttler: ThrottlerManager
 
     def __init__(self) -> None:
         """Initialize."""
+        # per-instance throttler so state (e.g. cooldown) never leaks between tests
+        self.throttler = ThrottlerManager(
+            rate_limit=100, period=0.01, retry_attempts=5, initial_backoff=4
+        )
         self.logger = logging.getLogger("test.fake_provider")
         self.call_count = 0
         self._side_effects: list[Exception | str] = []
@@ -61,10 +66,26 @@ def provider() -> FakeProvider:
 
 @pytest.fixture
 def mock_sleep() -> Generator[AsyncMock]:
-    """Patch asyncio.sleep to capture sleep times without actually sleeping."""
-    with patch(
-        "music_assistant.helpers.throttle_retry.asyncio.sleep", new_callable=AsyncMock
-    ) as mock:
+    """
+    Patch asyncio.sleep to capture sleep times without actually sleeping.
+
+    Each sleep advances a fake monotonic clock, so time-based behavior in the
+    helper (throttler slots, cooldown expiry) matches real time.
+    """
+    clock = time.monotonic()
+
+    async def fake_sleep(seconds: float) -> None:
+        nonlocal clock
+        clock += seconds
+
+    with (
+        patch(
+            "music_assistant.helpers.throttle_retry.asyncio.sleep",
+            new_callable=AsyncMock,
+            side_effect=fake_sleep,
+        ) as mock,
+        patch("music_assistant.helpers.throttle_retry.time.monotonic", side_effect=lambda: clock),
+    ):
         yield mock
 
 
@@ -194,6 +215,88 @@ class TestRateLimited:
 
         sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
         assert 3600.0 <= sleep_times[0] <= 3960.0
+
+
+class TestPerAttemptThrottling:
+    """Every attempt (including retries) must consume a throttler slot."""
+
+    async def test_each_retry_acquires_slot(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """Retries go through the throttler again instead of firing unthrottled."""
+        with patch.object(
+            provider.throttler.throttler, "acquire", new=AsyncMock(return_value=0.0)
+        ) as acquire_mock:
+            provider.set_side_effects(
+                [
+                    RateLimited("rate limited", backoff_time=1),
+                    ResourceTemporarilyUnavailable("unavailable", backoff_time=1),
+                    "ok",
+                ]
+            )
+            result = await provider.api_call("ok")
+        assert result == "ok"
+        assert acquire_mock.await_count == 3
+
+
+class TestSharedCooldown:
+    """A 429 pauses the whole provider, not just the coroutine that received it."""
+
+    async def test_cooldown_delays_acquire(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """An active cooldown makes acquire() wait out the remainder."""
+        provider.throttler.set_cooldown(42)
+        async with provider.throttler.acquire() as delay:
+            pass
+        assert delay >= 42
+        assert any(call.args[0] == pytest.approx(42) for call in mock_sleep.call_args_list)
+
+    async def test_rate_limited_sets_cooldown(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """A 429 during a decorated call installs a provider-wide cooldown."""
+        with patch.object(
+            provider.throttler, "set_cooldown", wraps=provider.throttler.set_cooldown
+        ) as spy:
+            provider.set_side_effects([RateLimited("rate limited", backoff_time=30), "ok"])
+            await provider.api_call("ok")
+        spy.assert_called_once()
+        # at least the (jittered) Retry-After window
+        assert spy.call_args.args[0] >= 30
+
+    async def test_server_error_does_not_set_cooldown(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """A plain 5xx only backs off the affected coroutine."""
+        with patch.object(
+            provider.throttler, "set_cooldown", wraps=provider.throttler.set_cooldown
+        ) as spy:
+            provider.set_side_effects(
+                [ResourceTemporarilyUnavailable("unavailable", backoff_time=30), "ok"]
+            )
+            await provider.api_call("ok")
+        spy.assert_not_called()
+
+    async def test_cooldown_set_even_when_retries_exhausted(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """A 429 on the final attempt still blocks other callers."""
+        provider.set_side_effects([RateLimited("rate limited", backoff_time=30)] * 5)
+        with pytest.raises(RetriesExhausted):
+            await provider.api_call("test")
+        # the final attempt set a cooldown that has not expired yet
+        assert provider.throttler._cooldown_until > time.monotonic()
+
+    async def test_bypass_skips_cooldown(
+        self, provider: FakeProvider, mock_sleep: AsyncMock
+    ) -> None:
+        """Bypassed (time-critical) calls are not held back by a cooldown."""
+        provider.throttler.set_cooldown(60)
+        async with provider.throttler.bypass(), provider.throttler.acquire() as delay:
+            pass
+        assert delay == 0
+        mock_sleep.assert_not_awaited()
 
 
 class TestExponentialBackoffWithJitter:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Users are still hitting rate limiting on the MusicBrainz mirror during Last.fm recommendation rebuilds, even after #4146 and #4155. Once the first 429  arrived, it became self-sustaining: every rate-limited request slept for 0s and then retried *without* going through the throttler, so they all burst at once while other callers kept firing during the backoff window.

So this PR ensures that:

1. **Retries are now throttled.** `throttle_with_retries` re-acquires a throttler slot for every attempt instead of only the first one. This was the actual bug.
2. **A 429 now pauses the whole provider.** The throttler gets a shared cooldown for the backoff window, so other callers stop firing into a window where every request just extends the block. Only set on 429 so a plain 502/503 still only backs off the affected request. Bypassed (time-critical playback) calls are unaffected.
3. **MusicBrainz pacing smoothed.** 10 req/10s allowed all 10 requests in one instant burst. Now it is 1 request per 1.25s which provides a bit of headroom.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
