### PR TITLE
Include the player id in PlayerUnavailableError messages

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -510,7 +510,9 @@ class PlayerQueuesController(CoreController):
         """
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
-            raise PlayerUnavailableError(f"Queue {queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Queue {queue_id} is not available", translation_args=[queue_id]
+            )
         # Lock is acquired by the @handle_play_action decorator on the internal handler
         await self._handle_play_media(
             queue_id, media, option, radio_mode, start_item, username, sort_by
@@ -620,7 +622,9 @@ class PlayerQueuesController(CoreController):
         :param name: The name for the new playlist.
         """
         if not self.get(queue_id):
-            raise PlayerUnavailableError(f"Queue {queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Queue {queue_id} is not available", translation_args=[queue_id]
+            )
         queue_items = self._queue_items.get(queue_id, [])
         if not queue_items:
             raise QueueEmpty("Cannot save an empty queue as a playlist.")
@@ -652,7 +656,9 @@ class PlayerQueuesController(CoreController):
         self._transitioning_players.discard(queue_id)
         queue_player = self.mass.players.get_player(queue_id, True)
         if queue_player is None:
-            raise PlayerUnavailableError(f"Player {queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Player {queue_id} is not available", translation_args=[queue_id]
+            )
         if (queue := self.get(queue_id)) and queue.active:
             if queue.state == PlaybackState.PLAYING:
                 queue.resume_pos = int(queue.corrected_elapsed_time)
@@ -671,7 +677,9 @@ class PlayerQueuesController(CoreController):
         """
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
-            raise PlayerUnavailableError(f"Queue {queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Queue {queue_id} is not available", translation_args=[queue_id]
+            )
         await self._handle_play(queue_id)
 
     @api_command("player_queues/pause")
@@ -830,7 +838,9 @@ class PlayerQueuesController(CoreController):
             raise InvalidCommand(f"Queue {queue_id} is not active")
         queue_player = self.mass.players.get_player(queue_id, True)
         if queue_player is None:
-            raise PlayerUnavailableError(f"Player {queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Player {queue_id} is not available", translation_args=[queue_id]
+            )
         if not queue.current_item:
             raise InvalidCommand(f"Queue {queue_player.state.name} has no item(s) loaded.")
         if not queue.current_item.duration:
@@ -872,7 +882,9 @@ class PlayerQueuesController(CoreController):
         if resume_item is not None:
             queue_player = self.mass.players.get_player(queue_id)
             if queue_player is None:
-                raise PlayerUnavailableError(f"Player {queue_id} is not available")
+                raise PlayerUnavailableError(
+                    f"Player {queue_id} is not available", translation_args=[queue_id]
+                )
             if (
                 fade_in is None
                 and queue_player.state.playback_state == PlaybackState.IDLE
@@ -921,7 +933,9 @@ class PlayerQueuesController(CoreController):
             queue.flow_mode_stream_log = []
             target_player = self.mass.players.get_player(queue_id)
             if target_player is None:
-                raise PlayerUnavailableError(f"Player {queue_id} is not available")
+                raise PlayerUnavailableError(
+                    f"Player {queue_id} is not available", translation_args=[queue_id]
+                )
             queue.next_item_id_enqueued = None
             # always update session id when we start a new playback session
             queue.session_id = shortuuid.random(length=8)
@@ -999,15 +1013,21 @@ class PlayerQueuesController(CoreController):
     ) -> None:
         """Transfer queue to another queue."""
         if not (source_queue := self.get(source_queue_id)):
-            raise PlayerUnavailableError(f"Queue {source_queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Queue {source_queue_id} is not available", translation_args=[source_queue_id]
+            )
         if not (target_queue := self.get(target_queue_id)):
-            raise PlayerUnavailableError(f"Queue {target_queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Queue {target_queue_id} is not available", translation_args=[target_queue_id]
+            )
         if auto_play is None:
             auto_play = source_queue.state == PlaybackState.PLAYING
 
         target_player = self.mass.players.get_player(target_queue_id)
         if target_player is None:
-            raise PlayerUnavailableError(f"Player {target_queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Player {target_queue_id} is not available", translation_args=[target_queue_id]
+            )
         if target_player.state.active_group or target_player.state.synced_to:
             # edge case: the user wants to move playback from the group as a whole, to a single
             # player in the group or it is grouped and the command targeted at the single player.
@@ -1233,7 +1253,7 @@ class PlayerQueuesController(CoreController):
         queue = self.get(queue_id)
         if not queue:
             msg = f"PlayerQueue {queue_id} is not available"
-            raise PlayerUnavailableError(msg)
+            raise PlayerUnavailableError(msg, translation_args=[queue_id])
         cur_index = self.index_by_id(queue_id, current_item_id)
         if cur_index is None:
             # this is just a guard for bad data
@@ -1302,7 +1322,9 @@ class PlayerQueuesController(CoreController):
         # happening in the background
         BYPASS_THROTTLER.set(True)
         if not (queue := self.get(queue_id)):
-            raise PlayerUnavailableError(f"Queue {queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Queue {queue_id} is not available", translation_args=[queue_id]
+            )
         # always fetch the underlying player so we can raise early if its not available
         queue_player = self.mass.players.get_player(queue_id, True)
         assert queue_player is not None  # for type checking
@@ -1542,7 +1564,9 @@ class PlayerQueuesController(CoreController):
         """Handle play without acquiring the queue lock."""
         queue_player = self.mass.players.get_player(queue_id, True)
         if queue_player is None:
-            raise PlayerUnavailableError(f"Player {queue_id} is not available")
+            raise PlayerUnavailableError(
+                f"Player {queue_id} is not available", translation_args=[queue_id]
+            )
         if (
             (queue := self._queues.get(queue_id))
             and queue.active
@@ -1681,7 +1705,7 @@ class PlayerQueuesController(CoreController):
         queue = self.get(queue_id)
         if not queue:
             msg = f"PlayerQueue {queue_id} is not available"
-            raise PlayerUnavailableError(msg)
+            raise PlayerUnavailableError(msg, translation_args=[queue_id])
         # store the index of the item that is currently (being) loaded in the buffer
         # which helps us a bit to determine how far the player has buffered ahead
         current_index = self.index_by_id(queue_id, item_id)

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -361,11 +361,11 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if player := self._players.get(player_id):
             if (not player.state.available or not player.state.enabled) and raise_unavailable:
                 msg = f"Player {player_id} is not available"
-                raise PlayerUnavailableError(msg)
+                raise PlayerUnavailableError(msg, translation_args=[player_id])
             return player
         if raise_unavailable:
             msg = f"Player {player_id} is not available"
-            raise PlayerUnavailableError(msg)
+            raise PlayerUnavailableError(msg, translation_args=[player_id])
         return None
 
     @api_command("players/get")

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -270,7 +270,7 @@ class ChromecastPlayer(Player):
                 self.last_poll = now
                 await asyncio.to_thread(self.cc.media_controller.update_status)
         except ConnectionResetError as err:
-            raise PlayerUnavailableError from err
+            raise PlayerUnavailableError(translation_args=[self.player_id]) from err
 
     async def on_unload(self) -> None:
         """Handle logic when the player is unloaded from the Player controller."""
@@ -402,7 +402,8 @@ class ChromecastPlayer(Player):
         except TimeoutError:
             self.logger.warning("Timed out waiting for app launch on %s", self.display_name)
             raise PlayerUnavailableError(
-                f"Timed out launching app on {self.display_name}"
+                f"Timed out launching app on {self.display_name}",
+                translation_args=[self.player_id],
             ) from None
 
     ### Callbacks from Chromecast Statuslistener

--- a/music_assistant/providers/dashie_kiosk/player.py
+++ b/music_assistant/providers/dashie_kiosk/player.py
@@ -138,4 +138,4 @@ class DashieKioskPlayer(Player):
                 self.update_state()
         except Exception as err:
             msg = f"Unable to connect to Dashie Kiosk device: {err!s}"
-            raise PlayerUnavailableError(msg) from err
+            raise PlayerUnavailableError(msg, translation_args=[self.player_id]) from err

--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -549,7 +549,7 @@ class DLNAPlayer(Player):
             try:
                 await self._device_connect()
             except UpnpError as err:
-                raise PlayerUnavailableError from err
+                raise PlayerUnavailableError(translation_args=[self.player_id]) from err
 
         assert self.device is not None
 
@@ -570,7 +570,7 @@ class DLNAPlayer(Player):
                 return
             self.logger.debug("Device unavailable: %r", err)
             await self._device_disconnect()
-            raise PlayerUnavailableError from err
+            raise PlayerUnavailableError(translation_args=[self.player_id]) from err
         finally:
             self.force_poll = False
 

--- a/music_assistant/providers/msx_bridge/player.py
+++ b/music_assistant/providers/msx_bridge/player.py
@@ -396,7 +396,8 @@ class MSXPlayer(Player):
         """
         if not self._attr_available:
             raise PlayerUnavailableError(
-                f"MSX TV {self.display_name} is offline (WebSocket disconnected)"
+                f"MSX TV {self.display_name} is offline (WebSocket disconnected)",
+                translation_args=[self.player_id],
             )
         if (
             self._attr_playback_state == PlaybackState.PLAYING

--- a/music_assistant/strings.json
+++ b/music_assistant/strings.json
@@ -864,7 +864,7 @@
     "audio_error": "An error occurred while processing audio.",
     "queue_empty": "The queue is empty.",
     "unsupported_feature": "This feature is not supported.",
-    "player_unavailable": "The player is not available.",
+    "player_unavailable": "The player {0} is not available.",
     "player_command_failed": "The command to the player failed.",
     "invalid_command": "Invalid or unsupported command.",
     "unplayable_media": "This media item cannot be played.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -267,7 +267,7 @@
   "common.errors.login_failed": "Login failed. Please check your credentials and try again.",
   "common.errors.media_not_found": "The requested media item could not be found.",
   "common.errors.player_command_failed": "The command to the player failed.",
-  "common.errors.player_unavailable": "The player is not available.",
+  "common.errors.player_unavailable": "The player {0} is not available.",
   "common.errors.provider_permission_denied": "The provider denied this action due to insufficient permissions.",
   "common.errors.provider_unavailable": "The provider is currently unavailable.",
   "common.errors.queue_empty": "The queue is empty.",

--- a/tests/core/test_translations.py
+++ b/tests/core/test_translations.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import ast
 import logging
 from contextlib import contextmanager
 from functools import partial
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -13,7 +15,11 @@ from music_assistant_models.api import ErrorResultMessage
 from music_assistant_models.background_task import BackgroundTask
 from music_assistant_models.config_entries import ConfigEntry, ProviderConfig
 from music_assistant_models.enums import ConfigEntryType, MediaType, ProviderType
-from music_assistant_models.errors import LoginFailed, ProviderUnavailableError
+from music_assistant_models.errors import (
+    LoginFailed,
+    PlayerUnavailableError,
+    ProviderUnavailableError,
+)
 from music_assistant_models.media_items.media_item import BrowseFolder, RecommendationFolder
 from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.translations import TRANSLATION_RESOLVER
@@ -211,6 +217,7 @@ def _nl_controller() -> TranslationController:
         "common.errors.provider_unavailable": "The provider is currently unavailable.",
         "common.errors.setup_required": "Music Assistant is not set up yet.",
         "common.errors.insufficient_permissions": "You do not have permission to perform this action.",
+        "common.errors.player_unavailable": "The player {0} is not available.",
         "provider.spotify.errors.token_expired": "Your Spotify session expired.",
     }
     ctrl._locales = {
@@ -227,6 +234,7 @@ def _nl_controller() -> TranslationController:
             "common.errors.provider_unavailable": "De provider is niet beschikbaar.",
             "common.errors.setup_required": "Music Assistant is nog niet ingesteld.",
             "common.errors.insufficient_permissions": "Je hebt geen toestemming voor deze actie.",
+            "common.errors.player_unavailable": "Speler {0} is niet beschikbaar.",
             "provider.spotify.errors.token_expired": "Je Spotify-sessie is verlopen.",
         }
     }
@@ -458,6 +466,48 @@ def test_error_result_message_protocol_error_localization() -> None:
     with _active_resolver(ctrl, "nl"):
         assert setup.to_dict()["details"] == "Music Assistant is nog niet ingesteld."
         assert admin.to_dict()["details"] == "Je hebt geen toestemming voor deze actie."
+
+
+def test_player_unavailable_error_fills_id_param() -> None:
+    """PlayerUnavailableError fills {0} in its default message from translation_args (the id)."""
+    ctrl = _nl_controller()
+    err = PlayerUnavailableError("Queue abc-123 is not available", translation_args=["abc-123"])
+    msg = ErrorResultMessage(
+        "m",
+        err.error_code,
+        str(err),
+        translation_key=err.translation_key,
+        translation_args=err.translation_args,
+    )
+    with _active_resolver(ctrl, "nl"):
+        assert msg.to_dict()["details"] == "Speler abc-123 is niet beschikbaar."
+
+
+def test_player_unavailable_raises_always_pass_translation_args() -> None:
+    """
+    Guard: every ``raise PlayerUnavailableError`` must pass translation_args.
+
+    Its default translation is parameterized ("The player {0} is not available."), so a raise
+    that omits translation_args would render a literal "{0}" to clients.
+    """
+    package_root = Path(translations_module.__file__).parents[2]
+    offenders: list[str] = []
+    for path in package_root.rglob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text(), filename=str(path))):
+            if not (isinstance(node, ast.Raise) and node.exc is not None):
+                continue
+            exc = node.exc
+            if isinstance(exc, ast.Call):
+                func = exc.func
+                name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+                has_args = any(kw.arg == "translation_args" for kw in exc.keywords)
+            elif isinstance(exc, ast.Name):
+                name, has_args = exc.id, False
+            else:
+                continue
+            if name == "PlayerUnavailableError" and not has_args:
+                offenders.append(f"{path.relative_to(package_root)}:{node.lineno}")
+    assert not offenders, f"PlayerUnavailableError raised without translation_args: {offenders}"
 
 
 def test_media_item_without_translation_key_is_untouched() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the error-localization work (#4228). The localized `errors.player_unavailable` default was generic ("The player is not available."), dropping the player/queue id that the in-code messages carried. This parameterizes it so the message names which player.

- `errors.player_unavailable` → "The player {0} is not available."
- every `raise PlayerUnavailableError` (22 sites: `player_queues.py`, `players/controller.py`, and the chromecast/dlna/msx_bridge/dashie_kiosk players) now passes the player/queue id as `translation_args`
- added a guard test that fails if a future `PlayerUnavailableError` raise omits `translation_args` (which would otherwise render a literal "{0}")

`PlayerUnavailableError` was the only error type uniform enough to parameterize safely — the rest have varied messages / multiple params, so they stay generic.

**Related issue (if applicable):**

- _None_

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
