### PR TITLE
Type ytmusic search filter as a Literal (unblock ytmusicapi 1.12.1 mypy)

### DIFF
--- a/music_assistant/providers/ytmusic/__init__.py
+++ b/music_assistant/providers/ytmusic/__init__.py
@@ -63,6 +63,7 @@ from music_assistant.helpers.util import infer_album_type, install_package, pars
 from music_assistant.models.music_provider import MusicProvider
 
 from .helpers import (
+    YTMSearchFilter,
     add_remove_playlist_tracks,
     convert_to_netscape,
     determine_recommendation_icon,
@@ -241,7 +242,7 @@ class YoutubeMusicProvider(MusicProvider):
         :param limit: Number of items to return in the search (per type).
         """
         parsed_results = SearchResults()
-        ytm_filter = None
+        ytm_filter: YTMSearchFilter | None = None
         if len(media_types) == 1:
             # YTM does not support multiple searchtypes, falls back to all if no type given
             if media_types[0] == MediaType.ARTIST:

--- a/music_assistant/providers/ytmusic/helpers.py
+++ b/music_assistant/providers/ytmusic/helpers.py
@@ -9,13 +9,16 @@ This also nicely separates the parsing logic from the Youtube Music provider log
 import asyncio
 from http.cookies import SimpleCookie
 from time import time
-from typing import Any
+from typing import Any, Literal
 
 import ytmusicapi
 from ytmusicapi import LikeStatus
 from ytmusicapi.exceptions import YTMusicError
 
 from music_assistant.providers.ytmusic.constants import YTMRecommendationIcons
+
+# subset of ytmusicapi's accepted search filters that we use
+YTMSearchFilter = Literal["artists", "albums", "songs", "playlists"]
 
 
 async def get_artist(
@@ -319,7 +322,7 @@ async def get_song_radio_tracks(
 
 
 async def search(
-    query: str, ytm_filter: str | None = None, limit: int = 20, language: str = "en"
+    query: str, ytm_filter: YTMSearchFilter | None = None, limit: int = 20, language: str = "en"
 ) -> list[dict[str, Any]]:
     """Async wrapper around the ytmusicapi search function."""
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A recent update to the ytmusicapi library (version 1.12.1, proposed by Dependabot) tightened up the list of allowed values for the "filter" option on its search function. Our code was passing that filter as a plain string, which the stricter library no longer accepts, so mypy failed is blocking the update.

This change simply tells our code to use the exact set of filter values we actually use ("artists", "albums", "songs", "playlists") instead of any string. That satisfies the new requirement. It's a safe, backward-compatible tidy-up and it also works fine with the current library version, so it can be merged on its own ahead of the update if desired.

Note: this only clears the type-check error blocking the upgrade. It does not confirm whether version 1.12.1 itself is safe to adopt that still needs checking on the Dependabot PR.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [X] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
