### PR TITLE
Persist playback speed for audiobooks and podcast episodes

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 41
+DB_SCHEMA_VERSION: Final[int] = 42
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -1329,6 +1329,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         queue_id: str | None = None,
         user_initiated: bool = True,
         skip_artist_ids: list[str] | None = None,
+        playback_speed: float | None = None,
     ) -> None:
         """
         Mark item as played in playlog.
@@ -1341,6 +1342,8 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param queue_id: The queue ID where the item was played.
         :param user_initiated: If True, the playback was initiated by the user (e.g. enqueued).
         :param skip_artist_ids: Library artist ids to skip when crediting an album's artists.
+        :param playback_speed: The current playback speed to persist (audiobooks/podcasts).
+            If None, any previously stored speed for the item is preserved.
         """
         timestamp = utc_timestamp()
         if (
@@ -1382,8 +1385,34 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             else:
                 # NOTE: if no user was found, we will alter the playlog for all users
                 user_ids = [user.user_id for user in await self.mass.webserver.auth.list_users()]
+            # only audiobooks/podcast episodes ever carry a non-default playback speed
+            preserve_speed = playback_speed is None and media_item.media_type in (
+                MediaType.AUDIOBOOK,
+                MediaType.PODCAST_EPISODE,
+            )
             for user_id in user_ids:
                 params["userid"] = user_id
+                # INSERT OR REPLACE rewrites the whole row, so the speed must be re-supplied
+                # or it reverts to the column default. When the caller has no speed (e.g. a
+                # provider sync), keep the value already stored for this item/user.
+                if playback_speed is not None:
+                    params["playback_speed"] = playback_speed
+                elif preserve_speed:
+                    existing = await self.database.get_row(
+                        DB_TABLE_PLAYLOG,
+                        {
+                            "item_id": params["item_id"],
+                            "provider": params["provider"],
+                            "media_type": params["media_type"],
+                            "userid": user_id,
+                        },
+                    )
+                    params["playback_speed"] = (
+                        existing["playback_speed"]
+                        if existing and existing["playback_speed"] is not None
+                        else 1.0
+                    )
+                # otherwise leave playback_speed out so the column default (1.0) applies
                 await self.database.insert(
                     DB_TABLE_PLAYLOG,
                     params,
@@ -1694,6 +1723,39 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         if ma_position_ms >= provider_position_ms:
             return ma_fully_played, ma_position_ms
         return provider_fully_played, provider_position_ms
+
+    async def get_playback_speed(
+        self, media_item: Audiobook | PodcastEpisode, userid: str | None = None
+    ) -> float:
+        """
+        Get the stored playback speed for the given audiobook or podcast episode.
+
+        Returns 1.0 (normal speed) when no custom speed was stored for the item,
+        or when no user can be determined to scope the lookup.
+
+        :param media_item: The audiobook or podcast episode to look up.
+        :param userid: The user ID to look up the speed for (instead of the current user).
+        """
+        if not userid:
+            if session_user := get_current_user():
+                userid = session_user.user_id
+            elif provider_user := await self._get_user_for_provider(media_item.provider_mappings):
+                userid = provider_user.user_id
+            else:
+                # the speed is stored per user; without one we can't scope the lookup
+                return 1.0
+        db_entry = await self.database.get_row(
+            DB_TABLE_PLAYLOG,
+            {
+                "item_id": media_item.item_id,
+                "provider": media_item.provider,
+                "media_type": media_item.media_type.value,
+                "userid": userid,
+            },
+        )
+        if db_entry and (stored_speed := db_entry["playback_speed"]) is not None:
+            return float(stored_speed)
+        return 1.0
 
     def get_controller(
         self, media_type: MediaType

--- a/music_assistant/controllers/music/database.py
+++ b/music_assistant/controllers/music/database.py
@@ -246,6 +246,7 @@ class MusicDatabaseSetupMixin:
                 [userid] TEXT NOT NULL,
                 [queue_id] TEXT,
                 [user_initiated] BOOLEAN NOT NULL DEFAULT 1,
+                [playback_speed] REAL NOT NULL DEFAULT 1.0,
                 UNIQUE(item_id, provider, media_type, userid));"""
         )
         await self.database.execute(

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -651,6 +651,17 @@ async def migrate_database(  # noqa: PLR0915
                     {"metadata": serialize_to_json(metadata)},
                 )
 
+    if prev_version <= 41:
+        # add playback_speed column to playlog (per-item speed for audiobooks/episodes)
+        try:
+            await database.execute(
+                f"ALTER TABLE {DB_TABLE_PLAYLOG} "
+                "ADD COLUMN playback_speed REAL NOT NULL DEFAULT 1.0"
+            )
+        except Exception as err:
+            if "duplicate column" not in str(err):
+                raise
+
     # save changes
     await database.commit()
 

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -877,6 +877,21 @@ class PlayerQueuesController(CoreController):
             ):
                 seek_position = max(0, int((resume_position_ms - 500) / 1000))
 
+            # restore the persisted playback speed for a freshly queued audiobook/episode
+            # (an in-session item already carries its speed in extra_attributes)
+            if (
+                (queue_item := self.get_item(queue_id, index))
+                and queue_item.media_item is not None
+                and queue_item.media_type in (MediaType.AUDIOBOOK, MediaType.PODCAST_EPISODE)
+                and "playback_speed" not in queue_item.extra_attributes
+            ):
+                stored_speed = await self.mass.music.get_playback_speed(
+                    cast("Audiobook | PodcastEpisode", queue_item.media_item),
+                    userid=queue.userid,
+                )
+                if stored_speed != 1.0:
+                    queue_item.extra_attributes["playback_speed"] = stored_speed
+
             # try to load the item, retry with next item if it fails
             for attempt in range(5):
                 try:
@@ -3195,6 +3210,11 @@ class PlayerQueuesController(CoreController):
                     userid=queue.userid,
                     queue_id=queue.queue_id,
                     user_initiated=self._is_user_initiated_play(queue, media_item),
+                    playback_speed=float(
+                        item_to_report.extra_attributes.get("playback_speed") or 1.0
+                    )
+                    if item_to_report.media_type in (MediaType.AUDIOBOOK, MediaType.PODCAST_EPISODE)
+                    else None,
                 )
             )
             if fully_played and not is_playing:

--- a/tests/core/test_playback_speed_persistence.py
+++ b/tests/core/test_playback_speed_persistence.py
@@ -1,0 +1,104 @@
+"""
+Tests for persisting the per-item playback speed of audiobooks/podcast episodes.
+
+The playback speed a listener picks for an audiobook or podcast episode is stored
+in the ``playlog`` table (alongside the resume position) so it can be restored when
+the item is queued again later. These integration tests use the ``mass`` fixture
+from ``tests/conftest.py`` which creates a full MusicAssistant instance with a real
+SQLite database in a temporary directory.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Audiobook, ProviderMapping
+
+from music_assistant.constants import DB_TABLE_PLAYLOG
+from music_assistant.mass import MusicAssistant
+
+
+def _library_mapping() -> set[ProviderMapping]:
+    """Create a single library provider mapping with a unique provider item id."""
+    return {
+        ProviderMapping(
+            item_id=uuid4().hex,
+            provider_domain="library",
+            provider_instance="library",
+            in_library=True,
+        )
+    }
+
+
+def _audiobook() -> Audiobook:
+    """Create a minimal audiobook with a unique item id."""
+    return Audiobook(
+        item_id=uuid4().hex,
+        provider="library",
+        name="A Book",
+        provider_mappings=_library_mapping(),
+        duration=3600,
+    )
+
+
+async def test_playback_speed_defaults_to_normal(mass: MusicAssistant) -> None:
+    """An item that never had a speed set reports the normal (1.0) speed."""
+    user = await mass.webserver.auth.create_user("speeduser_default")
+    book = _audiobook()
+    assert await mass.music.get_playback_speed(book, userid=user.user_id) == 1.0
+
+
+async def test_playback_speed_is_persisted(mass: MusicAssistant) -> None:
+    """A speed supplied while reporting progress is stored and read back."""
+    user = await mass.webserver.auth.create_user("speeduser_persist")
+    book = _audiobook()
+
+    await mass.music.mark_item_played(
+        book,
+        fully_played=False,
+        seconds_played=100,
+        userid=user.user_id,
+        user_initiated=False,
+        playback_speed=1.5,
+    )
+
+    assert await mass.music.get_playback_speed(book, userid=user.user_id) == 1.5
+
+
+async def test_progress_sync_preserves_stored_speed(mass: MusicAssistant) -> None:
+    """A speed-less progress write (e.g. a provider sync) must not reset the speed."""
+    user = await mass.webserver.auth.create_user("speeduser_preserve")
+    book = _audiobook()
+
+    # listener sets a custom speed (as MA's own report path does)
+    await mass.music.mark_item_played(
+        book,
+        fully_played=False,
+        seconds_played=100,
+        userid=user.user_id,
+        user_initiated=False,
+        playback_speed=1.5,
+    )
+    # a later progress update without a speed (e.g. Audiobookshelf/gpodder sync)
+    await mass.music.mark_item_played(
+        book,
+        fully_played=False,
+        seconds_played=200,
+        userid=user.user_id,
+        user_initiated=False,
+    )
+
+    # speed preserved, while the resume position still advanced
+    assert await mass.music.get_playback_speed(book, userid=user.user_id) == 1.5
+    row = await mass.music.database.get_row(
+        DB_TABLE_PLAYLOG,
+        {
+            "item_id": book.item_id,
+            "provider": "library",
+            "media_type": MediaType.AUDIOBOOK.value,
+            "userid": user.user_id,
+        },
+    )
+    assert row is not None
+    assert row["seconds_played"] == 200


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The playback speed a listener picks for an audiobook or podcast episode was only stored on the in-memory queue item, so re-queuing the same title from the library (which users experience as "resuming") created fresh queue items and reset the speed to 1.0x, even though the resume position was restored.

Persist the speed in the playlog table alongside the resume position:

- add a `playback_speed` column to the playlog table (+ migration)
- mark_item_played accepts an optional `playback_speed` and writes it; when a speed-less writer rewrites the row (e.g. an Audiobookshelf/gpodder progress sync) the previously stored speed is preserved instead of being reset by the INSERT OR REPLACE
- the queue reports the current speed when logging audiobook/episode progress
- on starting a freshly queued audiobook/episode, restore the stored speed onto the queue item (in-session items keep their own speed)

Absence of a stored value always means normal speed (1.0).

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
