### PR TITLE
Reconnect ICY radio streams on disconnect

### DIFF
--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -711,7 +711,14 @@ class StreamsAudio:
                     meta_int_str = resp.headers.get("icy-metaint")
                     if not meta_int_str:
                         raise InvalidDataError(f"No icy-metaint header for radio stream: {url}")
-                    meta_int = int(meta_int_str)
+                    try:
+                        meta_int = int(meta_int_str)
+                    except ValueError as err:
+                        raise InvalidDataError(
+                            f"Invalid icy-metaint value for radio stream: {url}"
+                        ) from err
+                    if meta_int <= 0:
+                        raise InvalidDataError(f"Invalid icy-metaint value for radio stream: {url}")
                     # readexactly raises IncompleteReadError when the server closes the
                     # connection mid-frame; that (and the network errors below) drops us
                     # out to the reconnect handler so a live stream survives the blip.

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -683,7 +683,7 @@ class StreamsAudio:
         self, url: str, streamdetails: StreamDetails
     ) -> AsyncGenerator[bytes]:
         """
-        Stream radio audio with ICY metadata support.
+        Stream radio audio with ICY metadata support, reconnecting on disconnect.
 
         Requires icy-metaint header support. Stream type should be validated
         by resolve_radio_stream() before calling this function.
@@ -693,24 +693,56 @@ class StreamsAudio:
         """
         self.logger.debug("Start streaming radio with ICY metadata from url %s", url)
         timeout = ClientTimeout(total=0, connect=30, sock_read=5 * 60)
+        reconnect_count = 0
+        max_reconnects = 1000  # Allow many reconnects for long-running radio
 
-        async with self._connect_radio_stream(
-            url, allow_redirects=True, headers=HTTP_HEADERS_ICY, timeout=timeout
-        ) as resp:
-            headers = resp.headers
-            meta_int = int(headers["icy-metaint"])
+        while reconnect_count <= max_reconnects:
+            try:
+                async with self._connect_radio_stream(
+                    url, allow_redirects=True, headers=HTTP_HEADERS_ICY, timeout=timeout
+                ) as resp:
+                    meta_int = int(resp.headers["icy-metaint"])
+                    # readexactly raises IncompleteReadError when the server closes the
+                    # connection mid-frame; that (and the network errors below) drops us
+                    # out to the reconnect handler so a live stream survives the blip.
+                    while True:
+                        yield await resp.content.readexactly(meta_int)
+                        meta_byte = await resp.content.readexactly(1)
+                        if meta_byte == b"\x00":
+                            continue
+                        meta_length = ord(meta_byte) * 16
+                        meta_data = await resp.content.readexactly(meta_length)
+                        self._parse_icy_metadata(meta_data, streamdetails)
+            except asyncio.CancelledError:
+                self.logger.debug("ICY radio stream cancelled for %s", url)
+                raise
+            except (
+                asyncio.IncompleteReadError,
+                aiohttp.ClientConnectionError,
+                aiohttp.ClientPayloadError,
+                aiohttp.ServerDisconnectedError,
+            ) as err:
+                reconnect_count += 1
+                if reconnect_count > max_reconnects:
+                    raise RetriesExhausted(
+                        f"ICY radio stream failed after {max_reconnects} reconnects: {err}"
+                    ) from err
+                self.logger.warning(
+                    "ICY radio stream disconnected (reconnect #%d): %s", reconnect_count, err
+                )
+                await asyncio.sleep(0.5)
+            except aiohttp.ClientResponseError as err:
+                if err.status == 404:
+                    raise MediaNotFoundError(f"Radio stream not found: {url}") from err
+                if err.status == 403:
+                    raise ProviderPermissionDenied(f"Radio stream access denied: {url}") from err
+                raise ProviderUnavailableError(
+                    f"Radio stream returned HTTP {err.status}: {err}"
+                ) from err
 
-            while True:
-                try:
-                    yield await resp.content.readexactly(meta_int)
-                    meta_byte = await resp.content.readexactly(1)
-                    if meta_byte == b"\x00":
-                        continue
-                    meta_length = ord(meta_byte) * 16
-                    meta_data = await resp.content.readexactly(meta_length)
-                    self._parse_icy_metadata(meta_data, streamdetails)
-                except asyncio.exceptions.IncompleteReadError:
-                    break
+        self.logger.warning(
+            "ICY radio stream reached max reconnects (%d) for %s", max_reconnects, url
+        )
 
     async def get_reconnecting_radio_stream(self, url: str) -> AsyncGenerator[bytes]:
         """

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -693,10 +693,14 @@ class StreamsAudio:
         """
         self.logger.debug("Start streaming radio with ICY metadata from url %s", url)
         timeout = ClientTimeout(total=0, connect=30, sock_read=5 * 60)
-        reconnect_count = 0
-        max_reconnects = 1000  # Allow many reconnects for long-running radio
+        # Budget for *consecutive* reconnects that delivered no audio. A connection
+        # that actually streamed data resets it, so a healthy long-running stream can
+        # reconnect indefinitely while a dead/looping one bails out instead of spinning.
+        failed_reconnects = 0
+        max_failed_reconnects = 25
 
-        while reconnect_count <= max_reconnects:
+        while True:
+            streamed_data = False
             try:
                 async with self._connect_radio_stream(
                     url, allow_redirects=True, headers=HTTP_HEADERS_ICY, timeout=timeout
@@ -712,7 +716,9 @@ class StreamsAudio:
                     # connection mid-frame; that (and the network errors below) drops us
                     # out to the reconnect handler so a live stream survives the blip.
                     while True:
-                        yield await resp.content.readexactly(meta_int)
+                        chunk = await resp.content.readexactly(meta_int)
+                        streamed_data = True
+                        yield chunk
                         meta_byte = await resp.content.readexactly(1)
                         if meta_byte == b"\x00":
                             continue
@@ -736,14 +742,23 @@ class StreamsAudio:
                 aiohttp.ClientPayloadError,
                 aiohttp.ServerDisconnectedError,
             ) as err:
-                reconnect_count += 1
-                if reconnect_count > max_reconnects:
-                    raise RetriesExhausted(
-                        f"ICY radio stream failed after {max_reconnects} reconnects: {err}"
-                    ) from err
-                self.logger.warning(
-                    "ICY radio stream disconnected (reconnect #%d): %s", reconnect_count, err
-                )
+                if streamed_data:
+                    # a healthy session that dropped - reconnect without spending budget
+                    failed_reconnects = 0
+                    self.logger.debug("ICY radio stream dropped, reconnecting: %s", err)
+                else:
+                    failed_reconnects += 1
+                    if failed_reconnects > max_failed_reconnects:
+                        raise RetriesExhausted(
+                            f"ICY radio stream failed after {max_failed_reconnects} "
+                            f"reconnects without data: {err}"
+                        ) from err
+                    self.logger.warning(
+                        "ICY radio stream reconnect produced no data (%d/%d): %s",
+                        failed_reconnects,
+                        max_failed_reconnects,
+                        err,
+                    )
                 await asyncio.sleep(0.5)
 
     async def get_reconnecting_radio_stream(self, url: str) -> AsyncGenerator[bytes]:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -701,7 +701,13 @@ class StreamsAudio:
                 async with self._connect_radio_stream(
                     url, allow_redirects=True, headers=HTTP_HEADERS_ICY, timeout=timeout
                 ) as resp:
-                    meta_int = int(resp.headers["icy-metaint"])
+                    # surface a non-200 (e.g. on reconnect) as a ClientResponseError so the
+                    # terminal/HTTP handling below applies instead of failing on the header
+                    resp.raise_for_status()
+                    meta_int_str = resp.headers.get("icy-metaint")
+                    if not meta_int_str:
+                        raise InvalidDataError(f"No icy-metaint header for radio stream: {url}")
+                    meta_int = int(meta_int_str)
                     # readexactly raises IncompleteReadError when the server closes the
                     # connection mid-frame; that (and the network errors below) drops us
                     # out to the reconnect handler so a live stream survives the blip.
@@ -716,6 +722,14 @@ class StreamsAudio:
             except asyncio.CancelledError:
                 self.logger.debug("ICY radio stream cancelled for %s", url)
                 raise
+            except aiohttp.ClientResponseError as err:
+                if err.status == 404:
+                    raise MediaNotFoundError(f"Radio stream not found: {url}") from err
+                if err.status == 403:
+                    raise ProviderPermissionDenied(f"Radio stream access denied: {url}") from err
+                raise ProviderUnavailableError(
+                    f"Radio stream returned HTTP {err.status}: {err}"
+                ) from err
             except (
                 asyncio.IncompleteReadError,
                 aiohttp.ClientConnectionError,
@@ -731,18 +745,6 @@ class StreamsAudio:
                     "ICY radio stream disconnected (reconnect #%d): %s", reconnect_count, err
                 )
                 await asyncio.sleep(0.5)
-            except aiohttp.ClientResponseError as err:
-                if err.status == 404:
-                    raise MediaNotFoundError(f"Radio stream not found: {url}") from err
-                if err.status == 403:
-                    raise ProviderPermissionDenied(f"Radio stream access denied: {url}") from err
-                raise ProviderUnavailableError(
-                    f"Radio stream returned HTTP {err.status}: {err}"
-                ) from err
-
-        self.logger.warning(
-            "ICY radio stream reached max reconnects (%d) for %s", max_reconnects, url
-        )
 
     async def get_reconnecting_radio_stream(self, url: str) -> AsyncGenerator[bytes]:
         """

--- a/tests/controllers/streams/test_icy_reconnect.py
+++ b/tests/controllers/streams/test_icy_reconnect.py
@@ -6,8 +6,10 @@ import asyncio
 from typing import Any
 from unittest.mock import MagicMock
 
+import aiohttp
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
@@ -34,10 +36,14 @@ class _FakeContent:
 class _FakeConnCtx:
     """Async context manager yielding a fake ICY response."""
 
-    def __init__(self, frames: list[bytes | Exception]) -> None:
+    def __init__(self, frames: list[bytes | Exception], status: int = 200) -> None:
         self._resp = MagicMock()
         self._resp.headers = {"icy-metaint": str(_META_INT)}
         self._resp.content = _FakeContent(frames)
+        if status >= 400:
+            self._resp.raise_for_status.side_effect = aiohttp.ClientResponseError(
+                MagicMock(), (), status=status
+            )
 
     async def __aenter__(self) -> Any:
         return self._resp
@@ -88,3 +94,19 @@ async def test_icy_stream_reconnects_after_disconnect(monkeypatch: pytest.Monkey
 
     assert chunks == [b"AAAA", b"BBBB"]
     assert connect_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_icy_stream_raises_on_http_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 404 response is terminal and surfaces as MediaNotFoundError, not a reconnect."""
+    audio = StreamsAudio(MagicMock())
+
+    monkeypatch.setattr(
+        audio, "_connect_radio_stream", lambda *_a, **_k: _FakeConnCtx([], status=404)
+    )
+
+    with pytest.raises(MediaNotFoundError):
+        async for _chunk in audio.get_icy_radio_stream(
+            "http://example.test/radio.mp3", _radio_streamdetails()
+        ):
+            pass

--- a/tests/controllers/streams/test_icy_reconnect.py
+++ b/tests/controllers/streams/test_icy_reconnect.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import MediaNotFoundError, RetriesExhausted
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
@@ -110,3 +110,29 @@ async def test_icy_stream_raises_on_http_404(monkeypatch: pytest.MonkeyPatch) ->
             "http://example.test/radio.mp3", _radio_streamdetails()
         ):
             pass
+
+
+@pytest.mark.asyncio
+async def test_icy_stream_gives_up_when_no_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A connection that never delivers audio bails out instead of reconnecting forever."""
+    audio = StreamsAudio(MagicMock())
+    connect_calls = 0
+
+    def _fake_connect(*_args: Any, **_kwargs: Any) -> _FakeConnCtx:
+        nonlocal connect_calls
+        connect_calls += 1
+        # empty frames -> readexactly immediately raises IncompleteReadError (no data)
+        return _FakeConnCtx([])
+
+    monkeypatch.setattr(audio, "_connect_radio_stream", _fake_connect)
+    # don't actually wait out the backoff between reconnect attempts
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    with pytest.raises(RetriesExhausted):
+        async for _chunk in audio.get_icy_radio_stream(
+            "http://example.test/radio.mp3", _radio_streamdetails()
+        ):
+            pass
+
+    # bails after the budget is exhausted rather than spinning indefinitely
+    assert connect_calls < 50

--- a/tests/controllers/streams/test_icy_reconnect.py
+++ b/tests/controllers/streams/test_icy_reconnect.py
@@ -9,7 +9,11 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
-from music_assistant_models.errors import MediaNotFoundError, RetriesExhausted
+from music_assistant_models.errors import (
+    InvalidDataError,
+    MediaNotFoundError,
+    RetriesExhausted,
+)
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
@@ -36,9 +40,11 @@ class _FakeContent:
 class _FakeConnCtx:
     """Async context manager yielding a fake ICY response."""
 
-    def __init__(self, frames: list[bytes | Exception], status: int = 200) -> None:
+    def __init__(
+        self, frames: list[bytes | Exception], status: int = 200, meta_int: str = str(_META_INT)
+    ) -> None:
         self._resp = MagicMock()
-        self._resp.headers = {"icy-metaint": str(_META_INT)}
+        self._resp.headers = {"icy-metaint": meta_int}
         self._resp.content = _FakeContent(frames)
         if status >= 400:
             self._resp.raise_for_status.side_effect = aiohttp.ClientResponseError(
@@ -136,3 +142,18 @@ async def test_icy_stream_gives_up_when_no_data(monkeypatch: pytest.MonkeyPatch)
 
     # bails after the budget is exhausted rather than spinning indefinitely
     assert connect_calls < 50
+
+
+@pytest.mark.asyncio
+async def test_icy_stream_invalid_metaint_is_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A malformed icy-metaint header raises a controlled InvalidDataError, not a raw ValueError."""
+    audio = StreamsAudio(MagicMock())
+    monkeypatch.setattr(
+        audio, "_connect_radio_stream", lambda *_a, **_k: _FakeConnCtx([], meta_int="not-a-number")
+    )
+
+    with pytest.raises(InvalidDataError):
+        async for _chunk in audio.get_icy_radio_stream(
+            "http://example.test/radio.mp3", _radio_streamdetails()
+        ):
+            pass

--- a/tests/controllers/streams/test_icy_reconnect.py
+++ b/tests/controllers/streams/test_icy_reconnect.py
@@ -1,0 +1,90 @@
+"""Tests for ICY radio stream reconnection on disconnect."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.streamdetails import StreamDetails
+
+from music_assistant.controllers.streams.audio import StreamsAudio
+
+_META_INT = 4
+
+
+class _FakeContent:
+    """Minimal stand-in for aiohttp StreamReader content, driven by a script of frames."""
+
+    def __init__(self, frames: list[bytes | Exception]) -> None:
+        self._frames = list(frames)
+
+    async def readexactly(self, _n: int) -> bytes:
+        if not self._frames:
+            raise asyncio.IncompleteReadError(b"", _n)
+        item = self._frames.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class _FakeConnCtx:
+    """Async context manager yielding a fake ICY response."""
+
+    def __init__(self, frames: list[bytes | Exception]) -> None:
+        self._resp = MagicMock()
+        self._resp.headers = {"icy-metaint": str(_META_INT)}
+        self._resp.content = _FakeContent(frames)
+
+    async def __aenter__(self) -> Any:
+        return self._resp
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+def _radio_streamdetails() -> StreamDetails:
+    return StreamDetails(
+        provider="test_provider",
+        item_id="radio1",
+        audio_format=AudioFormat(content_type=ContentType.MP3),
+        media_type=MediaType.RADIO,
+        stream_type=StreamType.ICY,
+        path="http://example.test/radio.mp3",
+    )
+
+
+@pytest.mark.asyncio
+async def test_icy_stream_reconnects_after_disconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mid-stream disconnect transparently reconnects and keeps yielding audio."""
+    audio = StreamsAudio(MagicMock())
+
+    # connection #1 yields one audio frame then drops; connection #2 yields another.
+    connections = [
+        _FakeConnCtx([b"AAAA", b"\x00", asyncio.IncompleteReadError(b"", _META_INT)]),
+        _FakeConnCtx([b"BBBB", b"\x00", asyncio.IncompleteReadError(b"", _META_INT)]),
+    ]
+    connect_calls = 0
+
+    def _fake_connect(*_args: Any, **_kwargs: Any) -> _FakeConnCtx:
+        nonlocal connect_calls
+        ctx = connections[connect_calls]
+        connect_calls += 1
+        return ctx
+
+    monkeypatch.setattr(audio, "_connect_radio_stream", _fake_connect)
+
+    chunks: list[bytes] = []
+    async for chunk in audio.get_icy_radio_stream(
+        "http://example.test/radio.mp3", _radio_streamdetails()
+    ):
+        chunks.append(chunk)
+        if len(chunks) == 2:
+            # got one frame from each connection - reconnection proven
+            break
+
+    assert chunks == [b"AAAA", b"BBBB"]
+    assert connect_calls == 2


### PR DESCRIPTION
## What does this implement/fix?

ICY (Icecast/Shoutcast MP3) radio streams had no reconnect logic: when the connection dropped — server cycling, idle-connection reaping, or a brief network blip — the stream simply ended. The OGG (`get_reconnecting_radio_stream`) and HTTP/HLS radio paths already recover from this, so ICY was the odd one out, and a typical Icecast `.mp3` station would just stop after a while with no way to resume until it was reloaded.

- Wrap the ICY reader in a reconnect loop: an `IncompleteReadError` or transient aiohttp connection error reconnects (re-reading the `icy-metaint` header) instead of ending the stream; `raise_for_status()` + header validation keep 404/403/non-200 terminal, and a cancel still cancels.
- Guard against a tight reconnect loop on a dead connection: the reconnect budget is only spent on *consecutive* reconnects that delivered **no** audio. A connection that actually streamed data resets it, so a healthy long-running stream reconnects indefinitely while a dead/looping one bails out after 25 attempts.
- Add regression tests for reconnect-on-disconnect, terminal 404, and the no-data give-up path.

The legacy Shoutcast raw-socket path (`get_shoutcast_stream`) has the same `IncompleteReadError -> break` shape and could get the same treatment as a small follow-up; it's left out here to keep this focused/backportable.

Complements #4421: this keeps the stream alive through a blip, #4421 keeps it restartable if it does die.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
