### PR TITLE
Improve global search reliability and database query parameter logic

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -371,7 +371,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 for prov_mapping in cast("MediaItemType", item).provider_mappings
             }
             # include results from library + all (unique) music providers
-            results_per_provider += await asyncio.gather(
+            # one failing provider must not break the entire search,
+            # so exceptions are logged and excluded from the results
+            gather_results = await asyncio.gather(
                 *[
                     self._search_provider(
                         search_query,
@@ -382,7 +384,13 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                     )
                     for provider_instance in search_providers
                 ],
+                return_exceptions=True,
             )
+            for res in gather_results:
+                if isinstance(res, SearchResults):
+                    results_per_provider.append(res)
+                else:
+                    self.logger.error("Search on provider failed", exc_info=res)
         # return result from all providers while keeping index
         # so the result is sorted as each provider delivered
         result = SearchResults(
@@ -2103,6 +2111,8 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
 
         # create safe search string
         search_query = search_query.replace("/", " ").replace("'", "")
+        # guard against a failing provider: return empty results instead of
+        # raising, so a global search can still succeed with the other providers
         try:
             prov_search_results = await prov.search(
                 search_query,
@@ -2110,8 +2120,11 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 limit,
             )
         except MusicAssistantError as err:
-            self.logger.warning("Search on provider %s failed: %s", prov.name, err)
-            raise MusicAssistantError(f"Search failed due to an error on {prov.name}") from err
+            self.logger.warning("Search on provider %s failed: %s", prov.name, str(err))
+            return SearchResults()
+        except Exception as err:
+            self.logger.error("Search on provider %s failed: %s", prov.name, str(err), exc_info=err)
+            return SearchResults()
         if skip_item_ids:
             # filter out items already in skip_item_ids
             prov_search_results.artists = [

--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import time
 from collections.abc import Mapping
 from contextlib import asynccontextmanager
@@ -88,7 +89,14 @@ def query_params(query: str, params: dict[str, Any] | None) -> tuple[str, dict[s
                 subparams.append(subparam_name)
                 count += 1
             params_str = ",".join(f":{x}" for x in subparams)
-            result_query = result_query.replace(f" :{key}", f" ({params_str})")
+            # replace the placeholder with the expanded (:_param_x, ...) list;
+            # consume optional parens already around the placeholder and use a
+            # word boundary so placeholders sharing the same prefix are untouched
+            result_query = re.sub(
+                rf"\(\s*:{re.escape(key)}\b\s*\)|:{re.escape(key)}\b",
+                f"({params_str})",
+                result_query,
+            )
         else:
             result_params[key] = value
     return (result_query, result_params)

--- a/tests/controllers/music/test_search.py
+++ b/tests/controllers/music/test_search.py
@@ -1,0 +1,88 @@
+"""Tests for the global search on the music controller."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, Mock
+
+from music_assistant_models.enums import MediaType, ProviderFeature
+from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.media_items import ProviderMapping, SearchResults, Track
+
+from music_assistant.controllers.music import MusicController
+from music_assistant.models.music_provider import MusicProvider
+
+
+def _make_track(item_id: str, provider: str, name: str) -> Track:
+    """Return a minimal Track for the given provider."""
+    return Track(
+        item_id=item_id,
+        provider=provider,
+        name=name,
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider,
+                provider_instance=provider,
+            )
+        },
+    )
+
+
+def _make_search_provider(instance_id: str) -> Mock:
+    """Return a mocked music provider that supports search."""
+    prov = Mock(spec=MusicProvider)
+    prov.instance_id = instance_id
+    prov.domain = instance_id
+    prov.name = instance_id
+    prov.supported_features = {ProviderFeature.SEARCH}
+    prov.search = AsyncMock(return_value=SearchResults())
+    return prov
+
+
+def _make_controller(providers: list[Mock]) -> MusicController:
+    """Return a music controller wired to the given mocked providers."""
+    mass = Mock()
+    mass.cache.get = AsyncMock(return_value=None)
+    mass.cache.set = AsyncMock(return_value=None)
+    mass.get_providers_supporting_feature.return_value = []
+    mass.get_provider = Mock(
+        side_effect=lambda instance_id, **_kwargs: next(
+            (p for p in providers if p.instance_id == instance_id), None
+        )
+    )
+    controller = MusicController.__new__(MusicController)
+    controller.mass = mass
+    controller.domain = "music"
+    controller.logger = logging.getLogger(__name__)
+    controller.get_unique_providers = Mock(  # type: ignore[method-assign]
+        return_value=[p.instance_id for p in providers]
+    )
+    controller.search_library = AsyncMock(return_value=SearchResults())  # type: ignore[method-assign]
+    return controller
+
+
+async def test_search_provider_returns_empty_on_provider_error() -> None:
+    """A provider error during search yields empty results instead of raising."""
+    prov = _make_search_provider("prov_a")
+    controller = _make_controller([prov])
+    for error in (MusicAssistantError("rate limited"), ValueError("unexpected")):
+        prov.search.side_effect = error
+        result = await controller._search_provider("query", "prov_a", [MediaType.TRACK])
+        assert result == SearchResults()
+
+
+async def test_global_search_returns_partial_results_when_provider_fails() -> None:
+    """One failing provider must not break the entire global search."""
+    prov_ok = _make_search_provider("prov_ok")
+    prov_ok.search.return_value = SearchResults(
+        tracks=[_make_track("track1", "prov_ok", "My Song")]
+    )
+    prov_bad = _make_search_provider("prov_bad")
+    prov_bad.search.side_effect = MusicAssistantError("provider down")
+    controller = _make_controller([prov_ok, prov_bad])
+
+    result = await controller.search("My Song", media_types=[MediaType.TRACK], limit=5)
+
+    assert [track.item_id for track in result.tracks] == ["track1"]
+    prov_bad.search.assert_awaited_once()

--- a/tests/helpers/test_database_connection.py
+++ b/tests/helpers/test_database_connection.py
@@ -9,7 +9,11 @@ from typing import Any
 
 import pytest
 
-from music_assistant.helpers.database import DatabaseConnection, get_sqlite_memory_settings
+from music_assistant.helpers.database import (
+    DatabaseConnection,
+    get_sqlite_memory_settings,
+    query_params,
+)
 from music_assistant.mass import MusicAssistant
 
 GIB = 1024**3
@@ -334,3 +338,27 @@ async def test_upsert_many_empty_is_noop(db_with_table: DatabaseConnection) -> N
     commits = _count_commits(db_with_table)
     await db_with_table.upsert_many("items", [])
     assert len(commits) == 0
+
+
+def test_query_params_expands_list_values() -> None:
+    """Test that list params are expanded into placeholders in all placeholder notations."""
+    query, params = query_params(
+        "SELECT * FROM items WHERE id IN :ids AND name = :name",
+        {"ids": [1, 2], "name": "foo"},
+    )
+    assert query == "SELECT * FROM items WHERE id IN (:_param_0,:_param_1) AND name = :name"
+    assert params == {"_param_0": 1, "_param_1": 2, "name": "foo"}
+    # placeholder already wrapped in parens must not end up double-wrapped
+    query, params = query_params("SELECT * FROM items WHERE id IN(:ids)", {"ids": [1, 2]})
+    assert query == "SELECT * FROM items WHERE id IN(:_param_0,:_param_1)"
+    assert params == {"_param_0": 1, "_param_1": 2}
+
+
+def test_query_params_leaves_prefixed_placeholders_untouched() -> None:
+    """Test that expanding a list param does not corrupt placeholders sharing its prefix."""
+    query, params = query_params(
+        "SELECT * FROM items WHERE id IN :ids AND other = :ids_extra",
+        {"ids": [1], "ids_extra": 2},
+    )
+    assert query == "SELECT * FROM items WHERE id IN (:_param_0) AND other = :ids_extra"
+    assert params == {"_param_0": 1, "ids_extra": 2}


### PR DESCRIPTION
# What does this implement/fix?

This PR improves the robustness and reliability of the Music Assistant server in two key areas:

1. **Global Search Resilience**: Previously, if a single music provider (e.g., Tidal, Spotify) encountered an error during a global search, the entire operation would fail, leaving the user with no results at all. I have modified `MusicController._search_provider` to catch exceptions per-provider and return empty results instead of crashing. I also updated the concurrent execution to use `asyncio.gather(..., return_exceptions=True)`.
2. **Robust Database Query Parameter Logic**: The `query_params` helper in `database.py` used a fragile string `replace` logic for expanding list parameters (used in `IN` clauses), which was susceptible to partial matches and required specific whitespace. I have implemented a robust regex-based replacement using `re.sub` with word boundaries (`\b`), ensuring placeholders like `:ids` are correctly identified in all formats (e.g. `IN :ids` or `IN(:ids)`).

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
