### PR TITLE
Accept Python 3.14 syntax in backports without reformatting stable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,9 @@ repos:
         name: 🐶 Ruff Formatter
         language: system
         types: [python]
-        entry: uv run ruff format
+        # Hold the formatter at py313 so it does not rewrite stable's tree to PEP 758
+        # parenthesis-free `except` (the lint/type target is py314); see pyproject.toml.
+        entry: uv run ruff format --target-version py313
         require_serial: true
         stages: [pre-commit, pre-push, manual]
 

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -53,8 +53,8 @@ from music_assistant_models.errors import (
     UnsupportedFeaturedException,
 )
 from music_assistant_models.media_items import AudioSource
-from music_assistant_models.player import PlayerOptionValueType  # noqa: TC002
-from music_assistant_models.player_control import PlayerControl  # noqa: TC002
+from music_assistant_models.player import PlayerOptionValueType
+from music_assistant_models.player_control import PlayerControl
 
 from music_assistant.constants import (
     ANNOUNCE_ALERT_FILE,

--- a/music_assistant/providers/nicovideo/converters/stream.py
+++ b/music_assistant/providers/nicovideo/converters/stream.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from music_assistant_models.enums import MediaType, StreamType
 from music_assistant_models.errors import UnplayableMediaError
 from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
-from niconico.objects.video.watch import (  # noqa: TC002 - Using by StreamConversionData(BaseModel Serialization)
+from niconico.objects.video.watch import (  # Using by StreamConversionData(BaseModel Serialization)
     WatchData,
     WatchMediaDomandAudio,
 )

--- a/music_assistant/providers/nicovideo/provider_mixins/album.py
+++ b/music_assistant/providers/nicovideo/provider_mixins/album.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import override
 
 from music_assistant_models.errors import MediaNotFoundError
-from music_assistant_models.media_items import Album, Track  # noqa: TC002 - used in @use_cache
+from music_assistant_models.media_items import Album, Track  # used in @use_cache
 
 from music_assistant.controllers.cache import use_cache
 from music_assistant.providers.nicovideo.provider_mixins.base import (

--- a/music_assistant/providers/nicovideo/provider_mixins/artist.py
+++ b/music_assistant/providers/nicovideo/provider_mixins/artist.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator
 from typing import override
 
 from music_assistant_models.errors import MediaNotFoundError
-from music_assistant_models.media_items import (  # noqa: TC002 - used in @use_cache
+from music_assistant_models.media_items import (  # used in @use_cache
     Album,
     Artist,
     Track,

--- a/music_assistant/providers/nicovideo/provider_mixins/playlist.py
+++ b/music_assistant/providers/nicovideo/provider_mixins/playlist.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, override
 
 from music_assistant_models.errors import MediaNotFoundError
-from music_assistant_models.media_items import Playlist, Track  # noqa: TC002 - used in @use_cache
+from music_assistant_models.media_items import Playlist, Track  # used in @use_cache
 
 from music_assistant.controllers.cache import use_cache
 from music_assistant.providers.nicovideo.provider_mixins.base import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,13 +97,11 @@ fix = true
 show-fixes = true
 
 line-length = 100
-# IMPORTANT: target-version is intentionally pinned ONE MINOR BEHIND the runtime
-# (.python-version = 3.14, target-version = py313) so that lint/format don't
-# introduce 3.14-only syntax (e.g. PEP 758 except-without-parens) while we still
-# need clean cherry-pick backports to `stable` (which runs Python 3.13).
-# BUMP TO "py314" BEFORE THE 2.9 RELEASE — once `stable` follows dev to 3.14,
-# this restriction can be lifted.
-target-version = "py313"
+# Stable runs Python 3.14, so the lint/type target is py314 — it must accept the
+# PEP 758 parenthesis-free `except` syntax that gets cherry-picked from dev. The ruff
+# *formatter* is held at py313 in .pre-commit-config.yaml so it does not rewrite
+# stable's existing tree to that style; transitional until stable next syncs from dev.
+target-version = "py314"
 
 [tool.ruff.lint.pydocstyle]
 # Use Sphinx-style docstrings with :param: syntax
@@ -119,9 +117,7 @@ max-statements = 50
 
 [tool.mypy]
 platform = "linux"
-# Kept at 3.13 to match [tool.ruff] target-version — see the note there.
-# BUMP TO "3.14" BEFORE THE 2.9 RELEASE.
-python_version = "3.13"
+python_version = "3.14"
 
 # set this to normal when we have fixed all exclusions
 follow_imports = "silent"
@@ -220,6 +216,11 @@ ignore = [
   "UP047", # Not yet ready to migrate to type parameters
   "PLW0108", # Just annoying, not really useful
   "FURB110", # Just annoying, not really useful
+  # py314-only lint fixes applied on dev but deferred here to avoid churning stable's
+  # existing tree; drop these when stable next syncs from dev.
+  "UP037", # quoted-annotation
+  "PYI055", # unnecessary-type-union
+  "TC002", # typing-only-third-party-import
   # TEMPORARY DISABLED rules  # The below rules must be enabled later one-by-one !
   "BLE001",
   "FBT001",

--- a/tests/providers/nicovideo/fixture_data/shared_types.py
+++ b/tests/providers/nicovideo/fixture_data/shared_types.py
@@ -8,7 +8,7 @@ manually maintained and versioned.
 from __future__ import annotations
 
 # Pydantic requires runtime type information, so these imports cannot be in TYPE_CHECKING block
-from niconico.objects.video.watch import WatchData, WatchMediaDomandAudio  # noqa: TC002
+from niconico.objects.video.watch import WatchData, WatchMediaDomandAudio
 from pydantic import BaseModel
 
 


### PR DESCRIPTION
# What does this implement/fix?

`dev` now targets Python 3.14, and its formatter emits PEP 758 parenthesis-free `except` clauses (e.g. `except A, B:`). `stable` runs Python 3.14 too, but its ruff/mypy targets are still pinned to `py313` — and at that target the linter rejects PEP 758 as invalid syntax. So a `bugfix` + `backport-to-stable` change whose diff happens to touch a multi-exception `except` line would fail CI here.

This makes `stable` accept the new syntax in backports **without** reformatting its existing tree.

- Bump `tool.ruff.target-version` → `py314` and `tool.mypy.python_version` → `3.14` so the linter/type-checker accept PEP 758 (and the `check-python-version` drift warning clears)
- Hold the ruff *formatter* at `py313` via `--target-version py313` in `.pre-commit-config.yaml`, so it does **not** rewrite stable's tree to the parens-free style
- Ignore the three py314-only lint rules (`UP037`, `PYI055`, `TC002`) so existing files aren't flagged/auto-fixed — these are applied on `dev`, deferred here to avoid churn
- Drop the now-redundant `# noqa: TC002` directives this surfaces (reasoned ones kept as plain comments)

Deliberately a transitional split (lint `py314` / format `py313`); it resolves automatically the next time `stable` syncs from `dev`. mypy is unaffected — the pre-existing 22 `ConfigValueOption`/`ConfigEntryDump` baseline errors are identical at 3.13 and 3.14.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
