### PR TITLE
fix: restore execute bit on bundled provider streaming binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,11 @@ RUN uv pip install \
     --no-cache \
     "music-assistant@dist/music_assistant-${MASS_VERSION}-py3-none-any.whl"
 
+# Provider streaming binaries are bundled in the wheel without the execute bit.
+RUN find "$VIRTUAL_ENV/lib" -path '*/music_assistant/providers/*/bin/*' -type f \
+    ! -name '*.md' ! -name '*.sh' ! -name '*.conf' ! -name '.gitkeep' \
+    -exec chmod +x {} +
+
 # Pre-compile Python bytecode for faster startup
 RUN $VIRTUAL_ENV/bin/python -m compileall -q $VIRTUAL_ENV/lib/python*/site-packages/music_assistant
 
@@ -96,6 +101,9 @@ RUN printf '#!/bin/sh\n\
 for path in /usr/lib/*/libjemalloc.so.2; do\n\
     [ -f "$path" ] && export LD_PRELOAD="$path" MALLOC_CONF="background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000" && break\n\
 done\n\
+find /app/venv/lib -path "*/music_assistant/providers/*/bin/*" -type f \\\n\
+    ! -name "*.md" ! -name "*.sh" ! -name "*.conf" ! -name ".gitkeep" \\\n\
+    -exec chmod +x {} + 2>/dev/null\n\
 exec mass "$@"\n' > /usr/local/bin/entrypoint.sh && chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "--data-dir", "/data", "--cache-dir", "/data/.cache"]

--- a/music_assistant/providers/airplay/helpers.py
+++ b/music_assistant/providers/airplay/helpers.py
@@ -7,8 +7,10 @@ import logging
 import os
 import platform
 import socket
+import stat
 import time
 from ipaddress import ip_address
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import ContentType
@@ -204,7 +206,18 @@ async def get_cli_binary(protocol: StreamingProtocol) -> str:
         RuntimeError: If the binary cannot be found
     """
 
+    def ensure_executable(cli_path: str) -> None:
+        """Restore execute bit dropped by wheel/Docker packaging (see ariacast_receiver)."""
+        path = Path(cli_path)
+        if not path.is_file():
+            return
+        mode = path.stat().st_mode
+        if mode & stat.S_IXUSR:
+            return
+        path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
     async def check_binary(cli_path: str) -> str | None:
+        ensure_executable(cli_path)
         try:
             if protocol == StreamingProtocol.RAOP:
                 args = [


### PR DESCRIPTION
# What does this implement/fix?

Provider streaming binaries (e.g. the airplay/RAOP CLI) are shipped inside the published wheel **without** the execute bit. In the slim runtime image they therefore fail to launch. This restores the execute bit in two complementary places:

- **`Dockerfile`** — after the wheel install (and again in the entrypoint as a safety net), `chmod +x` every file under `.../music_assistant/providers/*/bin/`, excluding docs/scripts/config (`*.md`, `*.sh`, `*.conf`, `.gitkeep`).
- **`airplay/helpers.py`** — `get_cli_binary()` now defensively restores the execute bit on the resolved CLI path before first use, so non-Docker installs are covered too.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
