### PR TITLE
Fix incorrect docstrings and comment in the music media controllers

### DIFF
--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -250,12 +250,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
     async def collections(
         self,
     ) -> list[AudiobookCollection]:
-        """
-        Get all available audiobook collections.
-
-        :param limit: Maximum number of items to return.
-        :param offset: Number of items to skip.
-        """
+        """Get all available audiobook collections."""
         # key is the collections' title
         collections_dict: dict[str, list[Audiobook]] = {}
         audiobooks_with_collections = await self.get_library_items_by_query(

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -1061,7 +1061,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         item: ItemCls,
         overwrite_existing: bool = False,
     ) -> int:
-        """Add artist to library and return the database id."""
+        """Add item to library and return the database id."""
 
     @abstractmethod
     async def _update_library_item(

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -641,7 +641,7 @@ class GenreController(MediaControllerBase[Genre]):
             DB_TABLE_GENRE_MEDIA_ITEM_EXCLUSION, {"genre_id": db_id}
         )
         if exclude_globally:
-            # Fetch the item while it is still visible (base_query filters is_excluded=1).
+            # Fetch the item while it is still visible (base_query hides is_excluded=1 rows).
             library_item = await self.get_library_item(db_id)
             await self.mass.music.database.update(
                 DB_TABLE_GENRES, {"item_id": db_id}, {"is_excluded": 1}


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4354. Fixes three pre-existing, incorrect inline docs in the music media controllers (flagged during review of #4354). Documentation-only — no behaviour change.

- `media/audiobooks.py`: the `collections()` docstring documented `limit`/`offset` parameters that the method does not accept. Reduced to a single-line docstring.
- `media/genres.py`: corrected a misleading comment — `base_query` filters out excluded genres (`WHERE is_excluded = 0`), so it hides `is_excluded=1` rows rather than filtering for them.
- `media/base.py`: the generic `_add_library_item` abstract method docstring said "Add artist"; changed to "Add item" so it is correct for all controllers that implement it.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
