### PR TITLE
Vectorize weighted distance in the sonic similarity provider

### DIFF
--- a/music_assistant/providers/sonic_similarity/similarity.py
+++ b/music_assistant/providers/sonic_similarity/similarity.py
@@ -11,7 +11,7 @@ from typing import NamedTuple
 
 import numpy as np
 
-from .vectors import compute_weighted_distance
+from .vectors import build_dimension_weights, compute_weighted_distance_vec
 
 
 class Candidate(NamedTuple):
@@ -111,9 +111,11 @@ def apply_mmr(
     seed_arr = np.array(seed_vec, dtype=np.float64)
 
     if weights is not None:
+        # Build the per-dimension weight vector once; _similarity runs O(n²) times.
+        dim_weights = build_dimension_weights(weights)
 
         def _similarity(a: np.ndarray, b: np.ndarray) -> float:
-            d = compute_weighted_distance(a, b, weights)
+            d = compute_weighted_distance_vec(a, b, dim_weights)
             return 1.0 / (1.0 + d)
 
         relevance: dict[str, float] = {

--- a/music_assistant/providers/sonic_similarity/similarity.py
+++ b/music_assistant/providers/sonic_similarity/similarity.py
@@ -113,7 +113,7 @@ def apply_mmr(
     if weights is not None:
 
         def _similarity(a: np.ndarray, b: np.ndarray) -> float:
-            d = compute_weighted_distance(a.tolist(), b.tolist(), weights)
+            d = compute_weighted_distance(a, b, weights)
             return 1.0 / (1.0 + d)
 
         relevance: dict[str, float] = {

--- a/music_assistant/providers/sonic_similarity/vectors.py
+++ b/music_assistant/providers/sonic_similarity/vectors.py
@@ -175,27 +175,27 @@ def compute_group_distances(
 
 
 def compute_weighted_distance(
-    sig_a: list[float],
-    sig_b: list[float],
+    sig_a: list[float] | np.ndarray,
+    sig_b: list[float] | np.ndarray,
     weights: dict[str, float],
 ) -> float:
     """Compute per-group weighted Euclidean distance between two feature vectors.
 
-    :param sig_a: First feature vector.
-    :param sig_b: Second feature vector.
+    :param sig_a: First feature vector (list or numpy array).
+    :param sig_b: Second feature vector (list or numpy array).
     :param weights: Per-group weight overrides keyed by FEATURE_GROUPS name.
     :returns: Weighted normalized distance as a float.
     """
-    group_dists = compute_group_distances(sig_a, sig_b)
-    weighted_sq_sum = 0.0
-    total_weighted_dims = 0.0
-    for group, (start, end) in FEATURE_GROUPS.items():
-        w = weights.get(group, 1.0)
-        dim_count = end - start
-        weighted_sq_sum += w * (group_dists[group] ** 2) * dim_count
-        total_weighted_dims += w * dim_count
+    # np.asarray is a no-op when the caller already holds a float64 array (the
+    # MMR hot path), avoiding the list round-trip the previous version forced.
+    a = np.asarray(sig_a, dtype=np.float64)
+    b = np.asarray(sig_b, dtype=np.float64)
+    dim_weights = _expand_group_weights(weights)
+    total_weighted_dims = float(dim_weights.sum())
     if total_weighted_dims == 0.0:
         return 0.0
+    diff = a - b
+    weighted_sq_sum = float(np.dot(dim_weights, diff * diff))
     return math.sqrt(weighted_sq_sum / total_weighted_dims)
 
 
@@ -222,3 +222,18 @@ def build_debug_breakdown(
             for k, v in compute_group_distances(seed_normalized, cand_normalized).items()
         },
     }
+
+
+def _expand_group_weights(weights: dict[str, float]) -> np.ndarray:
+    """
+    Expand per-group weights into a per-dimension weight vector.
+
+    :param weights: Per-group weight overrides keyed by FEATURE_GROUPS name. Groups
+        absent from the dict default to weight 1.0.
+    :returns: Float64 weight array of length VECTOR_DIMENSIONS.
+    """
+    dim_weights = np.ones(VECTOR_DIMENSIONS, dtype=np.float64)
+    for group, (start, end) in FEATURE_GROUPS.items():
+        if group in weights:
+            dim_weights[start:end] = weights[group]
+    return dim_weights

--- a/music_assistant/providers/sonic_similarity/vectors.py
+++ b/music_assistant/providers/sonic_similarity/vectors.py
@@ -174,26 +174,60 @@ def compute_group_distances(
     return result
 
 
+def build_dimension_weights(weights: dict[str, float]) -> np.ndarray:
+    """
+    Expand per-group weights into a per-dimension weight vector.
+
+    Callers in a hot loop (e.g. MMR re-ranking) can build this once and reuse it
+    across many compute_weighted_distance_vec calls instead of rebuilding it per call.
+
+    :param weights: Per-group weight overrides keyed by FEATURE_GROUPS name. Groups
+        absent from the dict default to weight 1.0.
+    :returns: Float64 weight array of length VECTOR_DIMENSIONS.
+    """
+    dim_weights = np.ones(VECTOR_DIMENSIONS, dtype=np.float64)
+    for group, (start, end) in FEATURE_GROUPS.items():
+        if group in weights:
+            dim_weights[start:end] = weights[group]
+    return dim_weights
+
+
 def compute_weighted_distance(
     sig_a: list[float] | np.ndarray,
     sig_b: list[float] | np.ndarray,
     weights: dict[str, float],
 ) -> float:
-    """Compute per-group weighted Euclidean distance between two feature vectors.
+    """
+    Compute per-group weighted Euclidean distance between two feature vectors.
 
     :param sig_a: First feature vector (list or numpy array).
     :param sig_b: Second feature vector (list or numpy array).
     :param weights: Per-group weight overrides keyed by FEATURE_GROUPS name.
     :returns: Weighted normalized distance as a float.
     """
+    return compute_weighted_distance_vec(sig_a, sig_b, build_dimension_weights(weights))
+
+
+def compute_weighted_distance_vec(
+    sig_a: list[float] | np.ndarray,
+    sig_b: list[float] | np.ndarray,
+    dim_weights: np.ndarray,
+) -> float:
+    """
+    Compute weighted Euclidean distance from a precomputed per-dimension weight vector.
+
+    :param sig_a: First feature vector (list or numpy array).
+    :param sig_b: Second feature vector (list or numpy array).
+    :param dim_weights: Per-dimension weights as built by build_dimension_weights.
+    :returns: Weighted normalized distance as a float.
+    """
+    total_weighted_dims = float(dim_weights.sum())
+    if total_weighted_dims == 0.0:
+        return 0.0
     # np.asarray is a no-op when the caller already holds a float64 array (the
     # MMR hot path), avoiding the list round-trip the previous version forced.
     a = np.asarray(sig_a, dtype=np.float64)
     b = np.asarray(sig_b, dtype=np.float64)
-    dim_weights = _expand_group_weights(weights)
-    total_weighted_dims = float(dim_weights.sum())
-    if total_weighted_dims == 0.0:
-        return 0.0
     diff = a - b
     weighted_sq_sum = float(np.dot(dim_weights, diff * diff))
     return math.sqrt(weighted_sq_sum / total_weighted_dims)
@@ -222,18 +256,3 @@ def build_debug_breakdown(
             for k, v in compute_group_distances(seed_normalized, cand_normalized).items()
         },
     }
-
-
-def _expand_group_weights(weights: dict[str, float]) -> np.ndarray:
-    """
-    Expand per-group weights into a per-dimension weight vector.
-
-    :param weights: Per-group weight overrides keyed by FEATURE_GROUPS name. Groups
-        absent from the dict default to weight 1.0.
-    :returns: Float64 weight array of length VECTOR_DIMENSIONS.
-    """
-    dim_weights = np.ones(VECTOR_DIMENSIONS, dtype=np.float64)
-    for group, (start, end) in FEATURE_GROUPS.items():
-        if group in weights:
-            dim_weights[start:end] = weights[group]
-    return dim_weights

--- a/tests/providers/sonic_similarity/test_vector_assembly.py
+++ b/tests/providers/sonic_similarity/test_vector_assembly.py
@@ -394,3 +394,63 @@ class TestComputeWeightedDistance:
         # With equal weights (1.0) and uniform diff of 1.0, result should be
         # normalized so large-dim vectors don't dominate
         assert d < 10.0  # Sanity: not an unnormalized sum
+
+    @staticmethod
+    def _reference_distance(
+        sig_a: list[float], sig_b: list[float], weights: dict[str, float]
+    ) -> float:
+        """
+        Replicate the pre-vectorization per-group sqrt-then-square formula.
+
+        Mirrors the original compute_weighted_distance implementation so the
+        refactored vectorized version can be asserted numerically equivalent.
+        """
+        a = np.array(sig_a, dtype=np.float64)
+        b = np.array(sig_b, dtype=np.float64)
+        weighted_sq_sum = 0.0
+        total_weighted_dims = 0.0
+        for group, (start, end) in FEATURE_GROUPS.items():
+            w = weights.get(group, 1.0)
+            dim_count = end - start
+            diff = a[start:end] - b[start:end]
+            group_dist = math.sqrt(float(np.dot(diff, diff)) / dim_count)
+            weighted_sq_sum += w * (group_dist**2) * dim_count
+            total_weighted_dims += w * dim_count
+        if total_weighted_dims == 0.0:
+            return 0.0
+        return math.sqrt(weighted_sq_sum / total_weighted_dims)
+
+    def test_matches_reference_per_group_formula(self) -> None:
+        """Vectorized result equals the original per-group formula across random inputs."""
+        rng = np.random.default_rng(1234)
+        weight_sets = [
+            {},
+            {"rhythm": 0.0},
+            {"mood": 2.5, "tonal": 0.3},
+            dict.fromkeys(FEATURE_GROUPS, 0.7),
+        ]
+        for _ in range(20):
+            a = rng.standard_normal(VECTOR_DIMENSIONS).tolist()
+            b = rng.standard_normal(VECTOR_DIMENSIONS).tolist()
+            for weights in weight_sets:
+                assert compute_weighted_distance(a, b, weights) == pytest.approx(
+                    self._reference_distance(a, b, weights)
+                )
+
+    def test_numpy_array_input_matches_list_input(self) -> None:
+        """Passing numpy arrays yields the same float as passing lists (the MMR hot path)."""
+        rng = np.random.default_rng(99)
+        a = rng.standard_normal(VECTOR_DIMENSIONS)
+        b = rng.standard_normal(VECTOR_DIMENSIONS)
+        weights = {"timbre": 1.5, "loudness": 0.2}
+        from_arrays = compute_weighted_distance(a, b, weights)
+        from_lists = compute_weighted_distance(a.tolist(), b.tolist(), weights)
+        assert isinstance(from_arrays, float)
+        assert from_arrays == pytest.approx(from_lists)
+
+    def test_all_zero_weights_returns_zero(self) -> None:
+        """When every group weight is 0, the distance is defined as 0.0."""
+        a = self._make_vector(0.0)
+        b = self._make_vector(1.0)
+        all_zero = dict.fromkeys(FEATURE_GROUPS, 0.0)
+        assert compute_weighted_distance(a, b, all_zero) == 0.0

--- a/tests/providers/sonic_similarity/test_vector_assembly.py
+++ b/tests/providers/sonic_similarity/test_vector_assembly.py
@@ -12,8 +12,10 @@ from music_assistant.providers.sonic_similarity.vectors import (
     FEATURE_GROUPS,
     VECTOR_DIMENSIONS,
     assemble_vector,
+    build_dimension_weights,
     compute_corpus_stats,
     compute_weighted_distance,
+    compute_weighted_distance_vec,
     encode_key_mode,
     normalize_features,
 )
@@ -454,3 +456,24 @@ class TestComputeWeightedDistance:
         b = self._make_vector(1.0)
         all_zero = dict.fromkeys(FEATURE_GROUPS, 0.0)
         assert compute_weighted_distance(a, b, all_zero) == 0.0
+
+    def test_precomputed_weights_match_dict_path(self) -> None:
+        """compute_weighted_distance_vec with a prebuilt vector equals the dict-based path."""
+        rng = np.random.default_rng(7)
+        a = rng.standard_normal(VECTOR_DIMENSIONS)
+        b = rng.standard_normal(VECTOR_DIMENSIONS)
+        weights = {"rhythm": 2.0, "dynamics": 0.0}
+        dim_weights = build_dimension_weights(weights)
+        assert compute_weighted_distance_vec(a, b, dim_weights) == pytest.approx(
+            compute_weighted_distance(a, b, weights)
+        )
+
+    def test_build_dimension_weights_expands_groups(self) -> None:
+        """Each group's weight lands on its dimensions; absent groups default to 1.0."""
+        dim_weights = build_dimension_weights({"timbre": 3.0})
+        assert len(dim_weights) == VECTOR_DIMENSIONS
+        start, end = FEATURE_GROUPS["timbre"]
+        assert list(dim_weights[start:end]) == [3.0] * (end - start)
+        # rhythm was not overridden, so it keeps the 1.0 default
+        r_start, r_end = FEATURE_GROUPS["rhythm"]
+        assert list(dim_weights[r_start:r_end]) == [1.0] * (r_end - r_start)


### PR DESCRIPTION
# What does this implement/fix?

`compute_weighted_distance` in the sonic similarity provider converted its numpy
inputs to Python lists on every call (`a.tolist()` / `b.tolist()`) and then rebuilt
numpy arrays internally, adding per-call allocations and Python overhead in the
similarity ranking / MMR-diversity path (an O(n²) loop). Since the feature groups
partition all 18 dimensions, the per-group result is just a weighted Euclidean
distance that numpy can compute directly.

Changes:
- Rework `compute_weighted_distance` to operate on numpy arrays and compute the
  distance with a single vectorized dot product, dropping the per-group `sqrt`s.
- Drop the `.tolist()` conversions at the MMR call site so arrays pass straight
  through without a list round-trip.
- Add tests covering numerical equivalence to the previous formula and array-vs-list
  input.

Results are numerically equivalent to the previous implementation; this is an
internal CPU/allocation win only (opt-in plugin), no behaviour change.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
