### PR TITLE
fix for #5652 - Fix YouTube Music radio / similar tracks failing with KeyError 'endpoint'

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -625,9 +625,13 @@ class YoutubeMusicProvider(MusicProvider):
     @use_cache(3600 * 24, allow_expired_cache=True)  # Cache for 1 day
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
         """Retrieve a dynamic list of tracks based on the provided item."""
-        result = await get_song_radio_tracks(
-            headers=self._headers, prov_item_id=prov_track_id, limit=limit, user=self._yt_user
-        )
+        try:
+            result = await get_song_radio_tracks(
+                headers=self._headers, prov_item_id=prov_track_id, limit=limit, user=self._yt_user
+            )
+        except Exception as err:
+            self.logger.warning("Failed to get similar/radio tracks from YT Music: %s", err)
+            return []
         if "tracks" in result:
             tracks = []
             for track in result["tracks"]:

--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -50,7 +50,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.streamdetails import StreamDetails
 from ytmusicapi.constants import SUPPORTED_LANGUAGES
-from ytmusicapi.exceptions import YTMusicServerError
+from ytmusicapi.exceptions import YTMusicError, YTMusicServerError
 from ytmusicapi.helpers import get_authorization, sapisid_from_cookie
 
 from music_assistant.constants import (
@@ -622,30 +622,83 @@ class YoutubeMusicProvider(MusicProvider):
             user=self._yt_user,
         )
 
-    @use_cache(3600 * 24, allow_expired_cache=True)  # Cache for 1 day
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
-        """Retrieve a dynamic list of tracks based on the provided item."""
+        """Retrieve a dynamic list of tracks based on the provided item.
+
+        :param prov_track_id: Provider track ID to base similar tracks on.
+        :param limit: Maximum number of tracks to return.
+        """
         try:
-            result = await get_song_radio_tracks(
-                headers=self._headers, prov_item_id=prov_track_id, limit=limit, user=self._yt_user
-            )
-        except Exception as err:
+            return await self._get_similar_tracks(prov_track_id, limit)
+        except (YTMusicError, KeyError, InvalidDataError) as err:
             self.logger.warning("Failed to get similar/radio tracks from YT Music: %s", err)
             return []
-        if "tracks" in result:
-            tracks = []
-            for track in result["tracks"]:
-                # Playlist tracks sometimes do not have a valid artist id
-                # In that case, call the API for track details based on track id
+
+    @use_cache(3600 * 24, allow_expired_cache=True)  # Cache for 1 day
+    async def _get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
+        """Get similar/radio tracks (internal cached implementation).
+
+        May return a partial list. Raises if every candidate item fails to parse
+        so transient data problems do not overwrite good cached results when
+        allow_expired_cache is active.
+        """
+        result = await get_song_radio_tracks(
+            headers=self._headers, prov_item_id=prov_track_id, limit=limit, user=self._yt_user
+        )
+
+        raw_tracks = result.get("tracks") or []
+        if not raw_tracks:
+            return []
+
+        tracks: list[Track] = []
+        for raw_track in raw_tracks:
+            # Try normal parse first
+            try:
+                if track := self._parse_track(raw_track):
+                    tracks.append(track)
+                    continue
+            except InvalidDataError:
+                # Playlist tracks sometimes do not have a valid artist id.
+                # Fall back to fetching the full track by ID.
+                vid = raw_track.get("videoId")
+                if vid:
+                    try:
+                        if track := await self.get_track(vid):
+                            tracks.append(track)
+                            continue
+                    except (
+                        MediaNotFoundError,
+                        InvalidDataError,
+                        YTMusicError,
+                        KeyError,
+                        TypeError,
+                    ) as err:
+                        self.logger.debug("Similar track fallback failed: %s", err)
+            except (KeyError, TypeError, ValueError) as err:
+                self.logger.debug("Failed to parse similar track: %s", err)
+
+            # Last-resort fallback using videoId if we haven't succeeded yet
+            vid = raw_track.get("videoId")
+            if vid:
                 try:
-                    track = self._parse_track(track)
-                    if track:
+                    if track := await self.get_track(vid):
                         tracks.append(track)
-                except InvalidDataError:
-                    if track := await self.get_track(track["videoId"]):
-                        tracks.append(track)
-            return tracks
-        return []
+                except (
+                    MediaNotFoundError,
+                    InvalidDataError,
+                    YTMusicError,
+                    KeyError,
+                    TypeError,
+                ) as err:
+                    self.logger.debug("Similar track fallback failed: %s", err)
+
+        if not tracks:
+            # All candidate tracks failed to parse. Raise so the failure is not
+            # treated as a successful empty result (preserves stale data via
+            # allow_expired_cache / background refresh).
+            raise InvalidDataError("Failed to parse any similar/radio tracks")
+
+        return tracks
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Return the content details for the given track when it will be streamed."""


### PR DESCRIPTION
# What does this implement/fix?

**Bug:** "Start Radio" (and "similar tracks" / dynamic radio) on YouTube Music tracks would fail with `Error handling message: player_queues/play_media: 'endpoint'`.

**Root cause:**
`YoutubeMusicProvider.get_similar_tracks()` calls `get_song_radio_tracks()`, which uses `ytmusicapi.get_watch_playlist(..., radio=True)`. The library's response parser (`get_tab_browse_id`) can raise a raw `KeyError('endpoint')` (or similar) when the watch/radio response contains a tab without the expected `["tabRenderer"]["endpoint"]` structure. This exception was not caught anywhere in the provider or the radio flow (`get_dynamic_radio_tracks` → `tracks.similar_tracks` → `play_media(radio_mode=True)`), which only catches `MusicAssistantError` in the main media handling path. The unhandled error aborted the entire play command.

**Fix:**
Wrap the `get_song_radio_tracks()` call in `get_similar_tracks()` with a try/except. On failure, log a warning and return `[]`. This lets radio mode gracefully fall back to the seed/base track(s) instead of crashing, matching the existing defensive style used elsewhere in the provider for YTM response fragility.

**Related issue (if applicable):**

- related issue: https://github.com/music-assistant/support/issues/5652

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
