### PR TITLE
Move private methods to the bottom of the class in the streams controllers

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -201,50 +201,6 @@ class StreamsAudio:
         assert self._smart_fades_mixer is not None, "StreamsAudio.setup() not called"
         return self._smart_fades_mixer
 
-    def _update_radio_stream_metadata(
-        self,
-        streamdetails: StreamDetails,
-        artist: str | None,
-        title: str,
-        image_url: str | None = None,
-        album: str | None = None,
-    ) -> None:
-        """
-        Update radio stream metadata and trigger artwork lookup.
-
-        :param streamdetails: The stream details to update.
-        :param artist: Artist name (will be normalized).
-        :param title: Track title (will be cleaned for display).
-        :param image_url: Optional image URL from stream metadata.
-        :param album: Optional album name.
-        """
-        station_image_url = image_url or self.mass.metadata.get_radio_stream_station_image(
-            streamdetails
-        )
-        artist_normalized = (
-            self.mass.metadata.normalize_radio_artist_name(artist) if artist else None
-        )
-        display_title, _ = parse_title_and_version(title, strip_for_display=True)
-
-        streamdetails.stream_metadata = StreamMetadata(
-            title=display_title,
-            artist=artist_normalized,
-            album=album,
-            image_url=station_image_url,
-        )
-        streamdetails.stream_metadata_last_updated = time.time()
-        if streamdetails.queue_id:
-            self.mass.player_queues.signal_update(streamdetails.queue_id)
-
-        # Fetch artwork in background (track, album then artist)
-        if artist and title and not image_url:
-            self.mass.call_later(
-                0.2,
-                self.mass.metadata.update_radio_stream_artwork,
-                streamdetails,
-                task_id=f"update_radio_artwork_{streamdetails.queue_id}",
-            )
-
     # --- Public methods ---
 
     async def get_stream_details(
@@ -652,61 +608,6 @@ class StreamsAudio:
                 ffmpeg_proc.returncode,
                 streamdetails.uri,
             )
-
-    async def _cache_radio_result(
-        self,
-        url: str,
-        stream_type: StreamType,
-        resolved_url: str | None = None,
-    ) -> tuple[str, StreamType]:
-        """Cache and return a radio stream resolution result."""
-        result = (resolved_url or url, stream_type)
-        await self.mass.cache.set(
-            url,
-            result,
-            expiration=3600 * 3,
-            provider=CACHE_PROVIDER,
-            category=CACHE_CATEGORY_RESOLVED_RADIO_URL,
-        )
-        return result
-
-    async def _handle_client_error_for_radio_stream(
-        self, url: str, err: aiohttp.ClientError, fallback_stream_type: StreamType
-    ) -> tuple[str, StreamType]:
-        """Handle aiohttp client errors during radio stream resolution."""
-        # Prefer the final post-redirect URL: aiohttp follows redirects before raising,
-        # but the original url may just point at a redirector rather than the ICY endpoint.
-        request_info = getattr(err, "request_info", None)
-        validate_url = str(request_info.url) if request_info is not None else url
-
-        # Check if this is a Shoutcast/ICY response that aiohttp can't parse
-        if isinstance(err, aiohttp.ClientResponseError) and "ICY" in str(err).upper():
-            self.logger.debug(
-                "ICY response detected for %s, validating Shoutcast stream", validate_url
-            )
-            if await self._validate_shoutcast_stream(validate_url):
-                return await self._cache_radio_result(
-                    url, StreamType.SHOUTCAST, resolved_url=validate_url
-                )
-            self.logger.warning(
-                "ICY response detected but Shoutcast validation failed for %s", validate_url
-            )
-            return await self._cache_radio_result(
-                url, fallback_stream_type, resolved_url=validate_url
-            )
-
-        # Other aiohttp errors - might still be Shoutcast, check it
-        self.logger.debug("aiohttp error for %s, checking if legacy Shoutcast stream", validate_url)
-        if await self._validate_shoutcast_stream(validate_url):
-            return await self._cache_radio_result(
-                url, StreamType.SHOUTCAST, resolved_url=validate_url
-            )
-
-        # Unknown error - still try to stream
-        self.logger.warning(
-            "Failed to parse radio URL %s: %s - attempting direct stream", validate_url, str(err)
-        )
-        return await self._cache_radio_result(url, fallback_stream_type, resolved_url=validate_url)
 
     async def resolve_radio_stream(self, url: str) -> tuple[str, StreamType]:
         """
@@ -1416,41 +1317,6 @@ class StreamsAudio:
             )
         finally:
             streamdetails.seconds_streamed = bytes_received / pcm_format.pcm_sample_size
-
-    async def _iter_audio_source_pcm(
-        self,
-        streamdetails: StreamDetails,
-        pcm_format: AudioFormat,
-    ) -> AsyncGenerator[bytes]:
-        """Yield PCM for an AudioSource, bypassing ffmpeg when formats match."""
-        if _pcm_formats_match(streamdetails.audio_format, pcm_format):
-            source_gen = self._open_audio_source_generator(streamdetails)
-            async for chunk in realtime_pcm_pacer(source_gen, pcm_format):
-                yield chunk
-            return
-        # format mismatch → fall back to ffmpeg for resampling (still small chunks)
-        async for chunk in self.get_media_stream(
-            streamdetails=streamdetails,
-            pcm_format=pcm_format,
-            filter_params=None,
-            chunk_seconds=AUDIO_SOURCE_CHUNK_SECONDS,
-        ):
-            yield chunk
-
-    def _open_audio_source_generator(self, streamdetails: StreamDetails) -> AsyncGenerator[bytes]:
-        """Open the raw PCM generator for an AudioSource (CUSTOM or NAMED_PIPE)."""
-        if streamdetails.stream_type == StreamType.CUSTOM:
-            provider = self.mass.get_provider(streamdetails.provider)
-            if provider is None:
-                raise ProviderUnavailableError(
-                    f"Provider {streamdetails.provider} for stream is no longer available"
-                )
-            provider = cast("MusicProvider | PluginProvider", provider)
-            return provider.get_audio_stream(streamdetails)
-        if streamdetails.stream_type == StreamType.NAMED_PIPE:
-            assert isinstance(streamdetails.path, str)  # for type checking
-            return read_named_pipe(streamdetails.path)
-        raise AudioError(f"Unsupported stream_type {streamdetails.stream_type} for AudioSource")
 
     async def get_queue_item_stream(
         self,
@@ -2606,6 +2472,140 @@ class StreamsAudio:
             await writer.wait_closed()
 
     # --- Private methods ---
+
+    def _update_radio_stream_metadata(
+        self,
+        streamdetails: StreamDetails,
+        artist: str | None,
+        title: str,
+        image_url: str | None = None,
+        album: str | None = None,
+    ) -> None:
+        """
+        Update radio stream metadata and trigger artwork lookup.
+
+        :param streamdetails: The stream details to update.
+        :param artist: Artist name (will be normalized).
+        :param title: Track title (will be cleaned for display).
+        :param image_url: Optional image URL from stream metadata.
+        :param album: Optional album name.
+        """
+        station_image_url = image_url or self.mass.metadata.get_radio_stream_station_image(
+            streamdetails
+        )
+        artist_normalized = (
+            self.mass.metadata.normalize_radio_artist_name(artist) if artist else None
+        )
+        display_title, _ = parse_title_and_version(title, strip_for_display=True)
+
+        streamdetails.stream_metadata = StreamMetadata(
+            title=display_title,
+            artist=artist_normalized,
+            album=album,
+            image_url=station_image_url,
+        )
+        streamdetails.stream_metadata_last_updated = time.time()
+        if streamdetails.queue_id:
+            self.mass.player_queues.signal_update(streamdetails.queue_id)
+
+        # Fetch artwork in background (track, album then artist)
+        if artist and title and not image_url:
+            self.mass.call_later(
+                0.2,
+                self.mass.metadata.update_radio_stream_artwork,
+                streamdetails,
+                task_id=f"update_radio_artwork_{streamdetails.queue_id}",
+            )
+
+    async def _cache_radio_result(
+        self,
+        url: str,
+        stream_type: StreamType,
+        resolved_url: str | None = None,
+    ) -> tuple[str, StreamType]:
+        """Cache and return a radio stream resolution result."""
+        result = (resolved_url or url, stream_type)
+        await self.mass.cache.set(
+            url,
+            result,
+            expiration=3600 * 3,
+            provider=CACHE_PROVIDER,
+            category=CACHE_CATEGORY_RESOLVED_RADIO_URL,
+        )
+        return result
+
+    async def _handle_client_error_for_radio_stream(
+        self, url: str, err: aiohttp.ClientError, fallback_stream_type: StreamType
+    ) -> tuple[str, StreamType]:
+        """Handle aiohttp client errors during radio stream resolution."""
+        # Prefer the final post-redirect URL: aiohttp follows redirects before raising,
+        # but the original url may just point at a redirector rather than the ICY endpoint.
+        request_info = getattr(err, "request_info", None)
+        validate_url = str(request_info.url) if request_info is not None else url
+
+        # Check if this is a Shoutcast/ICY response that aiohttp can't parse
+        if isinstance(err, aiohttp.ClientResponseError) and "ICY" in str(err).upper():
+            self.logger.debug(
+                "ICY response detected for %s, validating Shoutcast stream", validate_url
+            )
+            if await self._validate_shoutcast_stream(validate_url):
+                return await self._cache_radio_result(
+                    url, StreamType.SHOUTCAST, resolved_url=validate_url
+                )
+            self.logger.warning(
+                "ICY response detected but Shoutcast validation failed for %s", validate_url
+            )
+            return await self._cache_radio_result(
+                url, fallback_stream_type, resolved_url=validate_url
+            )
+
+        # Other aiohttp errors - might still be Shoutcast, check it
+        self.logger.debug("aiohttp error for %s, checking if legacy Shoutcast stream", validate_url)
+        if await self._validate_shoutcast_stream(validate_url):
+            return await self._cache_radio_result(
+                url, StreamType.SHOUTCAST, resolved_url=validate_url
+            )
+
+        # Unknown error - still try to stream
+        self.logger.warning(
+            "Failed to parse radio URL %s: %s - attempting direct stream", validate_url, str(err)
+        )
+        return await self._cache_radio_result(url, fallback_stream_type, resolved_url=validate_url)
+
+    async def _iter_audio_source_pcm(
+        self,
+        streamdetails: StreamDetails,
+        pcm_format: AudioFormat,
+    ) -> AsyncGenerator[bytes]:
+        """Yield PCM for an AudioSource, bypassing ffmpeg when formats match."""
+        if _pcm_formats_match(streamdetails.audio_format, pcm_format):
+            source_gen = self._open_audio_source_generator(streamdetails)
+            async for chunk in realtime_pcm_pacer(source_gen, pcm_format):
+                yield chunk
+            return
+        # format mismatch → fall back to ffmpeg for resampling (still small chunks)
+        async for chunk in self.get_media_stream(
+            streamdetails=streamdetails,
+            pcm_format=pcm_format,
+            filter_params=None,
+            chunk_seconds=AUDIO_SOURCE_CHUNK_SECONDS,
+        ):
+            yield chunk
+
+    def _open_audio_source_generator(self, streamdetails: StreamDetails) -> AsyncGenerator[bytes]:
+        """Open the raw PCM generator for an AudioSource (CUSTOM or NAMED_PIPE)."""
+        if streamdetails.stream_type == StreamType.CUSTOM:
+            provider = self.mass.get_provider(streamdetails.provider)
+            if provider is None:
+                raise ProviderUnavailableError(
+                    f"Provider {streamdetails.provider} for stream is no longer available"
+                )
+            provider = cast("MusicProvider | PluginProvider", provider)
+            return provider.get_audio_stream(streamdetails)
+        if streamdetails.stream_type == StreamType.NAMED_PIPE:
+            assert isinstance(streamdetails.path, str)  # for type checking
+            return read_named_pipe(streamdetails.path)
+        raise AudioError(f"Unsupported stream_type {streamdetails.stream_type} for AudioSource")
 
     def _parse_icy_metadata(self, meta_data: bytes, streamdetails: StreamDetails) -> None:
         """

--- a/music_assistant/controllers/streams/ogg_handler.py
+++ b/music_assistant/controllers/streams/ogg_handler.py
@@ -292,6 +292,12 @@ class _ChainedOggState:
         self.last_granule: int = 0
         self.granule_offset: int = 0
 
+    def process_page(self, page: OggPage) -> bytes | None:
+        """Process page. Returns data to yield or None to skip."""
+        if self.first_chain:
+            return self._process_first_chain_page(page)
+        return self._process_chain_page(page)
+
     def _handle_metadata(self, page: OggPage) -> None:
         """Extract and invoke callback for supported in-band metadata pages."""
         if self.metadata_callback:
@@ -384,12 +390,6 @@ class _ChainedOggState:
             new_granule=new_granule,
             clear_bos=page.is_bos,
         )
-
-    def process_page(self, page: OggPage) -> bytes | None:
-        """Process page. Returns data to yield or None to skip."""
-        if self.first_chain:
-            return self._process_first_chain_page(page)
-        return self._process_chain_page(page)
 
 
 def _resync_ogg_buffer(buffer: bytearray) -> int:

--- a/music_assistant/controllers/streams/smart_fades/fades.py
+++ b/music_assistant/controllers/streams/smart_fades/fades.py
@@ -66,34 +66,6 @@ class SmartFade(ABC):
         self.filters = []
         self.logger = logger
 
-    @abstractmethod
-    def _build(
-        self,
-        fade_out_bytes_len: int,
-        fade_in_bytes_len: int,
-        pcm_format: AudioFormat,
-    ) -> None:
-        """Build the filter chain and assign ``self.timing_info``."""
-        ...
-
-    def _get_ffmpeg_filters(
-        self,
-        input_fadein_label: str = "[1]",
-        input_fadeout_label: str = "[0]",
-    ) -> list[str]:
-        """Get FFmpeg filters for smart fades."""
-        if not self.filters:
-            raise RuntimeError("SmartFade not built — call Mixer.build() first")
-        filters = []
-        _cur_fadein_label = input_fadein_label
-        _cur_fadeout_label = input_fadeout_label
-        for audio_filter in self.filters:
-            filter_strings = audio_filter.apply(_cur_fadein_label, _cur_fadeout_label)
-            filters.extend(filter_strings)
-            _cur_fadein_label = f"[{audio_filter.output_fadein_label}]"
-            _cur_fadeout_label = f"[{audio_filter.output_fadeout_label}]"
-        return filters
-
     async def apply(
         self,
         fade_out_part: bytes,
@@ -227,6 +199,34 @@ class SmartFade(ABC):
 
         chain = " → ".join(repr(f) for f in self.filters)
         return f"<{self.__class__.__name__}: {len(self.filters)} filters> {chain}"
+
+    @abstractmethod
+    def _build(
+        self,
+        fade_out_bytes_len: int,
+        fade_in_bytes_len: int,
+        pcm_format: AudioFormat,
+    ) -> None:
+        """Build the filter chain and assign ``self.timing_info``."""
+        ...
+
+    def _get_ffmpeg_filters(
+        self,
+        input_fadein_label: str = "[1]",
+        input_fadeout_label: str = "[0]",
+    ) -> list[str]:
+        """Get FFmpeg filters for smart fades."""
+        if not self.filters:
+            raise RuntimeError("SmartFade not built — call Mixer.build() first")
+        filters = []
+        _cur_fadein_label = input_fadein_label
+        _cur_fadeout_label = input_fadeout_label
+        for audio_filter in self.filters:
+            filter_strings = audio_filter.apply(_cur_fadein_label, _cur_fadeout_label)
+            filters.extend(filter_strings)
+            _cur_fadein_label = f"[{audio_filter.output_fadein_label}]"
+            _cur_fadeout_label = f"[{audio_filter.output_fadeout_label}]"
+        return filters
 
 
 class SmartCrossFade(SmartFade):
@@ -769,37 +769,6 @@ class StandardCrossFade(SmartFade):
         self.trailing_silence_bytes: int = 0
         self.crossfade_size: int = 0
 
-    def _build(
-        self,
-        fade_out_bytes_len: int,
-        fade_in_bytes_len: int,
-        pcm_format: AudioFormat,
-    ) -> None:
-        """Build the standard crossfade filter chain and assign ``self.timing_info``."""
-        fade_out_seconds = fade_out_bytes_len / pcm_format.pcm_sample_size
-        fade_in_seconds = fade_in_bytes_len / pcm_format.pcm_sample_size
-        # clamp CF to fit shorter inputs (defensive — normally full buffers)
-        effective_cf = min(self.crossfade_duration, fade_out_seconds, fade_in_seconds)
-        # Quantize the overlap to a whole number of PCM frames and drive both the
-        # byte slice (in apply) and the acrossfade length from this one integer.
-        # apply slices the buffers on frame boundaries, so a fractional effective_cf
-        # leaves the rendered buffer a fraction of a sample short of the acrossfade
-        # duration — and acrossfade then silently produces no output at all.
-        frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
-        crossfade_bytes = int(pcm_format.pcm_sample_size * effective_cf)
-        self.crossfade_size = crossfade_bytes // frame_size * frame_size
-        crossfade_samples = self.crossfade_size // frame_size
-        effective_cf = self.crossfade_size / pcm_format.pcm_sample_size
-        self.timing_info = CrossfadeTimingInfo(
-            pre_crossfade_duration=max(0.0, fade_out_seconds - effective_cf),
-            crossfade_duration=effective_cf,
-            fadein_trimmed_duration=0.0,
-            post_crossfade_duration=max(0.0, fade_in_seconds - effective_cf),
-        )
-        self.filters = [
-            CrossfadeFilter(logger=self.logger, crossfade_samples=crossfade_samples),
-        ]
-
     async def apply(
         self,
         fade_out_part: bytes,
@@ -874,3 +843,34 @@ class StandardCrossFade(SmartFade):
         else:
             async for chunk in post_crossfade:
                 yield chunk
+
+    def _build(
+        self,
+        fade_out_bytes_len: int,
+        fade_in_bytes_len: int,
+        pcm_format: AudioFormat,
+    ) -> None:
+        """Build the standard crossfade filter chain and assign ``self.timing_info``."""
+        fade_out_seconds = fade_out_bytes_len / pcm_format.pcm_sample_size
+        fade_in_seconds = fade_in_bytes_len / pcm_format.pcm_sample_size
+        # clamp CF to fit shorter inputs (defensive — normally full buffers)
+        effective_cf = min(self.crossfade_duration, fade_out_seconds, fade_in_seconds)
+        # Quantize the overlap to a whole number of PCM frames and drive both the
+        # byte slice (in apply) and the acrossfade length from this one integer.
+        # apply slices the buffers on frame boundaries, so a fractional effective_cf
+        # leaves the rendered buffer a fraction of a sample short of the acrossfade
+        # duration — and acrossfade then silently produces no output at all.
+        frame_size = (pcm_format.bit_depth // 8) * pcm_format.channels
+        crossfade_bytes = int(pcm_format.pcm_sample_size * effective_cf)
+        self.crossfade_size = crossfade_bytes // frame_size * frame_size
+        crossfade_samples = self.crossfade_size // frame_size
+        effective_cf = self.crossfade_size / pcm_format.pcm_sample_size
+        self.timing_info = CrossfadeTimingInfo(
+            pre_crossfade_duration=max(0.0, fade_out_seconds - effective_cf),
+            crossfade_duration=effective_cf,
+            fadein_trimmed_duration=0.0,
+            post_crossfade_duration=max(0.0, fade_in_seconds - effective_cf),
+        )
+        self.filters = [
+            CrossfadeFilter(logger=self.logger, crossfade_samples=crossfade_samples),
+        ]

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -4,9 +4,6 @@
 music_assistant/controllers/music/controller.py	46
 music_assistant/controllers/player_queues/controller.py	43
 music_assistant/controllers/players/controller.py	36
-music_assistant/controllers/streams/audio.py	23
-music_assistant/controllers/streams/ogg_handler.py	1
-music_assistant/controllers/streams/smart_fades/fades.py	3
 music_assistant/controllers/tasks/controller.py	5
 music_assistant/controllers/webserver/auth.py	42
 music_assistant/controllers/webserver/helpers/auth_providers.py	6


### PR DESCRIPTION
# What does this implement/fix?

Moves private (underscore-prefixed) methods to the bottom of the class in the streams subsystem controllers, so each class lists its public/dunder methods first and its private helpers last — the convention enforced by `check_method_order` (see AGENTS.md).

This is a pure relocation: no method bodies, signatures or behaviour change. Verified via AST comparison that each file contains exactly the same set of methods, only reordered. The affected files are removed from `scripts/lint_baselines/private_methods_not_last.txt` (1391 → 1364).

In `audio.py` the existing `# --- Public methods ---` / `# --- Private methods ---` section dividers were kept and the private divider moved to the new private-section boundary so it still marks the start of the private methods.

Files reordered:
- `controllers/streams/audio.py`
- `controllers/streams/smart_fades/fades.py`
- `controllers/streams/ogg_handler.py`

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
