### PR TITLE
Wire up provider status reporting (structured errors + derived status)

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -33,7 +33,7 @@ PLAYLIST_MEDIA_TYPES: Final[tuple[MediaType, ...]] = (
 
 # API_SCHEMA_VERSION: bump this when adding new features to the API commands (and models)
 # or small non-breaking changes to existing commands
-API_SCHEMA_VERSION: Final[int] = 32
+API_SCHEMA_VERSION: Final[int] = 33
 
 # MIN_SCHEMA_VERSION is the minimum API schema version that the current server
 # version can work with. Only bump when there are breaking changes to existing

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -37,12 +37,20 @@ from music_assistant_models.enums import (
     PlayerFeature,
     PlayerType,
     ProviderFeature,
+    ProviderStatus,
     ProviderType,
 )
 from music_assistant_models.errors import (
     ActionUnavailable,
+    AuthenticationFailed,
+    AuthenticationRequired,
     InvalidDataError,
+    LoginFailed,
     UnsupportedFeaturedException,
+    UnsupportedSystemError,
+)
+from music_assistant_models.errors import (
+    InvalidToken as InvalidTokenError,
 )
 
 from music_assistant.constants import (
@@ -157,6 +165,32 @@ def _with_translation_owner(
             copied.value = values.get(copied.key, copied.default_value)
         result.append(copied)
     return result
+
+
+_AUTH_ERROR_CODES = frozenset(
+    {
+        AuthenticationRequired.error_code,
+        AuthenticationFailed.error_code,
+        LoginFailed.error_code,
+        InvalidTokenError.error_code,
+    }
+)
+
+
+def _provider_status(conf: ProviderConfig, is_loaded: bool) -> ProviderStatus:
+    """Derive the (lifecycle) status of a provider from its config and load state."""
+    if not conf.enabled:
+        return ProviderStatus.DISABLED
+    if is_loaded:
+        # runtime (un)availability of a loaded provider is conveyed via ProviderInstance.available
+        return ProviderStatus.LOADED
+    if conf.last_error is not None:
+        if conf.last_error.error_code in _AUTH_ERROR_CODES:
+            return ProviderStatus.AUTH_REQUIRED
+        if conf.last_error.error_code == UnsupportedSystemError.error_code:
+            return ProviderStatus.INCOMPATIBLE
+        return ProviderStatus.ERROR
+    return ProviderStatus.LOADING
 
 
 class ConfigController:
@@ -292,16 +326,26 @@ class ConfigController:
         """Return all known provider configurations, optionally filtered by ProviderType."""
         raw_values = self.get(CONF_PROVIDERS, {})
         prov_entries = {x.domain for x in self.mass.get_provider_manifests()}
-        return [
-            await self.get_provider_config(prov_conf["instance_id"])
-            if include_values
-            else cast("ProviderConfig", ProviderConfig.parse([], prov_conf))
-            for prov_conf in raw_values.values()
-            if (provider_type is None or prov_conf["type"] == provider_type)
-            and (provider_domain is None or prov_conf["domain"] == provider_domain)
+        configs: list[ProviderConfig] = []
+        for prov_conf in raw_values.values():
+            if provider_type is not None and prov_conf["type"] != provider_type:
+                continue
+            if provider_domain is not None and prov_conf["domain"] != provider_domain:
+                continue
             # guard for deleted providers
-            and prov_conf["domain"] in prov_entries
-        ]
+            if prov_conf["domain"] not in prov_entries:
+                continue
+            if include_values:
+                # get_provider_config already stamps the derived status
+                configs.append(await self.get_provider_config(prov_conf["instance_id"]))
+                continue
+            conf = cast("ProviderConfig", ProviderConfig.parse([], prov_conf))
+            is_loaded = (
+                self.mass.get_provider(conf.instance_id, return_unavailable=True) is not None
+            )
+            conf.status = _provider_status(conf, is_loaded)
+            configs.append(conf)
+        return configs
 
     @api_command("config/providers/get")
     async def get_provider_config(self, instance_id: str) -> ProviderConfig:
@@ -318,7 +362,10 @@ class ConfigController:
             else:
                 msg = f"Unknown provider domain: {raw_conf['domain']}"
                 raise KeyError(msg)
-            return cast("ProviderConfig", ProviderConfig.parse(config_entries, raw_conf))
+            conf = cast("ProviderConfig", ProviderConfig.parse(config_entries, raw_conf))
+            is_loaded = self.mass.get_provider(instance_id, return_unavailable=True) is not None
+            conf.status = _provider_status(conf, is_loaded)
+            return conf
         msg = f"No config found for provider id {instance_id}"
         raise KeyError(msg)
 

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -30,7 +30,7 @@ from urllib.parse import urlparse
 import chardet
 import ifaddr
 from music_assistant_models.enums import AlbumType, IdentifierType
-from music_assistant_models.errors import SetupFailedError
+from music_assistant_models.errors import UnsupportedSystemError
 from zeroconf import InterfaceChoice, IPVersion
 
 from music_assistant.constants import (
@@ -128,16 +128,6 @@ def get_total_system_memory() -> float:
         # Fallback if sysconf is not available (e.g., Windows)
         # Return a conservative default to disable buffering by default
         return 0.0
-
-
-class UnsupportedSystemError(SetupFailedError):
-    """
-    Raised when the host does not meet a provider's minimum requirements.
-
-    Subclass of SetupFailedError so existing setup handling still applies, but it
-    marks a permanent condition (RAM, CPU cores, CPU capability) that will not
-    resolve at runtime, so the provider load must not be retried.
-    """
 
 
 def verify_system_meets_requirements(

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -16,8 +16,13 @@ import aiofiles
 from aiofiles.os import wrap
 from music_assistant_models.api import ServerInfoMessage
 from music_assistant_models.auth import UserRole
+from music_assistant_models.config_entries import ProviderError
 from music_assistant_models.enums import CoreState, EventType, ProviderFeature, ProviderType
-from music_assistant_models.errors import MusicAssistantError, SetupFailedError
+from music_assistant_models.errors import (
+    MusicAssistantError,
+    SetupFailedError,
+    UnsupportedSystemError,
+)
 from music_assistant_models.event import MassEvent
 from music_assistant_models.helpers import set_global_cache_values
 from music_assistant_models.provider import ProviderManifest
@@ -50,7 +55,6 @@ from music_assistant.helpers.api import APICommandHandler, api_command
 from music_assistant.helpers.images import get_icon_string
 from music_assistant.helpers.util import (
     TaskManager,
-    UnsupportedSystemError,
     get_package_version,
     is_hass_supervisor,
     load_provider_module,
@@ -105,6 +109,19 @@ def is_audio_analysis_provider(
 ) -> TypeGuard[AudioAnalysisProvider]:
     """Type guard that returns true if a provider is an audio analysis provider."""
     return provider.type == ProviderType.AUDIO_ANALYSIS
+
+
+def _provider_error_from_exc(exc: BaseException) -> ProviderError:
+    """Build a serializable, localizable ProviderError from a provider setup exception."""
+    message = str(exc) or type(exc).__name__
+    if isinstance(exc, MusicAssistantError):
+        return ProviderError(
+            error_code=exc.error_code,
+            message=message,
+            translation_key=exc.translation_key,
+            translation_args=list(exc.translation_args),
+        )
+    return ProviderError(error_code=999, message=message)
 
 
 class MusicAssistant:
@@ -758,8 +775,10 @@ class MusicAssistant:
                 # cleanup we don't need here; a direct remove persists and is guard-free.)
                 self.config.remove(f"{CONF_PROVIDERS}/{instance_id}")
                 return
-            prov_conf.last_error = str(exc)
-            self.config.set(f"{CONF_PROVIDERS}/{instance_id}/last_error", str(exc))
+            prov_conf.last_error = _provider_error_from_exc(exc)
+            self.config.set(
+                f"{CONF_PROVIDERS}/{instance_id}/last_error", prov_conf.last_error.to_dict()
+            )
             LOGGER.warning(
                 "Provider(instance) %s can not run on this system: %s",
                 prov_conf.name or prov_conf.instance_id,
@@ -769,8 +788,10 @@ class MusicAssistant:
         except Exception as exc:
             # if loading failed, we store the error in the config object
             # so we can show something useful to the user
-            prov_conf.last_error = str(exc)
-            self.config.set(f"{CONF_PROVIDERS}/{instance_id}/last_error", str(exc))
+            prov_conf.last_error = _provider_error_from_exc(exc)
+            self.config.set(
+                f"{CONF_PROVIDERS}/{instance_id}/last_error", prov_conf.last_error.to_dict()
+            )
 
             # auto schedule a retry if the (re)load failed with a handled exception
             # unhandled exceptions (e.g. ValueError) are likely bugs that won't resolve themselves
@@ -832,7 +853,8 @@ class MusicAssistant:
 
     async def unload_provider_with_error(self, instance_id: str, error: str) -> None:
         """Unload a provider when it got into trouble which needs user interaction."""
-        self.config.set(f"{CONF_PROVIDERS}/{instance_id}/last_error", error)
+        prov_error = ProviderError(error_code=999, message=error)
+        self.config.set(f"{CONF_PROVIDERS}/{instance_id}/last_error", prov_error.to_dict())
         await self.unload_provider(instance_id)
 
     async def run_provider_discovery(self, instance_id: str) -> None:

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType
-from music_assistant_models.errors import MusicAssistantError, SetupFailedError
+from music_assistant_models.errors import (
+    MusicAssistantError,
+    SetupFailedError,
+    UnsupportedSystemError,
+)
 from zeroconf import InterfaceChoice, IPVersion
 
 from music_assistant.helpers import uri, util
@@ -436,7 +440,7 @@ def test_verify_cpu_supports_ml_inference_arm() -> None:
 
 def test_unsupported_system_error_is_setup_failed() -> None:
     """UnsupportedSystemError must subclass SetupFailedError so existing handling applies."""
-    assert issubclass(util.UnsupportedSystemError, SetupFailedError)
+    assert issubclass(UnsupportedSystemError, SetupFailedError)
 
 
 @pytest.mark.parametrize(
@@ -458,7 +462,7 @@ def test_verify_system_meets_requirements_cpu(
         patch("music_assistant.helpers.util.get_total_system_memory", return_value=64.0),
     ):
         if should_raise:
-            with pytest.raises(util.UnsupportedSystemError):
+            with pytest.raises(UnsupportedSystemError):
                 util.verify_system_meets_requirements(feature_name="X", min_cpu_cores=min_cpu_cores)
         else:
             util.verify_system_meets_requirements(feature_name="X", min_cpu_cores=min_cpu_cores)
@@ -484,7 +488,7 @@ def test_verify_system_meets_requirements_memory(
         patch("music_assistant.helpers.util.get_total_system_memory", return_value=total_gb),
     ):
         if should_raise:
-            with pytest.raises(util.UnsupportedSystemError):
+            with pytest.raises(UnsupportedSystemError):
                 util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)
         else:
             util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)
@@ -499,7 +503,7 @@ def test_verify_system_meets_requirements_ml_inference() -> None:
         patch("torch.backends.cpu.get_cpu_capability", return_value="DEFAULT"),
     ):
         # capable RAM/CPU but no AVX2: only raises when the ML inference check is requested
-        with pytest.raises(util.UnsupportedSystemError):
+        with pytest.raises(UnsupportedSystemError):
             util.verify_system_meets_requirements(
                 feature_name="X", min_cpu_cores=4, min_memory_gb=8.0, require_ml_inference=True
             )

--- a/tests/core/test_provider_status.py
+++ b/tests/core/test_provider_status.py
@@ -1,0 +1,57 @@
+"""Tests for provider status derivation and structured error building."""
+
+from __future__ import annotations
+
+from music_assistant_models.config_entries import ProviderConfig, ProviderError
+from music_assistant_models.enums import ProviderStatus, ProviderType
+from music_assistant_models.errors import (
+    AuthenticationRequired,
+    LoginFailed,
+    SetupFailedError,
+    UnsupportedSystemError,
+)
+
+from music_assistant.controllers.config import _provider_status
+from music_assistant.mass import _provider_error_from_exc
+
+
+def _conf(*, enabled: bool = True, last_error: ProviderError | None = None) -> ProviderConfig:
+    return ProviderConfig(
+        values={},
+        type=ProviderType.MUSIC,
+        domain="demo",
+        instance_id="demo--1",
+        enabled=enabled,
+        last_error=last_error,
+    )
+
+
+def test_provider_status_derivation() -> None:
+    """Status reflects the provider's config + load state, keyed off the error code."""
+    assert _provider_status(_conf(enabled=False), is_loaded=False) == ProviderStatus.DISABLED
+    assert _provider_status(_conf(), is_loaded=True) == ProviderStatus.LOADED
+    assert _provider_status(_conf(), is_loaded=False) == ProviderStatus.LOADING
+    err = ProviderError(error_code=SetupFailedError.error_code, message="boom")
+    assert _provider_status(_conf(last_error=err), is_loaded=False) == ProviderStatus.ERROR
+    auth = ProviderError(error_code=AuthenticationRequired.error_code, message="auth")
+    assert _provider_status(_conf(last_error=auth), is_loaded=False) == ProviderStatus.AUTH_REQUIRED
+    login = ProviderError(error_code=LoginFailed.error_code, message="login")
+    assert (
+        _provider_status(_conf(last_error=login), is_loaded=False) == ProviderStatus.AUTH_REQUIRED
+    )
+    incompat = ProviderError(error_code=UnsupportedSystemError.error_code, message="nope")
+    assert (
+        _provider_status(_conf(last_error=incompat), is_loaded=False) == ProviderStatus.INCOMPATIBLE
+    )
+
+
+def test_provider_error_from_exc() -> None:
+    """A MusicAssistantError keeps its code/translation_key; other exceptions get code 999."""
+    err = _provider_error_from_exc(LoginFailed("bad creds"))
+    assert err.error_code == LoginFailed.error_code
+    assert err.message == "bad creds"
+    assert err.translation_key == LoginFailed.translation_key
+    generic = _provider_error_from_exc(ValueError("oops"))
+    assert generic.error_code == 999
+    assert generic.message == "oops"
+    assert generic.translation_key is None


### PR DESCRIPTION
# What does this implement/fix?

Server side of the provider-status work, and the fix for the mypy error the `music-assistant-models` 1.1.133 bump surfaced (`ProviderConfig.last_error` is now a structured `ProviderError`, not a `str`).

- Build a `ProviderError` (`error_code` + `message` + `translation_key`) at the provider-load failure sites instead of assigning a raw string to `last_error`.
- Derive and stamp `ProviderConfig.status` (`loaded`/`loading`/`disabled`/`auth_required`/`incompatible`/`error`) on the `config/providers` read path, keyed off the error code.
- Import `UnsupportedSystemError` from the models package and drop the server-local copy.
- Bump `API_SCHEMA_VERSION`.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

---

Companion models PR: music-assistant/models#255 (merged, released in 1.1.133). Frontend consumption (switching the providers page onto `status`) is a follow-up.
