### PR TITLE
Pre-import numpy in scoped-coverage CI to avoid py3.14 reduction break

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,14 @@ jobs:
             targets="tests/"
             cov="--cov=music_assistant"
           fi
-          pytest -o addopts="" --durations 10 $cov --cov-report=term-missing --cov-report=xml $targets
+          # -p numpy: pre-import numpy before pytest-cov starts coverage. Scoping
+          # --cov to a submodule (partial mode) makes coverage import the parent
+          # music_assistant package inside its sys_modules_saved() block, which then
+          # evicts numpy from sys.modules. Re-importing numpy reinitialises its C
+          # extension and creates a second _NoValue sentinel, breaking ndarray
+          # reductions (sum/mean) on py3.14. Loading numpy as an early plugin keeps
+          # it in the saved snapshot so it is never evicted.
+          pytest -p numpy -o addopts="" --durations 10 $cov --cov-report=term-missing --cov-report=xml $targets
       - name: Upload coverage to Codecov
         if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: codecov/codecov-action@v7


### PR DESCRIPTION


# What does this implement/fix?

Partial-mode CI scopes --cov to a changed provider package (e.g. --cov=music_assistant.providers.sonic_similarity). coverage resolves that submodule with find_spec inside a sys_modules_saved() block, which imports the parent music_assistant package (pulling in numpy) and then restores sys.modules, evicting numpy. The next import of numpy reinitialises its C extension and creates a second _NoValue sentinel; ndarray reductions (sum/mean) then return the sentinel and fail with TypeError on py3.14.

Load numpy as an early pytest plugin (-p numpy) so it is already in the saved snapshot before coverage starts and is never evicted.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
