### PR TITLE
Fix elapsed time drift for live sources played to a sync group

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1662,17 +1662,27 @@ class Player(ABC):
         # wrong clock for live plugin sources (loses upstream seeks and
         # pause-resume on the queue's corrected_elapsed_time, which the
         # player_queues controller and several player providers consume).
-        if (
-            (active_source := self.__final_active_source)
-            and (queue := self.mass.player_queues.get(active_source))
-            and (current_item := queue.current_item) is not None
-            and (sd := current_item.streamdetails) is not None
-            and sd.media_type == MediaType.AUDIO_SOURCE
-            and sd.stream_metadata is not None
-            and sd.stream_metadata.elapsed_time is not None
-        ):
-            elapsed_time = sd.stream_metadata.elapsed_time
-            elapsed_time_last_updated = sd.stream_metadata.elapsed_time_last_updated or time.time()
+        # A group player outputs the AudioSource from its own queue, which
+        # __final_active_source may not resolve to, so the group's own queue
+        # is also consulted.
+        candidate_source_ids = [self.__final_active_source]
+        if self.type == PlayerType.GROUP:
+            candidate_source_ids.append(self.player_id)
+        for source_id in candidate_source_ids:
+            if (
+                source_id
+                and (queue := self.mass.player_queues.get(source_id))
+                and (current_item := queue.current_item) is not None
+                and (sd := current_item.streamdetails) is not None
+                and sd.media_type == MediaType.AUDIO_SOURCE
+                and sd.stream_metadata is not None
+                and sd.stream_metadata.elapsed_time is not None
+            ):
+                elapsed_time = sd.stream_metadata.elapsed_time
+                elapsed_time_last_updated = (
+                    sd.stream_metadata.elapsed_time_last_updated or time.time()
+                )
+                break
 
         return (playback_state, elapsed_time, elapsed_time_last_updated)
 

--- a/tests/controllers/players/test_player_protocol_state.py
+++ b/tests/controllers/players/test_player_protocol_state.py
@@ -11,7 +11,7 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
-from music_assistant_models.enums import PlaybackState, PlayerType
+from music_assistant_models.enums import MediaType, PlaybackState, PlayerType
 
 from music_assistant.controllers.players import PlayerController
 from tests.common import MockPlayer, MockProvider
@@ -122,3 +122,107 @@ class TestFinalPlaybackStateWithActiveProtocol:
         player.update_state(signal_event=False)
 
         assert player.state.playback_state == PlaybackState.PLAYING
+
+
+def _audio_source_queue(elapsed: float, updated: float) -> MagicMock:
+    """Build a mock queue whose current item is an AudioSource carrying a source clock."""
+    stream_metadata = MagicMock()
+    stream_metadata.elapsed_time = elapsed
+    stream_metadata.elapsed_time_last_updated = updated
+    streamdetails = MagicMock()
+    streamdetails.media_type = MediaType.AUDIO_SOURCE
+    streamdetails.stream_metadata = stream_metadata
+    current_item = MagicMock()
+    current_item.streamdetails = streamdetails
+    queue = MagicMock()
+    queue.current_item = current_item
+    return queue
+
+
+def _empty_queue() -> MagicMock:
+    """Build a mock queue with no current item (no AudioSource source clock)."""
+    queue = MagicMock()
+    queue.current_item = None
+    return queue
+
+
+class TestFinalPlaybackStateAudioSourceElapsed:
+    """The AudioSource source-clock override, including the group own-queue fallback."""
+
+    def test_standalone_uses_active_source_audio_source_elapsed(
+        self,
+        provider: MockProvider,
+        controller: PlayerController,
+        mock_mass: MagicMock,
+    ) -> None:
+        """A standalone player reports the AudioSource source clock from its active queue."""
+        player = MockPlayer(provider, "player_1", "Player")
+        player._attr_playback_state = PlaybackState.PLAYING
+        player._attr_active_source = "player_1"
+        player._attr_elapsed_time = 0.0
+        player._attr_elapsed_time_last_updated = time.time()
+
+        own_queue = _audio_source_queue(42.0, time.time())
+        mock_mass.player_queues.get = MagicMock(
+            side_effect=lambda qid: {"player_1": own_queue}.get(qid)
+        )
+        controller._players = {"player_1": player}
+
+        player.update_state(signal_event=False)
+
+        assert player.state.elapsed_time == 42.0
+
+    def test_group_falls_back_to_own_queue_audio_source_elapsed(
+        self,
+        provider: MockProvider,
+        controller: PlayerController,
+        mock_mass: MagicMock,
+    ) -> None:
+        """
+        A group reports the AudioSource source clock from its own queue.
+
+        The group's active source resolves to the sync leader, whose queue does not
+        carry the AudioSource, so without the own-queue fallback the group would report
+        the leader's byte clock instead of the source's logical position.
+        """
+        group = MockPlayer(provider, "group_1", "Group", player_type=PlayerType.GROUP)
+        group._attr_playback_state = PlaybackState.PLAYING
+        group._attr_active_source = "leader_1"
+        # stale leader byte clock that gets copied into the group
+        group._attr_elapsed_time = 999.0
+        group._attr_elapsed_time_last_updated = time.time()
+
+        leader_queue = _empty_queue()
+        own_queue = _audio_source_queue(42.0, time.time())
+        mock_mass.player_queues.get = MagicMock(
+            side_effect=lambda qid: {"leader_1": leader_queue, "group_1": own_queue}.get(qid)
+        )
+        controller._players = {"group_1": group}
+
+        group.update_state(signal_event=False)
+
+        assert group.state.elapsed_time == 42.0
+
+    def test_non_group_does_not_use_own_queue_fallback(
+        self,
+        provider: MockProvider,
+        controller: PlayerController,
+        mock_mass: MagicMock,
+    ) -> None:
+        """A non-group player ignores an AudioSource sitting on its own (inactive) queue."""
+        player = MockPlayer(provider, "player_1", "Player")
+        player._attr_playback_state = PlaybackState.PLAYING
+        player._attr_active_source = "other_src"
+        player._attr_elapsed_time = 5.0
+        player._attr_elapsed_time_last_updated = time.time()
+
+        other_queue = _empty_queue()
+        own_queue = _audio_source_queue(42.0, time.time())
+        mock_mass.player_queues.get = MagicMock(
+            side_effect=lambda qid: {"other_src": other_queue, "player_1": own_queue}.get(qid)
+        )
+        controller._players = {"player_1": player}
+
+        player.update_state(signal_event=False)
+
+        assert player.state.elapsed_time == 5.0


### PR DESCRIPTION
# What does this implement/fix?

When a live source (Spotify Connect, AirPlay receiver, Yandex Ynison) plays into a sync group, the progress bar drifted: it stalled while playing and jumped to the previous track's position on a track change. Single (ungrouped) players were unaffected.

A group reports the sync leader's elapsed time, which for these sources is a bytes-consumed clock — the wrong clock for a live stream. The AudioSource source-clock override in `__final_playback_state` only consulted `__final_active_source`, which for a group resolves to the leader's queue rather than the group's own queue where the source's `stream_metadata` lives, so the override never fired for the group.

- Group players now also consult their own queue for the AudioSource source clock, gated to `PlayerType.GROUP` so standalone/member resolution is unchanged.
- Covers both group types (sync group and universal group) and any live AudioSource (Spotify Connect, AirPlay receiver, Ynison).
- Added regression tests: the group fallback reports the source clock, and standalone players are left untouched.

**Related issue (if applicable):**

- Follow-up from the Spotify Connect → go-librespot migration (#4384), where the drift surfaced during sync-group testing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
