### PR TITLE
Skip dynamic playlists in refresh scan, sync provider-owned name/images

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -417,8 +417,9 @@ class MetaDataController(
         update_current_task_progress_text("Searching for playlists needing metadata refresh")
         refresh_before = int(time() - REFRESH_INTERVAL)
         query = (
+            f"{DB_TABLE_PLAYLISTS}.is_dynamic = 0 AND ("
             f"json_extract({DB_TABLE_PLAYLISTS}.metadata,'$.last_refresh') ISNULL "
-            f"OR json_extract({DB_TABLE_PLAYLISTS}.metadata,'$.last_refresh') < {refresh_before}"
+            f"OR json_extract({DB_TABLE_PLAYLISTS}.metadata,'$.last_refresh') < {refresh_before})"
         )
         playlists = await self.mass.music.playlists.get_library_items_by_query(
             limit=METADATA_SCAN_BATCH_SIZE,

--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -323,6 +323,13 @@ class MetadataEnrichmentMixin:
         self, playlist: Playlist, force_refresh: bool = False
     ) -> None:
         """Get/update rich metadata for a playlist."""
+        # dynamic playlists (e.g. Pandora stations, Apple Music stations) are
+        # provider-driven and endless: scanning "all" tracks for aggregate metadata
+        # doesn't make sense, and for providers with a stateful streaming API
+        # (e.g. Pandora) it can actively interfere with playback by triggering
+        # real, unintended fetches against the provider's API.
+        if playlist.is_dynamic:
+            return
         # collect metadata + create collage images
         # NOTE: we only do/allow this every REFRESH_INTERVAL
         needs_refresh = (time() - (playlist.metadata.last_refresh or 0)) > REFRESH_INTERVAL

--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -325,9 +325,7 @@ class MetadataEnrichmentMixin:
         """Get/update rich metadata for a playlist."""
         # dynamic playlists (e.g. Pandora stations, Apple Music stations) are
         # provider-driven and endless: scanning "all" tracks for aggregate metadata
-        # doesn't make sense, and for providers with a stateful streaming API
-        # (e.g. Pandora) it can actively interfere with playback by triggering
-        # real, unintended fetches against the provider's API.
+        # doesn't make sense
         if playlist.is_dynamic:
             return
         # collect metadata + create collage images

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1065,6 +1065,16 @@ class MusicProvider(Provider):
                     library_item = await self.mass.music.playlists.update_item_in_library(
                         library_item.item_id, prov_item
                     )
+                elif not library_item.is_editable and (
+                    prov_item.name != library_item.name
+                    or prov_item.metadata.images != library_item.metadata.images
+                ):
+                    # the provider is the sole source of truth for non-editable playlists
+                    # (e.g. Pandora/personalized-radio stations), so it's safe to overwrite
+                    # name/images here without risking clobbering a user's local customization
+                    library_item = await self.mass.music.playlists.update_item_in_library(
+                        library_item.item_id, prov_item, overwrite=True
+                    )
                 if not library_item.favorite and prov_item.favorite:
                     # existing library item not favorite but should be
                     await self.mass.music.playlists.set_favorite(library_item.item_id, True)

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -1065,13 +1065,20 @@ class MusicProvider(Provider):
                     library_item = await self.mass.music.playlists.update_item_in_library(
                         library_item.item_id, prov_item
                     )
-                elif not library_item.is_editable and (
-                    prov_item.name != library_item.name
-                    or prov_item.metadata.images != library_item.metadata.images
+                elif (
+                    prov_item.is_dynamic
+                    and not library_item.is_editable
+                    and (
+                        prov_item.name != library_item.name
+                        or prov_item.metadata.images != library_item.metadata.images
+                    )
                 ):
-                    # the provider is the sole source of truth for non-editable playlists
-                    # (e.g. Pandora/personalized-radio stations), so it's safe to overwrite
-                    # name/images here without risking clobbering a user's local customization
+                    # the provider is the sole source of truth for non-editable dynamic
+                    # playlists (e.g. Pandora/personalized-radio stations): overwrite=True
+                    # replaces the full stored record (not just name/images), which is fine
+                    # here since there's no local customization on these to lose. Restricted
+                    # to is_dynamic so static non-editable playlists (e.g. provider
+                    # "favorites") keep their locally-enriched metadata/images.
                     library_item = await self.mass.music.playlists.update_item_in_library(
                         library_item.item_id, prov_item, overwrite=True
                     )

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -68,7 +68,7 @@ async def test_refresh_playlist_metadata_batch_query_excludes_dynamic_playlists(
 
 
 # --------------------------------------------------------------------------- #
-#  Provider sync overwrites name/images for non-editable dynamic playlists    #
+#  Provider sync overwrites name/images for non-editable *dynamic* playlists  #
 # --------------------------------------------------------------------------- #
 
 
@@ -79,6 +79,7 @@ def _build_sync_fixture(
     prov_name: str,
     library_images: list[str],
     prov_images: list[str],
+    is_dynamic: bool = True,
 ) -> tuple[MusicProvider, AsyncMock, Mock]:
     """Build a MusicProvider + mocked playlists controller wired for one sync pass."""
     mapping = _provider_mapping()
@@ -91,6 +92,7 @@ def _build_sync_fixture(
     library_item.date_added = None
     library_item.supported_mediatypes = [MediaType.TRACK]
     library_item.favorite = True
+    library_item.is_dynamic = is_dynamic
 
     prov_item = Mock()
     prov_item.item_id = "station_1"
@@ -101,6 +103,7 @@ def _build_sync_fixture(
     prov_item.favorite = True
     prov_item.provider_mappings = UniqueList([mapping])
     prov_item.uri = "pandora://station_1"
+    prov_item.is_dynamic = is_dynamic
 
     updated_item = Mock()
     updated_item.item_id = "1"
@@ -176,6 +179,26 @@ async def test_sync_does_not_overwrite_editable_playlist_on_name_change() -> Non
         prov_name="New Name",
         library_images=["same.jpg"],
         prov_images=["same.jpg"],
+    )
+
+    await _run_sync(provider, prov_item)
+
+    playlists_ctrl.update_item_in_library.assert_not_called()
+
+
+async def test_sync_does_not_overwrite_noneditable_static_playlist_on_name_change() -> None:
+    """Non-editable, non-dynamic playlists (e.g. a provider's "Favorites") are spared.
+
+    Only non-editable *dynamic* playlists are treated as provider-owned; a static
+    non-editable playlist keeps its locally-enriched metadata/images.
+    """
+    provider, playlists_ctrl, prov_item = _build_sync_fixture(
+        library_is_editable=False,
+        library_name="Old Name",
+        prov_name="New Name",
+        library_images=["same.jpg"],
+        prov_images=["same.jpg"],
+        is_dynamic=False,
     )
 
     await _run_sync(provider, prov_item)

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -1,0 +1,198 @@
+"""Tests for dynamic-playlist handling in the metadata refresh scan and provider sync."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, Mock, patch
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import ProviderMapping, UniqueList
+
+from music_assistant.constants import DB_TABLE_PLAYLISTS
+from music_assistant.controllers.metadata import MetaDataController
+from music_assistant.controllers.metadata.enrichment import MetadataEnrichmentMixin
+from music_assistant.models.music_provider import MusicProvider
+
+
+def _controller() -> MetaDataController:
+    """Create a bare MetaDataController without running __init__."""
+    return MetaDataController.__new__(MetaDataController)
+
+
+def _provider() -> MusicProvider:
+    """Create a bare MusicProvider without running __init__."""
+    return MusicProvider.__new__(MusicProvider)
+
+
+def _provider_mapping(item_id: str = "station_1") -> ProviderMapping:
+    """Build a minimal ProviderMapping for a Pandora-style station."""
+    return ProviderMapping(
+        item_id=item_id,
+        provider_domain="pandora",
+        provider_instance="pandora_1",
+        in_library=True,
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  Metadata refresh scan skips dynamic playlists                              #
+# --------------------------------------------------------------------------- #
+
+
+async def test_update_playlist_metadata_skips_dynamic_playlists() -> None:
+    """Dynamic playlists must not be scanned for aggregate track metadata."""
+    mixin = MetadataEnrichmentMixin()
+    mixin.mass = Mock()
+    mixin.logger = Mock()
+    playlist = Mock()
+    playlist.is_dynamic = True
+
+    await mixin._update_playlist_metadata(playlist)
+
+    mixin.mass.music.playlists.tracks.assert_not_called()
+    mixin.logger.debug.assert_not_called()
+
+
+async def test_refresh_playlist_metadata_batch_query_excludes_dynamic_playlists() -> None:
+    """The metadata-refresh batch query filters out is_dynamic playlists at the DB level."""
+    ctrl = _controller()
+    mass = Mock()
+    mass.music.playlists.get_library_items_by_query = AsyncMock(return_value=[])
+    ctrl.mass = mass
+
+    await ctrl._refresh_playlist_metadata_batch()
+
+    _, kwargs = mass.music.playlists.get_library_items_by_query.call_args
+    query_parts = kwargs["extra_query_parts"]
+    assert any(f"{DB_TABLE_PLAYLISTS}.is_dynamic = 0" in part for part in query_parts)
+
+
+# --------------------------------------------------------------------------- #
+#  Provider sync overwrites name/images for non-editable dynamic playlists    #
+# --------------------------------------------------------------------------- #
+
+
+def _build_sync_fixture(
+    *,
+    library_is_editable: bool,
+    library_name: str,
+    prov_name: str,
+    library_images: list[str],
+    prov_images: list[str],
+) -> tuple[MusicProvider, AsyncMock, Mock]:
+    """Build a MusicProvider + mocked playlists controller wired for one sync pass."""
+    mapping = _provider_mapping()
+
+    library_item = Mock()
+    library_item.item_id = "1"
+    library_item.is_editable = library_is_editable
+    library_item.name = library_name
+    library_item.metadata = Mock(images=library_images)
+    library_item.date_added = None
+    library_item.supported_mediatypes = [MediaType.TRACK]
+    library_item.favorite = True
+
+    prov_item = Mock()
+    prov_item.item_id = "station_1"
+    prov_item.name = prov_name
+    prov_item.metadata = Mock(images=prov_images)
+    prov_item.date_added = None
+    prov_item.supported_mediatypes = [MediaType.TRACK]
+    prov_item.favorite = True
+    prov_item.provider_mappings = UniqueList([mapping])
+    prov_item.uri = "pandora://station_1"
+
+    updated_item = Mock()
+    updated_item.item_id = "1"
+    updated_item.favorite = True
+
+    playlists_ctrl = AsyncMock()
+    playlists_ctrl.get_library_item_by_prov_mappings = AsyncMock(return_value=library_item)
+    playlists_ctrl.update_item_in_library = AsyncMock(return_value=updated_item)
+
+    mass = Mock()
+    mass.music.playlists = playlists_ctrl
+
+    provider = _provider()
+    provider.mass = mass
+    provider.config = Mock(get_value=Mock(return_value=[]))
+    provider.logger = Mock()
+
+    return provider, playlists_ctrl, prov_item
+
+
+async def _get_single_playlist(prov_item: Mock) -> AsyncIterator[Mock]:
+    """Yield a single provider playlist item, mirroring get_library_playlists()."""
+    yield prov_item
+
+
+async def _run_sync(provider: MusicProvider, prov_item: Mock) -> None:
+    """Run _sync_library_playlists() with its provider-side hooks patched out."""
+    with patch.multiple(
+        provider,
+        get_library_playlists=Mock(return_value=_get_single_playlist(prov_item)),
+        _check_provider_mappings=Mock(return_value=True),
+        _update_sync_task_item_status=Mock(),
+        _report_sync_task_failure=Mock(),
+    ):
+        await provider._sync_library_playlists()
+
+
+async def test_sync_overwrites_name_for_noneditable_dynamic_playlist() -> None:
+    """A non-editable playlist whose name changed on the provider gets overwritten."""
+    provider, playlists_ctrl, prov_item = _build_sync_fixture(
+        library_is_editable=False,
+        library_name="Old Station Name",
+        prov_name="New Station Name",
+        library_images=["same.jpg"],
+        prov_images=["same.jpg"],
+    )
+
+    await _run_sync(provider, prov_item)
+
+    playlists_ctrl.update_item_in_library.assert_called_once_with("1", prov_item, overwrite=True)
+
+
+async def test_sync_overwrites_images_for_noneditable_dynamic_playlist() -> None:
+    """A non-editable playlist whose images changed on the provider gets overwritten."""
+    provider, playlists_ctrl, prov_item = _build_sync_fixture(
+        library_is_editable=False,
+        library_name="Same Name",
+        prov_name="Same Name",
+        library_images=["old.jpg"],
+        prov_images=["new.jpg"],
+    )
+
+    await _run_sync(provider, prov_item)
+
+    playlists_ctrl.update_item_in_library.assert_called_once_with("1", prov_item, overwrite=True)
+
+
+async def test_sync_does_not_overwrite_editable_playlist_on_name_change() -> None:
+    """User-editable playlists are never force-overwritten, even if names diverge."""
+    provider, playlists_ctrl, prov_item = _build_sync_fixture(
+        library_is_editable=True,
+        library_name="Old Name",
+        prov_name="New Name",
+        library_images=["same.jpg"],
+        prov_images=["same.jpg"],
+    )
+
+    await _run_sync(provider, prov_item)
+
+    playlists_ctrl.update_item_in_library.assert_not_called()
+
+
+async def test_sync_skips_update_when_noneditable_playlist_unchanged() -> None:
+    """No spurious update is issued when name/images already match."""
+    provider, playlists_ctrl, prov_item = _build_sync_fixture(
+        library_is_editable=False,
+        library_name="Same Name",
+        prov_name="Same Name",
+        library_images=["same.jpg"],
+        prov_images=["same.jpg"],
+    )
+
+    await _run_sync(provider, prov_item)
+
+    playlists_ctrl.update_item_in_library.assert_not_called()


### PR DESCRIPTION
# What does this implement/fix?

Dynamic playlists are provider-driven and effectively endless - they don't have a meaningful "full track list" to scan for aggregate metadata the way a normal playlist does. Right now, the generic metadata-refresh background process scans them anyway. At best, this wastes cycles on data that is irrelevant immediately after it is pulled. At worst, this actively interferes with playback for providers with stateful streaming APIs. In Pandora, this shows up as evicting an in-use streaming session in favor of metadata refresh. 

This PR establishes the baseline framework support dynamic playlists need:

- Skip `is_dynamic` playlists entirely in the metadata refresh scan
- During the provider sync, let non-editable dynamic playlists (provider is source of truth) pick up name/image changes pushed by the provider

**Related issue (if applicable):**

- supports #3765 

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
