### PR TITLE
Dynamically update group leader capability on a zone player in MusicCast

### DIFF
--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -169,7 +169,6 @@ class MusicCastPlayer(Player):
             PlayerFeature.PAUSE,  # for non MA control, see pause method
             PlayerFeature.POWER,
             PlayerFeature.SELECT_SOURCE,
-            PlayerFeature.SET_MEMBERS,
             PlayerFeature.NEXT_PREVIOUS,
             PlayerFeature.ENQUEUE,
             PlayerFeature.GAPLESS_PLAYBACK,
@@ -436,6 +435,13 @@ class MusicCastPlayer(Player):
             self._attr_group_members = [
                 self._get_player_id_from_zone_device(x) for x in self.zone_device.musiccast_group
             ]
+
+        # disallow set members (i.e. a zone to become a group leader) it it is currently grouped to the main zone
+        if self.zone_device.source_id == MC_SOURCE_MAIN_SYNC:
+            with suppress(KeyError):
+                self._attr_supported_features.remove(PlayerFeature.SET_MEMBERS)
+        else:
+            self._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
 
         # PLAYER OPTIONS
         # see https://github.com/vigonotion/aiomusiccast/blob/main/aiomusiccast/capabilities.py

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -438,8 +438,7 @@ class MusicCastPlayer(Player):
 
         # disallow set members (i.e. a zone to become a group leader) if it is currently grouped to the main zone
         if self.zone_device.source_id == MC_SOURCE_MAIN_SYNC:
-            with suppress(KeyError):
-                self._attr_supported_features.remove(PlayerFeature.SET_MEMBERS)
+            self._attr_supported_features.discard(PlayerFeature.SET_MEMBERS)
         else:
             self._attr_supported_features.add(PlayerFeature.SET_MEMBERS)
 

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -436,7 +436,7 @@ class MusicCastPlayer(Player):
                 self._get_player_id_from_zone_device(x) for x in self.zone_device.musiccast_group
             ]
 
-        # disallow set members (i.e. a zone to become a group leader) it it is currently grouped to the main zone
+        # disallow set members (i.e. a zone to become a group leader) if it is currently grouped to the main zone
         if self.zone_device.source_id == MC_SOURCE_MAIN_SYNC:
             with suppress(KeyError):
                 self._attr_supported_features.remove(PlayerFeature.SET_MEMBERS)


### PR DESCRIPTION
# What does this implement/fix?

In response to https://github.com/music-assistant/server/pull/4412 , prevent a main-grouped zone of an AV receiver in MusicCast from being accidentally promoted.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
