### PR TITLE
Plex: fix track sync re-scanning the whole library on every page

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -883,11 +883,15 @@ class PlexProvider(MusicProvider):
         page_size = 500
         offset = 0
         while True:
+            # maxresults caps a single page; without it container_size is only the HTTP
+            # batch size and plexapi keeps fetching until the end of the library, so every
+            # iteration would return all remaining tracks (an O(n^2) re-scan of the library).
             batch = cast(
                 "list[PlexTrack]",
                 await self._run_async(
                     self._plex_library.searchTracks,
                     title=None,
+                    maxresults=page_size,
                     container_size=page_size,
                     container_start=offset,
                 ),


### PR DESCRIPTION
# What does this implement/fix?

The Plex library track sync paged `searchTracks` with only `container_start`/`container_size`. In plexapi those control the *HTTP batch size*, not the number of results returned — each call keeps fetching until the end of the library. So every page actually returned *all* remaining tracks, making the sync re-scan the library O(n²) times: it never finished, reported absurd track counts (e.g. 100k+ for a 10k library) and memory climbed steadily until the container hit OOM.

Passing `maxresults` caps each call to a single page, so each track is scanned exactly once.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/5712

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
