### PR TITLE
Fix protocol player settings not reverting to their default value

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -648,6 +648,13 @@ class ConfigController:
         raw_conf: dict[str, Any]
         if raw_conf := self.get(f"{CONF_PLAYERS}/{player_id}"):
             raw_conf = deepcopy(raw_conf)
+            # protocol-prefixed entries are virtual mirrors of the linked protocol player's own
+            # config (the canonical store). Drop any that linger in this player's persisted values
+            # so a stale copy can never shadow the protocol player's current value; the live values
+            # are merged back in from the protocol player(s) below.
+            if stored_values := raw_conf.get("values"):
+                for key in [key for key in stored_values if CONF_PROTOCOL_KEY_SPLITTER in key]:
+                    del stored_values[key]
             if player := self.mass.players.get_player(player_id, False):
                 raw_conf["default_name"] = player.state.name
                 raw_conf["provider"] = player.provider.instance_id
@@ -875,6 +882,12 @@ class ConfigController:
         for key, value in existing_values.items():
             if key not in new_values and key not in config_entry_keys:
                 new_values[key] = value
+        # never persist protocol-prefixed (virtual) entries on this player; the linked protocol
+        # player is the canonical store (handled by _update_output_protocol_config). Storing a copy
+        # here would shadow the protocol player's value once it is reset back to its default.
+        new_values = {
+            key: value for key, value in new_values.items() if CONF_PROTOCOL_KEY_SPLITTER not in key
+        }
         new_raw["values"] = new_values
         self.set(conf_key, new_raw)
         try:

--- a/tests/core/test_config_protocol_defaults.py
+++ b/tests/core/test_config_protocol_defaults.py
@@ -1,0 +1,190 @@
+"""
+Regression tests for protocol-prefixed config values not reverting to default.
+
+Reproduces music-assistant/support#5685: for a player that streams via a linked
+protocol (e.g. a Sonos/Universal parent whose audio output is a separate DLNA
+"protocol player"), the config UI exposes protocol-specific entries as virtual
+entries keyed ``<protocol_player_id>||protocol||<actual_key>``. Setting such an
+entry (e.g. ``flow_mode_sample_rate`` / ``crossfade_different_sample_rates``) to
+a non-default value saved fine, but setting it back to the default did not stick.
+
+The linked protocol player is the canonical store for these values. A redundant
+copy persisted on the parent shadowed the protocol player's value once it was
+reset to its default (the parent copy lingered while the protocol player dropped
+the now-default value), so the old value kept reappearing.
+"""
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import PlayerFeature, PlayerType
+from music_assistant_models.player import OutputProtocol
+
+from music_assistant.constants import (
+    CONF_FLOW_MODE_SAMPLE_RATE,
+    CONF_PROTOCOL_KEY_SPLITTER,
+    FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
+    FLOW_MODE_SAMPLE_RATE_SMART,
+)
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.player import DeviceInfo, Player
+
+PARENT_ID = "sonos_123"
+CHILD_ID = "dlna_AABBCCDDEEFF"
+PREFIXED_KEY = f"{CHILD_ID}{CONF_PROTOCOL_KEY_SPLITTER}{CONF_FLOW_MODE_SAMPLE_RATE}"
+
+
+class _TestProvider:
+    """Minimal PlayerProvider stand-in backed by the real MusicAssistant."""
+
+    def __init__(self, mass: MusicAssistant, domain: str) -> None:
+        """Initialize the test provider."""
+        self.mass = mass
+        self.domain = domain
+        self.instance_id = domain
+        self.name = f"{domain.title()} Provider"
+        self.available = True
+        self.logger = logging.getLogger(f"test.{domain}")
+        self.manifest = MagicMock()
+        self.manifest.domain = domain
+        self.manifest.name = self.name
+
+
+class _TestPlayer(Player):
+    """Minimal concrete Player for driving the real ConfigController."""
+
+    def __init__(
+        self,
+        provider: _TestProvider,
+        player_id: str,
+        name: str,
+        player_type: PlayerType,
+    ) -> None:
+        """Initialize the test player."""
+        super().__init__(provider, player_id)  # type: ignore[arg-type]
+        self._attr_name = name
+        self._attr_type = player_type
+        self._attr_available = True
+        self._attr_powered = True
+        # PLAY_MEDIA is required for the audio/protocol config entries to be emitted.
+        self._attr_supported_features = {PlayerFeature.VOLUME_SET, PlayerFeature.PLAY_MEDIA}
+        self._attr_device_info = DeviceInfo(model="Test Model", manufacturer="Test Manufacturer")
+        self._cache.clear()
+        self.update_state(signal_event=False)
+
+    async def stop(self) -> None:
+        """Stop playback - required abstract method."""
+
+
+async def _setup_parent_with_protocol_child(mass: MusicAssistant) -> _TestPlayer:
+    """Register a native parent player linked to a DLNA protocol child player."""
+    sonos_provider = _TestProvider(mass, "sonos")
+    dlna_provider = _TestProvider(mass, "dlna")
+    mass._providers[sonos_provider.instance_id] = sonos_provider  # type: ignore[assignment]
+    mass._providers[dlna_provider.instance_id] = dlna_provider  # type: ignore[assignment]
+    mass._provider_manifests[sonos_provider.domain] = sonos_provider.manifest
+    mass._provider_manifests[dlna_provider.domain] = dlna_provider.manifest
+
+    # building the players auto-creates their (real) config roots via create_default_player_config
+    parent = _TestPlayer(sonos_provider, PARENT_ID, "Living Room", PlayerType.PLAYER)
+    child = _TestPlayer(dlna_provider, CHILD_ID, "Living Room DLNA", PlayerType.PROTOCOL)
+
+    mass.players._players[PARENT_ID] = parent
+    mass.players._players[CHILD_ID] = child
+
+    # link the DLNA protocol output to the parent so the virtual prefixed entry is emitted
+    parent.set_linked_output_protocols(
+        [
+            OutputProtocol(
+                output_protocol_id=CHILD_ID,
+                name="DLNA",
+                protocol_domain="dlna",
+                priority=50,
+            )
+        ]
+    )
+    # output_protocols is a cached property populated during __init__'s update_state
+    # (native-only at that point); drop the cache so the freshly linked protocol shows up
+    parent._cache.clear()
+
+    # avoid driving the full player-manager reload machinery
+    mass.players.on_player_config_change = AsyncMock()  # type: ignore[method-assign]
+    return parent
+
+
+def _parent_stored_values(mass: MusicAssistant) -> dict[str, Any]:
+    """Return the parent player's raw persisted config values."""
+    raw = mass.config.get(f"players/{PARENT_ID}") or {}
+    values: dict[str, Any] = raw.get("values", {})
+    return values
+
+
+async def test_protocol_prefixed_reset_to_default_sticks(mass: MusicAssistant) -> None:
+    """Resetting a protocol-prefixed value to its default must stick on read-back."""
+    await _setup_parent_with_protocol_child(mass)
+
+    # sanity: the virtual prefixed entry is exposed and defaults to "smart"
+    config = await mass.config.get_player_config(PARENT_ID)
+    assert config.values[PREFIXED_KEY].value == FLOW_MODE_SAMPLE_RATE_SMART
+
+    # set the prefixed value to a non-default, alongside an unrelated parent change
+    await mass.config.save_player_config(
+        PARENT_ID,
+        {PREFIXED_KEY: FLOW_MODE_SAMPLE_RATE_BIT_PERFECT, "volume_normalization": False},
+    )
+    config = await mass.config.get_player_config(PARENT_ID)
+    assert config.values[PREFIXED_KEY].value == FLOW_MODE_SAMPLE_RATE_BIT_PERFECT
+    # canonical store is the child protocol player; the parent must not carry a copy
+    assert (
+        mass.config.get_raw_player_config_value(CHILD_ID, CONF_FLOW_MODE_SAMPLE_RATE)
+        == FLOW_MODE_SAMPLE_RATE_BIT_PERFECT
+    )
+    assert PREFIXED_KEY not in _parent_stored_values(mass)
+
+    # reset the prefixed value back to its default
+    await mass.config.save_player_config(PARENT_ID, {PREFIXED_KEY: FLOW_MODE_SAMPLE_RATE_SMART})
+
+    # the child drops the now-default value, and the parent retains no shadowing copy
+    assert mass.config.get_raw_player_config_value(CHILD_ID, CONF_FLOW_MODE_SAMPLE_RATE) is None
+    assert PREFIXED_KEY not in _parent_stored_values(mass)
+    config = await mass.config.get_player_config(PARENT_ID)
+    assert config.values[PREFIXED_KEY].value == FLOW_MODE_SAMPLE_RATE_SMART
+
+
+async def test_stale_prefixed_copy_does_not_shadow_default(mass: MusicAssistant) -> None:
+    """A pre-existing stale prefixed copy on the parent must not shadow the default.
+
+    Covers installs that already accumulated a redundant prefixed value before the
+    fix: the protocol player holds the default (no stored value), so the config must
+    read back as the default regardless of the lingering parent copy.
+    """
+    await _setup_parent_with_protocol_child(mass)
+
+    # simulate a stale copy as written by older versions
+    mass.config.set(f"players/{PARENT_ID}/values/{PREFIXED_KEY}", FLOW_MODE_SAMPLE_RATE_BIT_PERFECT)
+    assert PREFIXED_KEY in _parent_stored_values(mass)
+    # child protocol player is at its default (nothing stored)
+    assert mass.config.get_raw_player_config_value(CHILD_ID, CONF_FLOW_MODE_SAMPLE_RATE) is None
+
+    # read-back must reflect the protocol player's default, not the stale parent copy
+    config = await mass.config.get_player_config(PARENT_ID)
+    assert config.values[PREFIXED_KEY].value == FLOW_MODE_SAMPLE_RATE_SMART
+
+
+async def test_full_form_save_does_not_persist_prefixed_copy_on_parent(
+    mass: MusicAssistant,
+) -> None:
+    """A full-form save must keep protocol-prefixed entries off the parent config."""
+    await _setup_parent_with_protocol_child(mass)
+
+    await mass.config.save_player_config(
+        PARENT_ID,
+        {PREFIXED_KEY: FLOW_MODE_SAMPLE_RATE_BIT_PERFECT, "volume_normalization": False},
+    )
+
+    stored = _parent_stored_values(mass)
+    # parent-level (non-protocol) change is fine to persist
+    assert stored.get("volume_normalization") is False
+    # protocol-prefixed entries are virtual mirrors of the child and must never live on the parent
+    assert not any(CONF_PROTOCOL_KEY_SPLITTER in key for key in stored)


### PR DESCRIPTION
# What does this implement/fix?

For a player that streams via a linked protocol (e.g. a DLNA renderer wrapped in a Universal Player, or a Sonos with an AirPlay/DLNA output), the protocol-specific audio settings — Flow Mode sample rate, "Enforce Gapless playback", output codec, supported sample rates — are shown on the parent as virtual entries keyed `<protocol_player_id>||protocol||<key>`. Setting one to a non-default value saved fine, but setting it back to the default did not stick: it kept reappearing as the previous value.

The linked protocol player is the canonical store for these values. A redundant copy was being persisted on the parent player as well, and once the value was reset to its default the protocol player correctly dropped it while the parent's stale copy lingered and shadowed it on read-back — so the old value kept coming back. "Reset to defaults" hit the same problem.

Changes:
- `get_player_config` now strips any protocol-prefixed keys from a player's own persisted values before merging the live values back in from the protocol player(s), so a stale copy can never shadow the protocol player's current value (also self-heals existing installs).
- `save_player_config` no longer writes protocol-prefixed entries onto the player itself — the protocol player remains the sole store for them.
- Added regression tests covering the reset-to-default flow, a pre-existing stale copy, and the full-form save.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5685

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
