### PR TITLE
Fix WebDAV sync failing on folder names with special characters

### DIFF
--- a/music_assistant/providers/webdav/helpers.py
+++ b/music_assistant/providers/webdav/helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from dataclasses import dataclass
-from urllib.parse import unquote, urljoin
+from urllib.parse import quote, unquote, urljoin
 
 import aiohttp
 from defusedxml import ElementTree
@@ -187,6 +187,16 @@ async def webdav_test_connection(
 
 
 def build_webdav_url(base_url: str, path: str) -> str:
-    """Build a WebDAV URL by joining base URL with path."""
+    """
+    Build a WebDAV URL by joining the base URL with a relative resource path.
+
+    :param base_url: The WebDAV base URL.
+    :param path: A relative resource path, or an absolute URL which is returned as-is.
+    """
+    if path.startswith(("http://", "https://")):
+        return path
     normalized_base = base_url if base_url.endswith("/") else f"{base_url}/"
-    return urljoin(normalized_base, path.removeprefix("/"))
+    # Percent-encode the path so reserved characters (e.g. ; ? # :) survive intact;
+    # left unencoded they would be misread as URL params/query/fragment/scheme.
+    quoted_path = quote(path.removeprefix("/"), safe="/")
+    return urljoin(normalized_base, quoted_path)

--- a/music_assistant/providers/webdav/provider.py
+++ b/music_assistant/providers/webdav/provider.py
@@ -201,9 +201,13 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
                 continue
 
             decoded_href = unquote(item.href)
-            href_path = (
-                urlparse(decoded_href).path if decoded_href.startswith("http") else decoded_href
-            )
+            if decoded_href.startswith(("http://", "https://")):
+                # Extract the path by hand: urlparse would treat ; ? # in the path as
+                # params/query/fragment and corrupt names containing those characters.
+                after_scheme = decoded_href.split("://", 1)[1]
+                href_path = after_scheme[after_scheme.find("/") :] if "/" in after_scheme else ""
+            else:
+                href_path = decoded_href
 
             # Calculate relative path
             if href_path.startswith(base_path):

--- a/music_assistant/providers/webdav/provider.py
+++ b/music_assistant/providers/webdav/provider.py
@@ -166,7 +166,7 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
         session = self._session
 
         webdav_items = await webdav_propfind(session, webdav_url, depth=1, auth=self._auth)
-        filesystem_items = self._convert_webdav_items(webdav_items, webdav_url, path)
+        filesystem_items = self._convert_webdav_items(webdav_items, path)
 
         await self.cache.set(
             key=cache_key,
@@ -189,12 +189,10 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
     def _convert_webdav_items(
         self,
         webdav_items: list[WebDAVItem],
-        webdav_url: str,
         scan_path: str,
     ) -> list[FileSystemItem]:
         """Convert WebDAV items to FileSystemItems."""
         base_path = urlparse(self.base_url).path.rstrip("/")
-        current_path = urlparse(webdav_url).path.rstrip("/")
         result: list[FileSystemItem] = []
 
         for item in webdav_items:
@@ -207,10 +205,6 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
                 urlparse(decoded_href).path if decoded_href.startswith("http") else decoded_href
             )
 
-            # Skip the directory itself
-            if href_path.rstrip("/") == current_path:
-                continue
-
             # Calculate relative path
             if href_path.startswith(base_path):
                 relative_path = href_path[len(base_path) :].strip("/")
@@ -219,6 +213,13 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
                 relative_path = (
                     str(PurePosixPath(scan_path) / decoded_name) if scan_path else decoded_name
                 )
+
+            # Skip the directory being scanned itself (a depth-1 PROPFIND returns it too).
+            # Comparing on the resolved relative path is reliable even when the name holds
+            # characters a URL parser treats specially (e.g. ; ? #), which would otherwise
+            # make the directory list itself and recurse endlessly.
+            if relative_path == scan_path:
+                continue
 
             result.append(
                 FileSystemItem(
@@ -274,7 +275,7 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
 
         self.sync_running = True
         try:
-            await self._scan_recursive("", cur_filenames, file_checksums)
+            await self._scan_recursive("", cur_filenames, file_checksums, set())
         finally:
             self.sync_running = False
 
@@ -287,8 +288,14 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
         path: str,
         cur_filenames: set[str],
         file_checksums: dict[str, str],
+        visited: set[str],
     ) -> None:
         """Recursively scan WebDAV directory."""
+        # Guard against directory cycles (e.g. server-side symlink loops) so a single
+        # bad path can never exhaust the recursion limit and abort the whole sync.
+        if path in visited:
+            return
+        visited.add(path)
         try:
             items = await self._scandir(path)
         except LoginFailed, SetupFailedError, ProviderUnavailableError:
@@ -299,7 +306,9 @@ class WebDAVFileSystemProvider(LocalFileSystemProvider):
 
         for item in items:
             if item.is_dir:
-                await self._scan_recursive(item.relative_path, cur_filenames, file_checksums)
+                await self._scan_recursive(
+                    item.relative_path, cur_filenames, file_checksums, visited
+                )
             else:
                 prev_checksum = file_checksums.get(item.relative_path)
                 if await self._process_item_async(item, prev_checksum):

--- a/tests/providers/webdav/__init__.py
+++ b/tests/providers/webdav/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the WebDAV provider."""

--- a/tests/providers/webdav/test_helpers.py
+++ b/tests/providers/webdav/test_helpers.py
@@ -1,0 +1,35 @@
+"""Tests for the WebDAV helper functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from music_assistant.providers.webdav.helpers import build_webdav_url
+
+BASE_URL = "https://host.example/remote.php/dav/files/user/Music"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("Artist/Album", f"{BASE_URL}/Artist/Album"),
+        ("/Artist/Album", f"{BASE_URL}/Artist/Album"),
+        # reserved characters must be percent-encoded, not interpreted as
+        # params/query/fragment/scheme by the URL machinery
+        ("Live; Unplugged", f"{BASE_URL}/Live%3B%20Unplugged"),
+        ("Die drei ???", f"{BASE_URL}/Die%20drei%20%3F%3F%3F"),
+        ("Rock #1", f"{BASE_URL}/Rock%20%231"),
+        ("Live: In Concert", f"{BASE_URL}/Live%3A%20In%20Concert"),
+        # the path separator and umlauts are handled as expected
+        ("Sigur Rós/Ágætis", f"{BASE_URL}/Sigur%20R%C3%B3s/%C3%81g%C3%A6tis"),
+    ],
+)
+def test_build_webdav_url_encodes_reserved_characters(path: str, expected: str) -> None:
+    """Reserved characters in resource paths must be percent-encoded."""
+    assert build_webdav_url(BASE_URL, path) == expected
+
+
+def test_build_webdav_url_passes_through_absolute_urls() -> None:
+    """An absolute URL (e.g. from a playlist line) must be returned unchanged."""
+    absolute = "http://other.example/song.mp3"
+    assert build_webdav_url(BASE_URL, absolute) == absolute

--- a/tests/providers/webdav/test_scan.py
+++ b/tests/providers/webdav/test_scan.py
@@ -1,0 +1,101 @@
+"""Tests for the WebDAV provider directory scan logic."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from music_assistant.providers.filesystem_local.helpers import FileSystemItem
+from music_assistant.providers.webdav.helpers import WebDAVItem
+from music_assistant.providers.webdav.provider import WebDAVFileSystemProvider
+
+BASE_URL = "https://host.example/dav"
+
+
+def _make_provider() -> WebDAVFileSystemProvider:
+    provider = WebDAVFileSystemProvider.__new__(WebDAVFileSystemProvider)
+    provider.base_url = BASE_URL
+    provider.username = None
+    provider.password = None
+    provider.logger = MagicMock()
+    return provider
+
+
+def test_convert_skips_scanned_directory_with_special_chars() -> None:
+    """
+    The directory being scanned is returned by a depth-1 PROPFIND and must be skipped.
+
+    A name with a URL-reserved character (here ``;``) previously slipped past the skip
+    check, making the directory list itself and recurse until the recursion limit.
+    """
+    provider = _make_provider()
+    scan_path = "Live; Unplugged"
+    webdav_items = [
+        WebDAVItem(href="/dav/Live; Unplugged", name="Live; Unplugged", is_dir=True),
+        WebDAVItem(href="/dav/Live; Unplugged/01 track.mp3", name="01 track.mp3", is_dir=False),
+    ]
+
+    result = provider._convert_webdav_items(webdav_items, scan_path)
+
+    relative_paths = [item.relative_path for item in result]
+    assert relative_paths == ["Live; Unplugged/01 track.mp3"]
+    assert scan_path not in relative_paths
+
+
+def test_convert_skips_base_directory_at_root() -> None:
+    """The base directory itself must be skipped when scanning the root."""
+    provider = _make_provider()
+    webdav_items = [
+        WebDAVItem(href="/dav", name="dav", is_dir=True),
+        WebDAVItem(href="/dav/Artist", name="Artist", is_dir=True),
+    ]
+
+    result = provider._convert_webdav_items(webdav_items, "")
+
+    assert [item.relative_path for item in result] == ["Artist"]
+
+
+async def test_scan_recursive_stops_on_directory_cycle() -> None:
+    """A directory cycle must not exhaust the recursion limit."""
+    provider = _make_provider()
+    # A -> A/B -> A (back-edge to an ancestor); only the guard can break this
+    listing = {
+        "": [FileSystemItem("A", "A", "", is_dir=True)],
+        "A": [FileSystemItem("B", "A/B", "", is_dir=True)],
+        "A/B": [FileSystemItem("A", "A", "", is_dir=True)],
+    }
+    scanned: list[str] = []
+
+    async def fake_scandir(path: str) -> list[FileSystemItem]:
+        scanned.append(path)
+        return listing[path]
+
+    provider._scandir = AsyncMock(side_effect=fake_scandir)  # type: ignore[method-assign]
+
+    await provider._scan_recursive("", set(), {}, set())
+
+    # each directory is scanned exactly once despite the cycle
+    assert sorted(scanned) == ["", "A", "A/B"]
+
+
+@pytest.mark.parametrize("special", ["Live; Unplugged", "Die drei ???", "Rock #1"])
+async def test_scan_recursive_does_not_loop_on_special_chars(special: str) -> None:
+    """Folders with reserved characters must be traversed without looping."""
+    provider = _make_provider()
+    track = FileSystemItem("t.mp3", f"{special}/t.mp3", "", is_dir=False)
+    listing = {
+        "": [FileSystemItem(special, special, "", is_dir=True)],
+        special: [track],
+    }
+
+    async def fake_scandir(path: str) -> list[FileSystemItem]:
+        return listing[path]
+
+    provider._scandir = AsyncMock(side_effect=fake_scandir)  # type: ignore[method-assign]
+    provider._process_item_async = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    cur_filenames: set[str] = set()
+
+    await provider._scan_recursive("", cur_filenames, {}, set())
+
+    assert cur_filenames == {f"{special}/t.mp3"}

--- a/tests/providers/webdav/test_scan.py
+++ b/tests/providers/webdav/test_scan.py
@@ -43,6 +43,33 @@ def test_convert_skips_scanned_directory_with_special_chars() -> None:
     assert scan_path not in relative_paths
 
 
+def test_convert_handles_absolute_href_with_special_chars() -> None:
+    """
+    Some servers return absolute hrefs; the path must be extracted without a URL parser.
+
+    ``urlparse`` would treat the ``;`` as params and truncate the name, mis-scanning the
+    folder; the resolved relative path must keep reserved characters intact.
+    """
+    provider = _make_provider()
+    scan_path = "Live; Unplugged"
+    webdav_items = [
+        WebDAVItem(
+            href="https://host.example/dav/Live; Unplugged",
+            name="Live; Unplugged",
+            is_dir=True,
+        ),
+        WebDAVItem(
+            href="https://host.example/dav/Live; Unplugged/01 track.mp3",
+            name="01 track.mp3",
+            is_dir=False,
+        ),
+    ]
+
+    result = provider._convert_webdav_items(webdav_items, scan_path)
+
+    assert [item.relative_path for item in result] == ["Live; Unplugged/01 track.mp3"]
+
+
 def test_convert_skips_base_directory_at_root() -> None:
     """The base directory itself must be skipped when scanning the root."""
     provider = _make_provider()


### PR DESCRIPTION
# What does this implement/fix?

WebDAV library sync crashed with `RecursionError: maximum recursion depth exceeded` and left only a handful of albums in the library when folder names contained URL-reserved characters.

The directory-self skip and the request URLs were built by running the path through `urljoin`/`urlparse`, which misinterpret reserved characters:

- `;` makes `urlparse(...).path` drop everything after it, so the skip of the directory currently being scanned fails — the directory lists itself and recurses until the recursion limit (the reported crash).
- `?`, `#` and a leading `scheme:` are read as query/fragment/scheme, so those folders (and their subtrees) are silently dropped — e.g. the popular "Die drei ???" audiobooks.

**Related issue:**

- https://github.com/music-assistant/support/issues/5667

## Changes

- Percent-encode resource paths in `build_webdav_url` so reserved characters survive instead of being interpreted by the URL machinery (absolute URLs are passed through unchanged).
- Skip the scanned directory itself by comparing the resolved relative path instead of a re-parsed URL.
- Guard the recursive scan with a visited set so a directory cycle can never exhaust the recursion limit.
- Add tests for the URL building and scan behaviour.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
