### PR TITLE
Trim Provider.to_dict() to match the ProviderInstance schema

### DIFF
--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -172,13 +172,11 @@ class Provider:
             "type": self.type.value,
             "domain": self.domain,
             "name": self.name,
-            "default_name": self.default_name,
-            "instance_name_postfix": self.instance_name_postfix,
             "instance_id": self.instance_id,
-            "lookup_key": self.instance_id,  # include for backwards compatibility
             "supported_features": [x.value for x in self.supported_features],
             "available": self.available,
             "is_streaming_provider": getattr(self, "is_streaming_provider", None),
+            "lookup_key": self.instance_id,  # include for backwards compatibility
         }
 
     def supports_feature(self, feature: ProviderFeature) -> bool:

--- a/tests/models/test_provider.py
+++ b/tests/models/test_provider.py
@@ -1,0 +1,32 @@
+"""Tests for the Provider base class serialization contract."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from unittest.mock import MagicMock
+
+from music_assistant_models.enums import ProviderType
+from music_assistant_models.provider import ProviderInstance
+
+from music_assistant.models.provider import Provider
+
+
+def _make_base_provider() -> Provider:
+    """Construct a minimal base Provider with stubbed mass/manifest/config."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.type = ProviderType.MUSIC
+    manifest.domain = "test_provider"
+    config = MagicMock()
+    config.name = "Test Provider"
+    config.instance_id = "test_instance"
+    config.get_value = MagicMock(return_value="GLOBAL")
+    return Provider(mass, manifest, config, supported_features=set())
+
+
+def test_to_dict_matches_provider_instance_schema() -> None:
+    """to_dict() emits exactly the fields declared by the ProviderInstance model."""
+    result = _make_base_provider().to_dict()
+    assert set(result) == {f.name for f in fields(ProviderInstance)}
+    # the served payload must also deserialize back into the model
+    ProviderInstance.from_dict(result)


### PR DESCRIPTION
# What does this implement/fix?

`Provider.to_dict()` emitted `default_name` and `instance_name_postfix`, which are not part of the `ProviderInstance` model that API clients / the frontend are generated from — so the served payload no longer matched the declared schema.

- Drop `default_name` (read from the provider config, not the instance) and `instance_name_postfix` (unused) from `to_dict()`.
- Add a contract test that locks the `to_dict()` key set to the `ProviderInstance` schema.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

---

Companion models PR: music-assistant/models#254
