### PR TITLE
Don't switch a playing group's output protocol when joining a player

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1687,6 +1687,9 @@ class ProtocolLinkingMixin:
         """
         if not (
             parent_player.active_output_protocol == "native"
+            # the active protocol lingers for a few seconds after stop, so confirm the
+            # parent actually holds a live session before adopting its native grouping
+            and parent_player.state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
             and not parent_protocol_domain
             and self._can_use_native_grouping(
                 child_player, parent_player, parent_supports_native_grouping

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1662,6 +1662,45 @@ class ProtocolLinkingMixin:
                 return parent_output_protocol, child_protocol
         return None, None
 
+    def _try_join_active_native_session(
+        self,
+        child_player: Player,
+        parent_player: Player,
+        parent_protocol_domain: str | None,
+        parent_supports_native_grouping: bool,
+        native_members: list[str],
+    ) -> bool:
+        """
+        Add the child to native_members if it can join the parent's active native session.
+
+        A child's preferred output protocol must only steer protocol selection when the child
+        initiates its own playback; when it joins a parent that is already playing natively it
+        should adopt native grouping if compatible, rather than forcing the whole group onto
+        the child's preferred protocol. Skipped once a protocol has been selected for the group,
+        so mixed batches stay cohesive on a single protocol.
+
+        :param child_player: The player being added to the group.
+        :param parent_player: The parent player being joined.
+        :param parent_protocol_domain: The protocol domain already selected for the group, if any.
+        :param parent_supports_native_grouping: Whether the parent can group natively.
+        :param native_members: The native members list to append to when the child joins.
+        """
+        if not (
+            parent_player.active_output_protocol == "native"
+            and not parent_protocol_domain
+            and self._can_use_native_grouping(
+                child_player, parent_player, parent_supports_native_grouping
+            )
+        ):
+            return False
+        native_members.append(child_player.player_id)
+        self.logger.log(
+            VERBOSE_LOG_LEVEL,
+            "Joining parent's active native session for %s",
+            child_player.state.name,
+        )
+        return True
+
     def _translate_members_for_protocols(
         self,
         parent_player: Player,
@@ -1673,6 +1712,9 @@ class ProtocolLinkingMixin:
         Translate member IDs to protocol or native IDs.
 
         Selection priority when grouping:
+        0. If the parent is already playing natively and the child can be grouped
+           natively, join that native session (a child joining an existing group must
+           not force the whole group onto its own preferred output protocol)
         1. Try child's preferred output protocol (from player settings)
         2. Try parent's active output protocol (if any and child supports it)
         3. Try native grouping (if parent and child are compatible)
@@ -1708,6 +1750,18 @@ class ProtocolLinkingMixin:
                 child_player.state.type,
                 [p.protocol_domain for p in child_player.output_protocols],
             )
+
+            # Priority 0: The parent is already playing natively and the child can join
+            # that native session directly - adopt it before considering the child's own
+            # preferred output protocol.
+            if self._try_join_active_native_session(
+                child_player,
+                parent_player,
+                parent_protocol_domain,
+                parent_supports_native_grouping,
+                native_members,
+            ):
+                continue
 
             # Priority 1: Try child's preferred output protocol
             # (only if no active protocol or if it matches the active protocol)

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1662,6 +1662,48 @@ class ProtocolLinkingMixin:
                 return parent_output_protocol, child_protocol
         return None, None
 
+    def _parent_has_live_native_session(self, parent_player: Player) -> bool:
+        """
+        Return True when the parent currently holds a live native playback session.
+
+        The active output protocol lingers for a few seconds after stop, so a non-idle
+        playback state is required to distinguish a real session from a just-stopped one.
+        """
+        return parent_player.active_output_protocol == "native" and (
+            parent_player.state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
+        )
+
+    def _order_members_for_native_join(
+        self,
+        player_ids: list[str],
+        parent_player: Player,
+        parent_supports_native_grouping: bool,
+    ) -> list[str]:
+        """
+        Order members so a live native session can be joined without splitting the group.
+
+        When the parent already holds a live native session, children that cannot group
+        natively are evaluated first: they may force a shared protocol for the whole group,
+        and processing them before the native-capable children lets those join that same
+        protocol instead of being stranded in a separate native sub-group. The order is left
+        untouched when the parent is not playing natively, so fresh-group selection is unchanged.
+
+        :param player_ids: The member IDs to be added, in their original order.
+        :param parent_player: The parent player being joined.
+        :param parent_supports_native_grouping: Whether the parent can group natively.
+        """
+        if not self._parent_has_live_native_session(parent_player):
+            return player_ids
+        return sorted(
+            player_ids,
+            key=lambda pid: bool(
+                (child := self.get_player(pid))
+                and self._can_use_native_grouping(
+                    child, parent_player, parent_supports_native_grouping
+                )
+            ),
+        )
+
     def _try_join_active_native_session(
         self,
         child_player: Player,
@@ -1686,10 +1728,7 @@ class ProtocolLinkingMixin:
         :param native_members: The native members list to append to when the child joins.
         """
         if not (
-            parent_player.active_output_protocol == "native"
-            # the active protocol lingers for a few seconds after stop, so confirm the
-            # parent actually holds a live session before adopting its native grouping
-            and parent_player.state.playback_state in (PlaybackState.PLAYING, PlaybackState.PAUSED)
+            self._parent_has_live_native_session(parent_player)
             and not parent_protocol_domain
             and self._can_use_native_grouping(
                 child_player, parent_player, parent_supports_native_grouping
@@ -1730,6 +1769,9 @@ class ProtocolLinkingMixin:
         native_members: list[str] = []
         parent_supports_native_grouping = (
             PlayerFeature.SET_MEMBERS in parent_player.supported_features
+        )
+        player_ids = self._order_members_for_native_join(
+            player_ids, parent_player, parent_supports_native_grouping
         )
 
         self.logger.log(

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1693,6 +1693,13 @@ class TestJoinActiveNativeSession:
     """
 
     @staticmethod
+    def _mark_native_playing(player: MockPlayer) -> None:
+        """Put the player into a live native playback session."""
+        player._attr_playback_state = PlaybackState.PLAYING
+        player._cache.clear()
+        player.set_active_output_protocol("native")
+
+    @staticmethod
     def _link_airplay(native_player: MockPlayer, airplay_id: str) -> None:
         """Link an AirPlay protocol player to a native player."""
         native_player.set_linked_output_protocols(
@@ -1836,7 +1843,7 @@ class TestJoinActiveNativeSession:
 
         controller, players = self._build_topology(mock_mass)
         # Parent A is already playing natively.
-        players["sonos_a"].set_active_output_protocol("native")
+        self._mark_native_playing(players["sonos_a"])
 
         protocol_members, native_members, _, _ = controller._translate_members_for_protocols(
             parent_player=players["sonos_a"],
@@ -1883,6 +1890,43 @@ class TestJoinActiveNativeSession:
         assert native_members == []
         assert protocol_domain == "airplay"
 
+    def test_idle_parent_with_stale_native_protocol_honors_child_preferred(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A stopped parent (active protocol lingers briefly) does not force the native-join path."""
+
+        def _get_raw(
+            player_id: str, key: str, default: str | int | None = None
+        ) -> str | int | None:
+            if key == CONF_PREFERRED_OUTPUT_PROTOCOL and player_id == "sonos_b":
+                return "airplay_b"
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 100
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
+
+        controller, players = self._build_topology(mock_mass)
+        # Parent A stopped: active protocol still reads "native" but playback is idle.
+        players["sonos_a"].set_active_output_protocol("native")
+        assert players["sonos_a"].state.playback_state == PlaybackState.IDLE
+
+        protocol_members, native_members, _, protocol_domain = (
+            controller._translate_members_for_protocols(
+                parent_player=players["sonos_a"],
+                player_ids=["sonos_b"],
+                parent_protocol_player=None,
+                parent_protocol_domain=None,
+            )
+        )
+
+        # No live session to join, so the child's preference applies.
+        assert protocol_members == ["airplay_b"]
+        assert native_members == []
+        assert protocol_domain == "airplay"
+
     def test_native_active_parent_airplay_only_child_uses_protocol(
         self, mock_mass: MagicMock
     ) -> None:
@@ -1903,7 +1947,7 @@ class TestJoinActiveNativeSession:
 
         controller, players = self._build_topology(mock_mass)
         self._add_airplay_only_child(controller, players, mock_mass)
-        players["sonos_a"].set_active_output_protocol("native")
+        self._mark_native_playing(players["sonos_a"])
 
         protocol_members, native_members, _, protocol_domain = (
             controller._translate_members_for_protocols(
@@ -1931,7 +1975,7 @@ class TestJoinActiveNativeSession:
         """
         controller, players = self._build_topology(mock_mass)
         self._add_airplay_only_child(controller, players, mock_mass)
-        players["sonos_a"].set_active_output_protocol("native")
+        self._mark_native_playing(players["sonos_a"])
 
         # No preferred_output_protocol override - the WiiM resolves via the common-protocol path.
         protocol_members, native_members, _, protocol_domain = (
@@ -1956,7 +2000,7 @@ class TestJoinActiveNativeSession:
         """
         controller, players = self._build_topology(mock_mass)
         self._add_airplay_only_child(controller, players, mock_mass)
-        players["sonos_a"].set_active_output_protocol("native")
+        self._mark_native_playing(players["sonos_a"])
 
         # AirPlay-only child first (forces AirPlay), then the natively-groupable Sonos child.
         protocol_members, native_members, _, protocol_domain = (

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -1991,22 +1991,28 @@ class TestJoinActiveNativeSession:
         assert native_members == []
         assert protocol_domain == "airplay"
 
-    def test_native_active_parent_keeps_mixed_batch_cohesive(self, mock_mass: MagicMock) -> None:
+    @pytest.mark.parametrize(
+        "member_order",
+        [["wiim_c", "sonos_b"], ["sonos_b", "wiim_c"]],
+    )
+    def test_native_active_parent_keeps_mixed_batch_cohesive(
+        self, mock_mass: MagicMock, member_order: list[str]
+    ) -> None:
         """
-        Once a protocol is forced for the group, a later native-capable child joins it too.
+        A mixed batch stays cohesive on one protocol regardless of member order.
 
-        When an AirPlay-only child forces the group onto AirPlay, a subsequent natively-groupable
-        child adopts that same protocol rather than splitting off into a native sub-group.
+        When an AirPlay-only child forces the group onto AirPlay, the natively-groupable Sonos
+        child adopts that same protocol rather than splitting off into a native sub-group -
+        whether it is added before or after the AirPlay-only child.
         """
         controller, players = self._build_topology(mock_mass)
         self._add_airplay_only_child(controller, players, mock_mass)
         self._mark_native_playing(players["sonos_a"])
 
-        # AirPlay-only child first (forces AirPlay), then the natively-groupable Sonos child.
         protocol_members, native_members, _, protocol_domain = (
             controller._translate_members_for_protocols(
                 parent_player=players["sonos_a"],
-                player_ids=["wiim_c", "sonos_b"],
+                player_ids=member_order,
                 parent_protocol_player=None,
                 parent_protocol_domain=None,
             )

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -9,7 +9,11 @@ import pytest
 from music_assistant_models.enums import IdentifierType, PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.player import OutputProtocol, PlayerMedia
 
-from music_assistant.constants import ATTR_ENABLED, CONF_PLAYERS
+from music_assistant.constants import (
+    ATTR_ENABLED,
+    CONF_PLAYERS,
+    CONF_PREFERRED_OUTPUT_PROTOCOL,
+)
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.players import PlayerController
 from music_assistant.helpers.util import enrich_device_mac_address
@@ -1676,6 +1680,297 @@ class TestPlayerGrouping:
         assert "airplay_wiim" in protocol_members
         assert protocol_domain == "airplay"
         assert protocol_player == sonos_airplay
+
+
+class TestJoinActiveNativeSession:
+    """
+    Grouping a child onto a parent that is already playing natively.
+
+    A child's preferred output protocol must only steer protocol selection when the child
+    initiates its own playback. When the child joins a parent that already holds an active
+    native session, it should adopt native grouping if compatible, instead of forcing the
+    whole group onto the child's preferred protocol.
+    """
+
+    @staticmethod
+    def _link_airplay(native_player: MockPlayer, airplay_id: str) -> None:
+        """Link an AirPlay protocol player to a native player."""
+        native_player.set_linked_output_protocols(
+            [
+                OutputProtocol(
+                    output_protocol_id=airplay_id,
+                    name="AirPlay",
+                    protocol_domain="airplay",
+                    priority=10,
+                    available=True,
+                )
+            ]
+        )
+
+    def _build_topology(
+        self, mock_mass: MagicMock
+    ) -> tuple[PlayerController, dict[str, MockPlayer]]:
+        """
+        Build parent Sonos A + child Sonos B, both AirPlay-capable and natively groupable.
+
+        The parent also exposes an AirPlay protocol player that supports SET_MEMBERS, so the
+        child's preferred AirPlay protocol *would* be selectable if it were given priority.
+        """
+        controller = PlayerController(mock_mass)
+        sonos_provider = MockProvider("sonos", instance_id="sonos_instance", mass=mock_mass)
+        airplay_provider = MockProvider("airplay", instance_id="airplay_instance", mass=mock_mass)
+
+        sonos_a = MockPlayer(
+            sonos_provider,
+            "sonos_a",
+            "Office",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:01"},
+        )
+        sonos_a._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        sonos_a._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        sonos_a._attr_can_group_with = {"sonos_b"}
+        sonos_a._cache.clear()
+
+        sonos_b = MockPlayer(
+            sonos_provider,
+            "sonos_b",
+            "Bathroom",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:02"},
+        )
+        sonos_b._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        sonos_b._attr_can_group_with = {"sonos_a"}
+        sonos_b._cache.clear()
+
+        airplay_a = MockPlayer(
+            airplay_provider,
+            "airplay_a",
+            "Office (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:01"},
+        )
+        airplay_a._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        airplay_a._attr_can_group_with = {"airplay_b"}
+        airplay_a._cache.clear()
+
+        airplay_b = MockPlayer(
+            airplay_provider,
+            "airplay_b",
+            "Bathroom (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:02"},
+        )
+        airplay_b._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        airplay_b._attr_can_group_with = {"airplay_a"}
+        airplay_b._cache.clear()
+
+        self._link_airplay(sonos_a, "airplay_a")
+        self._link_airplay(sonos_b, "airplay_b")
+
+        mock_mass.players = controller
+        players = {
+            "sonos_a": sonos_a,
+            "sonos_b": sonos_b,
+            "airplay_a": airplay_a,
+            "airplay_b": airplay_b,
+        }
+        controller._players = dict(players)
+        for player in players.values():
+            player.update_state(signal_event=False)
+        return controller, players
+
+    def _add_airplay_only_child(
+        self, controller: PlayerController, players: dict[str, MockPlayer], mock_mass: MagicMock
+    ) -> None:
+        """
+        Add a WiiM child that can only group via AirPlay (no native grouping with Sonos).
+
+        Different provider instance and absent from the parent's can_group_with, so
+        _can_use_native_grouping returns False for it.
+        """
+        wiim_provider = MockProvider("wiim", instance_id="wiim_instance", mass=mock_mass)
+        airplay_provider = MockProvider("airplay", instance_id="airplay_instance", mass=mock_mass)
+        wiim_c = MockPlayer(
+            wiim_provider,
+            "wiim_c",
+            "Bedroom",
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:03"},
+        )
+        wiim_c._attr_supported_features.add(PlayerFeature.PLAY_MEDIA)
+        wiim_c._cache.clear()
+        airplay_c = MockPlayer(
+            airplay_provider,
+            "airplay_c",
+            "Bedroom (AirPlay)",
+            player_type=PlayerType.PROTOCOL,
+            identifiers={IdentifierType.MAC_ADDRESS: "AA:BB:CC:DD:EE:03"},
+        )
+        airplay_c._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
+        airplay_c._attr_can_group_with = {"airplay_a"}
+        airplay_c._cache.clear()
+        self._link_airplay(wiim_c, "airplay_c")
+        # Allow the parent's AirPlay protocol to group with the new AirPlay child.
+        players["airplay_a"]._attr_can_group_with = {"airplay_b", "airplay_c"}
+        players["airplay_a"]._cache.clear()
+        controller._players["wiim_c"] = wiim_c
+        controller._players["airplay_c"] = airplay_c
+        wiim_c.update_state(signal_event=False)
+        airplay_c.update_state(signal_event=False)
+
+    def test_native_active_parent_ignores_child_preferred_protocol(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A child joining a natively-playing parent groups natively, not via preferred AirPlay."""
+
+        def _get_raw(
+            player_id: str, key: str, default: str | int | None = None
+        ) -> str | int | None:
+            if key == CONF_PREFERRED_OUTPUT_PROTOCOL and player_id == "sonos_b":
+                return "airplay_b"
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 100
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
+
+        controller, players = self._build_topology(mock_mass)
+        # Parent A is already playing natively.
+        players["sonos_a"].set_active_output_protocol("native")
+
+        protocol_members, native_members, _, _ = controller._translate_members_for_protocols(
+            parent_player=players["sonos_a"],
+            player_ids=["sonos_b"],
+            parent_protocol_player=None,
+            parent_protocol_domain=None,
+        )
+
+        # Native grouping is used; the child's AirPlay preference is ignored on join.
+        assert native_members == ["sonos_b"]
+        assert protocol_members == []
+
+    def test_fresh_group_still_honors_child_preferred_protocol(self, mock_mass: MagicMock) -> None:
+        """When the parent is not playing, the child's preferred protocol still steers selection."""
+
+        def _get_raw(
+            player_id: str, key: str, default: str | int | None = None
+        ) -> str | int | None:
+            if key == CONF_PREFERRED_OUTPUT_PROTOCOL and player_id == "sonos_b":
+                return "airplay_b"
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 100
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
+
+        controller, players = self._build_topology(mock_mass)
+        # Parent A has no active session (active_output_protocol stays None).
+        assert players["sonos_a"].active_output_protocol is None
+
+        protocol_members, native_members, _, protocol_domain = (
+            controller._translate_members_for_protocols(
+                parent_player=players["sonos_a"],
+                player_ids=["sonos_b"],
+                parent_protocol_player=None,
+                parent_protocol_domain=None,
+            )
+        )
+
+        # Same topology as the active-native case, but here the preference applies.
+        assert protocol_members == ["airplay_b"]
+        assert native_members == []
+        assert protocol_domain == "airplay"
+
+    def test_native_active_parent_airplay_only_child_uses_protocol(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """An AirPlay-only child (cannot group natively) still joins via its preferred protocol."""
+
+        def _get_raw(
+            player_id: str, key: str, default: str | int | None = None
+        ) -> str | int | None:
+            if key == CONF_PREFERRED_OUTPUT_PROTOCOL and player_id == "wiim_c":
+                return "airplay_c"
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 100
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_get_raw)
+
+        controller, players = self._build_topology(mock_mass)
+        self._add_airplay_only_child(controller, players, mock_mass)
+        players["sonos_a"].set_active_output_protocol("native")
+
+        protocol_members, native_members, _, protocol_domain = (
+            controller._translate_members_for_protocols(
+                parent_player=players["sonos_a"],
+                player_ids=["wiim_c"],
+                parent_protocol_player=None,
+                parent_protocol_domain=None,
+            )
+        )
+
+        # No native path exists for the WiiM, so it falls back to AirPlay grouping.
+        assert protocol_members == ["airplay_c"]
+        assert native_members == []
+        assert protocol_domain == "airplay"
+
+    def test_native_active_parent_protocol_only_child_switches_via_common_protocol(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """
+        A child with no native path (and no explicit preference) still forces the switch.
+
+        Even without a configured preferred protocol, a child that can only reach the group via
+        a shared protocol (here AirPlay, which the natively-playing parent also supports) is
+        grouped via that protocol - moving the group onto it.
+        """
+        controller, players = self._build_topology(mock_mass)
+        self._add_airplay_only_child(controller, players, mock_mass)
+        players["sonos_a"].set_active_output_protocol("native")
+
+        # No preferred_output_protocol override - the WiiM resolves via the common-protocol path.
+        protocol_members, native_members, _, protocol_domain = (
+            controller._translate_members_for_protocols(
+                parent_player=players["sonos_a"],
+                player_ids=["wiim_c"],
+                parent_protocol_player=None,
+                parent_protocol_domain=None,
+            )
+        )
+
+        assert protocol_members == ["airplay_c"]
+        assert native_members == []
+        assert protocol_domain == "airplay"
+
+    def test_native_active_parent_keeps_mixed_batch_cohesive(self, mock_mass: MagicMock) -> None:
+        """
+        Once a protocol is forced for the group, a later native-capable child joins it too.
+
+        When an AirPlay-only child forces the group onto AirPlay, a subsequent natively-groupable
+        child adopts that same protocol rather than splitting off into a native sub-group.
+        """
+        controller, players = self._build_topology(mock_mass)
+        self._add_airplay_only_child(controller, players, mock_mass)
+        players["sonos_a"].set_active_output_protocol("native")
+
+        # AirPlay-only child first (forces AirPlay), then the natively-groupable Sonos child.
+        protocol_members, native_members, _, protocol_domain = (
+            controller._translate_members_for_protocols(
+                parent_player=players["sonos_a"],
+                player_ids=["wiim_c", "sonos_b"],
+                parent_protocol_player=None,
+                parent_protocol_domain=None,
+            )
+        )
+
+        assert native_members == []
+        assert set(protocol_members) == {"airplay_c", "airplay_b"}
+        assert protocol_domain == "airplay"
 
 
 class TestCanGroupWith:


### PR DESCRIPTION
## What does this implement/fix?

When you group a player onto a leader that is already playing **natively**, the joining player's `preferred_output_protocol` (e.g. AirPlay) would override the leader's active native session and switch the **entire** group onto that protocol — even when the leader and the new player could group natively. For Sonos this turns a clean native group into an AirPlay one (and AP2 multi-room sync then frequently breaks).

A player's preferred output protocol should only steer protocol selection when that player initiates its own playback, not when it joins a group that is already playing.

- In `_translate_members_for_protocols`, add a first-priority step: if the leader is already playing natively and the joining player can group natively, join that native session before considering the player's preferred protocol.
- Players that can only reach the group via a shared protocol (no native path) still move the group onto that protocol, as before.
- Add regression tests covering the native-join, fresh-group, protocol-only-child and mixed-batch cases.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
