### PR TITLE
Make SQLite page-cache and mmap RAM-aware

### DIFF
--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -93,6 +93,44 @@ def query_params(query: str, params: dict[str, Any] | None) -> tuple[str, dict[s
     return (result_query, result_params)
 
 
+def get_sqlite_memory_settings() -> tuple[int, int]:
+    """
+    Return (cache_size_kib, mmap_size_bytes) scaled to available system memory.
+
+    The page cache is a per-connection ceiling that is filled lazily, so a small database
+    never consumes a large ceiling. Hosts with ample RAM keep the previous generous values
+    (and a much bigger cache on very large hosts) so performance is unaffected — only memory-
+    constrained devices are scaled down. Returns the generous defaults when memory is
+    unknown (e.g. Windows), so those hosts fail open to full performance.
+    """
+    # imported lazily to keep this low-level helper free of the heavier util import chain
+    from music_assistant.helpers.util import get_total_system_memory  # noqa: PLC0415
+
+    # SQLite caps mmap_size at its build-time SQLITE_MAX_MMAP_SIZE (~2GiB), so the previous
+    # 30GB request was already effectively ~2GiB. We keep that ceiling on capable hosts and
+    # only request less on memory-constrained devices (where a large DB would otherwise map
+    # most of the file into reclaimable RSS). The page cache is the only fast path for the
+    # part of a database beyond that ~2GiB window, so hosts with lots of RAM get a much larger
+    # cache to keep a very large library hot.
+    gib = 1024**3
+    total_ram_gb = get_total_system_memory()
+    if total_ram_gb >= 16.0:
+        # very large host: cache enough to keep a multi-GB library hot in memory
+        return 1024000, 2 * gib
+    if total_ram_gb >= 12.0:
+        return 512000, 2 * gib
+    if total_ram_gb >= 8.0:
+        # plenty of RAM: favour performance with a larger page cache
+        return 128000, 2 * gib
+    if total_ram_gb == 0.0 or total_ram_gb >= 4.0:
+        # unknown (fail open) or capable: keep the previous 64MB cache and ~2GiB mmap ceiling
+        return 64000, 2 * gib
+    if total_ram_gb >= 2.0:
+        return 32000, gib
+    # memory-constrained device: keep each connection's footprint small
+    return 16000, 256 * 1024 * 1024
+
+
 class DatabaseConnection:
     """Class that holds the (connection to the) database with some convenience helper functions."""
 
@@ -102,8 +140,27 @@ class DatabaseConnection:
         """Initialize class."""
         self.db_path = db_path
 
-    async def setup(self) -> None:
-        """Perform async initialization."""
+    async def setup(
+        self,
+        cache_size_kib: int | None = None,
+        mmap_size_bytes: int | None = None,
+    ) -> None:
+        """
+        Perform async initialization.
+
+        :param cache_size_kib: SQLite page-cache ceiling for this connection, in KiB.
+            Defaults to a value scaled to the host's available memory.
+        :param mmap_size_bytes: SQLite memory-map ceiling for this connection, in bytes.
+            Defaults to a value scaled to the host's available memory.
+        """
+        default_cache_kib, default_mmap_bytes = get_sqlite_memory_settings()
+        # coerce + clamp to non-negative ints so the values are always safe to interpolate
+        cache_size_kib = max(
+            0, int(default_cache_kib if cache_size_kib is None else cache_size_kib)
+        )
+        mmap_size_bytes = max(
+            0, int(default_mmap_bytes if mmap_size_bytes is None else mmap_size_bytes)
+        )
         self._db = await aiosqlite.connect(self.db_path)
         self._db.row_factory = aiosqlite.Row
         # setup some default settings for more performance
@@ -113,8 +170,8 @@ class DatabaseConnection:
         await self.execute("PRAGMA journal_size_limit = 6144000;")
         await self.execute("PRAGMA synchronous=normal;")
         await self.execute("PRAGMA temp_store=memory;")
-        await self.execute("PRAGMA mmap_size = 30000000000;")
-        await self.execute("PRAGMA cache_size = -64000;")
+        await self.execute(f"PRAGMA mmap_size = {mmap_size_bytes};")
+        await self.execute(f"PRAGMA cache_size = -{cache_size_kib};")
         await self.commit()
 
     async def close(self) -> None:

--- a/tests/core/test_database_connection.py
+++ b/tests/core/test_database_connection.py
@@ -8,8 +8,10 @@ from typing import Any
 
 import pytest
 
-from music_assistant.helpers.database import DatabaseConnection
+from music_assistant.helpers.database import DatabaseConnection, get_sqlite_memory_settings
 from music_assistant.mass import MusicAssistant
+
+GIB = 1024**3
 
 # PRAGMA temp_store integer values (sqlite docs)
 TEMP_STORE_FILE = 1
@@ -27,6 +29,13 @@ async def db_connection(tmp_path: pathlib.Path) -> AsyncGenerator[DatabaseConnec
 
 async def _get_temp_store(db: DatabaseConnection) -> int:
     async with db._db.execute("PRAGMA temp_store") as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+async def _read_pragma_int(db: DatabaseConnection, pragma: str) -> int:
+    async with db._db.execute(f"PRAGMA {pragma}") as cursor:
         row = await cursor.fetchone()
     assert row is not None
     return int(row[0])
@@ -90,3 +99,55 @@ def test_sqlite_tmpdir_respects_existing_value(
     monkeypatch.setenv("SQLITE_TMPDIR", "/custom/tmp")
     MusicAssistant(str(tmp_path / "data"), str(tmp_path / "cache"))
     assert os.environ["SQLITE_TMPDIR"] == "/custom/tmp"
+
+
+@pytest.mark.parametrize(
+    ("total_ram_gb", "expected_cache_kib", "expected_mmap_bytes"),
+    [
+        (0.0, 64000, 2 * GIB),  # unknown -> fail open to the generous "capable" tier
+        (1.0, 16000, 256 * 1024 * 1024),
+        (2.0, 32000, GIB),
+        (4.0, 64000, 2 * GIB),  # capable: unchanged from the previous 64MB cache
+        (8.0, 128000, 2 * GIB),  # plenty of RAM: larger cache for performance
+        (12.0, 512000, 2 * GIB),  # large host: keep a big library hot
+        (16.0, 1024000, 2 * GIB),  # very large host
+        (32.0, 1024000, 2 * GIB),
+    ],
+)
+def test_sqlite_memory_settings_scale_with_ram(
+    monkeypatch: pytest.MonkeyPatch,
+    total_ram_gb: float,
+    expected_cache_kib: int,
+    expected_mmap_bytes: int,
+) -> None:
+    """Test that the SQLite cache/mmap ceilings scale with available system memory."""
+    monkeypatch.setattr(
+        "music_assistant.helpers.util.get_total_system_memory", lambda: total_ram_gb
+    )
+    assert get_sqlite_memory_settings() == (expected_cache_kib, expected_mmap_bytes)
+
+
+async def test_setup_applies_ram_scaled_pragmas(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that setup() applies the RAM-scaled cache_size/mmap_size pragmas by default."""
+    # use the 2-4GB tier so the 1GiB mmap stays below SQLite's ~2GiB build cap and reads back
+    monkeypatch.setattr("music_assistant.helpers.util.get_total_system_memory", lambda: 2.0)
+    db = DatabaseConnection(str(tmp_path / "scaled.db"))
+    await db.setup()
+    try:
+        assert await _read_pragma_int(db, "cache_size") == -32000
+        assert await _read_pragma_int(db, "mmap_size") == GIB
+    finally:
+        await db.close()
+
+
+async def test_setup_clamps_pragma_values(tmp_path: pathlib.Path) -> None:
+    """Test that setup() clamps explicit cache/mmap values to non-negative integers."""
+    db = DatabaseConnection(str(tmp_path / "clamped.db"))
+    await db.setup(cache_size_kib=-50, mmap_size_bytes=-1)
+    try:
+        assert await _read_pragma_int(db, "cache_size") == 0
+        assert await _read_pragma_int(db, "mmap_size") == 0
+    finally:
+        await db.close()


### PR DESCRIPTION
# What does this implement/fix?

Every long-lived database connection (`library.db`, `cache.db`, `auth.db`) ran the same fixed pragmas regardless of the host's RAM: `PRAGMA cache_size = -64000` (a 64MB page-cache ceiling per connection) and `PRAGMA mmap_size = 30000000000`. The intent is good on capable hardware but doesn't adapt either way — it neither shrinks on constrained devices nor takes advantage of hosts with plenty of RAM and a very large library.

This makes both ceilings scale with available system memory, applied as the default in `DatabaseConnection.setup()` so every connection benefits without per-caller wiring.

`get_sqlite_memory_settings()` returns `(cache_size_kib, mmap_size_bytes)` based on `get_total_system_memory()` (which already honors cgroup limits):

| Total RAM | `cache_size` | Notes |
| --- | --- | --- |
| ≥16GB | ~1GB | keep a multi-GB library hot |
| ≥12GB | ~512MB | large library headroom |
| ≥8GB | ~128MB | bump over the previous 64MB |
| ≥4GB / unknown | 64MB | **unchanged** (unknown fails open) |
| 2–4GB | 32MB | scaled down |
| <2GB | 16MB | scaled down |

- The page cache is a *lazily-filled* ceiling, so a small database (e.g. `auth.db`) never consumes a large ceiling — which is why one uniform setting is fine and no per-database cap is needed.
- `mmap_size`: SQLite caps it at its build-time `SQLITE_MAX_MMAP_SIZE` (~2GiB), so the old 30GB request was *already* effectively ~2GiB. That means the page cache is the only fast path for the part of a database **beyond** ~2GiB — which is exactly why the larger cache tiers matter for very large libraries. The ~2GiB mmap ceiling is kept on capable hosts (no change) and only reduced on constrained devices, where a multi-GB database would otherwise map most of its file into (reclaimable) RSS.
- PRAGMA values are coerced to non-negative ints before interpolation.

Net effect: no change for ≥4GB hosts, a larger cache on hosts with more RAM (helping very large libraries), and a smaller footprint only on memory-constrained devices.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

