### PR TITLE
Move private methods to the bottom of the class in the tasks controller

### DIFF
--- a/music_assistant/controllers/tasks/controller.py
+++ b/music_assistant/controllers/tasks/controller.py
@@ -372,22 +372,6 @@ class TasksController(CoreController):
         """
         self._unregister_task(task_id, clear_persisted_state)
 
-    def _unregister_task(self, task_id: str, clear_persisted_state: bool = True) -> None:
-        """Unregister a managed task and cancel any active work."""
-        if not (managed := self._tasks.get(task_id)):
-            return
-        managed.removed = True
-        managed.clear_persisted_state_on_remove = clear_persisted_state
-        self.mass.cancel_timer(get_task_timer_id(task_id))
-        self._remove_from_pending(task_id)
-        if managed.current_task and not managed.current_task.done():
-            managed.current_task.cancel()
-            return
-        self._tasks.pop(task_id, None)
-        if clear_persisted_state:
-            self._clear_scheduled_task_state(task_id)
-        self._schedule_task_update(force=True)
-
     def update_task_progress(
         self, task_id: str, progress: int | None, text: str | None = None
     ) -> None:
@@ -470,6 +454,22 @@ class TasksController(CoreController):
             if all(managed.task_info.metadata.get(key) == value for key, value in metadata.items()):
                 result.append(managed.task_info)
         return result
+
+    def _unregister_task(self, task_id: str, clear_persisted_state: bool = True) -> None:
+        """Unregister a managed task and cancel any active work."""
+        if not (managed := self._tasks.get(task_id)):
+            return
+        managed.removed = True
+        managed.clear_persisted_state_on_remove = clear_persisted_state
+        self.mass.cancel_timer(get_task_timer_id(task_id))
+        self._remove_from_pending(task_id)
+        if managed.current_task and not managed.current_task.done():
+            managed.current_task.cancel()
+            return
+        self._tasks.pop(task_id, None)
+        if clear_persisted_state:
+            self._clear_scheduled_task_state(task_id)
+        self._schedule_task_update(force=True)
 
     def _get_managed_task(self, task_id: str) -> ManagedTask:
         """Return runtime state for a managed task."""

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -1,7 +1,6 @@
 # Classes that define a public/dunder method below a private one, predating this check.
 # Private methods must live at the bottom of the class (see AGENTS.md).
 # Regenerate with: uv run -m scripts.check_method_order --update-baseline
-music_assistant/controllers/tasks/controller.py	5
 music_assistant/helpers/named_pipe.py	5
 music_assistant/helpers/scrobbler.py	2
 music_assistant/helpers/throttle_retry.py	3


### PR DESCRIPTION
# What does this implement/fix?

Moves private (underscore-prefixed) methods to the bottom of the class in the tasks controller (`controllers/tasks/controller.py`), so the class lists its public/dunder methods first and its private helpers last — the convention enforced by `check_method_order` (see AGENTS.md).

This is a pure relocation: no method bodies, signatures or behaviour change. Verified via AST comparison that the file contains exactly the same set of methods, only reordered. The file is removed from `scripts/lint_baselines/private_methods_not_last.txt`.

**Related issue (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
