### PR TITLE
Add content_type to Genre schema with migration

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 43
+DB_SCHEMA_VERSION: Final[int] = 44
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/database.py
+++ b/music_assistant/controllers/music/database.py
@@ -405,7 +405,8 @@ class MusicDatabaseSetupMixin:
             [search_name] TEXT NOT NULL,
             [search_sort_name] TEXT NOT NULL,
             [is_excluded] BOOLEAN NOT NULL DEFAULT 0,
-            [is_default] BOOLEAN NOT NULL DEFAULT 0
+            [is_default] BOOLEAN NOT NULL DEFAULT 0,
+            [content_type] TEXT
             );"""
         )
         await self.database.execute(

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -1186,6 +1186,7 @@ class GenreController(MediaControllerBase[Genre]):
                 "search_sort_name": create_safe_string(item.sort_name or "", True, True),
                 "timestamp_added": UNSET,
                 "is_default": 0,
+                "content_type": item.content_type.value if item.content_type else None,
             },
         )
         self.logger.debug("added %s to database (id: %s)", item.name, db_id)
@@ -1217,6 +1218,8 @@ class GenreController(MediaControllerBase[Genre]):
         else:
             merged_aliases = self._dedup_aliases(existing_aliases, [*update_aliases, name])
 
+        content_type = update.content_type if overwrite else cur_item.content_type
+
         await self.mass.music.database.update(
             self.db_table,
             {"item_id": db_id},
@@ -1236,6 +1239,7 @@ class GenreController(MediaControllerBase[Genre]):
                 "search_name": create_safe_string(name, True, True),
                 "search_sort_name": create_safe_string(sort_name or "", True, True),
                 "timestamp_added": UNSET,
+                "content_type": content_type.value if content_type else None,
             },
         )
         self.logger.debug("updated %s in database: (id %s)", update.name, db_id)

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -673,6 +673,16 @@ async def migrate_database(  # noqa: PLR0915
                 if "duplicate column" not in str(err):
                     raise
 
+    if prev_version <= 43:
+        # add content_type column to the genres table to namespace spoken-word taxonomies
+        # (podcast/audiobook) apart from music genres. NULL = music/general; existing rows
+        # stay NULL so nothing re-keys.
+        try:
+            await database.execute(f"ALTER TABLE {DB_TABLE_GENRES} ADD COLUMN [content_type] TEXT")
+        except Exception as err:
+            if "duplicate column" not in str(err):
+                raise
+
     # save changes
     await database.commit()
 

--- a/tests/controllers/music/test_genres.py
+++ b/tests/controllers/music/test_genres.py
@@ -174,6 +174,40 @@ class TestGenreCRUD:
         assert fetched.genre_aliases is not None
         assert "Funk" in fetched.genre_aliases
 
+    async def test_content_type_defaults_to_none(self, genre_ctrl: GenreController) -> None:
+        """A genre added without a content_type round-trips as None (music/general)."""
+        created = await genre_ctrl.add_item_to_library(_make_genre("Soul"))
+        fetched = await genre_ctrl.get_library_item(int(created.item_id))
+        assert fetched.content_type is None
+
+    async def test_content_type_persists_and_round_trips(self, genre_ctrl: GenreController) -> None:
+        """A genre's content_type is persisted to the DB column and read back as the enum."""
+        genre = Genre(
+            item_id="0",
+            provider="library",
+            name="True Crime",
+            provider_mappings=set(),
+            content_type=MediaType.PODCAST,
+        )
+        created = await genre_ctrl.add_item_to_library(genre)
+        fetched = await genre_ctrl.get_library_item(int(created.item_id))
+        assert fetched.content_type is MediaType.PODCAST
+
+    async def test_content_type_overwrite_update(self, genre_ctrl: GenreController) -> None:
+        """An overwrite update writes the new content_type for the genre."""
+        created = await genre_ctrl.add_item_to_library(_make_genre("Documentary"))
+        update = Genre(
+            item_id="0",
+            provider="library",
+            name="Documentary",
+            provider_mappings=set(),
+            content_type=MediaType.AUDIOBOOK,
+        )
+        updated = await genre_ctrl.update_item_in_library(created.item_id, update, overwrite=True)
+        assert updated.content_type is MediaType.AUDIOBOOK
+        fetched = await genre_ctrl.get_library_item(int(created.item_id))
+        assert fetched.content_type is MediaType.AUDIOBOOK
+
     async def test_get_library_item_not_found(self, genre_ctrl: GenreController) -> None:
         """Raises MediaNotFoundError for nonexistent id."""
         with pytest.raises(MediaNotFoundError):


### PR DESCRIPTION
# What does this implement/fix?

Updates the DB schema adding a nullable content_type column to the genres table.
Change is fully back compat as nothing yet sets a not None content_type.

Trying to keep each incremental change as small as possible.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
