### PR TITLE
Target Python 3.14 for lint and type-checking

### DIFF
--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -318,7 +318,7 @@ class CacheController(CoreController):
                 prev_version = int(db_row["value"])
             else:
                 prev_version = 0
-        except (KeyError, ValueError):
+        except KeyError, ValueError:
             prev_version = 0
 
         if prev_version not in (0, DB_SCHEMA_VERSION):

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1484,7 +1484,7 @@ class ConfigController:
                 continue
             try:
                 port = int(old_values.get("port") or 2323)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 port = 2323
             entry = host if port == 2323 else f"{host}:{port}"
             if entry not in ip_entries:

--- a/music_assistant/controllers/media/genres.py
+++ b/music_assistant/controllers/media/genres.py
@@ -504,7 +504,7 @@ class GenreController(MediaControllerBase[Genre]):
         """
         try:
             media_id_int = int(media_id)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return []
         gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
         query = (
@@ -531,7 +531,7 @@ class GenreController(MediaControllerBase[Genre]):
         """
         try:
             media_id_int = int(media_id)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return []
         excl = DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION
         query = (
@@ -556,7 +556,7 @@ class GenreController(MediaControllerBase[Genre]):
         """
         try:
             media_id_int = int(media_id)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return False
         row = await self.mass.music.database.get_row(
             DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,

--- a/music_assistant/controllers/metadata.py
+++ b/music_assistant/controllers/metadata.py
@@ -669,7 +669,7 @@ class MetaDataController(CoreController):
             return await get_palette_for_url(self.mass, image)
         try:
             return await get_palette(self.mass, image.path, image.provider)
-        except (FileNotFoundError, OSError):
+        except FileNotFoundError, OSError:
             return None
 
     async def get_thumbnail(
@@ -1473,7 +1473,7 @@ class MetaDataController(CoreController):
                     expiration=CACHE_EXPIRATION_RADIO_ARTWORK_MISS,
                     category=CACHE_CATEGORY_RADIO_ARTWORK,
                 )
-        except (ProviderUnavailableError, ResourceTemporarilyUnavailable, InvalidDataError):
+        except ProviderUnavailableError, ResourceTemporarilyUnavailable, InvalidDataError:
             pass
 
         return image_url or fallback_image_url, corrected_artist, corrected_track

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1051,7 +1051,7 @@ class MusicController(CoreController):
             # instead of bubbling MediaNotFoundError from get_item_by_uri.
             try:
                 uri_media_type, _, _ = await parse_uri(item)
-            except (InvalidProviderURI, InvalidProviderID):
+            except InvalidProviderURI, InvalidProviderID:
                 uri_media_type = None
             if uri_media_type == MediaType.AUDIO_SOURCE:
                 raise UnsupportedFeaturedException("AudioSource items can not be favorites")
@@ -1159,7 +1159,7 @@ class MusicController(CoreController):
             # Mirrors the same guard in add_item_to_favorites.
             try:
                 uri_media_type, _, _ = await parse_uri(item)
-            except (InvalidProviderURI, InvalidProviderID):
+            except InvalidProviderURI, InvalidProviderID:
                 uri_media_type = None
             if uri_media_type == MediaType.AUDIO_SOURCE:
                 raise UnsupportedFeaturedException("AudioSource items can not be library items")
@@ -2374,7 +2374,7 @@ class MusicController(CoreController):
                 prev_version = int(db_row["value"])
             else:
                 prev_version = 0
-        except (KeyError, ValueError):
+        except KeyError, ValueError:
             prev_version = 0
 
         if prev_version not in (0, DB_SCHEMA_VERSION):
@@ -2490,7 +2490,7 @@ class MusicController(CoreController):
                     metadata = json_loads(db_row["metadata"])
                     try:
                         datetime.fromisoformat(metadata["release_date"])
-                    except (KeyError, ValueError):
+                    except KeyError, ValueError:
                         # this is not a valid date, so we set it to None
                         metadata["release_date"] = None
                         await self.database.update(

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1255,7 +1255,7 @@ class PlayerQueuesController(CoreController):
                 # we're all set, this is our next item
                 next_item = queue_item
                 break
-            except (MediaNotFoundError, AudioError):
+            except MediaNotFoundError, AudioError:
                 # No stream details found, skip this QueueItem
                 self.logger.warning(
                     "Skipping unplayable item %s (%s)", queue_item.name, queue_item.uri

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -2563,7 +2563,7 @@ class StreamsAudio:
                     try:
                         key, value = line.decode("latin-1", errors="ignore").split(":", 1)
                         headers[key.strip().lower()] = value.strip()
-                    except (UnicodeDecodeError, ValueError):
+                    except UnicodeDecodeError, ValueError:
                         continue
 
             # Get metadata interval
@@ -2697,7 +2697,7 @@ class StreamsAudio:
         except TimeoutError:
             self.logger.debug("Timeout during Shoutcast validation for %s", url)
             return False
-        except (OSError, ConnectionError):
+        except OSError, ConnectionError:
             self.logger.debug("Connection failed during Shoutcast validation for %s", url)
             return False
         except UnicodeDecodeError:

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -257,7 +257,7 @@ class AudioAnalysisController:
                 await asyncio.wait_for(
                     queue.put(pcm_data), timeout=REAL_TIME_PACE_INTERVAL_SECONDS_CEILING
                 )
-            except (TimeoutError, asyncio.QueueFull):
+            except TimeoutError, asyncio.QueueFull:
                 return
 
         async def _finalize_session() -> None:
@@ -440,7 +440,7 @@ class AudioAnalysisController:
         for row in rows:
             try:
                 data = json_loads(row["analysis_data"])
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 continue
             if not isinstance(data, dict):
                 continue

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -891,7 +891,7 @@ class StreamsController(CoreController):
         ):
             try:
                 await resp.write(chunk)
-            except (BrokenPipeError, ConnectionResetError, ConnectionError):
+            except BrokenPipeError, ConnectionResetError, ConnectionError:
                 # race condition
                 break
 
@@ -990,7 +990,7 @@ class StreamsController(CoreController):
         ):
             try:
                 await resp.write(chunk)
-            except (BrokenPipeError, ConnectionResetError):
+            except BrokenPipeError, ConnectionResetError:
                 break
 
         self.logger.debug(

--- a/music_assistant/controllers/streams/ogg_handler.py
+++ b/music_assistant/controllers/streams/ogg_handler.py
@@ -235,7 +235,7 @@ def parse_vorbis_comments(data: bytes) -> dict[str, str]:
                     comments[key.lower()] = value
             except UnicodeDecodeError:
                 continue
-    except (struct.error, IndexError):
+    except struct.error, IndexError:
         pass
     return comments
 

--- a/music_assistant/controllers/translations/__init__.py
+++ b/music_assistant/controllers/translations/__init__.py
@@ -272,5 +272,5 @@ def _format(template: str, params: list[str] | None) -> str:
         return template
     try:
         return template.format(*params)
-    except (IndexError, KeyError, ValueError):
+    except IndexError, KeyError, ValueError:
         return template

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -124,7 +124,7 @@ class AuthenticationManager:
                 prev_version = int(db_row["value"])
             else:
                 prev_version = DB_SCHEMA_VERSION
-        except (KeyError, ValueError, Exception):
+        except KeyError, ValueError, Exception:
             # settings table doesn't exist yet or other error
             prev_version = 0
 

--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -581,7 +581,7 @@ class WebRTCGateway:
                         # Handle HTTP proxy request
                         await self._handle_http_proxy_request(session, msg_data)
                         continue
-                except (json.JSONDecodeError, ValueError):
+                except json.JSONDecodeError, ValueError:
                     pass
 
                 # Regular WebSocket message
@@ -815,7 +815,7 @@ class WebRTCGateway:
                 # Use callback to set sendspin player on the websocket client
                 if self._set_sendspin_player_callback:
                     self._set_sendspin_player_callback(session.session_id, client_id)
-        except (json.JSONDecodeError, TypeError):
+        except json.JSONDecodeError, TypeError:
             pass  # Not valid JSON, ignore
 
     async def _forward_sendspin_from_local(self, session: WebRTCSession) -> None:

--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -496,7 +496,7 @@ def parse_value(  # noqa: PLR0911
                 return parse_value(
                     name, value, sub_arg_type, allow_value_convert=allow_value_convert
                 )
-            except (KeyError, TypeError, ValueError, MissingField):
+            except KeyError, TypeError, ValueError, MissingField:
                 pass
         # if we get to this point, all possibilities failed
         # find out if we should raise or log this

--- a/music_assistant/helpers/colors.py
+++ b/music_assistant/helpers/colors.py
@@ -208,7 +208,7 @@ def extract_palette(image_bytes: bytes) -> MediaItemPalette:
     """
     try:
         candidates = _extract_candidates(image_bytes)
-    except (ValueError, OSError):
+    except ValueError, OSError:
         return MediaItemPalette()
     return _derive_palette(candidates)
 
@@ -282,5 +282,5 @@ async def get_palette_for_url(
         path, provider = image_url, "builtin"
     try:
         return await get_palette(mass, path, provider)
-    except (FileNotFoundError, OSError):
+    except FileNotFoundError, OSError:
         return None

--- a/music_assistant/helpers/dsp.py
+++ b/music_assistant/helpers/dsp.py
@@ -1,6 +1,7 @@
 """Helper functions for DSP filters."""
 
 import math
+from typing import TYPE_CHECKING
 
 from music_assistant_models.dsp import (
     AudioChannel,
@@ -9,7 +10,9 @@ from music_assistant_models.dsp import (
     ParametricEQFilter,
     ToneControlFilter,
 )
-from music_assistant_models.media_items.audio_format import AudioFormat
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items.audio_format import AudioFormat
 
 # ruff: noqa: PLR0915
 

--- a/music_assistant/helpers/hls.py
+++ b/music_assistant/helpers/hls.py
@@ -29,7 +29,7 @@ class HLSMediaSegment:
         try:
             duration_part = self.extinf_line.split("#EXTINF:")[1].split(",", 1)[0]
             return float(duration_part.strip())
-        except (IndexError, ValueError):
+        except IndexError, ValueError:
             return 0.0
 
     @property

--- a/music_assistant/helpers/podcast_parsers.py
+++ b/music_assistant/helpers/podcast_parsers.py
@@ -2,9 +2,8 @@
 
 from datetime import UTC, datetime
 from io import BytesIO
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import aiohttp
 import podcastparser
 from aiohttp.client import ClientError
 from music_assistant_models.enums import ContentType, ImageType, MediaType
@@ -19,6 +18,9 @@ from music_assistant_models.media_items import (
     ProviderMapping,
     UniqueList,
 )
+
+if TYPE_CHECKING:
+    import aiohttp
 
 
 async def get_podcastparser_dict(

--- a/music_assistant/helpers/throttle_retry.py
+++ b/music_assistant/helpers/throttle_retry.py
@@ -46,14 +46,14 @@ def parse_retry_after(value: str | None) -> int:
     # Try delay-seconds (non-negative integer) first — the common case
     try:
         return max(0, int(value))
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         pass
     # Try HTTP-date format (e.g., "Fri, 31 Dec 1999 23:59:59 GMT")
     try:
         target = parsedate_to_datetime(value)
         delta = (target - datetime.datetime.now(tz=datetime.UTC)).total_seconds()
         return max(0, int(delta))
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return 0
 
 

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -72,7 +72,7 @@ async def warn_if_missing_x86_64_v2(logger: logging.Logger) -> None:
     def _check() -> bool | None:
         try:
             cpuinfo = Path("/proc/cpuinfo").read_text()
-        except (FileNotFoundError, PermissionError):
+        except FileNotFoundError, PermissionError:
             return None
 
         flags: set[str] = set()
@@ -124,7 +124,7 @@ def get_total_system_memory() -> float:
         # Works on Linux and macOS
         total_memory_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
         return total_memory_bytes / (1024**3)  # Convert to GB
-    except (AttributeError, ValueError):
+    except AttributeError, ValueError:
         # Fallback if sysconf is not available (e.g., Windows)
         # Return a conservative default to disable buffering by default
         return 0.0
@@ -296,7 +296,7 @@ def try_parse_int(possible_int: Any, default: int | None = 0) -> int | None:
     """Try to parse an int."""
     try:
         return int(float(possible_int))
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return default
 
 
@@ -304,7 +304,7 @@ def try_parse_float(possible_float: Any, default: float | None = 0.0) -> float |
     """Try to parse a float."""
     try:
         return float(possible_float)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return default
 
 
@@ -772,7 +772,7 @@ def empty_queue[T](q: asyncio.Queue[T]) -> None:
         try:
             q.get_nowait()
             q.task_done()
-        except (asyncio.QueueEmpty, ValueError):
+        except asyncio.QueueEmpty, ValueError:
             pass
 
 
@@ -863,7 +863,7 @@ async def has_tmpfs_mount() -> bool:
                 for line in file:
                     if "tmpfs /tmp tmpfs rw" in line:
                         return True
-        except (FileNotFoundError, OSError, PermissionError):
+        except FileNotFoundError, OSError, PermissionError:
             pass
         return False
 
@@ -878,7 +878,7 @@ async def get_free_space(folder: str) -> float:
         try:
             res = shutil.disk_usage(folder)
             return res.free / float(1 << 30)
-        except (FileNotFoundError, OSError, PermissionError):
+        except FileNotFoundError, OSError, PermissionError:
             return 0.0
 
     return await asyncio.to_thread(_get_free_space, folder)
@@ -892,7 +892,7 @@ async def get_free_space_percentage(folder: str) -> float:
         try:
             res = shutil.disk_usage(folder)
             return res.free / res.total * 100
-        except (FileNotFoundError, OSError, PermissionError):
+        except FileNotFoundError, OSError, PermissionError:
             return 0.0
 
     return await asyncio.to_thread(_get_free_space, folder)

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -879,7 +879,7 @@ class MusicAssistant:
                     continue
                 try:
                     obj = getattr(cls, attr_name)
-                except (AttributeError, RuntimeError):
+                except AttributeError, RuntimeError:
                     # Skip attributes that fail during initialization
                     continue
                 if hasattr(obj, "api_cmd"):

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -832,7 +832,7 @@ class Player(ABC):
                 try:
                     sample_rate_str, bit_depth_str = item.split(MULTI_VALUE_SPLITTER, 1)
                     config_rates.append((int(sample_rate_str.strip()), int(bit_depth_str.strip())))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     self.logger.warning(
                         "Ignoring malformed CONF_SAMPLE_RATES entry %r for player %s",
                         item,

--- a/music_assistant/providers/acoustid_lookup/provider.py
+++ b/music_assistant/providers/acoustid_lookup/provider.py
@@ -704,7 +704,7 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
             return
         try:
             album_item_id = int(album_item_id_raw)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             self.logger.debug(
                 "Skipping album lookup — album id %r is not an integer", album_item_id_raw
             )

--- a/music_assistant/providers/alexa/__init__.py
+++ b/music_assistant/providers/alexa/__init__.py
@@ -236,7 +236,7 @@ async def save_cookie(login: AlexaLogin, username: str, mass: MusicAssistant) ->
         _LOGGER.debug("Saving cookie to %s", login._cookiefile[0])
     try:
         await asyncio.to_thread(cookie_jar.save, login._cookiefile[0])
-    except (OSError, EOFError, TypeError, AttributeError):
+    except OSError, EOFError, TypeError, AttributeError:
         _LOGGER.debug("Error saving pickled cookie to %s", login._cookiefile[0])
 
 

--- a/music_assistant/providers/apple_music/recommendations.py
+++ b/music_assistant/providers/apple_music/recommendations.py
@@ -103,7 +103,7 @@ class AppleMusicRecommendationManager:
             station_obj = station_response["data"][0]
             station_obj["id"] = station_id
             return parse_station_as_playlist(self.provider, station_obj)
-        except (MediaNotFoundError, KeyError, IndexError):
+        except MediaNotFoundError, KeyError, IndexError:
             return parse_station_as_playlist(self.provider, {"id": station_id})
 
     @use_cache(3600)

--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -586,12 +586,12 @@ class AudibleHelper:
         """Parse chapter data into MediaItemChapter object."""
         try:
             start = int(chapter_data.get("start_offset_sec", 0))
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             start = 0
 
         try:
             length = int(chapter_data.get("length_ms", 0)) / 1000
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             length = 0
 
         raw_title = chapter_data.get("title")
@@ -1096,7 +1096,7 @@ class AudibleHelper:
                     sequence = s.get("sequence")
                     try:
                         seq_num = float(sequence) if sequence else 999
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         seq_num = 999
                     audiobooks.append((seq_num, self._parse_audiobook(item)))
                     break

--- a/music_assistant/providers/audiobookshelf/helpers.py
+++ b/music_assistant/providers/audiobookshelf/helpers.py
@@ -2,9 +2,12 @@
 
 import time
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
-from aioaudiobookshelf.schema.media_progress import MediaProgress
 from mashumaro.mixins.dict import DataClassDictMixin
+
+if TYPE_CHECKING:
+    from aioaudiobookshelf.schema.media_progress import MediaProgress
 
 
 @dataclass(kw_only=True)

--- a/music_assistant/providers/audiobookshelf/parsers.py
+++ b/music_assistant/providers/audiobookshelf/parsers.py
@@ -2,6 +2,7 @@
 
 from contextlib import suppress
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from aioaudiobookshelf.schema.library import (
     LibraryItemExpandedBook as AbsLibraryItemExpandedBook,
@@ -18,8 +19,6 @@ from aioaudiobookshelf.schema.library import (
 from aioaudiobookshelf.schema.library import (
     LibraryItemPodcast as AbsLibraryItemPodcast,
 )
-from aioaudiobookshelf.schema.media_progress import MediaProgress as AbsMediaProgress
-from aioaudiobookshelf.schema.playlist import PlaylistExpanded as AbsPlaylistExpanded
 from aioaudiobookshelf.schema.podcast import PodcastEpisode as AbsPodcastEpisode
 from aioaudiobookshelf.schema.podcast import (
     PodcastEpisodeExpanded as AbsPodcastEpisodeExpanded,
@@ -39,6 +38,10 @@ from music_assistant_models.media_items import Podcast as MassPodcast
 from music_assistant_models.media_items import PodcastEpisode as MassPodcastEpisode
 
 from music_assistant.helpers.datetime import from_utc_timestamp
+
+if TYPE_CHECKING:
+    from aioaudiobookshelf.schema.media_progress import MediaProgress as AbsMediaProgress
+    from aioaudiobookshelf.schema.playlist import PlaylistExpanded as AbsPlaylistExpanded
 
 
 def _build_cover_url(*, base_url: str, item_id: str, token: str, version: int | None = None) -> str:

--- a/music_assistant/providers/bandcamp/__init__.py
+++ b/music_assistant/providers/bandcamp/__init__.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 from contextlib import asynccontextmanager, suppress
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from bandcamp_async_api import (
     BandcampAPIClient,
@@ -52,7 +52,6 @@ from music_assistant_models.media_items import (
     Track,
     UniqueList,
 )
-from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
@@ -78,6 +77,9 @@ from .constants import (
     SUPPORTED_FEATURES,
 )
 from .converters import BandcampConverters
+
+if TYPE_CHECKING:
+    from music_assistant_models.provider import ProviderManifest
 
 
 async def setup(
@@ -760,7 +762,7 @@ class BandcampProvider(MusicProvider):
         if cached is not None:
             try:
                 return [self._deserialize_content_item(item) for item in cached]
-            except (LookupError, ValueError, UnserializableDataError, InvalidDataError):
+            except LookupError, ValueError, UnserializableDataError, InvalidDataError:
                 self.logger.warning("Stale cache for %s, fetching fresh", cache_key)
         results: list[Album | Track] = []
         context = f"Failed to get {collection_type.value} for person {person_id}"

--- a/music_assistant/providers/bandcamp/converters.py
+++ b/music_assistant/providers/bandcamp/converters.py
@@ -2,17 +2,8 @@
 
 from contextlib import suppress
 from datetime import UTC, datetime
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
-from bandcamp_async_api.models import BCAlbum as APIAlbum
-from bandcamp_async_api.models import BCArtist as APIArtist
-from bandcamp_async_api.models import BCTrack as APITrack
-from bandcamp_async_api.models import (
-    FeedTrack,
-    SearchResultAlbum,
-    SearchResultArtist,
-    SearchResultTrack,
-)
 from music_assistant_models.enums import ContentType, ImageType, MediaType
 from music_assistant_models.media_items import Album as MAAlbum
 from music_assistant_models.media_items import Artist as MAArtist
@@ -24,6 +15,17 @@ from music_assistant_models.media_items import (
     UniqueList,
 )
 from music_assistant_models.media_items import Track as MATrack
+
+if TYPE_CHECKING:
+    from bandcamp_async_api.models import BCAlbum as APIAlbum
+    from bandcamp_async_api.models import BCArtist as APIArtist
+    from bandcamp_async_api.models import BCTrack as APITrack
+    from bandcamp_async_api.models import (
+        FeedTrack,
+        SearchResultAlbum,
+        SearchResultArtist,
+        SearchResultTrack,
+    )
 
 
 class DiscographyItem(TypedDict, total=False):

--- a/music_assistant/providers/bbc_sounds/__init__.py
+++ b/music_assistant/providers/bbc_sounds/__init__.py
@@ -198,7 +198,7 @@ class BBCSoundsProvider(MusicProvider):
                 try:
                     await self.client.personal.get_experience_menu()
                     return
-                except (exceptions.UnauthorisedError, exceptions.APIResponseError):
+                except exceptions.UnauthorisedError, exceptions.APIResponseError:
                     await self.client.auth.renew_session()
 
             try:

--- a/music_assistant/providers/bbc_sounds/adaptor.py
+++ b/music_assistant/providers/bbc_sounds/adaptor.py
@@ -146,18 +146,20 @@ class ImageProvider:
 class Context:
     """Context information for object conversion."""
 
-    provider: "BBCSoundsProvider"
+    provider: BBCSoundsProvider
     provider_domain: str
     path_parts: list[str] | None = None
     force_type: (
-        type[Track]
-        | type[LiveStation]
-        | type[Radio]
-        | type[MAPodcast]
-        | type[MAPodcastEpisode]
-        | type[BrowseFolder]
-        | type[RecommendationFolder]
-        | type[RecommendedMenuItem]
+        type[
+            Track
+            | LiveStation
+            | Radio
+            | MAPodcast
+            | MAPodcastEpisode
+            | BrowseFolder
+            | RecommendationFolder
+            | RecommendedMenuItem
+        ]
         | None
     ) = None
 
@@ -213,7 +215,7 @@ class BaseConverter(ABC):
                 else:
                     return default
             return current
-        except (AttributeError, KeyError, TypeError):
+        except AttributeError, KeyError, TypeError:
             return default
 
 
@@ -734,7 +736,7 @@ class BrowseConverter(BaseConverter):
 class Adaptor:
     """An adaptor object to convert Sounds API objects into MA ones."""
 
-    def __init__(self, provider: "BBCSoundsProvider"):
+    def __init__(self, provider: BBCSoundsProvider):
         """Create new adaptor."""
         self.provider = provider
         self.logger = self.provider.logger
@@ -744,13 +746,9 @@ class Adaptor:
         self,
         path_parts: list[str] | None = None,
         force_type: (
-            type[Track]
-            | type[Any]
-            | type[Radio]
-            | type[Podcast]
-            | type[PodcastEpisode]
-            | type[BrowseFolder]
-            | type[RecommendationFolder]
+            type[
+                Track | Any | Radio | Podcast | PodcastEpisode | BrowseFolder | RecommendationFolder
+            ]
             | None
         ) = None,
     ) -> Context:
@@ -764,7 +762,7 @@ class Adaptor:
     async def new_streamable_object(
         self,
         source_obj: SoundsTypes,
-        force_type: type[Track] | type[Radio] | type[MAPodcastEpisode] | None = None,
+        force_type: type[Track | Radio | MAPodcastEpisode] | None = None,
         path_parts: list[str] | None = None,
     ) -> StreamDetails | None:
         """

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -543,7 +543,7 @@ class BuiltinProvider(MusicProvider):
                     continue
                 try:
                     entry = await self._build_m3u_entry_from_uri(uri)
-                except (MediaNotFoundError, InvalidDataError, ProviderUnavailableError):
+                except MediaNotFoundError, InvalidDataError, ProviderUnavailableError:
                     self.logger.warning("Can't add %s to playlist - item not found", uri)
                     continue
                 # check dedup against the newly built entry's providers too
@@ -1255,7 +1255,7 @@ class BuiltinProvider(MusicProvider):
                 )
                 if library_item is not None:
                     return library_item
-            except (InvalidDataError, KeyError, NotImplementedError):
+            except InvalidDataError, KeyError, NotImplementedError:
                 continue
         # return unresolved media item so the entry still shows in the playlist
         return media_item
@@ -1383,7 +1383,7 @@ class BuiltinProvider(MusicProvider):
             for uri in uris:
                 try:
                     entries.append(await self._build_m3u_entry_from_uri(uri))
-                except (MediaNotFoundError, InvalidDataError, ProviderUnavailableError):
+                except MediaNotFoundError, InvalidDataError, ProviderUnavailableError:
                     # parse URI for minimal provider info so the entry is resolvable later
                     entry = PlaylistItem(path=uri)
                     if "://" in uri:

--- a/music_assistant/providers/chromecast/helpers.py
+++ b/music_assistant/providers/chromecast/helpers.py
@@ -128,7 +128,7 @@ def get_multizone_info(
                 if group["multichannel_group"] and (udn := group.get("uuid")):
                     uuid = UUID(udn.replace("-", ""))
                     multichannel_groups.add(uuid)
-    except (urllib.error.HTTPError, urllib.error.URLError, OSError, KeyError, ValueError):
+    except urllib.error.HTTPError, urllib.error.URLError, OSError, KeyError, ValueError:
         pass
     return (dynamic_groups, multichannel_groups)
 
@@ -159,7 +159,7 @@ def get_mac_address(
             if ":" not in mac and len(mac) == 12:
                 mac = ":".join(mac[i : i + 2] for i in range(0, 12, 2))
             return str(mac)
-    except (urllib.error.HTTPError, urllib.error.URLError, OSError, KeyError, ValueError):
+    except urllib.error.HTTPError, urllib.error.URLError, OSError, KeyError, ValueError:
         pass
     return None
 

--- a/music_assistant/providers/deezer/__init__.py
+++ b/music_assistant/providers/deezer/__init__.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from math import ceil
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import deezer
 from aiohttp import ClientSession, ClientTimeout
@@ -45,7 +45,6 @@ from music_assistant_models.media_items import (
     Track,
     UniqueList,
 )
-from music_assistant_models.provider import ProviderManifest
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant import MusicAssistant
@@ -59,6 +58,9 @@ from music_assistant.models import ProviderInstanceType
 from music_assistant.models.music_provider import MusicProvider
 
 from .gw_client import DeezerGWError, GWClient
+
+if TYPE_CHECKING:
+    from music_assistant_models.provider import ProviderManifest
 
 SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_ARTISTS,

--- a/music_assistant/providers/deezer/gw_client.py
+++ b/music_assistant/providers/deezer/gw_client.py
@@ -7,14 +7,16 @@ cookie based on the api_token.
 import json
 from collections.abc import Mapping
 from http.cookies import BaseCookie, Morsel
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp import ClientSession, ClientTimeout
 from music_assistant_models.errors import MediaNotFoundError
-from music_assistant_models.streamdetails import StreamDetails
 from yarl import URL
 
 from music_assistant.helpers.datetime import future_timestamp, utc_timestamp
+
+if TYPE_CHECKING:
+    from music_assistant_models.streamdetails import StreamDetails
 
 USER_AGENT_HEADER = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "

--- a/music_assistant/providers/digitally_incorporated/__init__.py
+++ b/music_assistant/providers/digitally_incorporated/__init__.py
@@ -202,7 +202,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
             self.logger.info(
                 "%s: Successfully connected to Digitally Incorporated API", self.domain
             )
-        except (ProviderUnavailableError, MediaNotFoundError):
+        except ProviderUnavailableError, MediaNotFoundError:
             # Re-raise provider/media errors as-is (they already have domain prefix)
             raise
         except (aiohttp.ClientError, aiohttp.ServerTimeoutError) as err:
@@ -642,7 +642,7 @@ class DigitallyIncorporatedProvider(MusicProvider):
 
             return stream_url
 
-        except (ProviderUnavailableError, MediaNotFoundError):
+        except ProviderUnavailableError, MediaNotFoundError:
             # Re-raise provider/media errors as-is (they already have domain prefix)
             raise
         except (aiohttp.ClientError, ValueError, KeyError, IndexError) as err:

--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -9,13 +9,10 @@ from typing import TYPE_CHECKING, Any, Concatenate
 from urllib.parse import urlparse
 
 import defusedxml.ElementTree as DefusedET
-from async_upnp_client.client import UpnpDevice, UpnpService, UpnpStateVariable
 from async_upnp_client.exceptions import UpnpError, UpnpResponseError
 from async_upnp_client.profiles.dlna import DmrDevice, TransportState
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import IdentifierType, PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.errors import PlayerUnavailableError
-from music_assistant_models.player import PlayerMedia
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.upnp import create_didl_metadata
@@ -24,6 +21,10 @@ from music_assistant.models.player import DeviceInfo, Player
 from .constants import PLAYER_CONFIG_ENTRIES
 
 if TYPE_CHECKING:
+    from async_upnp_client.client import UpnpDevice, UpnpService, UpnpStateVariable
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
+    from music_assistant_models.player import PlayerMedia
+
     from .provider import DLNAPlayerProvider
 
 
@@ -72,7 +73,7 @@ class DLNAPlayer(Player):
 
     def __init__(
         self,
-        provider: "DLNAPlayerProvider",
+        provider: DLNAPlayerProvider,
         player_id: str,
         description_url: str,
         device: DmrDevice | None = None,
@@ -201,7 +202,7 @@ class DLNAPlayer(Player):
 
         try:
             self.update_state()
-        except (KeyError, TypeError):
+        except KeyError, TypeError:
             # at start the update might come faster than the config is initialized
             await asyncio.sleep(2)
             self.update_state()

--- a/music_assistant/providers/dlna/provider.py
+++ b/music_assistant/providers/dlna/provider.py
@@ -1,11 +1,10 @@
 """DLNA Player Provider."""
 
 import asyncio
+from typing import TYPE_CHECKING
 
 from async_upnp_client.aiohttp import AiohttpSessionRequester
-from async_upnp_client.client import UpnpRequester
 from async_upnp_client.client_factory import UpnpFactory
-from async_upnp_client.utils import CaseInsensitiveDict
 from music_assistant_models.player import DeviceInfo
 
 from music_assistant.constants import CONF_PLAYERS
@@ -13,6 +12,10 @@ from music_assistant.models.player_provider import PlayerProvider
 
 from .helpers import DLNANotifyServer
 from .player import DLNAPlayer
+
+if TYPE_CHECKING:
+    from async_upnp_client.client import UpnpRequester
+    from async_upnp_client.utils import CaseInsensitiveDict
 
 
 class DLNAPlayerProvider(PlayerProvider):

--- a/music_assistant/providers/fastmcp_server/auth.py
+++ b/music_assistant/providers/fastmcp_server/auth.py
@@ -47,7 +47,7 @@ def _extract_jwt_audience(token: str) -> str | list[str] | None:
     try:
         raw = base64.urlsafe_b64decode(payload_segment + pad)
         claims = json.loads(raw)
-    except (binascii.Error, ValueError, UnicodeDecodeError):
+    except binascii.Error, ValueError, UnicodeDecodeError:
         return None
     aud = claims.get("aud") if isinstance(claims, dict) else None
     if isinstance(aud, (str, list)) or aud is None:

--- a/music_assistant/providers/fastmcp_server/connect/handlers.py
+++ b/music_assistant/providers/fastmcp_server/connect/handlers.py
@@ -85,7 +85,7 @@ def _is_request_via_ha_ingress(request: web.Request) -> bool:
         from music_assistant.controllers.webserver.helpers.auth_middleware import (  # noqa: PLC0415
             is_request_from_ingress,
         )
-    except (ImportError, ModuleNotFoundError):
+    except ImportError, ModuleNotFoundError:
         # Bare provider venv — MA helper unavailable. Fail closed without noise.
         return False
     except Exception:

--- a/music_assistant/providers/fastmcp_server/debug/inspect_serializer.py
+++ b/music_assistant/providers/fastmcp_server/debug/inspect_serializer.py
@@ -198,7 +198,7 @@ def _convert_dict(obj: dict[Any, Any], depth: int, seen: set[int], state: _State
                 key_bytes = len(json.dumps(key).encode("utf-8"))
                 val_bytes = len(json.dumps(conv_v, default=str).encode("utf-8"))
                 state.bytes_used += key_bytes + val_bytes + 4  # ": ," overhead
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 state.bytes_used += 64
         if state.budget_exceeded():
             state.truncated = True

--- a/music_assistant/providers/fastmcp_server/http_bridge.py
+++ b/music_assistant/providers/fastmcp_server/http_bridge.py
@@ -172,7 +172,7 @@ async def _stop_asgi_lifespan(state: dict[str, Any]) -> None:
     if not task.done():
         try:
             await asyncio.wait_for(task, timeout=10)
-        except (TimeoutError, asyncio.CancelledError):
+        except TimeoutError, asyncio.CancelledError:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
@@ -346,7 +346,7 @@ async def _asgi_to_aiohttp(  # noqa: PLR0915 - single-purpose ASGI bridge, split
                     await response.write(body)
                 if not message.get("more_body", False):
                     await response.write_eof()
-        except (ConnectionResetError, ConnectionError, asyncio.CancelledError):
+        except ConnectionResetError, ConnectionError, asyncio.CancelledError:
             # The other side closed the (SSE) stream. Mark the response as
             # disconnected and feed an ASGI ``http.disconnect`` upstream so
             # the app's keep-alive / ping loops can wind down cleanly. Logged
@@ -362,7 +362,7 @@ async def _asgi_to_aiohttp(  # noqa: PLR0915 - single-purpose ASGI bridge, split
             async for chunk in request.content.iter_chunked(64 * 1024):
                 await body_queue.put({"type": "http.request", "body": chunk, "more_body": True})
             await body_queue.put({"type": "http.request", "body": b"", "more_body": False})
-        except (ConnectionResetError, ConnectionError, asyncio.CancelledError):
+        except ConnectionResetError, ConnectionError, asyncio.CancelledError:
             response_state["disconnected"] = True
             with contextlib.suppress(Exception):
                 await body_queue.put({"type": "http.disconnect"})
@@ -374,7 +374,7 @@ async def _asgi_to_aiohttp(  # noqa: PLR0915 - single-purpose ASGI bridge, split
     pump_task = asyncio.create_task(pump_request_body())
     try:
         await asgi_app(scope, receive, send)
-    except (ConnectionResetError, ConnectionError, asyncio.CancelledError):
+    except ConnectionResetError, ConnectionError, asyncio.CancelledError:
         # Client-driven disconnect during streaming — normal flow; don't
         # re-raise as 500.
         response_state["disconnected"] = True

--- a/music_assistant/providers/fastmcp_server/origins.py
+++ b/music_assistant/providers/fastmcp_server/origins.py
@@ -188,7 +188,7 @@ def is_origin_allowed_for_request(
         from music_assistant.controllers.webserver.helpers.auth_middleware import (  # noqa: PLC0415
             is_request_from_ingress,
         )
-    except (ImportError, ModuleNotFoundError):
+    except ImportError, ModuleNotFoundError:
         # ``music_assistant`` is a dev-only / test-extras dep here; absent in
         # the bare provider venv. Fail closed without log noise.
         return False

--- a/music_assistant/providers/fastmcp_server/tools/_common.py
+++ b/music_assistant/providers/fastmcp_server/tools/_common.py
@@ -328,7 +328,7 @@ def _int(value: Any) -> int | None:
         return None
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
 
 

--- a/music_assistant/providers/fastmcp_server/tools/debug.py
+++ b/music_assistant/providers/fastmcp_server/tools/debug.py
@@ -562,7 +562,7 @@ def _register_health_tool(
 
         try:
             queues = list(mass.player_queues.all())
-        except (AttributeError, TypeError):
+        except AttributeError, TypeError:
             queues = []
         queues_active = sum(1 for q in queues if getattr(q, "state", None) == "playing")
         queues_errors = sum(

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -733,7 +733,7 @@ class LocalFileSystemProvider(MusicProvider):
             return cached[0] if cached else None
         try:
             folder_files = await self._scandir(file_item.relative_parent_path)
-        except (OSError, MusicAssistantError):
+        except OSError, MusicAssistantError:
             return None
         target = file_item.name.lower()
         result: MediaItemImage | None = None

--- a/music_assistant/providers/genius_lyrics/helpers.py
+++ b/music_assistant/providers/genius_lyrics/helpers.py
@@ -1,8 +1,10 @@
 """Helpers for the Genius Lyrics provider."""
 
 import re
+from typing import TYPE_CHECKING
 
-from lyricsgenius.types import Song
+if TYPE_CHECKING:
+    from lyricsgenius.types import Song
 
 
 def clean_song_title(song_title: str) -> str:

--- a/music_assistant/providers/gpodder/client.py
+++ b/music_assistant/providers/gpodder/client.py
@@ -35,7 +35,7 @@ class SubscriptionsGet(SubscriptionsChangeRequest):
     timestamp: int
 
 
-def action_tagger(cls: "type[EpisodeAction]") -> list[str]:
+def action_tagger(cls: type[EpisodeAction]) -> list[str]:
     """Use action field to distinguish classes.
 
     NC Gpodder uses upper case values, opodsync lower case.

--- a/music_assistant/providers/heos/helpers.py
+++ b/music_assistant/providers/heos/helpers.py
@@ -1,9 +1,12 @@
 """Helpers for HEOS Player Provider."""
 
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
-from pyheos import HeosNowPlayingMedia
 from pyheos.util.mediauri import BASE_URI
+
+if TYPE_CHECKING:
+    from pyheos import HeosNowPlayingMedia
 
 
 def media_uri_from_now_playing_media(now_playing_media: HeosNowPlayingMedia) -> str:

--- a/music_assistant/providers/internet_archive/helpers.py
+++ b/music_assistant/providers/internet_archive/helpers.py
@@ -261,7 +261,7 @@ def parse_duration(duration_str: str) -> int | None:
                 return int(minutes * 60 + seconds)
             return None
         return int(float(duration_str))
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 
@@ -307,7 +307,7 @@ def extract_year(date_str: str | list[str] | None) -> int | None:
     try:
         match = re.search(r"\b(19\d{2}|20\d{2})\b", date_text)
         return int(match.group(1)) if match else None
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 

--- a/music_assistant/providers/internet_archive/parsers.py
+++ b/music_assistant/providers/internet_archive/parsers.py
@@ -59,7 +59,7 @@ def is_likely_album(doc: dict[str, Any]) -> bool:
             file_count = len(doc["files"]) if isinstance(doc["files"], list) else 0
             if file_count > 3:  # More than just 1-2 audio files + derivatives
                 return True
-        except (TypeError, KeyError):
+        except TypeError, KeyError:
             pass
 
     # Use title keywords to identify likely albums vs singles

--- a/music_assistant/providers/kion_music/provider.py
+++ b/music_assistant/providers/kion_music/provider.py
@@ -2507,7 +2507,7 @@ class KionMusicProvider(MusicProvider):
                 r = int(bg_clean[0:2], 16)
                 g = int(bg_clean[2:4], 16)
                 b = int(bg_clean[4:6], 16)
-            except (ValueError, IndexError):
+            except ValueError, IndexError:
                 return raw
             fg = PilImage.open(BytesIO(raw)).convert("RGBA")
             bg = PilImage.new("RGBA", fg.size, (r, g, b, 255))

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -644,7 +644,7 @@ class LastFMRecommendationManager:
         for artist, tags in zip(top_artists, tag_lists, strict=True):
             try:
                 artist_weight = float(artist.get("playcount", 0))
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 continue
             if artist_weight <= 0:
                 continue
@@ -654,7 +654,7 @@ class LastFMRecommendationManager:
                     continue
                 try:
                     tag_count = float(tag.get("count", 0))
-                except (TypeError, ValueError):
+                except TypeError, ValueError:
                     continue
                 key = name.lower()
                 scores[key] = scores.get(key, 0.0) + artist_weight * tag_count / 100

--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -5,7 +5,7 @@ import enum
 import logging
 import time
 from collections.abc import Callable, Mapping
-from typing import Final, cast
+from typing import TYPE_CHECKING, Final, cast
 
 import pylast
 from music_assistant_models.config_entries import (
@@ -17,8 +17,6 @@ from music_assistant_models.config_entries import (
 from music_assistant_models.constants import SECURE_STRING_SUBSTITUTE
 from music_assistant_models.enums import ConfigEntryType, EventType, MediaType, ProviderFeature
 from music_assistant_models.errors import LoginFailed, SetupFailedError
-from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
-from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.constants import MASS_LOGGER_NAME
 from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
@@ -27,6 +25,10 @@ from music_assistant.helpers.scrobbler import ScrobblerConfig, ScrobblerHelper
 from music_assistant.mass import MusicAssistant
 from music_assistant.models import ProviderInstanceType
 from music_assistant.models.plugin import PluginProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
+    from music_assistant_models.provider import ProviderManifest
 
 # Built-in Last.fm API credentials (not available for Libre.fm)
 _DEFAULT_API_KEY: str = app_var(12)

--- a/music_assistant/providers/listenbrainz_scrobble/__init__.py
+++ b/music_assistant/providers/listenbrainz_scrobble/__init__.py
@@ -8,21 +8,23 @@ import asyncio
 import logging
 import time
 from collections.abc import Callable
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from liblistenbrainz import Listen, ListenBrainz
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
 from music_assistant_models.constants import SECURE_STRING_SUBSTITUTE
 from music_assistant_models.enums import ConfigEntryType, EventType, MediaType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError
-from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
-from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.constants import UNKNOWN_ARTIST
 from music_assistant.helpers.scrobbler import ScrobblerConfig, ScrobblerHelper
 from music_assistant.mass import MusicAssistant
 from music_assistant.models import ProviderInstanceType
 from music_assistant.models.plugin import PluginProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
+    from music_assistant_models.provider import ProviderManifest
 
 CONF_USER_TOKEN = "_user_token"
 CONF_API_BASE_URL = "api_base_url"

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -53,7 +53,7 @@ def _int_param(query: MultiMapping[str], name: str, default: int, max_val: int =
     """Parse an integer query parameter safely, clamping to [0, max_val]."""
     try:
         return max(0, min(int(query.get(name, str(default))), max_val))
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return default
 
 
@@ -1274,7 +1274,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
             async for chunk in shared_stream.subscribe(player_id):
                 await response.write(chunk)
                 total_bytes += len(chunk)
-        except (ConnectionResetError, BrokenPipeError, ConnectionAbortedError):
+        except ConnectionResetError, BrokenPipeError, ConnectionAbortedError:
             logger.debug(
                 "[SharedStream] Client %s disconnected after %d bytes",
                 player_id,
@@ -1386,7 +1386,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
                     break
                 await response.write(chunk)
                 total_bytes += len(chunk)
-        except (ConnectionResetError, BrokenPipeError, ConnectionAbortedError):
+        except ConnectionResetError, BrokenPipeError, ConnectionAbortedError:
             logger.debug("Client disconnected from stream %s", player_id)
         except asyncio.CancelledError:
             logger.debug("Stream cancelled for player %s", player_id)
@@ -1716,7 +1716,7 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         """Process an inbound WebSocket message from MSX."""
         try:
             msg = json.loads(data)
-        except (json.JSONDecodeError, TypeError):
+        except json.JSONDecodeError, TypeError:
             logger.debug("Invalid WS message from %s: %s", player_id, data)
             return
 

--- a/music_assistant/providers/musiccast/__init__.py
+++ b/music_assistant/providers/musiccast/__init__.py
@@ -1,13 +1,17 @@
 """MusicCast for MusicAssistant."""
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+from typing import TYPE_CHECKING
+
 from music_assistant_models.enums import ProviderFeature
-from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.mass import MusicAssistant
 from music_assistant.models import ProviderInstanceType
 
 from .provider import MusicCastProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+    from music_assistant_models.provider import ProviderManifest
 
 SUPPORTED_FEATURES = {
     ProviderFeature.SYNC_PLAYERS,

--- a/music_assistant/providers/musiccast/musiccast.py
+++ b/music_assistant/providers/musiccast/musiccast.py
@@ -17,10 +17,9 @@ from contextlib import suppress
 from datetime import datetime
 from enum import Enum, auto
 from random import getrandbits
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from aiomusiccast.exceptions import MusicCastConnectionException, MusicCastGroupException
-from aiomusiccast.musiccast_device import MusicCastDevice
 
 from .constants import (
     MC_DEFAULT_ZONE,
@@ -29,6 +28,9 @@ from .constants import (
     MC_SOURCE_MAIN_SYNC,
     MC_SOURCE_MC_LINK,
 )
+
+if TYPE_CHECKING:
+    from aiomusiccast.musiccast_device import MusicCastDevice
 
 
 def random_uuid_hex() -> str:
@@ -58,7 +60,7 @@ class MusicCastZoneDevice:
     can be used for net playback (but the other ones can be synced internally).
     """
 
-    def __init__(self, zone_name: str, physical_device: "MusicCastPhysicalDevice") -> None:
+    def __init__(self, zone_name: str, physical_device: MusicCastPhysicalDevice) -> None:
         """Init."""
         self.zone_name = zone_name  # this is not the friendly name
         self.controller = physical_device.controller
@@ -171,7 +173,7 @@ class MusicCastZoneDevice:
         )
 
     @property
-    def other_zones(self) -> list["MusicCastZoneDevice"]:
+    def other_zones(self) -> list[MusicCastZoneDevice]:
         """Return media player entities of the other zones of this device."""
         return [
             entity
@@ -223,7 +225,7 @@ class MusicCastZoneDevice:
         return self.is_network_client or self.source_id == MC_SOURCE_MAIN_SYNC
 
     @property
-    def musiccast_zone_entity(self) -> "MusicCastZoneDevice":
+    def musiccast_zone_entity(self) -> MusicCastZoneDevice:
         """Return the musiccast entity of the physical device.
 
         It is possible that multiple zones use MusicCast as client at the same time.
@@ -236,7 +238,7 @@ class MusicCastZoneDevice:
         return self
 
     @property
-    def musiccast_group(self) -> list["MusicCastZoneDevice"]:
+    def musiccast_group(self) -> list[MusicCastZoneDevice]:
         """Return all media players of the current group, if the media player is server."""
         if self.is_client:
             # If we are a client we can still share group information, but we will take them from
@@ -252,7 +254,7 @@ class MusicCastZoneDevice:
         return [self, *clients]
 
     @property
-    def group_server(self) -> "MusicCastZoneDevice":
+    def group_server(self) -> MusicCastZoneDevice:
         """Return the server of the own group if present, self else."""
         for entity in self.controller.all_server_devices:
             if self.is_part_of_group(entity):
@@ -353,7 +355,7 @@ class MusicCastZoneDevice:
         """Select sound mode. Internal sound_mode name."""
         await self.device.select_sound_mode(self.zone_name, sound_mode_id)
 
-    def is_part_of_group(self, group_server: "MusicCastZoneDevice") -> bool:
+    def is_part_of_group(self, group_server: MusicCastZoneDevice) -> bool:
         """Return True if the given server is the server of self's group."""
         return group_server != self and (
             (
@@ -365,7 +367,7 @@ class MusicCastZoneDevice:
             or (self.device.ip == group_server.device.ip and self.source_id == MC_SOURCE_MAIN_SYNC)
         )
 
-    async def join_players(self, group_members: list["MusicCastZoneDevice"]) -> None:
+    async def join_players(self, group_members: list[MusicCastZoneDevice]) -> None:
         """Add all clients given in entities to the group of the server.
 
         Creates a new group if necessary. Used for join service.
@@ -419,7 +421,7 @@ class MusicCastZoneDevice:
 
     # Internal client functions
 
-    async def _client_join(self, group_id: str, server: "MusicCastZoneDevice") -> bool:
+    async def _client_join(self, group_id: str, server: MusicCastZoneDevice) -> bool:
         """Let the client join a group.
 
         If this client is a server, the server will stop distributing.
@@ -530,7 +532,7 @@ class MusicCastPhysicalDevice:
     def __init__(
         self,
         device: MusicCastDevice,
-        controller: "MusicCastController",
+        controller: MusicCastController,
     ):
         """Init."""
         self.device = device
@@ -545,7 +547,7 @@ class MusicCastPhysicalDevice:
         """
         try:
             await self.fetch()
-        except (MusicCastConnectionException, MusicCastGroupException):
+        except MusicCastConnectionException, MusicCastGroupException:
             return False
 
         self.device.build_capabilities()
@@ -576,7 +578,7 @@ class MusicCastPhysicalDevice:
         """
         await self.device.fetch()
 
-    def register_callback(self, fun: Callable[["MusicCastPhysicalDevice"], None]) -> None:
+    def register_callback(self, fun: Callable[[MusicCastPhysicalDevice], None]) -> None:
         """Register a non-async callback."""
 
         def _cb() -> None:

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -127,7 +127,7 @@ class MusicCastPlayer(Player):
 
     def __init__(
         self,
-        provider: "MusicCastProvider",
+        provider: MusicCastProvider,
         player_id: str,
         physical_device: MusicCastPhysicalDevice,
         zone_device: MusicCastZoneDevice,
@@ -740,7 +740,7 @@ class MusicCastPlayer(Player):
             _was_unavailable = not self._attr_available
             try:
                 await self.physical_device.fetch()
-            except (MusicCastConnectionException, MusicCastGroupException):
+            except MusicCastConnectionException, MusicCastGroupException:
                 await self._set_player_unavailable()
                 return
             except ClientError:

--- a/music_assistant/providers/musiccast/provider.py
+++ b/music_assistant/providers/musiccast/provider.py
@@ -3,14 +3,11 @@
 import asyncio
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from aiohttp.client_exceptions import ClientError
 from aiomusiccast.musiccast_device import MusicCastDevice
-from music_assistant_models.config_entries import ProviderConfig
-from music_assistant_models.enums import ProviderFeature
-from music_assistant_models.provider import ProviderManifest
 from zeroconf import ServiceStateChange
-from zeroconf.asyncio import AsyncServiceInfo
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.util import format_ip_for_url
@@ -26,6 +23,12 @@ from music_assistant.providers.sonos.helpers import get_primary_ip_address
 
 from .musiccast import MusicCastController, MusicCastPhysicalDevice, MusicCastZoneDevice
 from .player import MusicCastPlayer, UpnpUpdateHelper
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.enums import ProviderFeature
+    from music_assistant_models.provider import ProviderManifest
+    from zeroconf.asyncio import AsyncServiceInfo
 
 
 @dataclass(kw_only=True)

--- a/music_assistant/providers/musicme/provider.py
+++ b/music_assistant/providers/musicme/provider.py
@@ -626,7 +626,7 @@ class MusicMeProvider(MusicProvider):
                 disc_track_parts = disc_track.split("_")
                 track.disc_number = int(disc_track_parts[0])
                 track.track_number = int(disc_track_parts[1])
-            except (ValueError, IndexError):
+            except ValueError, IndexError:
                 pass
         for art_obj in track_obj.get("artists", []):
             if art_obj.get("id"):
@@ -843,7 +843,7 @@ class MusicMeProvider(MusicProvider):
                 if response.status == 429:
                     try:
                         backoff = min(int(response.headers.get("Retry-After", 10)), 300)
-                    except (ValueError, TypeError):
+                    except ValueError, TypeError:
                         backoff = 10
                     raise RateLimited("Rate limited", backoff_time=backoff)
                 if response.status in (502, 503):

--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -266,7 +266,7 @@ def _extract_code(payload: dict[str, Any]) -> int | None:
         raw_code = payload["data"].get("code")
     try:
         return int(raw_code) if raw_code is not None else None
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
 
 
@@ -376,7 +376,7 @@ def _decode_qr_data_url(data_url: str) -> tuple[bytes, str] | None:
     mime_type = meta.replace("data:", "", 1)
     try:
         return (base64.b64decode(b64_data), mime_type)
-    except (ValueError, binascii.Error):
+    except ValueError, binascii.Error:
         return None
 
 
@@ -1117,7 +1117,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
         async def _fetch_quality(track_id: str) -> tuple[str, dict[str, Any] | None]:
             try:
                 quality_obj = await self._get_song_music_detail(track_id)
-            except (InvalidDataError, ResourceTemporarilyUnavailable):
+            except InvalidDataError, ResourceTemporarilyUnavailable:
                 return track_id, None
             return track_id, quality_obj if isinstance(quality_obj, dict) else None
 

--- a/music_assistant/providers/pandora/provider.py
+++ b/music_assistant/providers/pandora/provider.py
@@ -168,7 +168,7 @@ class PandoraProvider(MusicProvider):
                 try:
                     flags: list[str] = response_data.get("config", {}).get("flags", [])
                     self._high_quality_available = ACCOUNT_FLAG_HIGH_QUALITY in flags
-                except (AttributeError, TypeError):
+                except AttributeError, TypeError:
                     self._high_quality_available = False
 
                 self.logger.info(

--- a/music_assistant/providers/phishin/provider.py
+++ b/music_assistant/providers/phishin/provider.py
@@ -187,7 +187,7 @@ class PhishInProvider(MusicProvider):
 
             return albums
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get artist albums: %s", err)
@@ -345,7 +345,7 @@ class PhishInProvider(MusicProvider):
                 can_seek=True,
             )
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get stream details for %s: %s", item_id, err)
@@ -371,7 +371,7 @@ class PhishInProvider(MusicProvider):
             for playlist_data in await self._get_playlists():
                 if playlist_data.get("tracks_count", 0) > 0:
                     yield playlist_to_ma_playlist(self, playlist_data)
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get library playlists: %s", err)
@@ -412,7 +412,7 @@ class PhishInProvider(MusicProvider):
 
             return tracks
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get playlist tracks for %s: %s", prov_playlist_id, err)
@@ -534,7 +534,7 @@ class PhishInProvider(MusicProvider):
 
                 return sorted(folders, key=lambda x: x.name, reverse=True)
 
-            except (MediaNotFoundError, ProviderUnavailableError):
+            except MediaNotFoundError, ProviderUnavailableError:
                 raise
             except Exception as err:
                 self.logger.error("Failed to browse years: %s", err)
@@ -555,7 +555,7 @@ class PhishInProvider(MusicProvider):
 
             return albums
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to browse recent shows: %s", err)
@@ -570,7 +570,7 @@ class PhishInProvider(MusicProvider):
                 return [album]
             return []
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get random show: %s", err)
@@ -632,7 +632,7 @@ class PhishInProvider(MusicProvider):
 
                 return folders[:50]
 
-            except (MediaNotFoundError, ProviderUnavailableError):
+            except MediaNotFoundError, ProviderUnavailableError:
                 raise
             except Exception as err:
                 self.logger.error("Failed to browse venues: %s", err)
@@ -668,7 +668,7 @@ class PhishInProvider(MusicProvider):
 
                 return sorted(folders, key=lambda x: x.name)
 
-            except (MediaNotFoundError, ProviderUnavailableError):
+            except MediaNotFoundError, ProviderUnavailableError:
                 raise
             except Exception as err:
                 self.logger.error("Failed to browse tags: %s", err)
@@ -709,7 +709,7 @@ class PhishInProvider(MusicProvider):
 
                 return subfolders
 
-            except (MediaNotFoundError, ProviderUnavailableError):
+            except MediaNotFoundError, ProviderUnavailableError:
                 raise
             except Exception as err:
                 self.logger.error("Failed to get tag subfolders: %s", err)
@@ -745,7 +745,7 @@ class PhishInProvider(MusicProvider):
 
             return tracks
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get tracks for tag %s: %s", tag_slug, err)
@@ -772,7 +772,7 @@ class PhishInProvider(MusicProvider):
 
             return albums
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get top shows: %s", err)
@@ -799,7 +799,7 @@ class PhishInProvider(MusicProvider):
 
             return tracks
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get top tracks: %s", err)
@@ -832,7 +832,7 @@ class PhishInProvider(MusicProvider):
 
             return sorted(albums, key=lambda x: x.name)
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to browse period %s: %s", period, err)
@@ -861,7 +861,7 @@ class PhishInProvider(MusicProvider):
 
             return albums
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get shows for venue %s: %s", venue_slug, err)
@@ -890,7 +890,7 @@ class PhishInProvider(MusicProvider):
 
             return albums
 
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             raise
         except Exception as err:
             self.logger.error("Failed to get shows for tag %s: %s", tag_slug, err)

--- a/music_assistant/providers/plex_connect/timeline.py
+++ b/music_assistant/providers/plex_connect/timeline.py
@@ -300,7 +300,7 @@ class TimelineMixin:
                 last_update = float(sub["last_update"])  # type: ignore[arg-type]
                 if current_time - last_update > 90:
                     stale_clients.append(client_id)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 LOGGER.debug(f"Invalid last_update for client {client_id}, treating as stale")
                 stale_clients.append(client_id)
 

--- a/music_assistant/providers/podcast_index/helpers.py
+++ b/music_assistant/providers/podcast_index/helpers.py
@@ -164,7 +164,7 @@ def parse_episode_from_data(
     raw_duration = episode_data.get("duration")
     try:
         duration = int(raw_duration) if raw_duration is not None else 0
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         duration = 0
 
     episode = PodcastEpisode(

--- a/music_assistant/providers/podcast_index/provider.py
+++ b/music_assistant/providers/podcast_index/provider.py
@@ -55,7 +55,7 @@ class PodcastIndexProvider(MusicProvider):
         # Test API connection
         try:
             await self._api_request("stats/current")
-        except (LoginFailed, ProviderUnavailableError):
+        except LoginFailed, ProviderUnavailableError:
             # Re-raise these specific errors as they have proper context
             raise
         except aiohttp.ClientConnectorError as err:
@@ -218,7 +218,7 @@ class PodcastIndexProvider(MusicProvider):
                 podcast = parse_podcast_from_feed(response["feed"], self.instance_id, self.domain)
                 if podcast:
                     return podcast
-        except (ProviderUnavailableError, InvalidDataError):
+        except ProviderUnavailableError, InvalidDataError:
             # Re-raise these specific errors
             raise
         except Exception as err:
@@ -272,7 +272,7 @@ class PodcastIndexProvider(MusicProvider):
                 if episode:
                     yield episode
 
-        except (ProviderUnavailableError, InvalidDataError):
+        except ProviderUnavailableError, InvalidDataError:
             # Re-raise these specific errors
             raise
         except Exception as err:
@@ -300,7 +300,7 @@ class PodcastIndexProvider(MusicProvider):
                 if episode:
                     return episode
 
-        except (ProviderUnavailableError, InvalidDataError):
+        except ProviderUnavailableError, InvalidDataError:
             # Re-raise these specific errors
             raise
         except ValueError as err:
@@ -345,7 +345,7 @@ class PodcastIndexProvider(MusicProvider):
                         allow_seek=True,
                     )
 
-        except (ProviderUnavailableError, InvalidDataError):
+        except ProviderUnavailableError, InvalidDataError:
             # Re-raise these specific errors
             raise
         except ValueError as err:
@@ -383,7 +383,7 @@ class PodcastIndexProvider(MusicProvider):
             response = await self._api_request("podcasts/byfeedid", params={"id": podcast_id})
             feed_data: dict[str, Any] = response.get("feed", {})
             return feed_data.get("url")
-        except (ProviderUnavailableError, InvalidDataError):
+        except ProviderUnavailableError, InvalidDataError:
             # Re-raise these specific errors
             raise
         except Exception as err:
@@ -400,7 +400,7 @@ class PodcastIndexProvider(MusicProvider):
         """Browse trending podcasts."""
         try:
             return await self._fetch_podcasts("podcasts/trending", {"max": 50})
-        except (ProviderUnavailableError, InvalidDataError):
+        except ProviderUnavailableError, InvalidDataError:
             raise
         except Exception as err:
             self.logger.warning(
@@ -433,7 +433,7 @@ class PodcastIndexProvider(MusicProvider):
 
             return episodes
 
-        except (ProviderUnavailableError, InvalidDataError):
+        except ProviderUnavailableError, InvalidDataError:
             # Re-raise these specific errors
             raise
         except Exception as err:
@@ -465,7 +465,7 @@ class PodcastIndexProvider(MusicProvider):
             # Sort by name
             return sorted(categories, key=lambda x: x.name)
 
-        except (ProviderUnavailableError, InvalidDataError):
+        except ProviderUnavailableError, InvalidDataError:
             # Re-raise these specific errors
             raise
         except Exception as err:
@@ -489,7 +489,7 @@ class PodcastIndexProvider(MusicProvider):
 
             return podcasts
 
-        except (ProviderUnavailableError, InvalidDataError):
+        except ProviderUnavailableError, InvalidDataError:
             raise
         except Exception as err:
             self.logger.warning(

--- a/music_assistant/providers/podcastfeed/__init__.py
+++ b/music_assistant/providers/podcastfeed/__init__.py
@@ -272,7 +272,7 @@ class PodcastMusicprovider(MusicProvider):
 
                 return await response.read()
 
-        except (ClientError, Exception):
+        except ClientError, Exception:
             # Try podcast cover fallback
             podcast_cover = self.parsed_podcast.get("cover_url")
             if podcast_cover and isinstance(podcast_cover, str) and podcast_cover != path:

--- a/music_assistant/providers/qqmusic/__init__.py
+++ b/music_assistant/providers/qqmusic/__init__.py
@@ -1043,7 +1043,7 @@ class QQMusicProvider(MusicProvider):
             )
             if isinstance(tab_albums, list):
                 raw_albums = [item for item in tab_albums if isinstance(item, dict)]
-        except (MediaNotFoundError, InvalidDataError, TypeError, ValueError):
+        except MediaNotFoundError, InvalidDataError, TypeError, ValueError:
             raw_albums = []
 
         if not raw_albums:
@@ -1197,7 +1197,7 @@ class QQMusicProvider(MusicProvider):
                 try:
                     yield self._parse_artist(artist_obj)
                     total_yielded += 1
-                except (InvalidDataError, TypeError, ValueError):
+                except InvalidDataError, TypeError, ValueError:
                     continue
             if len(artists) < num:
                 break
@@ -1224,7 +1224,7 @@ class QQMusicProvider(MusicProvider):
                 try:
                     yield self._parse_track(song)
                     yielded += 1
-                except (InvalidDataError, TypeError, ValueError):
+                except InvalidDataError, TypeError, ValueError:
                     continue
             if total and yielded >= total:
                 break
@@ -1258,7 +1258,7 @@ class QQMusicProvider(MusicProvider):
                 try:
                     yield self._parse_album(album_obj)
                     total_yielded += 1
-                except (InvalidDataError, TypeError, ValueError):
+                except InvalidDataError, TypeError, ValueError:
                     continue
             if len(albums) < num:
                 break
@@ -1274,7 +1274,7 @@ class QQMusicProvider(MusicProvider):
         for playlist_obj in created or []:
             try:
                 yield self._parse_playlist(playlist_obj)
-            except (InvalidDataError, TypeError, ValueError):
+            except InvalidDataError, TypeError, ValueError:
                 continue
 
         page = 1
@@ -1294,7 +1294,7 @@ class QQMusicProvider(MusicProvider):
             for playlist_obj in fav_playlists:
                 try:
                     yield self._parse_playlist(playlist_obj)
-                except (InvalidDataError, TypeError, ValueError):
+                except InvalidDataError, TypeError, ValueError:
                     continue
             if len(fav_playlists) < num:
                 break
@@ -1344,7 +1344,7 @@ class QQMusicProvider(MusicProvider):
                 track = self._parse_track(song)
                 track.position = index
                 results.append(track)
-            except (InvalidDataError, TypeError, ValueError):
+            except InvalidDataError, TypeError, ValueError:
                 continue
         return results
 

--- a/music_assistant/providers/qqmusic/parsers.py
+++ b/music_assistant/providers/qqmusic/parsers.py
@@ -34,7 +34,7 @@ def extract_song_id(track_obj: dict[str, Any]) -> int | None:
             continue
         try:
             song_id = int(raw_val)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             continue
         if song_id > 0:
             return song_id

--- a/music_assistant/providers/samsung_wam/__init__.py
+++ b/music_assistant/providers/samsung_wam/__init__.py
@@ -31,7 +31,7 @@ class SpeakerStatusFilter(logging.Filter):
                 event_obj = record.args[0]
                 if getattr(event_obj, "method", None) == "SpeakerStatus":
                     return False
-            except (IndexError, AttributeError):
+            except IndexError, AttributeError:
                 pass
         return True
 

--- a/music_assistant/providers/samsung_wam/features/discovery/handler.py
+++ b/music_assistant/providers/samsung_wam/features/discovery/handler.py
@@ -97,7 +97,7 @@ class DiscoveryHandler(WamProviderFeatureBase):
                 return None
 
             return str(udn_el.text.removeprefix("uuid:"))
-        except (TimeoutError, aiohttp.ClientError, ET.ParseError):
+        except TimeoutError, aiohttp.ClientError, ET.ParseError:
             return None
 
     async def _handle_presence(self, udn: str, ip_address: str) -> None:

--- a/music_assistant/providers/samsung_wam/features/state_sync/handler.py
+++ b/music_assistant/providers/samsung_wam/features/state_sync/handler.py
@@ -130,7 +130,7 @@ class StateSyncHandler(WamPlayerFeatureBase):
                 playtime = float(response.data["playtime"])
                 self.player._attr_elapsed_time = playtime
                 self.player._attr_elapsed_time_last_updated = time.time()
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 self.logger.debug("Failed to parse playtime from response: %s", response.data)
 
     def on_speaker_event(self, event: Any = None) -> None:
@@ -151,7 +151,7 @@ class StateSyncHandler(WamPlayerFeatureBase):
                 playtime = float(event.data["playtime"])
                 self.player._attr_elapsed_time = playtime
                 self.player._attr_elapsed_time_last_updated = time.time()
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 pass
 
         self.refresh_state(notify_provider=True)

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -110,7 +110,7 @@ def option_value_to_format(value: str) -> tuple[AudioCodec, SendspinAudioFormat]
             channels=int(channels_str),
         )
         return (codec, audio_format)
-    except (ValueError, KeyError):
+    except ValueError, KeyError:
         return None
 
 

--- a/music_assistant/providers/snapcast/__init__.py
+++ b/music_assistant/providers/snapcast/__init__.py
@@ -1,6 +1,7 @@
 """Snapcast Player provider for Music Assistant."""
 
 import re
+from typing import TYPE_CHECKING
 
 from music_assistant_models.config_entries import (
     ConfigEntry,
@@ -10,7 +11,6 @@ from music_assistant_models.config_entries import (
 )
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 from music_assistant_models.errors import SetupFailedError
-from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.helpers.process import check_output
 from music_assistant.mass import MusicAssistant
@@ -32,6 +32,9 @@ from music_assistant.providers.snapcast.constants import (
     DEFAULT_SNAPSTREAM_IDLE_THRESHOLD,
 )
 from music_assistant.providers.snapcast.provider import SnapCastProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.provider import ProviderManifest
 
 SUPPORTED_FEATURES = {
     ProviderFeature.SYNC_PLAYERS,

--- a/music_assistant/providers/snapcast/socket_server.py
+++ b/music_assistant/providers/snapcast/socket_server.py
@@ -231,7 +231,7 @@ class SnapcastSocketServer:
             data = json.dumps(message) + "\n"
             self._client_writer.write(data.encode())
             await self._client_writer.drain()
-        except (ConnectionResetError, BrokenPipeError):
+        except ConnectionResetError, BrokenPipeError:
             self._logger.debug("Failed to send message - connection closed")
             self._client_writer = None
 

--- a/music_assistant/providers/sonic_similarity/helpers.py
+++ b/music_assistant/providers/sonic_similarity/helpers.py
@@ -18,7 +18,7 @@ def _parse_clap_embedding(raw: Any) -> np.ndarray | None:
         return None
     try:
         arr = np.asarray(raw, dtype=np.float32).reshape(-1)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
     if arr.shape != (CLAP_EMBEDDING_DIM,):
         return None
@@ -34,7 +34,7 @@ def _parse_weights(params: dict[str, Any]) -> dict[str, float]:
     def _clamp(val: str, fallback: float) -> float:
         try:
             return max(0.0, min(1.0, float(val)))
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             return fallback
 
     for group, default in result.items():

--- a/music_assistant/providers/sonic_similarity/provider.py
+++ b/music_assistant/providers/sonic_similarity/provider.py
@@ -603,7 +603,7 @@ class SonicSimilarityPlugin(PluginProvider):
         # The slider is a 0-10 integer; the engine wants a 0.0-1.0 weight.
         try:
             diversity = int(str(self.config.get_value(CONF_SIMILAR_DIVERSITY) or 0)) / 10.0
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             diversity = 0.0
         self.logger.debug(
             "Traits Similar Tracks: seed=%s/%s preset=%s diversity=%s limit=%d",
@@ -742,7 +742,7 @@ class SonicSimilarityPlugin(PluginProvider):
         # The slider is a 0-10 integer; the engine wants a 0.0-1.0 weight.
         try:
             diversity = int(str(self.config.get_value(CONF_DISCOVER_DIVERSITY) or 0)) / 10.0
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             diversity = 0.0
         self.logger.debug(
             "Discover row: engine=%s seeds=%d preset=%s diversity=%s",
@@ -1264,7 +1264,7 @@ class SonicSimilarityPlugin(PluginProvider):
                     continue
                 try:
                     raw = json.loads(row["analysis_data"])
-                except (json.JSONDecodeError, TypeError):
+                except json.JSONDecodeError, TypeError:
                     continue
                 emb = _parse_clap_embedding(
                     (raw.get("extra_data") or {}).get(EXTRA_DATA_CLAP_EMBEDDING)

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -1236,7 +1236,7 @@ class SpotifyProvider(MusicProvider):
                 try:
                     error = await response.json(loads=json_loads)
                     message = error.get("error", {}).get("message") or response.reason
-                except (aiohttp.ContentTypeError, JSONDecodeError):
+                except aiohttp.ContentTypeError, JSONDecodeError:
                     message = (await response.text()) or response.reason
 
                 self.logger.debug(
@@ -1368,5 +1368,5 @@ class SpotifyProvider(MusicProvider):
             if e.status == 403:
                 return False  # Not available
             raise  # Re-raise other HTTP errors
-        except (MediaNotFoundError, ProviderUnavailableError):
+        except MediaNotFoundError, ProviderUnavailableError:
             return False

--- a/music_assistant/providers/squeezelite/multi_client_stream.py
+++ b/music_assistant/providers/squeezelite/multi_client_stream.py
@@ -4,11 +4,13 @@ import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import suppress
-
-from music_assistant_models.media_items import AudioFormat
+from typing import TYPE_CHECKING
 
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
 from music_assistant.helpers.util import empty_queue
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items import AudioFormat
 
 LOGGER = logging.getLogger(__name__)
 

--- a/music_assistant/providers/squeezelite/provider.py
+++ b/music_assistant/providers/squeezelite/provider.py
@@ -217,7 +217,7 @@ class SqueezelitePlayerProvider(PlayerProvider):
         ):
             try:
                 await resp.write(chunk)
-            except (BrokenPipeError, ConnectionResetError, ConnectionError):
+            except BrokenPipeError, ConnectionResetError, ConnectionError:
                 # race condition
                 break
         return resp

--- a/music_assistant/providers/subsonic_scrobble/__init__.py
+++ b/music_assistant/providers/subsonic_scrobble/__init__.py
@@ -3,14 +3,11 @@
 import logging
 import time
 from collections.abc import Callable
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
-from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
 from music_assistant_models.enums import EventType, MediaType
 from music_assistant_models.errors import SetupFailedError
 from music_assistant_models.media_items import Audiobook, PodcastEpisode, Track
-from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
-from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.helpers.scrobbler import ScrobblerConfig, ScrobblerHelper
 from music_assistant.helpers.uri import parse_uri
@@ -19,6 +16,11 @@ from music_assistant.models import ProviderInstanceType
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.opensubsonic.parsers import EP_CHAN_SEP
 from music_assistant.providers.opensubsonic.sonic_provider import OpenSonicProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, ProviderConfig
+    from music_assistant_models.playback_progress_report import MediaItemPlaybackProgressReport
+    from music_assistant_models.provider import ProviderManifest
 
 SUPPORTED_SCROBBLE_MEDIA_TYPES: Final[frozenset[MediaType]] = frozenset(
     {

--- a/music_assistant/providers/tidal/auth_manager.py
+++ b/music_assistant/providers/tidal/auth_manager.py
@@ -10,7 +10,6 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
 import pkce
-from aiohttp import ClientSession
 from music_assistant_models.enums import EventType
 from music_assistant_models.errors import LoginFailed
 
@@ -19,6 +18,8 @@ from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-define
 from .constants import AUTH_URL, LOGIN_URL, REDIRECT_URI, SESSIONS_URL
 
 if TYPE_CHECKING:
+    from aiohttp import ClientSession
+
     from music_assistant.mass import MusicAssistant
 
 TOKEN_REFRESH_BUFFER = 60 * 7  # 7 minutes
@@ -43,12 +44,12 @@ class ManualAuthenticationHelper:
     but instead requires the user to manually copy a URL after authentication.
     """
 
-    def __init__(self, mass: "MusicAssistant", session_id: str) -> None:
+    def __init__(self, mass: MusicAssistant, session_id: str) -> None:
         """Initialize the Manual Authentication Helper."""
         self.mass = mass
         self.session_id = session_id
 
-    async def __aenter__(self) -> "ManualAuthenticationHelper":
+    async def __aenter__(self) -> ManualAuthenticationHelper:
         """Enter context manager."""
         return self
 

--- a/music_assistant/providers/tidal/library.py
+++ b/music_assistant/providers/tidal/library.py
@@ -95,7 +95,7 @@ class TidalLibraryManager:
                     f"users/{self.auth.user_id}/{endpoint}", data=data, as_form=True
                 )
             return True
-        except (ClientError, MediaNotFoundError, ResourceTemporarilyUnavailable):
+        except ClientError, MediaNotFoundError, ResourceTemporarilyUnavailable:
             return False
 
     async def remove_item(self, prov_item_id: str, media_type: MediaType) -> bool:
@@ -110,7 +110,7 @@ class TidalLibraryManager:
             else:
                 await self.api.delete(f"users/{self.auth.user_id}/{endpoint}")
             return True
-        except (ClientError, MediaNotFoundError, ResourceTemporarilyUnavailable):
+        except ClientError, MediaNotFoundError, ResourceTemporarilyUnavailable:
             return False
 
     def _get_endpoint_data(

--- a/music_assistant/providers/tidal/media.py
+++ b/music_assistant/providers/tidal/media.py
@@ -252,6 +252,6 @@ class TidalMediaManager:
                 track = parse_track(self.provider, item)
                 track.position = offset + idx
                 result.append(track)
-            except (KeyError, TypeError):
+            except KeyError, TypeError:
                 continue
         return result

--- a/music_assistant/providers/tidal/parsers.py
+++ b/music_assistant/providers/tidal/parsers.py
@@ -131,7 +131,7 @@ def parse_album(provider: TidalProvider, album_obj: dict[str, Any]) -> Album:
     if release_date := album_obj_data.get("releaseDate", ""):
         try:
             album.year = int(release_date.split("-")[0])
-        except (ValueError, IndexError):
+        except ValueError, IndexError:
             provider.logger.debug("Invalid release date format: %s", release_date)
         with suppress(ValueError):
             album.metadata.release_date = datetime.fromisoformat(release_date)

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -623,7 +623,7 @@ class UniversalGroupPlayer(Player):
         ):
             try:
                 await resp.write(chunk)
-            except (ConnectionError, ConnectionResetError):
+            except ConnectionError, ConnectionResetError:
                 break
 
         return resp

--- a/music_assistant/providers/webdav/provider.py
+++ b/music_assistant/providers/webdav/provider.py
@@ -119,7 +119,7 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
         try:
             items = await webdav_propfind(session, webdav_url, depth=0, auth=self._auth)
             return len(items) > 0 or webdav_url.rstrip("/") == self.base_url.rstrip("/")
-        except (LoginFailed, SetupFailedError, ProviderUnavailableError):
+        except LoginFailed, SetupFailedError, ProviderUnavailableError:
             raise
         except aiohttp.ClientError:
             return False
@@ -291,7 +291,7 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
         """Recursively scan WebDAV directory."""
         try:
             items = await self._scandir(path)
-        except (LoginFailed, SetupFailedError, ProviderUnavailableError):
+        except LoginFailed, SetupFailedError, ProviderUnavailableError:
             raise
         except aiohttp.ClientError as err:
             self.logger.warning("WebDAV error scanning %s: %s", path, err)

--- a/music_assistant/providers/wikipedia/__init__.py
+++ b/music_assistant/providers/wikipedia/__init__.py
@@ -189,10 +189,10 @@ class WikipediaMetadataProvider(MetadataProvider):
                         return None
                     try:
                         return cast("dict[str, Any]", await response.json())
-                    except (aiohttp.ContentTypeError, JSONDecodeError):
+                    except aiohttp.ContentTypeError, JSONDecodeError:
                         return None
             # ClientError covers every fetch failure; TimeoutError is raised separately
-            except (aiohttp.ClientError, TimeoutError):
+            except aiohttp.ClientError, TimeoutError:
                 return None
 
 

--- a/music_assistant/providers/yandex_music/auth.py
+++ b/music_assistant/providers/yandex_music/auth.py
@@ -369,7 +369,7 @@ async def validate_x_token(x_token: SecretStr) -> bool:
     try:
         async with PassportClient.create() as client:
             return bool(await client.validate_x_token(x_token))
-    except (NetworkError, RateLimitedError):
+    except NetworkError, RateLimitedError:
         raise
     except YaPassportError:
         return False

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -3481,7 +3481,7 @@ class YandexMusicProvider(MusicProvider):
                 r = int(bg_clean[0:2], 16)
                 g = int(bg_clean[2:4], 16)
                 b = int(bg_clean[4:6], 16)
-            except (ValueError, IndexError):
+            except ValueError, IndexError:
                 return raw
             fg = PilImage.open(BytesIO(raw)).convert("RGBA")
             bg = PilImage.new("RGBA", fg.size, (r, g, b, 255))

--- a/music_assistant/providers/yandex_smarthome/auto_skill.py
+++ b/music_assistant/providers/yandex_smarthome/auto_skill.py
@@ -479,7 +479,7 @@ def _try_json(body: str) -> Any:
         return None
     try:
         return json.loads(body)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return None
 
 

--- a/music_assistant/providers/yandex_smarthome/auto_skill_state.py
+++ b/music_assistant/providers/yandex_smarthome/auto_skill_state.py
@@ -84,7 +84,7 @@ def load_artifacts(raw: str | None) -> SkillCreationArtifacts:
         return SkillCreationArtifacts()
     try:
         data = json.loads(raw)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         _LOGGER.warning("auto-skill artifacts corrupt, resetting")
         return SkillCreationArtifacts()
     if not isinstance(data, dict):

--- a/music_assistant/providers/yandex_smarthome/device.py
+++ b/music_assistant/providers/yandex_smarthome/device.py
@@ -447,7 +447,7 @@ async def execute_capability_action(  # noqa: PLR0915
                 ),
             )
 
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         return CapabilityActionResult(
             type=action.type,
             state=CapabilityActionResultState(

--- a/music_assistant/providers/yousee/auth_manager.py
+++ b/music_assistant/providers/yousee/auth_manager.py
@@ -39,7 +39,7 @@ class YouSeeAccessToken:
 class YouSeeAuthManager:
     """YouSee Musik authentication manager."""
 
-    def __init__(self, provider: "YouSeeMusikProvider"):
+    def __init__(self, provider: YouSeeMusikProvider):
         """Initialize YouSeeAuthManager."""
         self._access_token: YouSeeAccessToken | None = None
         self._refresh_token: str | None = None

--- a/music_assistant/providers/yousee/playlist.py
+++ b/music_assistant/providers/yousee/playlist.py
@@ -16,14 +16,14 @@ if TYPE_CHECKING:
 class YouSeePlaylistManager:
     """Manages YouSee Musik playlist operations."""
 
-    def __init__(self, provider: "YouSeeMusikProvider"):
+    def __init__(self, provider: YouSeeMusikProvider):
         """Initialize playlist manager."""
         self.provider = provider
         self.api = provider.api
         self.auth = provider.auth
         self.logger = provider.logger
 
-    async def create(self, name: str) -> "Playlist":
+    async def create(self, name: str) -> Playlist:
         """Create a new playlist on provider with given name."""
         query = """
             mutation createPlaylist($title: String!, $imageSize: Int = 512) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,13 +100,7 @@ fix = true
 show-fixes = true
 
 line-length = 100
-# IMPORTANT: target-version is intentionally pinned ONE MINOR BEHIND the runtime
-# (.python-version = 3.14, target-version = py313) so that lint/format don't
-# introduce 3.14-only syntax (e.g. PEP 758 except-without-parens) while we still
-# need clean cherry-pick backports to `stable` (which runs Python 3.13).
-# BUMP TO "py314" BEFORE THE 2.9 RELEASE — once `stable` follows dev to 3.14,
-# this restriction can be lifted.
-target-version = "py313"
+target-version = "py314"
 
 [tool.ruff.lint.pydocstyle]
 # Use Sphinx-style docstrings with :param: syntax
@@ -122,9 +116,7 @@ max-statements = 50
 
 [tool.mypy]
 platform = "linux"
-# Kept at 3.13 to match [tool.ruff] target-version — see the note there.
-# BUMP TO "3.14" BEFORE THE 2.9 RELEASE.
-python_version = "3.13"
+python_version = "3.14"
 
 # set this to normal when we have fixed all exclusions
 follow_imports = "silent"

--- a/scripts/check_package_safety.py
+++ b/scripts/check_package_safety.py
@@ -183,7 +183,7 @@ def check_package(package_name: str) -> dict[str, Any]:
                             upload_time_str = upload_time_str[:-1] + "+00:00"
                         upload_time = datetime.fromisoformat(upload_time_str)
                         upload_times.append(upload_time)
-                    except (ValueError, AttributeError):
+                    except ValueError, AttributeError:
                         continue
 
     first_upload = min(upload_times) if upload_times else None

--- a/scripts/parse_manifest_deps.py
+++ b/scripts/parse_manifest_deps.py
@@ -19,7 +19,7 @@ def parse_requirements(manifest_content: str) -> list[str]:
     try:
         data = json.loads(manifest_content)
         return data.get("requirements", [])
-    except (json.JSONDecodeError, KeyError):
+    except json.JSONDecodeError, KeyError:
         return []
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,15 +5,18 @@ import contextlib
 import logging
 import pathlib
 from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import aiofiles.os
 from music_assistant_models.enums import EventType, IdentifierType, PlayerFeature, PlayerType
-from music_assistant_models.event import MassEvent
 from music_assistant_models.player import DeviceInfo
 
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import Player
+
+if TYPE_CHECKING:
+    from music_assistant_models.event import MassEvent
 
 
 def _get_fixture_folder(provider: str | None = None) -> pathlib.Path:

--- a/tests/core/test_cache_controller.py
+++ b/tests/core/test_cache_controller.py
@@ -23,7 +23,7 @@ class _FakeModel:
     value: int = 0
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "_FakeModel":
+    def from_dict(cls, data: dict[str, Any]) -> _FakeModel:
         """Reconstruct from dict."""
         return cls(name=data.get("name", ""), value=data.get("value", 0))
 

--- a/tests/core/test_config_entries.py
+++ b/tests/core/test_config_entries.py
@@ -35,7 +35,7 @@ class TestRequiresReload:
 
     @pytest.mark.asyncio
     async def test_zeroconf_interfaces_entry_lives_on_discovery_controller(
-        self, mock_mass: "MockMass"
+        self, mock_mass: MockMass
     ) -> None:
         """Test that zeroconf interface selection belongs to the discovery controller."""
         discovery_controller = DiscoveryController(mock_mass)

--- a/tests/core/test_server_base.py
+++ b/tests/core/test_server_base.py
@@ -1,11 +1,14 @@
 """Tests for the core Music Assistant server object."""
 
 import asyncio
+from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import EventType
-from music_assistant_models.event import MassEvent
 
 from music_assistant.mass import MusicAssistant
+
+if TYPE_CHECKING:
+    from music_assistant_models.event import MassEvent
 
 
 async def test_start_and_stop_server(mass: MusicAssistant) -> None:

--- a/tests/providers/bandcamp/test_init.py
+++ b/tests/providers/bandcamp/test_init.py
@@ -1,14 +1,17 @@
 """Integration tests for the Bandcamp provider."""
 
 from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
-from music_assistant_models.config_entries import ProviderConfig
 from music_assistant_models.enums import MediaType, StreamType
 
 from music_assistant.mass import MusicAssistant
 from tests.common import wait_for_sync_completion
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ProviderConfig
 
 
 @pytest.fixture

--- a/tests/providers/jellyfin/test_init.py
+++ b/tests/providers/jellyfin/test_init.py
@@ -1,14 +1,17 @@
 """Tests for the Jellyfin provider."""
 
 from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
 from aiojellyfin.testing import FixtureBuilder
-from music_assistant_models.config_entries import ProviderConfig
 
 from music_assistant.mass import MusicAssistant
 from tests.common import get_fixtures_dir, wait_for_sync_completion
+
+if TYPE_CHECKING:
+    from music_assistant_models.config_entries import ProviderConfig
 
 
 @pytest.fixture

--- a/tests/providers/jellyfin/test_parsers.py
+++ b/tests/providers/jellyfin/test_parsers.py
@@ -3,7 +3,7 @@
 import logging
 import pathlib
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiofiles
 import aiohttp
@@ -11,7 +11,6 @@ import pytest
 from aiojellyfin import Artist, Connection
 from aiojellyfin.session import SessionConfiguration
 from mashumaro.codecs.json import JSONDecoder
-from syrupy.assertion import SnapshotAssertion
 
 from music_assistant.providers.jellyfin.const import (
     ITEM_KEY_MEDIA_CODEC,
@@ -23,6 +22,9 @@ from music_assistant.providers.jellyfin.parsers import (
     parse_artist,
     parse_track,
 )
+
+if TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
 
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 ARTIST_FIXTURES = list(FIXTURES_DIR.glob("artists/*.json"))

--- a/tests/providers/nicovideo/helpers.py
+++ b/tests/providers/nicovideo/helpers.py
@@ -47,7 +47,7 @@ def sort_dict_keys_and_lists(obj: JsonValue) -> JsonValue:
         try:
             # Sort items for deterministic ordering (handles serialized sets)
             return sorted(sorted_items, key=lambda x: (type(x).__name__, str(x)))
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             # If sorting fails, return in original order
             return sorted_items
     else:

--- a/tests/providers/opensubsonic/test_parsers.py
+++ b/tests/providers/opensubsonic/test_parsers.py
@@ -2,6 +2,7 @@
 
 import logging
 import pathlib
+from typing import TYPE_CHECKING
 
 import aiofiles
 import pytest
@@ -17,7 +18,6 @@ from libopensonic.media import (
     PodcastEpisode,
     StructuredLyrics,
 )
-from syrupy.assertion import SnapshotAssertion
 
 from music_assistant.providers.opensubsonic.parsers import (
     parse_album,
@@ -28,6 +28,9 @@ from music_assistant.providers.opensubsonic.parsers import (
     parse_structured_lyrics,
     parse_track,
 )
+
+if TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
 
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 ARTIST_FIXTURES = list(FIXTURES_DIR.glob("artists/*.artist.json"))

--- a/tests/providers/tidal/test_parsers.py
+++ b/tests/providers/tidal/test_parsers.py
@@ -2,12 +2,11 @@
 
 import json
 import pathlib
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
-from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import ItemMapping
-from syrupy.assertion import SnapshotAssertion
 
 from music_assistant.providers.tidal.parsers import (
     parse_album,
@@ -15,6 +14,10 @@ from music_assistant.providers.tidal.parsers import (
     parse_playlist,
     parse_track,
 )
+
+if TYPE_CHECKING:
+    from music_assistant_models.enums import MediaType
+    from syrupy.assertion import SnapshotAssertion
 
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 ARTIST_FIXTURES = list(FIXTURES_DIR.glob("artists/*.json"))


### PR DESCRIPTION
# What does this implement/fix?

The ruff and mypy targets were intentionally pinned one minor behind the runtime (`py313` / `3.13`) as a backport-safety measure — so `dev` stayed cleanly cherry-pickable onto `stable` while `stable` still ran Python 3.13. `stable` now runs Python 3.14, so the pin is obsolete and only kept the tooling from catching up to the actual runtime.

This bumps the lint/type targets to 3.14 and applies the modernizations that unlocks.

- Set `tool.ruff.target-version` → `py314` and `tool.mypy.python_version` → `3.14`, and drop the now-obsolete "pin one minor behind / bump before 2.9" comments
- Apply the lint fixes this enables: `UP037` (drop now-redundant quoted annotations), `PYI055` (collapse `type[X] | type[Y]` → `type[X | Y]`), `TC002` (move annotation-only imports into `TYPE_CHECKING`)
- Apply `ruff format`'s PEP 758 parenthesis-free `except` style across the tree

mypy is unchanged by this PR — the only remaining errors are the pre-existing `mass.py` baseline (from the `music-assistant-models` 1.1.133 bump), not introduced here.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
