### PR TITLE
Recover flow stream restart on Cast groups (players that don't report idle)

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -139,6 +139,8 @@ class PlayerQueuesController(CoreController):
         self._transitioning_players: set[str] = set()
         self._play_action_refcount: dict[str, int] = {}
         self._last_counted_play: dict[str, str] = {}
+        # queue_id -> session_id whose flow stream was fully generated
+        self._flow_buffer_completed: dict[str, str] = {}
         self.manifest.name = "Player Queues controller"
         self.manifest.description = (
             "Music Assistant's core controller which manages the queues for all players."
@@ -907,6 +909,7 @@ class PlayerQueuesController(CoreController):
             # At this point index is guaranteed to be int
             queue.index_in_buffer = index
             queue.flow_mode_stream_log = []
+            self._flow_buffer_completed.pop(queue_id, None)
             target_player = self.mass.players.get_player(queue_id)
             if target_player is None:
                 raise PlayerUnavailableError(f"Player {queue_id} is not available")
@@ -1327,6 +1330,9 @@ class PlayerQueuesController(CoreController):
 
         # capture session_id so we can bail out if playback restarts
         original_session_id = queue.session_id
+        # record so player providers can detect flow EOF without an idle report
+        if original_session_id is not None:
+            self._flow_buffer_completed[queue_id] = original_session_id
 
         async def _resume_on_idle() -> None:
             # wait for the player to finish playing the buffered audio and go idle
@@ -1358,6 +1364,20 @@ class PlayerQueuesController(CoreController):
 
         task_id = f"queue_buffer_completed_{queue_id}"
         self.mass.create_task(_resume_on_idle(), task_id=task_id)
+
+    def flow_stream_finished(self, queue_id: str) -> bool:
+        """
+        Return whether the flow stream for the current playback session is fully generated.
+
+        Lets player providers detect flow EOF when the device does not report idle
+        (e.g. a Cast group that underruns the LIVE flow stream and keeps reporting playing).
+
+        :param queue_id: The queue ID.
+        """
+        queue = self._queues.get(queue_id)
+        if queue is None or queue.session_id is None:
+            return False
+        return self._flow_buffer_completed.get(queue_id) == queue.session_id
 
     # Main queue manipulation methods
 

--- a/music_assistant/providers/chromecast/player.py
+++ b/music_assistant/providers/chromecast/player.py
@@ -21,7 +21,7 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import PlayerUnavailableError
 from music_assistant_models.player import PlayerSource
 from pychromecast import IDLE_APP_ID
-from pychromecast.controllers.media import STREAM_TYPE_LIVE
+from pychromecast.controllers.media import MEDIA_PLAYER_STATE_BUFFERING, STREAM_TYPE_LIVE
 from pychromecast.controllers.multizone import MultizoneController
 from pychromecast.socket_client import CONNECTION_STATUS_CONNECTED, CONNECTION_STATUS_DISCONNECTED
 
@@ -498,8 +498,16 @@ class ChromecastPlayer(Player):
             status = group_player.cc.media_controller.status
 
         # player state
+        # pychromecast reports BUFFERING as 'playing', so a Cast group that underruns the
+        # LIVE flow stream at EOF never goes idle. Treat that case as idle so the queue
+        # can resume/restart.
+        flow_underrun = (
+            status.player_state == MEDIA_PLAYER_STATE_BUFFERING and self._flow_stream_underrun()
+        )
+        is_playing = status.player_is_playing and not flow_underrun
+        is_idle = status.player_is_idle or flow_underrun
         self._attr_elapsed_time_last_updated = time.time()
-        if status.player_is_playing:
+        if is_playing:
             self._attr_playback_state = PlaybackState.PLAYING
             self.set_current_media(uri=status.content_id or "", clear_all=True)
         elif status.player_is_paused:
@@ -514,7 +522,7 @@ class ChromecastPlayer(Player):
         # elapsed time
         self._attr_elapsed_time_last_updated = time.time()
         self._attr_elapsed_time = status.adjusted_current_time
-        if status.player_is_playing:
+        if is_playing:
             self._attr_elapsed_time = status.adjusted_current_time
         else:
             self._attr_elapsed_time = status.current_time
@@ -541,7 +549,7 @@ class ChromecastPlayer(Player):
                     )
                 )
 
-        if status.content_id and not status.player_is_idle:
+        if status.content_id and not is_idle:
             self.set_current_media(
                 uri=status.content_id,
                 title=status.title,
@@ -651,3 +659,9 @@ class ChromecastPlayer(Player):
             "metadata": metadata,
             "duration": media.duration,
         }
+
+    def _flow_stream_underrun(self) -> bool:
+        """Return whether the active queue's flow stream has been fully consumed."""
+        # a group child mirrors the group's status, so use the queue-owning player
+        queue_id = self.active_cast_group or self.player_id
+        return self.mass.player_queues.flow_stream_finished(queue_id)

--- a/tests/controllers/player_queues/test_flow_stream_finished.py
+++ b/tests/controllers/player_queues/test_flow_stream_finished.py
@@ -1,0 +1,73 @@
+"""
+Tests for PlayerQueuesController flow-stream EOF tracking.
+
+Player providers query ``flow_stream_finished`` to recognise an end-of-stream
+condition that does not surface as a normal idle report (e.g. a Cast group that
+underruns the LIVE flow stream at EOF and keeps reporting buffering/playing).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+
+
+def _fake_controller(queue: MagicMock) -> MagicMock:
+    """Build a MagicMock standing in for the controller, owning a single queue."""
+
+    def _close_coro(coro: Any, **_kwargs: Any) -> None:
+        # close the scheduled resume coroutine so it doesn't raise 'never awaited'
+        coro.close()
+
+    fake = MagicMock()
+    fake._queues = {queue.queue_id: queue}
+    fake._flow_buffer_completed = {}
+    fake.mass.create_task = MagicMock(side_effect=_close_coro)
+    return fake
+
+
+def _finished(fake: MagicMock, queue_id: str) -> bool:
+    return PlayerQueuesController.flow_stream_finished(
+        cast("PlayerQueuesController", fake), queue_id
+    )
+
+
+def test_flow_stream_finished_false_without_completion() -> None:
+    """An untouched queue reports its flow stream as not finished."""
+    queue = MagicMock(queue_id="q", session_id="sess-1")
+    fake = _fake_controller(queue)
+
+    assert _finished(fake, "q") is False
+
+
+def test_queue_buffer_completed_marks_session_finished() -> None:
+    """Buffer completion records the session so flow_stream_finished returns True."""
+    queue = MagicMock(queue_id="q", session_id="sess-1")
+    fake = _fake_controller(queue)
+
+    PlayerQueuesController.queue_buffer_completed(cast("PlayerQueuesController", fake), "q")
+
+    assert fake._flow_buffer_completed == {"q": "sess-1"}
+    assert _finished(fake, "q") is True
+
+
+def test_flow_stream_finished_invalidated_by_new_session() -> None:
+    """A completion from a previous session must not count for a fresh session."""
+    queue = MagicMock(queue_id="q", session_id="sess-1")
+    fake = _fake_controller(queue)
+    PlayerQueuesController.queue_buffer_completed(cast("PlayerQueuesController", fake), "q")
+
+    # a new playback session starts (play_index assigns a fresh session_id)
+    queue.session_id = "sess-2"
+
+    assert _finished(fake, "q") is False
+
+
+def test_flow_stream_finished_false_for_unknown_queue() -> None:
+    """An unknown queue id never reports a finished flow stream."""
+    queue = MagicMock(queue_id="q", session_id="sess-1")
+    fake = _fake_controller(queue)
+
+    assert _finished(fake, "other") is False


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Casting a flow-mode queue to a Google/Nest speaker **group**, playback stalls at any flow restart, for example,when a sample-rate change in `smart` mode occurs. The first track plays, then the queue sits in "playing" forever and only a manual skip recovers it. Single Cast devices are unaffected.

The flow stream is sent as `STREAM_TYPE_LIVE`. At a restart, MA ends the HTTP response; a Cast **group** treats the EOF as a
live-stream underrun and reports `BUFFERING` (which pychromecast surfaces as `player_is_playing`, so MA maps it to `PlaybackState.PLAYING`) instead of going `IDLE`. `_resume_on_idle` only restarted on `IDLE`, which never arrived leading to a permanent stall.

`_resume_on_idle` now also treats the flow as finished once the player has played to the end of the streamed audio:
- **fast path** on the player's *reported* position reaching the streamed total (the underrun report), guarded by a fresh-status check so a stale position from the pre-restart stream can't skip a short track;
- **extrapolation backstop** for players that stop sending updates entirely.

Well-behaved players keep using the existing `IDLE` path. Also clarifies the `flow_mode_sample_rate` description: the
smart/bit-perfect restart briefly interrupts players that can't switch rate gaplessly, and the fixed-rate options avoid restarts.

Also clarifies the flow_mode_sample_rate description: the smart/bit-perfect restart briefly interrupts players that can't switch rate gaplessly (grouped speakers), and the fixed rate options avoid restarts.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5715

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
