### PR TITLE
Use threading.get_ident() instead of asyncio's private _thread_id

### DIFF
--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -150,7 +150,8 @@ class MusicAssistant:
     async def start(self) -> None:
         """Start running the Music Assistant server."""
         self.loop = asyncio.get_running_loop()
-        self.loop_thread_id = getattr(self.loop, "_thread_id")  # noqa: B009
+        # start() runs on the event loop thread, so this is the loop's thread id.
+        self.loop_thread_id = threading.get_ident()
         self.running_as_hass_addon = await is_hass_supervisor()
         self.version = await get_package_version("music_assistant") or "0.0.0"
         # setup config controller first and fetch important config values

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import pathlib
+import threading
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 
@@ -103,11 +104,8 @@ async def mass_minimal(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]
     mass_instance = MusicAssistant(str(storage_path), str(cache_path))
 
     mass_instance.loop = asyncio.get_running_loop()
-    mass_instance.loop_thread_id = (
-        getattr(mass_instance.loop, "_thread_id", None)
-        if hasattr(mass_instance.loop, "_thread_id")
-        else id(mass_instance.loop)
-    )
+    # fixture runs on the event loop thread, like MusicAssistant.start()
+    mass_instance.loop_thread_id = threading.get_ident()
 
     mass_instance.config = ConfigController(mass_instance)
     await mass_instance.config.setup()

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import logging
 import pathlib
+import threading
 from collections.abc import AsyncGenerator
 from datetime import timedelta
 from sqlite3 import IntegrityError
@@ -43,12 +44,8 @@ async def mass_minimal(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]
 
     # Initialize the minimum required for auth testing
     mass_instance.loop = asyncio.get_running_loop()
-    # Use id() as fallback since _thread_id is a private attribute that may not exist
-    mass_instance.loop_thread_id = (
-        getattr(mass_instance.loop, "_thread_id", None)
-        if hasattr(mass_instance.loop, "_thread_id")
-        else id(mass_instance.loop)
-    )
+    # fixture runs on the event loop thread, like MusicAssistant.start()
+    mass_instance.loop_thread_id = threading.get_ident()
 
     # Create config controller
     mass_instance.config = ConfigController(mass_instance)


### PR DESCRIPTION
# What does this implement/fix?

`MusicAssistant.start()` captured the event loop thread id by reading the loop's private `_thread_id` attribute — an undocumented CPython asyncio internal that can change between Python versions and isn't present on non-default event loop implementations. Since `start()` always runs on the event loop thread, `threading.get_ident()` returns the exact same value through a public, documented API.

- Use `threading.get_ident()` instead of `getattr(self.loop, "_thread_id")` in `mass.py` (also drops the `# noqa: B009`)
- Apply the same in the `mass_minimal` fixtures (`tests/conftest.py`, `tests/test_webserver_auth.py`), removing their `_thread_id`/`id()` fallback

**Related issue (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
