### PR TITLE
Plex: announce a stable client identity to plex.tv

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -89,8 +89,10 @@ from music_assistant.providers.plex.constants import (
     ERR_NO_LIBRARIES,
     ERR_TRACK_NOT_FOUND,
     FAKE_ARTIST_PREFIX,
+    PLEX_PRODUCT,
 )
 from music_assistant.providers.plex.helpers import (
+    configure_plex_identity,
     discover_local_servers,
     get_favorite_from_rating,
     get_libraries,
@@ -133,6 +135,7 @@ async def setup(
     if not config.get_value(CONF_AUTH_TOKEN):
         raise LoginFailed(ERR_INVALID_CREDENTIALS)
 
+    configure_plex_identity(mass.server_id)
     return PlexProvider(mass, manifest, config, SUPPORTED_FEATURES)
 
 
@@ -149,6 +152,10 @@ async def get_config_entries(  # noqa: PLR0915
     action: [optional] action key called from config entries UI.
     values: the (intermediate) raw values for config entries sent with the action.
     """
+    # ensure plexapi announces "Music Assistant" with a stable client identifier before
+    # any auth/connection happens (so OAuth tokens stay valid across restarts)
+    configure_plex_identity(mass.server_id)
+
     # handle action GDM discovery
     if action == CONF_ACTION_GDM:
         server_details = await discover_local_servers()
@@ -179,7 +186,7 @@ async def get_config_entries(  # noqa: PLR0915
         assert values
         values[CONF_AUTH_TOKEN] = None
         async with AuthenticationHelper(mass, str(values["session_id"])) as auth_helper:
-            plex_auth = MyPlexPinLogin(headers={"X-Plex-Product": "Music Assistant"}, oauth=True)
+            plex_auth = MyPlexPinLogin(oauth=True)
             # Generate the PIN/code by calling the Plex API
             await asyncio.to_thread(plex_auth._getCode)
             auth_url = plex_auth.oauthUrl(auth_helper.callback_url)
@@ -421,8 +428,8 @@ class PlexProvider(MusicProvider):
                 session.headers.update(
                     {
                         "X-Plex-Client-Identifier": self.instance_id,
-                        "X-Plex-Product": "Music Assistant",
-                        "X-Plex-Platform": "Music Assistant",
+                        "X-Plex-Product": PLEX_PRODUCT,
+                        "X-Plex-Platform": PLEX_PRODUCT,
                         "X-Plex-Version": self.mass.version,
                     }
                 )

--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -424,10 +424,12 @@ class PlexProvider(MusicProvider):
                     if self.config.get_value(CONF_LOCAL_SERVER_SSL)
                     else False
                 )
-                # Add Music Assistant client identification headers
+                # Add Music Assistant client identification headers. The client identifier
+                # is announced globally via configure_plex_identity() (plexapi rebuilds it
+                # from BASE_HEADERS per request, overriding any session-level value), so we
+                # only set the per-connection product/platform/version here.
                 session.headers.update(
                     {
-                        "X-Plex-Client-Identifier": self.instance_id,
                         "X-Plex-Product": PLEX_PRODUCT,
                         "X-Plex-Platform": PLEX_PRODUCT,
                         "X-Plex-Version": self.mass.version,

--- a/music_assistant/providers/plex/constants.py
+++ b/music_assistant/providers/plex/constants.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Final
+
+# Identity announced to Plex / plex.tv. Without this, plexapi falls back to the host
+# machine's name (e.g. in the plex.tv "authorized devices" list and during auth).
+PLEX_PRODUCT: Final = "Music Assistant"
+
 CONF_ACTION_AUTH_MYPLEX = "auth_myplex"
 CONF_ACTION_AUTH_LOCAL = "auth_local"
 CONF_ACTION_CLEAR_AUTH = "auth"

--- a/music_assistant/providers/plex/helpers.py
+++ b/music_assistant/providers/plex/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, cast
 
+import plexapi
 import requests
 from music_assistant_models.enums import ImageType
 from music_assistant_models.media_items import MediaItemImage, UniqueList
@@ -13,12 +14,33 @@ from plexapi.library import LibrarySection as PlexLibrarySection
 from plexapi.library import MusicSection as PlexMusicSection
 from plexapi.server import PlexServer
 
-from music_assistant.providers.plex.constants import AUTH_TOKEN_UNAUTH
+from music_assistant.providers.plex.constants import AUTH_TOKEN_UNAUTH, PLEX_PRODUCT
 
 if TYPE_CHECKING:
     from plexapi.base import PlexObject
 
     from music_assistant.mass import MusicAssistant
+
+
+def configure_plex_identity(client_id: str) -> None:
+    """
+    Make every plexapi client announce "Music Assistant" with a stable identity.
+
+    plexapi builds each request's headers from these process-global defaults. The device
+    name otherwise falls back to the machine's hostname, and - critically - the client
+    identifier defaults to the MAC address, which is unstable in containers. Plex binds
+    OAuth tokens to the client identifier, so an unstable one makes plex.tv reject the
+    stored token after a restart. We pin it to Music Assistant's persistent server id.
+
+    :param client_id: Stable client identifier to advertise (Music Assistant's server id).
+    """
+    plexapi.X_PLEX_PRODUCT = PLEX_PRODUCT
+    plexapi.X_PLEX_DEVICE_NAME = PLEX_PRODUCT
+    plexapi.BASE_HEADERS["X-Plex-Product"] = PLEX_PRODUCT
+    plexapi.BASE_HEADERS["X-Plex-Device-Name"] = PLEX_PRODUCT
+    if client_id:
+        plexapi.X_PLEX_IDENTIFIER = client_id
+        plexapi.BASE_HEADERS["X-Plex-Client-Identifier"] = client_id
 
 
 async def get_libraries(


### PR DESCRIPTION


# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
plexapi defaults the X-Plex-Client-Identifier to the machine's MAC address and the device name to the hostname. Plex binds OAuth tokens to the client identifier, and the MAC address is unstable in containers, so stored tokens could be rejected after a restart.

Pin plexapi's process-global identity to Music Assistant's persistent server id and announce 'Music Assistant' as product/device name, both before the OAuth pin login (config flow) and at provider setup. The pin login no longer needs its own headers override, and the provider session reuses the shared PLEX_PRODUCT constant.


## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
