### PR TITLE
Keep radio/live streams restartable after a mid-stream disconnect

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1286,10 +1286,7 @@ class StreamsAudio:
                 yield chunk
         except AudioError as err:
             streamdetails.stream_error = True
-            # Only revoke availability when the stream never produced audio (i.e. it
-            # failed to start). A mid-stream abort after real playback is typically a
-            # transient/network condition on a live source that can be reconnected, so
-            # the item must stay available to allow a restart.
+            # revoke availability when the stream never produced any audio
             if bytes_received == 0:
                 queue_item.available = False
             if raise_on_error:
@@ -1498,10 +1495,7 @@ class StreamsAudio:
             finished = True
         except AudioError as err:
             streamdetails.stream_error = True
-            # Only revoke availability when the stream never produced audio (i.e. it
-            # failed to start). A mid-stream abort after real playback is typically a
-            # transient/network condition - common for radio streams that drop and can
-            # be reconnected - so the item must stay available to allow a restart.
+            # revoke availability when the stream never produced any audio
             if bytes_received == 0:
                 queue_item.available = False
             if raise_on_error:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -1286,7 +1286,12 @@ class StreamsAudio:
                 yield chunk
         except AudioError as err:
             streamdetails.stream_error = True
-            queue_item.available = False
+            # Only revoke availability when the stream never produced audio (i.e. it
+            # failed to start). A mid-stream abort after real playback is typically a
+            # transient/network condition on a live source that can be reconnected, so
+            # the item must stay available to allow a restart.
+            if bytes_received == 0:
+                queue_item.available = False
             if raise_on_error:
                 raise
             logger.error(
@@ -1493,7 +1498,12 @@ class StreamsAudio:
             finished = True
         except AudioError as err:
             streamdetails.stream_error = True
-            queue_item.available = False
+            # Only revoke availability when the stream never produced audio (i.e. it
+            # failed to start). A mid-stream abort after real playback is typically a
+            # transient/network condition - common for radio streams that drop and can
+            # be reconnected - so the item must stay available to allow a restart.
+            if bytes_received == 0:
+                queue_item.available = False
             if raise_on_error:
                 raise
             logger.error(


### PR DESCRIPTION
## What does this implement/fix?

When a stream drops mid-playback — common for a long-running radio stream that hits a transient network blip — the queue item was hard-flagged `available = False`. For a single radio item there is nothing to fall back to, so the stream can no longer be restarted and pressing play gives *"Playback failed for &lt;station&gt; - no more tracks available"*. It only recovers once the item is re-loaded (e.g. re-selecting the station).

A stream that has already played for a while shouldn't be treated as a broken/unavailable item — availability should only be revoked when the stream never started.

- In `get_queue_item_stream` and `get_audio_source_stream`, only set `queue_item.available = False` when no audio was produced (`bytes_received == 0`); a mid-stream abort after real playback keeps the item available so it can be restarted (and reconnected).

Complements the ICY reconnect fix (#4422): that keeps the stream alive through a blip, this keeps it restartable if it does die.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
