### PR TITLE
Record explicit album/artist/track plays as user-initiated

### DIFF
--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -2049,7 +2049,7 @@ class MusicController(CoreController):
                 icon="mdi-motion-play",
                 items=cast(
                     "UniqueList[MediaItemType | ItemMapping | BrowseFolder]",
-                    await self.recently_played(limit=10, user_initiated_only=True),
+                    await self.recently_played(limit=10, user_initiated_only=False),
                 ),
             ),
             RecommendationFolder(

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -3599,12 +3599,7 @@ class MusicController(CoreController):
         queue_id: str | None,
         skip_ids: set[str],
     ) -> None:
-        """Credit each (library-resolvable) artist with a play, skipping skip_ids.
-
-        An artist credited this way is a side-effect of a track or album play, so its
-        playlog row is recorded as not user-initiated. An existing user-initiated flag
-        (set when the artist itself was explicitly played) is preserved, never downgraded.
-        """
+        """Credit each (library-resolvable) artist with a play, skipping skip_ids."""
         # ON CONFLICT keeps an explicit user-initiated artist play sticky across the
         # repeated side-effect credits its tracks generate.
         upsert_query = (
@@ -3648,4 +3643,3 @@ class MusicController(CoreController):
             for user_id in user_ids:
                 playlog_entry["userid"] = user_id
                 await self.database.execute(upsert_query, playlog_entry)
-        await self.database.commit()

--- a/music_assistant/controllers/music.py
+++ b/music_assistant/controllers/music.py
@@ -1473,7 +1473,6 @@ class MusicController(CoreController):
                 timestamp=timestamp,
                 user_ids=user_ids,
                 queue_id=queue_id,
-                user_initiated=user_initiated,
                 skip_ids=set(skip_artist_ids or ()),
             )
         await self.database.commit()
@@ -3598,10 +3597,28 @@ class MusicController(CoreController):
         timestamp: float,
         user_ids: list[str],
         queue_id: str | None,
-        user_initiated: bool,
         skip_ids: set[str],
     ) -> None:
-        """Credit each (library-resolvable) artist with a play, skipping skip_ids."""
+        """Credit each (library-resolvable) artist with a play, skipping skip_ids.
+
+        An artist credited this way is a side-effect of a track or album play, so its
+        playlog row is recorded as not user-initiated. An existing user-initiated flag
+        (set when the artist itself was explicitly played) is preserved, never downgraded.
+        """
+        # ON CONFLICT keeps an explicit user-initiated artist play sticky across the
+        # repeated side-effect credits its tracks generate.
+        upsert_query = (
+            f"INSERT INTO {DB_TABLE_PLAYLOG} "
+            "(item_id, provider, media_type, name, image, fully_played, "
+            "seconds_played, timestamp, queue_id, user_initiated, userid) "
+            "VALUES (:item_id, :provider, :media_type, :name, :image, :fully_played, "
+            ":seconds_played, :timestamp, :queue_id, :user_initiated, :userid) "
+            "ON CONFLICT(item_id, provider, media_type, userid) DO UPDATE SET "
+            "name = excluded.name, image = excluded.image, "
+            "fully_played = excluded.fully_played, seconds_played = excluded.seconds_played, "
+            "timestamp = excluded.timestamp, queue_id = excluded.queue_id, "
+            f"user_initiated = {DB_TABLE_PLAYLOG}.user_initiated OR excluded.user_initiated"
+        )
         for artist in artists:
             db_artist = await self.artists.get_library_item_by_prov_id(
                 artist.item_id, artist.provider
@@ -3626,8 +3643,9 @@ class MusicController(CoreController):
                 "seconds_played": None,
                 "timestamp": timestamp,
                 "queue_id": queue_id,
-                "user_initiated": user_initiated,
+                "user_initiated": False,
             }
             for user_id in user_ids:
                 playlog_entry["userid"] = user_id
-                await self.database.insert(DB_TABLE_PLAYLOG, playlog_entry, allow_replace=True)
+                await self.database.execute(upsert_query, playlog_entry)
+        await self.database.commit()

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -2526,6 +2526,11 @@ class PlayerQueuesController(CoreController):
             return list(await self.get_playlist_tracks(media_item, start_item, sort_by=sort_by))
         if media_item.media_type == MediaType.ARTIST:
             media_item = cast("Artist", media_item)
+            self.mass.create_task(
+                self.mass.music.mark_item_played(
+                    media_item, userid=userid, queue_id=queue_id, user_initiated=True
+                )
+            )
             return list(await self.get_artist_tracks(media_item))
         if media_item.media_type == MediaType.ALBUM:
             media_item = cast("Album", media_item)
@@ -3283,7 +3288,7 @@ class PlayerQueuesController(CoreController):
                     is_playing=is_playing,
                     userid=queue.userid,
                     queue_id=queue.queue_id,
-                    user_initiated=False,
+                    user_initiated=self._is_user_initiated_play(queue, media_item),
                 )
             )
             if fully_played and not is_playing:
@@ -3370,6 +3375,16 @@ class PlayerQueuesController(CoreController):
                 return None
         return enqueued
 
+    def _is_user_initiated_play(self, queue: PlayerQueue, media_item: MediaItemType) -> bool:
+        """Return whether a played item was explicitly chosen by the user.
+
+        True only when the item itself was directly enqueued (e.g. a single track the
+        user pressed play on). A track that plays as part of an enqueued album or
+        playlist, or as radio fill, is not user-initiated -- its container is recorded
+        separately.
+        """
+        return media_item in queue.enqueued_media_items
+
     async def _mark_album_played(
         self, album: Album, track: MediaItemType, queue: PlayerQueue
     ) -> None:
@@ -3382,7 +3397,7 @@ class PlayerQueuesController(CoreController):
             album,
             userid=queue.userid,
             queue_id=queue.queue_id,
-            user_initiated=False,
+            user_initiated=True,
             skip_artist_ids=list(skip),
         )
 

--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -3376,13 +3376,7 @@ class PlayerQueuesController(CoreController):
         return enqueued
 
     def _is_user_initiated_play(self, queue: PlayerQueue, media_item: MediaItemType) -> bool:
-        """Return whether a played item was explicitly chosen by the user.
-
-        True only when the item itself was directly enqueued (e.g. a single track the
-        user pressed play on). A track that plays as part of an enqueued album or
-        playlist, or as radio fill, is not user-initiated -- its container is recorded
-        separately.
-        """
+        """Return whether a played item was explicitly chosen by the user."""
         return media_item in queue.enqueued_media_items
 
     async def _mark_album_played(

--- a/tests/core/test_artist_play_credit.py
+++ b/tests/core/test_artist_play_credit.py
@@ -131,11 +131,7 @@ async def test_album_play_credits_album_artists_with_dedup(mass: MusicAssistant)
 
 
 async def test_track_credit_does_not_flag_artist_user_initiated(mass: MusicAssistant) -> None:
-    """A track play credits its artist as a side-effect, never as user-initiated.
-
-    Even when the track itself is user-initiated, the artist is only a consequence
-    of that play, so its playlog row must stay user_initiated=0.
-    """
+    """A track play credits its artist as a side-effect, never as user-initiated."""
     user = await mass.webserver.auth.create_user("trackcreditui")
     artist = await _add_artist(mass, "Sideeffect")
     track = await _add_track(mass, "A Song", [artist])
@@ -148,11 +144,7 @@ async def test_track_credit_does_not_flag_artist_user_initiated(mass: MusicAssis
 
 
 async def test_explicit_artist_play_survives_track_credit(mass: MusicAssistant) -> None:
-    """An explicit artist play stays user-initiated after later side-effect credits.
-
-    Playing the artist marks it user_initiated=1; a subsequent (non-user-initiated)
-    play of one of its tracks must not downgrade that flag.
-    """
+    """An explicit artist play stays user-initiated after later side-effect credits."""
     user = await mass.webserver.auth.create_user("artiststicky")
     artist = await _add_artist(mass, "Chosen")
     track = await _add_track(mass, "Their Song", [artist])

--- a/tests/core/test_artist_play_credit.py
+++ b/tests/core/test_artist_play_credit.py
@@ -80,6 +80,16 @@ async def _play_count(mass: MusicAssistant, table: str, item_id: str) -> int:
     return int(row["play_count"])
 
 
+async def _artist_user_initiated(mass: MusicAssistant, item_id: str, userid: str) -> int:
+    """Read the user_initiated flag of an artist playlog row."""
+    row = await mass.music.database.get_row(
+        DB_TABLE_PLAYLOG,
+        {"media_type": MediaType.ARTIST.value, "item_id": item_id, "userid": userid},
+    )
+    assert row is not None
+    return int(row["user_initiated"])
+
+
 async def test_played_track_credits_all_track_artists(mass: MusicAssistant) -> None:
     """A fully played track credits every one of its artists (not just the primary)."""
     user = await mass.webserver.auth.create_user("trackcredit")
@@ -118,6 +128,46 @@ async def test_album_play_credits_album_artists_with_dedup(mass: MusicAssistant)
     assert await _play_count(mass, DB_TABLE_ALBUMS, album.item_id) == 1
     assert await _play_count(mass, DB_TABLE_ARTISTS, kept.item_id) == 1
     assert await _play_count(mass, DB_TABLE_ARTISTS, skipped.item_id) == 0
+
+
+async def test_track_credit_does_not_flag_artist_user_initiated(mass: MusicAssistant) -> None:
+    """A track play credits its artist as a side-effect, never as user-initiated.
+
+    Even when the track itself is user-initiated, the artist is only a consequence
+    of that play, so its playlog row must stay user_initiated=0.
+    """
+    user = await mass.webserver.auth.create_user("trackcreditui")
+    artist = await _add_artist(mass, "Sideeffect")
+    track = await _add_track(mass, "A Song", [artist])
+
+    await mass.music.mark_item_played(
+        track, fully_played=True, user_initiated=True, userid=user.user_id
+    )
+
+    assert await _artist_user_initiated(mass, artist.item_id, user.user_id) == 0
+
+
+async def test_explicit_artist_play_survives_track_credit(mass: MusicAssistant) -> None:
+    """An explicit artist play stays user-initiated after later side-effect credits.
+
+    Playing the artist marks it user_initiated=1; a subsequent (non-user-initiated)
+    play of one of its tracks must not downgrade that flag.
+    """
+    user = await mass.webserver.auth.create_user("artiststicky")
+    artist = await _add_artist(mass, "Chosen")
+    track = await _add_track(mass, "Their Song", [artist])
+
+    # user explicitly plays the artist
+    await mass.music.mark_item_played(
+        artist, fully_played=True, user_initiated=True, userid=user.user_id
+    )
+    assert await _artist_user_initiated(mass, artist.item_id, user.user_id) == 1
+
+    # later, one of the artist's tracks auto-plays (not user-initiated)
+    await mass.music.mark_item_played(
+        track, fully_played=True, user_initiated=False, userid=user.user_id
+    )
+    assert await _artist_user_initiated(mass, artist.item_id, user.user_id) == 1
 
 
 def test_enqueued_album_decision() -> None:

--- a/tests/core/test_user_initiated_plays.py
+++ b/tests/core/test_user_initiated_plays.py
@@ -1,0 +1,90 @@
+"""
+Tests for tagging explicit (user-initiated) plays in the playlog.
+
+These cover the player-queue side of the decision: which plays count as
+user-initiated so they surface in the Discover "Recently played" row. The pure
+decisions are exercised as plain unit tests against a bare controller instance,
+mirroring ``test_play_report_dedup`` and ``test_enqueued_album_decision``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, Mock
+
+from music_assistant_models.enums import AlbumType, MediaType
+from music_assistant_models.media_items import Album, Artist, Track
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+
+if TYPE_CHECKING:
+    from music_assistant_models.player_queue import PlayerQueue
+
+
+def _controller() -> PlayerQueuesController:
+    """Create a bare controller instance without running __init__."""
+    return PlayerQueuesController.__new__(PlayerQueuesController)
+
+
+def test_directly_enqueued_track_is_user_initiated() -> None:
+    """A track the user pressed play on is user-initiated; an album track is not."""
+    album = Album(
+        item_id="ax",
+        provider="library",
+        name="X",
+        provider_mappings=set(),
+        album_type=AlbumType.ALBUM,
+    )
+    explicit_track = Track(item_id="t1", provider="library", name="T1", provider_mappings=set())
+    album_track = Track(
+        item_id="t2", provider="library", name="T2", provider_mappings=set(), album=album
+    )
+    # the user explicitly played a single track and (separately) an album
+    queue = cast("PlayerQueue", Mock(enqueued_media_items=[explicit_track, album]))
+
+    ctrl = _controller()
+    # the directly-enqueued track was explicitly chosen
+    assert ctrl._is_user_initiated_play(queue, explicit_track) is True
+    # a track that only played as part of the enqueued album was not
+    assert ctrl._is_user_initiated_play(queue, album_track) is False
+
+
+async def test_mark_album_played_is_user_initiated() -> None:
+    """Crediting an enqueued album records it as a user-initiated play."""
+    ctrl = _controller()
+    ctrl.logger = Mock()
+    mark = AsyncMock()
+    ctrl.mass = Mock()
+    ctrl.mass.music.mark_item_played = mark
+    ctrl.mass.music.resolve_library_artist_ids = AsyncMock(return_value=set())
+
+    album = Album(
+        item_id="a1",
+        provider="library",
+        name="A",
+        provider_mappings=set(),
+        album_type=AlbumType.ALBUM,
+    )
+    track = Track(item_id="t1", provider="library", name="T", provider_mappings=set())
+    queue = cast("PlayerQueue", Mock(queue_id="q1", userid="u1"))
+
+    await ctrl._mark_album_played(album, track, queue)
+
+    assert mark.call_args.kwargs["user_initiated"] is True
+
+
+async def test_resolve_artist_marks_user_initiated() -> None:
+    """Enqueuing an artist records the artist itself as a user-initiated play."""
+    ctrl = _controller()
+    ctrl.mass = Mock()
+    ctrl.mass.create_task = Mock(side_effect=lambda coro: coro)
+    ctrl.mass.music.mark_item_played = Mock()
+    ctrl.get_artist_tracks = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    artist = Artist(item_id="ar1", provider="library", name="Ar", provider_mappings=set())
+
+    await ctrl._resolve_media_items(artist, userid="u1", queue_id="q1")
+
+    call = ctrl.mass.music.mark_item_played.call_args
+    assert call.kwargs["user_initiated"] is True
+    assert call.args[0].media_type == MediaType.ARTIST

--- a/tests/providers/sonic_similarity/test_dispatcher_hooks.py
+++ b/tests/providers/sonic_similarity/test_dispatcher_hooks.py
@@ -201,10 +201,11 @@ class TestRecommendations:
     ) -> None:
         """recommendations() asks for partial plays and does NOT filter on user_initiated.
 
-        MA only sets user_initiated=True on container-level plays (album, artist,
-        playlist, genre); individual tracks always get user_initiated=False from
-        the playback-report hook. Restricting to user_initiated=True therefore
-        excludes the actual track-level plays we want as seeds.
+        MA sets user_initiated=True only for items the user explicitly chose (a
+        container such as an album, artist, playlist or genre, or a single track played
+        directly). Tracks that play as part of a container or as radio fill -- exactly
+        the track-level plays we want as seeds -- stay user_initiated=False, so
+        restricting to user_initiated=True would exclude them.
         """
         plugin = make_plugin(signatures={("spotify", "seed_id"): [0.1] * 18})
         mock_mass.music.recently_played = AsyncMock(return_value=[])


### PR DESCRIPTION
# What does this implement/fix?

Restores the Discover **Recently played** row, which stopped updating after upgrading to 2.9.x.

**Why it broke:** the row read the playlog with `user_initiated_only=True` (`user_initiated = 1`), but the most common in-app plays never set that flag — albums were credited `user_initiated=False`, artists were never marked on enqueue, and individual tracks were hard-coded `False` in the playback-report path. Only playlist/genre/podcast enqueues set it, so for anyone who mostly plays albums nothing new matched the filter. The 2.9.x migration added the column with `DEFAULT 1`, backfilling existing rows, which is why the row stayed **frozen on pre-upgrade items** rather than going empty. (The Albums "last played" sort kept working because it reads the library table's `last_played`, a separate path.)

**The fix —** the Discover **Recently played** row now reads the playlog with `user_initiated_only=False`, so it surfaces everything that actually played (newest-first), behaving like a history of what you heard rather than only what you explicitly clicked. This is the behavior discussed in review ([thread](https://github.com/music-assistant/server/pull/4260#issuecomment)).

**Also: corrected `user_initiated` tagging.** Independent of the row's filter, the flag was being recorded inconsistently. This PR makes it record a play as user-initiated whenever the user explicitly chose that exact item:

- **Albums** — `_mark_album_played` now passes `user_initiated=True` (already gated on the album being explicitly enqueued).
- **Artists** — the ARTIST enqueue branch now marks the artist, mirroring the existing playlist/genre/podcast branches.
- **Single tracks** — the playback-report path sets the flag from a new `_is_user_initiated_play()` helper (`media_item in queue.enqueued_media_items`), so a directly-played track counts but auto-advanced / radio tracks do not.

**Artist credit decoupling (the non-obvious part):** an album row is written in one place, so flipping its flag is safe; an artist row is rewritten on *every* track via `_credit_artist_plays`. That method is now always a side-effect write (`user_initiated=False`, parameter removed) using a non-downgrading upsert — `user_initiated = playlog.user_initiated OR excluded.user_initiated` — so an explicit artist play stays user-initiated across the repeated credits its tracks generate, and a track/album play never flags its artists. Order-independent, which matters since these run as `create_task`s.

**a playlog row is `user_initiated=True` iff that exact item was explicitly enqueued.** 

The default Recently played row no longer filters on it (it shows everything that has played in reverse chronological order, as expected for 'a row of stuff I have heard').

**Related issue (if applicable):**

- related issue music-assistant/support#5671

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
