### PR TITLE
Remove stale Cast players that are actually passive multichannel endpoints

### DIFF
--- a/music_assistant/providers/chromecast/constants.py
+++ b/music_assistant/providers/chromecast/constants.py
@@ -18,6 +18,10 @@ SENDSPIN_CAST_APP_ID = "DD107DDB"
 SENDSPIN_CAST_NAMESPACE = "urn:x-cast:sendspin"
 CONF_USE_MASS_APP = "use_mass_app"
 
+# Interval (seconds) before an unavailable player is re-evaluated as a possible
+# passive multichannel endpoint that should be removed from the setup.
+MULTICHANNEL_RECHECK_INTERVAL = 600
+
 # Devices known to not work with the Sendspin Cast bridge.
 # Tuple of (manufacturer, model) where "*" is a wildcard.
 # These devices will not get a Sendspin bridge, allowing other protocols

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -80,6 +80,7 @@ class ChromecastPlayer(Player):
         self.mz_controller: MultizoneController | None = None
         self.on_app_status_changed: Callable[[str | None], None] | None = None
         self.last_poll = 0.0
+        self.last_multichannel_check = 0.0
         self.flow_meta_checksum: str | None = None
         # set static variables
         self._attr_supported_features = {

--- a/music_assistant/providers/chromecast/provider.py
+++ b/music_assistant/providers/chromecast/provider.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import threading
+import time
 from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
@@ -20,6 +21,7 @@ from music_assistant.constants import (
 )
 from music_assistant.models.player_provider import PlayerProvider
 
+from .constants import MULTICHANNEL_RECHECK_INTERVAL
 from .helpers import ChromecastInfo
 from .player import ChromecastPlayer
 from .sendspin_bridge import SendspinBridgeManager
@@ -134,6 +136,16 @@ class ChromecastProvider(PlayerProvider):
                 assert isinstance(castplayer, ChromecastPlayer)  # for type checking
                 castplayer.cast_info.update(disc_info)
                 self.mass.loop.call_soon_threadsafe(castplayer.update_state)
+                # An unavailable player may be a passive multichannel endpoint that
+                # slipped past the discovery filter (e.g. incomplete multizone info
+                # while the stereo pair was rebooting). Re-evaluate and remove it
+                # if it is now positively identified as such.
+                if self._should_recheck_multichannel_child(castplayer, player_id):
+                    self._pending_discoveries.add(player_id)
+                    asyncio.run_coroutine_threadsafe(
+                        self._recheck_multichannel_child(player_id, disc_info),
+                        loop=self.mass.loop,
+                    )
                 return
 
             # Prevent duplicate discovery while async setup is in progress
@@ -203,3 +215,37 @@ class ChromecastProvider(PlayerProvider):
         player_id = str(uuid)
         self.logger.debug("Chromecast removed: %s - %s", cast_info.friendly_name, player_id)
         # we ignore this event completely as the Chromecast socket client handles this itself
+
+    def _should_recheck_multichannel_child(
+        self, castplayer: ChromecastPlayer, player_id: str
+    ) -> bool:
+        """Return whether an unavailable player should be re-evaluated as a multichannel child."""
+        if player_id in self._pending_discoveries:
+            return False
+        if castplayer.available or castplayer.cast_info.is_audio_group:
+            return False
+        return (
+            time.monotonic() - castplayer.last_multichannel_check
+        ) > MULTICHANNEL_RECHECK_INTERVAL
+
+    async def _recheck_multichannel_child(self, player_id: str, disc_info: CastInfo) -> None:
+        """Re-evaluate a player and remove it if it is a passive multichannel endpoint."""
+        try:
+            castplayer = self.mass.players.get_player(player_id)
+            if not isinstance(castplayer, ChromecastPlayer):
+                return
+            castplayer.last_multichannel_check = time.monotonic()
+            cast_info = ChromecastInfo.from_cast_info(disc_info)
+            await asyncio.to_thread(
+                cast_info.fill_out_missing_chromecast_info, self.mass.discovery.aiozc.zeroconf
+            )
+            if cast_info.is_multichannel_child and self.mass.players.get_player(player_id):
+                self.logger.info(
+                    "Removing %s as it is now identified as a passive (multichannel) endpoint",
+                    castplayer.cast_info.friendly_name,
+                )
+                await self.mass.players.unregister(player_id, permanent=True)
+        except Exception:
+            self.logger.debug("Multichannel re-check failed for %s", player_id, exc_info=True)
+        finally:
+            self._pending_discoveries.discard(player_id)

--- a/music_assistant/providers/chromecast/provider.py
+++ b/music_assistant/providers/chromecast/provider.py
@@ -142,10 +142,14 @@ class ChromecastProvider(PlayerProvider):
                 # if it is now positively identified as such.
                 if self._should_recheck_multichannel_child(castplayer, player_id):
                     self._pending_discoveries.add(player_id)
-                    asyncio.run_coroutine_threadsafe(
-                        self._recheck_multichannel_child(player_id, disc_info),
-                        loop=self.mass.loop,
-                    )
+                    try:
+                        asyncio.run_coroutine_threadsafe(
+                            self._recheck_multichannel_child(player_id, disc_info),
+                            loop=self.mass.loop,
+                        )
+                    except RuntimeError:
+                        # event loop already closed (shutdown): release the marker
+                        self._pending_discoveries.discard(player_id)
                 return
 
             # Prevent duplicate discovery while async setup is in progress


### PR DESCRIPTION
# What does this implement/fix?

A speaker that belongs to a multichannel (stereo pair) setup can occasionally slip past the discovery filter and get registered as a standalone player — for example when its multizone info is briefly incomplete (as happens with recent Nest Mini firmware during the nightly reboot cycle). It then lingers in the setup as a permanently unavailable "ghost" player.

This re-evaluates such a player on the next discovery and removes it once it is positively identified as a passive multichannel endpoint.

- On re-discovery, re-check an unavailable Cast player and unregister it (permanently) when it now resolves to a passive multichannel endpoint.
- Only acts on unavailable, non-group players and is throttled, so healthy devices are never re-queried or removed.
- Removal happens only on a positive multichannel-child confirmation, never on unavailability alone.

Follow-up to #4224.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5482

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
