### PR TITLE
Backfill missing album on provider album tracks

### DIFF
--- a/music_assistant/controllers/media/albums.py
+++ b/music_assistant/controllers/media/albums.py
@@ -290,13 +290,16 @@ class AlbumsController(MediaControllerBase[Album]):
             album_tracks = await self._get_provider_album_tracks(
                 item_id, provider_instance_id_or_domain
             )
-            if album_tracks and not album_tracks[0].image:
-                # set album image from provider album if not present on tracks
+            # some album-track listings omit the parent album and its image; backfill both
+            # from the provider album so the queue shows the album name and artwork.
+            if album_tracks and (not album_tracks[0].album or not album_tracks[0].image):
                 prov_album = await self.get_provider_item(item_id, provider_instance_id_or_domain)
-                if prov_album.image:
-                    for track in album_tracks:
-                        if not track.image:
-                            track.metadata.add_image(prov_album.image)
+                album_mapping = ItemMapping.from_item(prov_album)
+                for track in album_tracks:
+                    if prov_album.image and not track.image:
+                        track.metadata.add_image(prov_album.image)
+                    if track.album is None:
+                        track.album = album_mapping
             return album_tracks
 
         db_items = await self.get_library_album_tracks(library_album.item_id)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Some providers' album-track listings return tracks without the parent album (the album is the response's parent, e.g. Spotify and Qobuz nest tracks under the album object). The album name was therefore empty for those tracks in the queue.

In `AlbumsController.tracks()`, reuse that already-fetched provider album to also set `track.album` when missing, mirroring the in-library branch. Providers whose listings already include the album are unaffected.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
