### PR TITLE
Keep universal player when its protocol links can't migrate to the native player

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -858,7 +858,6 @@ class ProtocolLinkingMixin:
             active_protocol_ids = {
                 link.output_protocol_id for link in player.linked_output_protocols
             }
-            had_active_protocols = bool(active_protocol_ids)
             moved_protocol_ids: set[str] = set()
 
             # Transfer all protocol links from universal player to native player
@@ -874,8 +873,12 @@ class ProtocolLinkingMixin:
                         # Link refused, keep the protocol owned by the universal player.
                         protocol_player.set_protocol_parent_id(player.player_id)
 
-            if had_active_protocols and not moved_protocol_ids:
-                # No active link could migrate, keep the universal player as-is.
+            if active_protocol_ids - moved_protocol_ids:
+                # A link was refused, keep the universal player and hand over only
+                # what moved so the refused protocols are not orphaned.
+                self._migrate_protocol_ids_to_parent(native_player, moved_protocol_ids)
+                self._remove_protocol_ids_from_parent(player, moved_protocol_ids)
+                native_player.update_state()
                 continue
 
             cached_only_ids = known_protocol_ids - active_protocol_ids

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -858,6 +858,7 @@ class ProtocolLinkingMixin:
             active_protocol_ids = {
                 link.output_protocol_id for link in player.linked_output_protocols
             }
+            had_active_protocols = bool(active_protocol_ids)
             moved_protocol_ids: set[str] = set()
 
             # Transfer all protocol links from universal player to native player
@@ -869,6 +870,13 @@ class ProtocolLinkingMixin:
                     if protocol_player.protocol_parent_id == native_player.player_id:
                         moved_protocol_ids.add(protocol_player.player_id)
                         protocol_player.update_state()
+                    else:
+                        # Link refused, keep the protocol owned by the universal player.
+                        protocol_player.set_protocol_parent_id(player.player_id)
+
+            if had_active_protocols and not moved_protocol_ids:
+                # No active link could migrate, keep the universal player as-is.
+                continue
 
             cached_only_ids = known_protocol_ids - active_protocol_ids
             preserved_protocol_ids = moved_protocol_ids | cached_only_ids

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -5009,8 +5009,9 @@ class TestUniversalPlayerReplacement:
 
         If the native player already has an active link from the same protocol
         domain as every protocol on the universal player, each `_add_protocol_link`
-        call returns False. The universal player must NOT be permanently unregistered
-        in that case, otherwise it disappears from the UI on restart.
+        call refuses and leaves the protocol's parent unchanged. The universal player
+        must NOT be permanently unregistered in that case, otherwise it disappears
+        from the UI on restart.
         """
         controller = PlayerController(mock_mass)
         up_provider = create_mock_universal_provider(mock_mass)
@@ -5102,6 +5103,127 @@ class TestUniversalPlayerReplacement:
         assert spb_old.protocol_parent_id == "up_old"
         assert any(
             link.output_protocol_id == "spb_old" for link in universal.linked_output_protocols
+        )
+
+    def test_replace_keeps_universal_when_some_links_refused(self, mock_mass: MagicMock) -> None:
+        """
+        Keep the universal player when only some of its links could migrate.
+
+        The native player already owns the sendspin domain, so the universal player's
+        sendspin link is refused while its airplay link migrates. The universal player
+        must be kept (holding the refused link) instead of being unregistered, which
+        would orphan the refused protocol during cleanup.
+        """
+        controller = PlayerController(mock_mass)
+        up_provider = create_mock_universal_provider(mock_mass)
+
+        config_store: dict[str, object] = {
+            "players/cast_1": {"enabled": True},
+            "players/up_old": {"enabled": True},
+            "players/spb_old": {"enabled": True},
+            "players/spb_new": {"enabled": True},
+            "players/ap_old": {"enabled": True},
+        }
+
+        def config_get(key: str, default: object = None) -> object:
+            return config_store.get(key, default)
+
+        def config_set(key: str, value: object) -> None:
+            config_store[key] = value
+
+        def config_remove(key: str) -> None:
+            config_store.pop(key, None)
+
+        scheduled_tasks: list[Awaitable[object]] = []
+
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
+            scheduled_tasks.append(task)
+
+        mock_mass.config.get = MagicMock(side_effect=config_get)
+        mock_mass.config.set = MagicMock(side_effect=config_set)
+        mock_mass.config.remove = MagicMock(side_effect=config_remove)
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock(side_effect=capture_task)
+
+        universal = UniversalPlayer(
+            provider=up_provider,
+            player_id="up_old",
+            name="Soundbar (Universal)",
+            device_info=DeviceInfo(model="Test", manufacturer="Test"),
+            protocol_player_ids=["spb_old", "ap_old"],
+        )
+        universal._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, "AA:BB:CC:DD:EE:FF")
+        universal._cache.clear()
+        universal.update_state(signal_event=False)
+        universal.set_initialized()
+
+        cast_provider = MockProvider("cast", mass=mock_mass)
+        native = MockPlayer(
+            cast_provider,
+            "cast_1",
+            "Soundbar",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        native.set_initialized()
+
+        sendspin_provider = MockProvider("sendspin", mass=mock_mass)
+        spb_old = MockPlayer(
+            sendspin_provider,
+            "spb_old",
+            "Soundbar (Sendspin)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        spb_old.set_initialized()
+        spb_new = MockPlayer(
+            sendspin_provider,
+            "spb_new",
+            "Soundbar (Sendspin v2)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        spb_new.set_initialized()
+
+        airplay_provider = MockProvider("airplay", mass=mock_mass)
+        ap_old = MockPlayer(
+            airplay_provider,
+            "ap_old",
+            "Soundbar (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        ap_old.set_initialized()
+
+        controller._players = {
+            "up_old": universal,
+            "cast_1": native,
+            "spb_old": spb_old,
+            "spb_new": spb_new,
+            "ap_old": ap_old,
+        }
+
+        controller._add_protocol_link(universal, spb_old, "sendspin")
+        controller._add_protocol_link(universal, ap_old, "airplay")
+        controller._add_protocol_link(native, spb_new, "sendspin")
+
+        controller._check_replace_universal_player(native)
+
+        unregister_tasks = [t for t in scheduled_tasks if "unregister" in repr(t)]
+        assert unregister_tasks == []
+        assert "up_old" in controller._players
+        # The refused sendspin link stays owned by the universal player.
+        assert spb_old.protocol_parent_id == "up_old"
+        assert any(
+            link.output_protocol_id == "spb_old" for link in universal.linked_output_protocols
+        )
+        # The airplay link migrated to the native player and left the universal player.
+        assert ap_old.protocol_parent_id == "cast_1"
+        assert any(link.output_protocol_id == "ap_old" for link in native.linked_output_protocols)
+        assert all(
+            link.output_protocol_id != "ap_old" for link in universal.linked_output_protocols
         )
 
 

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -5003,6 +5003,107 @@ class TestUniversalPlayerReplacement:
             "dlna_cached",
         }
 
+    def test_replace_keeps_universal_when_all_links_refused(self, mock_mass: MagicMock) -> None:
+        """
+        Keep the universal player when no link could migrate.
+
+        If the native player already has an active link from the same protocol
+        domain as every protocol on the universal player, each `_add_protocol_link`
+        call returns False. The universal player must NOT be permanently unregistered
+        in that case, otherwise it disappears from the UI on restart.
+        """
+        controller = PlayerController(mock_mass)
+        up_provider = create_mock_universal_provider(mock_mass)
+
+        config_store: dict[str, object] = {
+            "players/cast_1": {"enabled": True},
+            "players/up_old": {"enabled": True},
+            "players/spb_old": {"enabled": True},
+            "players/spb_new": {"enabled": True},
+        }
+
+        def config_get(key: str, default: object = None) -> object:
+            return config_store.get(key, default)
+
+        def config_set(key: str, value: object) -> None:
+            config_store[key] = value
+
+        def config_remove(key: str) -> None:
+            config_store.pop(key, None)
+
+        scheduled_tasks: list[Awaitable[object]] = []
+
+        def capture_task(task: Awaitable[object], *_args: Any, **_kwargs: Any) -> None:
+            scheduled_tasks.append(task)
+
+        mock_mass.config.get = MagicMock(side_effect=config_get)
+        mock_mass.config.set = MagicMock(side_effect=config_set)
+        mock_mass.config.remove = MagicMock(side_effect=config_remove)
+        mock_mass.players = controller
+        mock_mass.player_queues = MagicMock()
+        mock_mass.call_later = MagicMock()
+        mock_mass.loop = MagicMock()
+        mock_mass.create_task = MagicMock(side_effect=capture_task)
+
+        universal = UniversalPlayer(
+            provider=up_provider,
+            player_id="up_old",
+            name="Soundbar (Universal)",
+            device_info=DeviceInfo(model="Test", manufacturer="Test"),
+            protocol_player_ids=["spb_old"],
+        )
+        universal._attr_device_info.add_identifier(IdentifierType.MAC_ADDRESS, "AA:BB:CC:DD:EE:FF")
+        universal._cache.clear()
+        universal.update_state(signal_event=False)
+        universal.set_initialized()
+
+        cast_provider = MockProvider("cast", mass=mock_mass)
+        native = MockPlayer(
+            cast_provider,
+            "cast_1",
+            "Soundbar",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        native.set_initialized()
+
+        sendspin_provider = MockProvider("sendspin", mass=mock_mass)
+        spb_old = MockPlayer(
+            sendspin_provider,
+            "spb_old",
+            "Soundbar (Sendspin)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        spb_old.set_initialized()
+        spb_new = MockPlayer(
+            sendspin_provider,
+            "spb_new",
+            "Soundbar (Sendspin v2)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:FF"},
+        )
+        spb_new.set_initialized()
+
+        controller._players = {
+            "up_old": universal,
+            "cast_1": native,
+            "spb_old": spb_old,
+            "spb_new": spb_new,
+        }
+
+        controller._add_protocol_link(universal, spb_old, "sendspin")
+        controller._add_protocol_link(native, spb_new, "sendspin")
+
+        controller._check_replace_universal_player(native)
+
+        unregister_tasks = [t for t in scheduled_tasks if "unregister" in repr(t)]
+        assert unregister_tasks == []
+        assert "up_old" in controller._players
+        assert spb_old.protocol_parent_id == "up_old"
+        assert any(
+            link.output_protocol_id == "spb_old" for link in universal.linked_output_protocols
+        )
+
 
 class TestEndToEndDuplicateProtocol:
     """


### PR DESCRIPTION
# What does this implement/fix?

When a native player appears, `_check_replace_universal_player` migrates each of
the universal player's protocols to it, then unregisters the universal player.
But `_add_protocol_link` silently no-ops when the native parent already holds an
active link from the same protoco. The loop ignored that and still
ran `unregister(permanent=True)`, so a previously synced universal player vanished from the UI on restart.

The replace flow now skips the permanent unregister when no active link could
migrate, and restores the original parent on refused links so the universal
player keeps owning its protocols.

**Related issue (if applicable):**

- related issue: music-assistant/support#5244

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally. (couldn't test the exact reported configuration but works on a very similar one)
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
