### PR TITLE
Fix now-playing artwork showing a solid background for transparent logos

### DIFF
--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -182,7 +182,8 @@ def _extract_imageproxy_id(url: str) -> str | None:
 
 
 def player_image_url(mass: MusicAssistant, url: str | None) -> str | None:
-    """Rewrite a public-webserver imageproxy URL to the internal streams server.
+    """
+    Rewrite an imageproxy URL for consumption by a (physical) player.
 
     :param mass: The MusicAssistant instance.
     :param url: Image URL as produced for frontend/API consumers.
@@ -191,7 +192,14 @@ def player_image_url(mass: MusicAssistant, url: str | None) -> str | None:
         return url
     webserver_base = mass.webserver.base_url
     if webserver_base and url.startswith(f"{webserver_base}/imageproxy"):
-        return mass.streams.base_url + url[len(webserver_base) :]
+        # players may not be able to reach the webserver, so serve from the streams
+        # server, and force jpeg (= flatten transparency) as players such as legacy
+        # AirPlay receivers cannot be assumed to handle PNG alpha
+        url = mass.streams.base_url + url[len(webserver_base) :]
+        parsed = urllib.parse.urlparse(url)
+        query = urllib.parse.parse_qs(parsed.query)
+        query["fmt"] = ["jpeg"]
+        return parsed._replace(query=urllib.parse.urlencode(query, doseq=True)).geturl()
     return url
 
 

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1787,8 +1787,11 @@ class Player(ABC):
             active_queue = self.mass.player_queues.get(self.player_id)
         if active_queue and (current_item := active_queue.current_item):
             item_image_url = (
-                # the image format needs to be 512x512 jpeg for maximum compatibility with players
-                self.mass.metadata.get_image_url(current_item.image, size=512, image_format="jpeg")
+                # no forced jpeg here: fmt=jpeg flattens transparency onto a solid
+                # background while this url is also rendered by the frontend/API clients.
+                # Providers forwarding it to a player that needs jpeg must rewrite it
+                # through player_image_url().
+                self.mass.metadata.get_image_url(current_item.image, size=512)
                 if current_item.image
                 else None
             )
@@ -1820,11 +1823,8 @@ class Player(ABC):
                 podcast = getattr(media_item, "podcast", None)
                 metadata = getattr(media_item, "metadata", None)
                 description = getattr(metadata, "description", None) if metadata else None
-                # the image format needs to be 512x512 jpeg for maximum player compatibility
                 image_url = (
-                    self.mass.metadata.get_image_url(
-                        current_item.media_item.image, size=512, image_format="jpeg"
-                    )
+                    self.mass.metadata.get_image_url(current_item.media_item.image, size=512)
                     or item_image_url
                     if current_item.media_item.image
                     else item_image_url

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1787,10 +1787,6 @@ class Player(ABC):
             active_queue = self.mass.player_queues.get(self.player_id)
         if active_queue and (current_item := active_queue.current_item):
             item_image_url = (
-                # no forced jpeg here: fmt=jpeg flattens transparency onto a solid
-                # background while this url is also rendered by the frontend/API clients.
-                # Providers forwarding it to a player that needs jpeg must rewrite it
-                # through player_image_url().
                 self.mass.metadata.get_image_url(current_item.image, size=512)
                 if current_item.image
                 else None

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1787,6 +1787,7 @@ class Player(ABC):
             active_queue = self.mass.player_queues.get(self.player_id)
         if active_queue and (current_item := active_queue.current_item):
             item_image_url = (
+             # the image format needs to be 512x512 jpeg for maximum compatibility with players
                 self.mass.metadata.get_image_url(current_item.image, size=512)
                 if current_item.image
                 else None

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1787,7 +1787,7 @@ class Player(ABC):
             active_queue = self.mass.player_queues.get(self.player_id)
         if active_queue and (current_item := active_queue.current_item):
             item_image_url = (
-             # the image format needs to be 512x512 jpeg for maximum compatibility with players
+                # the image format needs to be 512x512 jpeg for maximum compatibility with players
                 self.mass.metadata.get_image_url(current_item.image, size=512)
                 if current_item.image
                 else None

--- a/tests/core/test_image_proxy.py
+++ b/tests/core/test_image_proxy.py
@@ -23,6 +23,7 @@ from music_assistant.helpers.images import (
     create_thumb_hash,
     detect_image_content_format,
     is_svg_data,
+    player_image_url,
 )
 from music_assistant.mass import MusicAssistant
 
@@ -349,3 +350,20 @@ async def test_serve_thumbnail_sets_csp_for_svg(
     jpg_resp = await metadata_controller._serve_thumbnail("p", "builtin", 256, "jpeg")
     assert "Content-Security-Policy" not in jpg_resp.headers
     assert "X-Content-Type-Options" not in jpg_resp.headers
+
+
+def test_player_image_url_forces_jpeg_on_imageproxy_urls() -> None:
+    """Player-bound imageproxy URLs move to the streams server and force fmt=jpeg."""
+    mass = MagicMock()
+    mass.webserver.base_url = "http://192.168.1.2:8095"
+    mass.streams.base_url = "http://192.168.1.2:8097"
+    image_id = "a" * 64
+
+    url = f"http://192.168.1.2:8095/imageproxy/{image_id}?size=512&fmt=png"
+    result = player_image_url(mass, url)
+    assert result == f"http://192.168.1.2:8097/imageproxy/{image_id}?size=512&fmt=jpeg"
+
+    # non-imageproxy urls (e.g. remote radio artwork) pass through unchanged
+    remote = "https://example.com/art.png"
+    assert player_image_url(mass, remote) == remote
+    assert player_image_url(mass, None) is None


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The `Player.current_media` state property forced `fmt=jpeg` on its image URL, which flattens transparent station logos onto a solid background (black before #4094, white after). That URL is also rendered by the frontend, so the UI showed the flattened variant when reloading while a radio station is playing.

`current_media` now keeps the transparency-preserving format for frontend/ API consumers, while `player_image_url()` which is already used, for example, by AirPlay for artwork passed to cliraop. This forces `fmt=jpeg` at the point of device consumption, so players receive the exact same flattened jpeg as before.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
