### PR TITLE
Move private methods to the bottom of the class in core misc files

### DIFF
--- a/music_assistant/helpers/named_pipe.py
+++ b/music_assistant/helpers/named_pipe.py
@@ -31,11 +31,6 @@ class AsyncNamedPipeWriter:
         self._write_fd: int | None = None
 
     @property
-    def _log_owner(self) -> str:
-        """Return a short descriptor for logging (owner_id or pipe path)."""
-        return self._owner_id or self._pipe_path
-
-    @property
     def path(self) -> str:
         """Return the named pipe path."""
         return self._pipe_path
@@ -50,29 +45,6 @@ class AsyncNamedPipeWriter:
             os.mkfifo(self._pipe_path)
 
         await asyncio.to_thread(_create)
-
-    def _ensure_write_fd(self) -> bool:
-        """Ensure we have a write fd open. Returns True if successful."""
-        if self._write_fd is not None:
-            return True
-        if not Path(self._pipe_path).exists():
-            return False
-        # Retry opening until reader is available (up to 1s)
-        for _ in range(20):
-            try:
-                self._write_fd = os.open(self._pipe_path, os.O_WRONLY | os.O_NONBLOCK)
-                return True
-            except OSError as e:
-                if e.errno in (errno_module.ENXIO, errno_module.ENOENT):
-                    time.sleep(0.05)
-                    continue
-                raise
-        _LOGGER.warning(
-            "Could not open pipe %s (owner=%s): no reader after retries",
-            self._pipe_path,
-            self._log_owner,
-        )
-        return False
 
     async def write(self, data: bytes) -> None:
         """Write data to the named pipe."""
@@ -121,6 +93,34 @@ class AsyncNamedPipeWriter:
     def __str__(self) -> str:
         """Return string representation."""
         return self._pipe_path
+
+    @property
+    def _log_owner(self) -> str:
+        """Return a short descriptor for logging (owner_id or pipe path)."""
+        return self._owner_id or self._pipe_path
+
+    def _ensure_write_fd(self) -> bool:
+        """Ensure we have a write fd open. Returns True if successful."""
+        if self._write_fd is not None:
+            return True
+        if not Path(self._pipe_path).exists():
+            return False
+        # Retry opening until reader is available (up to 1s)
+        for _ in range(20):
+            try:
+                self._write_fd = os.open(self._pipe_path, os.O_WRONLY | os.O_NONBLOCK)
+                return True
+            except OSError as e:
+                if e.errno in (errno_module.ENXIO, errno_module.ENOENT):
+                    time.sleep(0.05)
+                    continue
+                raise
+        _LOGGER.warning(
+            "Could not open pipe %s (owner=%s): no reader after retries",
+            self._pipe_path,
+            self._log_owner,
+        )
+        return False
 
 
 async def read_named_pipe(

--- a/music_assistant/helpers/scrobbler.py
+++ b/music_assistant/helpers/scrobbler.py
@@ -45,16 +45,29 @@ class ScrobblerHelper:
         self.config = config or ScrobblerConfig(suffix_version=False)
         self.supported_media_types = supported_media_types
 
-    def _is_configured(self) -> bool:
-        """Override if subclass needs specific configuration."""
-        return True
-
     def get_name(self, report: MediaItemPlaybackProgressReport) -> str:
         """Get the track name to use for scrobbling, possibly appended with version info."""
         if self.config.suffix_version and report.version:
             return f"{report.name} ({report.version})"
 
         return report.name
+
+    def should_scrobble(self, report: MediaItemPlaybackProgressReport) -> bool:
+        """Determine if a track should be scrobbled, to be extended later."""
+        if self.last_scrobbled == report.uri:
+            self.logger.debug("skipped scrobbling due to duplicate event")
+            return False
+
+        # ideally we want more precise control
+        # but because the event is triggered every 30s
+        # and we don't have full queue details to determine
+        # the exact context in which the event was fired
+        # we can only rely on fully_played for now
+        return bool(report.fully_played)
+
+    def _is_configured(self) -> bool:
+        """Override if subclass needs specific configuration."""
+        return True
 
     async def _update_now_playing(self, report: MediaItemPlaybackProgressReport) -> None:
         """Send a Now Playing update to the scrobbling service."""
@@ -117,19 +130,6 @@ class ScrobblerHelper:
 
         if self.should_scrobble(report):
             await scrobble()
-
-    def should_scrobble(self, report: MediaItemPlaybackProgressReport) -> bool:
-        """Determine if a track should be scrobbled, to be extended later."""
-        if self.last_scrobbled == report.uri:
-            self.logger.debug("skipped scrobbling due to duplicate event")
-            return False
-
-        # ideally we want more precise control
-        # but because the event is triggered every 30s
-        # and we don't have full queue details to determine
-        # the exact context in which the event was fired
-        # we can only rely on fully_played for now
-        return bool(report.fully_played)
 
 
 CONF_VERSION_SUFFIX = "suffix_version"

--- a/music_assistant/helpers/throttle_retry.py
+++ b/music_assistant/helpers/throttle_retry.py
@@ -73,14 +73,6 @@ class Throttler:
         self.period = period
         self._task_logs: deque[float] = deque()
 
-    def _flush(self) -> None:
-        now = time.monotonic()
-        while self._task_logs:
-            if now - self._task_logs[0] > self.period:
-                self._task_logs.popleft()
-            else:
-                break
-
     async def acquire(self) -> float:
         """Acquire a free slot from the Throttler, returns the throttled time."""
         cur_time = time.monotonic()
@@ -108,6 +100,14 @@ class Throttler:
         exc_tb: TracebackType | None,
     ) -> bool | None:
         """Nothing to do on exit."""
+
+    def _flush(self) -> None:
+        now = time.monotonic()
+        while self._task_logs:
+            if now - self._task_logs[0] > self.period:
+                self._task_logs.popleft()
+            else:
+                break
 
 
 class ThrottlerManager:

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -884,6 +884,21 @@ class MusicAssistant:
                 f"Non-Async operation detected: {what} may only be called from the eventloop."
             )
 
+    async def __aenter__(self) -> Self:
+        """Return Context manager."""
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        """Exit context manager."""
+        await self.stop()
+        return None
+
     def _register_api_commands(self) -> None:
         """Register all methods decorated as api_command within a class(instance)."""
         for cls in (
@@ -1155,21 +1170,6 @@ class MusicAssistant:
                     continue
                 tg.create_task(load_provider_manifest(dir_str, dir_path))
         self.logger.debug("Loaded %s provider manifests", len(self._provider_manifests))
-
-    async def __aenter__(self) -> Self:
-        """Return Context manager."""
-        await self.start()
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        """Exit context manager."""
-        await self.stop()
-        return None
 
     async def _update_available_providers_cache(self) -> None:
         """Update the global cache variable of loaded/available providers."""

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -92,23 +92,6 @@ class AudioAnalysisProvider(Provider):
         return True
 
     @abstractmethod
-    async def _start_analysis(
-        self,
-        session_id: str,
-        streamdetails: StreamDetails,
-        audio_format: AudioFormat,
-    ) -> bool:
-        """
-        Provider-specific initialization for a new analysis session.
-
-        Return False to reject the session (e.g. unsupported format).
-
-        :param session_id: The analysis session ID.
-        :param streamdetails: The stream details for the item being analyzed.
-        :param audio_format: PCM format of the audio stream.
-        """
-
-    @abstractmethod
     async def process_pcm_chunk(
         self,
         session_id: str,
@@ -122,17 +105,6 @@ class AudioAnalysisProvider(Provider):
 
         :param session_id: The analysis session ID.
         :param pcm_chunk: Raw PCM audio data.
-        """
-
-    @abstractmethod
-    async def _finalize(self, session_id: str) -> AudioAnalysisData | None:
-        """
-        Compute and return the analysis for this session (or None to skip).
-
-        The base class persists the returned value via set_audio_analysis() and
-        then fires post_analysis(). Return None to skip both.
-
-        :param session_id: The analysis session ID.
         """
 
     async def finalize(self, session_id: str) -> None:
@@ -192,6 +164,34 @@ class AudioAnalysisProvider(Provider):
         for session_id in list(self._sessions):
             await self.cancel(session_id)
         await super().unload(is_removed)
+
+    @abstractmethod
+    async def _start_analysis(
+        self,
+        session_id: str,
+        streamdetails: StreamDetails,
+        audio_format: AudioFormat,
+    ) -> bool:
+        """
+        Provider-specific initialization for a new analysis session.
+
+        Return False to reject the session (e.g. unsupported format).
+
+        :param session_id: The analysis session ID.
+        :param streamdetails: The stream details for the item being analyzed.
+        :param audio_format: PCM format of the audio stream.
+        """
+
+    @abstractmethod
+    async def _finalize(self, session_id: str) -> AudioAnalysisData | None:
+        """
+        Compute and return the analysis for this session (or None to skip).
+
+        The base class persists the returned value via set_audio_analysis() and
+        then fires post_analysis(). Return None to skip both.
+
+        :param session_id: The analysis session ID.
+        """
 
     async def _run_offloaded(self, func: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
         """

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -1,11 +1,6 @@
 # Classes that define a public/dunder method below a private one, predating this check.
 # Private methods must live at the bottom of the class (see AGENTS.md).
 # Regenerate with: uv run -m scripts.check_method_order --update-baseline
-music_assistant/helpers/named_pipe.py	5
-music_assistant/helpers/scrobbler.py	2
-music_assistant/helpers/throttle_retry.py	3
-music_assistant/mass.py	2
-music_assistant/models/audio_analysis_provider.py	5
 music_assistant/models/music_provider.py	5
 music_assistant/models/player.py	58
 music_assistant/providers/_demo_audio_analysis_provider/__init__.py	3


### PR DESCRIPTION
# What does this implement/fix?

Continues the ongoing `check_method_order` lint cleanup. Moves private
(underscore-prefixed, non-dunder) methods to the bottom of their classes in a
batch of core, non-provider files so that public/dunder methods come first, per
the project convention.

This is a pure relocation — no method bodies were changed and there is no
behaviour change. Verified by comparing each class's method ASTs before/after.

Files reordered:

- `music_assistant/models/audio_analysis_provider.py`
- `music_assistant/helpers/named_pipe.py`
- `music_assistant/helpers/throttle_retry.py`
- `music_assistant/helpers/scrobbler.py`
- `music_assistant/mass.py`

The `check_method_order` baseline shrinks accordingly (these 5 entries removed).

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
