### PR TITLE
Fix Auto Release workflow failing at startup due to missing PR permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
   preflight-checks:
     name: Run tests and linting before release
     needs: determine-branch
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/test.yml
     with:
       ref: ${{ needs.determine-branch.outputs.branch }}


### PR DESCRIPTION
# What does this implement/fix?

The Auto Release workflow was failing at startup with an invalid-workflow error. The reusable `test.yml` jobs `changes` and `provider-scope` request `pull-requests: read`, but in the `auto-release.yml` → `release.yml` → `test.yml` chain the intermediate `preflight-checks` job in `release.yml` didn't declare permissions. It therefore inherited the workflow default (`contents: read`, i.e. `pull-requests: none`) and couldn't pass the required permission down, so GitHub rejected the whole run during validation.

## Changes

- Add job-level `permissions` (`contents: read`, `pull-requests: read`) to the `preflight-checks` job in `release.yml` so the nested `test.yml` call gets the permission it requests.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`