### PR TITLE
Move private methods to the bottom of the class in a few small providers

### DIFF
--- a/music_assistant/providers/loudness_analysis/provider.py
+++ b/music_assistant/providers/loudness_analysis/provider.py
@@ -83,6 +83,28 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
                 await data.ffmpeg.close()
         await super().cancel(session_id)
 
+    async def post_analysis(
+        self,
+        streamdetails: StreamDetails,
+        analysis: AudioAnalysisData,
+    ) -> None:
+        """Write the ReplayGain track-gain tag back to the source file when configured."""
+        if not isinstance(streamdetails.path, str) or not streamdetails.path:
+            return
+        if not self.config.get_value(CONF_WRITE_REPLAYGAIN_TAGS):
+            return
+        if analysis.loudness_integrated is None:
+            return
+        # ReplayGain 2.0: track_gain_db = -18 - loudness_lufs
+        track_gain_db = -18.0 - analysis.loudness_integrated
+        ok = await write_replaygain_track_gain(streamdetails.path, track_gain_db)
+        if ok:
+            self.logger.debug(
+                "Wrote ReplayGain tag to %s (gain=%.2f dB)",
+                streamdetails.path,
+                track_gain_db,
+            )
+
     async def _start_analysis(
         self,
         session_id: str,
@@ -174,28 +196,6 @@ class LoudnessAnalysisProvider(AudioAnalysisProvider):
             true_peak,
         )
         return analysis
-
-    async def post_analysis(
-        self,
-        streamdetails: StreamDetails,
-        analysis: AudioAnalysisData,
-    ) -> None:
-        """Write the ReplayGain track-gain tag back to the source file when configured."""
-        if not isinstance(streamdetails.path, str) or not streamdetails.path:
-            return
-        if not self.config.get_value(CONF_WRITE_REPLAYGAIN_TAGS):
-            return
-        if analysis.loudness_integrated is None:
-            return
-        # ReplayGain 2.0: track_gain_db = -18 - loudness_lufs
-        track_gain_db = -18.0 - analysis.loudness_integrated
-        ok = await write_replaygain_track_gain(streamdetails.path, track_gain_db)
-        if ok:
-            self.logger.debug(
-                "Wrote ReplayGain tag to %s (gain=%.2f dB)",
-                streamdetails.path,
-                track_gain_db,
-            )
 
     async def _send_eof(self, data: LoudnessSessionData) -> None:
         """Signal end-of-input to the session's ffmpeg process (idempotent)."""

--- a/music_assistant/providers/lrclib/__init__.py
+++ b/music_assistant/providers/lrclib/__init__.py
@@ -77,27 +77,6 @@ class LrclibProvider(MetadataProvider):
             self.throttler = ThrottlerManager(rate_limit=1, period=1)
             self.logger.debug("Using custom API endpoint: %s (throttling disabled)", self.api_url)
 
-    @use_cache(3600 * 24 * 14)  # Cache for 14 days
-    @throttle_with_retries
-    async def _get_data(self, **params: Any) -> dict[str, Any] | None:
-        """Get data from LRCLib API with throttling and retries."""
-        headers = {"User-Agent": USER_AGENT}
-
-        try:
-            async with self.mass.http_session.get(
-                f"{self.api_url}/get", params=params, headers=headers
-            ) as response:
-                response.raise_for_status()
-                if response.status == 204:  # No content
-                    return None
-                return cast("dict[str, Any]", await response.json())
-        except ClientResponseError as err:
-            self.logger.debug("Error fetching data from LRCLib API (%s): %s", self.api_url, err)
-            return None
-        except json.JSONDecodeError as err:
-            self.logger.debug("Error parsing response from LRCLib API: %s", err)
-            return None
-
     async def get_track_metadata(self, track: Track) -> MediaItemMetadata | None:
         """Retrieve synchronized lyrics for a track."""
         if track.metadata and (track.metadata.lyrics or track.metadata.lrc_lyrics):
@@ -172,3 +151,24 @@ class LrclibProvider(MetadataProvider):
                 duration,
             )
         return None
+
+    @use_cache(3600 * 24 * 14)  # Cache for 14 days
+    @throttle_with_retries
+    async def _get_data(self, **params: Any) -> dict[str, Any] | None:
+        """Get data from LRCLib API with throttling and retries."""
+        headers = {"User-Agent": USER_AGENT}
+
+        try:
+            async with self.mass.http_session.get(
+                f"{self.api_url}/get", params=params, headers=headers
+            ) as response:
+                response.raise_for_status()
+                if response.status == 204:  # No content
+                    return None
+                return cast("dict[str, Any]", await response.json())
+        except ClientResponseError as err:
+            self.logger.debug("Error fetching data from LRCLib API (%s): %s", self.api_url, err)
+            return None
+        except json.JSONDecodeError as err:
+            self.logger.debug("Error parsing response from LRCLib API: %s", err)
+            return None

--- a/music_assistant/providers/podcastfeed/__init__.py
+++ b/music_assistant/providers/podcastfeed/__init__.py
@@ -192,6 +192,32 @@ class PodcastMusicprovider(MusicProvider):
                 )
         raise MediaNotFoundError("Stream not found")
 
+    async def resolve_image(self, path: str) -> str | bytes:
+        """Resolve image for RSS provider with fallback to podcast cover."""
+        if not path.startswith("http"):
+            return path
+
+        try:
+            async with self.mass.http_session.get(path, raise_for_status=True) as response:
+                # Check if we got actual image content
+                content_type = response.headers.get("content-type", "").lower()
+                if not content_type.startswith(("image/", "application/octet-stream")):
+                    # Not an image - likely redirected to error page
+                    raise ClientError(f"Invalid content type: {content_type}")
+
+                return await response.read()
+
+        except ClientError, Exception:
+            # Try podcast cover fallback
+            podcast_cover = self.parsed_podcast.get("cover_url")
+            if podcast_cover and isinstance(podcast_cover, str) and podcast_cover != path:
+                async with self.mass.http_session.get(
+                    podcast_cover, raise_for_status=True
+                ) as response:
+                    return await response.read()
+
+            raise MediaNotFoundError(f"Episode image not found: {path}")
+
     async def _parse_podcast(self) -> Podcast:
         """Parse podcast information from podcast feed."""
         assert self.feed_url is not None
@@ -256,29 +282,3 @@ class PodcastMusicprovider(MusicProvider):
             data=self.parsed_podcast,
             expiration=60 * 60 * 24,  # 1 day
         )
-
-    async def resolve_image(self, path: str) -> str | bytes:
-        """Resolve image for RSS provider with fallback to podcast cover."""
-        if not path.startswith("http"):
-            return path
-
-        try:
-            async with self.mass.http_session.get(path, raise_for_status=True) as response:
-                # Check if we got actual image content
-                content_type = response.headers.get("content-type", "").lower()
-                if not content_type.startswith(("image/", "application/octet-stream")):
-                    # Not an image - likely redirected to error page
-                    raise ClientError(f"Invalid content type: {content_type}")
-
-                return await response.read()
-
-        except ClientError, Exception:
-            # Try podcast cover fallback
-            podcast_cover = self.parsed_podcast.get("cover_url")
-            if podcast_cover and isinstance(podcast_cover, str) and podcast_cover != path:
-                async with self.mass.http_session.get(
-                    podcast_cover, raise_for_status=True
-                ) as response:
-                    return await response.read()
-
-            raise MediaNotFoundError(f"Episode image not found: {path}")

--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -521,6 +521,23 @@ class QobuzProvider(MusicProvider):
             allow_seek=True,
         )
 
+    async def on_streamed(
+        self,
+        streamdetails: StreamDetails,
+    ) -> None:
+        """Handle callback when an item completed streaming."""
+        if self._user_auth_info is None:
+            msg = "User auth info not available"
+            raise LoginFailed(msg)
+        user_id = self._user_auth_info["user"]["id"]
+        async with self.throttler.bypass():
+            await self._get_data(
+                "track/reportStreamingEnd",
+                user_id=user_id,
+                track_id=str(streamdetails.item_id),
+                duration=try_parse_int(streamdetails.seconds_streamed),
+            )
+
     async def _report_playback_started(self, streamdata: dict[str, Any]) -> None:
         """Report playback start to qobuz."""
         # TODO: need to figure out if the streamed track is purchased by user
@@ -550,23 +567,6 @@ class QobuzProvider(MusicProvider):
         ]
         async with self.throttler.bypass():
             await self._post_data("track/reportStreamingStart", data=events)
-
-    async def on_streamed(
-        self,
-        streamdetails: StreamDetails,
-    ) -> None:
-        """Handle callback when an item completed streaming."""
-        if self._user_auth_info is None:
-            msg = "User auth info not available"
-            raise LoginFailed(msg)
-        user_id = self._user_auth_info["user"]["id"]
-        async with self.throttler.bypass():
-            await self._get_data(
-                "track/reportStreamingEnd",
-                user_id=user_id,
-                track_id=str(streamdetails.item_id),
-                duration=try_parse_int(streamdetails.seconds_streamed),
-            )
 
     def _parse_artist(self, artist_obj: dict[str, Any]) -> Artist:
         """Parse qobuz artist object to generic layout."""

--- a/music_assistant/providers/radiobrowser/__init__.py
+++ b/music_assistant/providers/radiobrowser/__init__.py
@@ -350,36 +350,6 @@ class RadioBrowserProvider(MusicProvider):
                 f"Failed to fetch radio station {prov_radio_id}: {err}"
             ) from err
 
-    async def _parse_radio(self, radio_obj: Station) -> Radio:
-        """Parse Radio object from json obj returned from api."""
-        radio = Radio(
-            item_id=radio_obj.uuid,
-            provider=self.domain,
-            name=radio_obj.name,
-            provider_mappings={
-                ProviderMapping(
-                    item_id=radio_obj.uuid,
-                    provider_domain=self.domain,
-                    provider_instance=self.instance_id,
-                )
-            },
-        )
-        radio.metadata.popularity = radio_obj.click_count
-        if radio_obj.homepage:
-            radio.metadata.links = {MediaItemLink(type=LinkType.WEBSITE, url=radio_obj.homepage)}
-        if radio_obj.favicon:
-            radio.metadata.images = UniqueList(
-                [
-                    MediaItemImage(
-                        type=ImageType.THUMB,
-                        path=radio_obj.favicon,
-                        provider=self.instance_id,
-                        remotely_accessible=True,
-                    )
-                ]
-            )
-        return radio
-
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Get streamdetails for a radio station."""
         try:
@@ -410,3 +380,33 @@ class RadioBrowserProvider(MusicProvider):
             raise ProviderUnavailableError(
                 f"Failed to get stream details for {item_id}: {err}"
             ) from err
+
+    async def _parse_radio(self, radio_obj: Station) -> Radio:
+        """Parse Radio object from json obj returned from api."""
+        radio = Radio(
+            item_id=radio_obj.uuid,
+            provider=self.domain,
+            name=radio_obj.name,
+            provider_mappings={
+                ProviderMapping(
+                    item_id=radio_obj.uuid,
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                )
+            },
+        )
+        radio.metadata.popularity = radio_obj.click_count
+        if radio_obj.homepage:
+            radio.metadata.links = {MediaItemLink(type=LinkType.WEBSITE, url=radio_obj.homepage)}
+        if radio_obj.favicon:
+            radio.metadata.images = UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=radio_obj.favicon,
+                        provider=self.instance_id,
+                        remotely_accessible=True,
+                    )
+                ]
+            )
+        return radio

--- a/music_assistant/providers/somafm/__init__.py
+++ b/music_assistant/providers/somafm/__init__.py
@@ -130,68 +130,6 @@ class SomaFMProvider(MusicProvider):
         msg = f"Item {prov_radio_id} not found"
         raise MediaNotFoundError(msg)
 
-    @use_cache(3600 * 24 * 1)  # Cache for 1 day
-    async def _get_stations(self) -> dict[str, dict[str, Any]]:
-        url = "https://somafm.com/channels.json"
-        locale = self.mass.metadata.locale.replace("_", "-")
-        language = locale.split("-")[0]
-        headers = {"Accept-Language": f"{locale}, {language};q=0.9, *;q=0.5"}
-        async with (
-            self.mass.http_session.get(url, headers=headers, ssl=False) as response,
-        ):
-            result: Any = await response.json()
-            if not result or "error" in result:
-                self.logger.error(url)
-            elif isinstance(result, dict):
-                stations = result.get("channels")
-                if stations:
-                    # Reformat into dict by channel id
-                    return {info.get("id"): info for info in stations if info.get("id")}
-            raise MediaNotFoundError("Could not fetch SomaFM stations list")
-
-    def _parse_channel(self, channel_info: dict[str, Any]) -> Radio:
-        """Convert SomaFM channel info into a Radio object."""
-        # Construct radio station information
-        item_id = channel_info.get("id")
-        if not item_id:
-            raise MediaNotFoundError("Soma FM station generation failed")
-
-        radio = Radio(
-            provider=self.instance_id,
-            item_id=item_id,
-            name=f"SomaFM: {channel_info.get('title', 'Unknown Radio')}",
-            metadata=MediaItemMetadata(
-                description=channel_info.get("description", "No description"),
-                genres={channel_info.get("genre", "No genre")},
-                popularity=int(channel_info.get("listeners", "0")),
-                performers={
-                    f"DJ: {channel_info.get('dj', 'No DJ info')}",
-                    f"DJ Email: {channel_info.get('djmail', 'No DJ email')}",
-                },
-            ),
-            provider_mappings={
-                ProviderMapping(
-                    provider_domain=self.domain,
-                    provider_instance=self.instance_id,
-                    item_id=item_id,
-                    available=True,
-                )
-            },
-        )
-
-        # Add station image URL
-        station_icon_url = channel_info.get("largeimage")
-        if station_icon_url:
-            radio.metadata.add_image(
-                MediaItemImage(
-                    provider=self.instance_id,
-                    type=ImageType.THUMB,
-                    path=station_icon_url,
-                    remotely_accessible=True,
-                )
-            )
-        return radio
-
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Get stream details for a track/radio."""
 
@@ -264,3 +202,65 @@ class SomaFMProvider(MusicProvider):
             allow_seek=False,
             can_seek=False,
         )
+
+    @use_cache(3600 * 24 * 1)  # Cache for 1 day
+    async def _get_stations(self) -> dict[str, dict[str, Any]]:
+        url = "https://somafm.com/channels.json"
+        locale = self.mass.metadata.locale.replace("_", "-")
+        language = locale.split("-")[0]
+        headers = {"Accept-Language": f"{locale}, {language};q=0.9, *;q=0.5"}
+        async with (
+            self.mass.http_session.get(url, headers=headers, ssl=False) as response,
+        ):
+            result: Any = await response.json()
+            if not result or "error" in result:
+                self.logger.error(url)
+            elif isinstance(result, dict):
+                stations = result.get("channels")
+                if stations:
+                    # Reformat into dict by channel id
+                    return {info.get("id"): info for info in stations if info.get("id")}
+            raise MediaNotFoundError("Could not fetch SomaFM stations list")
+
+    def _parse_channel(self, channel_info: dict[str, Any]) -> Radio:
+        """Convert SomaFM channel info into a Radio object."""
+        # Construct radio station information
+        item_id = channel_info.get("id")
+        if not item_id:
+            raise MediaNotFoundError("Soma FM station generation failed")
+
+        radio = Radio(
+            provider=self.instance_id,
+            item_id=item_id,
+            name=f"SomaFM: {channel_info.get('title', 'Unknown Radio')}",
+            metadata=MediaItemMetadata(
+                description=channel_info.get("description", "No description"),
+                genres={channel_info.get("genre", "No genre")},
+                popularity=int(channel_info.get("listeners", "0")),
+                performers={
+                    f"DJ: {channel_info.get('dj', 'No DJ info')}",
+                    f"DJ Email: {channel_info.get('djmail', 'No DJ email')}",
+                },
+            ),
+            provider_mappings={
+                ProviderMapping(
+                    provider_domain=self.domain,
+                    provider_instance=self.instance_id,
+                    item_id=item_id,
+                    available=True,
+                )
+            },
+        )
+
+        # Add station image URL
+        station_icon_url = channel_info.get("largeimage")
+        if station_icon_url:
+            radio.metadata.add_image(
+                MediaItemImage(
+                    provider=self.instance_id,
+                    type=ImageType.THUMB,
+                    path=station_icon_url,
+                    remotely_accessible=True,
+                )
+            )
+        return radio

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -80,8 +80,6 @@ music_assistant/providers/lastfm_recommendations/__init__.py	4
 music_assistant/providers/lastfm_recommendations/api_client.py	12
 music_assistant/providers/lastfm_recommendations/recommendations.py	2
 music_assistant/providers/local_audio/sendspin_bridge.py	2
-music_assistant/providers/loudness_analysis/provider.py	1
-music_assistant/providers/lrclib/__init__.py	1
 music_assistant/providers/mpd/player.py	7
 music_assistant/providers/msx_bridge/http_server.py	10
 music_assistant/providers/msx_bridge/player.py	9
@@ -106,10 +104,7 @@ music_assistant/providers/plex_connect/gdm.py	2
 music_assistant/providers/plex_connect/playback.py	10
 music_assistant/providers/plex_connect/queue_commands.py	3
 music_assistant/providers/plex_connect/server.py	8
-music_assistant/providers/podcastfeed/__init__.py	1
-music_assistant/providers/qobuz/__init__.py	1
 music_assistant/providers/qqmusic/__init__.py	22
-music_assistant/providers/radiobrowser/__init__.py	1
 music_assistant/providers/samsung_wam/features/grouping/coordinator.py	1
 music_assistant/providers/samsung_wam/features/state_sync/handler.py	8
 music_assistant/providers/sendspin/bridge_role.py	7
@@ -122,7 +117,6 @@ music_assistant/providers/smart_playlist/__init__.py	8
 music_assistant/providers/snapcast/control.py	1
 music_assistant/providers/snapcast/player.py	5
 music_assistant/providers/snapcast/provider.py	10
-music_assistant/providers/somafm/__init__.py	1
 music_assistant/providers/sonic_analysis/__init__.py	3
 music_assistant/providers/sonic_analysis/vendored_clap/clap_wrapper.py	4
 music_assistant/providers/sonic_analysis/vendored_clap/models/htsat.py	7


### PR DESCRIPTION
# What does this implement/fix?

Reorders the methods in a few small providers so that private methods live at the bottom of the class and public methods at the top, as required by `AGENTS.md` and enforced by `check_method_order`.

Each change is a pure relocation of a single method (no behaviour change):

- `loudness_analysis` — `post_analysis` moved above the private helpers
- `lrclib` — `get_track_metadata` moved above `_get_data`
- `podcastfeed` — `resolve_image` moved above the private helpers
- `qobuz` — `on_streamed` moved above `_report_playback_started`
- `radiobrowser` — `get_stream_details` moved above `_parse_radio`
- `somafm` — `get_stream_details` moved above the private helpers

These files are dropped from `scripts/lint_baselines/private_methods_not_last.txt`, shrinking the grandfathered baseline.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
