### PR TITLE
Don't lint downloaded translation files for spelling/EOF

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,6 +110,9 @@ repos:
         language: system
         types: [text]
         entry: uv run end-of-file-fixer
+        # downloaded Lokalise locale files don't carry a trailing newline; en.json's is
+        # guaranteed by build_translations (--check), so skip the whole translations dir
+        exclude: ^music_assistant/translations/
         stages: [pre-commit, pre-push, manual]
 
       - id: no-commit-to-branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,13 @@ mass = "music_assistant.__main__:main"
 # explicit is misspelled in the iTunes API
 # "additionals" is a fixed field name from the Nicovideo API fixtures
 # "connexion" is a French word in the MusicMe login URL path
+# translations/*.json are machine-translated locale files (Lokalise); foreign words aren't typos
 ignore-words-list = "provid,hass,followings,childs,explict,additionals,commitish,nam,connexion,"
 skip = """*.js,*.svg,\
 music_assistant/providers/itunes_podcasts/itunes_country_codes.json,\
 music_assistant/helpers/resources/genres/genre_mapping.json,\
 music_assistant/providers/sonic_analysis/vendored_clap/**,\
+music_assistant/translations/*.json,\
 NOTICE,\
 """
 


### PR DESCRIPTION
# What does this implement/fix?

The weekly Lokalise download PRs (e.g. #4209) fail the `lint` job on two hooks that have nothing useful to say about machine-translated locale files:

- **codespell** flags foreign words in `translations/<lang>.json` as misspellings.
- **end-of-file-fixer** rewrites them because Lokalise exports without a trailing newline.

This exempts `music_assistant/translations/*.json` from both. `en.json`'s formatting (incl. its trailing newline) stays enforced by `build_translations` (`--check`), so nothing about the source file changes.

## Types of changes

- [x] CI / workflow change — `ci`