### PR TITLE
Smarter CI test selection: scope coverage on partial runs + skip translation-only PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       mode: ${{ steps.scope.outputs.mode }}
       test_paths: ${{ steps.scope.outputs.test_paths }}
+      cov_paths: ${{ steps.scope.outputs.cov_paths }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v7
@@ -51,6 +52,7 @@ jobs:
             {
               echo "mode=full"
               echo "test_paths="
+              echo "cov_paths="
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -130,15 +132,23 @@ jobs:
         # https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes
         run: uv pip install --system --index-strategy unsafe-best-match . .[test] -r requirements_all.txt
       - name: Pytest
-        # mode=partial runs only the changed providers' tests (set by the changes job);
-        # mode=full runs everything.
+        # mode=partial runs only the changed providers' tests with coverage scoped to
+        # those provider packages; mode=full runs everything with full coverage.
+        # `-o addopts=` clears the default "--cov music_assistant" so the scope applies.
+        env:
+          MODE: ${{ needs.changes.outputs.mode }}
+          TEST_PATHS: ${{ needs.changes.outputs.test_paths }}
+          COV_PATHS: ${{ needs.changes.outputs.cov_paths }}
         run: |
-          if [ "${{ needs.changes.outputs.mode }}" = "partial" ]; then
-            targets="${{ needs.changes.outputs.test_paths }}"
+          if [ "$MODE" = "partial" ]; then
+            targets="$TEST_PATHS"
+            cov=""
+            for src in $COV_PATHS; do cov="$cov --cov=$src"; done
           else
             targets="tests/"
+            cov="--cov=music_assistant"
           fi
-          pytest --durations 10 --cov-report=term-missing --cov-report=xml ${targets}
+          pytest -o addopts="" --durations 10 $cov --cov-report=term-missing --cov-report=xml $targets
       - name: Upload coverage to Codecov
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: codecov/codecov-action@v5

--- a/scripts/ci_test_scope.py
+++ b/scripts/ci_test_scope.py
@@ -1,12 +1,15 @@
 """
 Decide which pytest targets a CI run should execute based on the changed files.
 
-Reads the changed file paths (one per line) from stdin and writes ``mode`` and
-``test_paths`` to ``$GITHUB_OUTPUT`` (and stdout). ``mode`` is one of:
+Reads the changed file paths (one per line) from stdin and writes ``mode``,
+``test_paths`` and ``cov_paths`` to ``$GITHUB_OUTPUT`` (and stdout). ``mode`` is one of:
 
 - ``full``: run the entire suite (a shared/core file, dependency or the CI itself changed)
 - ``partial``: run only the listed ``test_paths`` (one or more changed providers)
 - ``skip``: nothing testable changed (docs, unrelated workflows, ...)
+
+``cov_paths`` are the coverage sources matching ``test_paths`` so a partial run only
+measures the providers it actually ran (e.g. ``music_assistant.providers.plex``).
 """
 
 # ruff: noqa: T201
@@ -46,6 +49,11 @@ def target_for_provider(name: str, repo_root: Path) -> str | None:
     return None
 
 
+def cov_source(test_path: str) -> str:
+    """Map a provider test dir (``tests/providers/<X>``) to its coverage package."""
+    return f"music_assistant.providers.{test_path.rsplit('/', 1)[-1]}"
+
+
 def decide(changed: list[str], repo_root: Path) -> tuple[str, list[str]]:
     """
     Decide the test scope for a set of changed files.
@@ -80,7 +88,12 @@ def main() -> None:
     """Read changed files from stdin and emit the resolved scope."""
     changed = [line.strip() for line in sys.stdin if line.strip()]
     mode, paths = decide(changed, Path.cwd())
-    lines = [f"mode={mode}", f"test_paths={' '.join(paths)}"]
+    cov_paths = [cov_source(path) for path in paths]
+    lines = [
+        f"mode={mode}",
+        f"test_paths={' '.join(paths)}",
+        f"cov_paths={' '.join(cov_paths)}",
+    ]
     if github_output := os.environ.get("GITHUB_OUTPUT"):
         with open(github_output, "a", encoding="utf-8") as handle:
             handle.write("\n".join(lines) + "\n")

--- a/tests/core/test_ci_test_scope.py
+++ b/tests/core/test_ci_test_scope.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.ci_test_scope import decide, provider_name
+from scripts.ci_test_scope import cov_source, decide, provider_name
 
 
 @pytest.fixture(name="repo")
@@ -24,6 +24,11 @@ def test_provider_name() -> None:
     assert provider_name("tests/providers/spotify/test_init.py") == "spotify"
     assert provider_name("music_assistant/helpers/util.py") is None
     assert provider_name("tests/providers/__init__.py") is None
+
+
+def test_cov_source() -> None:
+    """cov_source maps a provider test dir to its coverage package."""
+    assert cov_source("tests/providers/plex") == "music_assistant.providers.plex"
 
 
 def test_single_provider(repo: Path) -> None:


### PR DESCRIPTION
Two follow-ups to #4335, both refining the test-scope selector.

**1. Scope coverage on partial runs.** A partial provider run still measured `--cov music_assistant` (whole package, from `addopts`), so the `term-missing` report listed ~600 modules at 0% even though only the provider's tests ran — looks like the whole suite ran, and makes the Codecov upload a misleading "everything dropped" report. Now the `changes` job emits `cov_paths` and the test job scopes `--cov` to the changed providers on partial runs (`--cov=music_assistant` on full); `-o addopts=` clears the whole-package default. A webdav-only run's report went from ~600 module lines to 4.

**2. Skip translation-only PRs.** A Lokalise locale update (e.g. #4340: only `music_assistant/translations/*.json`) was running the full suite, because anything under `music_assistant/` forces `full`. But those are generated locale files — no pytest validates their content (`test_translations` uses mock locale data), and lint's `check-json` already validates JSON syntax. So a locale-data-only PR now resolves to `skip`. Source `strings.json` authoring still triggers full (lint validates it, and it's rarer).

Both covered by `tests/core/test_ci_test_scope.py` (18 cases). Independent of the merged #4337.