### PR TITLE
Spotify Connect: don't block volume changes when no music provider is installed

### DIFF
--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -431,6 +431,11 @@ class SpotifyConnectProvider(PluginProvider):
         """Sync the Spotify app's volume slider with the player's new volume."""
         if source_id != AUDIO_SOURCE_ID:
             return
+        # Syncing the slider needs the Web API, which is only available with a
+        # matching Spotify music provider. Without one there is nothing to sync,
+        # so bail out instead of raising and breaking the player's volume change.
+        if not self._spotify_provider:
+            return
         if not self._librespot_playing and not self._spotify_session_active:
             raise AudioError(NOT_ACTIVE_DEVICE_MESSAGE)
         await self._on_volume(volume)

--- a/tests/providers/spotify_connect/__init__.py
+++ b/tests/providers/spotify_connect/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Spotify Connect plugin."""

--- a/tests/providers/spotify_connect/test_provider.py
+++ b/tests/providers/spotify_connect/test_provider.py
@@ -1,0 +1,77 @@
+# mypy: disable-error-code="attr-defined,method-assign,misc,assignment,unused-ignore"
+"""Tests for the SpotifyConnectProvider."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from music_assistant.providers.spotify_connect import (
+    AUDIO_SOURCE_ID,
+    CONF_MASS_PLAYER_ID,
+    CONF_PUBLISH_NAME,
+    PLAYER_ID_AUTO,
+    SpotifyConnectProvider,
+)
+
+
+def _make_mock_config(values: dict[str, Any] | None = None) -> MagicMock:
+    """Create a mock ProviderConfig."""
+    defaults: dict[str, Any] = {
+        CONF_MASS_PLAYER_ID: PLAYER_ID_AUTO,
+        CONF_PUBLISH_NAME: "Spotify Connect",
+        "log_level": "GLOBAL",
+    }
+    if values:
+        defaults.update(values)
+    config = MagicMock()
+    config.get_value.side_effect = defaults.get
+    config.instance_id = "spotify_connect_test"
+    config.name = "Spotify Connect"
+    return config
+
+
+def _make_mock_manifest() -> MagicMock:
+    """Create a mock ProviderManifest."""
+    manifest = MagicMock()
+    manifest.domain = "spotify_connect"
+    manifest.name = "Spotify Connect"
+    return manifest
+
+
+def _make_provider() -> SpotifyConnectProvider:
+    """Create a SpotifyConnectProvider with mock dependencies."""
+    mass = MagicMock()
+    mass.cache_path = "/var/cache/test-cache"
+    return SpotifyConnectProvider(mass, _make_mock_manifest(), _make_mock_config())
+
+
+async def test_on_volume_change_without_web_api_is_noop() -> None:
+    """Without a Spotify music provider, a volume change must not raise (regression #5627)."""
+    provider = _make_provider()
+    provider._spotify_provider = None
+    provider._librespot_playing = True
+    provider._on_volume = AsyncMock()
+
+    # must not raise (regression for support issue #5627)
+    await provider.on_volume_change(AUDIO_SOURCE_ID, 50)
+
+    provider._on_volume.assert_not_called()
+
+
+async def test_on_volume_change_with_web_api_syncs_volume() -> None:
+    """With a Spotify music provider available the new volume is synced upstream."""
+    provider = _make_provider()
+    provider._spotify_provider = MagicMock()
+    provider._librespot_playing = True
+    provider._on_volume = AsyncMock()
+
+    await provider.on_volume_change(AUDIO_SOURCE_ID, 42)
+
+    provider._on_volume.assert_awaited_once_with(42)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
> 🤖 This issue was auto-triaged and this PR was opened in draft for a maintainer to review.

# What does this implement/fix?

When Spotify Connect is used **without** a matching Spotify music provider installed, changing the volume from the Spotify app no longer worked on 2.9.0 (it worked on 2.8.0).

A volume change on the player fires the `on_volume_change` hook on the Spotify Connect AudioSource so the Spotify app's volume slider can be kept in sync. That sync goes through the Spotify Web API, which is only available when a matching Spotify music provider is configured. Without one, `_on_volume` raised `UnsupportedFeaturedException`, and because the hook is awaited from `PlayerController.cmd_volume_set`, the exception propagated and aborted the volume change.

There is nothing to sync back to when the Web API is unavailable, so `on_volume_change` now returns early in that case instead of raising.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5627

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.
