### PR TITLE
Handle deleted image files with a typed not-found error

### DIFF
--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -276,7 +276,7 @@ class ImageProxyMixin:
         except (MediaNotFoundError, OSError) as err:
             # normalize a missing/unreadable image into one typed error so callers
             # (and not just the HTTP imageproxy handler) can handle it uniformly
-            raise MediaNotFoundError(f"Image not found: {path}") from err
+            raise MediaNotFoundError(f"Image not found or unreadable: {path}") from err
         if base64:
             enc_image = b64encode(thumbnail_bytes).decode()
             return f"data:{_IMAGEPROXY_CONTENT_TYPES[content_format]};base64,{enc_image}"

--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, cast
 import aiofiles
 from aiohttp import web
 from music_assistant_models.enums import ImageType
-from music_assistant_models.errors import ProviderUnavailableError
+from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailableError
 from music_assistant_models.media_items import (
     Album,
     BrowseFolder,
@@ -158,7 +158,10 @@ class ImageProxyMixin:
         )
         if not img_path:
             return None
-        thumbnail = await self.get_thumbnail(img_path, provider="builtin", size=size)
+        try:
+            thumbnail = await self.get_thumbnail(img_path, provider="builtin", size=size)
+        except MediaNotFoundError:
+            return None
 
         return cast("bytes", thumbnail)
 
@@ -251,7 +254,7 @@ class ImageProxyMixin:
             return await get_palette_for_url(self.mass, image)
         try:
             return await get_palette(self.mass, image.path, image.provider)
-        except FileNotFoundError, OSError:
+        except MediaNotFoundError, OSError:
             return None
 
     async def get_thumbnail(
@@ -266,9 +269,14 @@ class ImageProxyMixin:
         """Get/create thumbnail image for path (image url or local path)."""
         if image_format is None:
             image_format = _detect_image_format(path)
-        thumbnail_bytes, content_format = await self._resolve_thumbnail(
-            path, provider, size, image_format, flatten_transparency
-        )
+        try:
+            thumbnail_bytes, content_format = await self._resolve_thumbnail(
+                path, provider, size, image_format, flatten_transparency
+            )
+        except (MediaNotFoundError, OSError) as err:
+            # normalize a missing/unreadable image into one typed error so callers
+            # (and not just the HTTP imageproxy handler) can handle it uniformly
+            raise MediaNotFoundError(f"Image not found: {path}") from err
         if base64:
             enc_image = b64encode(thumbnail_bytes).decode()
             return f"data:{_IMAGEPROXY_CONTENT_TYPES[content_format]};base64,{enc_image}"
@@ -443,7 +451,7 @@ class ImageProxyMixin:
             )
         except Exception as err:
             # broadly catch all exceptions here to ensure we dont crash the request handler
-            if isinstance(err, FileNotFoundError):
+            if isinstance(err, (MediaNotFoundError, FileNotFoundError)):
                 self.logger.log(VERBOSE_LOG_LEVEL, "Image not found: %s", path)
             else:
                 self.logger.warning(

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -791,7 +791,12 @@ class LocalFileSystemProvider(MusicProvider):
         a string with an http(s) URL or local path that is accessible from the server.
         """
         # drop the cache-busting suffix appended by _versioned_image_path
-        file_item = await self.resolve(path.split("?cs=", 1)[0])
+        try:
+            file_item = await self.resolve(path.split("?cs=", 1)[0])
+        except FileNotFoundError as err:
+            # the referenced image file was removed from disk; surface a typed
+            # not-found so the image layer treats it as a missing image
+            raise MediaNotFoundError(f"Image not found: {path}") from err
         return file_item.absolute_path
 
     async def check_write_access(self) -> None:

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -54,7 +54,7 @@ from music_assistant_models.enums import (
     ProviderType,
     RepeatMode,
 )
-from music_assistant_models.errors import PlayerCommandFailed
+from music_assistant_models.errors import MediaNotFoundError, PlayerCommandFailed
 from music_assistant_models.media_items import Album, Artist, is_track
 from music_assistant_models.player import DeviceInfo
 from PIL import Image
@@ -859,7 +859,13 @@ class SendspinPlayer(SendspinBasePlayer):
             if artwork_url is not None:
                 # Fetch from the resolved URL so the bytes match artwork_url, even when
                 # radio now-playing art differs from the queue item's own image.
-                image_data = await self.mass.metadata.get_thumbnail(artwork_url, provider="builtin")
+                try:
+                    image_data = await self.mass.metadata.get_thumbnail(
+                        artwork_url, provider="builtin"
+                    )
+                except MediaNotFoundError:
+                    # artwork file was removed from disk; skip rather than crash the send
+                    image_data = None
                 if isinstance(image_data, bytes):
                     # decode through the guard so undecodable art (e.g. SVG) is skipped, not crashed
                     image = await self._decode_artwork(image_data)
@@ -893,9 +899,13 @@ class SendspinPlayer(SendspinBasePlayer):
             if artist_artwork_url is not None:
                 # Fetch bytes from the already-resolved URL to avoid the secondary
                 # provider lookup that get_image_data_for_item triggers for ItemMappings.
-                artist_image_data = await self.mass.metadata.get_thumbnail(
-                    artist_artwork_url, provider="builtin"
-                )
+                try:
+                    artist_image_data = await self.mass.metadata.get_thumbnail(
+                        artist_artwork_url, provider="builtin"
+                    )
+                except MediaNotFoundError:
+                    # artwork file was removed from disk; skip rather than crash the send
+                    artist_image_data = None
                 if isinstance(artist_image_data, bytes):
                     artist_image = await self._decode_artwork(artist_image_data)
                     if (

--- a/tests/providers/filesystem/test_versioned_image_path.py
+++ b/tests/providers/filesystem/test_versioned_image_path.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from music_assistant_models.errors import MediaNotFoundError
 
 from music_assistant.providers.filesystem_local import LocalFileSystemProvider
 
@@ -54,3 +55,13 @@ class TestVersionedImagePath:
             mock_resolve.return_value = MagicMock(absolute_path="/music/track.flac")
             await provider.resolve_image("Moby Dick/track.flac")
         mock_resolve.assert_awaited_once_with("Moby Dick/track.flac")
+
+    @pytest.mark.asyncio
+    async def test_resolve_image_missing_file_raises_media_not_found(self) -> None:
+        """A removed image file surfaces as a typed MediaNotFoundError with chaining."""
+        provider = _create_provider()
+        with patch.object(provider, "resolve", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.side_effect = FileNotFoundError
+            with pytest.raises(MediaNotFoundError) as exc_info:
+                await provider.resolve_image("Moby Dick/folder.jpg?cs=123")
+        assert isinstance(exc_info.value.__cause__, FileNotFoundError)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

If a user deletes image files still referenced in the library, resolving them raised a raw `FileNotFoundError`. The HTTP imageproxy caught it (404), but fire-and-forget callers (e.g. sendspin's artwork sends) didn't and the exception
escaped as "Task exception was never retrieved" warnings.

This PR:
- raises a typed `MediaNotFoundError` at the source (`resolve_image`) instead of   leaking `FileNotFoundError`, and normalises it once in `get_thumbnail()`;
- guards the fire-and-forget artwork callers (sendspin album/artist art, and the  `get_image_data_for_item` helper) so a missing image is skipped, not fatal.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
