### PR TITLE
mcp: add explicit pause/resume playback tools

### DIFF
--- a/music_assistant/providers/fastmcp_server/tools/playback.py
+++ b/music_assistant/providers/fastmcp_server/tools/playback.py
@@ -39,7 +39,7 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
         """
         Pause playback on the given queue.
 
-        Always pauses — unlike ``play_pause``, this does not toggle. Prefer this
+        Always pauses — unlike ``playback_play_pause``, this does not toggle. Prefer this
         when the user asks to pause. Returns nothing.
 
         :param queue_id: Queue identifier — same as ``player_id`` from
@@ -56,7 +56,7 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
         """
         Resume paused playback on the given queue.
 
-        Always resumes — unlike ``play_pause``, this does not toggle. Prefer this
+        Always resumes — unlike ``playback_play_pause``, this does not toggle. Prefer this
         when the user asks to resume or unpause. Returns nothing.
 
         :param queue_id: Queue identifier — same as ``player_id`` from
@@ -73,9 +73,10 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
         """
         Toggle play/pause on the given queue.
 
-        Playing → pauses, paused → resumes. Prefer ``pause`` or ``resume`` when
-        the user gives an explicit instruction — toggling can flip the wrong way
-        if state is unknown. Use ``stop`` to halt and reset position. Returns
+        Playing → pauses, paused → resumes. Prefer ``playback_pause`` or
+        ``playback_resume`` when the user gives an explicit instruction —
+        toggling can flip the wrong way if state is unknown. Use
+        ``playback_stop`` to halt and reset position. Returns
         nothing.
 
         :param queue_id: Queue identifier from ``QueueBrief.queue_id``.
@@ -91,7 +92,7 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
         """
         Stop playback and reset the playback position. The queue is preserved.
 
-        Use ``play_pause`` to resume without losing position. Returns nothing.
+        Use ``playback_play_pause`` to resume without losing position. Returns nothing.
 
         :param queue_id: Queue identifier from ``QueueBrief.queue_id``.
         """
@@ -107,7 +108,7 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
         Skip to the next item in the queue.
 
         At the end of the queue the behaviour depends on the current repeat
-        mode. Use ``play_index`` to jump to a specific position. Returns
+        mode. Use ``playback_play_index`` to jump to a specific position. Returns
         nothing.
 
         :param queue_id: Queue identifier from ``QueueBrief.queue_id``.
@@ -184,7 +185,7 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
         """
         Load and start playing an album, track, playlist, or radio station on a player queue.
 
-        Replaces whatever the queue was playing. Use ``play_index`` to start an
+        Replaces whatever the queue was playing. Use ``playback_play_index`` to start an
         item that is already in the queue. Returns nothing.
 
         :param queue_id: Queue identifier — for a player queue this is the same
@@ -207,7 +208,7 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
         """
         Start playing the item at the given position in the existing queue.
 
-        Does not load new media — use ``play_media`` for that. Returns nothing.
+        Does not load new media — use ``playback_play_media`` for that. Returns nothing.
 
         :param queue_id: Queue identifier from ``QueueBrief.queue_id``.
         :param index: Zero-based position in the queue (``>= 0``).

--- a/music_assistant/providers/fastmcp_server/tools/playback.py
+++ b/music_assistant/providers/fastmcp_server/tools/playback.py
@@ -32,6 +32,40 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
 
     @sub.tool(
         tags={Tag.CONTROL_PLAYBACK},
+        annotations=_control_annotations(title="Pause playback"),
+        timeout=TIMEOUT_MUTATION,
+    )  # type: ignore[untyped-decorator, unused-ignore]
+    async def pause(queue_id: str) -> None:
+        """
+        Pause playback on the given queue.
+
+        Always pauses — unlike ``play_pause``, this does not toggle. Prefer this
+        when the user asks to pause. Returns nothing.
+
+        :param queue_id: Queue identifier — same as ``player_id`` from
+            ``players_list_players``.
+        """
+        await mass.player_queues.pause(queue_id)
+
+    @sub.tool(
+        tags={Tag.CONTROL_PLAYBACK},
+        annotations=_control_annotations(title="Resume playback"),
+        timeout=TIMEOUT_MUTATION,
+    )  # type: ignore[untyped-decorator, unused-ignore]
+    async def resume(queue_id: str) -> None:
+        """
+        Resume paused playback on the given queue.
+
+        Always resumes — unlike ``play_pause``, this does not toggle. Prefer this
+        when the user asks to resume or unpause. Returns nothing.
+
+        :param queue_id: Queue identifier — same as ``player_id`` from
+            ``players_list_players``.
+        """
+        await mass.player_queues.resume(queue_id)
+
+    @sub.tool(
+        tags={Tag.CONTROL_PLAYBACK},
         annotations=_control_annotations(title="Toggle play / pause"),
         timeout=TIMEOUT_MUTATION,
     )  # type: ignore[untyped-decorator, unused-ignore]
@@ -39,8 +73,10 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
         """
         Toggle play/pause on the given queue.
 
-        Playing → pauses, paused → resumes. Use ``stop`` to halt playback and
-        reset the current position. Returns nothing.
+        Playing → pauses, paused → resumes. Prefer ``pause`` or ``resume`` when
+        the user gives an explicit instruction — toggling can flip the wrong way
+        if state is unknown. Use ``stop`` to halt and reset position. Returns
+        nothing.
 
         :param queue_id: Queue identifier from ``QueueBrief.queue_id``.
         """
@@ -146,12 +182,13 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
         radio_mode: bool = False,
     ) -> None:
         """
-        Load and start playing media on the given queue.
+        Load and start playing an album, track, playlist, or radio station on a player queue.
 
         Replaces whatever the queue was playing. Use ``play_index`` to start an
         item that is already in the queue. Returns nothing.
 
-        :param queue_id: Queue identifier from ``QueueBrief.queue_id``.
+        :param queue_id: Queue identifier — for a player queue this is the same
+            ``player_id`` returned by ``players_list_players``.
         :param uri: Music Assistant URI of the artist, album, track, playlist
             or radio station to play, of the form
             ``<provider>://<media_type>/<id>`` (e.g. as found on

--- a/tests/providers/fastmcp_server/conftest.py
+++ b/tests/providers/fastmcp_server/conftest.py
@@ -159,6 +159,8 @@ def mock_mass(mock_user: MagicMock) -> MagicMock:
     mass.player_queues.items = MagicMock(return_value=[])
     mass.player_queues.play_media = AsyncMock()
     mass.player_queues.play_pause = AsyncMock()
+    mass.player_queues.pause = AsyncMock()
+    mass.player_queues.resume = AsyncMock()
     mass.player_queues.stop = AsyncMock()
     mass.player_queues.next = AsyncMock()
     mass.player_queues.previous = AsyncMock()

--- a/tests/providers/fastmcp_server/test_playback_tool.py
+++ b/tests/providers/fastmcp_server/test_playback_tool.py
@@ -1,0 +1,49 @@
+"""Tests for the ``playback`` sub-server tools."""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from music_assistant.providers.fastmcp_server.tools import build_playback_server
+
+
+@pytest.fixture
+def mounted_playback(mock_mass: Any) -> Iterator[FastMCP]:
+    """Build a root FastMCP with only the playback sub-server mounted."""
+    mcp: FastMCP = FastMCP(name="test")
+    mcp.mount(build_playback_server(mock_mass), namespace="playback")
+    try:
+        yield mcp
+    finally:
+        close = getattr(mcp, "close", None) or getattr(mcp, "shutdown", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
+
+
+async def test_pause_calls_player_queues_pause(mock_mass: Any, mounted_playback: FastMCP) -> None:
+    """``playback_pause`` always pauses via the non-toggling queue API."""
+    async with Client(mounted_playback) as client:
+        await client.call_tool("playback_pause", {"queue_id": "player1"})
+    mock_mass.player_queues.pause.assert_awaited_once_with("player1")
+
+
+async def test_resume_calls_player_queues_resume(mock_mass: Any, mounted_playback: FastMCP) -> None:
+    """``playback_resume`` always resumes via the non-toggling queue API."""
+    async with Client(mounted_playback) as client:
+        await client.call_tool("playback_resume", {"queue_id": "player1"})
+    mock_mass.player_queues.resume.assert_awaited_once_with("player1")
+
+
+async def test_play_pause_calls_player_queues_play_pause(
+    mock_mass: Any, mounted_playback: FastMCP
+) -> None:
+    """``playback_play_pause`` forwards to the toggling queue API."""
+    async with Client(mounted_playback) as client:
+        await client.call_tool("playback_play_pause", {"queue_id": "player1"})
+    mock_mass.player_queues.play_pause.assert_awaited_once_with("player1")


### PR DESCRIPTION
# What does this implement/fix?

Adds two dedicated playback tools to the FastMCP server alongside the existing toggle:

- **`playback_pause`** — always pauses the given queue (never toggles).
- **`playback_resume`** — always resumes/unpauses the given queue (never toggles).

The existing `play_pause` toggle remains, but blind toggling flips the wrong way when the current state is unknown — a common failure mode for LLM agents (observed as rapid play/pause oscillation). The `play_pause` and `play_media` docstrings are also clarified to steer agents toward the explicit tools and to note that `queue_id` is the same identifier as `player_id` from `players_list_players`.

Tests added under `tests/providers/fastmcp_server/test_playback_tool.py`.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
