### PR TITLE
fix(snapcast): fix ~65s stop delay caused by spurious inactivity timer

### DIFF
--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -254,9 +254,9 @@ class SnapcastMAStream:
             self._stop_timer_started_at = None
             if self._stop_timer:
                 self._stop_timer.cancel()
-        elif self._stop_timer_started_at is None:
+        elif self._stop_timer_started_at is None and not self._stop_requested:
             self._stop_timer_started_at = self._mass.loop.time()
-            self._stop_timer = self._mass.loop.call_later(60.0, self.request_stop_stream)
+            self._stop_timer = self._mass.loop.call_later(3.0, self.request_stop_stream)
 
     async def wait_for_stopped(self, timeout_sec: float | None = None) -> None:
         """


### PR DESCRIPTION
Two related bugs caused ~65s delay when stopping Snapcast playback:

1. set_in_use(False) was scheduling a new call_later(60.0) timer even after request_stop_stream() had already been called explicitly. request_stop_stream() resets _stop_timer_started_at to None, which set_in_use() interpreted as 'no timer scheduled yet' and started a new 60s countdown. Fix: skip scheduling if _stop_requested is already True.

2. The inactivity timer was hardcoded to 60s, causing unnecessary delays even in non-buggy code paths. Fix: reduce to 3s, sufficient to survive skip/seek transitions.

Tested with external Snapcast server v0.31.0 + MA 2.9.3:
- Before: ~65s from cmd_pause to audio stop
- After:  ~5s (limited by FFmpeg teardown + idle_threshold 500)

# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
