### PR TITLE
reset queue.flow_mode according to player capability

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1017,8 +1017,8 @@ class PlayerQueuesController(CoreController):
                 await self.stop(queue_id)
                 raise MediaNotFoundError("No playable item found to start playback")
 
-            # Reset flow_mode - the streams controller will set it if flow mode is used.
-            queue.flow_mode = False
+            # Reset flow_mode taking into account players capabilities - the streams controller will set it if flow mode is used.
+            queue.flow_mode = target_player.requires_flow_mode
             await self.mass.players.play_media(
                 queue_id,
                 await self.player_media_from_queue_item(queue_item),


### PR DESCRIPTION
# What does this implement/fix?
prevent UnsupportedFeaturedException crash in queue handling for players that don't support queue
<!-- Quick description and explanation of changes. -->
queue.flow_mode was reset to False also for players that require flow mode
This fix sets queue.flow_mode equal to the player's requires_flow_mode

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
