### PR TITLE
Transfer playback to a new leader when unjoining a sync group leader

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1018,6 +1018,16 @@ class PlayerQueuesController(CoreController):
             # propagate before we hand the queue over to the target player.
             group_id = target_player.state.active_group or target_player.state.synced_to
             assert group_id is not None  # checked in if condition above
+            # For an ad-hoc sync group (target is a sync member of a regular leader),
+            # ungroup the target itself so only it is freed - ungrouping the leader would
+            # transfer leadership to a remaining member and recurse back into this method.
+            # For a virtual group player (active_group), release the group so its static
+            # members are handled correctly.
+            ungroup_target = (
+                target_queue_id
+                if target_player.state.synced_to and not target_player.state.active_group
+                else group_id
+            )
             async with self.mass.players.wait_for_player_update(
                 target_queue_id,
                 attribute_name=(
@@ -1026,7 +1036,7 @@ class PlayerQueuesController(CoreController):
                 attribute_value=None,
                 timeout=5,
             ):
-                await self.mass.players.cmd_ungroup(group_id)
+                await self.mass.players.cmd_ungroup(ungroup_target)
 
         # capture source state before stopping (stop resets these)
         source_items = self._queue_items[source_queue_id]

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1308,10 +1308,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
         if player.state.group_members:
             # player is a sync leader (a non-group player with synced followers).
-            # Ungroup all followers from it.
-            await self.cmd_set_members(
-                player.player_id, player_ids_to_remove=player.state.group_members
-            )
+            # Remove only the leader itself: _handle_set_members will either transfer
+            # leadership to a remaining member (keeping playback alive) or, when no
+            # members remain / nothing is playing, dissolve the group and stop.
+            await self.cmd_set_members(player.player_id, player_ids_to_remove=[player.player_id])
             return
         # unjoin from any dynamic sync groups if we're currently in one (edge case)
         # this is in particular used for the Home Assistant integration which does
@@ -3106,10 +3106,23 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         :param player_ids_to_remove: List of player_id's to remove from the parent player.
         """
         target_player = parent_player.player_id
-        # handle dissolve sync group if the target player is currently
-        # a sync leader and is being removed from itself
+        # handle the sync leader being removed from itself: either transfer leadership
+        # to a remaining member (keeping playback alive) or dissolve the group entirely
         should_stop = False
         if player_ids_to_remove and target_player in player_ids_to_remove:
+            remaining_members = [
+                m
+                for m in parent_player.state.group_members
+                if m != target_player
+                and m not in player_ids_to_remove
+                and (member := self.get_player(m))
+                and member.state.available
+            ]
+            active_queue = self.get_active_queue(parent_player)
+            if remaining_members and active_queue and active_queue.state != PlaybackState.IDLE:
+                # transfer leadership to a remaining member instead of dissolving
+                await self._transfer_ad_hoc_leadership(parent_player, remaining_members)
+                return
             self.logger.info(
                 "Dissolving sync group of player %s as it is being removed from itself",
                 parent_player.name,
@@ -3310,6 +3323,66 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                     player_ids_to_add=filtered_native_add or None,
                     player_ids_to_remove=filtered_native_remove or None,
                 )
+
+    async def _transfer_ad_hoc_leadership(
+        self, leader: Player, remaining_members: list[str]
+    ) -> None:
+        """
+        Transfer leadership of an ad-hoc sync group to a remaining member.
+
+        Called when the sync leader of an ad-hoc group is unjoined while other
+        members remain and playback is active. The queue is moved to a newly
+        selected leader, the remaining members are regrouped under it and playback
+        resumes at the saved position (accepting a brief audio gap).
+
+        :param leader: The current sync leader being removed from the group.
+        :param remaining_members: Available group members (excluding the leader)
+            that should keep playing under a new leader.
+        """
+        active_queue = self.get_active_queue(leader)
+        was_playing = active_queue is not None and active_queue.state == PlaybackState.PLAYING
+        new_leader_id = self._select_ad_hoc_leader(remaining_members)
+        self.logger.info(
+            "Transferring leadership of %s to %s (%s remaining member(s))",
+            leader.name,
+            new_leader_id,
+            len(remaining_members),
+        )
+        # Move the queue to the new leader. transfer_queue frees the new leader from
+        # the old leader's group and stops the old leader; the playback position
+        # survives because stop() stores it in resume_pos.
+        await self.mass.player_queues.transfer_queue(
+            leader.player_id, new_leader_id, auto_play=False
+        )
+        # regroup the other remaining members under the new leader
+        other_members = [m for m in remaining_members if m != new_leader_id]
+        if other_members:
+            await self.cmd_set_members(new_leader_id, player_ids_to_add=other_members)
+        if was_playing:
+            await self.mass.player_queues.resume(new_leader_id)
+
+    def _select_ad_hoc_leader(self, remaining_members: list[str]) -> str:
+        """
+        Pick the new leader for an ad-hoc sync group leadership transfer.
+
+        Prefers the member that can group with the most other remaining members so
+        that regrouping succeeds; falls back (on a tie) to the first remaining member.
+
+        :param remaining_members: Candidate member player_ids, already filtered for
+            availability. Must not be empty.
+        """
+
+        def groupable_count(member_id: str) -> int:
+            member = self.get_player(member_id)
+            if member is None:
+                return -1
+            return sum(
+                1
+                for other in remaining_members
+                if other != member_id and other in member.state.can_group_with
+            )
+
+        return max(remaining_members, key=groupable_count)
 
     # Private command handlers (no permission checks)
 

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3341,7 +3341,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         active_queue = self.get_active_queue(leader)
         was_playing = active_queue is not None and active_queue.state == PlaybackState.PLAYING
-        new_leader_id = self._select_ad_hoc_leader(remaining_members)
+        new_leader_id = self._select_ad_hoc_leader(leader, remaining_members)
         self.logger.info(
             "Transferring leadership of %s to %s (%s remaining member(s))",
             leader.name,
@@ -3361,28 +3361,34 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if was_playing:
             await self.mass.player_queues.resume(new_leader_id)
 
-    def _select_ad_hoc_leader(self, remaining_members: list[str]) -> str:
+    def _select_ad_hoc_leader(self, leader: Player, remaining_members: list[str]) -> str:
         """
         Pick the new leader for an ad-hoc sync group leadership transfer.
 
-        Prefers the member that can group with the most other remaining members so
-        that regrouping succeeds; falls back (on a tie) to the first remaining member.
+        Prefers a remaining member that supports the protocol the group is currently
+        playing on, so the other members can be regrouped under it; falls back to the
+        first remaining member. The members' own ``can_group_with`` is unusable here
+        because it is empty while they are still synced to the old leader.
 
+        :param leader: The current sync leader being removed.
         :param remaining_members: Candidate member player_ids, already filtered for
             availability. Must not be empty.
         """
-
-        def groupable_count(member_id: str) -> int:
-            member = self.get_player(member_id)
-            if member is None:
-                return -1
-            return sum(
-                1
-                for other in remaining_members
-                if other != member_id and other in member.state.can_group_with
-            )
-
-        return max(remaining_members, key=groupable_count)
+        active_domain: str | None = None
+        if leader.active_output_protocol and leader.active_output_protocol != "native":
+            if protocol_player := self.get_player(leader.active_output_protocol):
+                active_domain = protocol_player.provider.domain
+        if active_domain:
+            for member_id in remaining_members:
+                member = self.get_player(member_id)
+                if member is None:
+                    continue
+                if member.provider.domain == active_domain or any(
+                    protocol.protocol_domain == active_domain and protocol.available
+                    for protocol in member.linked_output_protocols
+                ):
+                    return member_id
+        return remaining_members[0]
 
     # Private command handlers (no permission checks)
 

--- a/tests/controllers/player_queues/test_transfer_queue.py
+++ b/tests/controllers/player_queues/test_transfer_queue.py
@@ -1,0 +1,83 @@
+"""Tests for PlayerQueuesController.transfer_queue protocol/ungroup handling."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import PlaybackState
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+
+
+class _DummyACM:
+    """Minimal async context manager stand-in for wait_for_player_update."""
+
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, *args: object) -> bool:
+        return False
+
+
+def _fake_controller(source_id: str, target_player: MagicMock) -> MagicMock:
+    """
+    Build a MagicMock standing in for the controller for transfer_queue tests.
+
+    The source queue is idle so the capture/stop/resume path is a no-op; the test
+    only exercises the pre-transfer ungroup branch.
+    """
+    source_queue = MagicMock()
+    source_queue.state = PlaybackState.IDLE
+    source_queue.resume_pos = 0
+    source_queue.elapsed_time = 0
+    source_queue.current_index = 0
+    source_queue.current_item = None
+    target_queue = MagicMock()
+
+    fake = MagicMock()
+    fake.get = MagicMock(side_effect=lambda qid: source_queue if qid == source_id else target_queue)
+    fake._queue_items = {source_id: []}
+    fake.stop = AsyncMock()
+    fake.load = AsyncMock()
+    fake.resume = AsyncMock()
+    fake.clear = MagicMock()
+    fake.update_items = MagicMock()
+    fake.mass.players.get_player = MagicMock(return_value=target_player)
+    fake.mass.players.cmd_ungroup = AsyncMock()
+    fake.mass.players.wait_for_player_update = MagicMock(return_value=_DummyACM())
+    fake.mass.streams.is_smart_fades_active = MagicMock(return_value=False)
+    return fake
+
+
+async def test_transfer_queue_ad_hoc_member_ungroups_target_not_leader() -> None:
+    """
+    Transferring onto an ad-hoc sync member frees the target itself, not its leader.
+
+    Ungrouping the leader would transfer leadership to a remaining member and
+    recurse back into transfer_queue, so only the target may be ungrouped.
+    """
+    target_player = MagicMock()
+    target_player.state.synced_to = "leaderA"
+    target_player.state.active_group = None
+    fake = _fake_controller("src", target_player)
+
+    await PlayerQueuesController.transfer_queue(
+        cast("PlayerQueuesController", fake), "src", "memberB", auto_play=False
+    )
+
+    fake.mass.players.cmd_ungroup.assert_awaited_once_with("memberB")
+
+
+async def test_transfer_queue_group_member_ungroups_group() -> None:
+    """Transferring onto a virtual-group member releases the group player itself."""
+    target_player = MagicMock()
+    target_player.state.synced_to = None
+    target_player.state.active_group = "groupP"
+    fake = _fake_controller("src", target_player)
+
+    await PlayerQueuesController.transfer_queue(
+        cast("PlayerQueuesController", fake), "src", "memberB", auto_play=False
+    )
+
+    fake.mass.players.cmd_ungroup.assert_awaited_once_with("groupP")

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -11,7 +11,7 @@ This module tests the core grouping behavior including:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
@@ -463,6 +463,91 @@ class TestPlayerBaseIsActiveSession:
         provider = MockProvider("test", instance_id="test", mass=mock_mass)
         player = MockPlayer(provider, "p1", "P1")
         assert player.is_active_session is False
+
+
+class TestAdHocLeadershipTransfer:
+    """Unjoining an ad-hoc sync leader transfers leadership instead of dissolving."""
+
+    def test_select_ad_hoc_leader_prefers_most_groupable(
+        self, controller: PlayerController
+    ) -> None:
+        """The new leader should be the member that can group with the most others."""
+        player_a = MagicMock()
+        player_a.state.can_group_with = {"b", "c"}
+        player_b = MagicMock()
+        player_b.state.can_group_with = {"a"}
+        player_c = MagicMock()
+        player_c.state.can_group_with = {"a"}
+        controller._players = {"a": player_a, "b": player_b, "c": player_c}
+
+        assert controller._select_ad_hoc_leader(["a", "b", "c"]) == "a"
+
+    def test_select_ad_hoc_leader_single_member(self, controller: PlayerController) -> None:
+        """With a single remaining member, that member is selected."""
+        player_b = MagicMock()
+        player_b.state.can_group_with = set()
+        controller._players = {"b": player_b}
+
+        assert controller._select_ad_hoc_leader(["b"]) == "b"
+
+    async def test_handle_set_members_transfers_leader_when_playing(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Removing the leader from itself while playing routes to a leadership transfer."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_can_group_with = {"member_a", "member_b"}
+        leader._attr_group_members = ["leader", "member_a", "member_b"]
+        member_a = MockPlayer(provider, "member_a", "Member A")
+        member_b = MockPlayer(provider, "member_b", "Member B")
+
+        controller._players = {"leader": leader, "member_a": member_a, "member_b": member_b}
+        mock_mass.players = controller
+        leader.update_state(signal_event=False)
+
+        playing_queue = MagicMock()
+        playing_queue.state = PlaybackState.PLAYING
+        controller.get_active_queue = MagicMock(return_value=playing_queue)  # type: ignore[method-assign]
+        controller._transfer_ad_hoc_leadership = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
+
+        controller._transfer_ad_hoc_leadership.assert_awaited_once()
+        called_leader, called_remaining = controller._transfer_ad_hoc_leadership.call_args.args
+        assert called_leader is leader
+        assert set(called_remaining) == {"member_a", "member_b"}
+
+    async def test_handle_set_members_dissolves_leader_when_idle(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Removing the leader from itself while idle dissolves the group and stops."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test", instance_id="test", mass=mock_mass)
+
+        leader = MockPlayer(provider, "leader", "Leader")
+        leader._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        leader._attr_can_group_with = {"member_a"}
+        leader._attr_group_members = ["leader", "member_a"]
+        member_a = MockPlayer(provider, "member_a", "Member A")
+
+        controller._players = {"leader": leader, "member_a": member_a}
+        mock_mass.players = controller
+        leader.update_state(signal_event=False)
+
+        idle_queue = MagicMock()
+        idle_queue.state = PlaybackState.IDLE
+        controller.get_active_queue = MagicMock(return_value=idle_queue)  # type: ignore[method-assign]
+        controller._transfer_ad_hoc_leadership = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_set_members_with_protocols = AsyncMock()  # type: ignore[method-assign]
+        controller._handle_cmd_stop = AsyncMock()  # type: ignore[method-assign]
+
+        await controller._handle_set_members(leader, player_ids_to_remove=["leader"])
+
+        controller._transfer_ad_hoc_leadership.assert_not_awaited()
+        controller._handle_cmd_stop.assert_awaited_once_with("leader")
 
 
 if __name__ == "__main__":

--- a/tests/controllers/players/test_player_grouping.py
+++ b/tests/controllers/players/test_player_grouping.py
@@ -468,27 +468,33 @@ class TestPlayerBaseIsActiveSession:
 class TestAdHocLeadershipTransfer:
     """Unjoining an ad-hoc sync leader transfers leadership instead of dissolving."""
 
-    def test_select_ad_hoc_leader_prefers_most_groupable(
+    def test_select_ad_hoc_leader_prefers_active_protocol(
         self, controller: PlayerController
     ) -> None:
-        """The new leader should be the member that can group with the most others."""
-        player_a = MagicMock()
-        player_a.state.can_group_with = {"b", "c"}
-        player_b = MagicMock()
-        player_b.state.can_group_with = {"a"}
-        player_c = MagicMock()
-        player_c.state.can_group_with = {"a"}
-        controller._players = {"a": player_a, "b": player_b, "c": player_c}
+        """The new leader should be a member that supports the group's active protocol."""
+        # leader is playing via an airplay protocol player
+        leader = MagicMock()
+        leader.active_output_protocol = "leader_airplay"
+        protocol_player = MagicMock()
+        protocol_player.provider.domain = "airplay"
+        # member_a can't do airplay, member_b can
+        member_a = MagicMock()
+        member_a.provider.domain = "sonos"
+        member_a.linked_output_protocols = []
+        member_b = MagicMock()
+        member_b.provider.domain = "airplay"
+        member_b.linked_output_protocols = []
+        controller._players = {"leader_airplay": protocol_player, "a": member_a, "b": member_b}
 
-        assert controller._select_ad_hoc_leader(["a", "b", "c"]) == "a"
+        assert controller._select_ad_hoc_leader(leader, ["a", "b"]) == "b"
 
-    def test_select_ad_hoc_leader_single_member(self, controller: PlayerController) -> None:
-        """With a single remaining member, that member is selected."""
-        player_b = MagicMock()
-        player_b.state.can_group_with = set()
-        controller._players = {"b": player_b}
+    def test_select_ad_hoc_leader_falls_back_to_first(self, controller: PlayerController) -> None:
+        """Without an active protocol to match, fall back to the first remaining member."""
+        leader = MagicMock()
+        leader.active_output_protocol = None
+        controller._players = {"a": MagicMock(), "b": MagicMock()}
 
-        assert controller._select_ad_hoc_leader(["b"]) == "b"
+        assert controller._select_ad_hoc_leader(leader, ["a", "b"]) == "a"
 
     async def test_handle_set_members_transfers_leader_when_playing(
         self, mock_mass: MagicMock


### PR DESCRIPTION
# What does this implement/fix?

Unjoining the **leader** of a sync group used to dissolve the entire group and stop playback — the remaining speakers went silent even though they were perfectly able to keep playing. Unjoining the leader now transfers playback to a remaining member instead (the way the Sonos app does it), driven by the existing unjoin gesture (no new command).

- When the sync leader is unjoined while other members are still playing, auto-pick a remaining member, move the queue to it, regroup the rest under it and resume at the same position (brief audio gap).
- Falls back to the previous dissolve + stop when nothing is playing or no other members remain.
- `cmd_ungroup(leader)` now removes only the leader, so "unjoin" means "this player leaves the group" for leaders and followers alike (HA's single unjoin command included).
- Keep `transfer_queue`'s pre-ungroup targeted at the player being moved, so freeing it no longer dissolves the rest of the group (and avoids re-entering the transfer).

UI companion: music-assistant/frontend#1956

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
