### PR TITLE
Pace audio analysis and cap it to half the CPU cores

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -150,10 +150,10 @@ CONF_BACKGROUND_SCAN_CONCURRENCY: Final[str] = "background_scan_concurrency"
 
 
 def _default_background_scan_concurrency() -> int:
+    # Slow and steady by default: at most 2 tracks at once even on big machines. Users who
+    # want faster overnight scans can raise it (up to 16) at the cost of more CPU at night.
     cpu_count = os.process_cpu_count() or os.cpu_count() or 4
-    if cpu_count >= 16:
-        return 4
-    if cpu_count >= 8:
+    if cpu_count >= 4:
         return 2
     return 1
 

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -44,8 +44,15 @@ BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
 # Per-chunk dispatch interval bounds. One PCM chunk = one audio-second of decoded data:
 # the floor is the fastest pace allowed; the ceiling is both the slowest pace and the
 # per-chunk processing timeout that evicts unresponsive providers.
-REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR = 0.100
-REAL_TIME_PACE_INTERVAL_SECONDS_CEILING = 1.0
+#
+# Live analysis is paced to ~5x real-time, never faster, on every machine. The buffer fills
+# far ahead of playback (a whole track decodes in seconds), and draining that burst at full
+# speed only spikes CPU — at 5x the analysis still completes well ahead of the crossfade
+# point. The ceiling is generous enough that legitimately slow, serialized per-chunk work on a
+# small box isn't mistaken for a hung provider. A companion half-the-cores concurrency cap
+# (analysis_semaphore) keeps analysis off the rest of the box on every machine.
+REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR = 0.200
+REAL_TIME_PACE_INTERVAL_SECONDS_CEILING = 2.0
 BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR = 0.250
 BACKGROUND_PACE_INTERVAL_SECONDS_CEILING = 4.0
 ANALYSIS_QUEUE_MAXSIZE = 30
@@ -141,6 +148,10 @@ class AudioAnalysisController:
         # Kept alive to persist the process-wide native BLAS thread cap (set in
         # ensure_inference_runtime_configured); never used as a context manager.
         self._blas_limiter: object | None = None
+        # Bounds how many analysis offloads run concurrently to half the cores; created in
+        # ensure_inference_runtime_configured once the core count is known (None until then),
+        # and honored by AudioAnalysisProvider._run_offloaded.
+        self.analysis_semaphore: asyncio.Semaphore | None = None
 
     def setup(self) -> None:
         """Register the nightly background scan task."""
@@ -200,11 +211,17 @@ class AudioAnalysisController:
             # the log spam.
             with contextlib.suppress(Exception):
                 torch.backends.nnpack.set_flags(False)  # type: ignore[no-untyped-call]
+        # Cap concurrent analysis offloads to half the cores so analysis (live or background)
+        # never occupies the whole box and starves playback/the host — slow and steady on any
+        # machine. Applies to every host; honored by AudioAnalysisProvider._run_offloaded.
+        concurrency_cap = max(1, self._cpu_count() // 2)
+        self.analysis_semaphore = asyncio.Semaphore(concurrency_cap)
         self.logger.info(
-            "AudioAnalysis runtime: torch intra=%d interop=%d, blas<=%d, nnpack=%s",
+            "AudioAnalysis runtime: torch intra=%d interop=%d, blas<=%d, analysis concurrency<=%d, nnpack=%s",
             torch.get_num_threads(),
             torch.get_num_interop_threads(),
             budget,
+            concurrency_cap,
             "off" if arm else "on",
         )
         # Only mark done once configuration actually succeeded, so a failure retries.
@@ -1107,12 +1124,16 @@ class AudioAnalysisController:
                 self._workers.pop(session_key, None)
                 break
 
+    def _cpu_count(self) -> int:
+        """Return the CPU core count available to this process (fallback 4 when unknown)."""
+        return os.process_cpu_count() or os.cpu_count() or 4
+
     def _aa_thread_budget(self) -> int:
         """Return the per-op PyTorch intra-op thread budget for inference (~25% of cpu_count)."""
-        return max(1, (os.process_cpu_count() or os.cpu_count() or 4) // 4)
+        return max(1, self._cpu_count() // 4)
 
     def _get_scan_concurrency(self) -> int:
-        """Read background scan concurrency from config, clamped to [1, 8]."""
+        """Read background scan concurrency from config, clamped to [1, 16]."""
         try:
             value = int(
                 self.mass.config.get_raw_core_config_value(
@@ -1124,4 +1145,4 @@ class AudioAnalysisController:
             )
         except Exception:
             value = DEFAULT_BACKGROUND_SCAN_CONCURRENCY
-        return max(1, min(value, 8))
+        return max(1, min(value, 16))

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -263,7 +263,7 @@ class StreamsController(CoreController):
             ConfigEntry(
                 key=CONF_BACKGROUND_SCAN_CONCURRENCY,
                 type=ConfigEntryType.INTEGER,
-                range=(1, 8),
+                range=(1, 16),
                 default_value=DEFAULT_BACKGROUND_SCAN_CONCURRENCY,
                 category="audio_analysis",
             ),

--- a/music_assistant/controllers/streams/strings.json
+++ b/music_assistant/controllers/streams/strings.json
@@ -35,7 +35,7 @@
     },
     "background_scan_concurrency": {
       "label": "Background analysis concurrency",
-      "description": "Maximum number of tracks analyzed concurrently during the nightly background scan. Default 1 (serial). Increase only if your hardware can handle concurrent torch/ffmpeg work."
+      "description": "Maximum number of tracks analyzed concurrently during the nightly background scan (1-16). Defaults to 1, or 2 on machines with 4 or more cores. Raise it for faster overnight scans at the cost of more CPU; analysis still never uses more than half the cores."
     }
   },
   "manifest": {

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from .provider import Provider
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
     from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.enums import ProviderFeature
     from music_assistant_models.media_items import AudioFormat
@@ -17,6 +21,8 @@ if TYPE_CHECKING:
 
     from music_assistant.mass import MusicAssistant
     from music_assistant.models.audio_analysis import AudioAnalysisData
+
+_T = TypeVar("_T")
 
 
 @dataclass
@@ -186,3 +192,45 @@ class AudioAnalysisProvider(Provider):
         for session_id in list(self._sessions):
             await self.cancel(session_id)
         await super().unload(is_removed)
+
+    async def _run_offloaded(self, func: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
+        """
+        Run a blocking analysis function in a worker thread, bounded by the CPU cap.
+
+        The AudioAnalysisController caps how many of these run at once (half the cores) so
+        analysis never occupies the whole box; when no cap is configured this is a plain
+        asyncio.to_thread call. Route all CPU-heavy analysis work through this.
+
+        The permit is held until the worker thread actually finishes, even if the awaiting
+        coroutine is cancelled (e.g. a provider evicted on timeout, or a cancelled session):
+        asyncio.to_thread cannot stop a running thread, so releasing on cancellation would let
+        extra threads keep running and exceed the cap on exactly the hosts it protects.
+
+        :param func: The blocking callable to run off the event loop.
+        :param args: Positional arguments passed to func.
+        :param kwargs: Keyword arguments passed to func.
+        """
+        semaphore = self.mass.streams.audio_analysis.analysis_semaphore
+        if not isinstance(semaphore, asyncio.Semaphore):
+            return await asyncio.to_thread(func, *args, **kwargs)
+
+        def _release(done: asyncio.Future[_T]) -> None:
+            semaphore.release()
+            # Retrieve any exception so a cancelled awaiter doesn't leave it unretrieved.
+            if not done.cancelled():
+                done.exception()
+
+        await semaphore.acquire()
+        try:
+            future: asyncio.Future[_T] = asyncio.ensure_future(
+                asyncio.to_thread(func, *args, **kwargs)
+            )
+        except Exception:
+            # Scheduling the worker failed (e.g. the loop is shutting down) — release the
+            # permit we just took so it isn't leaked, which would shrink the cap over time.
+            semaphore.release()
+            raise
+        future.add_done_callback(_release)
+        # shield: if this coroutine is cancelled, the thread (and the permit) lives on until
+        # the work completes, rather than freeing the permit while the thread still runs.
+        return await asyncio.shield(future)

--- a/music_assistant/providers/smart_fades/feature_extractor.py
+++ b/music_assistant/providers/smart_fades/feature_extractor.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import math
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
 import torchaudio
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
 
 
 class AdvancedBeatFeatureExtractor:
@@ -41,6 +45,7 @@ class AdvancedBeatFeatureExtractor:
         fmin: float = 30.0,
         fmax: float = 11000.0,
         device: str = "cpu",
+        offload: Callable[..., Awaitable[Any]] | None = None,
     ):
         """Initialize the feature extractor.
 
@@ -51,7 +56,11 @@ class AdvancedBeatFeatureExtractor:
         :param fmin: Minimum frequency for mel filter.
         :param fmax: Maximum frequency for mel filter.
         :param device: Torch device to use.
+        :param offload: Awaitable runner for the blocking mel extraction. When given (the
+            provider passes its concurrency-bounded runner), it is used instead of a plain
+            asyncio.to_thread so the work counts against the host's analysis CPU cap.
         """
+        self._offload = offload
         self.n_fft = n_fft
         self.hop_length = hop_length
         self.sample_rate = sample_rate
@@ -172,6 +181,9 @@ class AdvancedBeatFeatureExtractor:
 
             return features[start_in_segment:end_in_segment]
 
+        if self._offload is not None:
+            offloaded: np.ndarray = await self._offload(_process_sync)
+            return offloaded
         return await asyncio.to_thread(_process_sync)
 
     async def finalize(self) -> np.ndarray:
@@ -202,6 +214,9 @@ class AdvancedBeatFeatureExtractor:
 
             return features[-extra_count:]
 
+        if self._offload is not None:
+            offloaded: np.ndarray = await self._offload(_finalize_sync)
+            return offloaded
         return await asyncio.to_thread(_finalize_sync)
 
     def reset(self) -> None:

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -120,7 +120,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
         if not data:
             return
 
-        pcm_mono = await asyncio.to_thread(
+        pcm_mono = await self._run_offloaded(
             decode_pcm_chunk_to_mono, data.input_audio_format, pcm_chunk
         )
         if pcm_mono.size == 0:
@@ -128,7 +128,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         # Per-chunk VQT for key detection (skip short tail chunks)
         if len(pcm_mono) >= data.input_audio_format.sample_rate:
-            await asyncio.to_thread(
+            await self._run_offloaded(
                 self._compute_musical_key_features,
                 pcm_mono,
                 data.input_audio_format.sample_rate,
@@ -174,6 +174,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
             features=AdvancedBeatFeatureExtractor(
                 sample_rate=ANALYSIS_SAMPLE_RATE,
                 device=self._device,
+                offload=self._run_offloaded,
             ),
             resampler=soxr.ResampleStream(
                 in_rate=audio_format.sample_rate,
@@ -215,11 +216,11 @@ class SmartFadesProvider(AudioAnalysisProvider):
             data.musical_key_feature_blocks.clear()
 
         # Run beat and key inference sequentially to keep peak CPU bounded.
-        beats, downbeats = await asyncio.to_thread(self._infer_beat_timings, feats)
+        beats, downbeats = await self._run_offloaded(self._infer_beat_timings, feats)
         if len(beats) < 2:
             self.logger.debug("Not enough beats detected, skipping storage")
             return None
-        key, mode = await asyncio.to_thread(self._infer_musical_key, all_vqt)
+        key, mode = await self._run_offloaded(self._infer_musical_key, all_vqt)
 
         bpm = calculate_overall_bpm(beats)
 
@@ -275,7 +276,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
         data.pcm_samples = 0
 
         if data.resampler is not None:
-            pcm_22k = await asyncio.to_thread(data.resampler.resample_chunk, pcm_raw, last)
+            pcm_22k = await self._run_offloaded(data.resampler.resample_chunk, pcm_raw, last)
         else:
             pcm_22k = pcm_raw
 
@@ -283,7 +284,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         feats, _ = await asyncio.gather(
             data.features.process_pcm(pcm_22k),
-            asyncio.to_thread(self._compute_energy_and_spectral_centroids, pcm_22k, data),
+            self._run_offloaded(self._compute_energy_and_spectral_centroids, pcm_22k, data),
         )
 
         if feats.size:

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -504,7 +504,7 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         if len(session.pcm_buffer) >= session.block_bytes:
             block_bytes = bytes(session.pcm_buffer[: session.block_bytes])
             del session.pcm_buffer[: session.block_bytes]
-            pre_audio, post_audio, bf = await asyncio.to_thread(
+            pre_audio, post_audio, bf = await self._run_offloaded(
                 _decode_resample_extract,
                 af,
                 block_bytes,
@@ -589,7 +589,7 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         af = session.audio_format
 
         if session.pcm_buffer:
-            pre_audio, _post_audio, bf = await asyncio.to_thread(
+            pre_audio, _post_audio, bf = await self._run_offloaded(
                 _decode_resample_extract,
                 af,
                 bytes(session.pcm_buffer),
@@ -609,7 +609,7 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
             self.logger.debug("No feature blocks for session %s, skipping", session_id)
             return None
 
-        analysis = await asyncio.to_thread(
+        analysis = await self._run_offloaded(
             collapse_to_analysis, session.accumulated, ANALYSIS_SAMPLE_RATE
         )
 
@@ -664,7 +664,7 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         if self._clap_model is None:
             return
         try:
-            result = await asyncio.to_thread(
+            result = await self._run_offloaded(
                 self._single_window_inference_sync, window_audio, source_sr
             )
         except Exception as err:

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -492,7 +492,7 @@
   "core.players.manifest.name": "Players",
   "core.streams.config_entries.allow_crossfade_same_album.description": "Enabling this option allows for crossfading between tracks that are part of the same album.",
   "core.streams.config_entries.allow_crossfade_same_album.label": "Allow crossfade between tracks from the same album",
-  "core.streams.config_entries.background_scan_concurrency.description": "Maximum number of tracks analyzed concurrently during the nightly background scan. Default 1 (serial). Increase only if your hardware can handle concurrent torch/ffmpeg work.",
+  "core.streams.config_entries.background_scan_concurrency.description": "Maximum number of tracks analyzed concurrently during the nightly background scan (1-16). Defaults to 1, or 2 on machines with 4 or more cores. Raise it for faster overnight scans at the cost of more CPU; analysis still never uses more than half the cores.",
   "core.streams.config_entries.background_scan_concurrency.label": "Background analysis concurrency",
   "core.streams.config_entries.buffer_size.description": "Controls how much audio is buffered in memory. A larger buffer improves playback stability and seeking but uses more memory.\n\n- **Minimal**: Small buffer, recommended for memory-constrained devices.\n- **Balanced**: Moderate buffer, good balance for most systems.\n- **Maximum**: Large buffer, best performance for systems with plenty of memory.",
   "core.streams.config_entries.buffer_size.label": "Audio buffer size",

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -15,7 +15,10 @@ from music_assistant_models.errors import ProviderUnavailableError
 from music_assistant_models.media_items import AudioFormat
 
 import music_assistant.controllers.streams.audio_analysis as audio_analysis_mod
-from music_assistant.constants import DEFAULT_BACKGROUND_SCAN_CONCURRENCY
+from music_assistant.constants import (
+    DEFAULT_BACKGROUND_SCAN_CONCURRENCY,
+    _default_background_scan_concurrency,
+)
 from music_assistant.controllers.streams.audio_analysis import (
     LOUDNESS_ANALYSIS_DOMAIN,
     SMART_FADES_ANALYSIS_DOMAIN,
@@ -60,6 +63,35 @@ def test_ensure_inference_runtime_configured_is_idempotent() -> None:
         controller.ensure_inference_runtime_configured()
     set_threads.assert_called_once()
     blas_limits.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("cpu_count", "expected_permits"),
+    [(2, 1), (4, 2), (8, 4), (16, 8)],
+)
+@pytest.mark.asyncio
+async def test_analysis_concurrency_capped_at_half_cores(
+    cpu_count: int, expected_permits: int
+) -> None:
+    """The analysis concurrency cap is half the cores (min 1) on every host."""
+    controller = _make_controller()
+    with (
+        patch(
+            "music_assistant.controllers.streams.audio_analysis.os.process_cpu_count",
+            return_value=cpu_count,
+        ),
+        patch("torch.set_num_threads"),
+        patch("torch.set_num_interop_threads"),
+        patch("threadpoolctl.threadpool_limits"),
+        patch("torch.backends.nnpack.set_flags"),
+    ):
+        controller.ensure_inference_runtime_configured()
+    semaphore = controller.analysis_semaphore
+    assert isinstance(semaphore, asyncio.Semaphore)
+    # Exactly `expected_permits` acquires exhaust the cap.
+    for _ in range(expected_permits):
+        await semaphore.acquire()
+    assert semaphore.locked()
 
 
 @pytest.mark.asyncio
@@ -113,10 +145,10 @@ def test_get_scan_concurrency_returns_default_on_unset() -> None:
 
 
 def test_get_scan_concurrency_clamps_to_max() -> None:
-    """Values above 8 are clamped to 8."""
+    """Values above 16 are clamped to 16."""
     controller = _make_controller()
     controller.mass.config.get_raw_core_config_value = MagicMock(return_value=99)  # type: ignore[method-assign]
-    assert controller._get_scan_concurrency() == 8
+    assert controller._get_scan_concurrency() == 16
 
 
 def test_get_scan_concurrency_clamps_to_min() -> None:
@@ -126,6 +158,16 @@ def test_get_scan_concurrency_clamps_to_min() -> None:
     # doesn't swap us out for the default before the min-clamp runs.
     controller.mass.config.get_raw_core_config_value = MagicMock(return_value=-1)  # type: ignore[method-assign]
     assert controller._get_scan_concurrency() == 1
+
+
+@pytest.mark.parametrize(
+    ("cpu_count", "expected"),
+    [(1, 1), (2, 1), (3, 1), (4, 2), (8, 2), (16, 2)],
+)
+def test_default_background_scan_concurrency(cpu_count: int, expected: int) -> None:
+    """Background scan defaults to 1 below 4 cores, 2 at/above (never more than 2)."""
+    with patch("music_assistant.constants.os.process_cpu_count", return_value=cpu_count):
+        assert _default_background_scan_concurrency() == expected
 
 
 def _make_stream_mock(chunks: list[bytes]) -> object:

--- a/tests/models/test_audio_analysis_provider.py
+++ b/tests/models/test_audio_analysis_provider.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -119,3 +121,80 @@ async def test_finalize_swallows_post_analysis_exception() -> None:
 
     provider.post_analysis.assert_awaited_once()
     assert "session-4" not in provider._sessions
+
+
+@pytest.mark.asyncio
+async def test_run_offloaded_acquires_semaphore_when_present() -> None:
+    """_run_offloaded holds the controller's analysis semaphore while the work runs."""
+    provider = _make_provider()
+    semaphore = asyncio.Semaphore(1)
+    provider.mass.streams.audio_analysis.analysis_semaphore = semaphore
+
+    def _work() -> bool:
+        # Runs in the worker thread; the cap must already be held here.
+        return semaphore.locked()
+
+    held_during = await provider._run_offloaded(_work)
+    assert held_during is True
+    assert not semaphore.locked()
+
+
+@pytest.mark.asyncio
+async def test_run_offloaded_without_cap_runs_plainly() -> None:
+    """With no real semaphore configured, _run_offloaded still runs the work and forwards args."""
+    provider = _make_provider()
+    # The MagicMock attribute is not an asyncio.Semaphore, so this falls back to a plain thread.
+    result = await provider._run_offloaded(lambda value: value * 2, 21)
+    assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_run_offloaded_holds_permit_until_thread_finishes_on_cancel() -> None:
+    """Cancelling the awaiter must not free the permit while the worker thread is still running."""
+    provider = _make_provider()
+    semaphore = asyncio.Semaphore(1)
+    provider.mass.streams.audio_analysis.analysis_semaphore = semaphore
+
+    started = threading.Event()
+    may_finish = threading.Event()
+
+    def _blocking() -> str:
+        started.set()
+        may_finish.wait(timeout=5)
+        return "done"
+
+    task = asyncio.create_task(provider._run_offloaded(_blocking))
+    assert await asyncio.to_thread(started.wait, 5)  # thread is running, permit acquired
+    assert semaphore.locked()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # Awaiter cancelled, but the thread is still running — the permit must NOT be freed yet.
+    assert semaphore.locked()
+
+    may_finish.set()  # let the thread complete; the done-callback then releases the permit
+    for _ in range(100):
+        if not semaphore.locked():
+            break
+        await asyncio.sleep(0.02)
+    assert not semaphore.locked()
+
+
+@pytest.mark.asyncio
+async def test_run_offloaded_releases_permit_if_scheduling_fails() -> None:
+    """A failure to schedule the worker must release the permit, not leak it."""
+    provider = _make_provider()
+    semaphore = asyncio.Semaphore(1)
+    provider.mass.streams.audio_analysis.analysis_semaphore = semaphore
+
+    with (
+        patch(
+            "music_assistant.models.audio_analysis_provider.asyncio.to_thread",
+            side_effect=RuntimeError("cannot schedule"),
+        ),
+        pytest.raises(RuntimeError, match="cannot schedule"),
+    ):
+        await provider._run_offloaded(lambda: "x")
+
+    assert not semaphore.locked()  # permit released despite the failure

--- a/tests/providers/sonic_analysis/test_clap_window_inference.py
+++ b/tests/providers/sonic_analysis/test_clap_window_inference.py
@@ -29,6 +29,9 @@ def _make_provider(
     p = SonicAnalysisProvider.__new__(SonicAnalysisProvider)
     fake_logger = MagicMock()
     p.logger = fake_logger
+    # _run_offloaded reads mass.streams.audio_analysis.analysis_semaphore; a plain Mock
+    # attribute is not an asyncio.Semaphore, so offloads fall back to a plain worker thread.
+    p.mass = MagicMock()
 
     fake_model = MagicMock()
     sim = similarity_row if similarity_row is not None else [1.0, 2.0, 3.0, 4.0]

--- a/tests/providers/sonic_analysis/test_decode_resample_extract.py
+++ b/tests/providers/sonic_analysis/test_decode_resample_extract.py
@@ -132,13 +132,13 @@ def test_decode_resample_extract_returns_three_tuple() -> None:
 
 
 @pytest.mark.asyncio
-async def test_process_pcm_chunk_offloads_via_to_thread() -> None:
-    """process_pcm_chunk must call _decode_resample_extract via asyncio.to_thread.
+async def test_process_pcm_chunk_offloads_via_run_offloaded() -> None:
+    """process_pcm_chunk must call _decode_resample_extract off the event loop.
 
     Verified by:
     1. Patching _decode_resample_extract with a MagicMock that returns a valid 3-tuple.
     2. Asserting the mock was called once per block.
-    3. Asserting the source of process_pcm_chunk references 'asyncio.to_thread'.
+    3. Asserting the source of process_pcm_chunk routes through the offload seam.
     """
     provider = _make_provider()
     session_id = "sess-t23-offload"
@@ -157,10 +157,11 @@ async def test_process_pcm_chunk_offloads_via_to_thread() -> None:
         f"_decode_resample_extract must be called once per block; got {mock_helper.call_count}"
     )
 
-    # Structural check: process_pcm_chunk must route through asyncio.to_thread
+    # Structural check: process_pcm_chunk must offload decode+extract off the event loop
+    # (via the concurrency-bounded _run_offloaded seam rather than running it inline).
     source = inspect.getsource(provider.process_pcm_chunk)
-    assert "asyncio.to_thread" in source, (
-        "process_pcm_chunk must call asyncio.to_thread (CPU offload for decode+extract)"
+    assert "_run_offloaded" in source, (
+        "process_pcm_chunk must offload decode+extract via _run_offloaded (CPU offload)"
     )
     assert "_decode_resample_extract" in source, (
         "process_pcm_chunk must reference _decode_resample_extract"


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4257. Audio analysis (Smart Fades / Sonic Analysis) could take every CPU core and make hosts unresponsive during playback. #4257 capped intra-op threads, but not how *fast* live analysis runs or how *many* offloads run at once. On a fresh track ffmpeg fills the buffer far faster than playback, so the live pacer drained that burst at its ~10x floor and the per-chunk work for both providers (plus CLAP windows) landed on the shared thread pool and spilled across every core, starving playback. Finishing a track's analysis in a fraction of its play time wins nothing but a CPU spike.

Slow and steady on any machine:
- Pace live analysis to ~5x real-time on every host (was ~10x). It still completes well ahead of the crossfade point.
- Cap concurrent analysis offloads to half the cores (min 1) on every host, via a single `AudioAnalysisProvider._run_offloaded` seam used by both providers and the Smart Fades feature extractor. Analysis never occupies more than half the box, leaving the rest for playback and the host.
- The nightly background scan runs through the same cap. It stays gentle by default (1 track, 2 on 4+ cores); its concurrency setting now goes up to 16 (was 8) for faster overnight scans on capable hardware, at the cost of more CPU at night — still within the half-cores ceiling.

**Related issue (if applicable):**

- follow-up to #4257

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
