### PR TITLE
Fix test suite hanging without ffmpeg + cap test jobs at 30min

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,8 @@ jobs:
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    # Backstop: a hung test process should fail in minutes, not sit at the 6h job cap.
+    timeout-minutes: 30
 
     steps:
       - name: Check out code from GitHub
@@ -114,6 +116,7 @@ jobs:
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Check out code from GitHub

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,12 @@ async def mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
             "music_assistant.controllers.discovery.controller.AsyncServiceBrowser",
             return_value=mock_browser,
         ),
+        # Booting the server runs an ffmpeg presence check; mock it so tests don't
+        # require the binary. Tests that genuinely exercise ffmpeg are marked needs_ffmpeg.
+        patch(
+            "music_assistant.controllers.streams.controller.check_ffmpeg_version",
+            new=AsyncMock(),
+        ),
     ):
         await mass_instance.start()
 


### PR DESCRIPTION
#4325 dropped ffmpeg from the `test` job, but the `mass` test fixture boots the full server, and the streams controller's startup calls `check_ffmpeg_version()` which hard-raises when the binary is absent. That errored ~163 tests at fixture setup and then the run never exited (6h timeout). It's hitting dev directly, so every dev push — and every open PR branched off dev — currently hangs for 6h.

- Mock `check_ffmpeg_version` in the `mass` fixture so booting the server in tests doesn't need the binary. Tests that genuinely exercise ffmpeg are marked `needs_ffmpeg` and run in `test-ffmpeg` (real ffmpeg), unaffected.
- Add `timeout-minutes: 30` to the test jobs as a backstop — a future hang fails in minutes instead of burning the full 6h.

Verified by running the affected tests with ffmpeg removed from PATH — green and exits cleanly.