### PR TITLE
Fix Last.fm Discover rows showing owned tracks under a different version name

### DIFF
--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -19,6 +19,7 @@ from music_assistant_models.media_items import (
 
 from music_assistant.constants import CONF_USERNAME
 from music_assistant.helpers.compare import compare_strings
+from music_assistant.helpers.util import parse_title_and_version
 from music_assistant.providers.lastfm_recommendations.constants import (
     CACHE_CATEGORY_RESOLVED_ITEMS,
     CACHE_EXPIRATION_SECONDS,
@@ -188,21 +189,27 @@ class LastFMRecommendationManager:
                 artist_info if isinstance(artist_info, str) else artist_info.get("name", "")
             )
             if name and artist_name:
-                search_query = f"{artist_name} {name}"
+                # Last.fm track names carry scrobbled version suffixes ("- 2006 Remaster");
+                # strip those so variants of an owned track still match
+                clean_name, _ = parse_title_and_version(name, strip_for_search=True)
+                # "Artist - Title" format so the tracks controller searches both fields
+                search_query = f"{artist_name} - {clean_name}"
                 track_results = await self.mass.music.tracks.library_items(
                     search=search_query, limit=LIBRARY_MATCH_SCAN_LIMIT
                 )
                 # Match both title and artist; a title-only check would treat a same-named
-                # track by a different artist as owned.
+                # track by a different artist as owned. Differing recording MBIDs identify
+                # genuinely different tracks, so those never count as a match.
                 track_match = next(
                     (
                         track
                         for track in track_results
-                        if compare_strings(name, track.name, strict=False)
+                        if compare_strings(clean_name, track.name, strict=False)
                         and any(
                             compare_strings(artist_name, track_artist.name, strict=False)
                             for track_artist in track.artists
                         )
+                        and not (mbid and track.mbid and track.mbid != mbid)
                     ),
                     None,
                 )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Last.fm track names often carry a scrobbled version suffix (e.g. 'Ventura Highway - 2006 Remaster'), which the library pre-filter could never match against the owned track: the version suffix defeated the name comparison, and the space-separated search query format meant the library search returned no candidates at all. Strip the version suffix and search as 'Artist - Title' so owned tracks are recognised. A name match is overruled when both sides carry recording MBIDs that differ, as those are genuinely different tracks.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
