### PR TITLE
Fix Party URL when webserver URL has trailing /

### DIFF
--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -514,7 +514,7 @@ class PartyPlugin(PluginProvider):
             )
 
         base_url = self.mass.webserver.base_url
-        assert base_url, "webserver base_url is not configured"
+        assert base_url  # for type-checker only
         return f"{base_url}/?join={code}"
 
     async def get_party_player(self) -> str | None:

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -514,9 +514,8 @@ class PartyPlugin(PluginProvider):
                 f"https://app.music-assistant.io/?remote_id={remote_access.remote_id}&join={code}"
             )
 
-        base_url_value = self.mass.webserver.config.get_value("base_url")
-        base_url = str(base_url_value) if base_url_value else f"http://localhost:{DEFAULT_PORT}"
-        return f"{base_url.rstrip('/')}/?join={code}"
+        base_url = self.mass.webserver.base_url or f"http://localhost:{DEFAULT_PORT}"
+        return f"{base_url}/?join={code}"
 
     async def get_party_player(self) -> str | None:
         """

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -24,7 +24,6 @@ from music_assistant_models.enums import ConfigEntryType, MediaType, PlaybackSta
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.queue_item import QueueItem
 
-from music_assistant.constants import DEFAULT_PORT
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.models.plugin import PluginProvider
 
@@ -514,7 +513,8 @@ class PartyPlugin(PluginProvider):
                 f"https://app.music-assistant.io/?remote_id={remote_access.remote_id}&join={code}"
             )
 
-        base_url = self.mass.webserver.base_url or f"http://localhost:{DEFAULT_PORT}"
+        base_url = self.mass.webserver.base_url
+        assert base_url, "webserver base_url is not configured"
         return f"{base_url}/?join={code}"
 
     async def get_party_player(self) -> str | None:

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -516,7 +516,7 @@ class PartyPlugin(PluginProvider):
 
         base_url_value = self.mass.webserver.config.get_value("base_url")
         base_url = str(base_url_value) if base_url_value else f"http://localhost:{DEFAULT_PORT}"
-        return f"{base_url}/?join={code}"
+        return f"{base_url.rstrip('/')}/?join={code}"
 
     async def get_party_player(self) -> str | None:
         """


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Stripping any trailing slash from base_url before appending /?join=... prevents the // when the configured webserver URL already ends in /.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5710

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
