### PR TITLE
mcp: add add_to_queue tool

### DIFF
--- a/music_assistant/providers/fastmcp_server/config.py
+++ b/music_assistant/providers/fastmcp_server/config.py
@@ -213,7 +213,7 @@ def build_config_entries(
             "Edit queue",
             False,
             "edit_permissions",
-            "Move queue items, save queue as playlist.",
+            "Enqueue media, move queue items, save queue as playlist.",
         ),
         _bool(
             CONF_EDIT_PLAYLISTS,

--- a/music_assistant/providers/fastmcp_server/models.py
+++ b/music_assistant/providers/fastmcp_server/models.py
@@ -113,6 +113,16 @@ class QueueBrief:
 
 
 @dataclass
+class AddToQueueResult:
+    """Confirmation of a successful ``add_to_queue`` call."""
+
+    item_id: str
+    uri: str
+    name: str
+    option: str
+
+
+@dataclass
 class RecommendationFolderBrief:
     """One curated recommendation folder (e.g. "Mood: Focus") with its track URIs."""
 

--- a/music_assistant/providers/fastmcp_server/server.py
+++ b/music_assistant/providers/fastmcp_server/server.py
@@ -143,9 +143,15 @@ class MCPServerRuntime:
         )
 
         require_confirmation = bool(self._config.get_value(CONF_REQUIRE_CONFIRMATION) or False)
+        from .tags import Tag  # noqa: PLC0415
+
         mcp.mount(build_library_server(self._mass), namespace="library")
         mcp.mount(
-            build_queue_server(self._mass, require_confirmation=require_confirmation),
+            build_queue_server(
+                self._mass,
+                require_confirmation=require_confirmation,
+                delete_queue_enabled=Tag.DELETE_QUEUE in enabled_tags(self._config),
+            ),
             namespace="queue",
         )
         mcp.mount(build_playback_server(self._mass), namespace="playback")

--- a/music_assistant/providers/fastmcp_server/tools/_common.py
+++ b/music_assistant/providers/fastmcp_server/tools/_common.py
@@ -357,11 +357,13 @@ def resolve_added_queue_item(
     :param uri: URI passed to ``add_to_queue``.
     :param before_item_ids: ``queue_item_id`` values present before the add.
     """
-    matches = [it for it in items if queue_item_uri(it) == uri]
     new_items = [it for it in items if str(getattr(it, "queue_item_id", "")) not in before_item_ids]
     if new_items:
-        return new_items[-1]
-    return matches[-1] if matches else None
+        return new_items[0]
+    matches = [it for it in items if queue_item_uri(it) == uri]
+    if matches:
+        return matches[-1]
+    return None
 
 
 # ── private helpers ──────────────────────────────────────────────────────────

--- a/music_assistant/providers/fastmcp_server/tools/_common.py
+++ b/music_assistant/providers/fastmcp_server/tools/_common.py
@@ -358,14 +358,10 @@ def resolve_added_queue_item(
     :param before_item_ids: ``queue_item_id`` values present before the add.
     """
     matches = [it for it in items if queue_item_uri(it) == uri]
-    if not matches:
-        return None
-    new_matches = [
-        it for it in matches if str(getattr(it, "queue_item_id", "")) not in before_item_ids
-    ]
-    if new_matches:
-        return new_matches[-1]
-    return matches[-1]
+    new_items = [it for it in items if str(getattr(it, "queue_item_id", "")) not in before_item_ids]
+    if new_items:
+        return new_items[-1]
+    return matches[-1] if matches else None
 
 
 # ── private helpers ──────────────────────────────────────────────────────────

--- a/music_assistant/providers/fastmcp_server/tools/_common.py
+++ b/music_assistant/providers/fastmcp_server/tools/_common.py
@@ -311,6 +311,63 @@ def to_brief_queue(queue: Any, items: Sequence[Any] | None = None) -> QueueBrief
     )
 
 
+def queue_item_uri(item: Any) -> str:
+    """
+    Return the media URI for a queue row, if present.
+
+    :param item: queue item object from ``player_queues.items``.
+    """
+    uri = getattr(item, "uri", None)
+    if uri:
+        return str(uri)
+    media_item = getattr(item, "media_item", None)
+    if media_item is not None:
+        media_uri = getattr(media_item, "uri", None)
+        if media_uri:
+            return str(media_uri)
+    return ""
+
+
+def queue_item_display_name(item: Any) -> str:
+    """
+    Return the display title for a queue row.
+
+    :param item: queue item object from ``player_queues.items``.
+    """
+    now_playing = _external_now_playing(item)
+    if now_playing and now_playing.title:
+        return now_playing.title
+    return str(getattr(item, "name", ""))
+
+
+def resolve_added_queue_item(
+    items: Sequence[Any],
+    uri: str,
+    *,
+    before_item_ids: frozenset[str],
+) -> Any | None:
+    """
+    Locate the queue row created by the most recent ``add_to_queue`` call.
+
+    Prefers rows whose ``queue_item_id`` was not present before the add.
+    Falls back to the last row matching ``uri`` when ids cannot be
+    distinguished (e.g. after ``replace``).
+
+    :param items: queue items after the add.
+    :param uri: URI passed to ``add_to_queue``.
+    :param before_item_ids: ``queue_item_id`` values present before the add.
+    """
+    matches = [it for it in items if queue_item_uri(it) == uri]
+    if not matches:
+        return None
+    new_matches = [
+        it for it in matches if str(getattr(it, "queue_item_id", "")) not in before_item_ids
+    ]
+    if new_matches:
+        return new_matches[-1]
+    return matches[-1]
+
+
 # ── private helpers ──────────────────────────────────────────────────────────
 
 

--- a/music_assistant/providers/fastmcp_server/tools/queue.py
+++ b/music_assistant/providers/fastmcp_server/tools/queue.py
@@ -29,7 +29,25 @@ if TYPE_CHECKING:
 MAX_QUEUE_ITEMS = 500
 
 
-def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = True) -> FastMCP:
+def _queue_items_window_offset(queue: object | None, queue_option: QueueOption) -> int:
+    """Return the ``items()`` offset for locating newly added rows in long queues."""
+    if queue is None:
+        return 0
+    total = int(getattr(queue, "items", 0) or 0)
+    current_index = int(getattr(queue, "current_index", 0) or 0)
+    if queue_option is QueueOption.ADD:
+        return max(0, total - MAX_QUEUE_ITEMS)
+    if queue_option is QueueOption.REPLACE:
+        return 0
+    return max(0, current_index)
+
+
+def build_queue_server(
+    mass: MusicAssistant,
+    *,
+    require_confirmation: bool = True,
+    delete_queue_enabled: bool = True,
+) -> FastMCP:
     """Construct the ``queue/*`` sub-server."""
     sub: FastMCP = FastMCP(name="queue")
 
@@ -152,7 +170,7 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
         annotations=ToolAnnotations(
             title="Add media to queue",
             readOnlyHint=False,
-            destructiveHint=False,
+            destructiveHint=True,
             idempotentHint=False,
             openWorldHint=False,
         ),
@@ -196,10 +214,21 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
             valid = ", ".join(f"``{e.value}``" for e in QueueOption if e is not QueueOption.UNKNOWN)
             raise ToolError(f"Invalid option {option!r}. Valid options: {valid}")
 
-        before_items = mass.player_queues.items(queue_id, limit=MAX_QUEUE_ITEMS)
+        if (
+            queue_option in {QueueOption.REPLACE, QueueOption.REPLACE_NEXT}
+            and not delete_queue_enabled
+        ):
+            raise ToolError(
+                "Option requires delete:queue permission "
+                "(``replace`` and ``replace_next`` clear queue items)."
+            )
+
+        queue = mass.player_queues.get(queue_id)
+        offset = _queue_items_window_offset(queue, queue_option)
+        before_items = mass.player_queues.items(queue_id, limit=MAX_QUEUE_ITEMS, offset=offset)
         before_item_ids = frozenset(str(getattr(it, "queue_item_id", "")) for it in before_items)
         await mass.player_queues.play_media(queue_id, uri, option=queue_option)
-        after_items = mass.player_queues.items(queue_id, limit=MAX_QUEUE_ITEMS)
+        after_items = mass.player_queues.items(queue_id, limit=MAX_QUEUE_ITEMS, offset=offset)
         added = resolve_added_queue_item(after_items, uri, before_item_ids=before_item_ids)
         if added is None:
             raise ToolError(

--- a/music_assistant/providers/fastmcp_server/tools/queue.py
+++ b/music_assistant/providers/fastmcp_server/tools/queue.py
@@ -170,12 +170,8 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
         :param queue_id: Queue identifier from ``QueueBrief.queue_id`` (distinct
             from ``PlayerBrief.player_id``).
         :param uri: Music Assistant URI of the media to add, of the form
-            ``<provider>://<media_type>/<id>``. Accepts track, album, artist,
-            and playlist URIs (e.g. ``TrackBrief.uri``, ``AlbumBrief.uri``,
-            ``ArtistBrief.uri``, ``PlaylistBrief.uri``). An **artist** URI
-            enqueues the artist's full discography; an **album** URI enqueues
-            all album tracks. Use ``library_search_*`` or ``library_get_*_by_uri``
-            to resolve URIs first.
+            ``<provider>://<media_type>/<id>`` (e.g. as found on
+            ``TrackBrief.uri`` / ``AlbumBrief.uri`` / ``PlaylistBrief.uri``).
         :param option: Enqueue mode controlling placement and playback:
 
             - ``add`` (default): Append to the end of the queue without

--- a/music_assistant/providers/fastmcp_server/tools/queue.py
+++ b/music_assistant/providers/fastmcp_server/tools/queue.py
@@ -170,11 +170,18 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
         :param queue_id: Queue identifier from ``QueueBrief.queue_id`` (distinct
             from ``PlayerBrief.player_id``).
         :param uri: Music Assistant URI of the media to add, of the form
-            ``<provider>://<media_type>/<id>`` (e.g. as found on
-            ``TrackBrief.uri`` / ``AlbumBrief.uri`` / ``PlaylistBrief.uri``).
+            ``<provider>://<media_type>/<id>``. Accepts track, album, artist,
+            and playlist URIs (e.g. ``TrackBrief.uri``, ``AlbumBrief.uri``,
+            ``ArtistBrief.uri``, ``PlaylistBrief.uri``). An **artist** URI
+            enqueues the artist's full discography; an **album** URI enqueues
+            all album tracks. Use ``library_search_*`` or ``library_get_*_by_uri``
+            to resolve URIs first.
         :param option: Enqueue mode controlling placement and playback:
 
-            - ``add`` (default): Append to the end of the queue.
+            - ``add`` (default): Append to the end of the queue without
+              interrupting the current item. Preferred for "add to queue"
+              requests — unlike ``playback_play_media``, this keeps what is
+              already playing.
             - ``next``: Insert after the currently playing item (plays next).
             - ``play``: Insert after current item and start playing immediately.
             - ``replace_next``: Replace all items after the current one.

--- a/music_assistant/providers/fastmcp_server/tools/queue.py
+++ b/music_assistant/providers/fastmcp_server/tools/queue.py
@@ -10,13 +10,15 @@ from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from music_assistant_models.enums import QueueOption
 
-from ..models import QueueBrief
+from ..models import AddToQueueResult, QueueBrief
 from ..tags import Tag
 from ._common import (
     TIMEOUT_FAST,
     TIMEOUT_MUTATION,
     TIMEOUT_QUERY,
     confirm_or_raise,
+    queue_item_display_name,
+    resolve_added_queue_item,
     to_brief_queue,
 )
 
@@ -160,12 +162,16 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
         queue_id: str,
         uri: str,
         option: str = "add",
-    ) -> None:
+    ) -> AddToQueueResult:
         """
         Enqueue media on a queue with an explicit placement mode.
 
         Supports different enqueue modes to control where items are placed
         and whether playback is affected.
+
+        Returns ``AddToQueueResult`` with the new row's ``item_id``, ``uri``,
+        ``name``, and ``option`` so callers can confirm the add succeeded
+        before enqueueing the next item.
 
         :param queue_id: Queue identifier from ``QueueBrief.queue_id`` (distinct
             from ``PlayerBrief.player_id``).
@@ -190,6 +196,20 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
             valid = ", ".join(f"``{e.value}``" for e in QueueOption if e is not QueueOption.UNKNOWN)
             raise ToolError(f"Invalid option {option!r}. Valid options: {valid}")
 
+        before_items = mass.player_queues.items(queue_id, limit=MAX_QUEUE_ITEMS)
+        before_item_ids = frozenset(str(getattr(it, "queue_item_id", "")) for it in before_items)
         await mass.player_queues.play_media(queue_id, uri, option=queue_option)
+        after_items = mass.player_queues.items(queue_id, limit=MAX_QUEUE_ITEMS)
+        added = resolve_added_queue_item(after_items, uri, before_item_ids=before_item_ids)
+        if added is None:
+            raise ToolError(
+                f"Added {uri!r} to queue {queue_id!r} but could not locate the new queue row."
+            )
+        return AddToQueueResult(
+            item_id=str(getattr(added, "queue_item_id", "")),
+            uri=uri,
+            name=queue_item_display_name(added),
+            option=option,
+        )
 
     return sub

--- a/music_assistant/providers/fastmcp_server/tools/queue.py
+++ b/music_assistant/providers/fastmcp_server/tools/queue.py
@@ -180,11 +180,12 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
             - ``replace_next``: Replace all items after the current one.
             - ``replace``: Clear the queue and replace with the new media.
         """
-        try:
-            queue_option = QueueOption(option)
-        except ValueError as exc:
-            valid = ", ".join(f"``{e.value}``" for e in QueueOption)
-            raise ToolError(f"Invalid option {option!r}. Valid options: {valid}") from exc
+        # QueueOption._missing_ silently falls back to UNKNOWN for invalid values
+        # instead of raising ValueError, so we must validate explicitly.
+        queue_option = QueueOption(option)
+        if queue_option is QueueOption.UNKNOWN:
+            valid = ", ".join(f"``{e.value}``" for e in QueueOption if e is not QueueOption.UNKNOWN)
+            raise ToolError(f"Invalid option {option!r}. Valid options: {valid}")
 
         await mass.player_queues.play_media(queue_id, uri, option=queue_option)
 

--- a/music_assistant/providers/fastmcp_server/tools/queue.py
+++ b/music_assistant/providers/fastmcp_server/tools/queue.py
@@ -6,11 +6,19 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
+from music_assistant_models.enums import QueueOption
 
 from ..models import QueueBrief
 from ..tags import Tag
-from ._common import TIMEOUT_FAST, TIMEOUT_MUTATION, confirm_or_raise, to_brief_queue
+from ._common import (
+    TIMEOUT_FAST,
+    TIMEOUT_MUTATION,
+    TIMEOUT_QUERY,
+    confirm_or_raise,
+    to_brief_queue,
+)
 
 if TYPE_CHECKING:
     from music_assistant.mass import MusicAssistant
@@ -136,5 +144,48 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
             receive the queue.
         """
         await mass.player_queues.transfer_queue(source_queue_id, target_queue_id)
+
+    @sub.tool(
+        tags={Tag.EDIT_QUEUE},
+        annotations=ToolAnnotations(
+            title="Add media to queue",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+        timeout=TIMEOUT_QUERY,
+    )  # type: ignore[untyped-decorator, unused-ignore]
+    async def add_to_queue(
+        queue_id: str,
+        uri: str,
+        option: str = "add",
+    ) -> None:
+        """
+        Add media item(s) to the queue without replacing the current queue.
+
+        Supports different enqueue modes to control where items are placed
+        and whether playback is affected.
+
+        :param queue_id: Queue identifier from ``QueueBrief.queue_id`` (distinct
+            from ``PlayerBrief.player_id``).
+        :param uri: Music Assistant URI of the media to add, of the form
+            ``<provider>://<media_type>/<id>`` (e.g. as found on
+            ``TrackBrief.uri`` / ``AlbumBrief.uri`` / ``PlaylistBrief.uri``).
+        :param option: Enqueue mode controlling placement and playback:
+
+            - ``add`` (default): Append to the end of the queue.
+            - ``next``: Insert after the currently playing item (plays next).
+            - ``play``: Insert after current item and start playing immediately.
+            - ``replace_next``: Replace all items after the current one.
+            - ``replace``: Clear the queue and replace with the new media.
+        """
+        try:
+            queue_option = QueueOption(option)
+        except ValueError as exc:
+            valid = ", ".join(f"``{e.value}``" for e in QueueOption)
+            raise ToolError(f"Invalid option {option!r}. Valid options: {valid}") from exc
+
+        await mass.player_queues.play_media(queue_id, uri, option=queue_option)
 
     return sub

--- a/music_assistant/providers/fastmcp_server/tools/queue.py
+++ b/music_assistant/providers/fastmcp_server/tools/queue.py
@@ -50,7 +50,7 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
         ``item_count``, shuffle / repeat flags, ``available`` and up to
         ``include_items`` lookahead ``items``. Note that
         ``QueueBrief.queue_id`` is the identifier the mutation tools
-        (``set_shuffle``, ``clear_queue``, ``transfer_queue``) expect — it is
+        (``set_shuffle``, ``add_to_queue``, ``clear_queue``, ``transfer_queue``) expect — it is
         distinct from ``player_id``. For a queue fed by an external plugin
         source (Connect / AirPlay / Ynison), the current item's ``name`` is
         the real track title rather than the source wrapper name.
@@ -162,7 +162,7 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
         option: str = "add",
     ) -> None:
         """
-        Add media item(s) to the queue without replacing the current queue.
+        Enqueue media on a queue with an explicit placement mode.
 
         Supports different enqueue modes to control where items are placed
         and whether playback is affected.

--- a/tests/providers/fastmcp_server/test_add_to_queue.py
+++ b/tests/providers/fastmcp_server/test_add_to_queue.py
@@ -37,7 +37,7 @@ async def test_add_to_queue_accepts_valid_options(
             await client.call_tool(
                 "queue_add_to_queue", {"queue_id": "q1", "uri": "spotify://track/1", "option": opt}
             )
-        mock_mass.player_queues.play_media.assert_called_once_with(
+        mock_mass.player_queues.play_media.assert_awaited_once_with(
             "q1", "spotify://track/1", option=QueueOption(opt)
         )
 
@@ -60,6 +60,6 @@ async def test_add_to_queue_defaults_to_add(mounted_queue: FastMCP, mock_mass: M
     mock_mass.player_queues.play_media.reset_mock()
     async with Client(mounted_queue) as client:
         await client.call_tool("queue_add_to_queue", {"queue_id": "q1", "uri": "spotify://track/1"})
-    mock_mass.player_queues.play_media.assert_called_once_with(
+    mock_mass.player_queues.play_media.assert_awaited_once_with(
         "q1", "spotify://track/1", option=QueueOption.ADD
     )

--- a/tests/providers/fastmcp_server/test_add_to_queue.py
+++ b/tests/providers/fastmcp_server/test_add_to_queue.py
@@ -1,0 +1,62 @@
+"""
+Tests for the add_to_queue MCP tool.
+
+Validates that:
+1. Valid option values (add/next/play/replace/replace_next) are accepted and forwarded to MA.
+2. Invalid option values raise a clean ToolError.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+from music_assistant_models.enums import QueueOption
+
+from music_assistant.providers.fastmcp_server.tools.queue import build_queue_server
+
+
+@pytest.fixture
+def mounted_queue(mock_mass: Any) -> FastMCP:
+    """Build a root FastMCP with the queue sub-server mounted."""
+    mcp: FastMCP = FastMCP(name="test")
+    mcp.mount(build_queue_server(mock_mass), namespace="queue")
+    return mcp
+
+
+async def test_add_to_queue_accepts_valid_options(
+    mounted_queue: FastMCP, mock_mass: MagicMock
+) -> None:
+    """Each valid option value is accepted and forwarded to MA."""
+    for opt in ("add", "next", "play", "replace", "replace_next"):
+        mock_mass.player_queues.play_media.reset_mock()
+        async with Client(mounted_queue) as client:
+            await client.call_tool(
+                "queue_add_to_queue", {"queue_id": "q1", "uri": "spotify://track/1", "option": opt}
+            )
+        mock_mass.player_queues.play_media.assert_called_once_with(
+            "q1", "spotify://track/1", option=QueueOption(opt)
+        )
+
+
+async def test_add_to_queue_rejects_invalid_option(mounted_queue: FastMCP) -> None:
+    """Invalid option raises ToolError with the list of valid options."""
+    async with Client(mounted_queue) as client:
+        with pytest.raises(ToolError, match="bogus"):
+            await client.call_tool(
+                "queue_add_to_queue",
+                {"queue_id": "q1", "uri": "spotify://track/1", "option": "bogus"},
+            )
+
+
+async def test_add_to_queue_defaults_to_add(mounted_queue: FastMCP, mock_mass: MagicMock) -> None:
+    """Calling add_to_queue without option defaults to 'add'."""
+    mock_mass.player_queues.play_media.reset_mock()
+    async with Client(mounted_queue) as client:
+        await client.call_tool("queue_add_to_queue", {"queue_id": "q1", "uri": "spotify://track/1"})
+    mock_mass.player_queues.play_media.assert_called_once_with(
+        "q1", "spotify://track/1", option=QueueOption.ADD
+    )

--- a/tests/providers/fastmcp_server/test_add_to_queue.py
+++ b/tests/providers/fastmcp_server/test_add_to_queue.py
@@ -29,6 +29,14 @@ def mounted_queue(mock_mass: Any) -> FastMCP:
     return mcp
 
 
+@pytest.fixture
+def mounted_queue_no_delete(mock_mass: Any) -> FastMCP:
+    """Queue server with delete:queue permission disabled."""
+    mcp: FastMCP = FastMCP(name="test")
+    mcp.mount(build_queue_server(mock_mass, delete_queue_enabled=False), namespace="queue")
+    return mcp
+
+
 def _queue_item(*, item_id: str, uri: str, name: str) -> SimpleNamespace:
     return SimpleNamespace(queue_item_id=item_id, uri=uri, name=name, media_item=None)
 
@@ -126,3 +134,61 @@ async def test_add_to_queue_raises_when_row_not_found(
                 "queue_add_to_queue",
                 {"queue_id": "q1", "uri": "spotify://track/1", "option": "add"},
             )
+
+
+async def test_add_to_queue_finds_album_expanded_track_by_id(
+    mounted_queue: FastMCP, mock_mass: MagicMock
+) -> None:
+    """Album URIs expand to track rows — detection uses id-diff, not input URI."""
+    album_uri = "library://album/42"
+    track_uri = "library://track/99"
+    _mock_items_before_after(
+        mock_mass,
+        before=[_queue_item(item_id="old-1", uri=track_uri, name="Existing")],
+        after=[
+            _queue_item(item_id="old-1", uri=track_uri, name="Existing"),
+            _queue_item(item_id="new-album-track", uri=track_uri, name="From Album"),
+        ],
+    )
+    async with Client(mounted_queue) as client:
+        result = await client.call_tool(
+            "queue_add_to_queue", {"queue_id": "q1", "uri": album_uri, "option": "add"}
+        )
+    assert result.data.item_id == "new-album-track"
+    assert result.data.uri == album_uri
+
+
+async def test_add_to_queue_uses_tail_window_for_long_queues(
+    mounted_queue: FastMCP, mock_mass: MagicMock
+) -> None:
+    """Queues longer than 500 items fetch the tail window to locate appended rows."""
+    uri = "spotify://track/1"
+    mock_mass.player_queues.get = MagicMock(
+        return_value=SimpleNamespace(items=501, current_index=0, queue_id="q1")
+    )
+    mock_mass.player_queues.items = MagicMock(
+        side_effect=[
+            [],
+            [_queue_item(item_id="tail-new", uri=uri, name="Tail Track")],
+        ]
+    )
+    async with Client(mounted_queue) as client:
+        result = await client.call_tool(
+            "queue_add_to_queue", {"queue_id": "q1", "uri": uri, "option": "add"}
+        )
+    assert result.data.item_id == "tail-new"
+    assert mock_mass.player_queues.items.call_args_list[0].kwargs["offset"] == 1
+    assert mock_mass.player_queues.items.call_args_list[1].kwargs["offset"] == 1
+
+
+async def test_add_to_queue_replace_requires_delete_permission(
+    mounted_queue_no_delete: FastMCP,
+) -> None:
+    """Replace and replace_next require delete:queue permission."""
+    async with Client(mounted_queue_no_delete) as client:
+        for opt in ("replace", "replace_next"):
+            with pytest.raises(ToolError, match="delete:queue"):
+                await client.call_tool(
+                    "queue_add_to_queue",
+                    {"queue_id": "q1", "uri": "spotify://track/1", "option": opt},
+                )

--- a/tests/providers/fastmcp_server/test_add_to_queue.py
+++ b/tests/providers/fastmcp_server/test_add_to_queue.py
@@ -123,6 +123,30 @@ async def test_add_to_queue_returns_ack_for_new_row(
     assert result.data.option == "add"
 
 
+async def test_add_to_queue_expanded_album_uri(
+    mounted_queue: FastMCP, mock_mass: MagicMock
+) -> None:
+    """Album URIs expand to track rows; ack uses the first newly added row."""
+    album_uri = "library://album/203"
+    _mock_items_before_after(
+        mock_mass,
+        before=[_queue_item(item_id="playing", uri="library://track/93", name="Adrift")],
+        after=[
+            _queue_item(item_id="playing", uri="library://track/93", name="Adrift"),
+            _queue_item(item_id="stunt-1", uri="library://track/206", name="One Week"),
+            _queue_item(item_id="stunt-2", uri="library://track/207", name="It's All Been Done"),
+        ],
+    )
+    async with Client(mounted_queue) as client:
+        result = await client.call_tool(
+            "queue_add_to_queue", {"queue_id": "q1", "uri": album_uri, "option": "add"}
+        )
+    assert result.data.item_id == "stunt-1"
+    assert result.data.uri == album_uri
+    assert result.data.name == "One Week"
+    assert result.data.option == "add"
+
+
 async def test_add_to_queue_raises_when_row_not_found(
     mounted_queue: FastMCP, mock_mass: MagicMock
 ) -> None:

--- a/tests/providers/fastmcp_server/test_add_to_queue.py
+++ b/tests/providers/fastmcp_server/test_add_to_queue.py
@@ -45,11 +45,14 @@ async def test_add_to_queue_accepts_valid_options(
 async def test_add_to_queue_rejects_invalid_option(mounted_queue: FastMCP) -> None:
     """Invalid option raises ToolError with the list of valid options."""
     async with Client(mounted_queue) as client:
-        with pytest.raises(ToolError, match="bogus"):
+        with pytest.raises(ToolError, match="bogus") as exc_info:
             await client.call_tool(
                 "queue_add_to_queue",
                 {"queue_id": "q1", "uri": "spotify://track/1", "option": "bogus"},
             )
+    msg = str(exc_info.value)
+    assert "``add``" in msg
+    assert "``replace_next``" in msg
 
 
 async def test_add_to_queue_defaults_to_add(mounted_queue: FastMCP, mock_mass: MagicMock) -> None:

--- a/tests/providers/fastmcp_server/test_add_to_queue.py
+++ b/tests/providers/fastmcp_server/test_add_to_queue.py
@@ -4,10 +4,12 @@ Tests for the add_to_queue MCP tool.
 Validates that:
 1. Valid option values (add/next/play/replace/replace_next) are accepted and forwarded to MA.
 2. Invalid option values raise a clean ToolError.
+3. A successful add returns AddToQueueResult with item_id, uri, name, and option.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -27,19 +29,38 @@ def mounted_queue(mock_mass: Any) -> FastMCP:
     return mcp
 
 
+def _queue_item(*, item_id: str, uri: str, name: str) -> SimpleNamespace:
+    return SimpleNamespace(queue_item_id=item_id, uri=uri, name=name, media_item=None)
+
+
+def _mock_items_before_after(
+    mock_mass: MagicMock, *, before: list[SimpleNamespace], after: list[SimpleNamespace]
+) -> None:
+    mock_mass.player_queues.items = MagicMock(side_effect=[before, after])
+
+
 async def test_add_to_queue_accepts_valid_options(
     mounted_queue: FastMCP, mock_mass: MagicMock
 ) -> None:
     """Each valid option value is accepted and forwarded to MA."""
+    uri = "spotify://track/1"
     for opt in ("add", "next", "play", "replace", "replace_next"):
         mock_mass.player_queues.play_media.reset_mock()
+        _mock_items_before_after(
+            mock_mass,
+            before=[],
+            after=[_queue_item(item_id=f"item-{opt}", uri=uri, name="Track One")],
+        )
         async with Client(mounted_queue) as client:
-            await client.call_tool(
-                "queue_add_to_queue", {"queue_id": "q1", "uri": "spotify://track/1", "option": opt}
+            result = await client.call_tool(
+                "queue_add_to_queue", {"queue_id": "q1", "uri": uri, "option": opt}
             )
         mock_mass.player_queues.play_media.assert_awaited_once_with(
-            "q1", "spotify://track/1", option=QueueOption(opt)
+            "q1", uri, option=QueueOption(opt)
         )
+        assert result.data.item_id == f"item-{opt}"
+        assert result.data.uri == uri
+        assert result.data.option == opt
 
 
 async def test_add_to_queue_rejects_invalid_option(mounted_queue: FastMCP) -> None:
@@ -57,9 +78,51 @@ async def test_add_to_queue_rejects_invalid_option(mounted_queue: FastMCP) -> No
 
 async def test_add_to_queue_defaults_to_add(mounted_queue: FastMCP, mock_mass: MagicMock) -> None:
     """Calling add_to_queue without option defaults to 'add'."""
+    uri = "spotify://track/1"
     mock_mass.player_queues.play_media.reset_mock()
-    async with Client(mounted_queue) as client:
-        await client.call_tool("queue_add_to_queue", {"queue_id": "q1", "uri": "spotify://track/1"})
-    mock_mass.player_queues.play_media.assert_awaited_once_with(
-        "q1", "spotify://track/1", option=QueueOption.ADD
+    _mock_items_before_after(
+        mock_mass,
+        before=[],
+        after=[_queue_item(item_id="item-1", uri=uri, name="Track One")],
     )
+    async with Client(mounted_queue) as client:
+        result = await client.call_tool("queue_add_to_queue", {"queue_id": "q1", "uri": uri})
+    mock_mass.player_queues.play_media.assert_awaited_once_with("q1", uri, option=QueueOption.ADD)
+    assert result.data.option == "add"
+    assert result.data.name == "Track One"
+
+
+async def test_add_to_queue_returns_ack_for_new_row(
+    mounted_queue: FastMCP, mock_mass: MagicMock
+) -> None:
+    """Returns the newly added row when the same uri already exists elsewhere."""
+    uri = "library://track/169"
+    _mock_items_before_after(
+        mock_mass,
+        before=[_queue_item(item_id="old-dup", uri=uri, name="If I Had $1000000")],
+        after=[
+            _queue_item(item_id="old-dup", uri=uri, name="If I Had $1000000"),
+            _queue_item(item_id="new-row", uri=uri, name="If I Had $1000000"),
+        ],
+    )
+    async with Client(mounted_queue) as client:
+        result = await client.call_tool(
+            "queue_add_to_queue", {"queue_id": "q1", "uri": uri, "option": "add"}
+        )
+    assert result.data.item_id == "new-row"
+    assert result.data.uri == uri
+    assert result.data.name == "If I Had $1000000"
+    assert result.data.option == "add"
+
+
+async def test_add_to_queue_raises_when_row_not_found(
+    mounted_queue: FastMCP, mock_mass: MagicMock
+) -> None:
+    """Surfaces ToolError when play_media succeeds but the new row cannot be located."""
+    mock_mass.player_queues.items = MagicMock(side_effect=[[], []])
+    async with Client(mounted_queue) as client:
+        with pytest.raises(ToolError, match="could not locate"):
+            await client.call_tool(
+                "queue_add_to_queue",
+                {"queue_id": "q1", "uri": "spotify://track/1", "option": "add"},
+            )

--- a/tests/providers/fastmcp_server/test_annotations.py
+++ b/tests/providers/fastmcp_server/test_annotations.py
@@ -33,6 +33,7 @@ _BUILDERS = [
 
 # Spec-mandated destructive tools per the C5 mapping table.
 _DESTRUCTIVE_NAMES = {
+    "queue_add_to_queue",
     "queue_clear_queue",
     "playlists_remove_tracks",
     "media_remove_from_favorites",


### PR DESCRIPTION
## Summary

Adds `queue_add_to_queue` to the MCP server's `queue/` namespace with explicit enqueue modes (default: append), returning a structured ack identifying the created queue row.

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Changes

- Added `add_to_queue(queue_id, uri, option="add")` tool in `tools/queue.py`
- Supports all `QueueOption` enqueue modes:
  - `add` (default) — append to end of queue
  - `next` — insert after currently playing item
  - `play` — insert and start playing immediately
  - `replace_next` — replace all items after current one
  - `replace` — clear queue and replace with new media
- Invalid option values raise `ToolError` with the list of valid options
- Tagged with `Tag.EDIT_QUEUE` for permission-based visibility
- Returns an `AddToQueueResult` (`item_id`, `uri`, `name`, `option`) identifying the created queue row, so callers can confirm a successful add instead of receiving `null`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

