### PR TITLE
Admit genuine 4GB hosts via a shared RAM reporting tolerance

### DIFF
--- a/music_assistant/controllers/streams/constants.py
+++ b/music_assistant/controllers/streams/constants.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Final
 
-from music_assistant.helpers.util import get_total_system_memory
+from music_assistant.helpers.util import get_total_system_memory, meets_memory_target
 
 
 class BufferMode(StrEnum):
@@ -26,12 +26,12 @@ class BufferSize(StrEnum):
 # Calculate total system memory once at module load time
 TOTAL_SYSTEM_MEMORY_GB: Final[float] = get_total_system_memory()
 
-# RAM thresholds (in GB) for the buffer-size presets. Balanced needs >= 4GB.
-# Maximum uses 7GB rather than a literal 8GB so machines marketed as "8GB" that
-# report slightly less still qualify for the largest buffer: integrated GPUs carve
-# out shared system memory, and container runtimes report their cgroup limit.
+# RAM thresholds for the buffer-size presets, as NOMINAL targets. Both are checked via
+# meets_memory_target(), which absorbs the gap between a host's nominal size and what it
+# reports (kernel MemTotal reservation plus any integrated-GPU carve-out), so a "4GB" box
+# (reporting ~3.8GB) and an "8GB" box (reporting ~7.4GB) both qualify for their tier.
 BALANCED_MIN_RAM_GB: Final[float] = 4.0
-MAXIMUM_MIN_RAM_GB: Final[float] = 7.0
+MAXIMUM_MIN_RAM_GB: Final[float] = 8.0
 
 # Buffer size in seconds for each preset
 BUFFER_SIZE_MAP: Final[dict[str, int]] = {
@@ -52,23 +52,29 @@ def get_available_buffer_sizes() -> list[BufferSize]:
     """
     Return the buffer-size presets allowed for this host's RAM.
 
-    Minimal is always available; Balanced requires >= 4GB and Maximum >= 7GB. When total
-    memory is unknown (0.0, e.g. Windows) all presets are offered (fail open).
+    Minimal is always available; Balanced needs ~4GB and Maximum ~8GB (both within the
+    reporting tolerance). When total memory is unknown (0.0, e.g. Windows) all presets are
+    offered (fail open).
     """
     if TOTAL_SYSTEM_MEMORY_GB == 0.0:
         return [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]
     sizes = [BufferSize.MINIMAL]
-    if TOTAL_SYSTEM_MEMORY_GB >= BALANCED_MIN_RAM_GB:
+    if meets_memory_target(TOTAL_SYSTEM_MEMORY_GB, BALANCED_MIN_RAM_GB):
         sizes.append(BufferSize.BALANCED)
-    if TOTAL_SYSTEM_MEMORY_GB >= MAXIMUM_MIN_RAM_GB:
+    if meets_memory_target(TOTAL_SYSTEM_MEMORY_GB, MAXIMUM_MIN_RAM_GB):
         sizes.append(BufferSize.MAXIMUM)
     return sizes
 
 
 def _get_default_buffer_size() -> str:
-    if TOTAL_SYSTEM_MEMORY_GB >= MAXIMUM_MIN_RAM_GB:
+    # Unknown memory (0.0) picks the conservative Minimal default, unlike the
+    # available-presets list which fails open — meets_memory_target() also fails open,
+    # so the 0.0 case is handled explicitly here before consulting it.
+    if TOTAL_SYSTEM_MEMORY_GB == 0.0:
+        return BufferSize.MINIMAL
+    if meets_memory_target(TOTAL_SYSTEM_MEMORY_GB, MAXIMUM_MIN_RAM_GB):
         return BufferSize.MAXIMUM
-    if TOTAL_SYSTEM_MEMORY_GB >= BALANCED_MIN_RAM_GB:
+    if meets_memory_target(TOTAL_SYSTEM_MEMORY_GB, BALANCED_MIN_RAM_GB):
         return BufferSize.BALANCED
     return BufferSize.MINIMAL
 

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -310,6 +310,28 @@ def system_meets_requirements(
     return _resource_shortfall(min_memory_gb=min_memory_gb, min_cpu_cores=min_cpu_cores) is None
 
 
+# The kernel reports MemTotal — installed RAM minus firmware/reserved pages — so a host
+# always shows a little under its nominal size (a "4GB" box reports ~3.8GB). Allow this
+# fraction of slack when checking a RAM target, in one place rather than per call site, so
+# nominal requirements (4, 8 GB) match the hardware they describe without ad-hoc thresholds.
+MEMORY_REPORTING_TOLERANCE: float = 0.08
+
+
+def meets_memory_target(total_memory_gb: float, target_gb: float) -> bool:
+    """
+    Return whether reported RAM satisfies a nominal target within the reporting tolerance.
+
+    Fails open (True) when the target is 0 (no requirement) or memory is unknown
+    (0.0, e.g. Windows), so callers never block on a guess.
+
+    :param total_memory_gb: RAM reported by get_total_system_memory() in GB.
+    :param target_gb: Nominal RAM target in GB (e.g. 4 or 8).
+    """
+    if not target_gb or not total_memory_gb:
+        return True
+    return total_memory_gb >= target_gb * (1.0 - MEMORY_REPORTING_TOLERANCE)
+
+
 def _resource_shortfall(
     *, min_memory_gb: float, min_cpu_cores: int
 ) -> tuple[str, str, list[Any]] | None:
@@ -329,9 +351,9 @@ def _resource_shortfall(
             [min_cpu_cores, cpu_cores],
         )
     total_memory_gb = get_total_system_memory()
-    # get_total_system_memory() returns 0.0 when the platform cannot report memory
-    # (e.g. Windows); treat that as unknown and pass rather than block on a guess.
-    if min_memory_gb and total_memory_gb and total_memory_gb < min_memory_gb:
+    # meets_memory_target() fails open on unknown memory (0.0, e.g. Windows) and absorbs
+    # the kernel's MemTotal under-report, so min_memory_gb stays a clean nominal figure.
+    if min_memory_gb and not meets_memory_target(total_memory_gb, min_memory_gb):
         return (
             f"at least {min_memory_gb:.0f}GB of RAM is required ({total_memory_gb:.1f}GB detected).",
             "errors.unsupported_system_memory",

--- a/music_assistant/providers/smart_fades/__init__.py
+++ b/music_assistant/providers/smart_fades/__init__.py
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
 SUPPORTED_FEATURES: set[ProviderFeature] = set()
 
 # Smart Fades runs on-device ML (torch) inference; gate it to capable hardware.
-# 4GB matches the Balanced buffer threshold, the minimum buffer smart crossfade needs.
+# 4GB nominal, matching the Balanced buffer threshold (the minimum buffer smart crossfade
+# needs). The gate applies meets_memory_target()'s tolerance, so a genuine 4GB host (which
+# reports ~3.8GB after the kernel/firmware reservation) still passes.
 MIN_RAM_GB = 4.0
 MIN_CPU_CORES = 2
 # Below the recommended thresholds the provider still runs, but we surface an

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -70,6 +70,8 @@ CLAP_WINDOW_COUNTS: dict[str, int] = {
 CONF_CLAP_SAMPLING: str = "clap_sampling"
 
 # Sonic Analysis runs on-device CLAP inference; gate it to capable hardware.
+# 4GB nominal; the gate's tolerance (meets_memory_target) admits genuine 4GB hosts,
+# which report ~3.8GB after the kernel/firmware reservation.
 MIN_RAM_GB: float = 4.0
 MIN_CPU_CORES: int = 2
 # Below the recommended thresholds the provider still runs, but we surface an

--- a/tests/controllers/streams/test_buffer_size.py
+++ b/tests/controllers/streams/test_buffer_size.py
@@ -12,13 +12,18 @@ from music_assistant.controllers.streams.constants import BufferSize
     ("total_gb", "expected"),
     [
         (2.0, [BufferSize.MINIMAL]),
-        (3.9, [BufferSize.MINIMAL]),
+        (3.6, [BufferSize.MINIMAL]),
+        # "4GB" hosts that report slightly less (kernel-reserved RAM, ~3.8GB) still reach
+        # Balanced: the 4GB target is checked with the reporting tolerance (floor ~3.68GB).
+        (3.7, [BufferSize.MINIMAL, BufferSize.BALANCED]),
+        (3.8, [BufferSize.MINIMAL, BufferSize.BALANCED]),
         (4.0, [BufferSize.MINIMAL, BufferSize.BALANCED]),
         (6.0, [BufferSize.MINIMAL, BufferSize.BALANCED]),
         (6.9, [BufferSize.MINIMAL, BufferSize.BALANCED]),
-        # "8GB" hosts that report slightly less (integrated GPU / container limit)
-        # still reach Maximum thanks to the 7GB threshold.
-        (7.0, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
+        # Maximum is an 8GB nominal target on the same tolerance (floor ~7.36GB), so a 7.0GB
+        # host gets Balanced only while an "8GB" box reporting ~7.4GB+ reaches Maximum.
+        (7.0, [BufferSize.MINIMAL, BufferSize.BALANCED]),
+        (7.4, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
         (7.7, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
         (8.0, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
         (16.0, [BufferSize.MINIMAL, BufferSize.BALANCED, BufferSize.MAXIMUM]),
@@ -27,7 +32,7 @@ from music_assistant.controllers.streams.constants import BufferSize
     ],
 )
 def test_get_available_buffer_sizes(total_gb: float, expected: list[BufferSize]) -> None:
-    """Balanced requires >= 4GB, Maximum >= 7GB; unknown RAM offers all (fail open)."""
+    """Balanced needs ~4GB (floor ~3.68GB), Maximum ~8GB (floor ~7.36GB); unknown RAM offers all."""
     with patch.object(constants, "TOTAL_SYSTEM_MEMORY_GB", total_gb):
         assert constants.get_available_buffer_sizes() == expected
 
@@ -36,9 +41,12 @@ def test_get_available_buffer_sizes(total_gb: float, expected: list[BufferSize])
     ("total_gb", "expected"),
     [
         (2.0, BufferSize.MINIMAL),
+        (3.6, BufferSize.MINIMAL),
+        (3.7, BufferSize.BALANCED),
         (4.0, BufferSize.BALANCED),
         (6.9, BufferSize.BALANCED),
-        (7.0, BufferSize.MAXIMUM),
+        (7.0, BufferSize.BALANCED),
+        (7.4, BufferSize.MAXIMUM),
         (7.7, BufferSize.MAXIMUM),
         (16.0, BufferSize.MAXIMUM),
         # unknown memory (0.0) -> Minimal default (conservative)
@@ -46,6 +54,6 @@ def test_get_available_buffer_sizes(total_gb: float, expected: list[BufferSize])
     ],
 )
 def test_default_buffer_size(total_gb: float, expected: BufferSize) -> None:
-    """The auto-selected default follows the same 4GB/7GB cutoffs as the available presets."""
+    """The auto-selected default follows the same ~4GB/~8GB cutoffs as the available presets."""
     with patch.object(constants, "TOTAL_SYSTEM_MEMORY_GB", total_gb):
         assert constants._get_default_buffer_size() == expected

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -476,6 +476,10 @@ def test_verify_system_meets_requirements_cpu(
         (16.0, 8.0, False),
         (4.0, 6.0, True),
         (3.5, 6.0, True),
+        # the gate applies the reporting tolerance: 3.8GB clears a 4GB minimum (within 8%),
+        # 3.6GB does not (below the 3.68GB floor) -- guards against reverting to strict `<`
+        (3.8, 4.0, False),
+        (3.6, 4.0, True),
         (0.0, 8.0, False),  # 0.0 == unknown memory -> fail open, never block
         (2.0, 0.0, False),  # 0 disables the check
     ],
@@ -483,7 +487,7 @@ def test_verify_system_meets_requirements_cpu(
 def test_verify_system_meets_requirements_memory(
     total_gb: float, min_memory_gb: float, should_raise: bool
 ) -> None:
-    """The RAM gate raises below the minimum but fails open when memory is unknown (0.0)."""
+    """The RAM gate raises below the minimum (within tolerance) but fails open when unknown (0.0)."""
     with (
         patch("music_assistant.helpers.util.os.process_cpu_count", return_value=16),
         patch("music_assistant.helpers.util.get_total_system_memory", return_value=total_gb),
@@ -493,6 +497,24 @@ def test_verify_system_meets_requirements_memory(
                 util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)
         else:
             util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)
+
+
+@pytest.mark.parametrize(
+    ("total_gb", "target_gb", "expected"),
+    [
+        (4.0, 4.0, True),
+        (3.8, 4.0, True),  # a "4GB" host reports ~3.8GB -> still meets a 4GB target
+        (3.7, 4.0, True),  # just above the 8% tolerance floor (3.68GB)
+        (3.6, 4.0, False),  # below the tolerance floor
+        (7.7, 8.0, True),  # an "8GB" host reporting ~7.7GB meets an 8GB target
+        (7.3, 8.0, False),  # below the 8GB tolerance floor (7.36GB)
+        (0.0, 4.0, True),  # unknown memory -> fail open
+        (2.0, 0.0, True),  # no requirement -> always met
+    ],
+)
+def test_meets_memory_target(total_gb: float, target_gb: float, expected: bool) -> None:
+    """A nominal RAM target is met within the reporting tolerance; unknown/zero fail open."""
+    assert util.meets_memory_target(total_gb, target_gb) is expected
 
 
 def test_verify_system_meets_requirements_ml_inference() -> None:


### PR DESCRIPTION
# What does this implement/fix?

A host marketed as 4GB reports ~3.8GB of *usable* RAM once firmware/kernel-reserved memory is excluded (`MemTotal`), and larger machines lose even more to integrated-GPU carve-out. So hard nominal gates rejected genuine hardware — Smart Fades / Sonic Analysis failed setup, and the Balanced buffer preset was hidden.

Rather than hand-tune each threshold, absorb the under-report in one place:

- Add `util.meets_memory_target(total, target)` — accepts a host as meeting a **nominal** RAM target within an **8%** reporting tolerance.
- Route the audio-analysis gate (`_resource_shortfall`) and **both** buffer tiers through it. Callers now pass clean nominal numbers — Balanced `4GB`, Maximum `8GB` — instead of effective magic numbers, so future RAM gates inherit the same tolerance automatically.
- Maximum's effective floor becomes ~7.36GB (8 × 0.92), replacing the previous literal `7GB` that worked around this exact under-report.
- Fails open on unknown memory (0.0, e.g. Windows); the buffer *default* stays conservatively Minimal in that case.

**Related issue (if applicable):**

- related issue none

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
