### PR TITLE
Fix high idle memory usage

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -1107,7 +1107,9 @@ DEFAULT_PROVIDERS: Final[set[tuple[str, bool, Callable[[], bool]]]] = {
     ("heos", True, lambda: True),
     ("wiim", True, lambda: True),
     ("party", False, lambda: True),
-    ("smart_fades", False, lambda: (os.cpu_count() or 1) > 1),
+    # smart_fades gates on system requirements (RAM/CPU) in its own setup(); an
+    # under-spec host has the auto-created config removed again at load time.
+    ("smart_fades", False, lambda: True),
     ("lastfm_recommendations", False, lambda: True),
 }
 

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -3,7 +3,6 @@
 import json
 import os
 import pathlib
-from collections.abc import Callable
 from copy import deepcopy
 from typing import Any, Final, cast
 
@@ -1094,23 +1093,22 @@ ACTIVE_PROTOCOL_FEATURES: Final[set[PlayerFeature]] = {
 }
 
 PLAYER_CONTROL_PROTOCOL: Final[str] = "follow_protocol"
-DEFAULT_PROVIDERS: Final[set[tuple[str, bool, Callable[[], bool]]]] = {
+DEFAULT_PROVIDERS: Final[set[tuple[str, bool]]] = {
     # list of providers that are setup by default once
     # (and they can be removed/disabled by the user if they want to)
     # the boolean value indicates whether it needs to be discovered on mdns
-    # the callable is a precondition that must return True for the provider to be setup
-    ("airplay", False, lambda: True),
-    ("chromecast", False, lambda: True),
-    ("dlna", False, lambda: True),
-    ("sonos", True, lambda: True),
-    ("bluesound", True, lambda: True),
-    ("heos", True, lambda: True),
-    ("wiim", True, lambda: True),
-    ("party", False, lambda: True),
+    ("airplay", False),
+    ("chromecast", False),
+    ("dlna", False),
+    ("sonos", True),
+    ("bluesound", True),
+    ("heos", True),
+    ("wiim", True),
+    ("party", False),
     # smart_fades gates on system requirements (RAM/CPU) in its own setup(); an
     # under-spec host has the auto-created config removed again at load time.
-    ("smart_fades", False, lambda: True),
-    ("lastfm_recommendations", False, lambda: True),
+    ("smart_fades", False),
+    ("lastfm_recommendations", False),
 }
 
 EXTERNAL_SOURCES: Final[set[str]] = {

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -67,7 +67,10 @@ from music_assistant.constants import (
     MASS_LOGGER_NAME,
     VERBOSE_LOG_LEVEL,
 )
-from music_assistant.controllers.streams.audio_analysis import LOUDNESS_ANALYSIS_DOMAIN
+from music_assistant.controllers.streams.audio_analysis import (
+    LOUDNESS_ANALYSIS_DOMAIN,
+    SMART_FADES_ANALYSIS_DOMAIN,
+)
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.streams.constants import (
     CACHE_CATEGORY_RESOLVED_RADIO_URL,
@@ -2054,10 +2057,11 @@ class StreamsAudio:
             if flow_player
             else []
         )
-        # smart crossfade requires a large buffer for beat analysis
-        if (
-            smart_fades_mode == SmartFadesMode.SMART_CROSSFADE
-            and self.mass.config.get_raw_core_config_value(
+        # smart crossfade needs the smart_fades analysis provider (for beat/key data) and a
+        # non-minimal buffer for beat analysis; fall back to standard crossfade otherwise.
+        if smart_fades_mode == SmartFadesMode.SMART_CROSSFADE and (
+            self.mass.get_provider(SMART_FADES_ANALYSIS_DOMAIN) is None
+            or self.mass.config.get_raw_core_config_value(
                 "streams", CONF_BUFFER_SIZE, CONF_BUFFER_SIZE_DEFAULT
             )
             == BufferSize.MINIMAL

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -168,7 +168,6 @@ class AudioAnalysisController:
         # with no audio analysis provider enabled never imports torch.
         if self._thread_caps_configured:
             return
-        self._thread_caps_configured = True
         import torch  # noqa: PLC0415
 
         budget = self._aa_thread_budget()
@@ -181,6 +180,8 @@ class AudioAnalysisController:
             torch.get_num_threads(),
             torch.get_num_interop_threads(),
         )
+        # Only mark done once configuration actually succeeded, so a failure retries.
+        self._thread_caps_configured = True
 
     @property
     def providers(self) -> list[AudioAnalysisProvider]:

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -962,9 +962,11 @@ class AudioAnalysisController:
         providers: list[AudioAnalysisProvider],
     ) -> set[str]:
         """Call start_analysis on each provider, returning IDs of those that accepted."""
-        # Apply torch thread caps now that analysis is actually starting (lazy, once).
-        # This is the shared chokepoint for both the live and background-scan paths.
-        self._ensure_thread_caps_configured()
+        # Apply torch thread caps once, but only when a provider that actually runs torch
+        # inference is active — so a host with only non-torch providers (e.g. the builtin
+        # loudness_analysis) never imports torch. Shared by the live and background paths.
+        if any(provider.uses_torch for provider in providers):
+            self._ensure_thread_caps_configured()
         provider_ids: set[str] = set()
         for provider in providers:
             try:

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -162,10 +162,16 @@ class AudioAnalysisController:
         if workers:
             await asyncio.gather(*workers, return_exceptions=True)
 
-    def _ensure_thread_caps_configured(self) -> None:
-        """Cap PyTorch threading (once) so Audio Analysis inference stays around a quarter of cpu_count."""
-        # Import torch lazily and only when analysis actually starts, so an idle server
-        # with no audio analysis provider enabled never imports torch.
+    def ensure_thread_caps_configured(self) -> None:
+        """
+        Cap PyTorch threading for analysis inference (process-wide, applied once).
+
+        Torch-backed analysis providers call this at the start of their handle_async_init,
+        before loading their models.
+        """
+        # Lazy torch import: only torch-backed providers call this, so a host running no
+        # such provider never imports torch. Running before the first model load also lets
+        # set_num_interop_threads take effect (it can only be set before the first torch op).
         if self._thread_caps_configured:
             return
         import torch  # noqa: PLC0415
@@ -962,11 +968,6 @@ class AudioAnalysisController:
         providers: list[AudioAnalysisProvider],
     ) -> set[str]:
         """Call start_analysis on each provider, returning IDs of those that accepted."""
-        # Apply torch thread caps once, but only when a provider that actually runs torch
-        # inference is active — so a host with only non-torch providers (e.g. the builtin
-        # loudness_analysis) never imports torch. Shared by the live and background paths.
-        if any(provider.uses_torch for provider in providers):
-            self._ensure_thread_caps_configured()
         provider_ids: set[str] = set()
         for provider in providers:
             try:

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -12,7 +12,6 @@ from collections.abc import AsyncGenerator, Iterable, Mapping
 from math import inf
 from typing import TYPE_CHECKING, Any
 
-import torch
 from music_assistant_models.audio_analysis import AudioAnalysisCoverage
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import ContentType, MediaType, ProviderType, StreamType
@@ -137,10 +136,10 @@ class AudioAnalysisController:
         self.logger = self.mass.logger.getChild("audio_analysis")
         self._active_sessions: dict[str, set[str]] = {}
         self._workers: dict[str, asyncio.Task[None]] = {}
+        self._thread_caps_configured = False
 
     def setup(self) -> None:
-        """Register the nightly background scan task and apply CPU caps."""
-        self._configure_thread_caps()
+        """Register the nightly background scan task."""
         utc_hour, utc_minute = local_clock_time_to_utc(0, 0)
         self.mass.tasks.register_scheduled_task(
             task_id=BACKGROUND_SCAN_TASK_ID,
@@ -163,8 +162,15 @@ class AudioAnalysisController:
         if workers:
             await asyncio.gather(*workers, return_exceptions=True)
 
-    def _configure_thread_caps(self) -> None:
-        """Cap PyTorch threading so Audio Analysis inference stays around a quarter of cpu_count."""
+    def _ensure_thread_caps_configured(self) -> None:
+        """Cap PyTorch threading (once) so Audio Analysis inference stays around a quarter of cpu_count."""
+        # Import torch lazily and only when analysis actually starts, so an idle server
+        # with no audio analysis provider enabled never imports torch.
+        if self._thread_caps_configured:
+            return
+        self._thread_caps_configured = True
+        import torch  # noqa: PLC0415
+
         budget = self._aa_thread_budget()
         torch.set_num_threads(budget)
         with contextlib.suppress(RuntimeError):
@@ -955,6 +961,9 @@ class AudioAnalysisController:
         providers: list[AudioAnalysisProvider],
     ) -> set[str]:
         """Call start_analysis on each provider, returning IDs of those that accepted."""
+        # Apply torch thread caps now that analysis is actually starting (lazy, once).
+        # This is the shared chokepoint for both the live and background-scan paths.
+        self._ensure_thread_caps_configured()
         provider_ids: set[str] = set()
         for provider in providers:
             try:

--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -41,10 +41,27 @@ RADIO_BUFFER_SIZE: Final[int] = 15
 CONF_BUFFER_SIZE: Final[str] = "buffer_size"
 
 
+def get_available_buffer_sizes() -> list[BufferSize]:
+    """
+    Return the buffer-size presets allowed for this host's RAM.
+
+    Minimal is always available; Balanced requires >= 4GB and Maximum >= 8GB. When total
+    memory is unknown (0.0, e.g. Windows) all presets are offered (fail open).
+    """
+    if TOTAL_SYSTEM_MEMORY_GB == 0.0:
+        return [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]
+    sizes = [BufferSize.MINIMAL]
+    if TOTAL_SYSTEM_MEMORY_GB >= 4.0:
+        sizes.append(BufferSize.BALANCED)
+    if TOTAL_SYSTEM_MEMORY_GB >= 8.0:
+        sizes.append(BufferSize.MAXIMUM)
+    return sizes
+
+
 def _get_default_buffer_size() -> str:
     if TOTAL_SYSTEM_MEMORY_GB >= 8.0:
         return BufferSize.MAXIMUM
-    if TOTAL_SYSTEM_MEMORY_GB > 4.0:
+    if TOTAL_SYSTEM_MEMORY_GB >= 4.0:
         return BufferSize.BALANCED
     return BufferSize.MINIMAL
 

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -69,7 +69,7 @@ from music_assistant.controllers.streams.constants import (
     CONF_BUFFER_SIZE_DEFAULT,
     CONF_SMART_FADES_LOG_LEVEL,
     DEFAULT_PORT,
-    BufferSize,
+    get_available_buffer_sizes,
 )
 from music_assistant.helpers.audio import (
     calculate_content_length,
@@ -189,10 +189,11 @@ class StreamsController(CoreController):
                 "good balance for most systems.\n"
                 "- **Maximum**: Large buffer, "
                 "best performance for systems with plenty of memory.",
+                # Only offer presets the host's RAM can sustain (Balanced >= 4GB,
+                # Maximum >= 8GB); see get_available_buffer_sizes.
                 options=[
-                    ConfigValueOption("Minimal", BufferSize.MINIMAL.value),
-                    ConfigValueOption("Balanced", BufferSize.BALANCED.value),
-                    ConfigValueOption("Maximum", BufferSize.MAXIMUM.value),
+                    ConfigValueOption(size.value.title(), size.value)
+                    for size in get_available_buffer_sizes()
                 ],
                 required=False,
                 category="playback",

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -145,6 +145,7 @@ def verify_system_meets_requirements(
     feature_name: str,
     min_memory_gb: float = 0.0,
     min_cpu_cores: int = 0,
+    require_ml_inference: bool = False,
 ) -> None:
     """
     Verify the host meets the minimum CPU/RAM requirements for a heavy provider.
@@ -152,6 +153,8 @@ def verify_system_meets_requirements(
     :param feature_name: Human-readable provider name used in the error message.
     :param min_memory_gb: Minimum total system RAM in GB (0 disables the check).
     :param min_cpu_cores: Minimum CPU core count (0 disables the check).
+    :param require_ml_inference: When True, also verify the CPU can run on-device
+        torch inference (AVX2 on x86). Checked last, as it imports torch.
     :raises UnsupportedSystemError: If the system does not meet the requirements.
     """
     cpu_cores = os.process_cpu_count() or os.cpu_count() or 1
@@ -169,6 +172,8 @@ def verify_system_meets_requirements(
             f"at least {min_memory_gb:.0f}GB of RAM is required "
             f"({total_memory_gb:.1f}GB detected)."
         )
+    if require_ml_inference:
+        verify_cpu_supports_ml_inference()
 
 
 def verify_cpu_supports_ml_inference() -> None:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -130,11 +130,52 @@ def get_total_system_memory() -> float:
         return 0.0
 
 
+class UnsupportedSystemError(SetupFailedError):
+    """
+    Raised when the host does not meet a provider's minimum requirements.
+
+    Subclass of SetupFailedError so existing setup handling still applies, but it
+    marks a permanent condition (RAM, CPU cores, CPU capability) that will not
+    resolve at runtime, so the provider load must not be retried.
+    """
+
+
+def verify_system_meets_requirements(
+    *,
+    feature_name: str,
+    min_memory_gb: float = 0.0,
+    min_cpu_cores: int = 0,
+) -> None:
+    """
+    Verify the host meets the minimum CPU/RAM requirements for a heavy provider.
+
+    :param feature_name: Human-readable provider name used in the error message.
+    :param min_memory_gb: Minimum total system RAM in GB (0 disables the check).
+    :param min_cpu_cores: Minimum CPU core count (0 disables the check).
+    :raises UnsupportedSystemError: If the system does not meet the requirements.
+    """
+    cpu_cores = os.process_cpu_count() or os.cpu_count() or 1
+    if min_cpu_cores and cpu_cores < min_cpu_cores:
+        raise UnsupportedSystemError(
+            f"This system does not meet the minimal requirements for {feature_name}: "
+            f"at least {min_cpu_cores} CPU cores are required ({cpu_cores} detected)."
+        )
+    total_memory_gb = get_total_system_memory()
+    # get_total_system_memory() returns 0.0 when the platform cannot report memory
+    # (e.g. Windows); treat that as unknown and fail open rather than block setup.
+    if min_memory_gb and total_memory_gb and total_memory_gb < min_memory_gb:
+        raise UnsupportedSystemError(
+            f"This system does not meet the minimal requirements for {feature_name}: "
+            f"at least {min_memory_gb:.0f}GB of RAM is required "
+            f"({total_memory_gb:.1f}GB detected)."
+        )
+
+
 def verify_cpu_supports_ml_inference() -> None:
     """
     Verify the CPU can run on-device ML (torch) inference.
 
-    :raises SetupFailedError: If this is an x86 CPU without AVX2 support, which
+    :raises UnsupportedSystemError: If this is an x86 CPU without AVX2 support, which
         torch's FBGEMM quantized backend requires.
     """
     if platform.machine().lower() not in ("x86_64", "amd64", "i386", "i686", "x86"):
@@ -143,7 +184,7 @@ def verify_cpu_supports_ml_inference() -> None:
     import torch  # noqa: PLC0415
 
     if torch.backends.cpu.get_cpu_capability() in ("DEFAULT", "NO AVX"):
-        raise SetupFailedError(
+        raise UnsupportedSystemError(
             "On-device audio analysis requires a CPU with AVX2 support "
             "(Intel Haswell / AMD Zen or newer). This CPU does not support AVX2. "
             "If you are running in a virtual machine (e.g. Proxmox), changing the "

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -49,6 +49,7 @@ from music_assistant.helpers.api import APICommandHandler, api_command
 from music_assistant.helpers.images import get_icon_string
 from music_assistant.helpers.util import (
     TaskManager,
+    UnsupportedSystemError,
     get_package_version,
     is_hass_supervisor,
     load_provider_module,
@@ -713,6 +714,7 @@ class MusicAssistant:
         self,
         instance_id: str,
         allow_retry: bool = False,
+        remove_if_unsupported: bool = False,
     ) -> None:
         """Try to load a provider and catch errors."""
         try:
@@ -732,6 +734,27 @@ class MusicAssistant:
 
         try:
             await self.load_provider_config(prov_conf)
+        except UnsupportedSystemError as exc:
+            # The host does not meet this provider's hardware requirements. This is a
+            # permanent condition, so we never retry. For a provider that was just
+            # auto-set-up as a default, drop the config again so it does not linger as a
+            # broken provider (it stays marked done so it is not auto-created again).
+            if remove_if_unsupported:
+                LOGGER.info(
+                    "Not enabling default provider %s: %s",
+                    prov_conf.name or prov_conf.instance_id,
+                    exc,
+                )
+                await self.config.remove_provider_config(instance_id)
+                return
+            prov_conf.last_error = str(exc)
+            self.config.set(f"{CONF_PROVIDERS}/{instance_id}/last_error", str(exc))
+            LOGGER.warning(
+                "Provider(instance) %s can not run on this system: %s",
+                prov_conf.name or prov_conf.instance_id,
+                exc,
+            )
+            return
         except Exception as exc:
             # if loading failed, we store the error in the config object
             # so we can show something useful to the user
@@ -895,6 +918,7 @@ class MusicAssistant:
         self.config.set_default(CONF_DEFAULT_PROVIDERS_SETUP, set())
         default_providers_setup = set(self.config.get(CONF_DEFAULT_PROVIDERS_SETUP))
         changes_made = False
+        newly_created_defaults: set[str] = set()
         for default_provider, require_mdns, precondition in DEFAULT_PROVIDERS:
             if default_provider in default_providers_setup:
                 # already processed/setup before, skip
@@ -915,6 +939,7 @@ class MusicAssistant:
                     continue
             await self.config.create_builtin_provider_config(manifest.domain)
             changes_made = True
+            newly_created_defaults.add(manifest.domain)
             # TEMP: migration - to be removed after 2.8 release
             # enable all existing players of the default providers if they are not already enabled
             # due to the linked protocol feature we introduced
@@ -944,7 +969,15 @@ class MusicAssistant:
             for prov_conf in other_configs:
                 # Use a task so we can load multiple providers at once.
                 # If a provider fails, that will not block the loading of other providers.
-                tg.create_task(self.load_provider(prov_conf.instance_id, allow_retry=True))
+                # For providers just auto-set-up as a default, drop the config again if the
+                # host does not meet their requirements (rather than retry a broken provider).
+                tg.create_task(
+                    self.load_provider(
+                        prov_conf.instance_id,
+                        allow_retry=True,
+                        remove_if_unsupported=prov_conf.domain in newly_created_defaults,
+                    )
+                )
 
     async def _load_provider(self, conf: ProviderConfig) -> None:
         """Load (or reload) a provider."""

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -745,7 +745,10 @@ class MusicAssistant:
                     prov_conf.name or prov_conf.instance_id,
                     exc,
                 )
-                await self.config.remove_provider_config(instance_id)
+                # The provider never loaded, so just drop its auto-created config key.
+                # (remove_provider_config refuses builtin providers and runs loaded-provider
+                # cleanup we don't need here; a direct remove persists and is guard-free.)
+                self.config.remove(f"{CONF_PROVIDERS}/{instance_id}")
                 return
             prov_conf.last_error = str(exc)
             self.config.set(f"{CONF_PROVIDERS}/{instance_id}/last_error", str(exc))

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -919,13 +919,11 @@ class MusicAssistant:
         default_providers_setup = set(self.config.get(CONF_DEFAULT_PROVIDERS_SETUP))
         changes_made = False
         newly_created_defaults: set[str] = set()
-        for default_provider, require_mdns, precondition in DEFAULT_PROVIDERS:
+        for default_provider, require_mdns in DEFAULT_PROVIDERS:
             if default_provider in default_providers_setup:
                 # already processed/setup before, skip
                 continue
             if not (manifest := self._provider_manifests.get(default_provider)):
-                continue
-            if not precondition():
                 continue
             if require_mdns:
                 # if mdns discovery is required, check if we have seen any mdns entries

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -42,12 +42,6 @@ class AudioAnalysisProvider(Provider):
     # the stored version to decide whether to re-analyze a track.
     analysis_version: int = 1
 
-    # Set True by providers that run on-device torch inference. The
-    # AudioAnalysisController only configures torch thread caps (and thus imports
-    # torch) when at least one active provider sets this, so a host running only
-    # non-torch providers (e.g. the builtin loudness_analysis) never imports torch.
-    uses_torch: bool = False
-
     def __init__(
         self,
         mass: MusicAssistant,

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -42,6 +42,12 @@ class AudioAnalysisProvider(Provider):
     # the stored version to decide whether to re-analyze a track.
     analysis_version: int = 1
 
+    # Set True by providers that run on-device torch inference. The
+    # AudioAnalysisController only configures torch thread caps (and thus imports
+    # torch) when at least one active provider sets this, so a host running only
+    # non-torch providers (e.g. the builtin loudness_analysis) never imports torch.
+    uses_torch: bool = False
+
     def __init__(
         self,
         mass: MusicAssistant,

--- a/music_assistant/providers/smart_fades/__init__.py
+++ b/music_assistant/providers/smart_fades/__init__.py
@@ -35,7 +35,10 @@ async def setup(
     # Gate before importing the provider module so the heavy torch/beat_this stack is
     # never imported on a host that does not meet the minimal requirements.
     verify_system_meets_requirements(
-        feature_name="Smart Fades", min_memory_gb=MIN_RAM_GB, min_cpu_cores=MIN_CPU_CORES
+        feature_name="Smart Fades",
+        min_memory_gb=MIN_RAM_GB,
+        min_cpu_cores=MIN_CPU_CORES,
+        require_ml_inference=True,
     )
     from .provider import SmartFadesProvider  # noqa: PLC0415
 

--- a/music_assistant/providers/smart_fades/__init__.py
+++ b/music_assistant/providers/smart_fades/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import ConfigEntryType
 
-from .provider import SmartFadesProvider
+from music_assistant.helpers.util import verify_system_meets_requirements
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ProviderConfig
@@ -17,7 +17,13 @@ if TYPE_CHECKING:
 
     from music_assistant.mass import MusicAssistant
 
+    from .provider import SmartFadesProvider
+
 SUPPORTED_FEATURES: set[ProviderFeature] = set()
+
+# Smart Fades runs on-device ML (torch) inference; gate it to capable hardware.
+MIN_RAM_GB = 6.0
+MIN_CPU_CORES = 4
 
 
 async def setup(
@@ -26,6 +32,13 @@ async def setup(
     config: ProviderConfig,
 ) -> SmartFadesProvider:
     """Set up the Smart Fades provider."""
+    # Gate before importing the provider module so the heavy torch/beat_this stack is
+    # never imported on a host that does not meet the minimal requirements.
+    verify_system_meets_requirements(
+        feature_name="Smart Fades", min_memory_gb=MIN_RAM_GB, min_cpu_cores=MIN_CPU_CORES
+    )
+    from .provider import SmartFadesProvider  # noqa: PLC0415
+
     return SmartFadesProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 

--- a/music_assistant/providers/smart_fades/__init__.py
+++ b/music_assistant/providers/smart_fades/__init__.py
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
 SUPPORTED_FEATURES: set[ProviderFeature] = set()
 
 # Smart Fades runs on-device ML (torch) inference; gate it to capable hardware.
-MIN_RAM_GB = 6.0
+# 4GB matches the Balanced buffer threshold, the minimum buffer smart crossfade needs.
+MIN_RAM_GB = 4.0
 MIN_CPU_CORES = 4
 
 

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -16,7 +16,6 @@ from music_assistant_models.enums import MediaType
 from torchaudio.transforms import SpectralCentroid
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
-from music_assistant.helpers.util import verify_cpu_supports_ml_inference
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
 
@@ -74,7 +73,6 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        verify_cpu_supports_ml_inference()
         (
             self._beat_this_model,
             self._beat_this_post_processor,

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -59,6 +59,8 @@ class SmartFadesData:
 class SmartFadesProvider(AudioAnalysisProvider):
     """Smart fades audio analysis provider using Beat This for beat tracking."""
 
+    uses_torch = True
+
     def __init__(
         self,
         mass: MusicAssistant,

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -59,8 +59,6 @@ class SmartFadesData:
 class SmartFadesProvider(AudioAnalysisProvider):
     """Smart fades audio analysis provider using Beat This for beat tracking."""
 
-    uses_torch = True
-
     def __init__(
         self,
         mass: MusicAssistant,
@@ -75,6 +73,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
+        # Configure torch thread caps before loading any model (see the controller method).
+        self.mass.streams.audio_analysis.ensure_thread_caps_configured()
         (
             self._beat_this_model,
             self._beat_this_post_processor,

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -13,7 +13,10 @@ import soxr
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ContentType
 
-from music_assistant.helpers.util import verify_cpu_supports_ml_inference
+from music_assistant.helpers.util import (
+    verify_cpu_supports_ml_inference,
+    verify_system_meets_requirements,
+)
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import (
     AnalysisSessionData,
@@ -65,6 +68,10 @@ CLAP_WINDOW_COUNTS: dict[str, int] = {
 }
 
 CONF_CLAP_SAMPLING: str = "clap_sampling"
+
+# Sonic Analysis runs on-device CLAP inference; gate it to capable hardware.
+MIN_RAM_GB: float = 8.0
+MIN_CPU_CORES: int = 4
 
 
 @dataclass
@@ -320,6 +327,9 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         available=False, which the AudioAnalysisController already honors when
         scheduling work.
         """
+        verify_system_meets_requirements(
+            feature_name="Sonic Analysis", min_memory_gb=MIN_RAM_GB, min_cpu_cores=MIN_CPU_CORES
+        )
         verify_cpu_supports_ml_inference()
         (
             self._clap_model,

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -302,7 +302,6 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
     """Audio analysis provider running librosa scalars + CLAP zero-shot per track."""
 
     analysis_version: int = 1
-    uses_torch = True
 
     def __init__(
         self,
@@ -331,6 +330,8 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
             min_cpu_cores=MIN_CPU_CORES,
             require_ml_inference=True,
         )
+        # Configure torch thread caps before loading the model (see the controller method).
+        self.mass.streams.audio_analysis.ensure_thread_caps_configured()
         (
             self._clap_model,
             self._clap_text_embeddings,

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -302,6 +302,7 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
     """Audio analysis provider running librosa scalars + CLAP zero-shot per track."""
 
     analysis_version: int = 1
+    uses_torch = True
 
     def __init__(
         self,

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -13,10 +13,7 @@ import soxr
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, ContentType
 
-from music_assistant.helpers.util import (
-    verify_cpu_supports_ml_inference,
-    verify_system_meets_requirements,
-)
+from music_assistant.helpers.util import verify_system_meets_requirements
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import (
     AnalysisSessionData,
@@ -328,9 +325,11 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         scheduling work.
         """
         verify_system_meets_requirements(
-            feature_name="Sonic Analysis", min_memory_gb=MIN_RAM_GB, min_cpu_cores=MIN_CPU_CORES
+            feature_name="Sonic Analysis",
+            min_memory_gb=MIN_RAM_GB,
+            min_cpu_cores=MIN_CPU_CORES,
+            require_ml_inference=True,
         )
-        verify_cpu_supports_ml_inference()
         (
             self._clap_model,
             self._clap_text_embeddings,

--- a/music_assistant/providers/sonic_similarity/provider.py
+++ b/music_assistant/providers/sonic_similarity/provider.py
@@ -113,7 +113,6 @@ class SonicSimilarityPlugin(PluginProvider):
         # CLAP text encoder — lazy: stays None until the first text_search call.
         self._text_encoder: Any = None
         self._text_encoder_lock = asyncio.Lock()
-        self._text_encoder_warm_started = False
         # Per-label last error from fire-and-forget rebuild tasks.
         self._last_rebuild_error: dict[str, str] = {}
         self._last_seen_row_count: int = 0
@@ -818,13 +817,12 @@ class SonicSimilarityPlugin(PluginProvider):
         if self._clap_index is None or len(self._clap_index) == 0:
             return SearchResults()
         # Never hold up the timeout-less global SEARCH gather on the ~500MB encoder load:
-        # kick off a one-time background warm on the first query, and short-circuit until ready.
+        # warm it in the background and short-circuit until it is ready. create_task dedupes
+        # on task_id while a load is in flight, and re-attempts after a previous load failed.
         if self._text_encoder is None:
-            if not self._text_encoder_warm_started:
-                self._text_encoder_warm_started = True
-                self.mass.create_task(
-                    self._get_text_encoder, task_id="sonic_similarity_text_encoder_warm"
-                )
+            self.mass.create_task(
+                self._get_text_encoder, task_id="sonic_similarity_text_encoder_warm"
+            )
             return SearchResults()
         emb_np = await self._embed_text_query(search_query)
         if emb_np is None:

--- a/music_assistant/providers/sonic_similarity/provider.py
+++ b/music_assistant/providers/sonic_similarity/provider.py
@@ -113,6 +113,7 @@ class SonicSimilarityPlugin(PluginProvider):
         # CLAP text encoder — lazy: stays None until the first text_search call.
         self._text_encoder: Any = None
         self._text_encoder_lock = asyncio.Lock()
+        self._text_encoder_warm_started = False
         # Per-label last error from fire-and-forget rebuild tasks.
         self._last_rebuild_error: dict[str, str] = {}
         self._last_seen_row_count: int = 0
@@ -218,12 +219,9 @@ class SonicSimilarityPlugin(PluginProvider):
                     "sonic_similarity/text_search", self._handle_text_search
                 )
             )
-            # Warm in background so the timeout-less global SEARCH dispatcher never blocks
-            # on the ~500MB GPT2 download; search() short-circuits until the encoder is set.
-            self.mass.create_task(
-                self._get_text_encoder, task_id="sonic_similarity_text_encoder_warm"
-            )
-            self.logger.info("Text search ready (encoder warming in background)")
+            # The ~500MB GPT2 text encoder loads lazily on the first query (see search()
+            # and _handle_text_search), not at plugin start.
+            self.logger.info("Text search enabled (encoder loads on first query)")
 
         self.mass.tasks.register_scheduled_task(
             task_id=PERIODIC_REFRESH_TASK_ID,
@@ -819,9 +817,14 @@ class SonicSimilarityPlugin(PluginProvider):
             return SearchResults()
         if self._clap_index is None or len(self._clap_index) == 0:
             return SearchResults()
-        # Only serve once the encoder is warm; never hold up the global search
-        # gather waiting on the lazy load (background-scheduled in loaded_in_mass).
+        # Never hold up the timeout-less global SEARCH gather on the ~500MB encoder load:
+        # kick off a one-time background warm on the first query, and short-circuit until ready.
         if self._text_encoder is None:
+            if not self._text_encoder_warm_started:
+                self._text_encoder_warm_started = True
+                self.mass.create_task(
+                    self._get_text_encoder, task_id="sonic_similarity_text_encoder_warm"
+                )
             return SearchResults()
         emb_np = await self._embed_text_query(search_query)
         if emb_np is None:

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -48,6 +48,30 @@ async def test_distribute_chunk_calls_all_providers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_thread_caps_only_configured_for_torch_providers() -> None:
+    """Torch thread caps (and the torch import) run only when an active provider uses torch."""
+    sd, af = MagicMock(), MagicMock()
+
+    # only a non-torch provider active (e.g. builtin loudness_analysis) -> torch never imported
+    controller = _make_controller()
+    controller._ensure_thread_caps_configured = MagicMock()  # type: ignore[method-assign]
+    non_torch = _make_aa_provider("loudness", available=True)
+    non_torch.uses_torch = False
+    non_torch.start_analysis = AsyncMock(return_value=False)
+    await controller._start_analysis_on_providers("k", sd, af, [non_torch])
+    controller._ensure_thread_caps_configured.assert_not_called()
+
+    # a torch-backed provider present -> caps configured
+    controller2 = _make_controller()
+    controller2._ensure_thread_caps_configured = MagicMock()  # type: ignore[method-assign]
+    torch_prov = _make_aa_provider("smart_fades", available=True)
+    torch_prov.uses_torch = True
+    torch_prov.start_analysis = AsyncMock(return_value=False)
+    await controller2._start_analysis_on_providers("k", sd, af, [torch_prov])
+    controller2._ensure_thread_caps_configured.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_distribute_chunk_evicts_provider_on_timeout() -> None:
     """A provider whose process_pcm_chunk exceeds max_interval is evicted."""
     controller = _make_controller()

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -6,7 +6,7 @@ import asyncio
 import inspect
 from collections.abc import AsyncGenerator, Mapping
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.audio_analysis import AudioAnalysisCoverage
@@ -47,28 +47,13 @@ async def test_distribute_chunk_calls_all_providers() -> None:
     p2.process_pcm_chunk.assert_awaited_once_with(session_key, b"\x00" * 1024)
 
 
-@pytest.mark.asyncio
-async def test_thread_caps_only_configured_for_torch_providers() -> None:
-    """Torch thread caps (and the torch import) run only when an active provider uses torch."""
-    sd, af = MagicMock(), MagicMock()
-
-    # only a non-torch provider active (e.g. builtin loudness_analysis) -> torch never imported
+def test_ensure_thread_caps_configured_is_idempotent() -> None:
+    """Torch thread caps are applied once per controller, however many providers init."""
     controller = _make_controller()
-    controller._ensure_thread_caps_configured = MagicMock()  # type: ignore[method-assign]
-    non_torch = _make_aa_provider("loudness", available=True)
-    non_torch.uses_torch = False
-    non_torch.start_analysis = AsyncMock(return_value=False)
-    await controller._start_analysis_on_providers("k", sd, af, [non_torch])
-    controller._ensure_thread_caps_configured.assert_not_called()
-
-    # a torch-backed provider present -> caps configured
-    controller2 = _make_controller()
-    controller2._ensure_thread_caps_configured = MagicMock()  # type: ignore[method-assign]
-    torch_prov = _make_aa_provider("smart_fades", available=True)
-    torch_prov.uses_torch = True
-    torch_prov.start_analysis = AsyncMock(return_value=False)
-    await controller2._start_analysis_on_providers("k", sd, af, [torch_prov])
-    controller2._ensure_thread_caps_configured.assert_called_once()
+    with patch("torch.set_num_threads") as set_threads, patch("torch.set_num_interop_threads"):
+        controller.ensure_thread_caps_configured()
+        controller.ensure_thread_caps_configured()
+    set_threads.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/streams/test_buffer_size.py
+++ b/tests/controllers/streams/test_buffer_size.py
@@ -1,0 +1,27 @@
+"""Tests for RAM-gated buffer-size presets."""
+
+from unittest.mock import patch
+
+import pytest
+
+from music_assistant.controllers.streams import constants
+from music_assistant.controllers.streams.constants import BufferSize
+
+
+@pytest.mark.parametrize(
+    ("total_gb", "expected"),
+    [
+        (2.0, [BufferSize.MINIMAL]),
+        (3.9, [BufferSize.MINIMAL]),
+        (4.0, [BufferSize.MINIMAL, BufferSize.BALANCED]),
+        (6.0, [BufferSize.MINIMAL, BufferSize.BALANCED]),
+        (8.0, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
+        (16.0, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
+        # unknown memory (0.0) -> offer everything (fail open)
+        (0.0, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
+    ],
+)
+def test_get_available_buffer_sizes(total_gb: float, expected: list[BufferSize]) -> None:
+    """Balanced requires >= 4GB, Maximum >= 8GB; unknown RAM offers all (fail open)."""
+    with patch.object(constants, "TOTAL_SYSTEM_MEMORY_GB", total_gb):
+        assert constants.get_available_buffer_sizes() == expected

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -488,3 +488,19 @@ def test_verify_system_meets_requirements_memory(
                 util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)
         else:
             util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)
+
+
+def test_verify_system_meets_requirements_ml_inference() -> None:
+    """require_ml_inference adds the AVX2 capability check after the RAM/CPU checks."""
+    with (
+        patch("music_assistant.helpers.util.os.process_cpu_count", return_value=16),
+        patch("music_assistant.helpers.util.get_total_system_memory", return_value=64.0),
+        patch("music_assistant.helpers.util.platform.machine", return_value="x86_64"),
+        patch("torch.backends.cpu.get_cpu_capability", return_value="DEFAULT"),
+    ):
+        # capable RAM/CPU but no AVX2: only raises when the ML inference check is requested
+        with pytest.raises(util.UnsupportedSystemError):
+            util.verify_system_meets_requirements(
+                feature_name="X", min_cpu_cores=4, min_memory_gb=8.0, require_ml_inference=True
+            )
+        util.verify_system_meets_requirements(feature_name="X", min_cpu_cores=4, min_memory_gb=8.0)

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -432,3 +432,59 @@ def test_verify_cpu_supports_ml_inference_arm() -> None:
         ),
     ):
         util.verify_cpu_supports_ml_inference()
+
+
+def test_unsupported_system_error_is_setup_failed() -> None:
+    """UnsupportedSystemError must subclass SetupFailedError so existing handling applies."""
+    assert issubclass(util.UnsupportedSystemError, SetupFailedError)
+
+
+@pytest.mark.parametrize(
+    ("cpu_cores", "min_cpu_cores", "should_raise"),
+    [
+        (4, 4, False),
+        (8, 4, False),
+        (2, 4, True),
+        (1, 4, True),
+        (1, 0, False),  # 0 disables the check
+    ],
+)
+def test_verify_system_meets_requirements_cpu(
+    cpu_cores: int, min_cpu_cores: int, should_raise: bool
+) -> None:
+    """The CPU-core gate raises UnsupportedSystemError below the minimum."""
+    with (
+        patch("music_assistant.helpers.util.os.process_cpu_count", return_value=cpu_cores),
+        patch("music_assistant.helpers.util.get_total_system_memory", return_value=64.0),
+    ):
+        if should_raise:
+            with pytest.raises(util.UnsupportedSystemError):
+                util.verify_system_meets_requirements(feature_name="X", min_cpu_cores=min_cpu_cores)
+        else:
+            util.verify_system_meets_requirements(feature_name="X", min_cpu_cores=min_cpu_cores)
+
+
+@pytest.mark.parametrize(
+    ("total_gb", "min_memory_gb", "should_raise"),
+    [
+        (8.0, 8.0, False),
+        (16.0, 8.0, False),
+        (4.0, 6.0, True),
+        (3.5, 6.0, True),
+        (0.0, 8.0, False),  # 0.0 == unknown memory -> fail open, never block
+        (2.0, 0.0, False),  # 0 disables the check
+    ],
+)
+def test_verify_system_meets_requirements_memory(
+    total_gb: float, min_memory_gb: float, should_raise: bool
+) -> None:
+    """The RAM gate raises below the minimum but fails open when memory is unknown (0.0)."""
+    with (
+        patch("music_assistant.helpers.util.os.process_cpu_count", return_value=16),
+        patch("music_assistant.helpers.util.get_total_system_memory", return_value=total_gb),
+    ):
+        if should_raise:
+            with pytest.raises(util.UnsupportedSystemError):
+                util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)
+        else:
+            util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -315,18 +315,17 @@ async def test_finalize_returns_none_on_early_exit(provider: SmartFadesProvider)
     assert result is None
 
 
-async def test_handle_async_init_raises_on_unsupported_cpu(
+async def test_setup_raises_when_requirements_not_met(
     mass_mock: Mock, manifest_mock: Mock, config_mock: Mock
 ) -> None:
-    """Setup fails before model initialization when the CPU lacks AVX2."""
-    prov = SmartFadesProvider(mass_mock, manifest_mock, config_mock, set())
+    """setup() fails (before importing the heavy provider module) when requirements aren't met."""
+    from music_assistant.providers import smart_fades  # noqa: PLC0415
+
     with (
         patch(
-            "music_assistant.providers.smart_fades.provider.verify_cpu_supports_ml_inference",
-            side_effect=SetupFailedError("CPU lacks AVX2"),
+            "music_assistant.providers.smart_fades.verify_system_meets_requirements",
+            side_effect=SetupFailedError("unsupported system"),
         ),
-        patch.object(SmartFadesProvider, "_initialize_models") as init_models_mock,
         pytest.raises(SetupFailedError),
     ):
-        await prov.handle_async_init()
-    init_models_mock.assert_not_called()
+        await smart_fades.setup(mass_mock, manifest_mock, config_mock)

--- a/tests/providers/sonic_analysis/test_clap_background_load.py
+++ b/tests/providers/sonic_analysis/test_clap_background_load.py
@@ -223,13 +223,13 @@ async def test_start_analysis_returns_false_without_duration(
     assert any("duration missing or zero" in c for c in debug_msgs)
 
 
-async def test_handle_async_init_raises_on_unsupported_cpu() -> None:
-    """Setup fails before any model load when the CPU lacks AVX2."""
+async def test_handle_async_init_raises_when_requirements_not_met() -> None:
+    """Setup fails before any model load when the system does not meet requirements."""
     provider = _make_provider()
     with (
         patch(
-            "music_assistant.providers.sonic_analysis.verify_cpu_supports_ml_inference",
-            side_effect=SetupFailedError("CPU lacks AVX2"),
+            "music_assistant.providers.sonic_analysis.verify_system_meets_requirements",
+            side_effect=SetupFailedError("unsupported system"),
         ),
         patch.object(SonicAnalysisProvider, "_load_clap") as load_clap_mock,
         pytest.raises(SetupFailedError),

--- a/tests/providers/sonic_similarity/test_search.py
+++ b/tests/providers/sonic_similarity/test_search.py
@@ -64,19 +64,19 @@ class TestSetupConditionalSearch:
         assert ProviderFeature.SEARCH not in plugin.supported_features
 
 
-class TestLoadedInMassWarmsTextEncoder:
-    """loaded_in_mass schedules the GPT2 text encoder warm off the request path.
+class TestTextEncoderWarmsLazily:
+    """The GPT2 text encoder is not warmed at load; the first search() warms it lazily.
 
-    The global SEARCH dispatcher gathers across all providers without a
-    per-provider timeout, so warming the ~500MB encoder via mass.create_task
-    prevents the first cold search() call from blocking the entire gather.
+    Warming the ~500MB encoder eagerly at startup defeats the point of an opt-in
+    feature, so loaded_in_mass leaves it cold and the first cold search() kicks off
+    a one-time background warm (see TestSearch.test_schedules_warm_when_encoder_cold).
     """
 
     @pytest.mark.asyncio
-    async def test_schedules_warm_task_when_text_search_enabled(
+    async def test_no_warm_task_at_load_when_text_search_enabled(
         self, mock_mass: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """text_search_enabled → mass.create_task called with the warm coroutine + task_id."""
+        """text_search_enabled → loaded_in_mass does NOT warm the encoder (it loads on first query)."""
 
         async def _noop_load(_self: Any) -> None:
             return None
@@ -88,9 +88,7 @@ class TestLoadedInMassWarmsTextEncoder:
         assert isinstance(plugin, SonicSimilarityPlugin)
         await plugin.loaded_in_mass()
 
-        mock_mass.create_task.assert_called_once_with(
-            plugin._get_text_encoder, task_id="sonic_similarity_text_encoder_warm"
-        )
+        mock_mass.create_task.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_warm_task_when_text_search_disabled(self, mock_mass: MagicMock) -> None:
@@ -156,23 +154,28 @@ class TestSearch:
         plugin._clap_index.search.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_returns_empty_when_encoder_cold(self, make_plugin: Callable[..., Any]) -> None:
-        """A cold _text_encoder short-circuits without attempting a lazy load.
+    async def test_schedules_warm_when_encoder_cold(self, make_plugin: Callable[..., Any]) -> None:
+        """A cold encoder short-circuits to empty but kicks off a one-time background warm.
 
-        The lazy load happens off the request path (loaded_in_mass schedules it
-        as a background task) so the global SEARCH dispatcher never blocks on
-        the ~500MB GPT2 download.
+        The encoder loads on first query rather than at startup, but the load runs off
+        the request path (via mass.create_task) so the global SEARCH dispatcher never
+        blocks on the ~500MB GPT2 download.
         """
         plugin = make_plugin(clap_enabled=True)
         plugin._clap_index.__len__ = MagicMock(return_value=5)
-        # Sentinel: if search() reached the lazy-load path, this would fire.
-        plugin._load_text_encoder = MagicMock(side_effect=RuntimeError("must not load"))
+        # Sentinel: search() must not load the encoder synchronously on the request path.
+        plugin._load_text_encoder = MagicMock(
+            side_effect=RuntimeError("must not load synchronously")
+        )
 
         result = await plugin.search("disco", [MediaType.TRACK])
 
         assert list(result.tracks) == []
         plugin._load_text_encoder.assert_not_called()
         plugin._clap_index.search.assert_not_called()
+        plugin.mass.create_task.assert_called_once_with(
+            plugin._get_text_encoder, task_id="sonic_similarity_text_encoder_warm"
+        )
 
     @pytest.mark.asyncio
     async def test_happy_path_returns_resolved_tracks(


### PR DESCRIPTION
# What does this implement/fix?

Since 2.9, `torch` is imported into the process at startup — via the always-on audio analysis controller and the Smart Fades provider, which is auto-enabled on any multi-core host. This pushed idle memory from ~300-500MB to ~1GB and causes OOM on small hardware (and, on CPUs that can't run optimized inference, a slow single-core software path during streaming).

This gates the heavy on-device analysis providers to capable hardware and keeps `torch` out of the process until it is actually needed.

Changes:

- Gate Smart Fades (>=4GB RAM / 4 cores) and Sonic Analysis (>=8GB RAM / 4 cores) on system resources, raising a non-retrying `UnsupportedSystemError` when unmet (the existing AVX2 check now uses it too).
- Stop loading `torch` at idle: lazy-import it in the audio analysis controller and the Smart Fades provider; torch thread caps are configured on the first analysis instead of at startup.
- Auto-created default providers that don't meet requirements are removed and not retried, instead of lingering as a broken/retrying provider.
- Lazy-load the Sonic Similarity free-text encoder (~500MB) on the first query instead of warming it at startup.
- Only offer the buffer-size presets the host's RAM can sustain (Balanced >=4GB, Maximum >=8GB).

**Related issue (if applicable):**

- Multiple support reports of high idle memory / OOM since 2.9

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

