### PR TITLE
mcp: add set_repeat tool to queue controls

### DIFF
--- a/music_assistant/providers/fastmcp_server/tools/queue.py
+++ b/music_assistant/providers/fastmcp_server/tools/queue.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
+from music_assistant_models.enums import RepeatMode
 
 from ..models import QueueBrief
 from ..tags import Tag
@@ -42,7 +44,8 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
         ``item_count``, shuffle / repeat flags, ``available`` and up to
         ``include_items`` lookahead ``items``. Note that
         ``QueueBrief.queue_id`` is the identifier the mutation tools
-        (``set_shuffle``, ``clear_queue``, ``transfer_queue``) expect — it is
+        (``set_shuffle``, ``set_repeat``, ``clear_queue``, ``transfer_queue``)
+        expect — it is
         distinct from ``player_id``. For a queue fed by an external plugin
         source (Connect / AirPlay / Ynison), the current item's ``name`` is
         the real track title rather than the source wrapper name.
@@ -83,6 +86,40 @@ def build_queue_server(mass: MusicAssistant, *, require_confirmation: bool = Tru
         :param enabled: ``True`` to shuffle, ``False`` to play in queue order.
         """
         await mass.player_queues.set_shuffle(queue_id, enabled)
+
+    @sub.tool(
+        tags={Tag.EDIT_QUEUE},
+        annotations=ToolAnnotations(
+            title="Set queue repeat mode",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+        timeout=TIMEOUT_MUTATION,
+    )  # type: ignore[untyped-decorator, unused-ignore]
+    async def set_repeat(queue_id: str, repeat_mode: str = "off") -> None:
+        """
+        Set the repeat mode for the given queue.
+
+        Setting the current value again is a no-op. Returns nothing.
+
+        :param queue_id: Queue identifier from ``QueueBrief.queue_id`` (distinct
+            from ``PlayerBrief.player_id``).
+        :param repeat_mode: Repeat mode:
+
+            - ``off`` (default): No repeating.
+            - ``one``: Repeat the current track.
+            - ``all``: Repeat the entire queue.
+        """
+        # RepeatMode._missing_ silently falls back to UNKNOWN for invalid values
+        # instead of raising ValueError, so we must validate explicitly.
+        mode = RepeatMode(repeat_mode.lower())
+        if mode is RepeatMode.UNKNOWN:
+            valid = ", ".join(f"``{e.value}``" for e in RepeatMode if e is not RepeatMode.UNKNOWN)
+            raise ToolError(f"Invalid repeat_mode {repeat_mode!r}. Valid options: {valid}")
+
+        mass.player_queues.set_repeat(queue_id, mode)
 
     @sub.tool(
         tags={Tag.DELETE_QUEUE},

--- a/tests/providers/fastmcp_server/conftest.py
+++ b/tests/providers/fastmcp_server/conftest.py
@@ -166,6 +166,7 @@ def mock_mass(mock_user: MagicMock) -> MagicMock:
     mass.player_queues.seek = AsyncMock()
     mass.player_queues.play_index = AsyncMock()
     mass.player_queues.set_shuffle = AsyncMock()
+    mass.player_queues.set_repeat = MagicMock()
     mass.player_queues.transfer_queue = AsyncMock()
     mass.player_queues.clear = MagicMock()
 

--- a/tests/providers/fastmcp_server/test_set_repeat.py
+++ b/tests/providers/fastmcp_server/test_set_repeat.py
@@ -1,0 +1,59 @@
+"""
+Tests for the set_repeat MCP tool.
+
+Validates that:
+1. Valid repeat_mode values (off/one/all) are accepted and forwarded to MA.
+2. Invalid repeat_mode values raise a clean ToolError.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+from music_assistant_models.enums import RepeatMode
+
+from music_assistant.providers.fastmcp_server.tools.queue import build_queue_server
+
+
+@pytest.fixture
+def mounted_queue(mock_mass: Any) -> FastMCP:
+    """Build a root FastMCP with the queue sub-server mounted."""
+    mcp: FastMCP = FastMCP(name="test")
+    mcp.mount(build_queue_server(mock_mass), namespace="queue")
+    return mcp
+
+
+async def test_set_repeat_accepts_valid_modes(mounted_queue: FastMCP, mock_mass: MagicMock) -> None:
+    """Each valid repeat_mode value is accepted and forwarded to MA."""
+    for mode in ("off", "one", "all"):
+        mock_mass.player_queues.set_repeat.reset_mock()
+        async with Client(mounted_queue) as client:
+            await client.call_tool("queue_set_repeat", {"queue_id": "q1", "repeat_mode": mode})
+        mock_mass.player_queues.set_repeat.assert_called_once_with("q1", RepeatMode(mode))
+
+
+async def test_set_repeat_accepts_mixed_case(mounted_queue: FastMCP, mock_mass: MagicMock) -> None:
+    """repeat_mode is normalized to lowercase before validation."""
+    mock_mass.player_queues.set_repeat.reset_mock()
+    async with Client(mounted_queue) as client:
+        await client.call_tool("queue_set_repeat", {"queue_id": "q1", "repeat_mode": "ALL"})
+    mock_mass.player_queues.set_repeat.assert_called_once_with("q1", RepeatMode.ALL)
+
+
+async def test_set_repeat_rejects_invalid_mode(mounted_queue: FastMCP) -> None:
+    """Invalid repeat_mode raises ToolError with the list of valid options."""
+    async with Client(mounted_queue) as client:
+        with pytest.raises(ToolError, match="bogus"):
+            await client.call_tool("queue_set_repeat", {"queue_id": "q1", "repeat_mode": "bogus"})
+
+
+async def test_set_repeat_defaults_to_off(mounted_queue: FastMCP, mock_mass: MagicMock) -> None:
+    """Calling set_repeat without repeat_mode defaults to 'off'."""
+    mock_mass.player_queues.set_repeat.reset_mock()
+    async with Client(mounted_queue) as client:
+        await client.call_tool("queue_set_repeat", {"queue_id": "q1"})
+    mock_mass.player_queues.set_repeat.assert_called_once_with("q1", RepeatMode.OFF)


### PR DESCRIPTION
# What does this implement/fix?

Adds a `set_repeat` tool to the MCP server's `queue/` namespace, allowing clients to set the repeat mode (`off` / `one` / `all`) on any queue.

Repeat is a queue-level setting in Music Assistant (`player_queues/repeat`), same as shuffle — so the tool lives alongside `set_shuffle` in `tools/queue.py` under the `edit_queue` permission.

Related: enqueue-without-replace is handled separately in #4376.

## Types of changes

- [x] New feature (non-breaking change which adds functionality) - `new-feature`

## Changes

- Added `queue_set_repeat(queue_id, repeat_mode="off")` in `tools/queue.py`
- Wraps `mass.player_queues.set_repeat()` (`player_queues/repeat` API)
- Permission tag: `edit:queue` (same as `set_shuffle`)
- Invalid values raise `ToolError` listing valid modes; input is normalized with `.lower()` before validation
- Updated `get_active_queue` docstring to list `set_repeat` among queue mutation tools
- Tests in `tests/providers/fastmcp_server/test_set_repeat.py` (valid modes, invalid input, default, mixed case)

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.