### PR TITLE
Speed up CI test jobs (split ffmpeg tests + skip on non-code PRs)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           python-version-file: ".python-version"
           check-latest: true
       - name: Install libchromaprint
-        run: sudo apt-get install -y libchromaprint1
+        run: sudo apt-get update && sudo apt-get install -y libchromaprint1
       - name: Install uv
         run: pip install uv
       - name: Cache uv packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,8 @@ jobs:
         with:
           python-version-file: ".python-version"
           check-latest: true
+      - name: Install libchromaprint
+        run: sudo apt-get install -y libchromaprint1
       - name: Install uv
         run: pip install uv
       - name: Cache uv packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Lint/test with pre-commit
         run: SKIP=no-commit-to-branch pre-commit run --all-files
 
-  test-fast:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,34 @@ jobs:
       - name: Lint/test with pre-commit
         run: SKIP=no-commit-to-branch pre-commit run --all-files
 
-  test:
+  test-fast:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version-file: ".python-version"
+          check-latest: true
+      - name: Install uv
+        run: pip install uv
+      - name: Cache uv packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('.python-version') }}-${{ hashFiles('requirements_all.txt', 'pyproject.toml') }}
+      - name: Install dependencies
+        # --index-strategy: allow PyPI packages when also using the PyTorch extra index
+        # https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes
+        run: uv pip install --system --index-strategy unsafe-best-match . .[test] -r requirements_all.txt
+      - name: Pytest
+        run: pytest --durations 10 --cov-report term-missing --cov=music_assistant --cov-report=xml -m "not needs_ffmpeg" tests/
+
+  test-ffmpeg:
     runs-on: ubuntu-latest
 
     steps:
@@ -102,4 +129,4 @@ jobs:
         # https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes
         run: uv pip install --system --index-strategy unsafe-best-match . .[test] -r requirements_all.txt
       - name: Pytest
-        run: pytest --durations 10 --cov-report term-missing --cov=music_assistant --cov-report=xml tests/
+        run: pytest --durations 10 -m needs_ffmpeg tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,34 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      # Skip the test jobs on PRs that only touch docs, translations metadata or
+      # unrelated workflows. Anything under music_assistant/ or tests/ still runs.
+      - name: Detect relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'music_assistant/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'requirements_all.txt'
+              - 'uv.lock'
+              - '.python-version'
+              - '.github/workflows/test.yml'
+
   lint:
     runs-on: ubuntu-latest
 
@@ -65,6 +93,8 @@ jobs:
         run: SKIP=no-commit-to-branch pre-commit run --all-files
 
   test:
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -94,6 +124,8 @@ jobs:
         run: pytest --durations 10 --cov-report term-missing --cov=music_assistant --cov-report=xml -m "not needs_ffmpeg" tests/
 
   test-ffmpeg:
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,9 @@ line-ending = "lf"
 [tool.pytest.ini_options]
 addopts = "--cov music_assistant"
 asyncio_mode = "auto"
+markers = [
+    "needs_ffmpeg: mark test as requiring a working ffmpeg installation",
+]
 filterwarnings = [
   # Suppress Python 3.14 AsyncMock internal warnings about unawaited coroutines
   "ignore:coroutine.*was never awaited:RuntimeWarning",

--- a/tests/core/test_tags.py
+++ b/tests/core/test_tags.py
@@ -19,6 +19,8 @@ from music_assistant.helpers.tags import (
     write_replaygain_track_gain,
 )
 
+pytestmark = pytest.mark.needs_ffmpeg
+
 RESOURCES_DIR = pathlib.Path(__file__).parent.parent.resolve().joinpath("fixtures")
 
 FILE_MP3 = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle.mp3"))

--- a/tests/core/test_tags.py
+++ b/tests/core/test_tags.py
@@ -19,8 +19,6 @@ from music_assistant.helpers.tags import (
     write_replaygain_track_gain,
 )
 
-pytestmark = pytest.mark.needs_ffmpeg
-
 RESOURCES_DIR = pathlib.Path(__file__).parent.parent.resolve().joinpath("fixtures")
 
 FILE_MP3 = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle.mp3"))
@@ -31,6 +29,7 @@ FILE_FLAC_SEMICOLON = str(RESOURCES_DIR.joinpath("ArtistWithSemicolon.flac"))
 FILE_WV = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle.wv"))
 
 
+@pytest.mark.needs_ffmpeg
 async def test_parse_metadata_from_id3tags() -> None:
     """Test parsing of parsing metadata from ID3 tags."""
     filename = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle.mp3"))
@@ -65,6 +64,7 @@ async def test_parse_metadata_from_id3tags() -> None:
     assert _tags.year is None
 
 
+@pytest.mark.needs_ffmpeg
 async def test_parse_id3v24_null_separated_artists() -> None:
     """Test parsing ID3v2.4 tags with null-separated multi-value TPE1/TPE2."""
     _tags = await tags.async_parse_tags(FILE_MP3_ID3V24_MULTIVALUE)
@@ -77,6 +77,7 @@ async def test_parse_id3v24_null_separated_artists() -> None:
     assert _tags.musicbrainz_albumartistids == ("mb-albumartist-1", "mb-albumartist-2")
 
 
+@pytest.mark.needs_ffmpeg
 async def test_parse_metadata_from_mp4tags() -> None:
     """Test parsing of metadata from MP4/AAC tags."""
     filename = FILE_M4A
@@ -134,6 +135,7 @@ def test_parse_metadata_from_apev2tags() -> None:
     assert result.get("albumartistsort") == ["MyAlbumArtist Sort"]
 
 
+@pytest.mark.needs_ffmpeg
 async def test_parse_metadata_from_flac_with_multiple_artist_fields() -> None:
     """Test parsing of FLAC file with multiple ARTIST fields (per Vorbis spec)."""
     _tags = await tags.async_parse_tags(FILE_FLAC)
@@ -154,6 +156,7 @@ async def test_parse_metadata_from_flac_with_multiple_artist_fields() -> None:
     assert _tags.disc == 1
 
 
+@pytest.mark.needs_ffmpeg
 async def test_parse_metadata_from_filename() -> None:
     """Test parsing of parsing metadata from filename."""
     filename = str(RESOURCES_DIR.joinpath("MyArtist - MyTitle without Tags.mp3"))
@@ -170,6 +173,7 @@ async def test_parse_metadata_from_filename() -> None:
     assert _tags.musicbrainz_recordingid is None
 
 
+@pytest.mark.needs_ffmpeg
 async def test_parse_metadata_from_invalid_filename() -> None:
     """Test parsing of parsing metadata from (invalid) filename."""
     filename = str(RESOURCES_DIR.joinpath("test.mp3"))
@@ -584,6 +588,7 @@ def test_vorbis_multiple_artist_fields_semicolon_in_name() -> None:
     assert len(audio_tags.artists) == len(audio_tags.musicbrainz_artistids)
 
 
+@pytest.mark.needs_ffmpeg
 async def test_flac_multiple_artist_fields_semicolon_e2e() -> None:
     """End-to-end test: FLAC with multiple ARTIST fields, one containing semicolon.
 

--- a/tests/integration/test_background_scan_streaming.py
+++ b/tests/integration/test_background_scan_streaming.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
     from music_assistant_models.streamdetails import StreamDetails
 
+pytestmark = pytest.mark.needs_ffmpeg
+
 FIXTURE_AUDIO = Path(__file__).parent.parent / "fixtures" / "audio" / "short_test.flac"
 
 


### PR DESCRIPTION
A few changes to stop running the full, heavy test suite for every PR.

**Split the test job by ffmpeg need**
- Add a `needs_ffmpeg` marker; split the old `test` job into `test` (no ffmpeg install) and `test-ffmpeg` (installs ffmpeg, runs only marked tests). They run in parallel.
- Only two test files actually spawn real ffprobe/ffmpeg: `test_tags.py` (the `async_parse_tags` tests) and `test_background_scan_streaming.py`. The rest mock it.
- `test` installs `libchromaprint1` directly (it used to come in transitively with ffmpeg, which `acoustid_lookup` needs at import).

**Skip tests entirely on non-code PRs**
- New `changes` job (paths-filter): on PRs that only touch docs/unrelated workflows, the test jobs are skipped. Anything under `music_assistant/` or `tests/` still runs, so translation PRs keep running `test_translations.py`.
- Pushes to dev/stable always run the full suite.