### PR TITLE
Localize injected protocol output config entries

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -160,7 +160,9 @@ def _with_translation_owner(
     result: list[ConfigEntry] = []
     for entry in entries:
         # replace() returns a copy so we never mutate the shared (often module-level) entry defs.
-        copied = replace(entry, translation_owner=owner)
+        # An entry that already declares an owner (e.g. an injected protocol entry that belongs to
+        # its origin provider, not the host player) keeps it; everything else gets the passed owner.
+        copied = replace(entry, translation_owner=entry.translation_owner or owner)
         if populate and values is not None and copied.value is None:
             copied.value = values.get(copied.key, copied.default_value)
         result.append(copied)
@@ -675,7 +677,16 @@ class ConfigController:
                 )
                 raw_conf.setdefault("player_id", player_id)
 
-            return cast("PlayerConfig", PlayerConfig.parse(config_entries, raw_conf))
+            conf = cast("PlayerConfig", PlayerConfig.parse(config_entries, raw_conf))
+            # parse() stamps every entry with this player's owner; injected protocol entries
+            # belong to their own protocol provider, so restore that owner for string resolution.
+            for entry in conf.values.values():
+                if CONF_PROTOCOL_KEY_SPLITTER not in entry.key:
+                    continue
+                protocol_player_id = entry.key.split(CONF_PROTOCOL_KEY_SPLITTER, 1)[0]
+                if protocol_player := self.mass.players.get_player(protocol_player_id, False):
+                    entry.translation_owner = protocol_player.translation_owner
+            return conf
         msg = f"No config found for player id {player_id}"
         raise KeyError(msg)
 
@@ -2082,7 +2093,7 @@ class ConfigController:
             protocol_prefix = f"{protocol.output_protocol_id}{CONF_PROTOCOL_KEY_SPLITTER}"
             protocol_enabled_key = f"{protocol_prefix}enabled"
             protocol_category = f"{CONF_PROTOCOL_CATEGORY_PREFIX}_{domain}"
-            category_translation_key = "config_categories.protocol_output_settings"
+            category_translation_key = "protocol_output_settings"
             if not protocol.is_native:
                 all_entries.append(
                     ConfigEntry(
@@ -2138,8 +2149,10 @@ class ConfigController:
                     entry.category_translation_key = category_translation_key
                     entry.category_translation_params = [protocol_name]
                     # the key gets prefixed below to avoid collisions; pin the catalog key to the
-                    # original so the label still resolves against config_entries.<original_key>
-                    entry.translation_key = entry.translation_key or f"config_entries.{entry.key}"
+                    # original (bare) slug and the protocol's own provider so the label still
+                    # resolves against provider.<domain>.config_entries.<original_key>
+                    entry.translation_key = entry.translation_key or entry.key
+                    entry.translation_owner = protocol_player.translation_owner
                     entry.key = f"{protocol_prefix}{entry.key}"
                     entry.depends_on = None if protocol.is_native else protocol_enabled_key
                     entry.action = f"{protocol_prefix}{entry.action}" if entry.action else None

--- a/tests/core/test_config_protocol_defaults.py
+++ b/tests/core/test_config_protocol_defaults.py
@@ -43,6 +43,7 @@ class _TestProvider:
         self.mass = mass
         self.domain = domain
         self.instance_id = domain
+        self.translation_owner = f"provider.{domain}"
         self.name = f"{domain.title()} Provider"
         self.available = True
         self.logger = logging.getLogger(f"test.{domain}")
@@ -188,3 +189,22 @@ async def test_full_form_save_does_not_persist_prefixed_copy_on_parent(
     assert stored.get("volume_normalization") is False
     # protocol-prefixed entries are virtual mirrors of the child and must never live on the parent
     assert not any(CONF_PROTOCOL_KEY_SPLITTER in key for key in stored)
+
+
+async def test_injected_protocol_entry_resolves_under_origin_provider(
+    mass: MusicAssistant,
+) -> None:
+    """Injected protocol entries carry their origin provider's owner + bare key, not the host's."""
+    await _setup_parent_with_protocol_child(mass)
+
+    # config/players/get (parsed PlayerConfig) path
+    config = await mass.config.get_player_config(PARENT_ID)
+    entry = config.values[PREFIXED_KEY]
+    assert entry.translation_owner == "provider.dlna"
+    assert entry.translation_key == CONF_FLOW_MODE_SAMPLE_RATE
+
+    # config/players/get_entries (raw entries) path
+    entries = await mass.config.get_player_config_entries(PARENT_ID)
+    proto_entry = next(entry for entry in entries if entry.key == PREFIXED_KEY)
+    assert proto_entry.translation_owner == "provider.dlna"
+    assert proto_entry.translation_key == CONF_FLOW_MODE_SAMPLE_RATE


### PR DESCRIPTION
# What does this implement/fix?

The per-protocol output config entries that get injected onto a player (re-keyed to `<protocol_id>||protocol||<key>`) showed their raw key instead of a translated label under server-owned i18n — e.g. `apf…||protocol||encryption` instead of "Enable encryption".

Two causes:
- they kept a fully-qualified `translation_key` (`config_entries.<key>`), which the new model double-prefixes to `config_entries.config_entries.<key>`
- they inherited the parent player's owner instead of the protocol provider's, so the AirPlay/etc. strings never resolved (only the `common` ones did, which is why some labels rendered and some didn't)

Fix:
- pin the catalog key to the original **bare** slug and stamp the protocol's own provider as the entry owner
- restore that owner after `PlayerConfig.parse` (which re-stamps every entry with the parent player's owner)
- same bare-key fix for the category label

The injection approach is kept as-is; this just makes the copied entries resolve under their origin provider.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.