### PR TITLE
Make the demo player provider a groupable end-to-end test bed

### DIFF
--- a/music_assistant/providers/_demo_player_provider/player.py
+++ b/music_assistant/providers/_demo_player_provider/player.py
@@ -28,7 +28,10 @@ class DemoPlayer(Player):
             PlayerFeature.VOLUME_SET,
             PlayerFeature.VOLUME_MUTE,
             PlayerFeature.PLAY_ANNOUNCEMENT,
+            PlayerFeature.SET_MEMBERS,
         }
+        # demo players can be (sync) grouped with other players of this provider
+        self._attr_can_group_with = {provider.instance_id}
         self._set_attributes()
 
     async def on_config_updated(self) -> None:
@@ -322,6 +325,23 @@ class DemoPlayer(Player):
         # OPTIONAL - required only if you specified PlayerFeature.SET_MEMBERS
         # This method is optional and should be implemented if the player supports
         # syncing/grouping with other players.
+        # This demo keeps a simple in-memory member list: the leader tracks its
+        # group_members and each member's synced_to is then derived automatically by
+        # the base Player from the leader's list. A real provider would also issue the
+        # native sync command to the device here.
+        members = dict.fromkeys(self._attr_group_members)
+        for member_id in player_ids_to_add or []:
+            members[member_id] = None
+        for member_id in player_ids_to_remove or []:
+            members.pop(member_id, None)
+        other_member_ids = [pid for pid in members if pid != self.player_id]
+        # the leader is always the first member while the group is non-empty
+        self._attr_group_members = [self.player_id, *other_member_ids] if other_member_ids else []
+        self.update_state()
+        # refresh affected members so their derived synced_to / can_group_with recompute
+        for member_id in [*(player_ids_to_add or []), *(player_ids_to_remove or [])]:
+            if (member := self.mass.players.get_player(member_id)) is not None:
+                member.update_state()
 
     async def set_option(self, option_key: str, option_value: PlayerOptionValueType) -> None:
         """Handle SET_OPTION command on the player."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -59,7 +59,9 @@ async def group_players(mass: MusicAssistant, leader: Player, members: list[Play
     await asyncio.sleep(0.5)
     for member in members:
         await mass.players.cmd_group(member.player_id, leader.player_id)
-    await wait_for(lambda: len(leader.state.group_members) >= 1 + len(members))
+    assert await wait_for(lambda: len(leader.state.group_members) >= 1 + len(members)), (
+        f"group did not form: {leader.state.group_members}"
+    )
 
 
 async def play_test_track(mass: MusicAssistant, queue_id: str, track_id: str = "0_0_0") -> None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,136 @@
+"""
+Hermetic end-to-end fixtures backed by the fake `test` + demo player providers.
+
+These boot a real MusicAssistant with only the fake music (`test`) and fake player
+(`_demo_player_provider`) providers, with all real network discovery disabled, so
+end-to-end behaviour (grouping, queue, current-media propagation) can be exercised
+without any hardware or LAN access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import pathlib
+from collections.abc import AsyncGenerator, Callable
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
+
+import pytest
+from zeroconf.asyncio import AsyncZeroconf
+
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
+from music_assistant.models.player import Player
+
+NUM_DEMO_PLAYERS = 3
+
+
+async def wait_for(predicate: Callable[[], bool], timeout: float = 25.0) -> bool:
+    """Poll ``predicate`` until it is truthy or ``timeout`` elapses; return the final value."""
+    elapsed = 0.0
+    while elapsed < timeout:
+        if predicate():
+            return True
+        await asyncio.sleep(0.25)
+        elapsed += 0.25
+    return predicate()
+
+
+def demo_players(mass: MusicAssistant) -> list[Player]:
+    """Return the registered demo players, sorted by id."""
+    return sorted(
+        (p for p in mass.players if p.player_id.startswith("demo_")),
+        key=lambda p: p.player_id,
+    )
+
+
+async def group_players(mass: MusicAssistant, leader: Player, members: list[Player]) -> None:
+    """
+    Form a sync group of demo players under ``leader``.
+
+    :param leader: The player that becomes the sync leader.
+    :param members: The players to join to the leader.
+    """
+    # refresh every player's state so can_group_with re-expands now that all players
+    # are registered (the cross-player refresh is otherwise debounced)
+    for player in [leader, *members]:
+        player.update_state(force_update=True)
+    await asyncio.sleep(0.5)
+    for member in members:
+        await mass.players.cmd_group(member.player_id, leader.player_id)
+    await wait_for(lambda: len(leader.state.group_members) >= 1 + len(members))
+
+
+async def play_test_track(mass: MusicAssistant, queue_id: str, track_id: str = "0_0_0") -> None:
+    """Play a fake `test`-provider track (which carries artwork) on the given queue."""
+    test_prov = cast("MusicProvider", mass.get_provider("test"))
+    assert test_prov is not None
+    track = await test_prov.get_track(track_id)
+    await mass.player_queues.play_media(queue_id, track)
+
+
+def _create_mock_zeroconf() -> MagicMock:
+    """Create a mock AsyncZeroconf that prevents real mDNS network I/O."""
+    mock_zc = MagicMock(spec=AsyncZeroconf)
+    mock_inner_zc = NonCallableMagicMock()
+    mock_inner_zc.cache = NonCallableMagicMock()
+    mock_inner_zc.cache.cache = {}  # empty cache - no discovered services
+    mock_zc.zeroconf = mock_inner_zc
+    mock_zc.async_register_service = AsyncMock()
+    mock_zc.async_update_service = AsyncMock()
+    mock_zc.async_unregister_service = AsyncMock()
+    mock_zc.async_close = AsyncMock()
+    return mock_zc
+
+
+@pytest.fixture
+async def e2e_mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
+    """
+    Boot a hermetic MusicAssistant with only the fake `test` + demo player providers.
+
+    No real network discovery happens: mDNS (zeroconf) and SSDP are mocked and the
+    default device providers (dlna/sonos/...) are suppressed. The `test` music provider
+    and three grouped-capable demo players are configured and ready.
+    """
+    storage_path = tmp_path / "data"
+    cache_path = tmp_path / "cache"
+    storage_path.mkdir(parents=True)
+    cache_path.mkdir(parents=True)
+    logging.getLogger("aiosqlite").level = logging.INFO
+
+    mass_instance = MusicAssistant(str(storage_path), str(cache_path))
+    # load the `_`-prefixed demo player provider (gated on dev mode)
+    mass_instance.dev_mode = True
+
+    with (
+        patch(
+            "music_assistant.controllers.discovery.controller.AsyncZeroconf",
+            return_value=_create_mock_zeroconf(),
+        ),
+        patch(
+            "music_assistant.controllers.discovery.controller.AsyncServiceBrowser",
+            return_value=NonCallableMagicMock(),
+        ),
+        patch(
+            "music_assistant.controllers.streams.controller.check_ffmpeg_version",
+            new=AsyncMock(),
+        ),
+        # hermetic: no real SSDP search and no auto-loaded device providers
+        patch(
+            "music_assistant.controllers.discovery.controller.async_upnp_search",
+            new=AsyncMock(),
+        ),
+        patch("music_assistant.mass.DEFAULT_PROVIDERS", ()),
+    ):
+        await mass_instance.start()
+        # configure the fake music + player providers
+        await mass_instance.config.save_provider_config("test", {})
+        await mass_instance.config.save_provider_config(
+            "_demo_player_provider", {"number_of_players": NUM_DEMO_PLAYERS}
+        )
+        await wait_for(lambda: len(demo_players(mass_instance)) >= NUM_DEMO_PLAYERS)
+        try:
+            yield mass_instance
+        finally:
+            await mass_instance.stop()

--- a/tests/integration/test_demo_group_e2e.py
+++ b/tests/integration/test_demo_group_e2e.py
@@ -1,0 +1,62 @@
+"""
+End-to-end demo: a sync group of fake players mirrors the leader's media.
+
+Exercises the full stack with no hardware/network: form a sync group of demo
+players, play a fake `test`-provider track, and assert the group's current media
+propagates to every member.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+import pytest
+
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.player import Player
+
+from .conftest import demo_players, group_players, play_test_track, wait_for
+
+
+def _mirrors_uri(player: Player, uri: str) -> bool:
+    """Return True if the player's current media matches the given uri."""
+    current = player.state.current_media
+    return current is not None and current.uri == uri
+
+
+@pytest.mark.asyncio
+async def test_demo_group_mirrors_current_media(e2e_mass: MusicAssistant) -> None:
+    """A grouped set of demo players all report the sync leader's current media."""
+    # hermetic boot: only the fake demo players exist (no real LAN devices discovered)
+    assert [p.player_id for p in e2e_mass.players] == ["demo_0", "demo_1", "demo_2"]
+
+    players = demo_players(e2e_mass)
+    assert len(players) >= 3
+    leader, *members = players[:3]
+
+    # 1. form the sync group
+    await group_players(e2e_mass, leader, members)
+    assert await wait_for(lambda: len(leader.state.group_members) == 3), (
+        f"group not formed: {leader.state.group_members}"
+    )
+    assert leader.state.group_members[0] == leader.player_id
+    for member in members:
+        assert member.state.synced_to == leader.player_id
+
+    # 2. play a fake track (carries artwork) on the group
+    await play_test_track(e2e_mass, leader.player_id)
+    assert await wait_for(lambda: leader.state.current_media is not None), (
+        "leader current_media never populated"
+    )
+    leader_media = leader.state.current_media
+    assert leader_media is not None
+    assert leader_media.image_url
+
+    # 3. every member mirrors the leader's media end-to-end
+    for member in members:
+        assert await wait_for(partial(_mirrors_uri, member, leader_media.uri)), (
+            f"{member.player_id} did not mirror the leader's media"
+        )
+        member_media = member.state.current_media
+        assert member_media is not None
+        assert member_media.image_url == leader_media.image_url

--- a/tests/integration/test_demo_group_e2e.py
+++ b/tests/integration/test_demo_group_e2e.py
@@ -28,7 +28,7 @@ def _mirrors_uri(player: Player, uri: str) -> bool:
 async def test_demo_group_mirrors_current_media(e2e_mass: MusicAssistant) -> None:
     """A grouped set of demo players all report the sync leader's current media."""
     # hermetic boot: only the fake demo players exist (no real LAN devices discovered)
-    assert [p.player_id for p in e2e_mass.players] == ["demo_0", "demo_1", "demo_2"]
+    assert sorted(p.player_id for p in e2e_mass.players) == ["demo_0", "demo_1", "demo_2"]
 
     players = demo_players(e2e_mass)
     assert len(players) >= 3


### PR DESCRIPTION
## What does this implement/fix?

While reproducing the grouped-player palette churn (#4425) I hit two gaps that make fake/no-hardware testing harder than it should be:

- The demo player provider's players **can't be grouped** — `set_members` is a no-op stub and `SET_MEMBERS` isn't advertised, so you can't form a sync group of fake players.
- A booted test server isn't **hermetic** — the `mass` fixture mocks only zeroconf (mDNS), but the default device providers (dlna/sonos/...) are auto-configured and **SSDP** is unmocked, so a test instance passively discovers real LAN renderers.

There's already a functional fake *music* provider (`test`); this adds the missing fake *player* side plus a hermetic way to boot them, so end-to-end behaviour (grouping, queue, current-media propagation) can be exercised with no hardware or network.

- `_demo_player_provider`: advertise `SET_MEMBERS` + `can_group_with`, and implement a minimal in-memory `set_members` so demo players form a real sync group (members' `synced_to` is then derived by the base `Player`).
- `tests/integration/conftest.py`: an `e2e_mass` fixture that boots MA with only the fake `test` music + demo player providers — mDNS and SSDP mocked, default device providers suppressed — plus `group_players` / `play_test_track` / `wait_for` helpers.
- `tests/integration/test_demo_group_e2e.py`: a demonstrator e2e test — group three demo players, play a fake track and assert every member mirrors the sync leader's current media (and that the boot is hermetic: only the demo players exist).

**Related issue (if applicable):**

- N/A (test-bed groundwork; complements #4425)

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`
