### PR TITLE
Player queues: prevent crash when queue drains during next-item preload

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -2340,6 +2340,9 @@ class PlayerQueuesController(CoreController):
                     return  # guard
                 retries = max(120, (queue.current_item.duration or 0) + 10)
                 while retries > 0:
+                    # current_item can become None while we sleep if the queue drains
+                    if not queue.current_item:
+                        return
                     if queue.current_item.queue_item_id == item_id_in_buffer:
                         break
                     retries -= 1


### PR DESCRIPTION
> 🤖 This issue was auto-triaged by a scheduled agent and this PR was opened in draft for human review.

# What does this implement/fix?

When the playback queue drains while the next item is being preloaded, `queue.current_item` can become `None` during the preload wait loop. The loop re-reads `queue.current_item.queue_item_id` after `await asyncio.sleep(1)` without re-checking for `None`, raising an unhandled `AttributeError`:

```
File ".../player_queues/controller.py", in _preload_streamdetails
    if queue.current_item.queue_item_id == item_id_in_buffer:
AttributeError: 'NoneType' object has no attribute 'queue_item_id'
```

This happens, for example, when every remaining queue item is unplayable and gets skipped — exactly the scenario in the linked issue, where a whole podcast feed produced no audio and the queue emptied mid-preload. The fix re-checks `queue.current_item` inside the loop so preloading bails out cleanly instead of crashing.

Note: this addresses only the secondary crash. The primary "podcast produces no audio" symptom could not be reproduced — the feed's enclosures resolve to valid `audio/mpeg` URLs, so the source-side discard described in the report does not occur in current code; that part looks environmental (container DNS/network) and still needs investigation.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5692

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
