### PR TITLE
Fix live metadata not refreshing for grouped AirPlay players

### DIFF
--- a/music_assistant/providers/universal_player/player.py
+++ b/music_assistant/providers/universal_player/player.py
@@ -111,6 +111,12 @@ class UniversalPlayer(Player):
         """Return the current media being played by the player."""
         if ext_player := self._get_external_source_protocol_player():
             return ext_player.current_media
+        if protocol_player := self._get_active_output_protocol_player():
+            # while playing through an output protocol player, surface its raw current_media
+            # so consumers of this player's raw value (e.g. a sync group mirroring its leader)
+            # can resolve the active queue item. Reading the protocol player's .state here would
+            # route back through this player's __final_current_media and lose the queue item id.
+            return protocol_player.current_media
         return None
 
     @property
@@ -165,6 +171,12 @@ class UniversalPlayer(Player):
         """Remove a protocol player from this universal player."""
         if protocol_player_id in self._protocol_player_ids:
             self._protocol_player_ids.remove(protocol_player_id)
+
+    def _get_active_output_protocol_player(self) -> Player | None:
+        """Return the protocol player currently selected as this player's output, if any."""
+        if self.active_output_protocol and self.active_output_protocol != "native":
+            return self.mass.players.get_player(self.active_output_protocol)
+        return None
 
     def _get_external_source_protocol_player(self) -> Player | None:
         """

--- a/tests/core/test_protocol_linking.py
+++ b/tests/core/test_protocol_linking.py
@@ -6926,3 +6926,40 @@ class TestDelayedEvalDisabledParentGuard:
             await controller._delayed_protocol_evaluation(protocol_player.player_id)
 
         mock_create_up.assert_called_once()
+
+
+class TestUniversalPlayerCurrentMedia:
+    """Tests for current_media resolution while an output protocol is active."""
+
+    def test_current_media_surfaces_active_output_protocol(self, mock_mass: MagicMock) -> None:
+        """While outputting via a protocol player, surface that player's raw current_media.
+
+        A sync group mirrors its leader's raw current_media to resolve the active queue
+        item. When the leader is a universal player outputting via AirPlay, returning None
+        here strands the group with a frozen current item (regression guard for grouped
+        AirPlay live-metadata never refreshing).
+        """
+        protocol_provider = MockProvider("airplay", mass=mock_mass)
+        protocol_player = MockPlayer(
+            protocol_provider, "ap_1", "AirPlay", player_type=PlayerType.PROTOCOL
+        )
+        media = PlayerMedia(
+            uri="http://x/flow/sess/queue_1/item_1/ap_1.flac", queue_item_id="item_1"
+        )
+        protocol_player._attr_current_media = media
+
+        universal = _create_universal_player(mock_mass, "up_1", "Universal", ["ap_1"])
+        players = {"up_1": universal, "ap_1": protocol_player}
+        mock_mass.players.get_player = MagicMock(side_effect=lambda pid: players.get(pid))
+
+        # without an active output protocol there is nothing to surface
+        assert universal.current_media is None
+
+        universal.set_active_output_protocol("ap_1")
+        assert universal.current_media is media
+
+    def test_current_media_none_for_native_output(self, mock_mass: MagicMock) -> None:
+        """A native output protocol has no separate protocol player to surface."""
+        universal = _create_universal_player(mock_mass, "up_1", "Universal", [])
+        universal.set_active_output_protocol("native")
+        assert universal.current_media is None


### PR DESCRIPTION
# What does this implement/fix?

Live streams with their own "now playing" metadata (e.g. BBC Sounds) got stuck on the first track when played to a Sync Group whose leader is a Universal Player outputting via AirPlay (shairport-sync). The title updated once at startup and then never refreshed.

The queue resolves its current item each poll from the player's raw `current_media`, and a sync group mirrors its leader's raw value. A Universal Player returned `None` while outputting through a protocol player, so the group could never resolve the current item and `_update_queue_from_player` bailed out before ever reaching the live-metadata refresh. This fixes it at the player level, so the existing per-second update path drives the refresh for grouped AirPlay exactly like every other player — no extra background polling.

Changes:
- `UniversalPlayer.current_media` now surfaces the active output protocol player's raw `current_media` while outputting via a protocol (instead of returning `None`), so the existing update path resolves the queue item and refreshes metadata on its normal cadence.
- Reads the protocol player's *raw* `current_media` (not `.state`) to avoid routing back through the group's `__final_current_media`.
- Added a regression test for `UniversalPlayer.current_media` with an active output protocol.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5668

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
