### PR TITLE
Fix next-track preload crash for fractional track durations

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -2337,7 +2337,7 @@ class PlayerQueuesController(CoreController):
                 current_item = queue.current_item
                 if current_item is None:
                     return  # guard
-                retries = max(120, (current_item.duration or 0) + 10)
+                retries = max(120, int(current_item.duration or 0) + 10)
                 for _ in range(retries):
                     # the queue can drain to empty while we sleep (e.g. all remaining
                     # items skipped as unplayable); stop waiting once it has no current item

--- a/music_assistant/providers/apple_music/parsers.py
+++ b/music_assistant/providers/apple_music/parsers.py
@@ -228,7 +228,7 @@ def parse_track(
         provider=provider.domain,
         name=cast("str", normalize_unicode(name)),
         version=version,
-        duration=attributes.get("durationInMillis", 0) / 1000,
+        duration=int(attributes.get("durationInMillis", 0) / 1000),
         provider_mappings={
             ProviderMapping(
                 item_id=track_id,

--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -317,7 +317,7 @@ class AudibleHelper:
             book.metadata.chapters = chapters
             # Update duration from chapters if available (more accurate)
             try:
-                duration = sum(chapter.get("length_ms", 0) for chapter in chapters_data) / 1000
+                duration = int(sum(chapter.get("length_ms", 0) for chapter in chapters_data) / 1000)
                 if duration > 0:
                     book.duration = duration
             except Exception as exc:
@@ -345,7 +345,7 @@ class AudibleHelper:
             chapters = await self._fetch_chapters(asin=asin)
             if chapters:
                 try:
-                    duration = sum(chapter.get("length_ms", 0) for chapter in chapters) / 1000
+                    duration = int(sum(chapter.get("length_ms", 0) for chapter in chapters) / 1000)
                 except Exception as exc:
                     self.logger.warning(f"Error calculating duration for ASIN {asin}: {exc}")
 

--- a/music_assistant/providers/soundcloud/__init__.py
+++ b/music_assistant/providers/soundcloud/__init__.py
@@ -564,7 +564,7 @@ class SoundcloudMusicProvider(MusicProvider):
             provider=self.domain,
             name=name,
             version=version,
-            duration=track_obj["duration"] / 1000,
+            duration=int(track_obj["duration"] / 1000),
             provider_mappings={
                 ProviderMapping(
                     item_id=track_id,

--- a/music_assistant/providers/spotify/parsers.py
+++ b/music_assistant/providers/spotify/parsers.py
@@ -152,7 +152,7 @@ def parse_track(
         provider=provider.instance_id,
         name=name,
         version=version,
-        duration=track_obj["duration_ms"] / 1000,
+        duration=int(track_obj["duration_ms"] / 1000),
         provider_mappings={
             ProviderMapping(
                 item_id=track_obj["id"],


### PR DESCRIPTION
# What does this implement/fix?

Preloading the next queue item crashed with `TypeError: 'float' object cannot be interpreted as an integer` for any track whose provider reported a fractional duration. `_preload_streamdetails` derives a retry count from the item duration and passes it to `range()`, which requires an int.

`QueueItem.duration` is typed `int | None`, but several provider parsers computed seconds with true division (`ms / 1000`), leaking a float that then propagates unchanged through `QueueItem.from_media_item`.

Changes:
- Guard the retry count in `_preload_streamdetails` with `int(...)` so it tolerates any non-integer duration.
- Coerce durations to `int` in the parsers that leaked floats: Spotify, Apple Music, SoundCloud (tracks) and Audible (audiobook + its stream details).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
