### PR TITLE
Move private methods to the bottom of the class in the music media controllers

### DIFF
--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -421,6 +421,102 @@ class AlbumsController(MediaControllerBase[Album]):
         album = self.album_from_item_mapping(item)
         return await self.add_item_to_library(album)
 
+    async def radio_mode_base_tracks(
+        self,
+        item: Album,
+        preferred_provider_instances: list[str] | None = None,
+    ) -> list[Track]:
+        """
+        Get the list of base tracks from the controller used to calculate the dynamic radio.
+
+        :param item: The Album to get base tracks for.
+        :param preferred_provider_instances: List of preferred provider instance IDs to use.
+        """
+        return await self.tracks(item.item_id, item.provider, in_library_only=False)
+
+    async def match_provider(
+        self, db_album: Album, provider: MusicProvider, strict: bool = True
+    ) -> list[ProviderMapping]:
+        """
+        Try to find match on (streaming) provider for the provided (database) album.
+
+        This is used to link objects of different providers/qualities together.
+        """
+        self.logger.debug("Trying to match album %s on provider %s", db_album.name, provider.name)
+        matches: list[ProviderMapping] = []
+        artist_name = db_album.artists[0].name
+        search_str = f"{artist_name} - {db_album.name}"
+        search_result = await self.search(search_str, provider.instance_id)
+        for search_result_item in search_result:
+            if not search_result_item.available:
+                continue
+            if not compare_media_item(db_album, search_result_item, strict=strict):
+                continue
+            # we must fetch the full album version, search results can be simplified objects
+            prov_album = await self.get_provider_item(
+                search_result_item.item_id,
+                search_result_item.provider,
+                fallback=search_result_item,
+            )
+            if compare_album(db_album, prov_album, strict=strict):
+                # 100% match
+                matches.extend(prov_album.provider_mappings)
+        if not matches:
+            self.logger.debug(
+                "Could not find match for Album %s on provider %s",
+                db_album.name,
+                provider.name,
+            )
+        return matches
+
+    async def match_providers(self, db_album: Album) -> None:
+        """
+        Try to find match on all (streaming) providers for the provided (database) album.
+
+        This is used to link objects of different providers/qualities together.
+        """
+        if db_album.provider != "library":
+            return  # Matching only supported for database items
+        if not db_album.artists:
+            return  # guard
+
+        # try to find match on all providers
+        processed_domains = set()
+        for provider in self.mass.music.providers:
+            if provider.domain in processed_domains:
+                continue
+            if ProviderFeature.SEARCH not in provider.supported_features:
+                continue
+            if not self.mass.music.library_supported(provider, MediaType.ALBUM):
+                continue
+            if not provider.is_streaming_provider:
+                # matching on unique providers is pointless as they push (all) their content to MA
+                continue
+            if match := await self.match_provider(db_album, provider):
+                # 100% match, we update the db with the additional provider mapping(s)
+                await self.add_provider_mappings(db_album.item_id, match)
+                processed_domains.add(provider.domain)
+
+    def album_from_item_mapping(self, item: ItemMapping) -> Album:
+        """Create an Album object from an ItemMapping object."""
+        domain, instance_id = None, None
+        if prov := self.mass.get_provider(item.provider):
+            domain = prov.domain
+            instance_id = prov.instance_id
+        return Album.from_dict(
+            {
+                **item.to_dict(),
+                "provider_mappings": [
+                    {
+                        "item_id": item.item_id,
+                        "provider_domain": domain,
+                        "provider_instance": instance_id,
+                        "available": item.available,
+                    }
+                ],
+            }
+        )
+
     async def _add_library_item(self, item: Album, overwrite_existing: bool = False) -> int:
         """Add a new record to the database."""
         if not isinstance(item, Album):  # TODO: Remove this once the codebase is fully typed
@@ -504,19 +600,6 @@ class AlbumsController(MediaControllerBase[Album]):
             return await prov.get_album_tracks(item_id)
         return []
 
-    async def radio_mode_base_tracks(
-        self,
-        item: Album,
-        preferred_provider_instances: list[str] | None = None,
-    ) -> list[Track]:
-        """
-        Get the list of base tracks from the controller used to calculate the dynamic radio.
-
-        :param item: The Album to get base tracks for.
-        :param preferred_provider_instances: List of preferred provider instance IDs to use.
-        """
-        return await self.tracks(item.item_id, item.provider, in_library_only=False)
-
     async def _set_album_artists(
         self,
         db_id: int,
@@ -578,87 +661,4 @@ class AlbumsController(MediaControllerBase[Album]):
                 "track_number": track.track_number,
                 "disc_number": track.disc_number,
             },
-        )
-
-    async def match_provider(
-        self, db_album: Album, provider: MusicProvider, strict: bool = True
-    ) -> list[ProviderMapping]:
-        """
-        Try to find match on (streaming) provider for the provided (database) album.
-
-        This is used to link objects of different providers/qualities together.
-        """
-        self.logger.debug("Trying to match album %s on provider %s", db_album.name, provider.name)
-        matches: list[ProviderMapping] = []
-        artist_name = db_album.artists[0].name
-        search_str = f"{artist_name} - {db_album.name}"
-        search_result = await self.search(search_str, provider.instance_id)
-        for search_result_item in search_result:
-            if not search_result_item.available:
-                continue
-            if not compare_media_item(db_album, search_result_item, strict=strict):
-                continue
-            # we must fetch the full album version, search results can be simplified objects
-            prov_album = await self.get_provider_item(
-                search_result_item.item_id,
-                search_result_item.provider,
-                fallback=search_result_item,
-            )
-            if compare_album(db_album, prov_album, strict=strict):
-                # 100% match
-                matches.extend(prov_album.provider_mappings)
-        if not matches:
-            self.logger.debug(
-                "Could not find match for Album %s on provider %s",
-                db_album.name,
-                provider.name,
-            )
-        return matches
-
-    async def match_providers(self, db_album: Album) -> None:
-        """
-        Try to find match on all (streaming) providers for the provided (database) album.
-
-        This is used to link objects of different providers/qualities together.
-        """
-        if db_album.provider != "library":
-            return  # Matching only supported for database items
-        if not db_album.artists:
-            return  # guard
-
-        # try to find match on all providers
-        processed_domains = set()
-        for provider in self.mass.music.providers:
-            if provider.domain in processed_domains:
-                continue
-            if ProviderFeature.SEARCH not in provider.supported_features:
-                continue
-            if not self.mass.music.library_supported(provider, MediaType.ALBUM):
-                continue
-            if not provider.is_streaming_provider:
-                # matching on unique providers is pointless as they push (all) their content to MA
-                continue
-            if match := await self.match_provider(db_album, provider):
-                # 100% match, we update the db with the additional provider mapping(s)
-                await self.add_provider_mappings(db_album.item_id, match)
-                processed_domains.add(provider.domain)
-
-    def album_from_item_mapping(self, item: ItemMapping) -> Album:
-        """Create an Album object from an ItemMapping object."""
-        domain, instance_id = None, None
-        if prov := self.mass.get_provider(item.provider):
-            domain = prov.domain
-            instance_id = prov.instance_id
-        return Album.from_dict(
-            {
-                **item.to_dict(),
-                "provider_mappings": [
-                    {
-                        "item_id": item.item_id,
-                        "provider_domain": domain,
-                        "provider_instance": instance_id,
-                        "available": item.available,
-                    }
-                ],
-            }
         )

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -651,98 +651,6 @@ class ArtistsController(MediaControllerBase[Artist]):
         # this will raise if the item still has references and recursive is false
         await super().remove_item_from_library(db_id)
 
-    def _validate_provider_filter(
-        self, provider_instance_id_or_domain: str, provider_filter: str | None
-    ) -> None:
-        """Raise when a provider filter is set that does not match the requested provider."""
-        if provider_filter is not None and provider_filter != provider_instance_id_or_domain:
-            raise MusicAssistantError(
-                f"provider_filter '{provider_filter}' does not match the requested "
-                f"provider '{provider_instance_id_or_domain}'"
-            )
-
-    async def _add_library_item(
-        self, item: Artist | ItemMapping, overwrite_existing: bool = False
-    ) -> int:
-        """Add a new item record to the database."""
-        # If item is an ItemMapping, convert it
-        if isinstance(item, ItemMapping):
-            item = self.artist_from_item_mapping(item)
-        # enforce various artists name + id
-        if compare_strings(item.name, VARIOUS_ARTISTS_NAME):
-            item.mbid = VARIOUS_ARTISTS_MBID
-        if item.mbid == VARIOUS_ARTISTS_MBID:
-            item.name = VARIOUS_ARTISTS_NAME
-        # no existing item matched: insert item
-        db_id = await self.mass.music.database.insert(
-            self.db_table,
-            {
-                "name": item.name,
-                "sort_name": item.sort_name,
-                "favorite": item.favorite,
-                "external_ids": serialize_to_json(item.external_ids),
-                "metadata": serialize_to_json(item.metadata),
-                "search_name": create_safe_string(item.name, True, True),
-                "search_sort_name": create_safe_string(item.sort_name or "", True, True),
-                "timestamp_added": int(item.date_added.timestamp()) if item.date_added else UNSET,
-            },
-        )
-        # update/set provider_mappings table
-        await self.set_provider_mappings(db_id, item.provider_mappings)
-        self.logger.debug("added %s to database (id: %s)", item.name, db_id)
-        return db_id
-
-    async def _update_library_item(
-        self, item_id: str | int, update: Artist | ItemMapping, overwrite: bool = False
-    ) -> None:
-        """Update existing record in the database."""
-        db_id = int(item_id)  # ensure integer
-        cur_item = await self.get_library_item(db_id)
-        if isinstance(update, ItemMapping):
-            # NOTE that artist is the only mediatype where its accepted we
-            # receive an itemmapping from streaming providers
-            update = self.artist_from_item_mapping(update)
-            metadata = cur_item.metadata
-        else:
-            metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
-        cur_item.external_ids.update(update.external_ids)
-        # enforce various artists name + id
-        mbid = cur_item.mbid
-        if (not mbid or overwrite) and getattr(update, "mbid", None):
-            if compare_strings(update.name, VARIOUS_ARTISTS_NAME):
-                update.mbid = VARIOUS_ARTISTS_MBID
-            if update.mbid == VARIOUS_ARTISTS_MBID:
-                update.name = VARIOUS_ARTISTS_NAME
-
-        name = update.name if overwrite else cur_item.name
-        sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name
-        await self.mass.music.database.update(
-            self.db_table,
-            {"item_id": db_id},
-            {
-                "name": name,
-                "sort_name": sort_name,
-                "external_ids": serialize_to_json(
-                    update.external_ids if overwrite else cur_item.external_ids
-                ),
-                "metadata": serialize_to_json(metadata),
-                "search_name": create_safe_string(name, True, True),
-                "search_sort_name": create_safe_string(sort_name or "", True, True),
-                "timestamp_added": int(update.date_added.timestamp())
-                if update.date_added
-                else UNSET,
-            },
-        )
-        self.logger.debug("updated %s in database: %s", update.name, db_id)
-        # update/set provider_mappings table
-        provider_mappings = (
-            update.provider_mappings
-            if overwrite
-            else {*update.provider_mappings, *cur_item.provider_mappings}
-        )
-        await self.set_provider_mappings(db_id, provider_mappings, overwrite)
-        self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
-
     async def radio_mode_base_tracks(
         self,
         item: Artist,
@@ -889,3 +797,95 @@ class ArtistsController(MediaControllerBase[Artist]):
                 ],
             }
         )
+
+    def _validate_provider_filter(
+        self, provider_instance_id_or_domain: str, provider_filter: str | None
+    ) -> None:
+        """Raise when a provider filter is set that does not match the requested provider."""
+        if provider_filter is not None and provider_filter != provider_instance_id_or_domain:
+            raise MusicAssistantError(
+                f"provider_filter '{provider_filter}' does not match the requested "
+                f"provider '{provider_instance_id_or_domain}'"
+            )
+
+    async def _add_library_item(
+        self, item: Artist | ItemMapping, overwrite_existing: bool = False
+    ) -> int:
+        """Add a new item record to the database."""
+        # If item is an ItemMapping, convert it
+        if isinstance(item, ItemMapping):
+            item = self.artist_from_item_mapping(item)
+        # enforce various artists name + id
+        if compare_strings(item.name, VARIOUS_ARTISTS_NAME):
+            item.mbid = VARIOUS_ARTISTS_MBID
+        if item.mbid == VARIOUS_ARTISTS_MBID:
+            item.name = VARIOUS_ARTISTS_NAME
+        # no existing item matched: insert item
+        db_id = await self.mass.music.database.insert(
+            self.db_table,
+            {
+                "name": item.name,
+                "sort_name": item.sort_name,
+                "favorite": item.favorite,
+                "external_ids": serialize_to_json(item.external_ids),
+                "metadata": serialize_to_json(item.metadata),
+                "search_name": create_safe_string(item.name, True, True),
+                "search_sort_name": create_safe_string(item.sort_name or "", True, True),
+                "timestamp_added": int(item.date_added.timestamp()) if item.date_added else UNSET,
+            },
+        )
+        # update/set provider_mappings table
+        await self.set_provider_mappings(db_id, item.provider_mappings)
+        self.logger.debug("added %s to database (id: %s)", item.name, db_id)
+        return db_id
+
+    async def _update_library_item(
+        self, item_id: str | int, update: Artist | ItemMapping, overwrite: bool = False
+    ) -> None:
+        """Update existing record in the database."""
+        db_id = int(item_id)  # ensure integer
+        cur_item = await self.get_library_item(db_id)
+        if isinstance(update, ItemMapping):
+            # NOTE that artist is the only mediatype where its accepted we
+            # receive an itemmapping from streaming providers
+            update = self.artist_from_item_mapping(update)
+            metadata = cur_item.metadata
+        else:
+            metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
+        cur_item.external_ids.update(update.external_ids)
+        # enforce various artists name + id
+        mbid = cur_item.mbid
+        if (not mbid or overwrite) and getattr(update, "mbid", None):
+            if compare_strings(update.name, VARIOUS_ARTISTS_NAME):
+                update.mbid = VARIOUS_ARTISTS_MBID
+            if update.mbid == VARIOUS_ARTISTS_MBID:
+                update.name = VARIOUS_ARTISTS_NAME
+
+        name = update.name if overwrite else cur_item.name
+        sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name
+        await self.mass.music.database.update(
+            self.db_table,
+            {"item_id": db_id},
+            {
+                "name": name,
+                "sort_name": sort_name,
+                "external_ids": serialize_to_json(
+                    update.external_ids if overwrite else cur_item.external_ids
+                ),
+                "metadata": serialize_to_json(metadata),
+                "search_name": create_safe_string(name, True, True),
+                "search_sort_name": create_safe_string(sort_name or "", True, True),
+                "timestamp_added": int(update.date_added.timestamp())
+                if update.date_added
+                else UNSET,
+            },
+        )
+        self.logger.debug("updated %s in database: %s", update.name, db_id)
+        # update/set provider_mappings table
+        provider_mappings = (
+            update.provider_mappings
+            if overwrite
+            else {*update.provider_mappings, *cur_item.provider_mappings}
+        )
+        await self.set_provider_mappings(db_id, provider_mappings, overwrite)
+        self.logger.debug("updated %s in database: (id %s)", update.name, db_id)

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -168,82 +168,6 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             )
         return result
 
-    async def _add_library_item(self, item: Audiobook, overwrite_existing: bool = False) -> int:
-        """Add a new record to the database."""
-        db_id = await self.mass.music.database.insert(
-            self.db_table,
-            {
-                "name": item.name,
-                "sort_name": item.sort_name,
-                "version": item.version,
-                "favorite": item.favorite,
-                "metadata": serialize_to_json(item.metadata),
-                "external_ids": serialize_to_json(item.external_ids),
-                "publisher": item.publisher,
-                "authors": serialize_to_json(item.authors),
-                "narrators": serialize_to_json(item.narrators),
-                "duration": item.duration,
-                "search_name": create_safe_string(item.name, True, True),
-                "search_sort_name": create_safe_string(item.sort_name or "", True, True),
-                "timestamp_added": int(item.date_added.timestamp()) if item.date_added else UNSET,
-            },
-        )
-        # update/set provider_mappings table
-        await self.set_provider_mappings(db_id, item.provider_mappings)
-        self.logger.debug("added %s to database (id: %s)", item.name, db_id)
-        await self._set_playlog(db_id, item)
-        return db_id
-
-    async def _update_library_item(
-        self, item_id: str | int, update: Audiobook, overwrite: bool = False
-    ) -> None:
-        """Update existing record in the database."""
-        db_id = int(item_id)  # ensure integer
-        cur_item = await self.get_library_item(db_id)
-        metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
-        if not overwrite and update.metadata.images is not None:
-            # audiobooks have no image picker, so keep the cover in sync with the
-            # provider instead of accumulating merged entries
-            metadata.images = update.metadata.images
-        cur_item.external_ids.update(update.external_ids)
-        name = update.name if overwrite else cur_item.name
-        sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name
-        await self.mass.music.database.update(
-            self.db_table,
-            {"item_id": db_id},
-            {
-                "name": name,
-                "sort_name": sort_name,
-                "version": update.version if overwrite else cur_item.version or update.version,
-                "metadata": serialize_to_json(metadata),
-                "external_ids": serialize_to_json(
-                    update.external_ids if overwrite else cur_item.external_ids
-                ),
-                "publisher": cur_item.publisher or update.publisher,
-                "authors": serialize_to_json(
-                    update.authors if overwrite else cur_item.authors or update.authors
-                ),
-                "narrators": serialize_to_json(
-                    update.narrators if overwrite else cur_item.narrators or update.narrators
-                ),
-                "duration": update.duration if overwrite else cur_item.duration or update.duration,
-                "search_name": create_safe_string(name, True, True),
-                "search_sort_name": create_safe_string(sort_name or "", True, True),
-                "timestamp_added": int(update.date_added.timestamp())
-                if update.date_added
-                else UNSET,
-            },
-        )
-        # update/set provider_mappings table
-        provider_mappings = (
-            update.provider_mappings
-            if overwrite
-            else {*update.provider_mappings, *cur_item.provider_mappings}
-        )
-        await self.set_provider_mappings(db_id, provider_mappings, overwrite)
-        self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
-        await self._set_playlog(db_id, update)
-
     async def radio_mode_base_tracks(
         self,
         item: Audiobook,
@@ -323,6 +247,135 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                 await self.add_provider_mappings(db_audiobook.item_id, match)
                 cur_provider_domains.add(provider.domain)
 
+    async def collections(
+        self,
+    ) -> list[AudiobookCollection]:
+        """
+        Get all available audiobook collections.
+
+        :param limit: Maximum number of items to return.
+        :param offset: Number of items to skip.
+        """
+        # key is the collections' title
+        collections_dict: dict[str, list[Audiobook]] = {}
+        audiobooks_with_collections = await self.get_library_items_by_query(
+            extra_query_parts=[
+                "WHERE json_extract(audiobooks.metadata, '$.collections') IS NOT NULL "
+                "AND json_extract(audiobooks.metadata, '$.collections') != '[]'",
+            ],
+        )
+        for audiobook in audiobooks_with_collections:
+            if audiobook.metadata.collections is None:
+                # this should never happen
+                continue
+            for collection_info in audiobook.metadata.collections:
+                audiobook_list = collections_dict.get(collection_info.title, [])
+                audiobook_list.append(audiobook)
+                collections_dict[collection_info.title] = audiobook_list
+
+        result: list[AudiobookCollection] = []
+        # Sort collections, first by number then alphabetically
+        for collection_title, audiobook_list in collections_dict.items():
+            audiobooks_with_number: list[tuple[Audiobook, float]] = []
+            audiobooks_with_string: list[tuple[Audiobook, str]] = []
+            audiobooks_with_none: list[Audiobook] = []
+            for audiobook in audiobook_list:
+                assert audiobook.metadata.collections is not None  # for type checking
+                collection_info = next(
+                    x for x in audiobook.metadata.collections if x.title == collection_title
+                )
+                if collection_info.sequence is None:
+                    audiobooks_with_none.append(audiobook)
+                    continue
+                try:
+                    sort_by = float(collection_info.sequence)
+                    audiobooks_with_number.append((audiobook, sort_by))
+                except ValueError:
+                    audiobooks_with_string.append((audiobook, str(collection_info.sequence)))
+            final_list = [x[0] for x in sorted(audiobooks_with_number, key=lambda x: x[1])]
+            final_list.extend([x[0] for x in sorted(audiobooks_with_string, key=lambda x: x[1])])
+            final_list.extend(audiobooks_with_none)
+
+            result.append(AudiobookCollection(title=collection_title, audiobooks=final_list))
+
+        return result
+
+    async def _add_library_item(self, item: Audiobook, overwrite_existing: bool = False) -> int:
+        """Add a new record to the database."""
+        db_id = await self.mass.music.database.insert(
+            self.db_table,
+            {
+                "name": item.name,
+                "sort_name": item.sort_name,
+                "version": item.version,
+                "favorite": item.favorite,
+                "metadata": serialize_to_json(item.metadata),
+                "external_ids": serialize_to_json(item.external_ids),
+                "publisher": item.publisher,
+                "authors": serialize_to_json(item.authors),
+                "narrators": serialize_to_json(item.narrators),
+                "duration": item.duration,
+                "search_name": create_safe_string(item.name, True, True),
+                "search_sort_name": create_safe_string(item.sort_name or "", True, True),
+                "timestamp_added": int(item.date_added.timestamp()) if item.date_added else UNSET,
+            },
+        )
+        # update/set provider_mappings table
+        await self.set_provider_mappings(db_id, item.provider_mappings)
+        self.logger.debug("added %s to database (id: %s)", item.name, db_id)
+        await self._set_playlog(db_id, item)
+        return db_id
+
+    async def _update_library_item(
+        self, item_id: str | int, update: Audiobook, overwrite: bool = False
+    ) -> None:
+        """Update existing record in the database."""
+        db_id = int(item_id)  # ensure integer
+        cur_item = await self.get_library_item(db_id)
+        metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
+        if not overwrite and update.metadata.images is not None:
+            # audiobooks have no image picker, so keep the cover in sync with the
+            # provider instead of accumulating merged entries
+            metadata.images = update.metadata.images
+        cur_item.external_ids.update(update.external_ids)
+        name = update.name if overwrite else cur_item.name
+        sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name
+        await self.mass.music.database.update(
+            self.db_table,
+            {"item_id": db_id},
+            {
+                "name": name,
+                "sort_name": sort_name,
+                "version": update.version if overwrite else cur_item.version or update.version,
+                "metadata": serialize_to_json(metadata),
+                "external_ids": serialize_to_json(
+                    update.external_ids if overwrite else cur_item.external_ids
+                ),
+                "publisher": cur_item.publisher or update.publisher,
+                "authors": serialize_to_json(
+                    update.authors if overwrite else cur_item.authors or update.authors
+                ),
+                "narrators": serialize_to_json(
+                    update.narrators if overwrite else cur_item.narrators or update.narrators
+                ),
+                "duration": update.duration if overwrite else cur_item.duration or update.duration,
+                "search_name": create_safe_string(name, True, True),
+                "search_sort_name": create_safe_string(sort_name or "", True, True),
+                "timestamp_added": int(update.date_added.timestamp())
+                if update.date_added
+                else UNSET,
+            },
+        )
+        # update/set provider_mappings table
+        provider_mappings = (
+            update.provider_mappings
+            if overwrite
+            else {*update.provider_mappings, *cur_item.provider_mappings}
+        )
+        await self.set_provider_mappings(db_id, provider_mappings, overwrite)
+        self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
+        await self._set_playlog(db_id, update)
+
     async def _set_playlog(self, db_id: int, media_item: Audiobook) -> None:
         """Update/set the playlog table for the given audiobook db item_id."""
         # Get user(s)
@@ -393,56 +446,3 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                 },
                 allow_replace=True,
             )
-
-    async def collections(
-        self,
-    ) -> list[AudiobookCollection]:
-        """
-        Get all available audiobook collections.
-
-        :param limit: Maximum number of items to return.
-        :param offset: Number of items to skip.
-        """
-        # key is the collections' title
-        collections_dict: dict[str, list[Audiobook]] = {}
-        audiobooks_with_collections = await self.get_library_items_by_query(
-            extra_query_parts=[
-                "WHERE json_extract(audiobooks.metadata, '$.collections') IS NOT NULL "
-                "AND json_extract(audiobooks.metadata, '$.collections') != '[]'",
-            ],
-        )
-        for audiobook in audiobooks_with_collections:
-            if audiobook.metadata.collections is None:
-                # this should never happen
-                continue
-            for collection_info in audiobook.metadata.collections:
-                audiobook_list = collections_dict.get(collection_info.title, [])
-                audiobook_list.append(audiobook)
-                collections_dict[collection_info.title] = audiobook_list
-
-        result: list[AudiobookCollection] = []
-        # Sort collections, first by number then alphabetically
-        for collection_title, audiobook_list in collections_dict.items():
-            audiobooks_with_number: list[tuple[Audiobook, float]] = []
-            audiobooks_with_string: list[tuple[Audiobook, str]] = []
-            audiobooks_with_none: list[Audiobook] = []
-            for audiobook in audiobook_list:
-                assert audiobook.metadata.collections is not None  # for type checking
-                collection_info = next(
-                    x for x in audiobook.metadata.collections if x.title == collection_title
-                )
-                if collection_info.sequence is None:
-                    audiobooks_with_none.append(audiobook)
-                    continue
-                try:
-                    sort_by = float(collection_info.sequence)
-                    audiobooks_with_number.append((audiobook, sort_by))
-                except ValueError:
-                    audiobooks_with_string.append((audiobook, str(collection_info.sequence)))
-            final_list = [x[0] for x in sorted(audiobooks_with_number, key=lambda x: x[1])]
-            final_list.extend([x[0] for x in sorted(audiobooks_with_string, key=lambda x: x[1])])
-            final_list.extend(audiobooks_with_none)
-
-            result.append(AudiobookCollection(title=collection_title, audiobooks=final_list))
-
-        return result

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -195,35 +195,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         return library_item
 
     @final
-    async def _get_library_item_by_match(self, item: ItemCls | ItemMapping) -> int | None:
-        if item.provider == "library":
-            return int(item.item_id)
-        # search by provider mappings if item is ItemMapping
-        if isinstance(item, ItemMapping):
-            if cur_item := await self.get_library_item_by_prov_id(item.item_id, item.provider):
-                return int(cur_item.item_id)
-
-        # for all other items that are MediaItemType, check provider_mappings if it exists
-        provider_mappings = getattr(item, "provider_mappings", None)
-        if provider_mappings:
-            if cur_item := await self.get_library_item_by_prov_mappings(provider_mappings):
-                return int(cur_item.item_id)
-        if cur_item := await self.get_library_item_by_external_ids(item.external_ids):
-            # existing item match by external id
-            # Double check external IDs - if MBID exists, regards that as overriding
-            if compare_media_item(item, cur_item):
-                return int(cur_item.item_id)
-        # search by (exact) name match
-        query = f"{self.db_table}.name = :name OR {self.db_table}.sort_name = :sort_name"
-        query_params = {"name": item.name, "sort_name": item.sort_name}
-        for db_item in await self.get_library_items_by_query(
-            extra_query_parts=[query], extra_query_params=query_params
-        ):
-            if compare_media_item(db_item, item, True):
-                return int(db_item.item_id)
-        return None
-
-    @final
     async def update_item_in_library(
         self, item_id: str | int, update: ItemCls, overwrite: bool = False
     ) -> ItemCls:
@@ -354,36 +325,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 genre=genre,
             )
         return items
-
-    async def _localized_search_fallback(
-        self, search_query: str, limit: int, offset: int = 0, **call_kwargs: Any
-    ) -> list[ItemCls]:
-        """
-        Retry a library search using the canonical names behind a localized query.
-
-        For genre/playlist searches that return nothing literally, reverse-resolve the query to the
-        canonical (English) names of matching localized items and search those, so an item is
-        findable by the localized name the user sees. The caller's other filters (favorite,
-        order_by, provider and any controller-specific kwargs) are forwarded unchanged so the retry
-        behaves like the literal search; results are merged, de-duplicated and paginated here. See
-        ``TranslationController.reverse_lookup_media_names``.
-        """
-        seen: set[Any] = set()
-        merged: list[ItemCls] = []
-        # iterate the canonical names in a stable order, and fetch each from the start so the
-        # offset/limit window can be applied to the merged, de-duplicated result set
-        for name in sorted(await self.mass.translations.reverse_lookup_media_names(search_query)):
-            for item in await self.library_items(
-                search=name,
-                limit=limit + offset,
-                offset=0,
-                _localized_fallback=False,
-                **call_kwargs,
-            ):
-                if item.item_id not in seen:
-                    seen.add(item.item_id)
-                    merged.append(item)
-        return merged[offset : offset + limit]
 
     async def iter_library_items(
         self,
@@ -977,20 +918,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             )
 
     @abstractmethod
-    async def _add_library_item(
-        self,
-        item: ItemCls,
-        overwrite_existing: bool = False,
-    ) -> int:
-        """Add artist to library and return the database id."""
-
-    @abstractmethod
-    async def _update_library_item(
-        self, item_id: str | int, update: ItemCls, overwrite: bool = False
-    ) -> None:
-        """Update existing library record in the database."""
-
-    @abstractmethod
     async def match_providers(self, db_item: ItemCls) -> None:
         """
         Try to find match on all (streaming) providers for the provided (database) item.
@@ -1068,6 +995,79 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 sql_query, query_params, limit=limit, offset=offset
             )
         ]
+
+    @final
+    async def _get_library_item_by_match(self, item: ItemCls | ItemMapping) -> int | None:
+        if item.provider == "library":
+            return int(item.item_id)
+        # search by provider mappings if item is ItemMapping
+        if isinstance(item, ItemMapping):
+            if cur_item := await self.get_library_item_by_prov_id(item.item_id, item.provider):
+                return int(cur_item.item_id)
+
+        # for all other items that are MediaItemType, check provider_mappings if it exists
+        provider_mappings = getattr(item, "provider_mappings", None)
+        if provider_mappings:
+            if cur_item := await self.get_library_item_by_prov_mappings(provider_mappings):
+                return int(cur_item.item_id)
+        if cur_item := await self.get_library_item_by_external_ids(item.external_ids):
+            # existing item match by external id
+            # Double check external IDs - if MBID exists, regards that as overriding
+            if compare_media_item(item, cur_item):
+                return int(cur_item.item_id)
+        # search by (exact) name match
+        query = f"{self.db_table}.name = :name OR {self.db_table}.sort_name = :sort_name"
+        query_params = {"name": item.name, "sort_name": item.sort_name}
+        for db_item in await self.get_library_items_by_query(
+            extra_query_parts=[query], extra_query_params=query_params
+        ):
+            if compare_media_item(db_item, item, True):
+                return int(db_item.item_id)
+        return None
+
+    async def _localized_search_fallback(
+        self, search_query: str, limit: int, offset: int = 0, **call_kwargs: Any
+    ) -> list[ItemCls]:
+        """
+        Retry a library search using the canonical names behind a localized query.
+
+        For genre/playlist searches that return nothing literally, reverse-resolve the query to the
+        canonical (English) names of matching localized items and search those, so an item is
+        findable by the localized name the user sees. The caller's other filters (favorite,
+        order_by, provider and any controller-specific kwargs) are forwarded unchanged so the retry
+        behaves like the literal search; results are merged, de-duplicated and paginated here. See
+        ``TranslationController.reverse_lookup_media_names``.
+        """
+        seen: set[Any] = set()
+        merged: list[ItemCls] = []
+        # iterate the canonical names in a stable order, and fetch each from the start so the
+        # offset/limit window can be applied to the merged, de-duplicated result set
+        for name in sorted(await self.mass.translations.reverse_lookup_media_names(search_query)):
+            for item in await self.library_items(
+                search=name,
+                limit=limit + offset,
+                offset=0,
+                _localized_fallback=False,
+                **call_kwargs,
+            ):
+                if item.item_id not in seen:
+                    seen.add(item.item_id)
+                    merged.append(item)
+        return merged[offset : offset + limit]
+
+    @abstractmethod
+    async def _add_library_item(
+        self,
+        item: ItemCls,
+        overwrite_existing: bool = False,
+    ) -> int:
+        """Add artist to library and return the database id."""
+
+    @abstractmethod
+    async def _update_library_item(
+        self, item_id: str | int, update: ItemCls, overwrite: bool = False
+    ) -> None:
+        """Update existing library record in the database."""
 
     @property
     def _search_filter_clause(self) -> str:

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -193,142 +193,6 @@ class GenreController(MediaControllerBase[Genre]):
         FROM (SELECT * FROM {DB_TABLE_GENRES} WHERE is_excluded = 0) AS {DB_TABLE_GENRES}"""
         return query, {}
 
-    @staticmethod
-    def _get_genre_icon_metadata(translation_key: str | None) -> MediaItemMetadata | None:
-        """
-        Build metadata with genre icon image if an SVG exists for the translation key.
-
-        :param translation_key: The genre's translation key (matches SVG filename).
-        """
-        if not translation_key:
-            return None
-        icon_path = RESOURCES_DIR.joinpath(GENRE_ICONS_DIR_NAME, f"{translation_key}.svg")
-        if not icon_path.is_file():
-            return None
-        image = MediaItemImage(
-            type=ImageType.THUMB,
-            path=f"{GENRE_ICONS_DIR_NAME}/{translation_key}.svg",
-            provider="builtin",
-        )
-        return MediaItemMetadata(images=UniqueList([image]))
-
-    @staticmethod
-    def _dedup_aliases(existing: list[str], new: list[str]) -> list[str]:
-        """
-        Merge alias lists, deduplicating by normalized form (create_safe_string).
-
-        Preserves the first occurrence's original casing.
-
-        :param existing: Current aliases (ordering preserved).
-        :param new: New aliases to add if not already present.
-        """
-        seen: set[str] = set()
-        result: list[str] = []
-        for alias in [*existing, *new]:
-            norm = create_safe_string(alias, True, True)
-            if norm and norm not in seen:
-                seen.add(norm)
-                result.append(alias)
-        return result
-
-    @property
-    def _search_filter_clause(self) -> str:
-        """Return search filter that also matches genre aliases."""
-        return (
-            f"({self.db_table}.search_name LIKE :search"
-            " OR EXISTS("
-            f"SELECT 1 FROM json_each({self.db_table}.genre_aliases) "
-            "WHERE LOWER(json_each.value) LIKE :search_raw))"
-        )
-
-    async def _add_library_item(self, item: Genre, overwrite_existing: bool = False) -> int:
-        """Add a new genre record to the database."""
-        aliases: list[str] = list(item.genre_aliases) if item.genre_aliases else [item.name]
-        # Ensure the genre's own name is always in aliases (normalized comparison)
-        name_norm = create_safe_string(item.name, True, True)
-        if not any(create_safe_string(a, True, True) == name_norm for a in aliases):
-            aliases.insert(0, item.name)
-        # If a soft-deleted genre with the same name exists, restore it instead of inserting
-        if excl_row := await self.mass.music.database.get_row(
-            DB_TABLE_GENRES, {"search_name": name_norm, "is_excluded": 1}
-        ):
-            db_id = int(excl_row["item_id"])
-            await self.mass.music.database.update(
-                DB_TABLE_GENRES, {"item_id": db_id}, {"is_excluded": 0}
-            )
-            self.logger.debug("restored soft-deleted genre %s (id: %s)", item.name, db_id)
-            return db_id
-        db_id = await self.mass.music.database.insert(
-            self.db_table,
-            {
-                "name": item.name,
-                "sort_name": item.sort_name,
-                "translation_key": item.translation_key,
-                "description": item.metadata.description if item.metadata else None,
-                "favorite": item.favorite,
-                "metadata": serialize_to_json(item.metadata),
-                "external_ids": serialize_to_json(item.external_ids),
-                "genre_aliases": serialize_to_json(aliases),
-                "play_count": 0,
-                "last_played": 0,
-                "search_name": create_safe_string(item.name, True, True),
-                "search_sort_name": create_safe_string(item.sort_name or "", True, True),
-                "timestamp_added": UNSET,
-                "is_default": 0,
-            },
-        )
-        self.logger.debug("added %s to database (id: %s)", item.name, db_id)
-        return db_id
-
-    async def _update_library_item(
-        self, item_id: str | int, update: Genre, overwrite: bool = False
-    ) -> None:
-        """Update existing genre record in the database."""
-        db_id = int(item_id)
-        cur_item = await self.get_library_item(db_id)
-        metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
-        cur_item.external_ids.update(update.external_ids)
-        name = update.name if overwrite else cur_item.name
-        sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name
-        existing_description = await self._get_description(db_id)
-        description = (
-            update.metadata.description
-            if update.metadata and update.metadata.description is not None
-            else None
-            if overwrite
-            else existing_description
-        )
-        # Merge aliases: keep existing, add any new from update (normalized dedup)
-        existing_aliases = list(cur_item.genre_aliases) if cur_item.genre_aliases else []
-        update_aliases = list(update.genre_aliases) if update.genre_aliases else []
-        if overwrite:
-            merged_aliases = self._dedup_aliases(update_aliases, [name])
-        else:
-            merged_aliases = self._dedup_aliases(existing_aliases, [*update_aliases, name])
-
-        await self.mass.music.database.update(
-            self.db_table,
-            {"item_id": db_id},
-            {
-                "name": name,
-                "sort_name": sort_name,
-                "translation_key": update.translation_key
-                if overwrite
-                else cur_item.translation_key,
-                "description": description,
-                "favorite": update.favorite,
-                "metadata": serialize_to_json(metadata),
-                "external_ids": serialize_to_json(
-                    update.external_ids if overwrite else cur_item.external_ids
-                ),
-                "genre_aliases": serialize_to_json(merged_aliases),
-                "search_name": create_safe_string(name, True, True),
-                "search_sort_name": create_safe_string(sort_name or "", True, True),
-                "timestamp_added": UNSET,
-            },
-        )
-        self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
-
     async def library_items(
         self,
         favorite: bool | None = None,
@@ -757,6 +621,625 @@ class GenreController(MediaControllerBase[Genre]):
             return []
         return [await self.get_library_item(item_id) for item_id in created_ids]
 
+    async def remove_item_from_library(
+        self, item_id: str | int, recursive: bool = True, exclude_globally: bool = True
+    ) -> None:
+        """
+        Delete genre record from the database.
+
+        :param item_id: Database ID of the genre to remove.
+        :param recursive: Unused for genres, kept for base-class compatibility.
+        :param exclude_globally: If True (default), soft-delete the genre so the scanner
+            will not recreate it. If False, hard-delete the row (used internally by
+            merge_genres where the source should not appear in the exclusion list).
+        """
+        db_id = int(item_id)
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING, {"genre_id": db_id}
+        )
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION, {"genre_id": db_id}
+        )
+        if exclude_globally:
+            # Fetch the item while it is still visible (base_query filters is_excluded=1).
+            library_item = await self.get_library_item(db_id)
+            await self.mass.music.database.update(
+                DB_TABLE_GENRES, {"item_id": db_id}, {"is_excluded": 1}
+            )
+            self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, library_item.uri, library_item)
+        else:
+            await super().remove_item_from_library(item_id, recursive)
+
+    async def add_alias(self, genre_id: str | int, alias: str) -> Genre:
+        """
+        Add an alias string to a genre.
+
+        :param genre_id: Database ID of the genre.
+        :param alias: Alias string to add.
+        """
+        db_id = int(genre_id)
+        genre = await self.get_library_item(db_id)
+        aliases = list(genre.genre_aliases) if genre.genre_aliases else []
+        aliases = self._dedup_aliases(aliases, [alias])
+        await self.mass.music.database.update(
+            self.db_table,
+            {"item_id": db_id},
+            {"genre_aliases": serialize_to_json(aliases)},
+        )
+        updated = await self.get_library_item(db_id)
+        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, updated.uri, updated)
+        return updated
+
+    async def remove_alias(self, genre_id: str | int, alias: str) -> Genre:
+        """
+        Remove an alias string from a genre.
+
+        :param genre_id: Database ID of the genre.
+        :param alias: Alias string to remove.
+        :raises ValueError: If trying to remove the genre's own name.
+        """
+        db_id = int(genre_id)
+        genre = await self.get_library_item(db_id)
+        if create_safe_string(alias, True, True) == create_safe_string(genre.name, True, True):
+            msg = (
+                f"Cannot remove self-alias '{alias}' from genre '{genre.name}'. "
+                f"Delete the genre instead."
+            )
+            raise ValueError(msg)
+        aliases = list(genre.genre_aliases) if genre.genre_aliases else []
+        alias_norm = create_safe_string(alias, True, True)
+        aliases = [a for a in aliases if create_safe_string(a, True, True) != alias_norm]
+        await self.mass.music.database.update(
+            self.db_table,
+            {"item_id": db_id},
+            {"genre_aliases": serialize_to_json(aliases)},
+        )
+        # Remove media mappings that were created via this alias (case-insensitive)
+        await self.mass.music.database.execute(
+            f"DELETE FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "WHERE genre_id = :genre_id AND LOWER(alias) = LOWER(:alias)",
+            {"genre_id": db_id, "alias": alias},
+        )
+        # Derived album/artist rows can be left orphaned by the deleted track rows.
+        await self._propagate_genre_mappings_to_parents()
+        updated = await self.get_library_item(db_id)
+        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, updated.uri, updated)
+        return updated
+
+    async def add_media_mapping(
+        self,
+        genre_id: str | int,
+        media_type: MediaType,
+        media_id: str | int,
+        alias: str | None = None,
+    ) -> None:
+        """
+        Map a media item to a genre.
+
+        :param genre_id: Database ID of the genre.
+        :param media_type: Type of media item (track, album, artist).
+        :param media_id: Database ID of the media item.
+        :param alias: The alias string that caused this mapping. If not provided,
+            the genre's primary name is used.
+        """
+        if alias is None:
+            genre = await self.get_library_item(int(genre_id))
+            alias = genre.name
+        await self.mass.music.database.insert(
+            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+            {
+                "genre_id": int(genre_id),
+                "media_id": int(media_id),
+                "media_type": media_type.value,
+                "alias": alias,
+                "is_manual": 1,
+            },
+            allow_replace=True,
+        )
+
+    async def remove_media_mapping(
+        self, genre_id: str | int, media_type: MediaType, media_id: str | int
+    ) -> None:
+        """
+        Remove a media item mapping from a genre.
+
+        If the mapping was derived (propagated from child tracks), an exclusion is
+        automatically inserted so the next propagation scan does not re-derive it.
+
+        :param genre_id: Database ID of the genre.
+        :param media_type: Type of media item (track, album, artist).
+        :param media_id: Database ID of the media item.
+        """
+        row = await self.mass.music.database.get_row(
+            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+            {"genre_id": int(genre_id), "media_id": int(media_id), "media_type": media_type.value},
+        )
+        if row and row["is_derived"]:
+            await self.exclude_genre_from_media_item(genre_id, media_type, media_id)
+            return
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+            {
+                "genre_id": int(genre_id),
+                "media_id": int(media_id),
+                "media_type": media_type.value,
+            },
+        )
+
+    async def exclude_genre_from_media_item(
+        self,
+        genre_id: str | int,
+        media_type: MediaType,
+        media_id: str | int,
+    ) -> None:
+        """
+        Permanently exclude a genre from being mapped to a media item.
+
+        Records the exclusion so the scanner will never re-add this mapping.
+        Any existing mapping for this genre/media pair is removed immediately.
+
+        :param genre_id: Database ID of the genre.
+        :param media_type: Type of media item (track, album, artist, etc.).
+        :param media_id: Database ID of the media item.
+        """
+        params = {
+            "genre_id": int(genre_id),
+            "media_id": int(media_id),
+            "media_type": media_type.value,
+        }
+        db = self.mass.music.database
+        # Run both statements without committing between them so the exclusion insert
+        # and the mapping delete are committed atomically.
+        await db.execute(
+            f"INSERT OR REPLACE INTO {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}"
+            "(genre_id, media_id, media_type) VALUES (:genre_id, :media_id, :media_type)",
+            params,
+        )
+        await db.execute(
+            f"DELETE FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            "WHERE genre_id = :genre_id AND media_id = :media_id AND media_type = :media_type",
+            params,
+        )
+        await db.commit()
+
+    async def remove_genre_exclusion(
+        self,
+        genre_id: str | int,
+        media_type: MediaType,
+        media_id: str | int,
+    ) -> None:
+        """
+        Remove a genre exclusion, allowing the scanner to re-map it on the next run.
+
+        :param genre_id: Database ID of the genre.
+        :param media_type: Type of media item (track, album, artist, etc.).
+        :param media_id: Database ID of the media item.
+        """
+        await self.mass.music.database.delete(
+            DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
+            {
+                "genre_id": int(genre_id),
+                "media_id": int(media_id),
+                "media_type": media_type.value,
+            },
+        )
+
+    async def get_global_genre_exclusions(self) -> list[dict[str, object]]:
+        """Return all globally excluded genres."""
+        rows = await self.mass.music.database.get_rows_from_query(
+            f"SELECT item_id, name, sort_name, search_name, translation_key, metadata "
+            f"FROM {DB_TABLE_GENRES} WHERE is_excluded = 1 ORDER BY sort_name",
+            limit=0,
+        )
+        result = []
+        for row in rows:
+            entry = dict(row)
+            if raw_metadata := entry.get("metadata"):
+                entry["metadata"] = json_loads(raw_metadata)
+            result.append(entry)
+        return result
+
+    async def remove_global_genre_exclusion(self, genre_id: int) -> Genre:
+        """
+        Lift a global genre exclusion, making the genre visible and scannable again.
+
+        :param genre_id: Database ID of the excluded genre (item_id in genres table).
+        :return: The restored Genre.
+        """
+        row = await self.mass.music.database.get_row(
+            DB_TABLE_GENRES, {"item_id": genre_id, "is_excluded": 1}
+        )
+        if not row:
+            msg = f"No globally excluded genre found with id {genre_id}"
+            raise KeyError(msg)
+        await self.mass.music.database.update(
+            DB_TABLE_GENRES, {"item_id": genre_id}, {"is_excluded": 0}
+        )
+        library_item = await self.get_library_item(genre_id)
+        self.mass.signal_event(EventType.MEDIA_ITEM_ADDED, library_item.uri, library_item)
+        return library_item
+
+    async def promote_alias_to_genre(self, genre_id: str | int, alias: str) -> Genre:
+        """
+        Promote an alias to become a standalone genre.
+
+        Every genre that claimed the alias loses it, and all media mapped via
+        the alias is moved to the new genre.
+
+        :param genre_id: Database ID of the source genre.
+        :param alias: The alias string to promote.
+        :return: The newly created Genre.
+        """
+        db_genre_id = int(genre_id)
+        source_genre = await self.get_library_item(db_genre_id)
+        alias_norm = create_safe_string(alias, True, True)
+
+        if alias_norm == create_safe_string(source_genre.name, True, True):
+            msg = (
+                f"Cannot promote self-alias '{alias}'. "
+                f"This alias is the primary name for genre '{source_genre.name}'."
+            )
+            raise ValueError(msg)
+
+        owning_ids = await self._find_genre_ids_for_alias(alias_norm)
+        if db_genre_id not in owning_ids:
+            owning_ids.append(db_genre_id)
+
+        new_genre = Genre(
+            item_id="0",
+            provider="library",
+            name=alias,
+            sort_name=alias,
+            translation_key=None,
+            provider_mappings=set(),
+            favorite=False,
+        )
+        created_genre = await self.add_item_to_library(new_genre)
+        new_genre_id = int(created_genre.item_id)
+
+        # UPDATE OR REPLACE drops any pre-existing mapping on the new genre for
+        # the same (media_id, media_type) so the moved row wins.
+        placeholders = ", ".join(str(g) for g in owning_ids)
+        await self.mass.music.database.execute(
+            f"UPDATE OR REPLACE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
+            f"SET genre_id = :new_id "
+            f"WHERE genre_id IN ({placeholders}) AND LOWER(alias) = LOWER(:alias)",
+            {"new_id": new_genre_id, "alias": alias},
+        )
+
+        for owning_id in owning_ids:
+            owning = await self.get_library_item(owning_id)
+            # Defensive: a genre whose primary name equals the alias would hit
+            # the self-alias guard in remove_alias; skip rather than raise.
+            if create_safe_string(owning.name, True, True) == alias_norm:
+                continue
+            owning_aliases = list(owning.genre_aliases) if owning.genre_aliases else []
+            filtered = [
+                a for a in owning_aliases if create_safe_string(a, True, True) != alias_norm
+            ]
+            if len(filtered) != len(owning_aliases):
+                await self.mass.music.database.update(
+                    self.db_table,
+                    {"item_id": owning_id},
+                    {"genre_aliases": serialize_to_json(filtered)},
+                )
+
+        # Derived album/artist rows still point at the old source genres; rebuild
+        # them from the moved track mappings.
+        await self._propagate_genre_mappings_to_parents()
+
+        return await self.get_library_item(new_genre_id)
+
+    async def merge_genres(self, genre_ids: list[str | int], target_genre_id: str | int) -> Genre:
+        """
+        Merge one or more genres into a target genre.
+
+        Transfers all aliases and media mappings from the source genres to the
+        target, then deletes the source genres. Aliases and mappings are
+        deduplicated so no duplicates are created on the target.
+
+        :param genre_ids: List of genre IDs to merge into the target.
+        :param target_genre_id: Database ID of the genre to merge into.
+        """
+        target_id = int(target_genre_id)
+        source_ids = [int(gid) for gid in genre_ids]
+
+        if target_id in source_ids:
+            msg = "Target genre cannot be in the list of genres to merge"
+            raise ValueError(msg)
+        if not source_ids:
+            msg = "No genre IDs provided to merge"
+            raise ValueError(msg)
+
+        target_genre = await self.get_library_item(target_id)
+        db = self.mass.music.database
+        gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
+
+        # Collect and merge aliases from all source genres into the target
+        all_new_aliases: list[str] = []
+        for source_id in source_ids:
+            source_genre = await self.get_library_item(source_id)
+            if source_genre.genre_aliases:
+                all_new_aliases.extend(source_genre.genre_aliases)
+
+        existing_aliases = list(target_genre.genre_aliases) if target_genre.genre_aliases else []
+        merged_aliases = self._dedup_aliases(existing_aliases, all_new_aliases)
+        await db.update(
+            self.db_table,
+            {"item_id": target_id},
+            {"genre_aliases": serialize_to_json(merged_aliases)},
+        )
+
+        # Transfer media mappings from source genres to target (deduplicated)
+        placeholders = ", ".join(str(sid) for sid in source_ids)
+        await db.execute(
+            f"INSERT OR IGNORE INTO {gm} (genre_id, media_id, media_type, alias) "
+            f"SELECT :target_id, media_id, media_type, alias FROM {gm} "
+            f"WHERE genre_id IN ({placeholders})",
+            {"target_id": target_id},
+        )
+
+        # Hard-delete source genres: merging is not a user exclusion so sources must
+        # not appear in the global exclusion list.
+        for source_id in source_ids:
+            await self.remove_item_from_library(source_id, exclude_globally=False)
+
+        # Rebuild derived album/artist rows against the merged track mappings.
+        await self._propagate_genre_mappings_to_parents()
+
+        updated = await self.get_library_item(target_id)
+        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, updated.uri, updated)
+        return updated
+
+    async def sync_media_item_genres(
+        self, media_type: MediaType, media_id: str | int, genre_names: set[str]
+    ) -> None:
+        """
+        Sync genre mappings for a media item.
+
+        Ensures genre records exist and updates genre-media mappings.
+        Removes mappings that are no longer present in the incoming genre_names set.
+
+        :param media_type: The type of media item being synced.
+        :param media_id: The database ID of the media item.
+        :param genre_names: Set of genre names from the provider.
+        """
+        media_id_int = int(media_id)
+        gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
+
+        # Build target set: (genre_id, alias_name) from incoming names.
+        # One alias can map to multiple genres (n:n).
+        target_mappings: dict[int, str] = {}
+        for name in genre_names:
+            normalized = self._normalize_genre_name(name)
+            if not normalized:
+                continue
+            genre_ids = await self._find_genres_for_alias(normalized[0])
+            for gid in genre_ids:
+                if gid not in target_mappings:
+                    target_mappings[gid] = normalized[0]
+
+        # Get current genre_ids from database
+        rows = await self.mass.music.database.get_rows_from_query(
+            f"SELECT genre_id FROM {gm} WHERE media_type = :media_type AND media_id = :media_id",
+            {"media_type": media_type.value, "media_id": media_id_int},
+            limit=0,
+        )
+        existing_genre_ids = {int(row["genre_id"]) for row in rows}
+
+        to_add = set(target_mappings.keys()) - existing_genre_ids
+        to_remove = existing_genre_ids - set(target_mappings.keys())
+
+        for genre_id in to_remove:
+            await self.mass.music.database.delete(
+                gm,
+                {
+                    "genre_id": genre_id,
+                    "media_id": media_id_int,
+                    "media_type": media_type.value,
+                },
+            )
+
+        for genre_id in to_add:
+            await self.mass.music.database.insert(
+                gm,
+                {
+                    "genre_id": genre_id,
+                    "media_id": media_id_int,
+                    "media_type": media_type.value,
+                    "alias": target_mappings[genre_id],
+                },
+                allow_replace=True,
+            )
+
+    def register_scheduled_scan_task(self) -> BackgroundTask:
+        """Register the recurring genre mapping scan task."""
+        utc_hour, utc_minute = local_clock_time_to_utc(4, 0)
+        desired_schedule = TaskSchedule.daily(hour=utc_hour, minute=utc_minute)
+        return self.mass.tasks.register_scheduled_task(
+            task_id=GENRE_SCAN_TASK_ID,
+            name="Scan genre mappings",
+            handler=self._scan_genre_mappings,
+            schedule=desired_schedule,
+            translation_key="scan_genre_mappings",
+            translation_owner=self.translation_owner,
+            metadata={
+                "task_domain": "genre_mapping_scan",
+            },
+            allow_retry=True,
+        )
+
+    async def scan_mappings(self) -> dict[str, Any]:
+        """
+        Manually trigger a genre mapping scan (admin only).
+
+        :return: Status information about the scan trigger.
+        """
+        if self._genre_scan_running:
+            return {
+                "status": "already_running",
+                "message": "Genre mapping scanner is already running",
+            }
+
+        self._queue_genre_mapping_scan_task()
+
+        return {
+            "status": "triggered",
+            "message": "Genre mapping scan triggered",
+            "last_scan": self._last_scan_time,
+        }
+
+    async def get_scanner_status(self) -> dict[str, Any]:
+        """
+        Get status of the genre mapping background scanner.
+
+        :return: Scanner status information.
+        """
+        return {
+            "running": self._genre_scan_running,
+            "last_scan_time": self._last_scan_time,
+            "last_scan_ago_seconds": (
+                int(time.time() - self._last_scan_time) if self._last_scan_time else None
+            ),
+            "last_scan_mapped": self._last_scan_mapped,
+        }
+
+    @staticmethod
+    def _get_genre_icon_metadata(translation_key: str | None) -> MediaItemMetadata | None:
+        """
+        Build metadata with genre icon image if an SVG exists for the translation key.
+
+        :param translation_key: The genre's translation key (matches SVG filename).
+        """
+        if not translation_key:
+            return None
+        icon_path = RESOURCES_DIR.joinpath(GENRE_ICONS_DIR_NAME, f"{translation_key}.svg")
+        if not icon_path.is_file():
+            return None
+        image = MediaItemImage(
+            type=ImageType.THUMB,
+            path=f"{GENRE_ICONS_DIR_NAME}/{translation_key}.svg",
+            provider="builtin",
+        )
+        return MediaItemMetadata(images=UniqueList([image]))
+
+    @staticmethod
+    def _dedup_aliases(existing: list[str], new: list[str]) -> list[str]:
+        """
+        Merge alias lists, deduplicating by normalized form (create_safe_string).
+
+        Preserves the first occurrence's original casing.
+
+        :param existing: Current aliases (ordering preserved).
+        :param new: New aliases to add if not already present.
+        """
+        seen: set[str] = set()
+        result: list[str] = []
+        for alias in [*existing, *new]:
+            norm = create_safe_string(alias, True, True)
+            if norm and norm not in seen:
+                seen.add(norm)
+                result.append(alias)
+        return result
+
+    @property
+    def _search_filter_clause(self) -> str:
+        """Return search filter that also matches genre aliases."""
+        return (
+            f"({self.db_table}.search_name LIKE :search"
+            " OR EXISTS("
+            f"SELECT 1 FROM json_each({self.db_table}.genre_aliases) "
+            "WHERE LOWER(json_each.value) LIKE :search_raw))"
+        )
+
+    async def _add_library_item(self, item: Genre, overwrite_existing: bool = False) -> int:
+        """Add a new genre record to the database."""
+        aliases: list[str] = list(item.genre_aliases) if item.genre_aliases else [item.name]
+        # Ensure the genre's own name is always in aliases (normalized comparison)
+        name_norm = create_safe_string(item.name, True, True)
+        if not any(create_safe_string(a, True, True) == name_norm for a in aliases):
+            aliases.insert(0, item.name)
+        # If a soft-deleted genre with the same name exists, restore it instead of inserting
+        if excl_row := await self.mass.music.database.get_row(
+            DB_TABLE_GENRES, {"search_name": name_norm, "is_excluded": 1}
+        ):
+            db_id = int(excl_row["item_id"])
+            await self.mass.music.database.update(
+                DB_TABLE_GENRES, {"item_id": db_id}, {"is_excluded": 0}
+            )
+            self.logger.debug("restored soft-deleted genre %s (id: %s)", item.name, db_id)
+            return db_id
+        db_id = await self.mass.music.database.insert(
+            self.db_table,
+            {
+                "name": item.name,
+                "sort_name": item.sort_name,
+                "translation_key": item.translation_key,
+                "description": item.metadata.description if item.metadata else None,
+                "favorite": item.favorite,
+                "metadata": serialize_to_json(item.metadata),
+                "external_ids": serialize_to_json(item.external_ids),
+                "genre_aliases": serialize_to_json(aliases),
+                "play_count": 0,
+                "last_played": 0,
+                "search_name": create_safe_string(item.name, True, True),
+                "search_sort_name": create_safe_string(item.sort_name or "", True, True),
+                "timestamp_added": UNSET,
+                "is_default": 0,
+            },
+        )
+        self.logger.debug("added %s to database (id: %s)", item.name, db_id)
+        return db_id
+
+    async def _update_library_item(
+        self, item_id: str | int, update: Genre, overwrite: bool = False
+    ) -> None:
+        """Update existing genre record in the database."""
+        db_id = int(item_id)
+        cur_item = await self.get_library_item(db_id)
+        metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
+        cur_item.external_ids.update(update.external_ids)
+        name = update.name if overwrite else cur_item.name
+        sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name
+        existing_description = await self._get_description(db_id)
+        description = (
+            update.metadata.description
+            if update.metadata and update.metadata.description is not None
+            else None
+            if overwrite
+            else existing_description
+        )
+        # Merge aliases: keep existing, add any new from update (normalized dedup)
+        existing_aliases = list(cur_item.genre_aliases) if cur_item.genre_aliases else []
+        update_aliases = list(update.genre_aliases) if update.genre_aliases else []
+        if overwrite:
+            merged_aliases = self._dedup_aliases(update_aliases, [name])
+        else:
+            merged_aliases = self._dedup_aliases(existing_aliases, [*update_aliases, name])
+
+        await self.mass.music.database.update(
+            self.db_table,
+            {"item_id": db_id},
+            {
+                "name": name,
+                "sort_name": sort_name,
+                "translation_key": update.translation_key
+                if overwrite
+                else cur_item.translation_key,
+                "description": description,
+                "favorite": update.favorite,
+                "metadata": serialize_to_json(metadata),
+                "external_ids": serialize_to_json(
+                    update.external_ids if overwrite else cur_item.external_ids
+                ),
+                "genre_aliases": serialize_to_json(merged_aliases),
+                "search_name": create_safe_string(name, True, True),
+                "search_sort_name": create_safe_string(sort_name or "", True, True),
+                "timestamp_added": UNSET,
+            },
+        )
+        self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
+
     async def _bulk_scan_media_genres(self) -> None:
         """
         Bulk-scan all media items and rebuild genre mappings using CTE.
@@ -1165,315 +1648,6 @@ class GenreController(MediaControllerBase[Genre]):
 
         await db.commit()
 
-    async def remove_item_from_library(
-        self, item_id: str | int, recursive: bool = True, exclude_globally: bool = True
-    ) -> None:
-        """
-        Delete genre record from the database.
-
-        :param item_id: Database ID of the genre to remove.
-        :param recursive: Unused for genres, kept for base-class compatibility.
-        :param exclude_globally: If True (default), soft-delete the genre so the scanner
-            will not recreate it. If False, hard-delete the row (used internally by
-            merge_genres where the source should not appear in the exclusion list).
-        """
-        db_id = int(item_id)
-        await self.mass.music.database.delete(
-            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING, {"genre_id": db_id}
-        )
-        await self.mass.music.database.delete(
-            DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION, {"genre_id": db_id}
-        )
-        if exclude_globally:
-            # Fetch the item while it is still visible (base_query filters is_excluded=1).
-            library_item = await self.get_library_item(db_id)
-            await self.mass.music.database.update(
-                DB_TABLE_GENRES, {"item_id": db_id}, {"is_excluded": 1}
-            )
-            self.mass.signal_event(EventType.MEDIA_ITEM_DELETED, library_item.uri, library_item)
-        else:
-            await super().remove_item_from_library(item_id, recursive)
-
-    async def add_alias(self, genre_id: str | int, alias: str) -> Genre:
-        """
-        Add an alias string to a genre.
-
-        :param genre_id: Database ID of the genre.
-        :param alias: Alias string to add.
-        """
-        db_id = int(genre_id)
-        genre = await self.get_library_item(db_id)
-        aliases = list(genre.genre_aliases) if genre.genre_aliases else []
-        aliases = self._dedup_aliases(aliases, [alias])
-        await self.mass.music.database.update(
-            self.db_table,
-            {"item_id": db_id},
-            {"genre_aliases": serialize_to_json(aliases)},
-        )
-        updated = await self.get_library_item(db_id)
-        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, updated.uri, updated)
-        return updated
-
-    async def remove_alias(self, genre_id: str | int, alias: str) -> Genre:
-        """
-        Remove an alias string from a genre.
-
-        :param genre_id: Database ID of the genre.
-        :param alias: Alias string to remove.
-        :raises ValueError: If trying to remove the genre's own name.
-        """
-        db_id = int(genre_id)
-        genre = await self.get_library_item(db_id)
-        if create_safe_string(alias, True, True) == create_safe_string(genre.name, True, True):
-            msg = (
-                f"Cannot remove self-alias '{alias}' from genre '{genre.name}'. "
-                f"Delete the genre instead."
-            )
-            raise ValueError(msg)
-        aliases = list(genre.genre_aliases) if genre.genre_aliases else []
-        alias_norm = create_safe_string(alias, True, True)
-        aliases = [a for a in aliases if create_safe_string(a, True, True) != alias_norm]
-        await self.mass.music.database.update(
-            self.db_table,
-            {"item_id": db_id},
-            {"genre_aliases": serialize_to_json(aliases)},
-        )
-        # Remove media mappings that were created via this alias (case-insensitive)
-        await self.mass.music.database.execute(
-            f"DELETE FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
-            "WHERE genre_id = :genre_id AND LOWER(alias) = LOWER(:alias)",
-            {"genre_id": db_id, "alias": alias},
-        )
-        # Derived album/artist rows can be left orphaned by the deleted track rows.
-        await self._propagate_genre_mappings_to_parents()
-        updated = await self.get_library_item(db_id)
-        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, updated.uri, updated)
-        return updated
-
-    async def add_media_mapping(
-        self,
-        genre_id: str | int,
-        media_type: MediaType,
-        media_id: str | int,
-        alias: str | None = None,
-    ) -> None:
-        """
-        Map a media item to a genre.
-
-        :param genre_id: Database ID of the genre.
-        :param media_type: Type of media item (track, album, artist).
-        :param media_id: Database ID of the media item.
-        :param alias: The alias string that caused this mapping. If not provided,
-            the genre's primary name is used.
-        """
-        if alias is None:
-            genre = await self.get_library_item(int(genre_id))
-            alias = genre.name
-        await self.mass.music.database.insert(
-            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
-            {
-                "genre_id": int(genre_id),
-                "media_id": int(media_id),
-                "media_type": media_type.value,
-                "alias": alias,
-                "is_manual": 1,
-            },
-            allow_replace=True,
-        )
-
-    async def remove_media_mapping(
-        self, genre_id: str | int, media_type: MediaType, media_id: str | int
-    ) -> None:
-        """
-        Remove a media item mapping from a genre.
-
-        If the mapping was derived (propagated from child tracks), an exclusion is
-        automatically inserted so the next propagation scan does not re-derive it.
-
-        :param genre_id: Database ID of the genre.
-        :param media_type: Type of media item (track, album, artist).
-        :param media_id: Database ID of the media item.
-        """
-        row = await self.mass.music.database.get_row(
-            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
-            {"genre_id": int(genre_id), "media_id": int(media_id), "media_type": media_type.value},
-        )
-        if row and row["is_derived"]:
-            await self.exclude_genre_from_media_item(genre_id, media_type, media_id)
-            return
-        await self.mass.music.database.delete(
-            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
-            {
-                "genre_id": int(genre_id),
-                "media_id": int(media_id),
-                "media_type": media_type.value,
-            },
-        )
-
-    async def exclude_genre_from_media_item(
-        self,
-        genre_id: str | int,
-        media_type: MediaType,
-        media_id: str | int,
-    ) -> None:
-        """
-        Permanently exclude a genre from being mapped to a media item.
-
-        Records the exclusion so the scanner will never re-add this mapping.
-        Any existing mapping for this genre/media pair is removed immediately.
-
-        :param genre_id: Database ID of the genre.
-        :param media_type: Type of media item (track, album, artist, etc.).
-        :param media_id: Database ID of the media item.
-        """
-        params = {
-            "genre_id": int(genre_id),
-            "media_id": int(media_id),
-            "media_type": media_type.value,
-        }
-        db = self.mass.music.database
-        # Run both statements without committing between them so the exclusion insert
-        # and the mapping delete are committed atomically.
-        await db.execute(
-            f"INSERT OR REPLACE INTO {DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION}"
-            "(genre_id, media_id, media_type) VALUES (:genre_id, :media_id, :media_type)",
-            params,
-        )
-        await db.execute(
-            f"DELETE FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
-            "WHERE genre_id = :genre_id AND media_id = :media_id AND media_type = :media_type",
-            params,
-        )
-        await db.commit()
-
-    async def remove_genre_exclusion(
-        self,
-        genre_id: str | int,
-        media_type: MediaType,
-        media_id: str | int,
-    ) -> None:
-        """
-        Remove a genre exclusion, allowing the scanner to re-map it on the next run.
-
-        :param genre_id: Database ID of the genre.
-        :param media_type: Type of media item (track, album, artist, etc.).
-        :param media_id: Database ID of the media item.
-        """
-        await self.mass.music.database.delete(
-            DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION,
-            {
-                "genre_id": int(genre_id),
-                "media_id": int(media_id),
-                "media_type": media_type.value,
-            },
-        )
-
-    async def get_global_genre_exclusions(self) -> list[dict[str, object]]:
-        """Return all globally excluded genres."""
-        rows = await self.mass.music.database.get_rows_from_query(
-            f"SELECT item_id, name, sort_name, search_name, translation_key, metadata "
-            f"FROM {DB_TABLE_GENRES} WHERE is_excluded = 1 ORDER BY sort_name",
-            limit=0,
-        )
-        result = []
-        for row in rows:
-            entry = dict(row)
-            if raw_metadata := entry.get("metadata"):
-                entry["metadata"] = json_loads(raw_metadata)
-            result.append(entry)
-        return result
-
-    async def remove_global_genre_exclusion(self, genre_id: int) -> Genre:
-        """
-        Lift a global genre exclusion, making the genre visible and scannable again.
-
-        :param genre_id: Database ID of the excluded genre (item_id in genres table).
-        :return: The restored Genre.
-        """
-        row = await self.mass.music.database.get_row(
-            DB_TABLE_GENRES, {"item_id": genre_id, "is_excluded": 1}
-        )
-        if not row:
-            msg = f"No globally excluded genre found with id {genre_id}"
-            raise KeyError(msg)
-        await self.mass.music.database.update(
-            DB_TABLE_GENRES, {"item_id": genre_id}, {"is_excluded": 0}
-        )
-        library_item = await self.get_library_item(genre_id)
-        self.mass.signal_event(EventType.MEDIA_ITEM_ADDED, library_item.uri, library_item)
-        return library_item
-
-    async def promote_alias_to_genre(self, genre_id: str | int, alias: str) -> Genre:
-        """
-        Promote an alias to become a standalone genre.
-
-        Every genre that claimed the alias loses it, and all media mapped via
-        the alias is moved to the new genre.
-
-        :param genre_id: Database ID of the source genre.
-        :param alias: The alias string to promote.
-        :return: The newly created Genre.
-        """
-        db_genre_id = int(genre_id)
-        source_genre = await self.get_library_item(db_genre_id)
-        alias_norm = create_safe_string(alias, True, True)
-
-        if alias_norm == create_safe_string(source_genre.name, True, True):
-            msg = (
-                f"Cannot promote self-alias '{alias}'. "
-                f"This alias is the primary name for genre '{source_genre.name}'."
-            )
-            raise ValueError(msg)
-
-        owning_ids = await self._find_genre_ids_for_alias(alias_norm)
-        if db_genre_id not in owning_ids:
-            owning_ids.append(db_genre_id)
-
-        new_genre = Genre(
-            item_id="0",
-            provider="library",
-            name=alias,
-            sort_name=alias,
-            translation_key=None,
-            provider_mappings=set(),
-            favorite=False,
-        )
-        created_genre = await self.add_item_to_library(new_genre)
-        new_genre_id = int(created_genre.item_id)
-
-        # UPDATE OR REPLACE drops any pre-existing mapping on the new genre for
-        # the same (media_id, media_type) so the moved row wins.
-        placeholders = ", ".join(str(g) for g in owning_ids)
-        await self.mass.music.database.execute(
-            f"UPDATE OR REPLACE {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} "
-            f"SET genre_id = :new_id "
-            f"WHERE genre_id IN ({placeholders}) AND LOWER(alias) = LOWER(:alias)",
-            {"new_id": new_genre_id, "alias": alias},
-        )
-
-        for owning_id in owning_ids:
-            owning = await self.get_library_item(owning_id)
-            # Defensive: a genre whose primary name equals the alias would hit
-            # the self-alias guard in remove_alias; skip rather than raise.
-            if create_safe_string(owning.name, True, True) == alias_norm:
-                continue
-            owning_aliases = list(owning.genre_aliases) if owning.genre_aliases else []
-            filtered = [
-                a for a in owning_aliases if create_safe_string(a, True, True) != alias_norm
-            ]
-            if len(filtered) != len(owning_aliases):
-                await self.mass.music.database.update(
-                    self.db_table,
-                    {"item_id": owning_id},
-                    {"genre_aliases": serialize_to_json(filtered)},
-                )
-
-        # Derived album/artist rows still point at the old source genres; rebuild
-        # them from the moved track mappings.
-        await self._propagate_genre_mappings_to_parents()
-
-        return await self.get_library_item(new_genre_id)
-
     async def _find_genre_ids_for_alias(self, alias_norm: str) -> list[int]:
         """
         Return ids of non-excluded genres that claim the given alias.
@@ -1490,128 +1664,6 @@ class GenreController(MediaControllerBase[Genre]):
             if any(create_safe_string(a.strip(), True, True) == alias_norm for a in aliases):
                 found.append(int(row["item_id"]))
         return found
-
-    async def merge_genres(self, genre_ids: list[str | int], target_genre_id: str | int) -> Genre:
-        """
-        Merge one or more genres into a target genre.
-
-        Transfers all aliases and media mappings from the source genres to the
-        target, then deletes the source genres. Aliases and mappings are
-        deduplicated so no duplicates are created on the target.
-
-        :param genre_ids: List of genre IDs to merge into the target.
-        :param target_genre_id: Database ID of the genre to merge into.
-        """
-        target_id = int(target_genre_id)
-        source_ids = [int(gid) for gid in genre_ids]
-
-        if target_id in source_ids:
-            msg = "Target genre cannot be in the list of genres to merge"
-            raise ValueError(msg)
-        if not source_ids:
-            msg = "No genre IDs provided to merge"
-            raise ValueError(msg)
-
-        target_genre = await self.get_library_item(target_id)
-        db = self.mass.music.database
-        gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
-
-        # Collect and merge aliases from all source genres into the target
-        all_new_aliases: list[str] = []
-        for source_id in source_ids:
-            source_genre = await self.get_library_item(source_id)
-            if source_genre.genre_aliases:
-                all_new_aliases.extend(source_genre.genre_aliases)
-
-        existing_aliases = list(target_genre.genre_aliases) if target_genre.genre_aliases else []
-        merged_aliases = self._dedup_aliases(existing_aliases, all_new_aliases)
-        await db.update(
-            self.db_table,
-            {"item_id": target_id},
-            {"genre_aliases": serialize_to_json(merged_aliases)},
-        )
-
-        # Transfer media mappings from source genres to target (deduplicated)
-        placeholders = ", ".join(str(sid) for sid in source_ids)
-        await db.execute(
-            f"INSERT OR IGNORE INTO {gm} (genre_id, media_id, media_type, alias) "
-            f"SELECT :target_id, media_id, media_type, alias FROM {gm} "
-            f"WHERE genre_id IN ({placeholders})",
-            {"target_id": target_id},
-        )
-
-        # Hard-delete source genres: merging is not a user exclusion so sources must
-        # not appear in the global exclusion list.
-        for source_id in source_ids:
-            await self.remove_item_from_library(source_id, exclude_globally=False)
-
-        # Rebuild derived album/artist rows against the merged track mappings.
-        await self._propagate_genre_mappings_to_parents()
-
-        updated = await self.get_library_item(target_id)
-        self.mass.signal_event(EventType.MEDIA_ITEM_UPDATED, updated.uri, updated)
-        return updated
-
-    async def sync_media_item_genres(
-        self, media_type: MediaType, media_id: str | int, genre_names: set[str]
-    ) -> None:
-        """
-        Sync genre mappings for a media item.
-
-        Ensures genre records exist and updates genre-media mappings.
-        Removes mappings that are no longer present in the incoming genre_names set.
-
-        :param media_type: The type of media item being synced.
-        :param media_id: The database ID of the media item.
-        :param genre_names: Set of genre names from the provider.
-        """
-        media_id_int = int(media_id)
-        gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
-
-        # Build target set: (genre_id, alias_name) from incoming names.
-        # One alias can map to multiple genres (n:n).
-        target_mappings: dict[int, str] = {}
-        for name in genre_names:
-            normalized = self._normalize_genre_name(name)
-            if not normalized:
-                continue
-            genre_ids = await self._find_genres_for_alias(normalized[0])
-            for gid in genre_ids:
-                if gid not in target_mappings:
-                    target_mappings[gid] = normalized[0]
-
-        # Get current genre_ids from database
-        rows = await self.mass.music.database.get_rows_from_query(
-            f"SELECT genre_id FROM {gm} WHERE media_type = :media_type AND media_id = :media_id",
-            {"media_type": media_type.value, "media_id": media_id_int},
-            limit=0,
-        )
-        existing_genre_ids = {int(row["genre_id"]) for row in rows}
-
-        to_add = set(target_mappings.keys()) - existing_genre_ids
-        to_remove = existing_genre_ids - set(target_mappings.keys())
-
-        for genre_id in to_remove:
-            await self.mass.music.database.delete(
-                gm,
-                {
-                    "genre_id": genre_id,
-                    "media_id": media_id_int,
-                    "media_type": media_type.value,
-                },
-            )
-
-        for genre_id in to_add:
-            await self.mass.music.database.insert(
-                gm,
-                {
-                    "genre_id": genre_id,
-                    "media_id": media_id_int,
-                    "media_type": media_type.value,
-                    "alias": target_mappings[genre_id],
-                },
-                allow_replace=True,
-            )
 
     async def _build_genre_lookup(
         self,
@@ -1776,23 +1828,6 @@ class GenreController(MediaControllerBase[Genre]):
         """Trigger genre mapping scan when music sync tasks have completed."""
         self._queue_genre_mapping_scan_task()
 
-    def register_scheduled_scan_task(self) -> BackgroundTask:
-        """Register the recurring genre mapping scan task."""
-        utc_hour, utc_minute = local_clock_time_to_utc(4, 0)
-        desired_schedule = TaskSchedule.daily(hour=utc_hour, minute=utc_minute)
-        return self.mass.tasks.register_scheduled_task(
-            task_id=GENRE_SCAN_TASK_ID,
-            name="Scan genre mappings",
-            handler=self._scan_genre_mappings,
-            schedule=desired_schedule,
-            translation_key="scan_genre_mappings",
-            translation_owner=self.translation_owner,
-            metadata={
-                "task_domain": "genre_mapping_scan",
-            },
-            allow_retry=True,
-        )
-
     def _queue_genre_mapping_scan_task(self) -> BackgroundTask:
         """Queue the genre mapping scanner as a managed background task."""
         self.register_scheduled_scan_task()
@@ -1842,38 +1877,3 @@ class GenreController(MediaControllerBase[Genre]):
                 str(err),
                 exc_info=err if self.logger.isEnabledFor(logging.DEBUG) else None,
             )
-
-    async def scan_mappings(self) -> dict[str, Any]:
-        """
-        Manually trigger a genre mapping scan (admin only).
-
-        :return: Status information about the scan trigger.
-        """
-        if self._genre_scan_running:
-            return {
-                "status": "already_running",
-                "message": "Genre mapping scanner is already running",
-            }
-
-        self._queue_genre_mapping_scan_task()
-
-        return {
-            "status": "triggered",
-            "message": "Genre mapping scan triggered",
-            "last_scan": self._last_scan_time,
-        }
-
-    async def get_scanner_status(self) -> dict[str, Any]:
-        """
-        Get status of the genre mapping background scanner.
-
-        :return: Scanner status information.
-        """
-        return {
-            "running": self._genre_scan_running,
-            "last_scan_time": self._last_scan_time,
-            "last_scan_ago_seconds": (
-                int(time.time() - self._last_scan_time) if self._last_scan_time else None
-            ),
-            "last_scan_mapped": self._last_scan_mapped,
-        }

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -84,34 +84,6 @@ class PlaylistController(MediaControllerBase[Playlist]):
         self.mass.register_api_command("music/playlists/export_playlist", self.export_playlist)
         self.mass.register_api_command("music/playlists/import_playlist", self.import_playlist)
 
-    def _verify_update_allowed(self, current_item: Playlist, update: Playlist) -> None:
-        """
-        Verify that the update is allowed from a security perspective.
-
-        Prevents updating item_id for non-streaming providers to prevent path traversal attacks.
-        """
-        # Build lookup dict of current mappings: provider_instance -> item_id
-        current_mappings = {
-            mapping.provider_instance: mapping.item_id for mapping in current_item.provider_mappings
-        }
-
-        # Check if any existing mapping's item_id has been modified for non-streaming providers
-        for update_mapping in update.provider_mappings:
-            # Only check if this is an existing mapping being modified
-            if update_mapping.provider_instance in current_mappings:
-                current_item_id = current_mappings[update_mapping.provider_instance]
-
-                # Disallow item_id changes for filesystem-based providers (filesystem, builtin)
-                if (
-                    current_item_id != update_mapping.item_id
-                    and update_mapping.provider_instance.startswith(("filesystem", "builtin"))
-                ):
-                    msg = (
-                        f"Updating item_id is not allowed for filesystem-based providers: "
-                        f"attempted to change '{current_item_id}' to '{update_mapping.item_id}'"
-                    )
-                    raise InvalidDataError(msg)
-
     async def tracks(
         self,
         item_id: str,
@@ -280,6 +252,130 @@ class PlaylistController(MediaControllerBase[Playlist]):
             priority=True,
         )
 
+    async def radio_mode_base_tracks(
+        self,
+        item: Playlist,
+        preferred_provider_instances: list[str] | None = None,
+    ) -> list[Track]:
+        """
+        Get the list of base tracks from the controller used to calculate the dynamic radio.
+
+        :param item: The Playlist to get base tracks for.
+        :param preferred_provider_instances: List of preferred provider instance IDs to use.
+        """
+        return [
+            x
+            async for x in self.tracks(item.item_id, item.provider)
+            # Radio mode only works with Tracks (filter out all other types)
+            if isinstance(x, Track) and x.available
+        ]
+
+    async def match_providers(self, db_item: Playlist) -> None:
+        """
+        Try to find match on all (streaming) providers for the provided (database) item.
+
+        This is used to link objects of different providers/qualities together.
+        """
+        # playlists can only be matched on the same provider (if not unique)
+        if self.mass.music.match_provider_instances(db_item):
+            await self.add_provider_mappings(db_item.item_id, db_item.provider_mappings)
+
+    async def export_playlist(self, db_playlist_id: str | int) -> str:
+        """
+        Export a playlist to M3U8 format.
+
+        :param db_playlist_id: The library database ID of the playlist.
+        """
+        db_id = int(db_playlist_id)
+        playlist = await self.get_library_item(db_id)
+        if not playlist:
+            msg = f"Playlist with id {db_id} not found"
+            raise MediaNotFoundError(msg)
+        items: list[PlaylistItem] = []
+        async for track in self.tracks(
+            item_id=str(db_id),
+            provider_instance_id_or_domain="library",
+        ):
+            items.append(media_item_to_playlist_item(track))
+        playlist_image_url = playlist.image.path if playlist.image else None
+        return generate_m3u(playlist.name, items, playlist_image_url)
+
+    async def import_playlist(
+        self,
+        m3u_data: str,
+        library_matching: bool = False,
+        match_providers: list[str] | None = None,
+    ) -> Playlist:
+        """
+        Import a playlist from M3U8 format.
+
+        Creates a new builtin playlist from the provided M3U data.
+
+        :param m3u_data: The M3U8 playlist data as a string.
+        :param library_matching: When True, attempt to find tracks by searching
+            providers using metadata when the original URI's provider is not
+            available. Defaults to False.
+        :param match_providers: Optional list of provider instance IDs or domains
+            to search when library_matching is enabled.
+        """
+        provider = self.mass.get_provider("builtin")
+        if not provider or not isinstance(provider, MusicProvider):
+            raise ProviderUnavailableError("Builtin provider is not available")
+        builtin_prov = cast("BuiltinProvider", provider)
+        playlist = await builtin_prov.import_playlist(m3u_data)
+        for prov_mapping in playlist.provider_mappings:
+            prov_mapping.in_library = True
+        db_playlist = await self.add_item_to_library(playlist, False)
+        if library_matching:
+            prov_playlist_id = playlist.item_id
+            user = get_current_user()
+            self.mass.tasks.run_background_task(
+                name=f"Import playlist {db_playlist.name}",
+                handler=lambda: builtin_prov.match_imported_playlist_tracks(
+                    prov_playlist_id, match_providers
+                ),
+                translation_key="import_playlist_matching",
+                translation_owner=self.translation_owner,
+                translation_args=[db_playlist.name],
+                user_id=user.user_id if user else None,
+                metadata={
+                    "task_domain": "playlist_import_matching",
+                    "playlist_id": str(db_playlist.item_id),
+                    "playlist_name": db_playlist.name,
+                },
+                allow_retry=True,
+                allow_cancel=True,
+            )
+        return db_playlist
+
+    def _verify_update_allowed(self, current_item: Playlist, update: Playlist) -> None:
+        """
+        Verify that the update is allowed from a security perspective.
+
+        Prevents updating item_id for non-streaming providers to prevent path traversal attacks.
+        """
+        # Build lookup dict of current mappings: provider_instance -> item_id
+        current_mappings = {
+            mapping.provider_instance: mapping.item_id for mapping in current_item.provider_mappings
+        }
+
+        # Check if any existing mapping's item_id has been modified for non-streaming providers
+        for update_mapping in update.provider_mappings:
+            # Only check if this is an existing mapping being modified
+            if update_mapping.provider_instance in current_mappings:
+                current_item_id = current_mappings[update_mapping.provider_instance]
+
+                # Disallow item_id changes for filesystem-based providers (filesystem, builtin)
+                if (
+                    current_item_id != update_mapping.item_id
+                    and update_mapping.provider_instance.startswith(("filesystem", "builtin"))
+                ):
+                    msg = (
+                        f"Updating item_id is not allowed for filesystem-based providers: "
+                        f"attempted to change '{current_item_id}' to '{update_mapping.item_id}'"
+                    )
+                    raise InvalidDataError(msg)
+
     async def _add_library_item(self, item: Playlist, overwrite_existing: bool = False) -> int:
         """Add a new record to the database."""
         db_id = await self.mass.music.database.insert(
@@ -381,34 +477,6 @@ class PlaylistController(MediaControllerBase[Playlist]):
         provider = cast("MusicProvider", provider)
         async with self.mass.cache.handle_refresh(force_refresh):
             return await provider.get_playlist_tracks(item_id, page=page)
-
-    async def radio_mode_base_tracks(
-        self,
-        item: Playlist,
-        preferred_provider_instances: list[str] | None = None,
-    ) -> list[Track]:
-        """
-        Get the list of base tracks from the controller used to calculate the dynamic radio.
-
-        :param item: The Playlist to get base tracks for.
-        :param preferred_provider_instances: List of preferred provider instance IDs to use.
-        """
-        return [
-            x
-            async for x in self.tracks(item.item_id, item.provider)
-            # Radio mode only works with Tracks (filter out all other types)
-            if isinstance(x, Track) and x.available
-        ]
-
-    async def match_providers(self, db_item: Playlist) -> None:
-        """
-        Try to find match on all (streaming) providers for the provided (database) item.
-
-        This is used to link objects of different providers/qualities together.
-        """
-        # playlists can only be matched on the same provider (if not unique)
-        if self.mass.music.match_provider_instances(db_item):
-            await self.add_provider_mappings(db_item.item_id, db_item.provider_mappings)
 
     async def _handle_add_playlist_tracks(self, db_playlist_id: str | int, uris: list[str]) -> None:
         """Handle adding playlist items inside a managed task."""
@@ -680,71 +748,3 @@ class PlaylistController(MediaControllerBase[Playlist]):
         # in the next scheduled run of the playlist metadata task
         playlist.metadata.last_refresh = None
         await self.update_item_in_library(db_playlist_id, playlist)
-
-    async def export_playlist(self, db_playlist_id: str | int) -> str:
-        """
-        Export a playlist to M3U8 format.
-
-        :param db_playlist_id: The library database ID of the playlist.
-        """
-        db_id = int(db_playlist_id)
-        playlist = await self.get_library_item(db_id)
-        if not playlist:
-            msg = f"Playlist with id {db_id} not found"
-            raise MediaNotFoundError(msg)
-        items: list[PlaylistItem] = []
-        async for track in self.tracks(
-            item_id=str(db_id),
-            provider_instance_id_or_domain="library",
-        ):
-            items.append(media_item_to_playlist_item(track))
-        playlist_image_url = playlist.image.path if playlist.image else None
-        return generate_m3u(playlist.name, items, playlist_image_url)
-
-    async def import_playlist(
-        self,
-        m3u_data: str,
-        library_matching: bool = False,
-        match_providers: list[str] | None = None,
-    ) -> Playlist:
-        """
-        Import a playlist from M3U8 format.
-
-        Creates a new builtin playlist from the provided M3U data.
-
-        :param m3u_data: The M3U8 playlist data as a string.
-        :param library_matching: When True, attempt to find tracks by searching
-            providers using metadata when the original URI's provider is not
-            available. Defaults to False.
-        :param match_providers: Optional list of provider instance IDs or domains
-            to search when library_matching is enabled.
-        """
-        provider = self.mass.get_provider("builtin")
-        if not provider or not isinstance(provider, MusicProvider):
-            raise ProviderUnavailableError("Builtin provider is not available")
-        builtin_prov = cast("BuiltinProvider", provider)
-        playlist = await builtin_prov.import_playlist(m3u_data)
-        for prov_mapping in playlist.provider_mappings:
-            prov_mapping.in_library = True
-        db_playlist = await self.add_item_to_library(playlist, False)
-        if library_matching:
-            prov_playlist_id = playlist.item_id
-            user = get_current_user()
-            self.mass.tasks.run_background_task(
-                name=f"Import playlist {db_playlist.name}",
-                handler=lambda: builtin_prov.match_imported_playlist_tracks(
-                    prov_playlist_id, match_providers
-                ),
-                translation_key="import_playlist_matching",
-                translation_owner=self.translation_owner,
-                translation_args=[db_playlist.name],
-                user_id=user.user_id if user else None,
-                metadata={
-                    "task_domain": "playlist_import_matching",
-                    "playlist_id": str(db_playlist.item_id),
-                    "playlist_name": db_playlist.name,
-                },
-                allow_retry=True,
-                allow_cancel=True,
-            )
-        return db_playlist

--- a/music_assistant/controllers/music/media/podcasts.py
+++ b/music_assistant/controllers/music/media/podcasts.py
@@ -153,6 +153,84 @@ class PodcastsController(MediaControllerBase[Podcast]):
             )
         return result
 
+    async def radio_mode_base_tracks(
+        self,
+        item: Podcast,
+        preferred_provider_instances: list[str] | None = None,
+    ) -> list[Track]:
+        """
+        Get the list of base tracks from the controller used to calculate the dynamic radio.
+
+        :param item: The Podcast to get base tracks for.
+        :param preferred_provider_instances: List of preferred provider instance IDs to use.
+        """
+        msg = "Dynamic tracks not supported for Podcast MediaItem"
+        raise NotImplementedError(msg)
+
+    async def match_provider(
+        self, db_podcast: Podcast, provider: MusicProvider, strict: bool = True
+    ) -> list[ProviderMapping]:
+        """
+        Try to find match on (streaming) provider for the provided (database) podcast.
+
+        This is used to link objects of different providers/qualities together.
+        """
+        self.logger.debug(
+            "Trying to match podcast %s on provider %s",
+            db_podcast.name,
+            provider.name,
+        )
+        matches: list[ProviderMapping] = []
+        search_str = db_podcast.name
+        search_result = await self.search(search_str, provider.instance_id)
+        for search_result_item in search_result:
+            if not search_result_item.available:
+                continue
+            if not compare_media_item(db_podcast, search_result_item, strict=strict):
+                continue
+            # we must fetch the full podcast version, search results can be simplified objects
+            prov_podcast = await self.get_provider_item(
+                search_result_item.item_id,
+                search_result_item.provider,
+                fallback=search_result_item,
+            )
+            if compare_podcast(db_podcast, prov_podcast, strict=strict):
+                # 100% match
+                matches.extend(prov_podcast.provider_mappings)
+        if not matches:
+            self.logger.debug(
+                "Could not find match for Podcast %s on provider %s",
+                db_podcast.name,
+                provider.name,
+            )
+        return matches
+
+    async def match_providers(self, db_podcast: Podcast) -> None:
+        """
+        Try to find match on all (streaming) providers for the provided (database) podcast.
+
+        This is used to link objects of different providers/qualities together.
+        """
+        if db_podcast.provider != "library":
+            return  # Matching only supported for database items
+
+        # try to find match on all providers
+        cur_provider_domains = {x.provider_domain for x in db_podcast.provider_mappings}
+        for provider in self.mass.music.providers:
+            if provider.domain in cur_provider_domains:
+                continue
+            if ProviderFeature.SEARCH not in provider.supported_features:
+                continue
+            if not self.mass.music.library_supported(provider, MediaType.PODCAST):
+                continue
+            if not provider.is_streaming_provider:
+                # matching on unique providers is pointless as they push (all) their content to MA
+                continue
+            if match := await self.match_provider(db_podcast, provider):
+                # 100% match, we update the db with the additional provider mapping(s)
+                await self.add_provider_mappings(db_podcast.item_id, match)
+                cur_provider_domains.add(provider.domain)
+
     async def _add_library_item(self, item: Podcast, overwrite_existing: bool = False) -> int:
         """Add a new record to the database."""
         db_id = await self.mass.music.database.insert(
@@ -269,81 +347,3 @@ class PodcastsController(MediaControllerBase[Podcast]):
         async for item in prov.get_podcast_episodes(item_id):
             await set_resume_position(item)
             yield item
-
-    async def radio_mode_base_tracks(
-        self,
-        item: Podcast,
-        preferred_provider_instances: list[str] | None = None,
-    ) -> list[Track]:
-        """
-        Get the list of base tracks from the controller used to calculate the dynamic radio.
-
-        :param item: The Podcast to get base tracks for.
-        :param preferred_provider_instances: List of preferred provider instance IDs to use.
-        """
-        msg = "Dynamic tracks not supported for Podcast MediaItem"
-        raise NotImplementedError(msg)
-
-    async def match_provider(
-        self, db_podcast: Podcast, provider: MusicProvider, strict: bool = True
-    ) -> list[ProviderMapping]:
-        """
-        Try to find match on (streaming) provider for the provided (database) podcast.
-
-        This is used to link objects of different providers/qualities together.
-        """
-        self.logger.debug(
-            "Trying to match podcast %s on provider %s",
-            db_podcast.name,
-            provider.name,
-        )
-        matches: list[ProviderMapping] = []
-        search_str = db_podcast.name
-        search_result = await self.search(search_str, provider.instance_id)
-        for search_result_item in search_result:
-            if not search_result_item.available:
-                continue
-            if not compare_media_item(db_podcast, search_result_item, strict=strict):
-                continue
-            # we must fetch the full podcast version, search results can be simplified objects
-            prov_podcast = await self.get_provider_item(
-                search_result_item.item_id,
-                search_result_item.provider,
-                fallback=search_result_item,
-            )
-            if compare_podcast(db_podcast, prov_podcast, strict=strict):
-                # 100% match
-                matches.extend(prov_podcast.provider_mappings)
-        if not matches:
-            self.logger.debug(
-                "Could not find match for Podcast %s on provider %s",
-                db_podcast.name,
-                provider.name,
-            )
-        return matches
-
-    async def match_providers(self, db_podcast: Podcast) -> None:
-        """
-        Try to find match on all (streaming) providers for the provided (database) podcast.
-
-        This is used to link objects of different providers/qualities together.
-        """
-        if db_podcast.provider != "library":
-            return  # Matching only supported for database items
-
-        # try to find match on all providers
-        cur_provider_domains = {x.provider_domain for x in db_podcast.provider_mappings}
-        for provider in self.mass.music.providers:
-            if provider.domain in cur_provider_domains:
-                continue
-            if ProviderFeature.SEARCH not in provider.supported_features:
-                continue
-            if not self.mass.music.library_supported(provider, MediaType.PODCAST):
-                continue
-            if not provider.is_streaming_provider:
-                # matching on unique providers is pointless as they push (all) their content to MA
-                continue
-            if match := await self.match_provider(db_podcast, provider):
-                # 100% match, we update the db with the additional provider mapping(s)
-                await self.add_provider_mappings(db_podcast.item_id, match)
-                cur_provider_domains.add(provider.domain)

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -88,68 +88,6 @@ class RadioController(MediaControllerBase[Radio]):
         # return the aggregated result
         return list(all_versions.values())
 
-    async def _add_library_item(self, item: Radio, overwrite_existing: bool = False) -> int:
-        """Add a new item record to the database."""
-        assert self.mass.music.database is not None  # For type checking
-        db_id = await self.mass.music.database.insert(
-            self.db_table,
-            {
-                "name": item.name,
-                "sort_name": item.sort_name,
-                "favorite": item.favorite,
-                "metadata": serialize_to_json(item.metadata),
-                "external_ids": serialize_to_json(item.external_ids),
-                "search_name": create_safe_string(item.name, True, True),
-                "search_sort_name": create_safe_string(
-                    item.sort_name if item.sort_name is not None else "", True, True
-                ),
-                "timestamp_added": int(item.date_added.timestamp()) if item.date_added else UNSET,
-            },
-        )
-        # update/set provider_mappings table
-        await self.set_provider_mappings(db_id, item.provider_mappings)
-        self.logger.debug("added %s to database (id: %s)", item.name, db_id)
-        return db_id
-
-    async def _update_library_item(
-        self, item_id: str | int, update: Radio, overwrite: bool = False
-    ) -> None:
-        """Update existing record in the database."""
-        db_id = int(item_id)  # ensure integer
-        cur_item = await self.get_library_item(db_id)
-        metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
-        cur_item.external_ids.update(update.external_ids)
-        match = {"item_id": db_id}
-        name = update.name if overwrite else cur_item.name
-        sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name
-        assert self.mass.music.database is not None  # For type checking
-        await self.mass.music.database.update(
-            self.db_table,
-            match,
-            {
-                # always prefer name from updated item here
-                "name": name,
-                "sort_name": sort_name,
-                "metadata": serialize_to_json(metadata),
-                "external_ids": serialize_to_json(
-                    update.external_ids if overwrite else cur_item.external_ids
-                ),
-                "search_name": create_safe_string(name, True, True),
-                "search_sort_name": create_safe_string(sort_name or "", True, True),
-                "timestamp_added": int(update.date_added.timestamp())
-                if update.date_added
-                else UNSET,
-            },
-        )
-        # update/set provider_mappings table
-        provider_mappings = (
-            update.provider_mappings
-            if overwrite
-            else {*update.provider_mappings, *cur_item.provider_mappings}
-        )
-        await self.set_provider_mappings(db_id, provider_mappings, overwrite)
-        self.logger.debug("updated %s in database: (id %s)", update.name, db_id)
-
     async def radio_mode_base_tracks(
         self,
         item: Radio,
@@ -227,3 +165,65 @@ class RadioController(MediaControllerBase[Radio]):
                 # 100% match, we update the db with the additional provider mapping(s)
                 await self.add_provider_mappings(db_radio.item_id, match)
                 cur_provider_domains.add(provider.domain)
+
+    async def _add_library_item(self, item: Radio, overwrite_existing: bool = False) -> int:
+        """Add a new item record to the database."""
+        assert self.mass.music.database is not None  # For type checking
+        db_id = await self.mass.music.database.insert(
+            self.db_table,
+            {
+                "name": item.name,
+                "sort_name": item.sort_name,
+                "favorite": item.favorite,
+                "metadata": serialize_to_json(item.metadata),
+                "external_ids": serialize_to_json(item.external_ids),
+                "search_name": create_safe_string(item.name, True, True),
+                "search_sort_name": create_safe_string(
+                    item.sort_name if item.sort_name is not None else "", True, True
+                ),
+                "timestamp_added": int(item.date_added.timestamp()) if item.date_added else UNSET,
+            },
+        )
+        # update/set provider_mappings table
+        await self.set_provider_mappings(db_id, item.provider_mappings)
+        self.logger.debug("added %s to database (id: %s)", item.name, db_id)
+        return db_id
+
+    async def _update_library_item(
+        self, item_id: str | int, update: Radio, overwrite: bool = False
+    ) -> None:
+        """Update existing record in the database."""
+        db_id = int(item_id)  # ensure integer
+        cur_item = await self.get_library_item(db_id)
+        metadata = update.metadata if overwrite else cur_item.metadata.update(update.metadata)
+        cur_item.external_ids.update(update.external_ids)
+        match = {"item_id": db_id}
+        name = update.name if overwrite else cur_item.name
+        sort_name = update.sort_name if overwrite else cur_item.sort_name or update.sort_name
+        assert self.mass.music.database is not None  # For type checking
+        await self.mass.music.database.update(
+            self.db_table,
+            match,
+            {
+                # always prefer name from updated item here
+                "name": name,
+                "sort_name": sort_name,
+                "metadata": serialize_to_json(metadata),
+                "external_ids": serialize_to_json(
+                    update.external_ids if overwrite else cur_item.external_ids
+                ),
+                "search_name": create_safe_string(name, True, True),
+                "search_sort_name": create_safe_string(sort_name or "", True, True),
+                "timestamp_added": int(update.date_added.timestamp())
+                if update.date_added
+                else UNSET,
+            },
+        )
+        # update/set provider_mappings table
+        provider_mappings = (
+            update.provider_mappings
+            if overwrite
+            else {*update.provider_mappings, *cur_item.provider_mappings}
+        )
+        await self.set_provider_mappings(db_id, provider_mappings, overwrite)
+        self.logger.debug("updated %s in database: (id %s)", update.name, db_id)

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -2,14 +2,6 @@
 # Private methods must live at the bottom of the class (see AGENTS.md).
 # Regenerate with: uv run -m scripts.check_method_order --update-baseline
 music_assistant/controllers/music/controller.py	46
-music_assistant/controllers/music/media/albums.py	4
-music_assistant/controllers/music/media/artists.py	4
-music_assistant/controllers/music/media/audiobooks.py	4
-music_assistant/controllers/music/media/base.py	25
-music_assistant/controllers/music/media/genres.py	26
-music_assistant/controllers/music/media/playlists.py	9
-music_assistant/controllers/music/media/podcasts.py	3
-music_assistant/controllers/music/media/radio.py	3
 music_assistant/controllers/player_queues/controller.py	43
 music_assistant/controllers/players/controller.py	36
 music_assistant/controllers/streams/audio.py	23


### PR DESCRIPTION
# What does this implement/fix?

Moves private (underscore-prefixed) methods to the bottom of the class in the music media controllers, so each class lists its public/dunder methods first and its private helpers last — the convention enforced by `check_method_order` (see AGENTS.md).

This is a pure relocation: no method bodies, signatures or behaviour change. Verified via AST comparison that each file contains exactly the same set of methods, only reordered. The affected files are removed from `scripts/lint_baselines/private_methods_not_last.txt` (1469 → 1391).

Files reordered:
- `controllers/music/media/base.py`
- `controllers/music/media/genres.py`
- `controllers/music/media/playlists.py`
- `controllers/music/media/albums.py`
- `controllers/music/media/artists.py`
- `controllers/music/media/audiobooks.py`
- `controllers/music/media/podcasts.py`
- `controllers/music/media/radio.py`

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
