### PR TITLE
Adapt methods for audiobook collections support

### DIFF
--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -271,14 +271,15 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         # The query gives distinct titles, and a provider mappings column to ensure user filtering
         query = """
             SELECT distinct json_extract(metadata_iter.value, '$.title') AS title, pm as provider_mappings FROM (
-                SELECT pm, json_extract("metadata", "$.collections") as md FROM(
-                    SELECT
-                        * from audiobooks,
-                        (SELECT JSON_GROUP_ARRAY(
+                SELECT pm, json_extract("metadata", "$.collections") as md FROM (
+                    SELECT * from audiobooks, (
+                        SELECT JSON_GROUP_ARRAY(
                             json_object(
                                     'provider_instance', audiobook_pm.provider_instance
                             )
-                        )as pm FROM provider_mappings audiobook_pm WHERE audiobook_pm.item_id = item_id AND audiobook_pm.media_type = 'audiobook') AS provider_mappings
+                        ) as pm FROM provider_mappings audiobook_pm WHERE audiobook_pm.item_id = item_id
+                                                                    AND audiobook_pm.media_type = 'audiobook'
+                    ) AS provider_mappings
                  )
             ), json_each(md) as metadata_iter
         """
@@ -313,12 +314,14 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
     async def get_collection(self, title: str, search: str | None = None) -> AudiobookCollection:
         """Get a single, sorted collection."""
         # The query yields all possible item_ids
-        query = f"""
-        SELECT item_id FROM (
-            SELECT * FROM audiobooks WHERE json_extract(audiobooks.metadata, '$.collections') IS NOT NULL AND json_extract(audiobooks.metadata, '$.collections') != '[]'
-            ),
-        json_each(json_extract("metadata", "$.collections")) WHERE json_extract(json_each.value, '$.title') = '{title}'
-        """
+        query = (
+            "SELECT item_id FROM ("
+            "   SELECT * FROM audiobooks WHERE "
+            '       json_extract(audiobooks.metadata, "$.collections") IS NOT NULL AND '
+            '       json_extract(audiobooks.metadata, "$.collections") != "[]" '
+            '), json_each(json_extract("metadata", "$.collections")) WHERE '
+            f'json_extract(json_each.value, "$.title") = "{title}"'
+        )
         rows = await self.mass.music.database.get_rows_from_query(query, params={"title": title})
         item_ids: list[int] = []
         for row in rows:

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.enums import MediaType, ProviderFeature
-from music_assistant_models.media_items import Audiobook, ProviderMapping, UniqueList
+from music_assistant_models.enums import BrowseFolderType, MediaType, ProviderFeature
+from music_assistant_models.media_items import Audiobook, BrowseFolder, ProviderMapping, UniqueList
 from music_assistant_models.media_items.helpers import AudiobookCollection
 
 from music_assistant.constants import DB_TABLE_AUDIOBOOKS, DB_TABLE_PLAYLOG
@@ -45,6 +46,10 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         api_base = self.api_base
         self.mass.register_api_command(f"music/{api_base}/audiobook_versions", self.versions)
         self.mass.register_api_command(f"music/{api_base}/collections", self.collections)
+        self.mass.register_api_command(f"music/{api_base}/get_collection", self.get_collection)
+        self.mass.register_api_command(
+            f"music/{api_base}/collection_folders", self.collection_folders
+        )
 
     @property
     def base_query(self) -> tuple[str, dict[str, Any]]:
@@ -259,6 +264,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                 "AND json_extract(audiobooks.metadata, '$.collections') != '[]'",
             ],
         )
+
         for audiobook in audiobooks_with_collections:
             if audiobook.metadata.collections is None:
                 # this should never happen
@@ -294,6 +300,63 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             result.append(AudiobookCollection(title=collection_title, audiobooks=final_list))
 
         return result
+
+    async def collection_folders(self, search: str | None = None) -> Sequence[BrowseFolder]:
+        """Get BrowseFolder with collections."""
+        query = """
+            SELECT distinct json_extract(metadata_outer.value, '$.title') AS title FROM (
+                SELECT json_extract("metadata", "$.collections") as metadata FROM(
+                    SELECT * FROM audiobooks WHERE json_extract(audiobooks.metadata, '$.collections') IS NOT NULL AND json_extract(audiobooks.metadata, '$.collections') != '[]'
+                )
+            ), json_each(metadata) as metadata_outer
+            """
+        folders: list[BrowseFolder] = []
+        rows = await self.mass.music.database.get_rows_from_query(query)
+        for row in rows:
+            folders.append(
+                BrowseFolder(
+                    item_id=row["title"],
+                    provider="",
+                    name=row["title"],
+                    folder_type=BrowseFolderType.AUDIOBOOK_COLLECTION,
+                )
+            )
+        if search is not None:
+            return [folder for folder in folders if search.lower() in folder.name.lower()]
+        return folders
+
+    async def get_collection(self, title: str, search: str | None = None) -> Sequence[Audiobook]:
+        """Get a single, sorted collection."""
+        # The query yields all possible item_ids
+        query = f"""
+        SELECT item_id FROM (
+            SELECT * FROM audiobooks WHERE json_extract(audiobooks.metadata, '$.collections') IS NOT NULL AND json_extract(audiobooks.metadata, '$.collections') != '[]'
+            ),
+        json_each(json_extract("metadata", "$.collections")) WHERE json_extract(json_each.value, '$.title') = '{title}'
+        """
+        rows = await self.mass.music.database.get_rows_from_query(query, params={"title": title})
+        item_ids: list[int] = []
+        for row in rows:
+            item_ids.append(int(row["item_id"]))
+
+        books: list[Audiobook] = []
+        extra_query = f"WHERE {self.db_table}.item_id in {tuple(item_ids)}"
+        # the standard query yields the full item, and ensures the provider filter
+        for db_item in await self.get_library_items_by_query(
+            extra_query_parts=[extra_query],
+            extra_query_params={"item_ids": item_ids},
+            in_library_only=True,
+        ):
+            books.append(db_item)
+
+        collections = self._sort_collections(books)
+        audiobooks: list[Audiobook] = []
+        for collection in collections:
+            if collection.title == title:
+                audiobooks = collection.audiobooks
+        if search:
+            return [book for book in audiobooks if search.lower() in book.name.lower()]
+        return audiobooks
 
     async def _add_library_item(self, item: Audiobook, overwrite_existing: bool = False) -> int:
         """Add a new record to the database."""
@@ -441,3 +504,42 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                 },
                 allow_replace=True,
             )
+
+    def _sort_collections(self, audiobooks: Sequence[Audiobook]) -> list[AudiobookCollection]:
+        """Get all present sorted collections in audiobooks."""
+        collections_dict: dict[str, list[Audiobook]] = {}
+        for audiobook in audiobooks:
+            if audiobook.metadata.collections is None:
+                # this should never happen
+                continue
+            for collection_info in audiobook.metadata.collections:
+                audiobook_list = collections_dict.get(collection_info.title, [])
+                audiobook_list.append(audiobook)
+                collections_dict[collection_info.title] = audiobook_list
+
+        result: list[AudiobookCollection] = []
+        # Sort collections, first by number then alphabetically
+        for collection_title, audiobook_list in collections_dict.items():
+            audiobooks_with_number: list[tuple[Audiobook, float]] = []
+            audiobooks_with_string: list[tuple[Audiobook, str]] = []
+            audiobooks_with_none: list[Audiobook] = []
+            for audiobook in audiobook_list:
+                assert audiobook.metadata.collections is not None  # for type checking
+                collection_info = next(
+                    x for x in audiobook.metadata.collections if x.title == collection_title
+                )
+                if collection_info.sequence is None:
+                    audiobooks_with_none.append(audiobook)
+                    continue
+                try:
+                    sort_by = float(collection_info.sequence)
+                    audiobooks_with_number.append((audiobook, sort_by))
+                except ValueError:
+                    audiobooks_with_string.append((audiobook, str(collection_info.sequence)))
+            final_list = [x[0] for x in sorted(audiobooks_with_number, key=lambda x: x[1])]
+            final_list.extend([x[0] for x in sorted(audiobooks_with_string, key=lambda x: x[1])])
+            final_list.extend(audiobooks_with_none)
+
+            result.append(AudiobookCollection(title=collection_title, audiobooks=final_list))
+
+        return result

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -257,7 +257,6 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
     ) -> list[AudiobookCollection]:
         """Get all available audiobook collections."""
         # key is the collections' title
-        collections_dict: dict[str, list[Audiobook]] = {}
         audiobooks_with_collections = await self.get_library_items_by_query(
             extra_query_parts=[
                 "WHERE json_extract(audiobooks.metadata, '$.collections') IS NOT NULL "
@@ -265,67 +264,53 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             ],
         )
 
-        for audiobook in audiobooks_with_collections:
-            if audiobook.metadata.collections is None:
-                # this should never happen
-                continue
-            for collection_info in audiobook.metadata.collections:
-                audiobook_list = collections_dict.get(collection_info.title, [])
-                audiobook_list.append(audiobook)
-                collections_dict[collection_info.title] = audiobook_list
-
-        result: list[AudiobookCollection] = []
-        # Sort collections, first by number then alphabetically
-        for collection_title, audiobook_list in collections_dict.items():
-            audiobooks_with_number: list[tuple[Audiobook, float]] = []
-            audiobooks_with_string: list[tuple[Audiobook, str]] = []
-            audiobooks_with_none: list[Audiobook] = []
-            for audiobook in audiobook_list:
-                assert audiobook.metadata.collections is not None  # for type checking
-                collection_info = next(
-                    x for x in audiobook.metadata.collections if x.title == collection_title
-                )
-                if collection_info.sequence is None:
-                    audiobooks_with_none.append(audiobook)
-                    continue
-                try:
-                    sort_by = float(collection_info.sequence)
-                    audiobooks_with_number.append((audiobook, sort_by))
-                except ValueError:
-                    audiobooks_with_string.append((audiobook, str(collection_info.sequence)))
-            final_list = [x[0] for x in sorted(audiobooks_with_number, key=lambda x: x[1])]
-            final_list.extend([x[0] for x in sorted(audiobooks_with_string, key=lambda x: x[1])])
-            final_list.extend(audiobooks_with_none)
-
-            result.append(AudiobookCollection(title=collection_title, audiobooks=final_list))
-
-        return result
+        return self._sort_collections(audiobooks_with_collections)
 
     async def collection_folders(self, search: str | None = None) -> Sequence[BrowseFolder]:
         """Get BrowseFolder with collections."""
+        # The query gives distinct titles, and a provider mappings column to ensure user filtering
         query = """
-            SELECT distinct json_extract(metadata_outer.value, '$.title') AS title FROM (
-                SELECT json_extract("metadata", "$.collections") as metadata FROM(
-                    SELECT * FROM audiobooks WHERE json_extract(audiobooks.metadata, '$.collections') IS NOT NULL AND json_extract(audiobooks.metadata, '$.collections') != '[]'
-                )
-            ), json_each(metadata) as metadata_outer
-            """
-        folders: list[BrowseFolder] = []
+            SELECT distinct json_extract(metadata_iter.value, '$.title') AS title, pm as provider_mappings FROM (
+                SELECT pm, json_extract("metadata", "$.collections") as md FROM(
+                    SELECT
+                        * from audiobooks,
+                        (SELECT JSON_GROUP_ARRAY(
+                            json_object(
+                                    'provider_instance', audiobook_pm.provider_instance
+                            )
+                        )as pm FROM provider_mappings audiobook_pm WHERE audiobook_pm.item_id = item_id AND audiobook_pm.media_type = 'audiobook') AS provider_mappings
+                 )
+            ), json_each(md) as metadata_iter
+        """
         rows = await self.mass.music.database.get_rows_from_query(query)
+        titles: list[str] = []
+        provider_mapping_dict: dict[str, str]
+        # ensure provider filter if present
         for row in rows:
-            folders.append(
-                BrowseFolder(
-                    item_id=row["title"],
-                    provider="",
-                    name=row["title"],
-                    folder_type=BrowseFolderType.AUDIOBOOK_COLLECTION,
-                )
+            if (user := get_current_user()) and user.provider_filter:
+                for provider_mapping_dict in row["provider_mappings"]:
+                    if provider_mapping_dict.get("provider_instance") in user.provider_filter:
+                        titles.append(row["title"])
+                        break
+                continue
+            # no provider filter
+            titles.append(row["title"])
+
+        folders = [
+            BrowseFolder(
+                item_id=title,
+                provider="",
+                name=title,
+                folder_type=BrowseFolderType.AUDIOBOOK_COLLECTION,
             )
+            for title in titles
+        ]
+
         if search is not None:
             return [folder for folder in folders if search.lower() in folder.name.lower()]
         return folders
 
-    async def get_collection(self, title: str, search: str | None = None) -> Sequence[Audiobook]:
+    async def get_collection(self, title: str, search: str | None = None) -> AudiobookCollection:
         """Get a single, sorted collection."""
         # The query yields all possible item_ids
         query = f"""
@@ -340,8 +325,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             item_ids.append(int(row["item_id"]))
 
         books: list[Audiobook] = []
-        extra_query = f"WHERE {self.db_table}.item_id in {tuple(item_ids)}"
-        # the standard query yields the full item, and ensures the provider filter
+        extra_query = f"WHERE {self.db_table}.item_id in ({', '.join(str(x) for x in item_ids)})"
         for db_item in await self.get_library_items_by_query(
             extra_query_parts=[extra_query],
             extra_query_params={"item_ids": item_ids},
@@ -349,14 +333,21 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         ):
             books.append(db_item)
 
+        # ensure provider filter
+        if (user := get_current_user()) and user.provider_filter:
+            for book in books:
+                for pm in book.provider_mappings:
+                    if pm.provider_instance not in user.provider_filter:
+                        books.remove(book)
+
         collections = self._sort_collections(books)
         audiobooks: list[Audiobook] = []
         for collection in collections:
             if collection.title == title:
                 audiobooks = collection.audiobooks
         if search:
-            return [book for book in audiobooks if search.lower() in book.name.lower()]
-        return audiobooks
+            audiobooks = [book for book in audiobooks if search.lower() in book.name.lower()]
+        return AudiobookCollection(title=title, audiobooks=audiobooks)
 
     async def _add_library_item(self, item: Audiobook, overwrite_existing: bool = False) -> int:
         """Add a new record to the database."""


### PR DESCRIPTION
# What does this implement/fix?

Adds additional methods for audiobook collections. I tried to move more logic into sql queries to make it faster too. The frontend does not use the collections method, only the other two. 

Frontend PR: https://github.com/music-assistant/frontend/pull/1941
Models PR: https://github.com/music-assistant/models/pull/267

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
