### PR TITLE
mcp: add players ungroup tool 

### DIFF
--- a/music_assistant/providers/fastmcp_server/tools/players.py
+++ b/music_assistant/providers/fastmcp_server/tools/players.py
@@ -114,9 +114,9 @@ def build_players_server(mass: MusicAssistant) -> FastMCP:
         """
         Power a player on or off.
 
-        Does not affect sync-group membership — use ``group_player`` to
-        change that. Setting the current power state again is a no-op.
-        Returns nothing.
+        Does not affect sync-group membership — use ``group_player`` to add a
+        player to a sync group, or ``ungroup_player`` to remove one. Setting
+        the current power state again is a no-op. Returns nothing.
 
         :param player_id: Player identifier from ``PlayerBrief.player_id``.
         :param powered: ``True`` to power on, ``False`` to power off.
@@ -139,12 +139,36 @@ def build_players_server(mass: MusicAssistant) -> FastMCP:
         Add a player to another player's sync group so both play in lockstep.
 
         Does not change volume — use ``set_group_volume`` on the volume
-        sub-server for that. Returns nothing.
+        sub-server for that. Use ``ungroup_player`` to remove a player from
+        a sync group. Returns nothing.
 
         :param player_id: Player to add to the group.
         :param target_player_id: Player whose sync group ``player_id`` joins
             (typically the group leader).
         """
         await mass.players.cmd_group(player_id, target_player_id)
+
+    @sub.tool(
+        tags={Tag.CONTROL_PLAYERS},
+        annotations=ToolAnnotations(
+            title="Ungroup player from sync group",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+        timeout=TIMEOUT_MUTATION,
+    )  # type: ignore[untyped-decorator, unused-ignore]
+    async def ungroup_player(player_id: str) -> None:
+        """
+        Remove a player from its sync group so it plays independently again.
+
+        If the player is not currently grouped, this is a no-op. Use
+        ``group_player`` to add a player to another player's sync group.
+        Returns nothing.
+
+        :param player_id: Player to remove from any active sync group.
+        """
+        await mass.players.cmd_ungroup(player_id)
 
     return sub

--- a/tests/providers/fastmcp_server/conftest.py
+++ b/tests/providers/fastmcp_server/conftest.py
@@ -174,6 +174,7 @@ def mock_mass(mock_user: MagicMock) -> MagicMock:
     mass.players.get_player = MagicMock(return_value=None)
     mass.players.cmd_power = AsyncMock()
     mass.players.cmd_group = AsyncMock()
+    mass.players.cmd_ungroup = AsyncMock()
     mass.players.cmd_volume_set = AsyncMock()
     mass.players.cmd_volume_up = AsyncMock()
     mass.players.cmd_volume_down = AsyncMock()

--- a/tests/providers/fastmcp_server/test_players_tool.py
+++ b/tests/providers/fastmcp_server/test_players_tool.py
@@ -309,6 +309,23 @@ async def test_get_player_returns_unavailable_player(
     assert result.data.state == "unavailable"
 
 
+async def test_group_player_calls_cmd_group(mock_mass: Any, mounted_players: FastMCP) -> None:
+    """``players_group_player`` forwards to ``mass.players.cmd_group``."""
+    async with Client(mounted_players) as client:
+        await client.call_tool(
+            "players_group_player",
+            {"player_id": "follower", "target_player_id": "leader"},
+        )
+    mock_mass.players.cmd_group.assert_awaited_once_with("follower", "leader")
+
+
+async def test_ungroup_player_calls_cmd_ungroup(mock_mass: Any, mounted_players: FastMCP) -> None:
+    """``players_ungroup_player`` forwards to ``mass.players.cmd_ungroup``."""
+    async with Client(mounted_players) as client:
+        await client.call_tool("players_ungroup_player", {"player_id": "follower"})
+    mock_mass.players.cmd_ungroup.assert_awaited_once_with("follower")
+
+
 async def test_get_player_reports_external_source(mock_mass: Any, mounted_players: FastMCP) -> None:
     """An idle player driven by a Connect source reports playing + provider."""
     player = _player(player_id="lenco", name="Lenco LS-500", state="idle")


### PR DESCRIPTION
# What does this implement/fix?

Adds a **`players_ungroup_player`** tool to the FastMCP server. It removes a player from its sync group so it plays independently again (idempotent — a no-op if the player is not currently grouped).

Previously agents could add a player to a sync group via `group_player` but had no tool to undo it. The `group_player` and `set_power` docstrings are also updated to cross-reference the new tool.

Tests added under `tests/providers/fastmcp_server/test_players_tool.py` for both `group_player` and `ungroup_player`.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
