### PR TITLE
Only run affected tests on PRs (pytest-testmon)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,8 +107,24 @@ jobs:
         # --index-strategy: allow PyPI packages when also using the PyTorch extra index
         # https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes
         run: uv pip install --system --index-strategy unsafe-best-match . .[test] -r requirements_all.txt
+      # testmon only re-runs tests whose covered code changed since the cached baseline.
+      # The baseline is rebuilt on every push to dev/stable; PRs restore it read-only.
+      # The dep hash in the key invalidates the baseline whenever dependencies change.
+      - name: Restore testmon baseline
+        uses: actions/cache/restore@v5
+        with:
+          path: .testmondata
+          key: testmon-${{ runner.os }}-${{ hashFiles('.python-version', 'requirements_all.txt', 'pyproject.toml') }}-${{ github.run_id }}
+          restore-keys: |
+            testmon-${{ runner.os }}-${{ hashFiles('.python-version', 'requirements_all.txt', 'pyproject.toml') }}-
       - name: Pytest
-        run: pytest --durations 10 --cov-report term-missing --cov=music_assistant --cov-report=xml -m "not needs_ffmpeg" tests/
+        run: pytest --durations 10 --testmon -m "not needs_ffmpeg" tests/
+      - name: Save testmon baseline
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v5
+        with:
+          path: .testmondata
+          key: testmon-${{ runner.os }}-${{ hashFiles('.python-version', 'requirements_all.txt', 'pyproject.toml') }}-${{ github.run_id }}
 
   test-ffmpeg:
     needs: changes

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ venv/
 .history
 .idea
 .coverage
+.testmondata*
 uv.lock
 /.claude/*
 !/.claude/skills

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ test = [
   "pytest==9.0.3",
   "pytest-aiohttp==1.1.0",
   "pytest-cov==7.0.0",
+  "pytest-testmon==2.2.0",
   "syrupy==5.2.0",
   "tomli==2.4.1",
   "ruff==0.15.6",


### PR DESCRIPTION
Draft / proof-of-concept. Follow-up to #4325 (now merged).

Even after splitting out ffmpeg, every PR still runs the full ~4200-test suite. testmon records which tests cover which code and, on a PR, re-runs only the tests affected by the diff.

**How it works**
- Baseline (`.testmondata`) is rebuilt and cached on every push to dev/stable (full run).
- PRs restore that baseline read-only and run `pytest --testmon`, which selects only the affected tests. A one-line controller change runs a handful of tests instead of all of them.
- Cache key includes the dependency hash, so any dep change invalidates the baseline and forces a full run.
- `test-ffmpeg` is left alone (only a couple of files, not worth it).

**Caveats / why this is a draft**
- testmon can occasionally under-select (miss a test that should have run). The safety net is that **every push to dev/stable still runs the full suite**, so anything missed on a PR is caught right after merge.
- This does **not** reduce dependency install time (torch etc.) — that's the bigger chunk of the job and a separate problem (torch marker split, or running CI inside our `Dockerfile.base`).
- Dropped `--cov` on this job (testmon and coverage both hook the tracer, and nothing consumed the coverage xml anyway).

Opening as draft to validate the cache/select behaviour over a few real PRs before committing to it.