### PR TITLE
Rename 'don't stop the music' to 'autoplay'

### DIFF
--- a/music_assistant/controllers/player_queues/README.md
+++ b/music_assistant/controllers/player_queues/README.md
@@ -75,7 +75,7 @@ and the targets for playback, and coordinates with several sibling controllers:
 | Type | Role |
 | --- | --- |
 | `PlayerQueuesController` | The controller: owns all live `PlayerQueue` objects and their items, exposes the API commands, and bridges player events to queue state. Subclass of `CoreController`. |
-| `PlayerQueue` | Per-player queue model holding the playback state and the flags that drive behaviour — playback state, shuffle/repeat, don't-stop-the-music, flow mode, dynamic/radio source, the current item and index, and elapsed time. Serializable to and from the cache. |
+| `PlayerQueue` | Per-player queue model holding the playback state and the flags that drive behaviour — playback state, shuffle/repeat, autoplay, flow mode, dynamic/radio source, the current item and index, and elapsed time. Serializable to and from the cache. |
 | `QueueItem` | A single playable entry: the media-item reference, its resolved stream details, an ordering index, and per-item `extra_attributes` (e.g. playback speed). Serializable to and from the cache. |
 | `Player` / `PlayerMedia` | `Player` is the device whose real-time state the queue is reconciled against (state, active source, corrected elapsed time, type). `PlayerMedia` is the resolved playback payload (uri, images, ...) handed to the player for a queue item. |
 | `MediaItemType` family | The source media abstractions (track, album, artist, playlist, podcast, podcast episode, audiobook, genre, browse folder, item mapping) that the controller expands/resolves into concrete tracks and `QueueItem`s before enqueueing. |
@@ -157,13 +157,13 @@ Data flow: current index → next-item computation → stream-detail resolution 
 
 ## Radio and Dynamic Continuation
 
-When a queue is a radio source or has don't-stop-the-music enabled, the controller keeps it topped
+When a queue is a radio source or has autoplay enabled, the controller keeps it topped
 up as it nears its end by fetching additional dynamic/similar/recently-played tracks from the Music
 Controller (user-scoped where relevant) and appending them as new `QueueItem`s. Dynamic playlists
 are detected at the queue level, and freshly added items can be shuffled to avoid placing identical
 tracks next to each other.
 
-Data flow: radio-source / dynamic / don't-stop-the-music flags → Music Controller dynamic-track
+Data flow: radio-source / dynamic / autoplay flags → Music Controller dynamic-track
 fetch → appended `QueueItem`s.
 
 ## Track Resolution

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -340,22 +340,22 @@ class PlayerQueuesController(CoreController):
             shuffle=shuffle_enabled,
         )
 
-    @api_command("player_queues/dont_stop_the_music")
-    def set_dont_stop_the_music(self, queue_id: str, dont_stop_the_music_enabled: bool) -> None:
-        """Configure Don't stop the music setting on the queue."""
+    @api_command("player_queues/autoplay")
+    def set_autoplay(self, queue_id: str, autoplay_enabled: bool) -> None:
+        """Configure Autoplay setting on the queue."""
         providers_available_with_similar_tracks = any(
             ProviderFeature.SIMILAR_TRACKS in provider.supported_features
             for provider in self.mass.music.providers
         )
-        if dont_stop_the_music_enabled and not providers_available_with_similar_tracks:
+        if autoplay_enabled and not providers_available_with_similar_tracks:
             raise UnsupportedFeaturedException(
-                "Don't stop the music is not supported by any of the available music providers"
+                "Autoplay is not supported by any of the available music providers"
             )
         queue = self._queues[queue_id]
-        queue.dont_stop_the_music_enabled = dont_stop_the_music_enabled
+        queue.autoplay_enabled = autoplay_enabled
         # if this happens to be the last track in the queue, fill the radio source
         if (
-            queue.dont_stop_the_music_enabled
+            queue.autoplay_enabled
             and queue.enqueued_media_items
             and queue.current_index is not None
             and (queue.items - queue.current_index) <= 1
@@ -365,6 +365,11 @@ class PlayerQueuesController(CoreController):
             task_id = f"fill_radio_tracks_{queue_id}"
             self.mass.call_later(5, self._fill_radio_tracks, queue_id, task_id=task_id)
         self.signal_update(queue_id=queue_id)
+
+    @api_command("player_queues/dont_stop_the_music", alias=True)
+    def set_dont_stop_the_music(self, queue_id: str, dont_stop_the_music_enabled: bool) -> None:
+        """Backwards-compatible alias for the autoplay command, used by older clients."""
+        self.set_autoplay(queue_id, dont_stop_the_music_enabled)
 
     @api_command("player_queues/repeat")
     def set_repeat(self, queue_id: str, repeat_mode: RepeatMode) -> None:
@@ -1044,7 +1049,7 @@ class PlayerQueuesController(CoreController):
         target_queue.crossfade_enabled = source_queue.crossfade_enabled
         # refresh the derived smart-fades indicator for the target's own config/availability
         target_queue.smart_fades_active = self.mass.streams.is_smart_fades_active(target_queue)
-        target_queue.dont_stop_the_music_enabled = source_queue.dont_stop_the_music_enabled
+        target_queue.autoplay_enabled = source_queue.autoplay_enabled
         target_queue.radio_source = source_queue.radio_source
         target_queue.is_dynamic = source_queue.is_dynamic
         target_queue.enqueued_media_items = source_queue.enqueued_media_items
@@ -1108,7 +1113,7 @@ class PlayerQueuesController(CoreController):
                 active=False,
                 display_name=player.state.name,
                 available=player.state.available,
-                dont_stop_the_music_enabled=False,
+                autoplay_enabled=False,
                 items=0,
             )
 
@@ -1894,7 +1899,7 @@ class PlayerQueuesController(CoreController):
                         )
 
                 # Save requested media item to play on the queue so we can use it as a source
-                # for Don't stop the music. Use FIFO list to keep track of the last 10 played items
+                # for Autoplay. Use FIFO list to keep track of the last 10 played items
                 # Skip ItemMapping and BrowseFolder - only queue full MediaItemType objects
                 if not isinstance(
                     media_item, (ItemMapping, BrowseFolder)
@@ -2889,19 +2894,19 @@ class PlayerQueuesController(CoreController):
 
         # watch dynamic radio items refill if needed
         if "current_item_id" in changed_keys:
-            # auto enable radio mode if dont stop the music is enabled
+            # auto enable radio mode if autoplay is enabled
             if (
-                queue.dont_stop_the_music_enabled
+                queue.autoplay_enabled
                 and queue.enqueued_media_items
                 and queue.current_index is not None
                 and (queue.items - queue.current_index) <= 1
             ):
-                # We have received the last item in the queue and Don't stop the music is enabled
+                # We have received the last item in the queue and Autoplay is enabled
                 # set the played media item(s) as radio items (which will refill the queue)
                 # note that this will fail if there are no media items for which we have
                 # a dynamic radio source.
                 self.logger.debug(
-                    "End of queue detected and Don't stop the music is enabled for %s"
+                    "End of queue detected and Autoplay is enabled for %s"
                     " - setting enqueued media items as radio source: %s",
                     queue.display_name,
                     ", ".join([x.uri for x in queue.enqueued_media_items]),  # type: ignore[misc]  # uri set in __post_init__

--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -366,7 +366,10 @@ class APICommandHandler:
 
 
 def api_command(
-    command: str, authenticated: bool = True, required_role: str | None = None
+    command: str,
+    authenticated: bool = True,
+    required_role: str | None = None,
+    alias: bool = False,
 ) -> Callable[[_F], _F]:
     """
     Decorate a function as API route/command.
@@ -374,12 +377,15 @@ def api_command(
     :param command: The command name/path.
     :param authenticated: Whether authentication is required (default: True).
     :param required_role: Required user role ("admin" or "user"), None means any authenticated user.
+    :param alias: Whether this is a backward-compatible alias (default: False).
+        Aliases remain functional but are hidden from the API documentation.
     """
 
     def decorate(func: _F) -> _F:
         func.api_cmd = command  # type: ignore[attr-defined]
         func.api_authenticated = authenticated  # type: ignore[attr-defined]
         func.api_required_role = required_role  # type: ignore[attr-defined]
+        func.api_alias = alias  # type: ignore[attr-defined]
         return func
 
     return decorate

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -930,7 +930,8 @@ class MusicAssistant:
                     # method is decorated with our api decorator
                     authenticated = getattr(obj, "api_authenticated", True)
                     required_role = getattr(obj, "api_required_role", None)
-                    self.register_api_command(obj.api_cmd, obj, authenticated, required_role)
+                    alias = getattr(obj, "api_alias", False)
+                    self.register_api_command(obj.api_cmd, obj, authenticated, required_role, alias)
 
     async def _load_builtin_providers(self) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "ifaddr==0.2.0",
   "getmac==0.9.5",
   "mashumaro==3.20",
-  "music-assistant-models==1.1.142",
+  "music-assistant-models==1.1.143",
   "music-assistant-frontend==2.17.195",
   "mutagen==1.47.0",
   "orjson==3.11.6",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -49,7 +49,7 @@ lyricsgenius==3.12.2
 mashumaro==3.20
 modern_colorthief==0.2.1
 music-assistant-frontend==2.17.195
-music-assistant-models==1.1.142
+music-assistant-models==1.1.143
 mutagen==1.47.0
 niconico.py-ma==2.1.0.post2
 nnAudio==0.3.3


### PR DESCRIPTION
# What does this implement/fix?

Aligns the backend with the frontend rebrand of *Don't stop the music* → **Autoplay** (the one-word, industry-standard term for this feature).

- Rename the queue flag and API command: `player_queues/dont_stop_the_music` → `player_queues/autoplay` (`set_autoplay` / `autoplay_enabled`).
- Keep `player_queues/dont_stop_the_music` as a hidden, backwards-compatible command alias (`@api_command(alias=True)`, excluded from the API docs) so older clients can still toggle it.
- The model still emits *and* accepts the legacy `dont_stop_the_music_enabled` key, so older clients and cached queue state keep working.
- Bumps `music-assistant-models` to 1.1.143, which carries the matching model rename (so this replaces the auto-bump PR).

**Related issue (if applicable):**

- Frontend rebrand: music-assistant/frontend#1945
- Models companion: music-assistant/models#273

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
