### PR TITLE
Pause external sources instead of stopping them

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3803,6 +3803,16 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             ):
                 await target_player.play()
                 return
+            # No active protocol target: if the player natively supports pause and the active
+            # (external) source can be paused, unpause the player directly instead of
+            # restarting the source.
+            if (
+                active_source
+                and active_source.can_play_pause
+                and PlayerFeature.PAUSE in player.state.supported_features
+            ):
+                await player.play()
+                return
 
         # player is not paused: try to resume the player
         # Note: We handle resume inline here without calling _handle_cmd_resume
@@ -3853,17 +3863,24 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             )
             raise PlayerCommandFailed(msg)
         # Delegate to active protocol player if one is active
-        if not (
-            target_player := self._get_control_target(
-                player, PlayerFeature.PAUSE, require_active=True
-            )
+        if target_player := self._get_control_target(
+            player, PlayerFeature.PAUSE, require_active=True
         ):
-            # if player(protocol) does not support pause, we need to send stop
-            self.logger.debug(
-                "Player/protocol %s does not support pause, using STOP instead",
-                player.state.name,
-            )
-            await self._handle_cmd_stop(player.player_id)
+            await target_player.pause()
             return
-        # handle command on player(protocol) directly
-        await target_player.pause()
+        # No active protocol target: if the player natively supports pause and the active
+        # (external) source can be paused, forward the command to the player itself instead
+        # of stopping it (mirrors the external-source handling in cmd_seek/cmd_next_track).
+        if (
+            active_source
+            and active_source.can_play_pause
+            and PlayerFeature.PAUSE in player.state.supported_features
+        ):
+            await player.pause()
+            return
+        # player/protocol does not support pause: fall back to stop
+        self.logger.debug(
+            "Player/protocol %s does not support pause, using STOP instead",
+            player.state.name,
+        )
+        await self._handle_cmd_stop(player.player_id)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.errors import UnsupportedFeaturedException
+from music_assistant_models.player import PlayerSource
 
 from music_assistant.controllers.players import PlayerController
 from tests.common import MockPlayer, MockProvider
@@ -54,6 +55,12 @@ def mock_mass() -> MagicMock:
 def controller(mock_mass: MagicMock) -> PlayerController:
     """Create a PlayerController instance."""
     return PlayerController(mock_mass)
+
+
+@pytest.fixture
+def provider(mock_mass: MagicMock) -> MockProvider:
+    """Create a mock provider."""
+    return MockProvider("test_provider", instance_id="test_prov", mass=mock_mass)
 
 
 class TestSetMembersValidation:
@@ -670,6 +677,94 @@ class TestPlayMediaOverride:
         assert power_calls == []
         # ... and play_media was issued directly on the member
         assert played_on == ["member"]
+
+
+class TestExternalSourcePlayPause:
+    """Pause/play handling for externally-initiated sources (no active output protocol)."""
+
+    @staticmethod
+    def _make_external_source_player(
+        provider: MockProvider,
+        controller: PlayerController,
+        mock_mass: MagicMock,
+        *,
+        playback_state: PlaybackState,
+        can_play_pause: bool = True,
+        supports_pause: bool = True,
+    ) -> MockPlayer:
+        """Build a player playing a passive external source, with no active output protocol."""
+        player = MockPlayer(provider, "player_1", "Test Player")
+        player._attr_supported_features = {PlayerFeature.PAUSE} if supports_pause else set()
+        player._attr_source_list = [
+            PlayerSource(
+                id="spotify",
+                name="Spotify",
+                passive=True,
+                can_play_pause=can_play_pause,
+                can_next_previous=True,
+                can_seek=True,
+            )
+        ]
+        player._attr_active_source = "spotify"
+        player._attr_playback_state = playback_state
+        player._cache.clear()
+        controller._players = {"player_1": player}
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.player_queues.get = MagicMock(return_value=None)
+        player.update_state(signal_event=False)
+        return player
+
+    def test_pause_external_source_forwards_to_player(
+        self, mock_mass: MagicMock, controller: PlayerController, provider: MockProvider
+    ) -> None:
+        """Pausing a pausable external source forwards to the player, not STOP."""
+        player = self._make_external_source_player(
+            provider, controller, mock_mass, playback_state=PlaybackState.PLAYING
+        )
+        player.pause = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        asyncio.run(controller._handle_cmd_pause("player_1"))
+
+        player.pause.assert_awaited_once()
+        controller._handle_cmd_stop.assert_not_called()
+
+    def test_play_external_source_unpauses_player(
+        self, mock_mass: MagicMock, controller: PlayerController, provider: MockProvider
+    ) -> None:
+        """Unpausing a paused external source forwards to the player, not a restart."""
+        player = self._make_external_source_player(
+            provider, controller, mock_mass, playback_state=PlaybackState.PAUSED
+        )
+        player.play = AsyncMock()  # type: ignore[method-assign]
+        player.play_media = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_select_source = AsyncMock()  # type: ignore[method-assign]
+
+        asyncio.run(controller._handle_cmd_play("player_1"))
+
+        player.play.assert_awaited_once()
+        player.play_media.assert_not_called()
+        controller._handle_select_source.assert_not_called()
+
+    def test_pause_falls_back_to_stop_without_pause_support(
+        self, mock_mass: MagicMock, controller: PlayerController, provider: MockProvider
+    ) -> None:
+        """A player that cannot pause natively still falls back to STOP."""
+        player = self._make_external_source_player(
+            provider,
+            controller,
+            mock_mass,
+            playback_state=PlaybackState.PLAYING,
+            supports_pause=False,
+        )
+        player.pause = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        asyncio.run(controller._handle_cmd_pause("player_1"))
+
+        controller._handle_cmd_stop.assert_awaited_once()
+        player.pause.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this implement/fix?

When a player is playing an external source that supports pause (e.g. Spotify Connect on a Sonos), sending pause translated to **stop**. Stopping the transport tears down the external session and hands the source back to MA, instead of simply pausing/resuming it.

The pause/play handlers only routed the command through an active output protocol. For an externally-initiated source there is no active protocol target, so they fell back to stop — even though the active source advertises `can_play_pause`. This also made pause inconsistent with seek and next/previous, which already forward natively to the player based on the source capability.

Changes:

- `_handle_cmd_pause`: when there is no active protocol target, forward pause to the player itself if it natively supports pause and the active source can be paused, instead of falling back to stop.
- `_handle_cmd_play`: mirror the same handling so a paused external source is unpaused natively rather than restarted.
- The provider still has the final say (e.g. Sonos consults its live transport `can_pause`), so sources that genuinely cannot pause still degrade to stop.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
