### PR TITLE
Allow Bandcamp feed and wishlist to be playable.

### DIFF
--- a/music_assistant/providers/bandcamp/__init__.py
+++ b/music_assistant/providers/bandcamp/__init__.py
@@ -63,6 +63,7 @@ from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
     BROWSE_FANS,
+    BROWSE_FEED,
     BROWSE_FOLLOWERS,
     BROWSE_FOLLOWING,
     BROWSE_WISHLIST,
@@ -506,6 +507,7 @@ class BandcampProvider(MusicProvider):
                     name="Bandcamp Feed",
                     translation_key="feed",
                     icon="mdi-rss",
+                    is_playable=True,
                     items=UniqueList(feed_tracks),
                 )
             )
@@ -517,6 +519,7 @@ class BandcampProvider(MusicProvider):
                     name="Wishlist",
                     translation_key="wishlist",
                     icon="mdi-heart",
+                    is_playable=True,
                     items=UniqueList(wishlist),
                 )
             )
@@ -569,6 +572,11 @@ class BandcampProvider(MusicProvider):
         if path_parts and path_parts[0] in (BROWSE_FANS, BROWSE_FOLLOWERS):
             return await self._browse_person(path_parts, base)
 
+        # The feed/wishlist recommendation folders resolve to their tracks here when played;
+        # the folder's explicit path is dropped on deserialization, so play arrives as the
+        # bare item_id slug (e.g. ".../feed") rather than ".../recommendations/feed".
+        if path_parts == [BROWSE_FEED]:
+            return await self._get_feed_tracks()
         if path_parts == [BROWSE_WISHLIST]:
             return await self._browse_person_content(None, CollectionType.WISHLIST)
         if path_parts == [BROWSE_FOLLOWING]:

--- a/music_assistant/providers/bandcamp/constants.py
+++ b/music_assistant/providers/bandcamp/constants.py
@@ -26,6 +26,7 @@ CACHE_EMPTY_RESULTS = 300  # 5 minutes - avoid hammering API for genuinely empty
 
 # Browse path slugs
 BROWSE_COLLECTION = "collection"
+BROWSE_FEED = "feed"
 BROWSE_WISHLIST = "wishlist"
 BROWSE_FOLLOWING = "following"
 BROWSE_FANS = "fans"

--- a/tests/providers/bandcamp/test_provider.py
+++ b/tests/providers/bandcamp/test_provider.py
@@ -809,6 +809,20 @@ async def test_recommendations_returns_feed_and_wishlist(provider: BandcampProvi
         assert [f.name for f in folders] == ["Bandcamp Feed", "Wishlist"]
         assert feed_track in folders[0].items
         assert wishlist_album in folders[1].items
+        # Both folders must be playable; browsing their slug resolves to tracks
+        # (see test_browse_feed_returns_tracks and the existing wishlist browse tests).
+        assert all(f.is_playable for f in folders)
+
+
+async def test_browse_feed_returns_tracks(provider: BandcampProvider) -> None:
+    """Test browsing the feed slug resolves to the feed tracks (the play path for the folder)."""
+    feed_track = Mock()
+    with patch.object(provider, "_get_feed_tracks", new_callable=AsyncMock) as mock_feed:
+        mock_feed.return_value = [feed_track]
+
+        result = await provider.browse("bandcamp_test://feed")
+
+        assert result == [feed_track]
 
 
 async def test_recommendations_no_identity(provider: BandcampProvider) -> None:


### PR DESCRIPTION
# What does this implement/fix?

This commit flips both of these virtual folders to be `is_playable=True`, and adds the explicit item slug handling to allow `feed` to play; `wishlist` was already implemented (but not enabled), so I followed the same pattern.

New tests cover the behavior, and manually verified.

**Related issue (if applicable):**

None.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
