### PR TITLE
support cgroups on linux for memory detection

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -119,15 +119,108 @@ async def warn_if_missing_x86_64_v2(logger: logging.Logger) -> None:
 
 
 def get_total_system_memory() -> float:
-    """Get total system memory in GB."""
-    try:
-        # Works on Linux and macOS
-        total_memory_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
-        return total_memory_bytes / (1024**3)  # Convert to GB
-    except (AttributeError, ValueError):
-        # Fallback if sysconf is not available (e.g., Windows)
-        # Return a conservative default to disable buffering by default
+    """
+    Get total usable memory in GB.
+
+    On Linux containers (Docker, Podman, systemd-nspawn, LXC, Kubernetes...) the
+    host's physical RAM is usually not what the process can actually use: the
+    cgroup memory limit is the real ceiling. This function reads the cgroup
+    limit when present and returns the smaller of the host RAM and the cgroup
+    limit, so auto-sizing of buffers/connectors tracks the *effective* memory
+    budget of the process rather than the host's.
+
+    Falls back to host RAM (sysconf) on non-Linux or when cgroup files are
+    absent/unreadable, and to ``0.0`` if even sysconf is unavailable.
+    """
+    host_gb = _get_host_memory_gb()
+    if host_gb <= 0:
         return 0.0
+    if sys.platform != "linux":
+        return host_gb
+    cgroup_gb = _get_cgroup_memory_limit_gb()
+    if cgroup_gb is None or cgroup_gb <= 0:
+        return host_gb
+    return min(host_gb, cgroup_gb)
+
+
+def _get_host_memory_gb() -> float:
+    """Get host physical RAM in GB via sysconf, or 0.0 if unavailable."""
+    try:
+        total_memory_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+        return total_memory_bytes / (1024**3)
+    except (AttributeError, ValueError, OSError):
+        return 0.0
+
+
+def _get_cgroup_memory_limit_gb() -> float | None:
+    """
+    Read the effective cgroup memory limit in GB, or ``None`` if no limit is set.
+
+    Supports both cgroup v1 (``memory.limit_in_bytes``) and v2 (``memory.max``).
+    Returns ``None`` for the v2 "max" sentinel or v1 sentinel very-large values
+    (i.e. effectively unlimited), so the caller can fall back to host RAM.
+    """
+    # cgroup v2 first (modern systems)
+    limit = _read_cgroup_v2_limit()
+    if limit is not None:
+        return limit
+    # cgroup v1 fallback
+    return _read_cgroup_v1_limit()
+
+
+def _read_cgroup_v2_limit() -> float | None:
+    """
+    Read cgroup v2 ``memory.max`` and return the limit in GB, or ``None`` when
+    the file is missing, unreadable, or set to the "unlimited" sentinel "max".
+    """
+    path = "/sys/fs/cgroup/memory.max"
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+    if not raw or raw == "max":
+        return None
+    try:
+        limit_bytes = int(raw)
+    except ValueError:
+        return None
+    if limit_bytes <= 0 or limit_bytes >= _CGROUP_UNLIMITED_THRESHOLD:
+        return None
+    return limit_bytes / (1024**3)
+
+
+def _read_cgroup_v1_limit() -> float | None:
+    """
+    Read cgroup v1 ``memory.limit_in_bytes`` and return the limit in GB, or
+    ``None`` when the file is missing, unreadable, or set to a sentinel
+    "unlimited" value (a very large number that the kernel writes when no
+    limit is configured).
+    """
+    # the cgroup v1 hierarchy may live in a custom mount; check the canonical
+    # location first, then fall back to a global memory cgroup path.
+    for path in ("/sys/fs/cgroup/memory/memory.limit_in_bytes",):
+        try:
+            with open(path) as fh:
+                raw = fh.read().strip()
+        except (FileNotFoundError, PermissionError, OSError):
+            continue
+        if not raw:
+            continue
+        try:
+            limit_bytes = int(raw)
+        except ValueError:
+            continue
+        if limit_bytes <= 0 or limit_bytes >= _CGROUP_UNLIMITED_THRESHOLD:
+            return None
+        return limit_bytes / (1024**3)
+    return None
+
+
+# cgroup v1 writes a very large number (PAGE_SIZE * LONG_MAX on most kernels)
+# to memory.limit_in_bytes when no limit is configured. Treat anything above
+# this threshold as "unlimited" rather than a real cap.
+_CGROUP_UNLIMITED_THRESHOLD: int = 1 << 62
 
 
 def verify_cpu_supports_ml_inference() -> None:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -119,19 +119,7 @@ async def warn_if_missing_x86_64_v2(logger: logging.Logger) -> None:
 
 
 def get_total_system_memory() -> float:
-    """
-    Get total usable memory in GB.
-
-    On Linux containers (Docker, Podman, systemd-nspawn, LXC, Kubernetes...) the
-    host's physical RAM is usually not what the process can actually use: the
-    cgroup memory limit is the real ceiling. This function reads the cgroup
-    limit when present and returns the smaller of the host RAM and the cgroup
-    limit, so auto-sizing of buffers/connectors tracks the *effective* memory
-    budget of the process rather than the host's.
-
-    Falls back to host RAM (sysconf) on non-Linux or when cgroup files are
-    absent/unreadable, and to ``0.0`` if even sysconf is unavailable.
-    """
+    """Get total system memory in GB."""
     host_gb = _get_host_memory_gb()
     if host_gb <= 0:
         return 0.0
@@ -170,14 +158,6 @@ def _get_cgroup_memory_limit_gb() -> float | None:
 
 @lru_cache(maxsize=1)
 def _get_self_cgroup_path_v2() -> str | None:
-    """
-    Return the cgroup v2 path of the current process relative to the cgroup
-    mount root, or ``None`` if it cannot be determined.
-
-    Reads ``/proc/self/cgroup`` which contains lines of the form
-    ``0::<path>`` for v2 and resolves the path by walking up to the cgroup
-    mount root (the ancestor that owns its own cgroup directory).
-    """
     try:
         with open("/proc/self/cgroup") as fh:
             for line in fh:
@@ -194,14 +174,6 @@ def _get_self_cgroup_path_v2() -> str | None:
 
 @lru_cache(maxsize=1)
 def _get_cgroup_v1_memory_mounts() -> tuple[str, ...]:
-    """
-    Return the memory cgroup mountpoints visible to the current process, in
-    preference order, parsed from ``/proc/self/mountinfo``.
-
-    The cgroup v1 memory controller may be mounted at a custom path (e.g.
-    ``/sys/fs/cgroup/memory``, ``/sys/fs/cgroup/memory/<slice>`` or a fully
-    separate hierarchy), so we cannot assume a fixed location.
-    """
     mounts: list[str] = []
     seen: set[str] = set()
     try:
@@ -230,15 +202,6 @@ def _get_cgroup_v1_memory_mounts() -> tuple[str, ...]:
 
 
 def _read_cgroup_v2_limit() -> float | None:
-    """
-    Read cgroup v2 ``memory.max`` and return the limit in GB, or ``None`` when
-    the file is missing, unreadable, or set to the "unlimited" sentinel "max".
-
-    The v2 unified hierarchy is mounted at a single root (typically
-    ``/sys/fs/cgroup``), and the process's effective cgroup is given by the
-    path reported in ``/proc/self/cgroup``; the limit file is read relative
-    to that path so sub-cgroup limits are honored.
-    """
     rel = _get_self_cgroup_path_v2()
     if rel is None:
         return None
@@ -270,17 +233,6 @@ def _read_cgroup_v2_limit() -> float | None:
 
 
 def _read_cgroup_v1_limit() -> float | None:
-    """
-    Read cgroup v1 ``memory.limit_in_bytes`` and return the limit in GB, or
-    ``None`` when the file is missing, unreadable, or set to a sentinel
-    "unlimited" value (a very large number that the kernel writes when no
-    limit is configured).
-
-    The v1 memory controller may be mounted at various locations; the
-    mountpoints are discovered from ``/proc/self/mountinfo`` and the
-    process's cgroup path is read from ``/proc/self/cgroup`` so sub-cgroup
-    limits (e.g. systemd slices, Kubernetes pods) are honored.
-    """
     mounts = _get_cgroup_v1_memory_mounts()
     if not mounts:
         return None
@@ -312,11 +264,6 @@ def _read_cgroup_v1_limit() -> float | None:
 
 @lru_cache(maxsize=8)
 def _get_self_cgroup_v1_path(controller: str) -> str | None:
-    """
-    Return the cgroup path of the current process for the given v1 controller
-    (e.g. ``"memory"``), relative to the controller's cgroupfs root, or
-    ``None`` if not found.
-    """
     try:
         with open("/proc/self/cgroup") as fh:
             for line in fh:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -168,26 +168,105 @@ def _get_cgroup_memory_limit_gb() -> float | None:
     return _read_cgroup_v1_limit()
 
 
+@lru_cache(maxsize=1)
+def _get_self_cgroup_path_v2() -> str | None:
+    """
+    Return the cgroup v2 path of the current process relative to the cgroup
+    mount root, or ``None`` if it cannot be determined.
+
+    Reads ``/proc/self/cgroup`` which contains lines of the form
+    ``0::<path>`` for v2 and resolves the path by walking up to the cgroup
+    mount root (the ancestor that owns its own cgroup directory).
+    """
+    try:
+        with open("/proc/self/cgroup") as fh:
+            for line in fh:
+                parts = line.strip().split(":", 2)
+                if len(parts) != 3:
+                    continue
+                # v2 unified hierarchy: id "0" with empty controllers list
+                if parts[0] == "0" and parts[1] == "":
+                    return parts[2] or "/"
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+    return None
+
+
+@lru_cache(maxsize=1)
+def _get_cgroup_v1_memory_mounts() -> tuple[str, ...]:
+    """
+    Return the memory cgroup mountpoints visible to the current process, in
+    preference order, parsed from ``/proc/self/mountinfo``.
+
+    The cgroup v1 memory controller may be mounted at a custom path (e.g.
+    ``/sys/fs/cgroup/memory``, ``/sys/fs/cgroup/memory/<slice>`` or a fully
+    separate hierarchy), so we cannot assume a fixed location.
+    """
+    mounts: list[str] = []
+    seen: set[str] = set()
+    try:
+        with open("/proc/self/mountinfo") as fh:
+            for line in fh:
+                # mountinfo format:
+                # mount_id parent_id major:minor root mountpoint options -
+                # fstype source super_options
+                fields = line.split()
+                if len(fields) < 10:
+                    continue
+                if fields[-3] != "cgroup":
+                    continue
+                # The list of controllers a v1 cgroup mount provides lives in
+                # the super_options field (the last field) of mountinfo.
+                super_opts = fields[-1].split(",")
+                if "memory" not in super_opts:
+                    continue
+                mountpoint = fields[4]
+                if mountpoint and mountpoint not in seen:
+                    seen.add(mountpoint)
+                    mounts.append(mountpoint)
+    except (FileNotFoundError, PermissionError, OSError):
+        pass
+    return tuple(mounts)
+
+
 def _read_cgroup_v2_limit() -> float | None:
     """
     Read cgroup v2 ``memory.max`` and return the limit in GB, or ``None`` when
     the file is missing, unreadable, or set to the "unlimited" sentinel "max".
+
+    The v2 unified hierarchy is mounted at a single root (typically
+    ``/sys/fs/cgroup``), and the process's effective cgroup is given by the
+    path reported in ``/proc/self/cgroup``; the limit file is read relative
+    to that path so sub-cgroup limits are honored.
     """
-    path = "/sys/fs/cgroup/memory.max"
-    try:
-        with open(path) as fh:
-            raw = fh.read().strip()
-    except (FileNotFoundError, PermissionError, OSError):
+    rel = _get_self_cgroup_path_v2()
+    if rel is None:
         return None
-    if not raw or raw == "max":
-        return None
-    try:
-        limit_bytes = int(raw)
-    except ValueError:
-        return None
-    if limit_bytes <= 0 or limit_bytes >= _CGROUP_UNLIMITED_THRESHOLD:
-        return None
-    return limit_bytes / (1024**3)
+    if rel == "/":
+        rel_path = "memory.max"
+        candidates = ("/sys/fs/cgroup/memory.max",)
+    else:
+        rel_path = f"{rel.lstrip('/')}/memory.max"
+        candidates = (
+            f"/sys/fs/cgroup/{rel_path}",
+            "/sys/fs/cgroup/memory.max",  # fall back to the root cgroup's limit
+        )
+    for path in candidates:
+        try:
+            with open(path) as fh:
+                raw = fh.read().strip()
+        except (FileNotFoundError, PermissionError, OSError):
+            continue
+        if not raw or raw == "max":
+            return None
+        try:
+            limit_bytes = int(raw)
+        except ValueError:
+            return None
+        if limit_bytes <= 0 or limit_bytes >= _CGROUP_UNLIMITED_THRESHOLD:
+            return None
+        return limit_bytes / (1024**3)
+    return None
 
 
 def _read_cgroup_v1_limit() -> float | None:
@@ -196,12 +275,26 @@ def _read_cgroup_v1_limit() -> float | None:
     ``None`` when the file is missing, unreadable, or set to a sentinel
     "unlimited" value (a very large number that the kernel writes when no
     limit is configured).
+
+    The v1 memory controller may be mounted at various locations; the
+    mountpoints are discovered from ``/proc/self/mountinfo`` and the
+    process's cgroup path is read from ``/proc/self/cgroup`` so sub-cgroup
+    limits (e.g. systemd slices, Kubernetes pods) are honored.
     """
-    # the cgroup v1 hierarchy may live in a custom mount; check the canonical
-    # location first, then fall back to a global memory cgroup path.
-    for path in ("/sys/fs/cgroup/memory/memory.limit_in_bytes",):
+    mounts = _get_cgroup_v1_memory_mounts()
+    if not mounts:
+        return None
+    rel = _get_self_cgroup_v1_path("memory")
+    if rel is None:
+        return None
+    rel = rel.lstrip("/")
+    for mountpoint in mounts:
+        if rel:
+            candidate = os.path.join(mountpoint, rel, "memory.limit_in_bytes")
+        else:
+            candidate = os.path.join(mountpoint, "memory.limit_in_bytes")
         try:
-            with open(path) as fh:
+            with open(candidate) as fh:
                 raw = fh.read().strip()
         except (FileNotFoundError, PermissionError, OSError):
             continue
@@ -214,6 +307,27 @@ def _read_cgroup_v1_limit() -> float | None:
         if limit_bytes <= 0 or limit_bytes >= _CGROUP_UNLIMITED_THRESHOLD:
             return None
         return limit_bytes / (1024**3)
+    return None
+
+
+@lru_cache(maxsize=8)
+def _get_self_cgroup_v1_path(controller: str) -> str | None:
+    """
+    Return the cgroup path of the current process for the given v1 controller
+    (e.g. ``"memory"``), relative to the controller's cgroupfs root, or
+    ``None`` if not found.
+    """
+    try:
+        with open("/proc/self/cgroup") as fh:
+            for line in fh:
+                parts = line.strip().split(":", 2)
+                if len(parts) != 3:
+                    continue
+                controllers = parts[1]
+                if controller in controllers.split(","):
+                    return parts[2] or ""
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
     return None
 
 

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -141,13 +141,6 @@ def _get_host_memory_gb() -> float:
 
 
 def _get_cgroup_memory_limit_gb() -> float | None:
-    """
-    Read the effective cgroup memory limit in GB, or ``None`` if no limit is set.
-
-    Supports both cgroup v1 (``memory.limit_in_bytes``) and v2 (``memory.max``).
-    Returns ``None`` for the v2 "max" sentinel or v1 sentinel very-large values
-    (i.e. effectively unlimited), so the caller can fall back to host RAM.
-    """
     # cgroup v2 first (modern systems)
     limit = _read_cgroup_v2_limit()
     if limit is not None:


### PR DESCRIPTION


# What does this implement/fix?

Currently we look for sysconf, which is not exact available memory when using containers. We must read cgroup values under Linux.

This will permit to better tune music-assistant when memory constraints are sets on containers

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ x `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
