### PR TITLE
Localized-name search for genres and playlists

### DIFF
--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -312,7 +312,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
         """
-        return await self.get_library_items_by_query(
+        items = await self.get_library_items_by_query(
             favorite=favorite,
             search=search,
             limit=limit,
@@ -322,6 +322,34 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             genre_ids=genre,
             in_library_only=True,
         )
+        if (
+            kwargs.get("_localized_fallback", True)
+            and search
+            and not items
+            and self.media_type in (MediaType.GENRE, MediaType.PLAYLIST)
+        ):
+            return await self._localized_search_fallback(search, limit)
+        return items
+
+    async def _localized_search_fallback(self, search_query: str, limit: int) -> list[ItemCls]:
+        """
+        Retry a library search using the canonical names behind a localized query.
+
+        For genre/playlist searches that return nothing literally, reverse-resolve the query to the
+        canonical (English) names of matching localized items and search those, so an item is
+        findable by the localized name the user sees. See
+        ``TranslationController.reverse_lookup_media_names``.
+        """
+        seen: set[Any] = set()
+        merged: list[ItemCls] = []
+        for name in await self.mass.translations.reverse_lookup_media_names(search_query):
+            for item in await self.library_items(
+                search=name, limit=limit, _localized_fallback=False
+            ):
+                if item.item_id not in seen:
+                    seen.add(item.item_id)
+                    merged.append(item)
+        return merged[:limit]
 
     async def iter_library_items(
         self,

--- a/music_assistant/controllers/media/base.py
+++ b/music_assistant/controllers/media/base.py
@@ -328,28 +328,46 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             and not items
             and self.media_type in (MediaType.GENRE, MediaType.PLAYLIST)
         ):
-            return await self._localized_search_fallback(search, limit)
+            return await self._localized_search_fallback(
+                search,
+                limit=limit,
+                offset=offset,
+                favorite=favorite,
+                order_by=order_by,
+                provider=provider,
+                genre=genre,
+            )
         return items
 
-    async def _localized_search_fallback(self, search_query: str, limit: int) -> list[ItemCls]:
+    async def _localized_search_fallback(
+        self, search_query: str, limit: int, offset: int = 0, **call_kwargs: Any
+    ) -> list[ItemCls]:
         """
         Retry a library search using the canonical names behind a localized query.
 
         For genre/playlist searches that return nothing literally, reverse-resolve the query to the
         canonical (English) names of matching localized items and search those, so an item is
-        findable by the localized name the user sees. See
+        findable by the localized name the user sees. The caller's other filters (favorite,
+        order_by, provider and any controller-specific kwargs) are forwarded unchanged so the retry
+        behaves like the literal search; results are merged, de-duplicated and paginated here. See
         ``TranslationController.reverse_lookup_media_names``.
         """
         seen: set[Any] = set()
         merged: list[ItemCls] = []
-        for name in await self.mass.translations.reverse_lookup_media_names(search_query):
+        # iterate the canonical names in a stable order, and fetch each from the start so the
+        # offset/limit window can be applied to the merged, de-duplicated result set
+        for name in sorted(await self.mass.translations.reverse_lookup_media_names(search_query)):
             for item in await self.library_items(
-                search=name, limit=limit, _localized_fallback=False
+                search=name,
+                limit=limit + offset,
+                offset=0,
+                _localized_fallback=False,
+                **call_kwargs,
             ):
                 if item.item_id not in seen:
                     seen.add(item.item_id)
                     merged.append(item)
-        return merged[:limit]
+        return merged[offset : offset + limit]
 
     async def iter_library_items(
         self,

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -388,7 +388,15 @@ class GenreController(MediaControllerBase[Genre]):
         if kwargs.get("_localized_fallback", True) and search and not items:
             # retry with the canonical name behind a localized query, so genres are findable
             # by the name shown in the user's language (see _localized_search_fallback)
-            return await self._localized_search_fallback(search, limit)
+            return await self._localized_search_fallback(
+                search,
+                limit=limit,
+                offset=offset,
+                favorite=favorite,
+                order_by=order_by,
+                hide_empty=hide_empty,
+                media_type=media_type,
+            )
         return items
 
     async def radio_mode_base_tracks(

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -376,7 +376,7 @@ class GenreController(MediaControllerBase[Genre]):
             extra_parts.append(
                 f"EXISTS(SELECT 1 FROM {gm} gm WHERE gm.genre_id = {self.db_table}.item_id)"
             )
-        return await self.get_library_items_by_query(
+        items = await self.get_library_items_by_query(
             favorite=favorite,
             search=search,
             limit=limit,
@@ -385,6 +385,11 @@ class GenreController(MediaControllerBase[Genre]):
             extra_query_params=extra_params,
             extra_query_parts=extra_parts,
         )
+        if kwargs.get("_localized_fallback", True) and search and not items:
+            # retry with the canonical name behind a localized query, so genres are findable
+            # by the name shown in the user's language (see _localized_search_fallback)
+            return await self._localized_search_fallback(search, limit)
+        return items
 
     async def radio_mode_base_tracks(
         self,

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -291,6 +291,9 @@ class MetaDataController(CoreController):
                 required=False,
                 default_value=DEFAULT_LANGUAGE,
                 description="Preferred language for metadata.\n\n"
+                "This language is also used as the fallback locale for text-based searches, so "
+                "localized item names (e.g. genres and built-in playlists) can be found by the "
+                "name shown in this language.\n\n"
                 "Note that English will always be used as fallback when content "
                 "in your preferred language is not available.",
                 options=[ConfigValueOption(key, title=value) for key, value in LOCALES.items()],

--- a/music_assistant/controllers/translations/__init__.py
+++ b/music_assistant/controllers/translations/__init__.py
@@ -18,6 +18,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from music_assistant.helpers.api import api_command
+from music_assistant.helpers.compare import create_safe_string
 from music_assistant.helpers.json import load_json_dict
 from music_assistant.models.core_controller import CoreController
 
@@ -131,6 +132,38 @@ class TranslationController(CoreController):
                 if candidate in self._locales:
                     continue
                 self._locales[candidate] = await self._load_flat(self._locale_files[candidate])
+
+    async def reverse_lookup_media_names(self, query: str, locale: str | None = None) -> set[str]:
+        """
+        Return the canonical (English) media names whose localized value matches ``query``.
+
+        Lets localized item names be found by the name the user sees: a text search that returns
+        nothing literally can be retried against these canonical names (which equal the items'
+        stored ``search_name``). Only ``common.media.*.name`` entries are considered.
+
+        The locale defaults to the metadata controller's configured language (``CONF_LANGUAGE``),
+        which doubles as the fallback search locale; an English/unknown/untranslatable locale
+        yields an empty set (the literal search already covers English).
+
+        :param query: The (possibly localized) search query.
+        :param locale: Locale to reverse-translate from; defaults to the configured metadata language.
+        """
+        locale = locale or self.mass.metadata.locale
+        normalized = create_safe_string(query, True, True)
+        if not normalized or not locale or locale.split("_")[0] == SOURCE_LANGUAGE:
+            return set()
+        await self.ensure_locale_loaded(locale)
+        bundle = self._locales.get(locale) or self._locales.get(locale.split("_")[0])
+        if not bundle:
+            return set()
+        matches: set[str] = set()
+        for key, value in bundle.items():
+            if not (key.startswith("common.media.") and key.endswith(".name")):
+                continue
+            if normalized in create_safe_string(value, True, True):
+                if english := self._source.get(key):
+                    matches.add(english)
+        return matches
 
     def _lookup(self, key: str, locale: str | None) -> str | None:
         """Look up a single candidate key, locale bundle first then English source."""

--- a/music_assistant/controllers/translations/__init__.py
+++ b/music_assistant/controllers/translations/__init__.py
@@ -133,7 +133,7 @@ class TranslationController(CoreController):
                     continue
                 self._locales[candidate] = await self._load_flat(self._locale_files[candidate])
 
-    async def reverse_lookup_media_names(self, query: str, locale: str | None = None) -> set[str]:
+    async def reverse_lookup_media_names(self, query: str) -> set[str]:
         """
         Return the canonical (English) media names whose localized value matches ``query``.
 
@@ -141,14 +141,13 @@ class TranslationController(CoreController):
         nothing literally can be retried against these canonical names (which equal the items'
         stored ``search_name``). Only ``common.media.*.name`` entries are considered.
 
-        The locale defaults to the metadata controller's configured language (``CONF_LANGUAGE``),
-        which doubles as the fallback search locale; an English/unknown/untranslatable locale
-        yields an empty set (the literal search already covers English).
+        The reverse-translation always uses the metadata controller's configured language
+        (``CONF_LANGUAGE``), which doubles as the fallback search locale; an English, unknown or
+        untranslatable language yields an empty set (the literal search already covers English).
 
         :param query: The (possibly localized) search query.
-        :param locale: Locale to reverse-translate from; defaults to the configured metadata language.
         """
-        locale = locale or self.mass.metadata.locale
+        locale = self.mass.metadata.locale
         normalized = create_safe_string(query, True, True)
         if not normalized or not locale or locale.split("_")[0] == SOURCE_LANGUAGE:
             return set()

--- a/tests/core/test_translations.py
+++ b/tests/core/test_translations.py
@@ -6,6 +6,7 @@ import logging
 from contextlib import contextmanager
 from functools import partial
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
@@ -334,11 +335,13 @@ async def test_build_translations_matches_runtime_source() -> None:
 async def test_reverse_lookup_media_names() -> None:
     """A localized media name maps back to its canonical English name for the search fallback."""
     ctrl = _nl_controller()
+    ctrl.mass = MagicMock()
+    # reverse lookups always use the metadata controller's configured language
+    ctrl.mass.metadata.locale = "nl"
     # a localized (nl) query resolves to the canonical English name
-    assert await ctrl.reverse_lookup_media_names("onlangs afgespeeld", locale="nl") == {
-        "Recently played"
-    }
+    assert await ctrl.reverse_lookup_media_names("onlangs afgespeeld") == {"Recently played"}
     # a non-matching query yields nothing
-    assert await ctrl.reverse_lookup_media_names("zzznomatch", locale="nl") == set()
+    assert await ctrl.reverse_lookup_media_names("zzznomatch") == set()
     # English (source) locale: nothing to reverse-translate (literal search already covers it)
-    assert await ctrl.reverse_lookup_media_names("recently played", locale="en") == set()
+    ctrl.mass.metadata.locale = "en"
+    assert await ctrl.reverse_lookup_media_names("recently played") == set()

--- a/tests/core/test_translations.py
+++ b/tests/core/test_translations.py
@@ -329,3 +329,16 @@ async def test_build_translations_matches_runtime_source() -> None:
     ctrl = _make_controller()
     await ctrl.setup(None)  # type: ignore[arg-type]  # scans the real repo authoring files
     assert ctrl._source == build_translations_source()
+
+
+async def test_reverse_lookup_media_names() -> None:
+    """A localized media name maps back to its canonical English name for the search fallback."""
+    ctrl = _nl_controller()
+    # a localized (nl) query resolves to the canonical English name
+    assert await ctrl.reverse_lookup_media_names("onlangs afgespeeld", locale="nl") == {
+        "Recently played"
+    }
+    # a non-matching query yields nothing
+    assert await ctrl.reverse_lookup_media_names("zzznomatch", locale="nl") == set()
+    # English (source) locale: nothing to reverse-translate (literal search already covers it)
+    assert await ctrl.reverse_lookup_media_names("recently played", locale="en") == set()


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the server-side translations work. Genre and built-in-playlist display names are now localized per the connection locale, but search still only matched the canonical (English) name — so a user couldn't find an item by the localized name they actually see.

This adds a **reverse-resolve fallback**: a literal library search runs first; only if a genre/playlist search returns nothing does it reverse-resolve the query against the catalog → the canonical (English) names → and retry. Items become findable by their localized name with **no schema change** and without touching the **user-editable** `genre_aliases`.

## Changes

- `TranslationController.reverse_lookup_media_names(query, locale)`: returns the canonical (English) `common.media.<key>.name` values whose localized form matches the query.
- Base `library_items` gains a localized-search fallback, gated to genre + playlist; genres' custom `library_items` uses it too. Re-searches the canonical names (which equal the items' stored `search_name`).
- Reverse-resolution uses the **metadata controller's configured language** as the fallback search locale (there's no session-locale available at search time today). Documented on `CONF_LANGUAGE`; a dedicated fallback locale can be introduced later.
- Unit test for the reverse lookup.

Notes: covers genres + built-in playlists (the only library items with localized names); ordinary tracks/albums/artists/radios carry real provider names and are unaffected. Inert until the Lokalise download workflow populates the locale files (only `en.json` ships today), same as the rest of the translation display.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
