### PR TITLE
Fix ISRC lookups failing for Last.fm track MBIDs

### DIFF
--- a/music_assistant/providers/musicbrainz/__init__.py
+++ b/music_assistant/providers/musicbrainz/__init__.py
@@ -436,7 +436,7 @@ class MusicbrainzProvider(MetadataProvider):
 
         :param recording_id: MusicBrainz recording ID, or a track ID as
             handed out by e.g. Last.fm.
-        :return: List of ISRCs, or empty list if not found or on error.
+        :return: List of ISRCs, or empty list if not found.
         """
         # the search response includes the ISRCs, so either ID kind costs one call
         safe_id = re.sub(LUCENE_SPECIAL, r"\\\1", recording_id)

--- a/music_assistant/providers/musicbrainz/__init__.py
+++ b/music_assistant/providers/musicbrainz/__init__.py
@@ -429,13 +429,23 @@ class MusicbrainzProvider(MetadataProvider):
         msg = "Invalid MusicBrainz recording ID provided"
         raise InvalidDataError(msg)
 
+    @use_cache(86400 * 30)
     async def get_isrcs_for_recording(self, recording_id: str) -> list[str]:
         """
         Get ISRCs for a MusicBrainz Recording ID.
 
-        :param recording_id: MusicBrainz recording ID.
+        :param recording_id: MusicBrainz recording ID, or a track ID as
+            handed out by e.g. Last.fm.
         :return: List of ISRCs, or empty list if not found or on error.
         """
+        # the search response includes the ISRCs, so either ID kind costs one call
+        query = f"rid:{recording_id} OR tid:{recording_id}"
+        if (result := await self.get_data("recording", query=query)) and (
+            recordings := result.get("recordings")
+        ):
+            return recordings[0].get("isrcs") or []
+        # merged (redirected) recording MBIDs are absent from the search
+        # index but still resolve via direct lookup
         with suppress(InvalidDataError):
             recording = await self.get_recording_details(recording_id)
             return recording.isrcs or []

--- a/music_assistant/providers/musicbrainz/__init__.py
+++ b/music_assistant/providers/musicbrainz/__init__.py
@@ -439,7 +439,8 @@ class MusicbrainzProvider(MetadataProvider):
         :return: List of ISRCs, or empty list if not found or on error.
         """
         # the search response includes the ISRCs, so either ID kind costs one call
-        query = f"rid:{recording_id} OR tid:{recording_id}"
+        safe_id = re.sub(LUCENE_SPECIAL, r"\\\1", recording_id)
+        query = f"rid:{safe_id} OR tid:{safe_id}"
         if (result := await self.get_data("recording", query=query)) and (
             recordings := result.get("recordings")
         ):


### PR DESCRIPTION

# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Last.fm often supplies a track MBID where a recording MBID is expected, so the direct recording lookup returned 404 and most tracks resolved without ISRCs even though they exist in MusicBrainz. Resolve the ID via a single search on both ID kinds instead (the search response includes the ISRCs), keep the direct lookup as fallback for merged recording MBIDs, and cache the result for 30 days.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
