### PR TITLE
Parse "Track" by Artist radio stream titles and use album for artwork

### DIFF
--- a/music_assistant/controllers/metadata/radio.py
+++ b/music_assistant/controllers/metadata/radio.py
@@ -30,7 +30,7 @@ from music_assistant_models.media_items import (
 from music_assistant_models.streamdetails import StreamMetadata
 from music_assistant_models.unique_list import UniqueList
 
-from music_assistant.helpers.compare import compare_strings
+from music_assistant.helpers.compare import compare_strings, create_safe_string
 from music_assistant.helpers.tags import split_artists
 from music_assistant.helpers.util import parse_title_and_version
 
@@ -81,6 +81,7 @@ class RadioArtworkMixin:
         self,
         artist_name: str,
         track_name: str,
+        album_name: str | None = None,
     ) -> tuple[MediaItemMetadata | None, str | None, str | None, str | None]:
         """
         Search for track/artist metadata by name.
@@ -90,6 +91,7 @@ class RadioArtworkMixin:
 
         :param artist_name: Artist name to search for.
         :param track_name: Track title to search for.
+        :param album_name: Album announced by the stream, used to refine which artwork is chosen.
         :returns: Tuple of (metadata, source_description, corrected_artist, corrected_track).
         """
         # Clean track name by stripping version suffixes and featuring credits
@@ -132,6 +134,13 @@ class RadioArtworkMixin:
         # Prefer single artwork (exact track art), then fall back to album artwork
         singles = [rg for rg in mb_release_groups if rg.primary_type == "Single"]
         albums = [rg for rg in mb_release_groups if rg.primary_type == "Album"]
+
+        # When the station told us the album, move a matching release group to the front so
+        # the cover reflects the broadcast release rather than an arbitrary one. This only
+        # reorders within each type; singles still take precedence over albums.
+        if album_name:
+            singles = self._prioritize_release_groups(singles, album_name)
+            albums = self._prioritize_release_groups(albums, album_name)
 
         for mb_release_group in singles:
             if result := await self._get_release_group_artwork(mb_release_group):
@@ -277,6 +286,7 @@ class RadioArtworkMixin:
         artist_name: str,
         track_name: str,
         fallback_image_url: str | None = None,
+        album_name: str | None = None,
     ) -> tuple[str | None, str | None, str | None]:
         """
         Look up artwork by artist and track name.
@@ -288,6 +298,7 @@ class RadioArtworkMixin:
         :param artist_name: Artist name to search for.
         :param track_name: Track title to search for.
         :param fallback_image_url: Fallback image URL if no artwork found.
+        :param album_name: Album announced by the stream, used to refine which artwork is chosen.
         :returns: Tuple of (image_url, corrected_artist, corrected_track).
         """
         if " / " in artist_name:
@@ -331,6 +342,7 @@ class RadioArtworkMixin:
             ) = await self.get_track_metadata_by_name(
                 artist_name=artist_name,
                 track_name=track_name,
+                album_name=album_name,
             )
             # Use corrected artist/track for logging if available (handles swapped metadata)
             log_artist = corrected_artist or artist_name
@@ -386,10 +398,12 @@ class RadioArtworkMixin:
             fallback_url = streamdetails.stream_metadata.image_url
             original_artist = streamdetails.stream_metadata.artist
             original_title = streamdetails.stream_metadata.title
+            album = streamdetails.stream_metadata.album
             image_url, corrected_artist, corrected_track = await self.get_image_url_by_name(
                 artist_name=original_artist,
                 track_name=original_title,
                 fallback_image_url=fallback_url,
+                album_name=album,
             )
             # Use corrected artist/track if metadata was swapped
             final_artist = corrected_artist or original_artist
@@ -402,6 +416,7 @@ class RadioArtworkMixin:
                 streamdetails.stream_metadata = StreamMetadata(
                     title=final_title,
                     artist=final_artist,
+                    album=album,
                     image_url=image_url,
                 )
                 streamdetails.stream_metadata_last_updated = time()
@@ -409,6 +424,28 @@ class RadioArtworkMixin:
                     self.mass.player_queues.signal_update(streamdetails.queue_id)
         except MusicAssistantError:
             pass
+
+    @staticmethod
+    def _prioritize_release_groups(
+        release_groups: list[MusicBrainzReleaseGroup], album_name: str
+    ) -> list[MusicBrainzReleaseGroup]:
+        """
+        Return the release groups reordered with album-name matches first.
+
+        :param release_groups: Release groups to reorder.
+        :param album_name: Album name announced in the stream metadata.
+        """
+        announced = create_safe_string(album_name)
+        if not announced or len(release_groups) < 2:
+            return release_groups
+
+        # loose substring match either way, so an original album still wins when the
+        # station announces a compilation whose title embeds the original album name
+        def matches(release_group: MusicBrainzReleaseGroup) -> bool:
+            title = create_safe_string(release_group.title)
+            return bool(title) and (title in announced or announced in title)
+
+        return sorted(release_groups, key=lambda rg: not matches(rg))
 
     async def _get_release_group_artwork(
         self, mb_release_group: MusicBrainzReleaseGroup

--- a/music_assistant/controllers/metadata/radio.py
+++ b/music_assistant/controllers/metadata/radio.py
@@ -310,7 +310,10 @@ class RadioArtworkMixin:
         if any(phrase in artist_name.lower() for phrase in AD_DETECTION_PHRASES):
             return fallback_image_url, None, None
 
-        cache_key = f"{artist_name.lower()}|{track_name.lower()}"
+        # album_name influences which release group's artwork is chosen, so it must be
+        # part of the cache key, else two albums for the same track would alias.
+        album_key = create_safe_string(album_name) if album_name else ""
+        cache_key = f"{artist_name.lower()}|{track_name.lower()}|{album_key}"
         cached_result = await self.mass.cache.get(
             key=cache_key,
             category=CACHE_CATEGORY_RADIO_ARTWORK,

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -107,6 +107,7 @@ from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
 from music_assistant.helpers.util import (
     clean_stream_title,
     detect_charset,
+    parse_quoted_stream_title,
     parse_title_and_version,
     remove_file,
 )
@@ -2650,17 +2651,28 @@ class StreamsAudio:
         )
         streamdetails.stream_title = cleaned_stream_title
 
-        if " - " in cleaned_stream_title:
+        # Parse the original title for structured fields first so stations that announce
+        # an album can refine the artwork lookup; fall back to the "Artist - Track" split.
+        album: str | None = None
+        if parsed := parse_quoted_stream_title(stream_title):
+            track_name, artist_name_raw, album = parsed
+        elif " - " in cleaned_stream_title:
             artist_name_raw, track_name = (
                 part.strip() for part in cleaned_stream_title.split(" - ", 1)
             )
-            if artist_name_raw and track_name:
-                self.logger.debug(
-                    "ICY metadata: artist='%s', track='%s'", artist_name_raw, track_name
-                )
-                self._update_radio_stream_metadata(
-                    streamdetails, artist=artist_name_raw, title=track_name
-                )
+        else:
+            return
+
+        if artist_name_raw and track_name:
+            self.logger.debug(
+                "ICY metadata: artist='%s', track='%s', album='%s'",
+                artist_name_raw,
+                track_name,
+                album,
+            )
+            self._update_radio_stream_metadata(
+                streamdetails, artist=artist_name_raw, title=track_name, album=album
+            )
 
     async def _validate_shoutcast_stream(self, url: str) -> bool:
         """

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -392,6 +392,13 @@ ad_pattern = re.compile(r"((ad|advertisement)_)|^AD\s\d+$|ADBREAK", flags=re.IGN
 title_artist_order_pattern = re.compile(r"(?P<title>.+)\sBy:\s(?P<artist>.+)", flags=re.IGNORECASE)
 # German format used by some stations: "Track" von Artist
 german_von_pattern = re.compile(r'^"(?P<title>[^"]+)"\s+von\s+(?P<artist>.+)$', flags=re.IGNORECASE)
+# English format used by some stations: "Track" by Artist from "Album" (album optional).
+# Title and album are quote-delimited, so the non-greedy artist plus the anchored,
+# quoted album group keep "by"/"from" inside the artist name from being mis-split.
+english_by_pattern = re.compile(
+    r'^"(?P<title>[^"]+)"\s+by\s+(?P<artist>.+?)(?:\s+from\s+"(?P<album>[^"]*)")?$',
+    flags=re.IGNORECASE,
+)
 multi_space_pattern = re.compile(r"\s{2,}")
 end_junk_pattern = re.compile(r"(.+?)(\s\W+)$")
 
@@ -700,17 +707,42 @@ def multi_strip(line: str) -> str:
     ).rstrip()
 
 
+def parse_quoted_stream_title(line: str) -> tuple[str, str, str | None] | None:
+    """
+    Parse stream titles that name the track in natural language with a quoted title.
+
+    Recognises '"Track" by Artist from "Album"' (album optional) and the German
+    '"Track" von Artist'.
+
+    :param line: Raw (uncleaned) stream title.
+    :returns: Tuple of (title, artist, album), or None when the line is not in one of
+        these formats. ``album`` is None when the station omits it.
+    """
+    stripped = line.strip()
+    if match := english_by_pattern.match(stripped):
+        title = multi_strip(match.group("title"))
+        artist = multi_strip(match.group("artist")).strip('"')
+        album_raw = match.group("album")
+        album = multi_strip(album_raw).strip('"') if album_raw else None
+        if title and artist:
+            return title, artist, album or None
+    if match := german_von_pattern.match(stripped):
+        title = multi_strip(match.group("title"))
+        artist = multi_strip(match.group("artist")).strip('"')
+        if title and artist:
+            return title, artist, None
+    return None
+
+
 def clean_stream_title(line: str) -> str:
     """Strip junk text from radio streamtitle."""
     title: str = ""
     artist: str = ""
 
     if not keyword_pattern.search(line):
-        if german_match := german_von_pattern.match(line.strip()):
-            title = multi_strip(german_match.group("title"))
-            artist = multi_strip(german_match.group("artist")).strip('"')
-            if title and artist:
-                return f"{artist} - {title}"
+        if parsed := parse_quoted_stream_title(line):
+            track_name, artist_name, _ = parsed
+            return f"{artist_name} - {track_name}"
         return multi_strip(line)
 
     if match := title_pattern.search(line):

--- a/tests/controllers/metadata/test_metadata_radio.py
+++ b/tests/controllers/metadata/test_metadata_radio.py
@@ -11,11 +11,17 @@ from music_assistant_models.media_items import (
 from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.controllers.metadata import MetaDataController
+from music_assistant.providers.musicbrainz import MusicBrainzReleaseGroup
 
 
 def _artist(name: str) -> Artist | ItemMapping:
     """Build a minimal artist ItemMapping with the given name."""
     return ItemMapping(item_id=name, provider="library", name=name)
+
+
+def _release_group(title: str) -> MusicBrainzReleaseGroup:
+    """Build a minimal release group with the given title."""
+    return MusicBrainzReleaseGroup(id=title, title=title)
 
 
 def _controller() -> MetaDataController:
@@ -94,3 +100,43 @@ class TestGetThumbImage:
         """Metadata without any images yields None."""
         ctrl = _controller()
         assert ctrl._get_thumb_image(MediaItemMetadata()) is None
+
+
+class TestPrioritizeReleaseGroups:
+    """`_prioritize_release_groups` floats announced-album matches to the front."""
+
+    def test_matching_album_moves_first(self) -> None:
+        """The release group whose title matches the announced album sorts first."""
+        groups = [_release_group("Some Album"), _release_group("Greatest Hits")]
+        result = MetaDataController._prioritize_release_groups(groups, "Greatest Hits")
+        assert [rg.title for rg in result] == ["Greatest Hits", "Some Album"]
+
+    def test_announced_substring_of_title_matches(self) -> None:
+        """A shorter announced album still matches a longer release-group title."""
+        groups = [_release_group("Some Album"), _release_group("Greatest Hits Vol. 1")]
+        result = MetaDataController._prioritize_release_groups(groups, "Greatest Hits")
+        assert result[0].title == "Greatest Hits Vol. 1"
+
+    def test_title_substring_of_announced_matches(self) -> None:
+        """A shorter release-group title still matches a longer announced album."""
+        groups = [_release_group("Live in Tokyo"), _release_group("Hits")]
+        result = MetaDataController._prioritize_release_groups(groups, "Greatest Hits")
+        assert result[0].title == "Hits"
+
+    def test_no_match_preserves_order(self) -> None:
+        """Without any album match the original order is kept (stable sort)."""
+        groups = [_release_group("First"), _release_group("Second")]
+        result = MetaDataController._prioritize_release_groups(groups, "Unrelated")
+        assert [rg.title for rg in result] == ["First", "Second"]
+
+    def test_single_group_returned_unchanged(self) -> None:
+        """A list with fewer than two groups short-circuits and is returned as-is."""
+        groups = [_release_group("Only One")]
+        result = MetaDataController._prioritize_release_groups(groups, "Only One")
+        assert result is groups
+
+    def test_album_normalizing_to_empty_returns_unchanged(self) -> None:
+        """An album name that normalizes to an empty string leaves the order untouched."""
+        groups = [_release_group("First"), _release_group("Second")]
+        result = MetaDataController._prioritize_release_groups(groups, "!!!")
+        assert result is groups

--- a/tests/helpers/test_radio_stream_title.py
+++ b/tests/helpers/test_radio_stream_title.py
@@ -1,6 +1,6 @@
 """Tests for cleaning radio streamtitle."""
 
-from music_assistant.helpers.util import clean_stream_title
+from music_assistant.helpers.util import clean_stream_title, parse_quoted_stream_title
 
 
 def test_cleaning_streamtitle() -> None:
@@ -80,3 +80,55 @@ def test_cleaning_streamtitle_german_format() -> None:
     line = '"Closer to the Edge" von "Thirty Seconds To Mars"'
     stream_title = clean_stream_title(line)
     assert stream_title == "Thirty Seconds To Mars - Closer to the Edge"
+
+
+def test_cleaning_streamtitle_english_format() -> None:
+    """Test normalisation of the English "Track" by Artist from "Album" format."""
+    line = '"Nickel Wound" by Texas Is The Reason from "Do You Know Who You Are?"'
+    assert clean_stream_title(line) == "Texas Is The Reason - Nickel Wound"
+
+    # album is optional
+    line = '"Cornflake Girl" by Tori Amos'
+    assert clean_stream_title(line) == "Tori Amos - Cornflake Girl"
+
+
+def test_parse_quoted_stream_title() -> None:
+    """Test structured parsing of quoted stream titles, including album extraction."""
+    # English format with album
+    assert parse_quoted_stream_title(
+        '"Nickel Wound" by Texas Is The Reason from "Do You Know Who You Are?: '
+        'The Complete Collection"'
+    ) == (
+        "Nickel Wound",
+        "Texas Is The Reason",
+        "Do You Know Who You Are?: The Complete Collection",
+    )
+
+    # English format without album
+    assert parse_quoted_stream_title('"Cornflake Girl" by Tori Amos') == (
+        "Cornflake Girl",
+        "Tori Amos",
+        None,
+    )
+
+    # "by" and "from" appearing inside the artist name must not be mis-split
+    assert parse_quoted_stream_title('"Romeo" by Death From Above 1979 from "Heads Up"') == (
+        "Romeo",
+        "Death From Above 1979",
+        "Heads Up",
+    )
+    assert parse_quoted_stream_title('"Romeo" by Death From Above 1979') == (
+        "Romeo",
+        "Death From Above 1979",
+        None,
+    )
+
+    # German format yields no album
+    assert parse_quoted_stream_title('"Cornflake Girl" von Tori Amos') == (
+        "Cornflake Girl",
+        "Tori Amos",
+        None,
+    )
+
+    # conventional "Artist - Track" is not a quoted format
+    assert parse_quoted_stream_title("Tori Amos - Cornflake Girl") is None


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A user reported a station with a different metadata format. This PR adds support for `"Track" by Artist from "Album"`

Also now use that album info to further refine the artwork selection.

**Related issue (if applicable):**

- related issue Half fixes https://github.com/music-assistant/support/issues/5701

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
