### PR TITLE
Cut repeated reflection on hot cache-hit and event-dispatch paths

### DIFF
--- a/music_assistant/controllers/cache/helpers.py
+++ b/music_assistant/controllers/cache/helpers.py
@@ -78,9 +78,8 @@ def use_cache(
         def _reconstruct(cachedata: Any) -> R:
             if base_class is not None:
                 return cast("R", cachedata)
-            # fallback: reconstruct using type annotations
-            type_hints = get_type_hints(func)
-            return cast("R", parse_value(func.__name__, cachedata, type_hints["return"]))
+            # fallback: reconstruct using the (memoized) return-type annotation
+            return cast("R", parse_value(func.__name__, cachedata, _resolve_return_hint(func)))
 
         @functools.wraps(func)
         async def wrapper(self: ProviderT, *args: P.args, **kwargs: P.kwargs) -> R:
@@ -156,3 +155,18 @@ def use_cache(
         return wrapper
 
     return _decorator
+
+
+@functools.cache
+def _resolve_return_hint(func: Callable[..., Any]) -> Any:
+    """
+    Return the resolved return-type annotation of func, memoized per function.
+
+    A function's return annotation is invariant for the process lifetime, so it is resolved
+    once and cached instead of re-running get_type_hints() — which re-evaluates the PEP-563
+    string annotations — on every cache hit. Resolution stays lazy (it happens on the first
+    hit, not at decoration time), so forward-reference handling is unchanged.
+
+    :param func: The decorated function whose return-type annotation to resolve.
+    """
+    return get_type_hints(func)["return"]

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -82,7 +82,7 @@ rename = wrap(os.rename)
 
 EventCallBackType = Callable[[MassEvent], None] | Callable[[MassEvent], Coroutine[Any, Any, None]]
 EventSubscriptionType = tuple[
-    EventCallBackType, tuple[EventType, ...] | None, tuple[str, ...] | None
+    EventCallBackType, tuple[EventType, ...] | None, tuple[str, ...] | None, bool
 ]
 
 LOGGER = logging.getLogger(MASS_LOGGER_NAME)
@@ -511,12 +511,12 @@ class MusicAssistant:
             LOGGER.getChild("event").log(VERBOSE_LOG_LEVEL, "%s %s", event.value, object_id or "")
 
         event_obj = MassEvent(event=event, object_id=object_id, data=data)
-        for cb_func, event_filter, id_filter in list(self._subscribers):
+        for cb_func, event_filter, id_filter, is_coro in list(self._subscribers):
             if not (event_filter is None or event in event_filter):
                 continue
             if not (id_filter is None or object_id in id_filter):
                 continue
-            if inspect.iscoroutinefunction(cb_func):
+            if is_coro:
                 if TYPE_CHECKING:
                     cb_func = cast("Callable[[MassEvent], Coroutine[Any, Any, None]]", cb_func)
                 self.create_task(cb_func, event_obj)
@@ -542,7 +542,9 @@ class MusicAssistant:
             event_filter = (event_filter,)
         if isinstance(id_filter, str):
             id_filter = (id_filter,)
-        listener = (cb_func, event_filter, id_filter)
+        # precompute whether the callback is a coroutine so signal_event does not have to
+        # re-derive it via reflection for every subscriber on every (high-frequency) event
+        listener = (cb_func, event_filter, id_filter, inspect.iscoroutinefunction(cb_func))
         self._subscribers.add(listener)
 
         def remove_listener() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Two hot paths re-did per-call reflection that has a constant result:

1. **`@use_cache` re-resolved type hints on every cache hit.** When no `base_class` is given (the vast majority of the ~376 decorated sites), `_reconstruct` called `typing.get_type_hints(func)` on every hit. Providers use `from __future__ import annotations`, so this re-evaluates the PEP-563 string annotations against module globals each time (~10–25µs/call), even though a function's return annotation never changes. A single UI browse/search request fans out to dozens of these cached sub-calls.
2. **`signal_event` re-derived coroutine-ness per subscriber on every event.** `inspect.iscoroutinefunction(cb_func)` was called for every matching subscriber on every event, including high-frequency ones like `QUEUE_TIME_UPDATED` (~1/sec per playing queue), even though whether a callback is a coroutine is fixed when it subscribes.

- Memoize the resolved return-type annotation per function (`_resolve_return_hint`, `@functools.cache`). Resolution stays lazy (first hit, not decoration time), so forward-reference handling is unchanged.
- Precompute `iscoroutinefunction` once in `subscribe()` and store it in the listener tuple; `signal_event` branches on the stored flag instead of calling `inspect` per subscriber.

Both are behaviour-preserving; the cost is paid during active browse/search and playback, not at idle.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
