### PR TITLE
Fix WiiM UPnP event-callback binding on multi-homed / containerized hosts

### DIFF
--- a/music_assistant/providers/wiim/provider.py
+++ b/music_assistant/providers/wiim/provider.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import socket
+from ipaddress import ip_address as parse_ip_address
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import IdentifierType
@@ -23,6 +26,52 @@ from .player import WiimPlayer
 
 if TYPE_CHECKING:
     from zeroconf.asyncio import AsyncServiceInfo
+
+    from music_assistant.mass import MusicAssistant
+
+
+async def _resolve_callback_host(mass: MusicAssistant, target_ip: str) -> str:
+    """
+    Resolve the local IP for the WiiM device's UPnP event callbacks.
+
+    The WiiM SDK binds its UPnP notify server to this address and advertises it
+    back to the device as the callback host, so it must be BOTH a locally
+    bindable interface address AND reachable by the device. ``streams.publish_ip``
+    is the *advertised* stream address and is not necessarily locally bindable
+    (a container behind a published IP, or a multi-homed host), so binding the
+    notify server to it fails with ``EADDRNOTAVAIL``. Resolve the source IP per
+    device via the routing table instead, mirroring the AirPlay provider's
+    ``resolve_if_ip`` helper. Falls back to ``publish_ip`` (the previous
+    behaviour) when the lookup is inconclusive, so this is never worse than before.
+    """
+    # Honour an explicitly configured, concrete stream bind IP first.
+    bind_ip = str(mass.streams.bind_ip)
+    if bind_ip not in ("0.0.0.0", "::", ""):
+        return bind_ip
+
+    def _routing_lookup() -> str:
+        try:
+            is_ipv6 = parse_ip_address(target_ip).version == 6
+        except ValueError:
+            is_ipv6 = False
+        family = socket.AF_INET6 if is_ipv6 else socket.AF_INET
+        route_target: tuple[str, int] | tuple[str, int, int, int] = (
+            (target_ip, 80, 0, 0) if is_ipv6 else (target_ip, 80)
+        )
+        with socket.socket(family, socket.SOCK_DGRAM) as sock:
+            try:
+                sock.settimeout(1.0)
+                sock.connect(route_target)
+                routed_ip = str(sock.getsockname()[0])
+                if routed_ip and routed_ip not in ("0.0.0.0", "::", ""):
+                    return routed_ip
+            except OSError:
+                pass
+        return ""
+
+    if routed := await asyncio.to_thread(_routing_lookup):
+        return routed
+    return str(mass.streams.publish_ip or "") or bind_ip
 
 
 class WiimProvider(PlayerProvider):
@@ -157,7 +206,7 @@ class WiimProvider(PlayerProvider):
                 upnp_location,
                 self.mass.http_session_no_ssl,
                 host=ip_address,
-                local_host=str(self.mass.streams.publish_ip),
+                local_host=await _resolve_callback_host(self.mass, ip_address),
                 polling_interval=60,
             )
         except (WiimRequestException, WiimDeviceException) as err:

--- a/tests/providers/wiim/test_provider.py
+++ b/tests/providers/wiim/test_provider.py
@@ -1,0 +1,46 @@
+"""Tests for the WiiM provider's UPnP event-callback host resolution."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from music_assistant.providers.wiim.provider import _resolve_callback_host
+
+
+def _mass(bind_ip: str = "0.0.0.0", publish_ip: str = "10.45.0.20") -> MagicMock:
+    """Build a mock MusicAssistant exposing only streams.bind_ip / publish_ip."""
+    mass = MagicMock()
+    mass.streams.bind_ip = bind_ip
+    mass.streams.publish_ip = publish_ip
+    return mass
+
+
+class TestResolveCallbackHost:
+    """_resolve_callback_host returns a bindable, device-reachable source IP."""
+
+    @pytest.mark.asyncio
+    async def test_prefers_explicit_bind_ip(self) -> None:
+        """A concrete (non-wildcard) stream bind_ip is honoured as-is."""
+        mass = _mass(bind_ip="10.0.0.5", publish_ip="10.45.0.20")
+        result = await _resolve_callback_host(mass, "10.10.20.31")
+        assert result == "10.0.0.5"
+
+    @pytest.mark.asyncio
+    async def test_uses_routing_lookup_when_bind_ip_wildcard(self) -> None:
+        """With bind_ip=0.0.0.0, the per-device routing lookup result wins."""
+        mass = _mass(bind_ip="0.0.0.0", publish_ip="10.45.0.20")
+        with patch("music_assistant.providers.wiim.provider.socket.socket") as mock_socket:
+            sock = mock_socket.return_value.__enter__.return_value
+            sock.getsockname.return_value = ("10.10.20.106", 0)
+            result = await _resolve_callback_host(mass, "10.10.20.31")
+        assert result == "10.10.20.106"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_publish_ip_on_lookup_failure(self) -> None:
+        """If the routing lookup cannot resolve, fall back to publish_ip (prior behaviour)."""
+        mass = _mass(bind_ip="0.0.0.0", publish_ip="10.45.0.20")
+        with patch("music_assistant.providers.wiim.provider.socket.socket") as mock_socket:
+            sock = mock_socket.return_value.__enter__.return_value
+            sock.connect.side_effect = OSError("no route to host")
+            result = await _resolve_callback_host(mass, "10.10.20.31")
+        assert result == "10.45.0.20"


### PR DESCRIPTION
# What does this implement/fix?

Fixes WiiM players going `unavailable` on multi-homed / containerized hosts where Music Assistant's advertised IP is not a locally bindable interface address.

The WiiM provider passes `streams.publish_ip` as `local_host` to `async_create_wiim_device()`. The WiiM SDK uses `local_host` to **bind** its UPnP event-notify (aiohttp) server and to build the callback URL the device subscribes to. But `publish_ip` is the *advertised* stream address — not necessarily a bindable local interface address. When the advertised IP differs from a bindable local interface (Docker with a published/mapped IP, or a host with multiple NICs), the bind fails:

```
ERROR  async_upnp_client.aiohttp: Failed to create HTTP server at <publish_ip>:5xxxx: could not bind on any address
WARNING wiim.sdk: Device <name>: Failed to start AiohttpNotifyServer: no free port in 50031..50286
WARNING wiim.sdk: Device <name>: Notify server not started, cannot subscribe to service events.
```

The device then can't (re)subscribe to UPnP events and the player goes `unavailable` on the next re-subscribe.

The AirPlay provider already handles this exact case: `resolve_if_ip()` in `providers/airplay/helpers.py` resolves the bind interface via a routing-table lookup to the target, only falling back to `publish_ip` as a last resort (its comment calls out the Docker scenario). This change brings the WiiM provider in line: resolve `local_host` per device by preferring an explicitly configured concrete stream `bind_ip`, else a routing-table lookup to the device IP, else falling back to `publish_ip` (previous behaviour — so it is strictly no worse than before).

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

