### PR TITLE
Use the shared datetime helpers instead of calling datetime directly

### DIFF
--- a/music_assistant/controllers/tasks/helpers.py
+++ b/music_assistant/controllers/tasks/helpers.py
@@ -11,6 +11,8 @@ from music_assistant_models.auth import User, UserRole
 from music_assistant_models.background_task import BackgroundTask, TaskSchedule
 from music_assistant_models.enums import TaskScheduleType, TaskStatus
 
+from music_assistant.helpers.datetime import utc
+
 from .constants import ACTIVE_TASK_ID
 from .models import ManagedTask
 
@@ -24,7 +26,7 @@ TASK_LOG_FORMATTER = logging.Formatter(TASK_LOG_FORMAT, datefmt=TASK_LOG_DATE_FO
 
 def utcnow() -> datetime:
     """Return current UTC datetime."""
-    return datetime.now(UTC)
+    return utc()
 
 
 def get_task_timer_id(task_id: str) -> str:

--- a/music_assistant/helpers/throttle_retry.py
+++ b/music_assistant/helpers/throttle_retry.py
@@ -1,7 +1,6 @@
 """Context manager using asyncio_throttle that catches and re-raises RetriesExhausted."""
 
 import asyncio
-import datetime
 import functools
 import logging
 import random
@@ -21,6 +20,7 @@ from music_assistant_models.errors import (
 )
 
 from music_assistant.constants import MASS_LOGGER_NAME
+from music_assistant.helpers.datetime import utc
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.throttle_retry")
 
@@ -52,7 +52,7 @@ def parse_retry_after(value: str | None) -> int:
     # Try HTTP-date format (e.g., "Fri, 31 Dec 1999 23:59:59 GMT")
     try:
         target = parsedate_to_datetime(value)
-        delta = (target - datetime.datetime.now(tz=datetime.UTC)).total_seconds()
+        delta = (target - utc()).total_seconds()
         return max(0, int(delta))
     except ValueError, TypeError:
         return 0

--- a/music_assistant/helpers/webrtc_certificate.py
+++ b/music_assistant/helpers/webrtc_certificate.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import base64
 import logging
 import stat
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -19,6 +19,8 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import NameOID
+
+from music_assistant.helpers.datetime import utc
 
 if TYPE_CHECKING:
     from aiortc import RTCConfiguration, RTCPeerConnection
@@ -43,7 +45,7 @@ def _generate_certificate() -> tuple[ec.EllipticCurvePrivateKey, x509.Certificat
     # Generate ECDSA key (SECP256R1 - same as aiortc default)
     private_key = ec.generate_private_key(ec.SECP256R1())
 
-    now = datetime.now(UTC)
+    now = utc()
     not_before = now - timedelta(days=1)
     not_after = now + timedelta(days=CERT_VALIDITY_DAYS)
 
@@ -131,7 +133,7 @@ def _is_certificate_valid(cert: x509.Certificate) -> bool:
     :param cert: The X.509 certificate to check.
     :return: True if certificate is valid and has sufficient time remaining.
     """
-    now = datetime.now(UTC)
+    now = utc()
     not_after = cert.not_valid_after_utc
 
     if now >= not_after:

--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -42,6 +42,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.streamdetails import StreamDetails
 
+from music_assistant.helpers.datetime import utc
 from music_assistant.mass import MusicAssistant
 
 CACHE_DOMAIN = "audible"
@@ -91,7 +92,7 @@ async def refresh_access_token_compat(
         resp_dict = await resp.json()
 
     expires_in_sec = int(resp_dict.get("expires_in", 3600))
-    expires = (datetime.now(UTC) + timedelta(seconds=expires_in_sec)).timestamp()
+    expires = (utc() + timedelta(seconds=expires_in_sec)).timestamp()
 
     # Handle new format (actor_access_token) or fall back to legacy (access_token)
     access_token = resp_dict.get("actor_access_token") or resp_dict.get("access_token")

--- a/music_assistant/providers/fastmcp_server/debug/event_buffer.py
+++ b/music_assistant/providers/fastmcp_server/debug/event_buffer.py
@@ -18,6 +18,8 @@ from collections import Counter, deque
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from music_assistant.helpers.datetime import now
+
 from ..models import EventBufferStats, EventRecord
 from .inspect_serializer import dump
 
@@ -33,7 +35,7 @@ def _now() -> datetime:
     template-generated (cannot be hand-edited). Tests replace this
     module-level callable to control timestamps deterministically.
     """
-    return datetime.now().astimezone()
+    return now()
 
 
 class EventBuffer:

--- a/music_assistant/providers/fastmcp_server/debug/log_reader.py
+++ b/music_assistant/providers/fastmcp_server/debug/log_reader.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING
 
 from fastmcp.exceptions import ToolError
 
+from music_assistant.helpers.datetime import now
+
 from ..models import LogLine, LogTailResult
 
 if TYPE_CHECKING:
@@ -113,7 +115,7 @@ class SafeLogTail:
             raise ToolError(f"log file {name!r} not found")
 
         component_filter = re.compile(component_regex) if component_regex else None
-        now = datetime.now().astimezone()
+        current_time = now()
 
         raw_lines, bytes_scanned, truncated = self._read_last_lines(path, lines)
 
@@ -131,7 +133,7 @@ class SafeLogTail:
                     when = datetime.fromisoformat(parsed.timestamp)
                 except ValueError:
                     continue
-                if (now - when).total_seconds() > since_seconds:
+                if (current_time - when).total_seconds() > since_seconds:
                     continue
             out.append(parsed)
 

--- a/music_assistant/providers/fastmcp_server/tools/debug.py
+++ b/music_assistant/providers/fastmcp_server/tools/debug.py
@@ -21,6 +21,8 @@ from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
+from music_assistant.helpers.datetime import now
+
 from ..debug.event_buffer import EventBuffer
 from ..debug.inspect_serializer import dump
 from ..debug.log_reader import SafeLogTail
@@ -600,7 +602,7 @@ def _register_health_tool(
                 subscribed_at = datetime.fromisoformat(stats.subscribed_since)
                 elapsed_min = max(
                     1.0 / 60,
-                    (datetime.now().astimezone() - subscribed_at).total_seconds() / 60.0,
+                    (now() - subscribed_at).total_seconds() / 60.0,
                 )
                 events_per_min = {
                     et: round(count / elapsed_min, 2) for et, count in stats.by_type.items()

--- a/music_assistant/providers/gpodder/client.py
+++ b/music_assistant/providers/gpodder/client.py
@@ -18,6 +18,8 @@ from mashumaro.config import BaseConfig
 from mashumaro.mixins.json import DataClassJSONMixin
 from mashumaro.types import Discriminator
 
+from music_assistant.helpers.datetime import utc
+
 
 # https://gpoddernet.readthedocs.io/en/latest/api/reference/subscriptions.html#upload-subscription-changes
 @dataclass(kw_only=True)
@@ -284,9 +286,7 @@ class GPodderClient:
         duration_s: float,
     ) -> None:
         """Update progress."""
-        utc_timestamp = (
-            datetime.datetime.now(datetime.UTC).replace(microsecond=0, tzinfo=None).isoformat()
-        )
+        utc_timestamp = utc().replace(microsecond=0, tzinfo=None).isoformat()
 
         episode_action: EpisodeActionNew | EpisodeActionPlay
         if position_s == 0:

--- a/music_assistant/providers/kion_music/api_client.py
+++ b/music_assistant/providers/kion_music/api_client.py
@@ -27,6 +27,7 @@ from yandex_music import Track as KionTrack
 from yandex_music.exceptions import BadRequestError, NetworkError, UnauthorizedError
 from yandex_music.utils.sign_request import DEFAULT_SIGN_KEY
 
+from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER, Throttler
 
 if TYPE_CHECKING:
@@ -267,7 +268,7 @@ class KionMusicClient:
         :param total_played_seconds: Seconds played (for trackFinished, skip).
         :return: True if the request succeeded.
         """
-        timestamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        timestamp = utc().isoformat().replace("+00:00", "Z")
 
         async def _send(c: ClientAsync) -> bool:
             if feedback_type == "radioStarted":

--- a/music_assistant/providers/kion_music/provider.py
+++ b/music_assistant/providers/kion_music/provider.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import random
 from collections.abc import AsyncGenerator, Coroutine, Sequence
-from datetime import UTC, datetime
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
@@ -35,6 +34,7 @@ from music_assistant_models.media_items import (
 from PIL import Image as PilImage
 
 from music_assistant.controllers.cache import use_cache
+from music_assistant.helpers.datetime import utc
 from music_assistant.models.music_provider import MusicProvider
 
 from .api_client import KionMusicClient
@@ -2248,7 +2248,7 @@ class KionMusicProvider(MusicProvider):
         :return: RecommendationFolder with seasonal playlists, or None if unavailable.
         """
         # Determine current season tag
-        current_month = datetime.now(tz=UTC).month
+        current_month = utc().month
         seasonal_tag = TAG_SEASONAL_MAP.get(current_month, "autumn")
 
         # Validate the seasonal tag; fall back to autumn if not available

--- a/music_assistant/providers/lastfm_recommendations/recommendations.py
+++ b/music_assistant/providers/lastfm_recommendations/recommendations.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import random
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -19,6 +18,7 @@ from music_assistant_models.media_items import (
 
 from music_assistant.constants import CONF_USERNAME
 from music_assistant.helpers.compare import compare_strings
+from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.util import parse_title_and_version
 from music_assistant.providers.lastfm_recommendations.constants import (
     CACHE_CATEGORY_RESOLVED_ITEMS,
@@ -263,7 +263,7 @@ class LastFMRecommendationManager:
         random_count = target_count - TOP_ITEMS_TO_TAKE
 
         # Hourly seed keeps the sampled remainder stable within the hour and rotates it each hour.
-        now = datetime.datetime.now(tz=datetime.UTC)
+        now = utc()
         seed = f"{now.date().isoformat()}_{now.hour}_{seed_suffix}"
         rng = random.Random(seed)
         random_items = rng.sample(remaining, min(random_count, len(remaining)))
@@ -502,7 +502,7 @@ class LastFMRecommendationManager:
             return
 
         # cycle through the user's top genres day by day so the genre rows vary
-        day_index = datetime.datetime.now(tz=datetime.UTC).date().toordinal()
+        day_index = utc().date().toordinal()
         tag_name = top_genres[day_index % len(top_genres)]
 
         # Over-fetch so there's enough left after library filtering and resolution failures.

--- a/music_assistant/providers/orf_radiothek/__init__.py
+++ b/music_assistant/providers/orf_radiothek/__init__.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import AsyncGenerator, Sequence
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -54,6 +54,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.controllers.cache import use_cache
+from music_assistant.helpers.datetime import utc
 from music_assistant.models.music_provider import MusicProvider
 
 from .helpers import (
@@ -765,7 +766,7 @@ class RadiothekProvider(MusicProvider):
             raise MediaNotFoundError("Podcast not found.")
         podcast_title = st.name or station_id
 
-        today = datetime.now(UTC).date()
+        today = utc().date()
         for day_offset in range(CATCHUP_DAYS):
             d = today - timedelta(days=day_offset)
             yyyymmdd = f"{d.year:04d}{d.month:02d}{d.day:02d}"

--- a/music_assistant/providers/yandex_music/api_client.py
+++ b/music_assistant/providers/yandex_music/api_client.py
@@ -12,7 +12,7 @@ import re
 import time
 from collections import OrderedDict, defaultdict, deque
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, cast
 
 from music_assistant_models.errors import (
@@ -29,6 +29,7 @@ from yandex_music import Track as YandexTrack
 from yandex_music.exceptions import BadRequestError, NetworkError, UnauthorizedError
 from yandex_music.utils.sign_request import DEFAULT_SIGN_KEY
 
+from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER, Throttler
 
 if TYPE_CHECKING:
@@ -654,7 +655,7 @@ class YandexMusicClient:
         :param total_played_seconds: Seconds played (for trackFinished, skip).
         :return: True if the request succeeded.
         """
-        timestamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        timestamp = utc().isoformat().replace("+00:00", "Z")
 
         async def _send(c: ClientAsync) -> bool:
             if feedback_type == "radioStarted":
@@ -902,7 +903,7 @@ class YandexMusicClient:
             response; anchors the event to a specific batch.
         :return: True if the POST succeeded.
         """
-        timestamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        timestamp = utc().isoformat().replace("+00:00", "Z")
         event: dict[str, Any] = {"type": event_type, "timestamp": timestamp}
         if event_type == "radioStarted":
             if track_id is not None:

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -7,7 +7,6 @@ import logging
 import random
 import uuid
 from collections.abc import AsyncGenerator, Sequence
-from datetime import UTC, datetime
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
@@ -42,6 +41,7 @@ from PIL import Image as PilImage
 from ya_passport_auth import SecretStr
 
 from music_assistant.controllers.cache import use_cache
+from music_assistant.helpers.datetime import utc
 from music_assistant.models.music_provider import MusicProvider
 
 from .api_client import YandexMusicClient
@@ -3000,7 +3000,7 @@ class YandexMusicProvider(MusicProvider):
         """
         # Determine current season tag; fall back to autumn if the seasonal
         # endpoint returns nothing (e.g. spring/autumn handover gap).
-        current_month = datetime.now(tz=UTC).month
+        current_month = utc().month
         seasonal_tag = TAG_SEASONAL_MAP.get(current_month, "autumn")
         playlists = await self.client.get_tag_playlists(seasonal_tag)
         if not playlists and seasonal_tag != "autumn":

--- a/scripts/check_datetime_helpers.py
+++ b/scripts/check_datetime_helpers.py
@@ -28,7 +28,14 @@ PACKAGE_ROOT = REPO_ROOT / "music_assistant"
 BASELINE_PATH = REPO_ROOT / "scripts" / "lint_baselines" / "naive_datetime_usage.txt"
 
 # The helper module itself is the one legitimate place to call datetime.now()/utcnow().
-EXCLUDED_FILES = frozenset({PACKAGE_ROOT / "helpers" / "datetime.py"})
+# spotify_connect/events.py is a standalone librespot ``--onevent`` subprocess script that must not
+# import the music_assistant package, so it cannot use the helpers and stays on the stdlib.
+EXCLUDED_FILES = frozenset(
+    {
+        PACKAGE_ROOT / "helpers" / "datetime.py",
+        PACKAGE_ROOT / "providers" / "spotify_connect" / "events.py",
+    }
+)
 
 _BASELINE_HEADER = (
     "Direct datetime.now()/utcnow() call sites that predate the helpers check.\n"

--- a/scripts/lint_baselines/naive_datetime_usage.txt
+++ b/scripts/lint_baselines/naive_datetime_usage.txt
@@ -1,18 +1,3 @@
 # Direct datetime.now()/utcnow() call sites that predate the helpers check.
 # New code must use music_assistant.helpers.datetime (utc(), now(), ...).
 # Regenerate with: uv run -m scripts.check_datetime_helpers --update-baseline
-music_assistant/controllers/tasks/helpers.py	1
-music_assistant/helpers/throttle_retry.py	1
-music_assistant/helpers/webrtc_certificate.py	2
-music_assistant/providers/audible/audible_helper.py	1
-music_assistant/providers/fastmcp_server/debug/event_buffer.py	1
-music_assistant/providers/fastmcp_server/debug/log_reader.py	1
-music_assistant/providers/fastmcp_server/tools/debug.py	1
-music_assistant/providers/gpodder/client.py	1
-music_assistant/providers/kion_music/api_client.py	1
-music_assistant/providers/kion_music/provider.py	1
-music_assistant/providers/lastfm_recommendations/recommendations.py	2
-music_assistant/providers/orf_radiothek/__init__.py	1
-music_assistant/providers/spotify_connect/events.py	1
-music_assistant/providers/yandex_music/api_client.py	2
-music_assistant/providers/yandex_music/provider.py	1

--- a/tests/providers/yandex_music/test_recommendations.py
+++ b/tests/providers/yandex_music/test_recommendations.py
@@ -664,12 +664,12 @@ async def test_get_seasonal_mix_recommendations_winter(provider_mock: Mock) -> N
     mock_parsed_playlist.item_id = "playlist_1"
     mock_parsed_playlist.name = "Winter Playlist"
 
-    # Patch datetime to return January (month 1)
-    mock_datetime = Mock()
-    mock_datetime.now.return_value.month = 1
+    # Patch utc() to return January (month 1)
+    mock_utc = Mock()
+    mock_utc.return_value.month = 1
 
     with (
-        patch("music_assistant.providers.yandex_music.provider.datetime", mock_datetime),
+        patch("music_assistant.providers.yandex_music.provider.utc", mock_utc),
         patch(
             "music_assistant.providers.yandex_music.provider.parse_playlist",
             return_value=mock_parsed_playlist,
@@ -699,12 +699,12 @@ async def test_get_seasonal_mix_recommendations_summer(provider_mock: Mock) -> N
     mock_parsed_playlist.item_id = "playlist_1"
     mock_parsed_playlist.name = "Summer Playlist"
 
-    # Patch datetime to return July (month 7)
-    mock_datetime = Mock()
-    mock_datetime.now.return_value.month = 7
+    # Patch utc() to return July (month 7)
+    mock_utc = Mock()
+    mock_utc.return_value.month = 7
 
     with (
-        patch("music_assistant.providers.yandex_music.provider.datetime", mock_datetime),
+        patch("music_assistant.providers.yandex_music.provider.utc", mock_utc),
         patch(
             "music_assistant.providers.yandex_music.provider.parse_playlist",
             return_value=mock_parsed_playlist,
@@ -730,12 +730,12 @@ async def test_get_seasonal_mix_recommendations_spring_fallback(provider_mock: M
     mock_parsed_playlist.item_id = "playlist_1"
     mock_parsed_playlist.name = "Autumn Playlist"
 
-    # Patch datetime to return March (month 3 - spring)
-    mock_datetime = Mock()
-    mock_datetime.now.return_value.month = 3
+    # Patch utc() to return March (month 3 - spring)
+    mock_utc = Mock()
+    mock_utc.return_value.month = 3
 
     with (
-        patch("music_assistant.providers.yandex_music.provider.datetime", mock_datetime),
+        patch("music_assistant.providers.yandex_music.provider.utc", mock_utc),
         patch(
             "music_assistant.providers.yandex_music.provider.parse_playlist",
             return_value=mock_parsed_playlist,
@@ -754,10 +754,10 @@ async def test_get_seasonal_mix_recommendations_empty(provider_mock: Mock) -> No
     """Test _get_seasonal_mix_recommendations returns None when API returns empty."""
     provider_mock.client.get_tag_playlists = AsyncMock(return_value=[])
 
-    mock_datetime = Mock()
-    mock_datetime.now.return_value.month = 6
+    mock_utc = Mock()
+    mock_utc.return_value.month = 6
 
-    with patch("music_assistant.providers.yandex_music.provider.datetime", mock_datetime):
+    with patch("music_assistant.providers.yandex_music.provider.utc", mock_utc):
         result = await YandexMusicProvider._get_seasonal_mix_recommendations(provider_mock)
 
     assert result is None
@@ -768,11 +768,11 @@ async def test_get_seasonal_mix_recommendations_invalid_data_error(provider_mock
     """Test _get_seasonal_mix_recommendations handles InvalidDataError gracefully."""
     provider_mock.client.get_tag_playlists = AsyncMock(return_value=[Mock()])
 
-    mock_datetime = Mock()
-    mock_datetime.now.return_value.month = 9
+    mock_utc = Mock()
+    mock_utc.return_value.month = 9
 
     with (
-        patch("music_assistant.providers.yandex_music.provider.datetime", mock_datetime),
+        patch("music_assistant.providers.yandex_music.provider.utc", mock_utc),
         patch(
             "music_assistant.providers.yandex_music.provider.parse_playlist",
             side_effect=InvalidDataError("Parse error"),


### PR DESCRIPTION
# What does this implement/fix?

Replaces the remaining direct `datetime.now(UTC)` / `datetime.now().astimezone()` call sites with the shared `music_assistant.helpers.datetime` helpers (`utc()` / `now()`), and empties the naive-datetime baseline now that there are no grandfathered call sites left.

`utc()` is `datetime.now(UTC)` and `now()` is `datetime.now().astimezone()`, so this is a behaviour-preserving change.

`providers/spotify_connect/events.py` intentionally stays on the stdlib — it is a standalone librespot `--onevent` subprocess that must not import the `music_assistant` package — so it is now permanently excluded in `scripts/check_datetime_helpers.py` instead of being baselined.

The yandex seasonal-mix tests are updated to patch the `utc()` helper instead of the module-level `datetime`.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
