### PR TITLE
Prevent a player from linking to itself on player type change

### DIFF
--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -1716,8 +1716,11 @@ class ConfigController:
 
     def _migrate_self_referential_protocol_links(self) -> bool:
         """Clear protocol links that point a player at its own id."""
+        all_player_configs = self._data.get(CONF_PLAYERS, {})
+        if not isinstance(all_player_configs, dict):
+            return False
         changed = False
-        for player_id, player_cfg in self._data.get(CONF_PLAYERS, {}).items():
+        for player_id, player_cfg in all_player_configs.items():
             if not isinstance(player_cfg, dict):
                 continue
             values = player_cfg.get("values")

--- a/music_assistant/controllers/config.py
+++ b/music_assistant/controllers/config.py
@@ -95,6 +95,7 @@ from music_assistant.constants import (
     CONF_ENTRY_VOLUME_NORMALIZATION,
     CONF_EXPOSE_PLAYER_TO_HA,
     CONF_HIDE_IN_UI,
+    CONF_LINKED_PROTOCOL_IDS,
     CONF_MUTE_CONTROL,
     CONF_ONBOARD_DONE,
     CONF_PLAYER_DSP,
@@ -106,6 +107,7 @@ from music_assistant.constants import (
     CONF_PREFERRED_OUTPUT_PROTOCOL,
     CONF_PROTOCOL_CATEGORY_PREFIX,
     CONF_PROTOCOL_KEY_SPLITTER,
+    CONF_PROTOCOL_PARENT_ID,
     CONF_PROVIDERS,
     CONF_SERVER_ID,
     CONF_SMART_FADES_MODE,
@@ -1592,6 +1594,12 @@ class ConfigController:
                 )
                 changed = True
 
+        # Clear self-referential protocol links: a player whose protocol_parent_id or
+        # linked_protocol_ids pointed at its own id was hidden as its own protocol child.
+        # TODO: remove after 2.10 release
+        if self._migrate_self_referential_protocol_links():
+            changed = True
+
         # Drop the persisted schedule for the metadata maintenance tasks that were hardcoded
         # to run at 04:00 local. They are now registered under new ("_v2") task ids with a
         # randomized full-day schedule (to avoid spiking the shared MusicBrainz mirror), so the
@@ -1705,6 +1713,28 @@ class ConfigController:
                     player_id,
                 )
         return True
+
+    def _migrate_self_referential_protocol_links(self) -> bool:
+        """Clear protocol links that point a player at its own id."""
+        changed = False
+        for player_id, player_cfg in self._data.get(CONF_PLAYERS, {}).items():
+            if not isinstance(player_cfg, dict):
+                continue
+            values = player_cfg.get("values")
+            if not isinstance(values, dict):
+                continue
+            repaired = False
+            if values.get(CONF_PROTOCOL_PARENT_ID) == player_id:
+                values[CONF_PROTOCOL_PARENT_ID] = None
+                repaired = True
+            linked = values.get(CONF_LINKED_PROTOCOL_IDS)
+            if isinstance(linked, list) and player_id in linked:
+                values[CONF_LINKED_PROTOCOL_IDS] = [pid for pid in linked if pid != player_id]
+                repaired = True
+            if repaired:
+                LOGGER.warning("Repaired self-referential protocol link for %s", player_id)
+                changed = True
+        return changed
 
     def _migrate_metadata_maintenance_schedule(self) -> bool:
         """Remove the orphaned persisted state for the pre-randomization metadata task ids."""

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -872,6 +872,8 @@ class ProtocolLinkingMixin:
 
             cached_only_ids = known_protocol_ids - active_protocol_ids
             preserved_protocol_ids = moved_protocol_ids | cached_only_ids
+            # A device that kept its id across a type change lists itself here.
+            preserved_protocol_ids.discard(native_player.player_id)
             self._migrate_protocol_ids_to_parent(native_player, preserved_protocol_ids)
             self._remove_protocol_ids_from_parent(player, preserved_protocol_ids)
             native_player.update_state()
@@ -909,6 +911,9 @@ class ProtocolLinkingMixin:
         self, native_player: Player, protocol_player: Player, protocol_domain: str
     ) -> None:
         """Add a protocol link from native player to protocol player."""
+        # Never link a player to itself (hides it as its own protocol child).
+        if native_player.player_id == protocol_player.player_id:
+            return
         # Guard: refuse to replace an existing active link from the same domain.
         # This prevents a second instance of the same protocol (e.g., two AirPlay
         # instances on the same host) from silently replacing the first one.

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -10,6 +10,7 @@ from music_assistant_models.enums import IdentifierType, PlaybackState, PlayerFe
 from music_assistant_models.player import OutputProtocol, PlayerMedia
 
 from music_assistant.constants import ATTR_ENABLED, CONF_PLAYERS
+from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.players import PlayerController
 from music_assistant.helpers.util import enrich_device_mac_address
 from music_assistant.models.player import DeviceInfo, Player
@@ -7011,3 +7012,75 @@ class TestUniversalPlayerCurrentMedia:
         universal = _create_universal_player(mock_mass, "up_1", "Universal", [])
         universal.set_active_output_protocol("native")
         assert universal.current_media is None
+
+
+class TestSelfReferentialProtocolLinks:
+    """
+    Tests for the self-link bug when a Sendspin device changes player type.
+
+    A Sendspin device keeps a stable client_id (the MA player_id) across reflashes.
+    When it first registers as a protocol player it gets wrapped in a universal
+    player that caches that id as one of its protocols. If the device later
+    reconnects as a non-protocol player (e.g. its roles changed to display-only)
+    with the same id, the replace logic could link it to itself, hiding it.
+    """
+
+    def test_add_protocol_link_refuses_self(self, mock_mass: MagicMock) -> None:
+        """A player must never become its own protocol parent."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("sendspin", mass=mock_mass)
+        player = MockPlayer(provider, "esp_client", "ESP", player_type=PlayerType.PROTOCOL)
+        mock_mass.players = controller
+        controller._players = {"esp_client": player}
+
+        controller._add_protocol_link(player, player, "sendspin")
+
+        assert player.protocol_parent_id is None
+        assert all(
+            link.output_protocol_id != "esp_client" for link in player.linked_output_protocols
+        )
+
+    def test_type_change_replaces_universal_without_self_link(self, mock_mass: MagicMock) -> None:
+        """Replacing a universal player with the same-id native player must not self-link."""
+        universal = _create_universal_player(
+            mock_mass, "upespclient", "ESP", protocol_player_ids=["esp_client"]
+        )
+        display_provider = MockProvider("sendspin", mass=mock_mass)
+        display_player = MockPlayer(
+            display_provider, "esp_client", "ESP", player_type=PlayerType.DISPLAY
+        )
+
+        store: dict[str, Any] = {"players/esp_client": {"enabled": True}}
+        mock_mass.config.get.side_effect = lambda key, default=None: store.get(key, default)
+        mock_mass.config.set.side_effect = lambda key, value: store.__setitem__(key, value)
+        mock_mass.create_task = MagicMock()
+        mock_mass.players = controller = PlayerController(mock_mass)
+        controller._players = {"upespclient": universal, "esp_client": display_player}
+
+        controller._check_replace_universal_player(display_player)
+
+        assert display_player.protocol_parent_id is None
+        assert store.get("players/esp_client/values/protocol_parent_id") != "esp_client"
+        assert "esp_client" not in store.get("players/esp_client/values/linked_protocol_ids", [])
+
+    async def test_migrate_clears_persisted_self_referential_link(self) -> None:
+        """Config migration scrubs a self-referential link left by an older version."""
+        config = ConfigController.__new__(ConfigController)
+        config._data = {
+            CONF_PLAYERS: {
+                "esp_client": {
+                    "provider": "sendspin",
+                    "player_id": "esp_client",
+                    "values": {
+                        "protocol_parent_id": "esp_client",
+                        "linked_protocol_ids": ["esp_client"],
+                    },
+                }
+            }
+        }
+        with patch.object(config, "_async_save", AsyncMock()):
+            await config._migrate()
+
+        values = config._data[CONF_PLAYERS]["esp_client"]["values"]
+        assert values["protocol_parent_id"] is None
+        assert "esp_client" not in values["linked_protocol_ids"]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A Sendspin device keeps a stable `client_id` (the MA `player_id`) across
reflashes. When such a device changes the player type it presents while keeping
the same id (for example dropping its player role to become a display, or
toggling album art and visualizer roles), it silently disappeared from the
player list. While replacing a universal player wrapper,
`_check_replace_universal_player` could link the new player to itself, leaving
`protocol_parent_id` and `linked_protocol_ids` pointing at its own id, so it was
hidden as its own protocol child.

A guard in `_add_protocol_link` (and `_check_replace_universal_player`) now
refuses to link a player onto itself, and a startup config migration clears any
persisted self link so configs corrupted by older versions recover on upgrade.

**Related issue (if applicable):**

- related issue music-assistant/support#5547

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
