### PR TITLE
Release drained audio buffers in the inactivity monitor

### DIFF
--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -645,14 +645,22 @@ class AudioBuffer:
             loop = asyncio.get_running_loop()
             self._inactivity_task = loop.create_task(self._monitor_inactivity())
 
-    async def _monitor_inactivity(self) -> None:
-        """Clear the buffer if inactive for 5 minutes."""
-        inactivity_timeout = 60 * 5
-        check_interval = 30
+    async def _monitor_inactivity(
+        self, inactivity_timeout: float = 300, check_interval: float = 30
+    ) -> None:
+        """
+        Clear the buffer once it has been inactive for inactivity_timeout seconds.
+
+        :param inactivity_timeout: Seconds without access before the buffer is released.
+        :param check_interval: Seconds between inactivity checks.
+        """
         while True:
             await asyncio.sleep(check_interval)
             time_since_access = time.time() - self._last_access_time
-            if len(self._chunks) > 0 and time_since_access > inactivity_timeout:
+            # break on inactivity regardless of how many chunks remain: a rolling buffer
+            # that has drained to empty (e.g. an abandoned radio stream) must still release
+            # its resources and stop this monitor, otherwise the task loops forever
+            if time_since_access > inactivity_timeout:
                 LOGGER.log(
                     VERBOSE_LOG_LEVEL,
                     "AudioBuffer: No activity for %.1fs, clearing (%s chunks)",

--- a/tests/core/test_audio_buffer.py
+++ b/tests/core/test_audio_buffer.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 
 import pytest
 from music_assistant_models.enums import ContentType
@@ -584,3 +586,44 @@ async def test_clear_fires_cancel_callbacks() -> None:
     assert cancel_called is True
     assert len(buf._chunk_callbacks) == 0
     assert len(buf._cancel_callbacks) == 0
+
+
+# -- Inactivity monitor --
+
+
+@pytest.mark.asyncio
+async def test_inactivity_monitor_releases_drained_buffer() -> None:
+    """
+    A buffer that has drained to empty is still released by the inactivity monitor.
+
+    Regression test: the monitor previously only cleared when chunks remained, so an
+    abandoned rolling buffer that drained to zero chunks looped forever and leaked it
+    (and its producer/ffmpeg) until the process exited.
+    """
+    buf = AudioBuffer(TEST_PCM_FORMAT, mode=BufferMode.ROLLING)
+    # no chunks buffered and last access long ago -> the buffer is inactive
+    assert buf.size_seconds == 0
+    buf._last_access_time = time.time() - 10_000
+
+    await buf._monitor_inactivity(inactivity_timeout=0.01, check_interval=0.01)
+
+    assert buf.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_inactivity_monitor_keeps_active_buffer() -> None:
+    """A buffer that is still being accessed is not cleared by the inactivity monitor."""
+    buf = AudioBuffer(TEST_PCM_FORMAT, mode=BufferMode.ROLLING)
+    buf._last_access_time = time.time()
+
+    monitor = asyncio.create_task(
+        buf._monitor_inactivity(inactivity_timeout=5, check_interval=0.01)
+    )
+    await asyncio.sleep(0.05)
+
+    assert not monitor.done()
+    assert buf.cancelled is False
+
+    monitor.cancel()
+    with suppress(asyncio.CancelledError):
+        await monitor


### PR DESCRIPTION
# What does this implement/fix?

The `AudioBuffer` inactivity monitor releases an idle buffer (and cancels its producer, which tears down the ffmpeg subprocess) after 5 minutes without access. Its exit condition required chunks to still be present:

```python
if len(self._chunks) > 0 and time_since_access > inactivity_timeout:
```

A ROLLING/abandoned buffer that reaches EOF and drains to **zero** chunks — e.g. an internet-radio stream whose consumer disconnects without an explicit stop — never satisfies that guard, so the monitor task wakes every 30s forever and keeps the `AudioBuffer`, its registered callbacks, and (for a live source) the producer/ffmpeg subprocess resident until the process exits.

- Break on inactivity regardless of how many chunks remain, then clear. This is safe because `_last_access_time` is refreshed on every read (`get_raw_stream`) and on `is_valid()`, so an actively-consumed buffer never reaches the timeout.
- Make the timeout/check interval parameters of `_monitor_inactivity` (replacing the inline magic numbers) so the behavior is unit-testable; defaults are unchanged (300s / 30s).
- Add regression tests: a drained/empty buffer is released, and an actively-accessed buffer is not.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
