### PR TITLE
Skip multichannel files in AcoustID scan instead of crashing

### DIFF
--- a/music_assistant/providers/acoustid_lookup/provider.py
+++ b/music_assistant/providers/acoustid_lookup/provider.py
@@ -163,6 +163,19 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
             )
             return False
 
+        # Chromaprint only fingerprints mono/stereo audio. Feeding it multichannel
+        # (e.g. 5.1) trips a C-level assertion in its AudioProcessor that aborts the
+        # whole process rather than raising, so it cannot be caught and logged — the
+        # only safe option is to skip the file. See acoustid/chromaprint#90.
+        if audio_format.channels > 2:
+            self.logger.warning(
+                "AcoustID can only scan mono/stereo files; skipping multichannel "
+                "(%d-channel) file: %s",
+                audio_format.channels,
+                streamdetails.path or streamdetails.uri,
+            )
+            return False
+
         fingerprinter = self._create_fingerprinter(audio_format.sample_rate, audio_format.channels)
         if fingerprinter is None:
             return False

--- a/tests/providers/acoustid_lookup/test_provider.py
+++ b/tests/providers/acoustid_lookup/test_provider.py
@@ -375,6 +375,31 @@ async def test_start_analysis_skips_within_no_match_cooldown(
 
 
 @pytest.mark.asyncio
+async def test_start_analysis_skips_multichannel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A multichannel (e.g. 5.1) file is declined before any fingerprinting work.
+
+    Feeding chromaprint multichannel audio trips a C-level assertion that aborts the
+    process, so the session must be refused up-front rather than risk the crash.
+    """
+    provider = _make_provider()
+    track = MagicMock(mbid=None)
+    track.get_external_id.return_value = None
+    cast("MagicMock", provider.mass.music.tracks).get_library_item_by_prov_id = AsyncMock(
+        return_value=track
+    )
+    fp = _FakeFingerprinter()
+    _install_fake_chromaprint(monkeypatch, fp)
+
+    accepted = await provider.start_analysis(
+        "session", _make_streamdetails(), _make_audio_format(channels=6)
+    )
+
+    assert accepted is False
+    # declined before the fingerprinter was ever started
+    assert fp.start_args is None
+
+
+@pytest.mark.asyncio
 async def test_start_analysis_retries_after_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
     """Once the cooldown has elapsed, the track is accepted for a fresh lookup."""
     provider = _make_provider()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Chromaprint's AudioProcessor asserts `length % m_num_channels == 0` and aborts the whole process (a C-level abort, not a catchable exception) when fed audio it can't frame-align. AcoustID/chromaprint is built around mono/stereo, so scanning a multichannel file (e.g. a 5.1 FLAC) took down the entire server.

Gate the analysis session on channel count: decline anything with more than two channels up front and log a warning naming the offending file, so the scan logs it and moves on rather than crashing.

See https://github.com/acoustid/chromaprint/issues/90

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
