### PR TITLE
fix(local_audio): fall back to PulseAudio when /proc/asound is masked

### DIFF
--- a/music_assistant/providers/local_audio/pulse_audio.py
+++ b/music_assistant/providers/local_audio/pulse_audio.py
@@ -1,0 +1,229 @@
+"""PulseAudio Simple API fallback for environments where PortAudio cannot enumerate devices.
+
+Used inside the Home Assistant OS Supervisor addon container where /proc/asound
+is masked, preventing PortAudio/ALSA from discovering sound cards. The PulseAudio
+socket at /run/audio/pulse.sock remains accessible.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+import subprocess
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# The Supervisor mounts the PulseAudio socket at this path inside addon containers.
+_DEFAULT_PULSE_SOCKET = "unix:/run/audio/pulse.sock"
+PULSE_SERVER = os.environ.get("PULSE_SERVER", _DEFAULT_PULSE_SOCKET)
+
+PA_STREAM_PLAYBACK = 1
+PA_SAMPLE_S16LE = 3
+
+
+class pa_sample_spec(ctypes.Structure):  # noqa: N801
+    """PulseAudio sample specification (pa_sample_spec)."""
+
+    _fields_ = [
+        ("format", ctypes.c_int),
+        ("rate", ctypes.c_uint32),
+        ("channels", ctypes.c_uint8),
+    ]
+
+
+def _load_libpulse_simple() -> ctypes.CDLL | None:
+    """Load libpulse-simple shared library, return None if unavailable."""
+    try:
+        lib = ctypes.CDLL("libpulse-simple.so.0")
+    except OSError:
+        return None
+
+    lib.pa_simple_new.restype = ctypes.c_void_p
+    lib.pa_simple_new.argtypes = [
+        ctypes.c_char_p,  # server
+        ctypes.c_char_p,  # name
+        ctypes.c_int,  # dir
+        ctypes.c_char_p,  # dev (sink name)
+        ctypes.c_char_p,  # stream_name
+        ctypes.POINTER(pa_sample_spec),  # ss
+        ctypes.c_void_p,  # channel_map (NULL)
+        ctypes.c_void_p,  # attr (NULL)
+        ctypes.POINTER(ctypes.c_int),  # error
+    ]
+    lib.pa_simple_free.argtypes = [ctypes.c_void_p]
+    lib.pa_simple_free.restype = None
+    lib.pa_simple_write.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_int),
+    ]
+    lib.pa_simple_write.restype = ctypes.c_int
+    lib.pa_simple_drain.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
+    lib.pa_simple_drain.restype = ctypes.c_int
+    return lib
+
+
+_libpulse = _load_libpulse_simple()
+
+
+def is_available() -> bool:
+    """Return True if PulseAudio Simple API is usable."""
+    return _libpulse is not None
+
+
+def _get_sink_descriptions() -> dict[str, str]:
+    """Query PulseAudio for sink descriptions (friendly names).
+
+    Returns a mapping of sink_name -> description.
+    """
+    descriptions: dict[str, str] = {}
+    try:
+        result = subprocess.run(
+            ["pactl", "list", "sinks"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={**os.environ, "PULSE_SERVER": PULSE_SERVER},
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return descriptions
+
+    if result.returncode != 0:
+        return descriptions
+
+    current_name: str | None = None
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Name: "):
+            current_name = stripped[6:]
+        elif stripped.startswith("Description: ") and current_name:
+            descriptions[current_name] = stripped[13:]
+            current_name = None
+
+    return descriptions
+
+
+def enumerate_pulse_sinks() -> list[dict[str, Any]]:
+    """Enumerate PulseAudio output sinks via pactl.
+
+    Returns a list of dicts compatible with the device format expected by
+    LocalAudioBridgeManager.discover_and_register().
+    """
+    devices: list[dict[str, Any]] = []
+    try:
+        result = subprocess.run(
+            ["pactl", "list", "sinks", "short"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={**os.environ, "PULSE_SERVER": PULSE_SERVER},
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return devices
+
+    if result.returncode != 0:
+        return devices
+
+    # Get friendly descriptions for each sink
+    descriptions = _get_sink_descriptions()
+
+    for line in result.stdout.strip().splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        sink_index = int(parts[0])
+        sink_name = parts[1]
+
+        # Use PulseAudio's own description if available, otherwise derive one
+        display_name = descriptions.get(sink_name)
+        if not display_name:
+            display_name = (
+                sink_name.replace("alsa_output.", "")
+                .replace(".", " ")
+                .replace("-", " ")
+            )
+            for suffix in (" analog stereo", " analog mono"):
+                if display_name.lower().endswith(suffix):
+                    display_name = display_name[: -len(suffix)]
+            display_name = display_name.strip()
+
+        devices.append(
+            {
+                "index": sink_index,
+                "name": display_name,
+                "pulse_sink": sink_name,
+                "hostapi": 0,
+                "max_output_channels": 2,
+            }
+        )
+
+    _LOGGER.debug("PulseAudio enumeration found %d sink(s)", len(devices))
+    return devices
+
+
+class PulseOutputStream:
+    """Write-based output stream using PulseAudio Simple API.
+
+    Provides the same interface (start/write/stop/close) as sd.RawOutputStream
+    so it can be used as a drop-in replacement in the audio writer loop.
+    """
+
+    def __init__(
+        self,
+        sink_name: str | None = None,
+        samplerate: int = 48000,
+        channels: int = 2,
+    ) -> None:
+        if _libpulse is None:
+            msg = "libpulse-simple.so.0 not available"
+            raise RuntimeError(msg)
+
+        spec = pa_sample_spec(PA_SAMPLE_S16LE, samplerate, channels)
+        error = ctypes.c_int(0)
+        sink_bytes = sink_name.encode() if sink_name else None
+
+        self._handle = _libpulse.pa_simple_new(
+            PULSE_SERVER.encode(),
+            b"music_assistant",
+            PA_STREAM_PLAYBACK,
+            sink_bytes,
+            b"local_audio_out",
+            ctypes.byref(spec),
+            None,
+            None,
+            ctypes.byref(error),
+        )
+        if not self._handle:
+            msg = f"Failed to open PulseAudio stream to sink '{sink_name}' (error {error.value})"
+            raise RuntimeError(msg)
+
+    def write(self, data: bytes) -> None:
+        """Write raw PCM data to the stream (blocking)."""
+        error = ctypes.c_int(0)
+        ret = _libpulse.pa_simple_write(
+            self._handle,
+            data,
+            len(data),
+            ctypes.byref(error),
+        )
+        if ret < 0:
+            msg = f"PulseAudio write error (code {error.value})"
+            raise RuntimeError(msg)
+
+    def start(self) -> None:
+        """No-op for API compatibility with sd.RawOutputStream."""
+
+    def stop(self) -> None:
+        """Drain remaining buffered audio."""
+        if self._handle:
+            error = ctypes.c_int(0)
+            _libpulse.pa_simple_drain(self._handle, ctypes.byref(error))
+
+    def close(self) -> None:
+        """Free the PulseAudio connection."""
+        if self._handle:
+            _libpulse.pa_simple_free(self._handle)
+            self._handle = None

--- a/music_assistant/providers/local_audio/sendspin_bridge.py
+++ b/music_assistant/providers/local_audio/sendspin_bridge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
@@ -25,6 +26,7 @@ from music_assistant.providers.sendspin.helpers import bridge_client_id_from_uui
 
 from .constants import DEFAULT_BUFFER_FRAMES, VOLUME_CONTROL_SOFTWARE
 from .player import LocalAudioPlayer, get_device_uuid
+from .pulse_audio import PulseOutputStream, enumerate_pulse_sinks, is_available as pulse_available
 
 if TYPE_CHECKING:
     from aiosendspin.server import ExternalStreamStartRequest, SendspinClient, SendspinServer
@@ -52,7 +54,8 @@ class SendspinLocalAudioBridge:
         :param provider: The Local Audio provider instance.
         :param player: The LocalAudioPlayer that owns this bridge.
         :param device_index: The PortAudio device index.
-        :param device_info: The device info dict from sounddevice.query_devices().
+        :param device_info: The device info dict from sounddevice.query_devices(),
+            or from PulseAudio fallback enumeration (see ``pulse_sink``).
         :param sendspin_server: The Sendspin server to register with.
         """
         self.provider = provider
@@ -60,6 +63,10 @@ class SendspinLocalAudioBridge:
         self.player = player
         self.sendspin_server = sendspin_server
         self.device_index = device_index
+        # When enumeration falls back to PulseAudio (e.g. inside the HA OS
+        # Supervisor sandbox where /proc/asound is masked), playback goes
+        # through libpulse-simple instead of PortAudio.
+        self.pulse_sink: str | None = device_info.get("pulse_sink")
         self.device_name: str = device_info["name"]
         self.device_info = device_info
         self.logger = provider.logger.getChild(f"bridge.{self.device_name}")
@@ -70,7 +77,7 @@ class SendspinLocalAudioBridge:
         self._is_streaming = False
         self._write_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
         self._writer_task: asyncio.Task[None] | None = None
-        self._output_stream: sd.RawOutputStream | None = None
+        self._output_stream: sd.RawOutputStream | PulseOutputStream | None = None
         self._lock = asyncio.Lock()
 
     @property
@@ -220,13 +227,20 @@ class SendspinLocalAudioBridge:
         """Write queued audio data to the soundcard."""
         loop = asyncio.get_running_loop()
         try:
-            self._output_stream = sd.RawOutputStream(
-                device=self.device_index,
-                samplerate=BRIDGE_SAMPLE_RATE,
-                channels=BRIDGE_CHANNELS,
-                dtype="int16",
-                blocksize=DEFAULT_BUFFER_FRAMES,
-            )
+            if self.pulse_sink is not None:
+                self._output_stream = PulseOutputStream(
+                    sink_name=self.pulse_sink,
+                    samplerate=BRIDGE_SAMPLE_RATE,
+                    channels=BRIDGE_CHANNELS,
+                )
+            else:
+                self._output_stream = sd.RawOutputStream(
+                    device=self.device_index,
+                    samplerate=BRIDGE_SAMPLE_RATE,
+                    channels=BRIDGE_CHANNELS,
+                    dtype="int16",
+                    blocksize=DEFAULT_BUFFER_FRAMES,
+                )
             self._output_stream.start()
             self.logger.debug("Audio output stream opened for %s", self.device_name)
 
@@ -240,10 +254,10 @@ class SendspinLocalAudioBridge:
                 data = self._apply_software_volume(data)
                 try:
                     await loop.run_in_executor(None, self._output_stream.write, data)
-                except sd.PortAudioError as err:
-                    self.logger.error("PortAudio error writing to %s: %s", self.device_name, err)
+                except (sd.PortAudioError, RuntimeError) as err:
+                    self.logger.error("Audio write error for %s: %s", self.device_name, err)
                     break
-        except sd.PortAudioError as err:
+        except (sd.PortAudioError, RuntimeError) as err:
             self.logger.error(
                 "Failed to open audio output stream for %s: %s", self.device_name, err
             )
@@ -387,6 +401,23 @@ class LocalAudioBridgeManager:
 
     @staticmethod
     def _enumerate_output_devices() -> list[dict[str, Any]]:
+        """Enumerate available audio output devices, with a PulseAudio fallback."""
+        devices = LocalAudioBridgeManager._enumerate_output_devices_via_portaudio()
+        if devices:
+            return devices
+        # PortAudio's ALSA host API enumerates cards via /proc/asound. In
+        # sandboxed environments (e.g. the HA OS Supervisor addon container)
+        # /proc/asound is masked, so query_devices() returns nothing. Fall back
+        # to PulseAudio via the Supervisor-provided socket at /run/audio/pulse.sock.
+        if pulse_available():
+            logging.getLogger(__name__).info(
+                "PortAudio found no devices, falling back to PulseAudio enumeration"
+            )
+            return enumerate_pulse_sinks()
+        return []
+
+    @staticmethod
+    def _enumerate_output_devices_via_portaudio() -> list[dict[str, Any]]:
         """
         Enumerate available audio output devices via sounddevice.
 
@@ -420,3 +451,5 @@ class LocalAudioBridgeManager:
             dev_with_index["index"] = idx
             devices.append(dev_with_index)
         return devices
+
+


### PR DESCRIPTION
# What does this implement/fix?

The **Local Audio Out** player provider fails to detect any audio devices when running as a Home Assistant OS addon because the Supervisor masks `/proc/asound` inside addon containers. This adds a transparent PulseAudio Simple API fallback that activates only when PortAudio cannot enumerate devices.

**Root cause:** PortAudio's ALSA backend reads `/proc/asound/cards` to discover sound cards. The HA OS Supervisor includes `/proc/asound` in the container's `MaskedPaths`, so `sounddevice.query_devices()` returns `[]` — even though the PulseAudio socket at `/run/audio/pulse.sock` is mounted and fully functional.

**Fix:** When PortAudio returns zero devices and `libpulse-simple.so.0` is available, enumerate sinks via `pactl` and stream PCM audio via the PulseAudio Simple API (ctypes). No new dependencies, no impact on non-HAOS installations.

<details>
<summary>Design diagram</summary>

```
_enumerate_output_devices()
  │
  ├─ Try: PortAudio (existing path, unchanged)
  │   └─ sd.query_devices() + test-open each device
  │   └─ Returns devices? → done (normal path)
  │
  └─ Fallback: PulseAudio (new, only when PortAudio finds nothing)
      ├─ enumerate_pulse_sinks()
      │   ├─ `pactl list sinks short` → sink names/indices
      │   └─ `pactl list sinks` → friendly descriptions
      └─ PulseOutputStream (drop-in for sd.RawOutputStream)
          └─ ctypes wrapper around libpulse-simple.so.0
              ├─ pa_simple_new() → open stream to specific sink
              ├─ pa_simple_write() → blocking PCM write
              ├─ pa_simple_drain() → flush on stop
              └─ pa_simple_free() → cleanup
```

</details>

**Related issue (if applicable):**

- N/A (discovered during testing on HAOS)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

## Testing

Tested on Raspberry Pi 5, HAOS, with a USB audio device (C-Media Electronics USB PnP Sound Device):

- [x] Device appears in Music Assistant UI under Local Audio Out
- [x] Audio playback works end-to-end through PulseAudio
- [x] Volume control (hardware via amixer) works
- [x] Seek works
- [x] Fallback log: `"PortAudio found no devices, falling back to PulseAudio enumeration"`
- [x] Friendly device name from PulseAudio: `"USB PnP Sound Device Analog Stereo"`
- [x] Non-HAOS path unaffected (PortAudio enumeration succeeds → PulseAudio code never reached)