### PR TITLE
Fix image download from CDNs that reject our User-Agent

### DIFF
--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -17,9 +17,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import aiofiles
-from aiohttp.client_exceptions import ClientError
+from aiohttp.client_exceptions import ClientError, ClientResponseError
 from PIL import Image, UnidentifiedImageError
 
+from music_assistant.constants import APPLICATION_NAME
 from music_assistant.helpers.security import is_safe_path
 from music_assistant.helpers.tags import get_embedded_image
 from music_assistant.models.metadata_provider import MetadataProvider
@@ -259,8 +260,7 @@ async def get_image_data(
             msg = f"Invalid imageproxy URL (missing path): {path_or_url}"
             raise FileNotFoundError(msg)
         try:
-            async with mass.http_session_no_ssl.get(path_or_url, raise_for_status=True) as resp:
-                return await resp.read()
+            return await _fetch_remote_image(mass, path_or_url)
         except ClientError as err:
             msg = f"Failed to fetch image from {path_or_url}: {err}"
             raise FileNotFoundError(msg) from err
@@ -279,6 +279,30 @@ async def get_image_data(
         return img_data
     msg = f"Image not found: {path_or_url}"
     raise FileNotFoundError(msg)
+
+
+async def _fetch_remote_image(mass: MusicAssistant, url: str) -> bytes:
+    """
+    Fetch raw image bytes over HTTP.
+
+    :param mass: The MusicAssistant instance.
+    :param url: The (http/https) image URL to fetch.
+    """
+    try:
+        async with mass.http_session_no_ssl.get(url, raise_for_status=True) as resp:
+            return await resp.read()
+    except ClientResponseError as err:
+        # Some CDNs (e.g. Akamai) 403 our default User-Agent; retry once with
+        # a UA they allowlist before giving up.
+        if err.status not in (401, 403):
+            raise
+        fallback_ua = (
+            f"{APPLICATION_NAME}/{mass.version} (Wget/1.24.5; +https://music-assistant.io)"
+        )
+        async with mass.http_session_no_ssl.get(
+            url, raise_for_status=True, headers={"User-Agent": fallback_ua}
+        ) as resp:
+            return await resp.read()
 
 
 async def get_image_thumb(

--- a/music_assistant/helpers/images.py
+++ b/music_assistant/helpers/images.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import aiofiles
-from aiohttp.client_exceptions import ClientError, ClientResponseError
+from aiohttp.client_exceptions import ClientError
 from PIL import Image, UnidentifiedImageError
 
 from music_assistant.constants import APPLICATION_NAME
@@ -288,21 +288,15 @@ async def _fetch_remote_image(mass: MusicAssistant, url: str) -> bytes:
     :param mass: The MusicAssistant instance.
     :param url: The (http/https) image URL to fetch.
     """
-    try:
-        async with mass.http_session_no_ssl.get(url, raise_for_status=True) as resp:
-            return await resp.read()
-    except ClientResponseError as err:
-        # Some CDNs (e.g. Akamai) 403 our default User-Agent; retry once with
-        # a UA they allowlist before giving up.
-        if err.status not in (401, 403):
-            raise
-        fallback_ua = (
-            f"{APPLICATION_NAME}/{mass.version} (Wget/1.24.5; +https://music-assistant.io)"
-        )
-        async with mass.http_session_no_ssl.get(
-            url, raise_for_status=True, headers={"User-Agent": fallback_ua}
-        ) as resp:
-            return await resp.read()
+    # Bot-protected CDNs (e.g. Akamai) reject our normal self-identifying User-Agent,
+    # and even regular browser User-Agents, while still serving well-known fetch tools.
+    # We keep identifying as Music Assistant but carry a Wget compatibility token, which
+    # such CDNs allowlist, so artwork is served on the first (and only) request.
+    user_agent = f"{APPLICATION_NAME}/{mass.version} (Wget/1.24.5; +https://music-assistant.io)"
+    async with mass.http_session_no_ssl.get(
+        url, raise_for_status=True, headers={"User-Agent": user_agent}
+    ) as resp:
+        return await resp.read()
 
 
 async def get_image_thumb(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A user reported that artwork for the Swedish radio station P3 (added via Radio Browser) never downloads. The image URL loads fine in a browser.

The cause is the User-Agent. Music Assistant fetches images server-side and identifies itself with a `Music Assistant/… aiohttp/… Python/…` User-Agent. The station's artwork is served by Akamai, whose bot protection returns 403 for any User-Agent it doesn't recognise as a known-good client and our identifying string falls into that blocked bucket.

So now when an image fetch comes back 401/403, retry it once with a User-Agent that these CDNs allow. We keep our normal, self-identifying User-Agent for the first attempt (and for every host that already works), so the only behaviour change is for hosts that were rejecting us outright and those now succeed on the retry. Verified end-to-end against the reporting station: first attempt 403, retry returns the real image.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5675

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
