### PR TITLE
Support common-string references in the translations build

### DIFF
--- a/scripts/build_translations.py
+++ b/scripts/build_translations.py
@@ -6,6 +6,13 @@ per-provider/per-controller strings.json) into one flat, fully-qualified ``key -
 JSON at ``music_assistant/translations/en.json``. ``lokalise-upload.yml`` pushes that file to
 Lokalise; ``lokalise-download.yml`` pulls the translated languages back into translations/.
 
+A string value may reference another (typically shared ``common.``) string with the Home
+Assistant style token ``[%key:owner::path::to::key%]`` (``::`` separates the dotted key
+segments). Such a reference declares that an owner reuses a shared string: the target is
+validated to exist and the referencing key is omitted from the generated source, so Lokalise
+translates the shared string once while the server resolves the owner's key at runtime via its
+owner -> common fallback.
+
 Standalone (no ``music_assistant`` imports) so it runs under any music-assistant-models version
 and without the full server import chain.
 
@@ -17,6 +24,7 @@ Usage:
 from __future__ import annotations
 
 import os
+import re
 import sys
 from typing import Any
 
@@ -36,16 +44,18 @@ ROOT_STRINGS_FILE = os.path.join(PACKAGE_ROOT, "strings.json")
 SOURCE_LANGUAGE = "en"
 SOURCE_FILE = os.path.join(TRANSLATIONS_PATH, f"{SOURCE_LANGUAGE}.json")
 COMMON_PREFIX = "common."
+# Home Assistant style reference token: [%key:owner::path::to::key%] -> owner.path.to.key
+REFERENCE_PATTERN = re.compile(r"^\[%key:(.+)%\]$")
 
 
 def build_translations_source() -> dict[str, str]:
     """Assemble the flat English source from all authoring strings.json files."""
-    source: dict[str, str] = {}
+    raw: dict[str, str] = {}
     for prefix, path in _collect_source_files():
         with open(path, "rb") as file:
             data = orjson.loads(file.read())
-        _flatten_into(data, prefix, source)
-    return source
+        _flatten_into(data, prefix, raw)
+    return _resolve_references(raw)
 
 
 def _collect_source_files() -> list[tuple[str, str]]:
@@ -91,6 +101,33 @@ def _flatten_into(data: dict[str, Any], prefix: str, out: dict[str, str]) -> Non
             out[full_key] = value
 
 
+def _resolve_references(raw: dict[str, str]) -> dict[str, str]:
+    """
+    Drop reference-valued keys after validating each points at an existing concrete string.
+
+    A reference value ``[%key:owner::path::to::key%]`` declares that this key reuses a shared
+    string defined elsewhere; the referenced key stays the single translatable source, so the
+    referencing key is left out of the generated catalog (the server resolves it at runtime via
+    its owner -> common fallback).
+
+    :param raw: The flattened catalog, still containing any reference-valued keys.
+    :raises ValueError: When a reference points at a key that is not a concrete string.
+    """
+    concrete = {key: value for key, value in raw.items() if not REFERENCE_PATTERN.match(value)}
+    unresolved: list[str] = []
+    for key, value in raw.items():
+        if not (match := REFERENCE_PATTERN.match(value)):
+            continue
+        target = match.group(1).replace("::", ".")
+        if target not in concrete:
+            unresolved.append(f"{key} -> {target}")
+    if unresolved:
+        raise ValueError(
+            "Unresolved translation reference target(s): " + ", ".join(sorted(unresolved))
+        )
+    return concrete
+
+
 def _render(catalog: dict[str, str]) -> bytes:
     """Render the catalog as deterministic, sorted, indented JSON."""
     return orjson.dumps(
@@ -101,7 +138,12 @@ def _render(catalog: dict[str, str]) -> bytes:
 
 def main() -> int:
     """Generate (or, with --check, validate) the Lokalise source file."""
-    rendered = _render(build_translations_source())
+    try:
+        source = build_translations_source()
+    except ValueError as err:
+        print(str(err), file=sys.stderr)
+        return 1
+    rendered = _render(source)
     if "--check" in sys.argv[1:]:
         existing = b""
         if os.path.isfile(SOURCE_FILE):
@@ -118,7 +160,7 @@ def main() -> int:
     os.makedirs(TRANSLATIONS_PATH, exist_ok=True)
     with open(SOURCE_FILE, "wb") as file:
         file.write(rendered)
-    print(f"Wrote {len(build_translations_source())} source strings to {SOURCE_FILE}")
+    print(f"Wrote {len(source)} source strings to {SOURCE_FILE}")
     return 0
 
 

--- a/tests/core/test_translations.py
+++ b/tests/core/test_translations.py
@@ -28,7 +28,11 @@ from music_assistant.controllers.translations import (
     _format,
     _locale_candidates,
 )
-from scripts.build_translations import _flatten_into, build_translations_source
+from scripts.build_translations import (
+    _flatten_into,
+    _resolve_references,
+    build_translations_source,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -65,6 +69,30 @@ def test_flatten_into() -> None:
         "provider.ytmusic.config_entries.cookie.description": "From a session.",
         "provider.ytmusic.media.mixes": "Your Mixes",
     }
+
+
+def test_resolve_references_validated_and_omitted() -> None:
+    """A reference reuses an existing string: its target is validated and the key is omitted."""
+    resolved = _resolve_references(
+        {
+            "common.media.recommendations.recommended_tracks.name": "Recommended tracks",
+            "provider.deezer.media.recommendations.recommended_tracks.name": (
+                "[%key:common::media::recommendations::recommended_tracks::name%]"
+            ),
+        }
+    )
+    # the shared (target) string stays; the referencing key is dropped (resolved via the fallback)
+    assert resolved == {
+        "common.media.recommendations.recommended_tracks.name": "Recommended tracks",
+    }
+
+
+def test_resolve_references_missing_target_raises() -> None:
+    """A reference whose target does not exist fails the build with a clear error."""
+    with pytest.raises(ValueError, match="Unresolved translation reference"):
+        _resolve_references(
+            {"provider.deezer.media.x.name": "[%key:common::media::does::not::exist%]"}
+        )
 
 
 def test_candidate_keys_common_rewrite() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Several providers and core controllers use a `translation_key` that is **not** defined in their own `strings.json` and only exists in the shared `common` strings, relying on a silent runtime fallback to `common`. That coupling is invisible and unenforced, so a renamed or removed common key breaks them quietly.

This adds the foundation for the Home Assistant style reference pattern, where a `strings.json` declares its own key and points it at a shared string instead of duplicating the English text or relying on the silent fallback.

- `build_translations.py` now resolves `[%key:owner::path::to::key%]` reference tokens: it validates the referenced target exists and omits the referencing key from `en.json`, so a shared string is uploaded to Lokalise (and translated) only once.
- The build fails with a clear error when a reference target does not exist.
- Added tests for reference resolution and the missing-target failure.

No runtime or `en.json` output change yet (no references exist today) — this is the building block for the follow-up PRs that move owner-specific keys out of `common` and convert the remaining `common` reliances into explicit references.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
