### PR TITLE
Cap concurrent realtime audio analysis sessions

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -54,6 +54,10 @@ CHUNK_HANG_GUARD_SECONDS = 120.0
 # OS nice value for analysis worker threads (Linux): keeps analysis below playback so the
 # scheduler favors the event loop and ffmpeg under contention.
 ANALYSIS_THREAD_NICE = 10
+# Cap on concurrent realtime analysis sessions (the playing track plus the preloaded next).
+# Rapid track skipping would otherwise spawn an analysis per abandoned track; the oldest is
+# evicted to keep the count bounded.
+REALTIME_ANALYSIS_MAX_SESSIONS = 2
 FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
     "filesystem_local",
     "filesystem_smb",
@@ -307,6 +311,11 @@ class AudioAnalysisController:
         if not provider_ids:
             self.logger.debug("No providers accepted analysis for %s", session_key)
             return
+
+        # Bound concurrent realtime sessions, evicting the oldest (the current track and its
+        # preloaded next are the youngest, so they survive a burst of skips).
+        while len(self._workers) >= REALTIME_ANALYSIS_MAX_SESSIONS:
+            self._evict_realtime_session(next(iter(self._workers)))
 
         self._active_sessions[session_key] = provider_ids
         worker = self.mass.create_task(self._buffer_reader_worker(session_key, audio_buffer))
@@ -1029,6 +1038,14 @@ class AudioAnalysisController:
             provider = self.mass.get_provider(provider_id)
             if provider and isinstance(provider, AudioAnalysisProvider) and provider.available:
                 self.mass.create_task(provider.cancel(session_key))
+
+    def _evict_realtime_session(self, session_key: str) -> None:
+        """Stop a realtime analysis worker and cancel its providers to free a session slot."""
+        worker = self._workers.pop(session_key, None)
+        if worker is not None and not worker.done():
+            worker.cancel()
+        self._cancel_providers(session_key)
+        self.logger.debug("Evicted realtime analysis session %s", session_key)
 
     async def _distribute_chunk(
         self,

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -159,6 +159,9 @@ class AudioAnalysisController:
         self.logger = self.mass.logger.getChild("audio_analysis")
         self._active_sessions: dict[str, set[str]] = {}
         self._workers: dict[str, asyncio.Task[None]] = {}
+        # Realtime session key -> queue id, insertion-ordered, so the session cap is applied
+        # per queue (concurrent queues don't evict each other's still-playing analysis).
+        self._session_queues: dict[str, str] = {}
         self._inference_runtime_configured = False
         # Kept alive to persist the process-wide native BLAS thread cap (set in
         # ensure_inference_runtime_configured); never used as a context manager.
@@ -312,23 +315,22 @@ class AudioAnalysisController:
             self.logger.debug("No providers accepted analysis for %s", session_key)
             return
 
-        # Bound concurrent realtime sessions, evicting the oldest (the current track and its
-        # preloaded next are the youngest, so they survive a burst of skips).
-        while len(self._workers) >= REALTIME_ANALYSIS_MAX_SESSIONS:
-            self._evict_realtime_session(next(iter(self._workers)))
+        # Bound concurrent realtime sessions per queue, evicting the oldest in this queue (the
+        # current track and its preloaded next are the youngest, so they survive a burst of
+        # skips). Scoping per queue keeps simultaneous queues from evicting each other.
+        queue_id = streamdetails.queue_id or session_key
+        in_queue = [key for key, qid in self._session_queues.items() if qid == queue_id]
+        for stale_key in in_queue[: max(0, len(in_queue) - REALTIME_ANALYSIS_MAX_SESSIONS + 1)]:
+            self._evict_realtime_session(stale_key)
 
         self._active_sessions[session_key] = provider_ids
+        self._session_queues[session_key] = queue_id
         worker = self.mass.create_task(self._buffer_reader_worker(session_key, audio_buffer))
         self._workers[session_key] = worker
 
         def _on_cancel() -> None:
-            # Buffer torn down (track skipped / inactivity). Cancel the reader and its providers
-            # here: a task cancelled before it first runs never executes its body (no finally).
-            self.logger.debug("Cancelling analysis session %s", session_key)
-            self._workers.pop(session_key, None)
-            if not worker.done():
-                worker.cancel()
-            self._cancel_providers(session_key)
+            # Buffer torn down (track skipped / inactivity) — free the session.
+            self._evict_realtime_session(session_key)
 
         audio_buffer.register_cancel_callback(_on_cancel)
 
@@ -1040,12 +1042,14 @@ class AudioAnalysisController:
                 self.mass.create_task(provider.cancel(session_key))
 
     def _evict_realtime_session(self, session_key: str) -> None:
-        """Stop a realtime analysis worker and cancel its providers to free a session slot."""
+        """Stop a realtime analysis worker and cancel its providers, freeing the session slot."""
+        self._session_queues.pop(session_key, None)
         worker = self._workers.pop(session_key, None)
         if worker is not None and not worker.done():
             worker.cancel()
+        # Cancel providers directly: a task cancelled before it first runs has no finally to run.
         self._cancel_providers(session_key)
-        self.logger.debug("Evicted realtime analysis session %s", session_key)
+        self.logger.debug("Stopped realtime analysis session %s", session_key)
 
     async def _distribute_chunk(
         self,
@@ -1145,6 +1149,7 @@ class AudioAnalysisController:
                 cursor += 1
         finally:
             self._workers.pop(session_key, None)
+            self._session_queues.pop(session_key, None)
             if completed:
                 self._finalize_providers(session_key)
             else:

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -310,6 +310,7 @@ async def test_realtime_sessions_capped_evicting_oldest(
         sd.provider = "test"
         sd.item_id = f"t{i}"
         sd.media_type = MediaType.TRACK
+        sd.queue_id = "queue-1"  # same queue, so the per-queue cap applies
         keys.append(sd.uri)
         await controller.start_analysis(AudioBuffer(TEST_PCM_FORMAT), sd)
 
@@ -321,6 +322,44 @@ async def test_realtime_sessions_capped_evicting_oldest(
     mock_provider.cancel.assert_any_call(keys[0])
 
     # Drain the pending reader/cancel tasks so nothing leaks past the test.
+    for task in mock_mass._created_tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*mock_mass._created_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_realtime_session_cap_is_per_queue(
+    controller: AudioAnalysisController,
+    mock_provider: MagicMock,
+    mock_mass: MagicMock,
+) -> None:
+    """Concurrent queues are capped independently; one queue's burst can't evict another's."""
+
+    async def _start(uri: str, queue_id: str) -> None:
+        sd = MagicMock()
+        sd.uri = uri
+        sd.provider = "test"
+        sd.item_id = uri
+        sd.media_type = MediaType.TRACK
+        sd.queue_id = queue_id
+        await controller.start_analysis(AudioBuffer(TEST_PCM_FORMAT), sd)
+
+    # Fill two queues to the cap each (interleaved).
+    for i in range(REALTIME_ANALYSIS_MAX_SESSIONS):
+        await _start(f"a://{i}", "queueA")
+        await _start(f"b://{i}", "queueB")
+
+    # Both queues are fully populated and nothing was evicted across queues.
+    assert len(controller._workers) == 2 * REALTIME_ANALYSIS_MAX_SESSIONS
+    mock_provider.cancel.assert_not_called()
+
+    # One more in queueA evicts queueA's oldest only; queueB is untouched.
+    await _start("a://new", "queueA")
+    assert "a://0" not in controller._workers
+    assert "b://0" in controller._workers
+    mock_provider.cancel.assert_called_once_with("a://0")
+
     for task in mock_mass._created_tasks:
         if not task.done():
             task.cancel()

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -10,7 +10,10 @@ import pytest
 from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.controllers.streams.audio_analysis import AudioAnalysisController
+from music_assistant.controllers.streams.audio_analysis import (
+    REALTIME_ANALYSIS_MAX_SESSIONS,
+    AudioAnalysisController,
+)
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer, AudioBufferDiscarded
 from music_assistant.models.audio_analysis_provider import (
     AnalysisSessionData,
@@ -291,6 +294,37 @@ async def test_worker_cancelled_on_buffer_clear(
     await audio_buffer.clear()
     await _await_tasks(mock_mass)
     assert worker.cancelled() or worker.done()
+
+
+@pytest.mark.asyncio
+async def test_realtime_sessions_capped_evicting_oldest(
+    controller: AudioAnalysisController,
+    mock_provider: MagicMock,
+    mock_mass: MagicMock,
+) -> None:
+    """Starting past the cap evicts the oldest realtime session and cancels its providers."""
+    keys: list[str] = []
+    for i in range(REALTIME_ANALYSIS_MAX_SESSIONS + 1):
+        sd = MagicMock()
+        sd.uri = f"test://track/{i}"
+        sd.provider = "test"
+        sd.item_id = f"t{i}"
+        sd.media_type = MediaType.TRACK
+        keys.append(sd.uri)
+        await controller.start_analysis(AudioBuffer(TEST_PCM_FORMAT), sd)
+
+    # Only the cap's worth survive; the oldest was evicted, the newest kept.
+    assert len(controller._workers) == REALTIME_ANALYSIS_MAX_SESSIONS
+    assert keys[0] not in controller._workers
+    assert keys[0] not in controller._active_sessions
+    assert keys[-1] in controller._workers
+    mock_provider.cancel.assert_any_call(keys[0])
+
+    # Drain the pending reader/cancel tasks so nothing leaks past the test.
+    for task in mock_mass._created_tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*mock_mass._created_tasks, return_exceptions=True)
 
 
 # -- Edge cases --


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4449. Rapid track skipping spawned a realtime analysis session per abandoned track — each kept a worker reading its buffer and accumulating feature state (beat grid, per-chunk VQT, CLAP windows) until the deferred queue-buffer cleanup caught up, so CPU and memory climbed under fast skipping.

- Cap concurrent realtime analysis sessions to the playing track plus its preloaded next (2), evicting the oldest — cancelling its worker and freeing its provider state — when a new one starts.
- Steady state is already current + next, so normal playback is unaffected; a burst of skips can no longer stack more than two analyses.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
