### PR TITLE
Reduce idle memory usage by tuning jemalloc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,10 +88,13 @@ EXPOSE 8095
 
 WORKDIR $VIRTUAL_ENV
 
-# Entrypoint script that enables jemalloc for the main process only
+# Entrypoint script that enables jemalloc for the main process only.
+# MALLOC_CONF enables jemalloc's background thread so freed pages are returned to
+# the OS while the process is idle; without it an idle server holds onto the peak
+# RSS reached during startup (db migration, provider setup, metadata, image decode).
 RUN printf '#!/bin/sh\n\
 for path in /usr/lib/*/libjemalloc.so.2; do\n\
-    [ -f "$path" ] && export LD_PRELOAD="$path" && break\n\
+    [ -f "$path" ] && export LD_PRELOAD="$path" MALLOC_CONF="background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000" && break\n\
 done\n\
 exec mass "$@"\n' > /usr/local/bin/entrypoint.sh && chmod +x /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
# What does this implement/fix?

Our Docker image preloads jemalloc but never configures it, so it runs with `background_thread:false`. jemalloc then only returns freed memory to the OS during allocation activity, so an otherwise idle server keeps the high RSS peak reached during startup (database migration, provider setup, metadata fetches, image decoding) and never gives it back.

This sets `MALLOC_CONF` so jemalloc runs a background thread that decays and releases freed pages while idle, lowering the baseline memory footprint of a running instance.

- Set `MALLOC_CONF=background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000` next to the existing jemalloc `LD_PRELOAD` in the Docker entrypoint.
- Applies to the main process only — subprocesses already strip `LD_PRELOAD` (`helpers/process.py`), so it is a no-op for them.

**Related issue (if applicable):**

- Follow-up to #4198 (high idle memory usage)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
