### PR TITLE
Support `seek` Sendspin controller commands

### DIFF
--- a/music_assistant/providers/sendspin/manifest.json
+++ b/music_assistant/providers/sendspin/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://music-assistant.io/player-support/sendspin/",
   "codeowners": ["@music-assistant"],
   "credits": ["[Sendspin](https://sendspin-audio.com)"],
-  "requirements": ["aiosendspin[server]==6.0.5", "av==16.1.0"],
+  "requirements": ["aiosendspin[server]==6.1.0", "av==16.1.0"],
   "builtin": true,
   "allow_disable": false
 }

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -620,12 +620,20 @@ class SendspinPlayer(SendspinBasePlayer):
                         self.mass.player_queues.set_repeat(queue.queue_id, RepeatMode.ALL)
             case ControllerShuffleEvent(shuffle=shuffle) if queue:
                 await self.mass.player_queues.set_shuffle(queue.queue_id, shuffle_enabled=shuffle)
-            case ControllerSeekEvent(position_ms=position_ms) if queue:
-                await self.mass.player_queues.seek(queue.queue_id, position_ms // 1000)
-            case ControllerSeekRelativeEvent(offset_ms=offset_ms) if queue and queue.current_item:
+            case ControllerSeekEvent(position_ms=position_ms) if (
+                queue and queue.current_item and queue.current_item.duration
+            ):
+                # Clamp in case track duration changed after we advertised the seek range.
+                duration_ms = int(queue.current_item.duration * 1000)
+                await self.mass.player_queues.seek(
+                    queue.queue_id, max(0, min(position_ms, duration_ms)) // 1000
+                )
+            case ControllerSeekRelativeEvent(offset_ms=offset_ms) if (
+                queue and queue.current_item and queue.current_item.duration
+            ):
                 # Clamp current position + offset to the 0..duration range.
                 target_ms = int(queue.corrected_elapsed_time * 1000) + offset_ms
-                duration_ms = int((queue.current_item.duration or 0) * 1000)
+                duration_ms = int(queue.current_item.duration * 1000)
                 await self.mass.player_queues.seek(
                     queue.queue_id, max(0, min(target_ms, duration_ms)) // 1000
                 )

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -33,6 +33,8 @@ from aiosendspin.server.roles import (
     ControllerPlayEvent,
     ControllerPreviousEvent,
     ControllerRepeatEvent,
+    ControllerSeekEvent,
+    ControllerSeekRelativeEvent,
     ControllerShuffleEvent,
     ControllerStopEvent,
     MetadataGroupRole,
@@ -83,6 +85,8 @@ SUPPORTED_GROUP_COMMANDS = [
     MediaCommand.REPEAT_ALL,
     MediaCommand.SHUFFLE,
     MediaCommand.UNSHUFFLE,
+    MediaCommand.SEEK,
+    MediaCommand.SEEK_RELATIVE,
 ]
 
 # Config constants for Sendspin audio format
@@ -616,6 +620,15 @@ class SendspinPlayer(SendspinBasePlayer):
                         self.mass.player_queues.set_repeat(queue.queue_id, RepeatMode.ALL)
             case ControllerShuffleEvent(shuffle=shuffle) if queue:
                 await self.mass.player_queues.set_shuffle(queue.queue_id, shuffle_enabled=shuffle)
+            case ControllerSeekEvent(position_ms=position_ms) if queue:
+                await self.mass.player_queues.seek(queue.queue_id, position_ms // 1000)
+            case ControllerSeekRelativeEvent(offset_ms=offset_ms) if queue and queue.current_item:
+                # Clamp current position + offset to the 0..duration range.
+                target_ms = int(queue.corrected_elapsed_time * 1000) + offset_ms
+                duration_ms = int((queue.current_item.duration or 0) * 1000)
+                await self.mass.player_queues.seek(
+                    queue.queue_id, max(0, min(target_ms, duration_ms)) // 1000
+                )
 
     async def _sync_membership_from_group(self, group: SendspinGroup) -> None:
         """Sync MA/player + playback session membership from authoritative group state."""
@@ -960,6 +973,8 @@ class SendspinPlayer(SendspinBasePlayer):
             await artwork_role.set_artist_artwork(None)
         if (color_role := self._color_role) is not None:
             color_role.clear()
+        if (controller_role := self._controller_role) is not None:
+            controller_role.set_seek_max_ms(None)
         self.last_sent_artwork_url = None
         self.last_sent_artist_artwork_url = None
         self._last_beat_queue_item_id = None
@@ -1056,6 +1071,8 @@ class SendspinPlayer(SendspinBasePlayer):
                     album_artist = full_album.artist_str
 
         track_duration = current_media.duration or 0
+        if controller_role := self._controller_role:
+            controller_role.set_seek_max_ms(int(track_duration * 1000) if track_duration else None)
         repeat = SendspinRepeatMode.OFF
         if queue and queue.repeat_mode == RepeatMode.ALL:
             repeat = SendspinRepeatMode.ALL

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ aiohttp-socks==0.11.0
 aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
-aiosendspin[server]==6.0.5
+aiosendspin[server]==6.1.0
 aioslimproto==3.1.8
 aiosonos==0.1.12
 aiosqlite==0.22.1

--- a/tests/providers/sendspin/test_controller_seek.py
+++ b/tests/providers/sendspin/test_controller_seek.py
@@ -1,0 +1,81 @@
+"""Tests for sendspin controller seek / seek-relative event handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+from aiosendspin.server.roles import ControllerSeekEvent, ControllerSeekRelativeEvent
+
+from music_assistant.providers.sendspin.player import SendspinPlayer
+
+
+def _player(
+    *, duration: float | None, elapsed: float = 0.0, has_item: bool = True
+) -> tuple[SendspinPlayer, AsyncMock]:
+    current_item = SimpleNamespace(duration=duration) if has_item else None
+    queue = SimpleNamespace(
+        queue_id="q1",
+        current_item=current_item,
+        corrected_elapsed_time=elapsed,
+    )
+    seek = AsyncMock()
+    player_queues = SimpleNamespace(get_active_queue=lambda _pid: queue, seek=seek)
+    fake = SimpleNamespace(player_id="p1", mass=SimpleNamespace(player_queues=player_queues))
+    return cast("SendspinPlayer", fake), seek
+
+
+async def test_absolute_seek_converts_ms_to_seconds() -> None:
+    """An absolute seek forwards the position to the queue in seconds."""
+    player, seek = _player(duration=100.0)
+    await SendspinPlayer._handle_controller_event(player, ControllerSeekEvent(position_ms=5400))
+    seek.assert_awaited_once_with("q1", 5)
+
+
+async def test_absolute_seek_clamps_to_duration() -> None:
+    """An absolute seek past the end clamps to the track duration."""
+    player, seek = _player(duration=100.0)
+    await SendspinPlayer._handle_controller_event(player, ControllerSeekEvent(position_ms=120_000))
+    seek.assert_awaited_once_with("q1", 100)
+
+
+async def test_absolute_seek_ignored_without_current_item() -> None:
+    """An absolute seek is dropped when no item is loaded."""
+    player, seek = _player(duration=None, has_item=False)
+    await SendspinPlayer._handle_controller_event(player, ControllerSeekEvent(position_ms=5400))
+    seek.assert_not_awaited()
+
+
+async def test_absolute_seek_ignored_when_duration_unknown() -> None:
+    """An absolute seek is dropped when the current item has no duration."""
+    player, seek = _player(duration=None)
+    await SendspinPlayer._handle_controller_event(player, ControllerSeekEvent(position_ms=5400))
+    seek.assert_not_awaited()
+
+
+async def test_relative_seek_clamps_to_duration() -> None:
+    """A relative seek past the end clamps to the track duration."""
+    player, seek = _player(duration=100.0, elapsed=95.0)
+    await SendspinPlayer._handle_controller_event(
+        player, ControllerSeekRelativeEvent(offset_ms=30_000)
+    )
+    seek.assert_awaited_once_with("q1", 100)
+
+
+async def test_relative_seek_clamps_to_zero() -> None:
+    """A relative seek before the start clamps to zero."""
+    player, seek = _player(duration=100.0, elapsed=5.0)
+    await SendspinPlayer._handle_controller_event(
+        player, ControllerSeekRelativeEvent(offset_ms=-30_000)
+    )
+    seek.assert_awaited_once_with("q1", 0)
+
+
+async def test_relative_seek_ignored_when_duration_unknown() -> None:
+    """A relative seek is dropped when the current item has no duration."""
+    player, seek = _player(duration=None, elapsed=10.0)
+    await SendspinPlayer._handle_controller_event(
+        player, ControllerSeekRelativeEvent(offset_ms=30_000)
+    )
+    seek.assert_not_awaited()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Implements the new `seek` and `seek_relative` controller commands:
- https://github.com/Sendspin/spec/pull/103

This PR also updates `aiosendspin` from 6.0.5 to 6.1.0, which also fixes (another) syncing bug:
-  https://github.com/Sendspin/aiosendspin/pull/280

And removes a no longer needed workaround so playing to and grouping Sendspin players can be slightly faster now (if supported by the client):
- https://github.com/Sendspin/aiosendspin/pull/279

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
