### PR TITLE
Derive Last.fm genre rows from listening history, not manual tags

### DIFF
--- a/music_assistant/providers/lastfm_recommendations/api_client.py
+++ b/music_assistant/providers/lastfm_recommendations/api_client.py
@@ -299,27 +299,74 @@ class LastFMAPIClient:
 
         return tracks
 
-    async def get_user_top_tags(self, username: str, limit: int = 1) -> list[dict[str, Any]]:
+    async def get_user_top_artists(
+        self, username: str, period: str = "overall", limit: int = 50
+    ) -> list[dict[str, Any]]:
         """
-        Get a user's top tags from Last.fm.
+        Get a user's most played artists from Last.fm, most played first.
 
         :param username: Last.fm username.
-        :param limit: Maximum number of tags to return (default 1 for top genre).
+        :param period: Span to rank over (overall, 7day, 1month, 3month, 6month, 12month).
+        :param limit: Maximum number of artists to return.
         """
-        self.logger.debug("Fetching top tags for user: %s", username)
+        self.logger.debug("Fetching top artists for user: %s (period: %s)", username, period)
         try:
-            data = await self._get_data("user.getTopTags", user=username, limit=limit)
+            data = await self._get_data(
+                "user.getTopArtists", user=username, period=period, limit=limit
+            )
         except (TimeoutError, ClientError, InvalidDataError) as err:
-            self.logger.debug("User top tags request failed: %s", err)
+            self.logger.debug("User top artists request failed: %s", err)
             return []
 
-        tags: list[dict[str, Any]] | dict[str, Any] = data.get("toptags", {}).get("tag", [])
+        artists: list[dict[str, Any]] | dict[str, Any] = data.get("topartists", {}).get(
+            "artist", []
+        )
 
         # Last.fm returns a single dict when only one result is present.
-        if isinstance(tags, dict):
-            return [tags]
+        if isinstance(artists, dict):
+            return [artists]
 
-        return tags
+        return artists
+
+    async def get_artist_top_tags(
+        self, artist_name: str, artist_mbid: str | None = None, limit: int = 5
+    ) -> list[dict[str, Any]]:
+        """
+        Get an artist's top community tags from Last.fm, most agreed-upon first.
+
+        :param artist_name: Name of the artist.
+        :param artist_mbid: Optional MusicBrainz ID for more accurate matching.
+        :param limit: Maximum number of tags to return.
+        """
+        self.logger.debug(
+            "Fetching top tags for artist: %s (MBID: %s)", artist_name, artist_mbid or "none"
+        )
+        name_params: dict[str, Any] | None = (
+            {"artist": artist_name, "autocorrect": 1} if artist_name else None
+        )
+        primary_params: dict[str, Any] | None
+        fallback_params: dict[str, Any] | None
+        # Lead with the MBID (exact when Last.fm has it), fall back to the name lookup.
+        if artist_mbid:
+            primary_params = {"mbid": artist_mbid}
+            fallback_params = name_params
+        else:
+            primary_params = name_params
+            fallback_params = None
+
+        if primary_params is None:
+            return []
+
+        # artist.getTopTags has no limit parameter, so cap the (count-ordered) result ourselves.
+        tags = await self._get_list(
+            "artist.getTopTags",
+            "toptags",
+            "tag",
+            "Artist top tags",
+            primary_params,
+            fallback_params,
+        )
+        return tags[:limit]
 
     async def get_tag_top_artists(self, tag: str, limit: int = 10) -> list[dict[str, Any]]:
         """

--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -17,8 +17,15 @@ REFRESH_TASK_ID: Final[str] = "lastfm_recommendations_refresh"
 # Cache category for resolved Artist/Album/Track objects
 CACHE_CATEGORY_RESOLVED_ITEMS = 1
 
+# Cache category for the user's derived top genres
+CACHE_CATEGORY_TOP_GENRES = 2
+
 # Expiration time for cached resolved items (in seconds)
 CACHE_EXPIRATION_SECONDS = 60 * 60 * 24 * 90  # 90 days
+
+# Expiration for the derived top genres; genre identity is stable and the genre rows only
+# rotate daily, so a daily recompute is plenty and keeps the per-artist tag fan-out cheap.
+TOP_GENRES_CACHE_EXPIRATION_SECONDS = 60 * 60 * 24  # 1 day
 
 # Concurrency limits
 # Maximum number of concurrent provider searches to prevent overwhelming APIs
@@ -66,8 +73,18 @@ RECENT_TRACKS_SCAN_LIMIT = 200
 # Number of top tracks fetched as seeds; over-fetched so enough are recognised by Last.fm
 TOP_TRACKS_LIMIT = 10
 
-# Number of top genre tags fetched; the genre rows cycle through them daily
+# Number of derived genres; the genre rows cycle through them daily
 TOP_TAGS_LIMIT = 3
+
+# Genres are derived from the community tags of the user's most played artists. Last.fm has no
+# genre data of its own, so an artist's top tags stand in for its genre.
+# Number of the user's top artists to analyse, and the time span to rank them over.
+GENRE_ARTISTS_LIMIT = 25
+GENRE_ARTISTS_PERIOD = "overall"
+
+# Number of top tags to take from each artist. Kept small because an artist's leading tags are
+# almost always its genre; folksonomy noise ("seen live", "favourites") sits further down.
+TAGS_PER_ARTIST = 5
 
 # API search settings
 # Search limit for provider API calls (workaround for Spotify API bug with limit=1)

--- a/music_assistant/providers/lastfm_recommendations/constants.py
+++ b/music_assistant/providers/lastfm_recommendations/constants.py
@@ -74,7 +74,7 @@ RECENT_TRACKS_SCAN_LIMIT = 200
 TOP_TRACKS_LIMIT = 10
 
 # Number of derived genres; the genre rows cycle through them daily
-TOP_TAGS_LIMIT = 3
+TOP_GENRES_LIMIT = 3
 
 # Genres are derived from the community tags of the user's most played artists. Last.fm has no
 # genre data of its own, so an artist's top tags stand in for its genre.

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -41,8 +41,8 @@ from music_assistant.providers.lastfm_recommendations.constants import (
     TARGET_ITEM_COUNT,
     TOP_ARTISTS_LIMIT,
     TOP_GENRES_CACHE_EXPIRATION_SECONDS,
+    TOP_GENRES_LIMIT,
     TOP_ITEMS_TO_TAKE,
-    TOP_TAGS_LIMIT,
     TOP_TRACKS_LIMIT,
 )
 from music_assistant.providers.lastfm_recommendations.parsers import (
@@ -654,7 +654,7 @@ class LastFMRecommendationManager:
                 display_names.setdefault(key, name)
 
         ranked = sorted(scores, key=lambda key: scores[key], reverse=True)
-        top_genres = [display_names[key] for key in ranked[:TOP_TAGS_LIMIT]]
+        top_genres = [display_names[key] for key in ranked[:TOP_GENRES_LIMIT]]
 
         if top_genres:
             await self.mass.cache.set(

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -21,12 +21,15 @@ from music_assistant.constants import CONF_USERNAME
 from music_assistant.helpers.compare import compare_strings
 from music_assistant.providers.lastfm_recommendations.constants import (
     CACHE_CATEGORY_RESOLVED_ITEMS,
+    CACHE_CATEGORY_TOP_GENRES,
     CACHE_EXPIRATION_SECONDS,
     CONF_ENABLE_GENRE,
     CONF_ENABLE_GEO,
     CONF_ENABLE_GLOBAL_CHARTS,
     CONF_ENABLE_PERSONALIZED,
     CONF_GEO_COUNTRY,
+    GENRE_ARTISTS_LIMIT,
+    GENRE_ARTISTS_PERIOD,
     LIBRARY_MATCH_SCAN_LIMIT,
     RECENT_TRACKS_SCAN_LIMIT,
     RESOLUTION_BUFFER_LARGE,
@@ -34,8 +37,10 @@ from music_assistant.providers.lastfm_recommendations.constants import (
     SIMILAR_ITEMS_BUFFER,
     SIMILAR_ITEMS_PER_SEED,
     SIMILAR_TRACKS_BUFFER,
+    TAGS_PER_ARTIST,
     TARGET_ITEM_COUNT,
     TOP_ARTISTS_LIMIT,
+    TOP_GENRES_CACHE_EXPIRATION_SECONDS,
     TOP_ITEMS_TO_TAKE,
     TOP_TAGS_LIMIT,
     TOP_TRACKS_LIMIT,
@@ -81,6 +86,10 @@ class LastFMRecommendationManager:
 
         await self.mass.cache.clear(
             category_filter=CACHE_CATEGORY_RESOLVED_ITEMS,
+            provider_filter=self.provider.instance_id,
+        )
+        await self.mass.cache.clear(
+            category_filter=CACHE_CATEGORY_TOP_GENRES,
             provider_filter=self.provider.instance_id,
         )
 
@@ -472,26 +481,20 @@ class LastFMRecommendationManager:
 
     async def _get_genre_based_recommendations(self) -> AsyncIterator[RecommendationFolder]:
         """
-        Yield genre-based recommendation folders derived from the user's top Last.fm tag.
+        Yield genre-based recommendation folders derived from the user's top genres.
 
         Requires a username to be configured.
         """
         if not self.provider.config.get_value(CONF_ENABLE_GENRE):
             return
 
-        username = self.provider.config.get_value(CONF_USERNAME)
-        if not username or not isinstance(username, str):
-            return
-
-        top_tags = await self.api.get_user_top_tags(username, limit=TOP_TAGS_LIMIT)
-        if not top_tags:
+        top_genres = await self._get_top_genres()
+        if not top_genres:
             return
 
         # cycle through the user's top genres day by day so the genre rows vary
         day_index = datetime.datetime.now(tz=datetime.UTC).date().toordinal()
-        tag_name = top_tags[day_index % len(top_tags)].get("name")
-        if not tag_name:
-            return
+        tag_name = top_genres[day_index % len(top_genres)]
 
         # Over-fetch so there's enough left after library filtering and resolution failures.
         genre_artists_raw = await self.api.get_tag_top_artists(
@@ -524,7 +527,7 @@ class LastFMRecommendationManager:
                     name=f"Discover {tag_name.title()} Artists",
                     provider=self.provider.instance_id,
                     items=UniqueList(genre_artists),
-                    subtitle="Top artists in your most played genre",
+                    subtitle="Top artists in your top genres",
                     icon="mdi-account-music",
                 )
 
@@ -558,7 +561,7 @@ class LastFMRecommendationManager:
                     name=f"Discover {tag_name.title()} Albums",
                     provider=self.provider.instance_id,
                     items=UniqueList(genre_albums),
-                    subtitle="Top albums in your most played genre",
+                    subtitle="Top albums in your top genres",
                     icon="mdi-album",
                 )
 
@@ -592,9 +595,76 @@ class LastFMRecommendationManager:
                     name=f"Discover {tag_name.title()} Tracks",
                     provider=self.provider.instance_id,
                     items=UniqueList(genre_tracks),
-                    subtitle="Top tracks in your most played genre",
+                    subtitle="Top tracks in your top genres",
                     icon="mdi-music",
                 )
+
+    async def _get_top_genres(self) -> list[str]:
+        """Return the user's top genres, most prominent first, derived from their listening."""
+        username = self.provider.config.get_value(CONF_USERNAME)
+        if not username or not isinstance(username, str):
+            return []
+
+        # Deriving genres costs a request per top artist, so cache the result.
+        cached = await self.mass.cache.get(
+            key="top_genres",
+            category=CACHE_CATEGORY_TOP_GENRES,
+            provider=self.provider.instance_id,
+        )
+        if isinstance(cached, list):
+            return cached
+
+        top_artists = await self.api.get_user_top_artists(
+            username, period=GENRE_ARTISTS_PERIOD, limit=GENRE_ARTISTS_LIMIT
+        )
+        if not top_artists:
+            return []
+
+        # Last.fm has no genre data, so an artist's top community tags stand in for its genre.
+        # The user's genres are those tags aggregated across their most played artists, weighted
+        # by how much they play each (playcount) and how strongly each tag applies (count 0-100).
+        tag_lists = await asyncio.gather(
+            *[
+                self.api.get_artist_top_tags(
+                    artist.get("name", ""), artist.get("mbid"), limit=TAGS_PER_ARTIST
+                )
+                for artist in top_artists
+            ]
+        )
+
+        scores: dict[str, float] = {}
+        display_names: dict[str, str] = {}
+        for artist, tags in zip(top_artists, tag_lists, strict=True):
+            try:
+                artist_weight = float(artist.get("playcount", 0))
+            except (TypeError, ValueError):
+                continue
+            if artist_weight <= 0:
+                continue
+            for tag in tags:
+                name = tag.get("name", "")
+                if not name:
+                    continue
+                try:
+                    tag_count = float(tag.get("count", 0))
+                except (TypeError, ValueError):
+                    continue
+                key = name.lower()
+                scores[key] = scores.get(key, 0.0) + artist_weight * tag_count / 100
+                display_names.setdefault(key, name)
+
+        ranked = sorted(scores, key=lambda key: scores[key], reverse=True)
+        top_genres = [display_names[key] for key in ranked[:TOP_TAGS_LIMIT]]
+
+        if top_genres:
+            await self.mass.cache.set(
+                "top_genres",
+                top_genres,
+                category=CACHE_CATEGORY_TOP_GENRES,
+                provider=self.provider.instance_id,
+                expiration=TOP_GENRES_CACHE_EXPIRATION_SECONDS,
+            )
+        return top_genres
 
     async def _get_geo_based_recommendations(self) -> AsyncIterator[RecommendationFolder]:
         """Yield geography-based recommendation folders for the configured country."""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

I misunderstood what the last.fm tags were. I thought they were a different name for the genre but they are actually just manually applied tags by users. However, generally most users do add a genre and thus the genre tends to bubble to the top as the top tag which can be accessed by calling `artist.getTopTags`. 

Previously the genre rows sourced their tag from `user.getTopTags`, which is the tags the user has manually applied on Last.fm, not their listening history. If a user has not applied any tags then they will see no rows at all.

Now we derive genres from the listening history instead. We take the user's most played artists (`user.getTopArtists`), aggregate each artist's top community tags weighted by playcount and tag strength, and use the top 3 as the rotating genres.  Result is cached daily to keep the per-artist tag fan-out cheap.

Also corrects the row subtitles from 'your most played genre' (which implied a playcount basis that never existed) to 'your top genres'.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
