### PR TITLE
Avoid loading aiortc/PyAV when remote access is disabled

### DIFF
--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -16,11 +16,10 @@ from mashumaro import DataClassDictMixin
 from music_assistant_models.enums import EventType
 
 from music_assistant.constants import CONF_CORE
-from music_assistant.controllers.webserver.remote_access.gateway import WebRTCGateway
 from music_assistant.helpers.util import format_ip_for_url
 from music_assistant.helpers.webrtc_certificate import (
+    get_or_create_remote_id,
     get_or_create_webrtc_certificate,
-    get_remote_id_from_certificate,
 )
 
 if TYPE_CHECKING:
@@ -28,6 +27,7 @@ if TYPE_CHECKING:
     from music_assistant_models.event import MassEvent
 
     from music_assistant.controllers.webserver import WebserverController
+    from music_assistant.controllers.webserver.remote_access.gateway import WebRTCGateway
     from music_assistant.providers.hass import HomeAssistantProvider
 
 # Signaling server URL
@@ -69,9 +69,9 @@ class RemoteAccessManager:
 
     async def setup(self) -> None:
         """Initialize the remote access manager."""
-        self._certificate = get_or_create_webrtc_certificate(self.mass.storage_path)
-
-        self._remote_id = get_remote_id_from_certificate(self._certificate)
+        # derive the Remote ID without importing aiortc, so a disabled instance keeps
+        # aiortc/PyAV (~51MB) out of memory while the remote_access/info endpoint still works
+        self._remote_id = get_or_create_remote_id(self.mass.storage_path)
 
         enabled_value = self.mass.config.get(f"{CONF_CORE}/{CONF_KEY_MAIN}/{CONF_ENABLED}", False)
         self._enabled = bool(enabled_value)
@@ -106,6 +106,14 @@ class RemoteAccessManager:
         if not self._enabled:
             self.logger.debug("Remote access disabled, skipping start")
             return
+
+        # imported here (and the certificate built here) so aiortc/PyAV is only
+        # loaded when remote access is actually enabled, never at idle
+        from music_assistant.controllers.webserver.remote_access.gateway import (  # noqa: PLC0415
+            WebRTCGateway,
+        )
+
+        self._certificate = get_or_create_webrtc_certificate(self.mass.storage_path)
 
         base_url = self.mass.webserver.base_url
         local_ws_url = base_url.replace("http", "ws")

--- a/music_assistant/helpers/webrtc_certificate.py
+++ b/music_assistant/helpers/webrtc_certificate.py
@@ -12,13 +12,16 @@ import logging
 import stat
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from aiortc import RTCConfiguration, RTCPeerConnection
-from aiortc.rtcdtlstransport import RTCCertificate
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import NameOID
+
+if TYPE_CHECKING:
+    from aiortc import RTCConfiguration, RTCPeerConnection
+    from aiortc.rtcdtlstransport import RTCCertificate
 
 LOGGER = logging.getLogger(__name__)
 
@@ -133,64 +136,70 @@ def _is_certificate_valid(cert: x509.Certificate) -> bool:
     return not days_remaining < CERT_RENEWAL_THRESHOLD_DAYS
 
 
-def get_or_create_webrtc_certificate(storage_path: str) -> RTCCertificate:
-    """Get or create a persistent WebRTC DTLS certificate.
-
-    Loads an existing certificate from disk if available and valid.
-    Otherwise, generates a new certificate and saves it.
+def _get_or_create_certificate(
+    storage_path: str,
+) -> tuple[ec.EllipticCurvePrivateKey, x509.Certificate]:
+    """
+    Load a valid persisted DTLS keypair, or generate and persist a new one.
 
     :param storage_path: Directory to store/load the certificate files.
-    :return: RTCCertificate instance for use with WebRTC.
+    :return: Tuple of (private_key, certificate).
     """
     loaded = _load_certificate(storage_path)
-
-    if loaded is not None:
-        private_key, cert = loaded
-
-        if _is_certificate_valid(cert):
-            return RTCCertificate(key=private_key, cert=cert)
+    if loaded is not None and _is_certificate_valid(loaded[1]):
+        return loaded
 
     LOGGER.debug("Generating new WebRTC DTLS certificate (valid for %d days)", CERT_VALIDITY_DAYS)
     private_key, cert = _generate_certificate()
     _save_certificate(storage_path, private_key, cert)
+    return private_key, cert
 
+
+def _remote_id_from_certificate(cert: x509.Certificate) -> str:
+    """
+    Derive the deterministic Remote ID from a certificate.
+
+    :param cert: The X.509 certificate to derive the Remote ID from.
+    :return: Custom base32-encoded (with 9s instead of 2s) Remote ID string
+        (26 characters, uppercase, no-padding).
+    """
+    # SHA-256 over the DER certificate, matching aiortc's certificate_digest; take the
+    # first 128 bits and base32-encode (with 9s instead of 2s) without padding.
+    digest = cert.fingerprint(hashes.SHA256())
+    return base64.b32encode(digest[:16]).decode("ascii").rstrip("=").replace("2", "9")
+
+
+def get_or_create_webrtc_certificate(storage_path: str) -> RTCCertificate:
+    """
+    Get or create a persistent WebRTC DTLS certificate.
+
+    Loads an existing certificate from disk if available and valid, otherwise
+    generates a new certificate and saves it.
+
+    :param storage_path: Directory to store/load the certificate files.
+    :return: RTCCertificate instance for use with WebRTC.
+    """
+    # imported here so importing this module never pulls in aiortc/PyAV (~51MB);
+    # only the (rarely-used) WebRTC paths actually need it
+    from aiortc.rtcdtlstransport import RTCCertificate  # noqa: PLC0415
+
+    private_key, cert = _get_or_create_certificate(storage_path)
     return RTCCertificate(key=private_key, cert=cert)
 
 
-def _get_certificate_fingerprint(certificate: RTCCertificate) -> str:
-    """Get the SHA-256 fingerprint of a certificate.
-
-    :param certificate: The RTCCertificate to get the fingerprint for.
-    :return: SHA-256 fingerprint as colon-separated hex string (e.g., "A1:B2:C3:...").
+def get_or_create_remote_id(storage_path: str) -> str:
     """
-    fingerprints = certificate.getFingerprints()
-    for fp in fingerprints:
-        if fp.algorithm == "sha-256":
-            return fp.value
-    raise ValueError("SHA-256 fingerprint not found in certificate")
+    Return the stable Remote ID for this instance without importing aiortc.
 
+    Loads (or creates and persists) the WebRTC DTLS certificate and derives the
+    Remote ID from it, so the always-on remote_access/info endpoint can report the
+    Remote ID even when remote access is disabled and aiortc was never loaded.
 
-def get_remote_id_from_certificate(certificate: RTCCertificate) -> str:
-    """Generate a remote ID from the certificate fingerprint.
-
-    Uses base32-encoded 128-bit truncation of the SHA-256 fingerprint.
-    This creates a deterministic remote ID tied to the certificate.
-
-    :param certificate: The RTCCertificate to derive the remote ID from.
-    :return: Custom base32-encoded (with 9s instead of 2s) remote ID string
-        (26 characters, uppercase, no-padding).
+    :param storage_path: Directory to store/load the certificate files.
+    :return: The Remote ID derived from the persistent certificate.
     """
-    fingerprint = _get_certificate_fingerprint(certificate)
-
-    # Parse the colon-separated hex fingerprint to bytes
-    # Format: "A1:B2:C3:D4:..." -> bytes
-    fingerprint_bytes = bytes.fromhex(fingerprint.replace(":", ""))
-
-    # Take first 128 bits (16 bytes) of SHA-256
-    truncated = fingerprint_bytes[:16]
-
-    # Base32 encode (with 9s instead of 2s) and return (uppercase) without padding
-    return base64.b32encode(truncated).decode("ascii").rstrip("=").replace("2", "9")
+    _, cert = _get_or_create_certificate(storage_path)
+    return _remote_id_from_certificate(cert)
 
 
 def create_peer_connection_with_certificate(
@@ -203,6 +212,8 @@ def create_peer_connection_with_certificate(
     :param configuration: Optional RTCConfiguration with ICE servers.
     :return: RTCPeerConnection configured with the provided certificate.
     """
+    from aiortc import RTCPeerConnection  # noqa: PLC0415
+
     pc = RTCPeerConnection(configuration=configuration)
     # Replace the auto-generated certificate with our persistent one
     # Uses name-mangled private attribute access

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1,5 +1,6 @@
 """Tests for remote access feature."""
 
+import base64
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -13,8 +14,8 @@ from music_assistant.controllers.webserver.remote_access.gateway import (
 )
 from music_assistant.helpers.webrtc_certificate import (
     _generate_certificate,
+    _remote_id_from_certificate,
     create_peer_connection_with_certificate,
-    get_remote_id_from_certificate,
 )
 
 
@@ -32,15 +33,32 @@ def mock_certificate() -> Mock:
     return cert
 
 
-async def test_get_remote_id_from_certificate(mock_certificate: Mock) -> None:
-    """Test remote ID generation from certificate fingerprint."""
-    remote_id = get_remote_id_from_certificate(mock_certificate)
+async def test_remote_id_from_certificate() -> None:
+    """Test deterministic remote ID generation from a certificate."""
+    _, cert = _generate_certificate()
+    remote_id = _remote_id_from_certificate(cert)
 
     # Should be base32 encoded, uppercase, no padding
     assert remote_id.isalnum()
     assert remote_id == remote_id.upper()
     # 128 bits = 16 bytes -> 26 base32 chars (without padding)
     assert len(remote_id) == 26
+    # deterministic: the same certificate always yields the same id
+    assert _remote_id_from_certificate(cert) == remote_id
+
+
+async def test_remote_id_matches_aiortc_fingerprint() -> None:
+    """The aiortc-free remote ID must match aiortc's own certificate fingerprint derivation."""
+    private_key, cert = _generate_certificate()
+    rtc_cert = RTCCertificate(key=private_key, cert=cert)
+    fingerprint = next(fp.value for fp in rtc_cert.getFingerprints() if fp.algorithm == "sha-256")
+    expected = (
+        base64.b32encode(bytes.fromhex(fingerprint.replace(":", ""))[:16])
+        .decode("ascii")
+        .rstrip("=")
+        .replace("2", "9")
+    )
+    assert _remote_id_from_certificate(cert) == expected
 
 
 async def test_remote_access_info_dataclass() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`aiortc` + PyAV (~51MB resident) were loaded at idle on every install, even though remote access is disabled by default. The webserver controller imports the `remote_access` module, which imported `gateway` (→ `aiortc`) and `webrtc_certificate` (→ `aiortc`) at module top, and `setup()` then built an `RTCCertificate` unconditionally — so the import happened regardless of the `enabled` setting.

The Remote ID exposed by the always-on `remote_access/info` endpoint is just a base32 truncation of the certificate's SHA-256 fingerprint, which `cryptography` (already a dependency) can compute without `aiortc`. So the certificate/gateway machinery only needs to load when remote access is actually enabled.

- Derive the Remote ID with `cryptography` only (`get_or_create_remote_id`), so `setup()` no longer touches `aiortc`. The value is byte-for-byte identical to the previous `aiortc`-based derivation (a regression test locks this in).
- Move the `aiortc` imports in `webrtc_certificate.py` to function scope, and build the `RTCCertificate` lazily.
- Import `WebRTCGateway` and build the certificate inside `_start_gateway()`, which only runs when remote access is enabled.

Result: with remote access disabled (the default), `aiortc`/`av` are no longer imported at idle (verified: importing the webserver controller leaves both out of `sys.modules`).

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
