### PR TITLE
Relax 'Maximum' buffer tier to 7GB RAM

### DIFF
--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -26,6 +26,13 @@ class BufferSize(StrEnum):
 # Calculate total system memory once at module load time
 TOTAL_SYSTEM_MEMORY_GB: Final[float] = get_total_system_memory()
 
+# RAM thresholds (in GB) for the buffer-size presets. Balanced needs >= 4GB.
+# Maximum uses 7GB rather than a literal 8GB so machines marketed as "8GB" that
+# report slightly less still qualify for the largest buffer: integrated GPUs carve
+# out shared system memory, and container runtimes report their cgroup limit.
+BALANCED_MIN_RAM_GB: Final[float] = 4.0
+MAXIMUM_MIN_RAM_GB: Final[float] = 7.0
+
 # Buffer size in seconds for each preset
 BUFFER_SIZE_MAP: Final[dict[str, int]] = {
     BufferSize.MINIMAL: 60,
@@ -45,23 +52,23 @@ def get_available_buffer_sizes() -> list[BufferSize]:
     """
     Return the buffer-size presets allowed for this host's RAM.
 
-    Minimal is always available; Balanced requires >= 4GB and Maximum >= 8GB. When total
+    Minimal is always available; Balanced requires >= 4GB and Maximum >= 7GB. When total
     memory is unknown (0.0, e.g. Windows) all presets are offered (fail open).
     """
     if TOTAL_SYSTEM_MEMORY_GB == 0.0:
         return [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]
     sizes = [BufferSize.MINIMAL]
-    if TOTAL_SYSTEM_MEMORY_GB >= 4.0:
+    if TOTAL_SYSTEM_MEMORY_GB >= BALANCED_MIN_RAM_GB:
         sizes.append(BufferSize.BALANCED)
-    if TOTAL_SYSTEM_MEMORY_GB >= 8.0:
+    if TOTAL_SYSTEM_MEMORY_GB >= MAXIMUM_MIN_RAM_GB:
         sizes.append(BufferSize.MAXIMUM)
     return sizes
 
 
 def _get_default_buffer_size() -> str:
-    if TOTAL_SYSTEM_MEMORY_GB >= 8.0:
+    if TOTAL_SYSTEM_MEMORY_GB >= MAXIMUM_MIN_RAM_GB:
         return BufferSize.MAXIMUM
-    if TOTAL_SYSTEM_MEMORY_GB >= 4.0:
+    if TOTAL_SYSTEM_MEMORY_GB >= BALANCED_MIN_RAM_GB:
         return BufferSize.BALANCED
     return BufferSize.MINIMAL
 

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -180,7 +180,7 @@ class StreamsController(CoreController):
                 type=ConfigEntryType.STRING,
                 default_value=CONF_BUFFER_SIZE_DEFAULT,
                 # Only offer presets the host's RAM can sustain (Balanced >= 4GB,
-                # Maximum >= 8GB); see get_available_buffer_sizes.
+                # Maximum >= 7GB); see get_available_buffer_sizes.
                 options=[ConfigValueOption(size.value) for size in get_available_buffer_sizes()],
                 required=False,
                 category="playback",

--- a/tests/controllers/streams/test_buffer_size.py
+++ b/tests/controllers/streams/test_buffer_size.py
@@ -30,3 +30,22 @@ def test_get_available_buffer_sizes(total_gb: float, expected: list[BufferSize])
     """Balanced requires >= 4GB, Maximum >= 7GB; unknown RAM offers all (fail open)."""
     with patch.object(constants, "TOTAL_SYSTEM_MEMORY_GB", total_gb):
         assert constants.get_available_buffer_sizes() == expected
+
+
+@pytest.mark.parametrize(
+    ("total_gb", "expected"),
+    [
+        (2.0, BufferSize.MINIMAL),
+        (4.0, BufferSize.BALANCED),
+        (6.9, BufferSize.BALANCED),
+        (7.0, BufferSize.MAXIMUM),
+        (7.7, BufferSize.MAXIMUM),
+        (16.0, BufferSize.MAXIMUM),
+        # unknown memory (0.0) -> Minimal default (conservative)
+        (0.0, BufferSize.MINIMAL),
+    ],
+)
+def test_default_buffer_size(total_gb: float, expected: BufferSize) -> None:
+    """The auto-selected default follows the same 4GB/7GB cutoffs as the available presets."""
+    with patch.object(constants, "TOTAL_SYSTEM_MEMORY_GB", total_gb):
+        assert constants._get_default_buffer_size() == expected

--- a/tests/controllers/streams/test_buffer_size.py
+++ b/tests/controllers/streams/test_buffer_size.py
@@ -15,6 +15,11 @@ from music_assistant.controllers.streams.constants import BufferSize
         (3.9, [BufferSize.MINIMAL]),
         (4.0, [BufferSize.MINIMAL, BufferSize.BALANCED]),
         (6.0, [BufferSize.MINIMAL, BufferSize.BALANCED]),
+        (6.9, [BufferSize.MINIMAL, BufferSize.BALANCED]),
+        # "8GB" hosts that report slightly less (integrated GPU / container limit)
+        # still reach Maximum thanks to the 7GB threshold.
+        (7.0, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
+        (7.7, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
         (8.0, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
         (16.0, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
         # unknown memory (0.0) -> offer everything (fail open)
@@ -22,6 +27,6 @@ from music_assistant.controllers.streams.constants import BufferSize
     ],
 )
 def test_get_available_buffer_sizes(total_gb: float, expected: list[BufferSize]) -> None:
-    """Balanced requires >= 4GB, Maximum >= 8GB; unknown RAM offers all (fail open)."""
+    """Balanced requires >= 4GB, Maximum >= 7GB; unknown RAM offers all (fail open)."""
     with patch.object(constants, "TOTAL_SYSTEM_MEMORY_GB", total_gb):
         assert constants.get_available_buffer_sizes() == expected


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4249. The **Maximum** buffer preset (and the auto-selected default) required exactly **8GB** of RAM. Machines marketed as "8GB" frequently report a little less — integrated GPUs carve out shared system memory (e.g. a real 7.7GB), and container runtimes report their cgroup limit — so they silently dropped to the Balanced tier and never got the largest buffer.

- Lower the **Maximum** threshold from 8GB to **7GB**, so near-8GB hosts qualify for the optimal buffer.
- Keep the **4GB Balanced** minimum intact (the genuine lower bound).
- Replace the repeated magic numbers with named `BALANCED_MIN_RAM_GB` / `MAXIMUM_MIN_RAM_GB` constants and extend the buffer-tier test with the boundary cases (6.9 → Balanced, 7.0 / 7.7 → Maximum).

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.