### PR TITLE
Fix unjoining a syncgroup member that joined the leader externally

### DIFF
--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -478,6 +478,17 @@ class SyncGroupPlayer(Player):
         leader_removed = False
         for member_id in player_ids_to_remove or []:
             if member_id not in self._attr_group_members:
+                # Fallback for a member that was grouped to the sync leader
+                # outside of MA (e.g. via the Sonos app): it isn't part of our
+                # tracked member list but does show up in group_members via the
+                # leader's live state. Forward its removal to the sync leader
+                # instead of silently skipping it.
+                if (
+                    self.sync_leader
+                    and member_id != self.sync_leader.player_id
+                    and member_id in self.sync_leader.state.group_members
+                ):
+                    final_players_to_remove.append(member_id)
                 continue
             if member_id in self._attr_static_group_members:
                 # static members can not be removed from the group

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -547,6 +547,64 @@ class TestSetMembersDoesNotRegisterIncompatible:
         mass.players._handle_set_members.assert_not_awaited()
 
 
+class TestSetMembersRemovesExternalJoiner:
+    """Regression: a member joined to the leader outside MA must be removable."""
+
+    @pytest.mark.asyncio
+    async def test_external_joiner_removal_forwards_to_leader(self) -> None:
+        """
+        Removing an external joiner must forward straight to the sync leader.
+
+        A player grouped directly to the sync leader (e.g. via the Sonos app)
+        appears in group_members via the leader's live state but is not in the
+        group's tracked member list, so it must not be silently skipped.
+        """
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        # the leader's live native group includes an external joiner the group
+        # itself never registered
+        leader.state.group_members = ["leader", "external_x"]
+        external = _make_mock_player("external_x", provider_domain="sonos")
+
+        mass.players.get_player = _player_lookup({"leader": leader, "external_x": external})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader"]
+
+        await sgp.set_members(player_ids_to_remove=["external_x"])
+
+        # the removal must be forwarded to the sync leader
+        mass.players._handle_set_members.assert_awaited_once()
+        call = mass.players._handle_set_members.await_args
+        assert call.args[0] is leader
+        assert call.kwargs.get("player_ids_to_remove") == ["external_x"]
+        # the group's tracked member list is untouched (external was never in it)
+        assert sgp._attr_group_members == ["leader"]
+
+    @pytest.mark.asyncio
+    async def test_tracked_member_removal_uses_managed_path(self) -> None:
+        """A member the group actually manages is removed via the managed path."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        leader.state.group_members = ["leader", "member_b"]
+        member_b = _make_mock_player("member_b", provider_domain="sonos")
+
+        mass.players.get_player = _player_lookup({"leader": leader, "member_b": member_b})
+        sgp.sync_leader = leader
+        sgp._attr_group_members = ["leader", "member_b"]
+
+        await sgp.set_members(player_ids_to_remove=["member_b"])
+
+        # tracked member is dropped from the internal list and forwarded
+        assert "member_b" not in sgp._attr_group_members
+        mass.players._handle_set_members.assert_awaited_once()
+        call = mass.players._handle_set_members.await_args
+        assert call.kwargs.get("player_ids_to_remove") == ["member_b"]
+
+
 def _make_sync_group_with_filters(
     mass: MagicMock,
     allowed_members: list[str] | None = None,


### PR DESCRIPTION
## What does this implement/fix?

When a player is grouped to a syncgroup's sync leader outside of Music Assistant (e.g. directly from the Sonos app or any other native controller), MA shows the extra member correctly but cannot unjoin it from the UI or the Home Assistant API — only the external controller can.

Such a member shows up in the group's `group_members` (via the sync leader's live state) but is never part of the group's tracked member list, so the unjoin was silently skipped.

- `sync_group` player: when a removal targets a member that isn't in the group's tracked members but is present on the sync leader, forward that removal to the sync leader instead of skipping it.
- add regression tests for external-member removal.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
