### PR TITLE
Resolve player palette only on the media owner, not per grouped member

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1773,8 +1773,15 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             )
 
         # Kick async palette extraction on cold cache. On transition prefetch
-        # the next queue item too.
-        if (current_media := player.state.current_media) and current_media.image_url:
+        # the next queue item too. Skip players that mirror another player's media
+        # (grouped/synced members, protocol children): their current_media - palette
+        # included - is taken wholesale from the owner, so resolving it per member is
+        # wasted work that also produces duplicate state updates across the group.
+        if (
+            not self._mirrors_parent_media(player)
+            and (current_media := player.state.current_media)
+            and current_media.image_url
+        ):
             if current_media.palette is None:
                 self._schedule_palette_fetch(player_id, current_media.image_url)
             if "current_media.image_url" in changed_values or "current_media" in changed_values:
@@ -2345,6 +2352,20 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                     player.state.name,
                 )
                 await self._handle_cmd_stop(group.player_id)
+
+    def _mirrors_parent_media(self, player: Player) -> bool:
+        """
+        Return True if the player's current_media is taken from another player.
+
+        Grouped/synced members and protocol children mirror their parent's
+        current_media (palette included), so they must not resolve it themselves.
+
+        :param player: The player to check.
+        """
+        state = player.state
+        if state.active_group or state.synced_to:
+            return True
+        return state.type == PlayerType.PROTOCOL and player.protocol_parent_id is not None
 
     def _schedule_palette_fetch(
         self, player_id: str, image_url: str | None, *, trigger_update: bool = True

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -2363,7 +2363,10 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         :param player: The player to check.
         """
         state = player.state
-        if state.active_group or state.synced_to:
+        # a self-referential active_group/synced_to is not a real parent (mirror the
+        # != self guard in Player.__final_current_media), so it must not skip resolution
+        parent_id = state.active_group or state.synced_to
+        if parent_id and parent_id != player.player_id:
             return True
         return state.type == PlayerType.PROTOCOL and player.protocol_parent_id is not None
 

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -774,12 +774,14 @@ class TestMirrorsParentMedia:
     @staticmethod
     def _fake_player(
         *,
+        player_id: str = "p1",
         active_group: str | None = None,
         synced_to: str | None = None,
         player_type: PlayerType = PlayerType.PLAYER,
         protocol_parent_id: str | None = None,
     ) -> SimpleNamespace:
         return SimpleNamespace(
+            player_id=player_id,
             state=SimpleNamespace(active_group=active_group, synced_to=synced_to, type=player_type),
             protocol_parent_id=protocol_parent_id,
         )
@@ -804,6 +806,11 @@ class TestMirrorsParentMedia:
     def test_protocol_player_without_parent_owns_media(self, controller: PlayerController) -> None:
         """A protocol player with no parent resolves its own media."""
         player = self._fake_player(player_type=PlayerType.PROTOCOL)
+        assert controller._mirrors_parent_media(player) is False  # type: ignore[arg-type]
+
+    def test_self_referential_parent_owns_media(self, controller: PlayerController) -> None:
+        """A self-referential active_group/synced_to is not a real parent, so resolve locally."""
+        player = self._fake_player(player_id="p1", synced_to="p1", active_group="p1")
         assert controller._mirrors_parent_media(player) is False  # type: ignore[arg-type]
 
 

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -765,6 +766,45 @@ class TestExternalSourcePlayPause:
 
         controller._handle_cmd_stop.assert_awaited_once()
         player.pause.assert_not_called()
+
+
+class TestMirrorsParentMedia:
+    """Tests for _mirrors_parent_media (palette-fetch gating for grouped players)."""
+
+    @staticmethod
+    def _fake_player(
+        *,
+        active_group: str | None = None,
+        synced_to: str | None = None,
+        player_type: PlayerType = PlayerType.PLAYER,
+        protocol_parent_id: str | None = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            state=SimpleNamespace(active_group=active_group, synced_to=synced_to, type=player_type),
+            protocol_parent_id=protocol_parent_id,
+        )
+
+    def test_standalone_player_owns_media(self, controller: PlayerController) -> None:
+        """A standalone player resolves its own media (and palette)."""
+        assert controller._mirrors_parent_media(self._fake_player()) is False  # type: ignore[arg-type]
+
+    def test_group_member_mirrors(self, controller: PlayerController) -> None:
+        """A group member borrows its parent's media."""
+        assert controller._mirrors_parent_media(self._fake_player(active_group="g1")) is True  # type: ignore[arg-type]
+
+    def test_synced_member_mirrors(self, controller: PlayerController) -> None:
+        """A synced member borrows its leader's media."""
+        assert controller._mirrors_parent_media(self._fake_player(synced_to="leader")) is True  # type: ignore[arg-type]
+
+    def test_protocol_child_mirrors(self, controller: PlayerController) -> None:
+        """A protocol child borrows its parent's media."""
+        player = self._fake_player(player_type=PlayerType.PROTOCOL, protocol_parent_id="parent")
+        assert controller._mirrors_parent_media(player) is True  # type: ignore[arg-type]
+
+    def test_protocol_player_without_parent_owns_media(self, controller: PlayerController) -> None:
+        """A protocol player with no parent resolves its own media."""
+        player = self._fake_player(player_type=PlayerType.PROTOCOL)
+        assert controller._mirrors_parent_media(player) is False  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this implement/fix?

In a sync group, a verbose log shows a burst of `current_media.palette*` state updates on every radio metadata change — the same player updating several times within milliseconds, multiplied across all group members.

Root cause: a grouped/synced member (and a protocol child) takes its `current_media` — palette included — wholesale from the owning player. But `signal_player_state_update` scheduled a color-palette fetch for *every* player whose `current_media` had no palette yet, members included. So on each track/metadata change every member would:

- do its own (redundant) palette lookup for the same image,
- call `set_resolved_palette` on itself — which its serialized state never reads, because a member's `current_media` comes from the owner, and
- emit a `force_update` state update anyway,

which also fans back through the group, producing the duplicate updates. The palette already reaches members correctly via the owner's single fetch + the existing state-forward.

- Gate the palette fetch/prefetch to the media *owner* (skip grouped/synced members and protocol children) via a small `_mirrors_parent_media` helper.
- Members still receive the resolved palette through the owner's forwarded state update — one fetch per image instead of one per player.
- Add unit tests for the owner/member/protocol cases.


**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`
