### PR TITLE
Add Nix development shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,88 @@
+{
+  description = "Music Assistant development shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          python = pkgs.python314;
+
+          commonPackages = with pkgs; [
+            ffmpeg
+            git
+            pkg-config
+            python
+            uv
+          ];
+
+          buildPackages = with pkgs; [
+            stdenv.cc
+          ];
+
+          nativeLibraries = with pkgs; [
+            bzip2
+            chromaprint
+            curl
+            expat
+            ffmpeg
+            libffi
+            libsndfile
+            openssl
+            portaudio
+            sqlite
+            stdenv.cc.cc.lib
+            zlib
+            zstd
+          ] ++ lib.optionals stdenv.isLinux [
+            alsa-lib
+            avahi
+            json_c
+            libconfuse
+            libgcrypt
+            libplist
+            libpulseaudio
+            libsodium
+            libunistring
+            libuuid
+            nfs-utils
+            util-linux
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            packages = commonPackages ++ buildPackages ++ nativeLibraries;
+
+            env = {
+              UV_PROJECT_ENVIRONMENT = ".venv";
+              LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath nativeLibraries;
+            };
+
+            shellHook = ''
+              echo "Music Assistant dev shell"
+              echo "Python: $(${python}/bin/python --version)"
+              if [ -f .venv/bin/activate ]; then
+                source .venv/bin/activate
+                echo "Activated .venv"
+              else
+                echo "Run scripts/setup.sh once, then pytest to run tests."
+              fi
+            '';
+          };
+        });
+    };
+}


### PR DESCRIPTION
# What does this implement/fix?
Adds a Nix flake development shell. The shell provides Python 3.14, `uv`, `ffmpeg`, native build/runtime libraries, and automatic `.venv` activation.  This is very much like venv, but for more than just python. On my system I don't have all of the development dependencies installed globally, this creates a shell that gives me everything I need to run tests. Other Nix users would appreciate this.
**Related issue (if applicable):**
- related issue N/A
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
## Checklist
- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.