### PR TITLE
Block DNS-based SSRF on the deprecated imageproxy endpoint

### DIFF
--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -9,6 +9,8 @@ collage images.
 
 from __future__ import annotations
 
+import asyncio
+import ipaddress
 import os
 import random
 import threading
@@ -344,6 +346,25 @@ class ImageProxyMixin:
             path = decoded
         if not _is_safe_imageproxy_request_path(path):
             return web.Response(status=400)
+        # _is_safe_imageproxy_request_path blocks IP-literal private addresses but cannot
+        # stop a hostname that *resolves* to a private IP (DNS-rebinding / DNS-based SSRF).
+        # Resolve here and re-check before we hand the URL to aiohttp.
+        if path.startswith(("http://", "https://")):
+            parsed = urllib.parse.urlparse(path)
+            host = parsed.hostname
+            if not host:
+                return web.Response(status=400)
+            try:
+                infos = await asyncio.get_running_loop().getaddrinfo(host, None)
+            except OSError:
+                return web.Response(status=400)
+            for *_, sockaddr in infos:
+                try:
+                    ip = ipaddress.ip_address(sockaddr[0])
+                except ValueError:
+                    continue
+                if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_multicast:
+                    return web.Response(status=403)
         if not self.mass.get_provider(provider) and not path.startswith("http"):
             return web.Response(status=404)
         return await self._serve_thumbnail(path, provider, size, image_format)


### PR DESCRIPTION
Partial mitigation for GHSA-hc8p-f7fx-828m while the deprecated
`/imageproxy?provider=&path=` endpoint is still needed by Home Assistant.

## Problem

The existing `_is_safe_imageproxy_request_path` helper blocks IP-literal
private addresses (`http://192.168.x.x/`) but cannot stop a hostname that
**resolves** to a private IP at fetch time (DNS-based SSRF / DNS-rebinding).
An unauthenticated caller on the local network could craft a URL whose DNS
record points to an internal host and have MA fetch it.

## Fix

- After the existing path-safety check passes, resolve the target hostname
  with `getaddrinfo` and reject the request (HTTP 403) if **any** returned
  address falls in a loopback, private, link-local, or multicast range.
- DNS failures (NXDOMAIN, timeout) return HTTP 400 so the request is not
  silently forwarded.

This does not fully eliminate the SSRF surface (TOCTOU between our check and
aiohttp's own DNS resolve still exists), which is why the deprecated endpoint
will be removed once HA no longer uses it — see the new ID-based endpoint
introduced in [#3960](https://github.com/music-assistant/server/pull/3960).

## Types of changes
- [x] Bug fix