### PR TITLE
Fix podcast episode lookup and a queue preload crash on a drained queue

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -2338,7 +2338,12 @@ class PlayerQueuesController(CoreController):
                     return  # guard
                 retries = max(120, (queue.current_item.duration or 0) + 10)
                 while retries > 0:
-                    if queue.current_item.queue_item_id == item_id_in_buffer:
+                    # the queue can drain to empty while we sleep (e.g. all remaining
+                    # items skipped as unplayable); stop waiting once it has no current item
+                    current_item = queue.current_item
+                    if current_item is None:
+                        return
+                    if current_item.queue_item_id == item_id_in_buffer:
                         break
                     retries -= 1
                     await asyncio.sleep(1)

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -333,10 +333,12 @@ class ITunesPodcastsProvider(MusicProvider):
     async def _get_episode_stream_url(self, podcast_id: str, guid_or_stream_url: str) -> str | None:
         podcast = await self._cache_get_podcast(podcast_id)
         episodes = podcast.get("episodes", [])
-        for cnt, episode in enumerate(episodes):
+        for episode in episodes:
             episode_enclosures = episode.get("enclosures", [])
             if len(episode_enclosures) < 1:
-                raise MediaNotFoundError
+                # episode without an enclosure carries no stream; skip it instead of
+                # aborting the lookup for the (potentially later) requested episode
+                continue
             stream_url: str | None = episode_enclosures[0].get("url", None)
             guid = episode.get("guid")
             if guid is not None and len(guid.split(" ")) == 1:


### PR DESCRIPTION
# What does this implement/fix?

Two robustness fixes surfaced while investigating #5692 (podcast episodes skipped as "produced no audio data").

Note on the reported root cause: the feed declaring enclosures as `type="file"` is *not* discarded — `podcastparser` normalizes the MIME and keeps the enclosure, and the episode's mp3 URL resolves and decodes fine, so the "no audio" symptom does not reproduce on current code. The `text/xml` URL the reporter curled is the feed URL embedded in the episode URI, not the resolved stream path. These changes fix two real issues found along the way.

**Related issue:**

- https://github.com/music-assistant/support/issues/5692

## Changes

- **itunes_podcasts:** `_get_episode_stream_url` raised `MediaNotFoundError` on the first episode without an enclosure, aborting the lookup for the requested episode. It now skips enclosure-less episodes, so a feed mixing episodes with and without enclosures can still play its valid ones.
- **player_queues:** the preload retry loop re-read `queue.current_item` after sleeping but dereferenced it unguarded. When the queue drains to empty mid-loop (e.g. all remaining items skipped as unplayable) the background preload task crashed with `AttributeError: 'NoneType' object has no attribute 'queue_item_id'` (the secondary crash in the issue). The loop now re-reads and guards `current_item` each iteration.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
