### PR TITLE
Make live audio analysis a passive observer so it can never stall playback

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -294,9 +294,7 @@ class AudioAnalysisController:
             if is_last_chunk:
                 finalized = True
                 # The terminator must always land or the worker blocks forever on get().
-                # _on_chunk is the sole producer and runs single-threaded with no await
-                # between the full() check and put_nowait, so evicting one chunk to make
-                # room is race-free.
+                # Sole producer, no await before put_nowait, so evicting to make room is race-free.
                 if queue.full():
                     with contextlib.suppress(asyncio.QueueEmpty):
                         queue.get_nowait()

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -287,21 +287,20 @@ class AudioAnalysisController:
 
         finalized = False
 
-        # Reuse the background path's per-track budget to bound the live session too.
-        session_timeout_seconds = max(
-            BACKGROUND_PER_TRACK_TIMEOUT_SECONDS,
-            int((streamdetails.duration or 0) * BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER),
-        )
-
         async def _on_chunk(position_seconds: int, pcm_data: bytes, is_last_chunk: bool) -> None:  # noqa: ARG001
             nonlocal finalized
             if finalized or session_key not in self._active_sessions:
                 return
             if is_last_chunk:
                 finalized = True
-                # Don't block _set_eof; _finalize_session still cleans up if this drops.
-                with contextlib.suppress(asyncio.QueueFull):
-                    queue.put_nowait(None)
+                # The terminator must always land or the worker blocks forever on get().
+                # _on_chunk is the sole producer and runs single-threaded with no await
+                # between the full() check and put_nowait, so evicting one chunk to make
+                # room is race-free.
+                if queue.full():
+                    with contextlib.suppress(asyncio.QueueEmpty):
+                        queue.get_nowait()
+                queue.put_nowait(None)
                 self.mass.create_task(_finalize_session())
                 return
             # Awaited inline by the audio producer — drop rather than ever block playback.
@@ -309,20 +308,11 @@ class AudioAnalysisController:
                 queue.put_nowait(pcm_data)
 
         async def _finalize_session() -> None:
-            """Await the worker within the session budget, then finalize each provider."""
+            """Await the worker, then dispatch finalize to each provider."""
             worker = self._workers.pop(session_key, None)
             if worker is not None:
-                try:
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await asyncio.wait_for(worker, timeout=session_timeout_seconds)
-                except TimeoutError:
-                    self.logger.warning(
-                        "Live analysis exceeded %ds budget for %s, cancelling",
-                        session_timeout_seconds,
-                        session_key,
-                    )
-                    self._cancel_providers(session_key)
-                    return
+                with contextlib.suppress(asyncio.CancelledError):
+                    await worker
             self._finalize_providers(session_key)
 
         def _on_cancel() -> None:

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -287,28 +287,42 @@ class AudioAnalysisController:
 
         finalized = False
 
+        # Reuse the background path's per-track budget to bound the live session too.
+        session_timeout_seconds = max(
+            BACKGROUND_PER_TRACK_TIMEOUT_SECONDS,
+            int((streamdetails.duration or 0) * BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER),
+        )
+
         async def _on_chunk(position_seconds: int, pcm_data: bytes, is_last_chunk: bool) -> None:  # noqa: ARG001
             nonlocal finalized
             if finalized or session_key not in self._active_sessions:
                 return
             if is_last_chunk:
                 finalized = True
-                await queue.put(None)
+                # Don't block _set_eof; _finalize_session still cleans up if this drops.
+                with contextlib.suppress(asyncio.QueueFull):
+                    queue.put_nowait(None)
                 self.mass.create_task(_finalize_session())
                 return
-            try:
-                await asyncio.wait_for(
-                    queue.put(pcm_data), timeout=REAL_TIME_PACE_INTERVAL_SECONDS_CEILING
-                )
-            except TimeoutError, asyncio.QueueFull:
-                return
+            # Awaited inline by the audio producer — drop rather than ever block playback.
+            with contextlib.suppress(asyncio.QueueFull):
+                queue.put_nowait(pcm_data)
 
         async def _finalize_session() -> None:
-            """Await the worker, then dispatch finalize to each provider."""
+            """Await the worker within the session budget, then finalize each provider."""
             worker = self._workers.pop(session_key, None)
             if worker is not None:
-                with contextlib.suppress(asyncio.CancelledError):
-                    await worker
+                try:
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await asyncio.wait_for(worker, timeout=session_timeout_seconds)
+                except TimeoutError:
+                    self.logger.warning(
+                        "Live analysis exceeded %ds budget for %s, cancelling",
+                        session_timeout_seconds,
+                        session_key,
+                    )
+                    self._cancel_providers(session_key)
+                    return
             self._finalize_providers(session_key)
 
         def _on_cancel() -> None:

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -11,6 +11,7 @@ from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.controllers.streams.audio_analysis import (
+    ANALYSIS_QUEUE_MAXSIZE,
     AudioAnalysisController,
 )
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
@@ -496,3 +497,122 @@ async def test_finalize_swallows_finalize_exception_and_cleans_up() -> None:
 
     assert "test_session" not in provider._sessions
     provider.logger.error.assert_called_once()
+
+
+async def _cancel_created_tasks(mock_mass: MagicMock) -> None:
+    """Cancel and drain any tasks created during the test (cleanup helper)."""
+    for task in mock_mass._created_tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*mock_mass._created_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_chunk_delivery_does_not_block_producer_when_queue_full(
+    controller: AudioAnalysisController,
+    audio_buffer: AudioBuffer,
+    mock_stream_details: MagicMock,
+    mock_mass: MagicMock,
+) -> None:
+    """
+    A full analysis queue must not stall the audio producer.
+
+    The chunk callback is awaited inline by the buffer, so it must return
+    promptly (dropping the chunk) when the worker cannot keep up — never wait.
+    """
+
+    # Replace the worker so the queue is never drained, guaranteeing it fills.
+    async def _never_drain(*_args: object, **_kwargs: object) -> None:
+        await asyncio.Event().wait()
+
+    controller._chunk_worker = _never_drain  # type: ignore[method-assign]
+
+    await controller.start_analysis(audio_buffer, mock_stream_details)
+    cb = audio_buffer._chunk_callbacks[0]
+    for i in range(ANALYSIS_QUEUE_MAXSIZE):
+        await cb(i, ONE_SECOND_CHUNK, False)
+
+    # The next chunk hits a full queue. It must return promptly, not block on it.
+    await asyncio.wait_for(cb(ANALYSIS_QUEUE_MAXSIZE, ONE_SECOND_CHUNK, False), timeout=1.0)
+
+    await _cancel_created_tasks(mock_mass)
+
+
+@pytest.mark.asyncio
+async def test_eof_does_not_block_producer_when_queue_full(
+    controller: AudioAnalysisController,
+    audio_buffer: AudioBuffer,
+    mock_stream_details: MagicMock,
+    mock_mass: MagicMock,
+) -> None:
+    """
+    EOF must not stall the producer when the worker has stopped draining a full queue.
+
+    The EOF sentinel is enqueued by the same inline callback; if the queue is
+    full and the worker has exited, an unguarded put would block _set_eof forever.
+    """
+
+    async def _never_drain(*_args: object, **_kwargs: object) -> None:
+        await asyncio.Event().wait()
+
+    controller._chunk_worker = _never_drain  # type: ignore[method-assign]
+
+    await controller.start_analysis(audio_buffer, mock_stream_details)
+    cb = audio_buffer._chunk_callbacks[0]
+    for i in range(ANALYSIS_QUEUE_MAXSIZE):
+        await cb(i, ONE_SECOND_CHUNK, False)
+
+    # EOF on a full, undrained queue must return promptly.
+    await asyncio.wait_for(cb(ANALYSIS_QUEUE_MAXSIZE, b"", True), timeout=1.0)
+
+    await _cancel_created_tasks(mock_mass)
+
+
+@pytest.mark.asyncio
+async def test_live_session_times_out_and_cancels_wedged_worker(
+    controller: AudioAnalysisController,
+    audio_buffer: AudioBuffer,
+    mock_stream_details: MagicMock,
+    mock_provider: MagicMock,
+    mock_mass: MagicMock,
+) -> None:
+    """
+    A live worker that never finishes after EOF is cancelled once its budget elapses.
+
+    Mirrors the overall timeout the background-analysis path already has, so a
+    provider stuck just under the per-chunk timeout cannot leak the session.
+    """
+    never_done = asyncio.Event()
+
+    async def _hang(_session_id: str, _chunk: bytes) -> None:
+        await never_done.wait()
+
+    mock_provider.process_pcm_chunk = AsyncMock(side_effect=_hang)
+    mock_stream_details.duration = 0
+
+    session_key = "test_prov://track/test_123"
+
+    with (
+        unittest.mock.patch(
+            "music_assistant.controllers.streams.audio_analysis."
+            "BACKGROUND_PER_TRACK_TIMEOUT_SECONDS",
+            0.2,
+        ),
+        unittest.mock.patch(
+            "music_assistant.controllers.streams.audio_analysis."
+            "REAL_TIME_PACE_INTERVAL_SECONDS_CEILING",
+            100.0,  # keep the hung provider from being evicted by the per-chunk timeout
+        ),
+    ):
+        await controller.start_analysis(audio_buffer, mock_stream_details)
+        worker = controller._workers[session_key]
+        cb = audio_buffer._chunk_callbacks[0]
+        await cb(0, ONE_SECOND_CHUNK, False)  # worker pulls this and wedges in _distribute_chunk
+        await cb(1, b"", True)  # EOF → schedules _finalize_session
+        # Bounded so an unguarded await would surface as a clean failure, not a hang.
+        await asyncio.wait_for(_await_tasks(mock_mass), timeout=3.0)
+
+    assert worker.cancelled() or worker.done()
+    mock_provider.finalize.assert_not_called()
+    mock_provider.cancel.assert_called()
+    assert session_key not in controller._active_sessions

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import unittest.mock
+from collections.abc import Coroutine
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -539,80 +541,44 @@ async def test_chunk_delivery_does_not_block_producer_when_queue_full(
 
 
 @pytest.mark.asyncio
-async def test_eof_does_not_block_producer_when_queue_full(
+async def test_eof_sentinel_lands_even_when_queue_full(
     controller: AudioAnalysisController,
     audio_buffer: AudioBuffer,
     mock_stream_details: MagicMock,
     mock_mass: MagicMock,
 ) -> None:
     """
-    EOF must not stall the producer when the worker has stopped draining a full queue.
+    The EOF terminator must always reach the worker, even on a full queue.
 
-    The EOF sentinel is enqueued by the same inline callback; if the queue is
-    full and the worker has exited, an unguarded put would block _set_eof forever.
+    The producer bursts the whole decoded buffer in, so the queue is full at EOF
+    for any track longer than the queue depth. A plain drop-on-full would lose the
+    sentinel and the worker would block forever on get(), leaking the session. The
+    callback evicts one chunk to guarantee the terminator lands; it must also still
+    return promptly, since it is awaited inline by the producer.
     """
+    captured: dict[str, asyncio.Queue[bytes | None]] = {}
 
-    async def _never_drain(*_args: object, **_kwargs: object) -> None:
-        await asyncio.Event().wait()
+    def _capture_and_never_drain(*args: Any, **_kwargs: Any) -> Coroutine[Any, Any, None]:
+        # Capture synchronously at the call site: _on_chunk no longer awaits, so the
+        # worker coroutine itself never gets a turn to run before we inspect the queue.
+        captured["queue"] = args[1]
+        return asyncio.sleep(3600)
 
-    controller._chunk_worker = _never_drain  # type: ignore[method-assign]
+    controller._chunk_worker = _capture_and_never_drain  # type: ignore[method-assign]
 
     await controller.start_analysis(audio_buffer, mock_stream_details)
     cb = audio_buffer._chunk_callbacks[0]
     for i in range(ANALYSIS_QUEUE_MAXSIZE):
         await cb(i, ONE_SECOND_CHUNK, False)
 
-    # EOF on a full, undrained queue must return promptly.
+    # EOF on a full, undrained queue must return promptly (never block the producer).
     await asyncio.wait_for(cb(ANALYSIS_QUEUE_MAXSIZE, b"", True), timeout=1.0)
 
+    # ...and the terminator must be present, not dropped, so the worker can stop.
+    queue = captured["queue"]
+    drained: list[bytes | None] = []
+    while not queue.empty():
+        drained.append(queue.get_nowait())
+    assert None in drained
+
     await _cancel_created_tasks(mock_mass)
-
-
-@pytest.mark.asyncio
-async def test_live_session_times_out_and_cancels_wedged_worker(
-    controller: AudioAnalysisController,
-    audio_buffer: AudioBuffer,
-    mock_stream_details: MagicMock,
-    mock_provider: MagicMock,
-    mock_mass: MagicMock,
-) -> None:
-    """
-    A live worker that never finishes after EOF is cancelled once its budget elapses.
-
-    Mirrors the overall timeout the background-analysis path already has, so a
-    provider stuck just under the per-chunk timeout cannot leak the session.
-    """
-    never_done = asyncio.Event()
-
-    async def _hang(_session_id: str, _chunk: bytes) -> None:
-        await never_done.wait()
-
-    mock_provider.process_pcm_chunk = AsyncMock(side_effect=_hang)
-    mock_stream_details.duration = 0
-
-    session_key = "test_prov://track/test_123"
-
-    with (
-        unittest.mock.patch(
-            "music_assistant.controllers.streams.audio_analysis."
-            "BACKGROUND_PER_TRACK_TIMEOUT_SECONDS",
-            0.2,
-        ),
-        unittest.mock.patch(
-            "music_assistant.controllers.streams.audio_analysis."
-            "REAL_TIME_PACE_INTERVAL_SECONDS_CEILING",
-            100.0,  # keep the hung provider from being evicted by the per-chunk timeout
-        ),
-    ):
-        await controller.start_analysis(audio_buffer, mock_stream_details)
-        worker = controller._workers[session_key]
-        cb = audio_buffer._chunk_callbacks[0]
-        await cb(0, ONE_SECOND_CHUNK, False)  # worker pulls this and wedges in _distribute_chunk
-        await cb(1, b"", True)  # EOF → schedules _finalize_session
-        # Bounded so an unguarded await would surface as a clean failure, not a hang.
-        await asyncio.wait_for(_await_tasks(mock_mass), timeout=3.0)
-
-    assert worker.cancelled() or worker.done()
-    mock_provider.finalize.assert_not_called()
-    mock_provider.cancel.assert_called()
-    assert session_key not in controller._active_sessions


### PR DESCRIPTION
# What does this implement/fix?

When the analysis queue fills, the producer used to wait for room — which could drag it below real-time and starve players to silence. So we drop chunks instead of ever blocking. A passive observer should lose data, never stall playback.

When a track ends, the producer has already burst-filled the queue, so the end-of-stream marker landed on a full queue and got dropped — which could leave the worker waiting forever and leak the session. So we evict one chunk to guarantee the marker always lands, and the worker always terminates on its own.

With the marker delivered reliably, the overall session timeout we'd added is redundant — and on normal tracks it would have thrown away good analysis and only logged it 5 minutes later — so we removed it. Genuinely stuck providers are already evicted by the existing per-chunk timeout.

**Related issue (if applicable):**

[- related issue <link to issue>](https://github.com/music-assistant/support/issues/5718)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
