### PR TITLE
Respect container cgroup memory limits when detecting system memory

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -119,15 +119,137 @@ async def warn_if_missing_x86_64_v2(logger: logging.Logger) -> None:
 
 
 def get_total_system_memory() -> float:
-    """Get total system memory in GB."""
-    try:
-        # Works on Linux and macOS
-        total_memory_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
-        return total_memory_bytes / (1024**3)  # Convert to GB
-    except AttributeError, ValueError:
-        # Fallback if sysconf is not available (e.g., Windows)
-        # Return a conservative default to disable buffering by default
+    """
+    Return the memory available to this process in GB (0.0 when unknown).
+
+    On Linux this is min(physical RAM, cgroup memory limit), so a container's
+    --memory limit is honored when sizing buffers and gating heavy features.
+    Returns 0.0 when the platform cannot report memory (e.g. Windows), which
+    callers treat as "unknown" and fail open.
+    """
+    host_gb = _get_host_memory_gb()
+    if host_gb <= 0.0:
         return 0.0
+    if sys.platform != "linux":
+        return host_gb
+    cgroup_gb = _get_cgroup_memory_limit_gb()
+    if cgroup_gb is None or cgroup_gb <= 0.0:
+        return host_gb
+    return min(host_gb, cgroup_gb)
+
+
+def _get_host_memory_gb() -> float:
+    """Return host physical RAM in GB via sysconf, or 0.0 when unavailable."""
+    try:
+        total_memory_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+        return total_memory_bytes / (1024**3)
+    except AttributeError, ValueError, OSError:
+        # sysconf is unavailable on some platforms (e.g. Windows); treat as unknown.
+        return 0.0
+
+
+def _get_cgroup_memory_limit_gb(
+    cgroup_root: str = "/sys/fs/cgroup", proc_cgroup: str = "/proc/self/cgroup"
+) -> float | None:
+    """
+    Return this process's cgroup memory limit in GB, or None if unlimited/unavailable.
+
+    cgroup v2 (memory.max) is tried first, then v1 (memory/memory.limit_in_bytes).
+
+    :param cgroup_root: Mount point of the cgroup filesystem (overridable for tests).
+    :param proc_cgroup: Path to the process cgroup file (overridable for tests).
+    """
+    limit = _read_cgroup_v2_limit(cgroup_root, proc_cgroup)
+    if limit is not None:
+        return limit
+    return _read_cgroup_v1_limit(cgroup_root, proc_cgroup)
+
+
+def _read_cgroup_v2_limit(cgroup_root: str, proc_cgroup: str) -> float | None:
+    """Read the cgroup v2 memory.max limit in GB, or None."""
+    rel = _read_self_cgroup_path(proc_cgroup, controller=None)
+    candidates: list[str] = []
+    if rel and rel != "/":
+        # Non-namespaced container: limit lives at the process's own sub-cgroup.
+        candidates.append(os.path.join(cgroup_root, rel.lstrip("/"), "memory.max"))
+    # Namespaced container (the common case): the mount root is the leaf cgroup.
+    candidates.append(os.path.join(cgroup_root, "memory.max"))
+    return _first_cgroup_limit(candidates)
+
+
+def _read_cgroup_v1_limit(cgroup_root: str, proc_cgroup: str) -> float | None:
+    """Read the cgroup v1 memory.limit_in_bytes limit in GB, or None."""
+    # On v1 the memory controller is conventionally mounted at <root>/memory.
+    base = os.path.join(cgroup_root, "memory")
+    rel = _read_self_cgroup_path(proc_cgroup, controller="memory")
+    candidates: list[str] = []
+    if rel and rel != "/":
+        candidates.append(os.path.join(base, rel.lstrip("/"), "memory.limit_in_bytes"))
+    candidates.append(os.path.join(base, "memory.limit_in_bytes"))
+    return _first_cgroup_limit(candidates)
+
+
+def _first_cgroup_limit(paths: list[str]) -> float | None:
+    """Return the first parseable, bounded cgroup limit (in GB) among the given paths."""
+    for path in paths:
+        limit = _read_cgroup_limit_file(path)
+        if limit is not None:
+            return limit
+    return None
+
+
+def _read_cgroup_limit_file(path: str) -> float | None:
+    """
+    Parse a cgroup memory-limit file into GB, or None if missing/unlimited/invalid.
+
+    :param path: Path to a cgroup memory.max (v2) or memory.limit_in_bytes (v1) file.
+    """
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+    except OSError:
+        # File absent or unreadable (covers FileNotFoundError/PermissionError/etc.).
+        return None
+    # "max" (v2) or a near-INT64_MAX sentinel (v1) both mean "no limit set".
+    if not raw or raw == "max":
+        return None
+    try:
+        limit_bytes = int(raw)
+    except ValueError:
+        return None
+    if limit_bytes <= 0 or limit_bytes >= _CGROUP_UNLIMITED_THRESHOLD:
+        return None
+    return limit_bytes / (1024**3)
+
+
+def _read_self_cgroup_path(proc_cgroup: str, *, controller: str | None) -> str | None:
+    """
+    Return the process's cgroup path from /proc/self/cgroup, or None.
+
+    :param proc_cgroup: Path to the process cgroup file.
+    :param controller: For cgroup v1, the controller name (e.g. "memory") whose path
+        to return. None selects the cgroup v2 unified hierarchy line ("0::<path>").
+    """
+    try:
+        with open(proc_cgroup) as fh:
+            for line in fh:
+                parts = line.strip().split(":", 2)
+                if len(parts) != 3:
+                    continue
+                hierarchy_id, controllers, path = parts
+                if controller is None:
+                    if hierarchy_id == "0" and controllers == "":
+                        return path or "/"
+                elif controller in controllers.split(","):
+                    return path or "/"
+    except OSError:
+        return None
+    return None
+
+
+# cgroup v1 writes a near-INT64_MAX value (PAGE_SIZE * LONG_MAX on most kernels) to
+# memory.limit_in_bytes when no limit is set; treat anything this large as unlimited.
+_CGROUP_UNLIMITED_THRESHOLD: int = 1 << 62
 
 
 def is_arm() -> bool:

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -1,6 +1,7 @@
 """Tests for utility/helper functions."""
 
 from ipaddress import IPv4Address, IPv6Address
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -573,3 +574,97 @@ def test_is_arm(machine: str, expected: bool) -> None:
     """is_arm recognizes 32/64-bit ARM and rejects x86."""
     with patch("music_assistant.helpers.util.platform.machine", return_value=machine):
         assert util.is_arm() is expected
+
+
+# 4/8/2 GiB expressed in bytes, for cgroup fixture files.
+_GIB = 1024**3
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (str(4 * _GIB), 4.0),
+        (str(8 * _GIB), 8.0),
+        ("max", None),  # v2 unlimited sentinel
+        ("", None),  # empty file
+        (str(1 << 62), None),  # v1 unlimited sentinel
+        ("0", None),  # zero is not a real limit
+        ("-1", None),  # negative is not a real limit
+        ("not-a-number", None),
+    ],
+)
+def test_read_cgroup_limit_file(tmp_path: Path, raw: str, expected: float | None) -> None:
+    """A cgroup limit file parses to GB, treating max/sentinel/garbage as no limit."""
+    limit_file = tmp_path / "memory.max"
+    limit_file.write_text(raw)
+    assert util._read_cgroup_limit_file(str(limit_file)) == expected
+
+
+def test_read_cgroup_limit_file_missing(tmp_path: Path) -> None:
+    """A missing cgroup limit file yields None rather than raising."""
+    assert util._read_cgroup_limit_file(str(tmp_path / "absent")) is None
+
+
+def test_cgroup_limit_v2(tmp_path: Path) -> None:
+    """Cgroup v2 memory.max at the mount root is read (namespaced container case)."""
+    (tmp_path / "memory.max").write_text(str(4 * _GIB))
+    # proc file absent -> rel is None -> falls back to the mount root.
+    limit = util._get_cgroup_memory_limit_gb(
+        cgroup_root=str(tmp_path), proc_cgroup=str(tmp_path / "absent")
+    )
+    assert limit == 4.0
+
+
+def test_cgroup_limit_v2_prefers_leaf(tmp_path: Path) -> None:
+    """When /proc/self/cgroup names a sub-cgroup, its memory.max wins over the root."""
+    (tmp_path / "memory.max").write_text(str(8 * _GIB))
+    leaf = tmp_path / "leaf"
+    leaf.mkdir()
+    (leaf / "memory.max").write_text(str(2 * _GIB))
+    proc = tmp_path / "proc_cgroup"
+    proc.write_text("0::/leaf\n")
+    limit = util._get_cgroup_memory_limit_gb(cgroup_root=str(tmp_path), proc_cgroup=str(proc))
+    assert limit == 2.0
+
+
+def test_cgroup_limit_v1_fallback(tmp_path: Path) -> None:
+    """With no v2 file, the v1 memory controller limit is used."""
+    mem = tmp_path / "memory"
+    mem.mkdir()
+    (mem / "memory.limit_in_bytes").write_text(str(4 * _GIB))
+    proc = tmp_path / "proc_cgroup"
+    proc.write_text("3:memory:/\n")
+    limit = util._get_cgroup_memory_limit_gb(cgroup_root=str(tmp_path), proc_cgroup=str(proc))
+    assert limit == 4.0
+
+
+def test_cgroup_limit_none_when_unset(tmp_path: Path) -> None:
+    """No cgroup files present -> no limit detected."""
+    assert (
+        util._get_cgroup_memory_limit_gb(
+            cgroup_root=str(tmp_path), proc_cgroup=str(tmp_path / "absent")
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("host_gb", "cgroup_gb", "platform", "expected"),
+    [
+        (16.0, 4.0, "linux", 4.0),  # container limit below host -> use the limit
+        (8.0, 16.0, "linux", 8.0),  # limit above host -> host wins
+        (8.0, None, "linux", 8.0),  # no limit -> host RAM
+        (0.0, 4.0, "linux", 0.0),  # host unknown -> unknown (fail open)
+        (8.0, 4.0, "darwin", 8.0),  # non-linux never consults cgroups
+    ],
+)
+def test_get_total_system_memory(
+    host_gb: float, cgroup_gb: float | None, platform: str, expected: float
+) -> None:
+    """Total memory is min(host RAM, cgroup limit) on Linux; host RAM elsewhere."""
+    with (
+        patch("music_assistant.helpers.util._get_host_memory_gb", return_value=host_gb),
+        patch("music_assistant.helpers.util._get_cgroup_memory_limit_gb", return_value=cgroup_gb),
+        patch("music_assistant.helpers.util.sys.platform", platform),
+    ):
+        assert util.get_total_system_memory() == expected


### PR DESCRIPTION
# What does this implement/fix?

`get_total_system_memory()` only read the host's physical RAM, so inside a memory-constrained container (e.g. `docker run --memory=4g` on a 32GB host) it reported the full 32GB. Music Assistant then offered buffer presets and gated heavy audio-analysis providers as if all that RAM were available, risking OOM-kills.

On Linux it now returns `min(physical RAM, cgroup memory limit)` so the container's real allocation is respected. This is a reworked, tested take on the idea from #4197.

- Read cgroup **v2** (`memory.max`) first, with a **v1** (`memory/memory.limit_in_bytes`) fallback.
- Use the process's own cgroup (from `/proc/self/cgroup`) with a mount-root fallback for the common namespaced-container case.
- Treat `max` / the v1 near-`INT64_MAX` sentinel as "unlimited", and fail open to host RAM on any read error or non-Linux platform.
- Compared to #4197, this drops the fragile `/proc/self/mountinfo` parsing in favour of the conventional `/sys/fs/cgroup` mount points, splits the logic into small testable helpers, and adds fixture-based unit tests (v2, v1, leaf-vs-root preference, sentinels, and the `min()` selection).

Credit to @nerzhul (#4197) for raising the cgroup gap.

> Note: this does not change behaviour for Home Assistant OS add-ons, which generally run without a per-container memory limit and so continue to see the shared host RAM.

**Related issue (if applicable):**

- Supersedes #4197

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.