### PR TITLE
Fix Home Assistant control of universal players running an external source

### DIFF
--- a/music_assistant/providers/universal_player/player.py
+++ b/music_assistant/providers/universal_player/player.py
@@ -27,8 +27,7 @@ if TYPE_CHECKING:
     from .provider import UniversalPlayerProvider
 
 
-# Volume, mute and power are intentionally excluded: the base Player resolves
-# those to the protocol player itself, so advertising them here is not needed.
+# Volume and mute are excluded: the base Player resolves those to the protocol player.
 FORWARDED_FEATURES = {
     PlayerFeature.PAUSE,
     PlayerFeature.SEEK,

--- a/music_assistant/providers/universal_player/player.py
+++ b/music_assistant/providers/universal_player/player.py
@@ -27,6 +27,15 @@ if TYPE_CHECKING:
     from .provider import UniversalPlayerProvider
 
 
+# Volume, mute and power are intentionally excluded: the base Player resolves
+# those to the protocol player itself, so advertising them here is not needed.
+FORWARDED_FEATURES = {
+    PlayerFeature.PAUSE,
+    PlayerFeature.SEEK,
+    PlayerFeature.NEXT_PREVIOUS,
+}
+
+
 class UniversalPlayer(Player):
     """
     Universal Player implementation.
@@ -74,42 +83,42 @@ class UniversalPlayer(Player):
     @property
     def supported_features(self) -> set[PlayerFeature]:
         """Return the supported features of the player."""
-        if ext_player := self._get_external_source_protocol_player():
-            return ext_player.supported_features
+        if ext_player := self._get_protocol_player_with_external_source():
+            return ext_player.supported_features & FORWARDED_FEATURES
         return self._attr_supported_features
 
     @property
     def active_source(self) -> str | None:
         """Return the active source of the player."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             return ext_player.active_source
         return None
 
     @property
     def playback_state(self) -> PlaybackState:
         """Return the current playback state of the player."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             return ext_player.playback_state
         return self._attr_playback_state
 
     @property
     def elapsed_time(self) -> float | None:
         """Return the elapsed time in (fractional) seconds of the current track."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             return ext_player.elapsed_time
         return None
 
     @property
     def elapsed_time_last_updated(self) -> float | None:
         """Return when the elapsed time was last updated."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             return ext_player.elapsed_time_last_updated
         return None
 
     @property
     def current_media(self) -> PlayerMedia | None:
         """Return the current media being played by the player."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             return ext_player.current_media
         if protocol_player := self._get_active_output_protocol_player():
             # while playing through an output protocol player, surface its raw current_media
@@ -122,43 +131,39 @@ class UniversalPlayer(Player):
     @property
     def source_list(self) -> list[PlayerSource]:
         """Return list of available sources for this player."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             # if an external source is active, show sources from that protocol player
             return ext_player.source_list
         return super().source_list
 
     async def stop(self) -> None:
         """Handle STOP command on the player."""
-        if ext_player := self._get_external_source_protocol_player():
-            # power off the protocol player to fully stop external apps (e.g. quit cast app)
-            if PlayerFeature.POWER in ext_player.supported_features:
-                await ext_player.power(False)
-            else:
-                await ext_player.stop()
+        if ext_player := self._get_protocol_player_with_external_source():
+            await ext_player.stop()
 
     async def play(self) -> None:
         """Handle PLAY command on the player."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             await ext_player.play()
 
     async def pause(self) -> None:
         """Handle PAUSE command on the player."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             await ext_player.pause()
 
     async def next_track(self) -> None:
         """Handle NEXT_TRACK command on the player."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             await ext_player.next_track()
 
     async def previous_track(self) -> None:
         """Handle PREVIOUS_TRACK command on the player."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             await ext_player.previous_track()
 
     async def seek(self, position: int) -> None:
         """Handle SEEK command on the player."""
-        if ext_player := self._get_external_source_protocol_player():
+        if ext_player := self._get_protocol_player_with_external_source():
             await ext_player.seek(position)
             self.mass.players.trigger_player_update(ext_player.player_id, debounce_delay=2)
 
@@ -178,7 +183,7 @@ class UniversalPlayer(Player):
             return self.mass.players.get_player(self.active_output_protocol)
         return None
 
-    def _get_external_source_protocol_player(self) -> Player | None:
+    def _get_protocol_player_with_external_source(self) -> Player | None:
         """
         Return a chromecast or dlna protocol player that has an external source active.
 

--- a/tests/providers/universal_player/__init__.py
+++ b/tests/providers/universal_player/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Universal Player provider."""

--- a/tests/providers/universal_player/test_player.py
+++ b/tests/providers/universal_player/test_player.py
@@ -6,6 +6,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from music_assistant_models.constants import PLAYER_CONTROL_NATIVE
 from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
 
 from music_assistant.models.player import DeviceInfo, Player
@@ -136,6 +137,15 @@ def test_supported_features_forwards_only_transport(
         PlayerFeature.SEEK,
         PlayerFeature.NEXT_PREVIOUS,
     }
+
+
+def test_volume_and_mute_not_captured_as_native(
+    setup: tuple[UniversalPlayer, MagicMock],
+) -> None:
+    """With an external source active, the player does not capture native volume/mute control."""
+    universal, _chromecast = setup
+    assert universal.volume_control != PLAYER_CONTROL_NATIVE
+    assert universal.mute_control != PLAYER_CONTROL_NATIVE
 
 
 async def test_transport_proxied_to_external_source(

--- a/tests/providers/universal_player/test_player.py
+++ b/tests/providers/universal_player/test_player.py
@@ -1,0 +1,160 @@
+"""Regression tests for universal player external-source delegation (#5443)."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import PlaybackState, PlayerFeature, PlayerType
+
+from music_assistant.models.player import DeviceInfo, Player
+from music_assistant.providers.universal_player.player import UniversalPlayer
+from music_assistant.providers.universal_player.provider import UniversalPlayerProvider
+
+
+def _make_mock_mass() -> MagicMock:
+    mass = MagicMock()
+    mass.closing = False
+    mass.config = MagicMock()
+    mass.config.get = MagicMock(return_value=[])
+
+    def _get_raw_player_config_value(
+        _player_id: str, key: str, default: object | None = None
+    ) -> object | None:
+        if key == "min_volume":
+            return 0
+        if key == "max_volume":
+            return 100
+        return default if default is not None else "auto"
+
+    mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw_player_config_value)
+    mass.config.get_raw_core_config_value = MagicMock(return_value="GLOBAL")
+    mass.config.set = MagicMock()
+    mass.signal_event = MagicMock()
+    mass.get_providers = MagicMock(return_value=[])
+    return mass
+
+
+def _make_universal_provider(mock_mass: MagicMock) -> UniversalPlayerProvider:
+    manifest = MagicMock()
+    manifest.domain = "universal_player"
+    manifest.name = "Universal Player"
+    provider = UniversalPlayerProvider.__new__(UniversalPlayerProvider)
+    provider.mass = mock_mass
+    provider.manifest = manifest
+    provider.logger = logging.getLogger("test.universal_player")
+    config = MagicMock()
+    config.instance_id = "universal_player"
+    config.name = None
+    provider.config = config
+    provider._universal_player_locks = {}
+    return provider
+
+
+def _make_chromecast_player(
+    mass: MagicMock,
+    player_id: str,
+    *,
+    active_source: str | None,
+    features: set[PlayerFeature],
+) -> MagicMock:
+    """Return a chromecast-domain protocol player with the given active source and features."""
+    player = MagicMock(spec=Player)
+    player.player_id = player_id
+    player.available = True
+    player.active_source = active_source
+    player.playback_state = PlaybackState.PLAYING
+    player.supported_features = features
+    provider = MagicMock()
+    provider.domain = "chromecast"
+    player.provider = provider
+    player.play = AsyncMock()
+    player.pause = AsyncMock()
+    player.stop = AsyncMock()
+    player.next_track = AsyncMock()
+    player.previous_track = AsyncMock()
+    player.seek = AsyncMock()
+    mass.players.get_player = MagicMock(return_value=player)
+    return player
+
+
+def _make_universal_player(mass: MagicMock, protocol_player_ids: list[str]) -> UniversalPlayer:
+    provider = _make_universal_provider(mass)
+    base_cfg = MagicMock()
+    base_cfg.name = None
+    base_cfg.default_name = "Universal"
+    mass.config.get_base_player_config.return_value = base_cfg
+    player = UniversalPlayer(
+        provider=provider,
+        player_id="up_test",
+        name="Universal",
+        device_info=DeviceInfo(model="Universal Player", manufacturer="Music Assistant"),
+        protocol_player_ids=list(protocol_player_ids),
+    )
+    player._attr_available = True
+    player._attr_type = PlayerType.PLAYER
+    player._cache.clear()
+    player.set_initialized()
+    return player
+
+
+@pytest.fixture
+def setup() -> tuple[UniversalPlayer, MagicMock]:
+    """Universal player with a chromecast running Spotify Connect."""
+    mass = _make_mock_mass()
+    chromecast = _make_chromecast_player(
+        mass,
+        "cc_1",
+        active_source="spotify_connect",
+        features={
+            PlayerFeature.PAUSE,
+            PlayerFeature.SEEK,
+            PlayerFeature.NEXT_PREVIOUS,
+            PlayerFeature.VOLUME_SET,
+            PlayerFeature.VOLUME_MUTE,
+            PlayerFeature.POWER,
+            PlayerFeature.PLAY_MEDIA,
+        },
+    )
+    universal = _make_universal_player(mass, ["cc_1"])
+    return universal, chromecast
+
+
+def test_supported_features_forwards_only_transport(
+    setup: tuple[UniversalPlayer, MagicMock],
+) -> None:
+    """
+    Only transport features are forwarded; volume/mute/power/play_media are not.
+
+    Volume, mute and power resolve to the protocol player via the base Player's
+    *_control logic, so the universal player must not advertise them itself.
+    """
+    universal, _chromecast = setup
+    assert universal.supported_features == {
+        PlayerFeature.PAUSE,
+        PlayerFeature.SEEK,
+        PlayerFeature.NEXT_PREVIOUS,
+    }
+
+
+async def test_transport_proxied_to_external_source(
+    setup: tuple[UniversalPlayer, MagicMock],
+) -> None:
+    """Transport commands delegate to the active external source protocol player."""
+    universal, chromecast = setup
+    await universal.pause()
+    chromecast.pause.assert_awaited_once_with()
+
+
+def test_no_features_without_external_source() -> None:
+    """Without an active external source the universal player advertises nothing of its own."""
+    mass = _make_mock_mass()
+    _make_chromecast_player(
+        mass,
+        "cc_1",
+        active_source=None,
+        features={PlayerFeature.PAUSE, PlayerFeature.VOLUME_SET},
+    )
+    universal = _make_universal_player(mass, ["cc_1"])
+    assert universal.supported_features == set()


### PR DESCRIPTION
# What does this implement/fix?

Only `play`, `pause`, `stop`, `next`, `previous`, and `seek` were proxied to the
active external source protocol player. `volume_set`, `volume_mute`, and `power`
fell through to the base `Player` and raised `NotImplementedError` whenever Home
Assistant tried to control a Chromecast running Spotify Connect (or any other
external source).

The universal player now only forwards pause/seek/next/previous. Volume and mute
are left to the base `Player`, which already routes them to the protocol player,
so we no longer advertise them here. Power and `play_media` stay excluded too.

**Related issue (if applicable):**

- related issue music-assistant/support#5443

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

