### PR TITLE
Unload idle audio-analysis models to reclaim memory

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -58,6 +58,10 @@ ANALYSIS_THREAD_NICE = 10
 # Rapid track skipping would otherwise spawn an analysis per abandoned track; the oldest is
 # evicted to keep the count bounded.
 REALTIME_ANALYSIS_MAX_SESSIONS = 2
+# Free the heavy analysis models after this long with no analysis activity; they are reloaded
+# on the next track. Long enough that gaps between tracks/sessions don't thrash the reload.
+MODEL_IDLE_UNLOAD_SECONDS = 300
+MODEL_IDLE_CHECK_INTERVAL_SECONDS = 60
 FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
     "filesystem_local",
     "filesystem_smb",
@@ -176,6 +180,9 @@ class AudioAnalysisController:
         # Niced worker pool that runs analysis offloads, so the lower priority applies to
         # analysis threads only; created in ensure_inference_runtime_configured.
         self.analysis_executor: ThreadPoolExecutor | None = None
+        # Monotonic time of the last analysis start, and the monitor that unloads idle models.
+        self._last_analysis_activity: float = 0.0
+        self._idle_unload_task: asyncio.Task[None] | None = None
 
     def setup(self) -> None:
         """Register the nightly background scan task."""
@@ -191,6 +198,8 @@ class AudioAnalysisController:
 
     async def close(self) -> None:
         """Drain in-flight sessions and chunk workers on shutdown."""
+        if self._idle_unload_task is not None and not self._idle_unload_task.done():
+            self._idle_unload_task.cancel()
         workers = list(self._workers.values())
         self._workers.clear()
         for worker in workers:
@@ -1006,6 +1015,7 @@ class AudioAnalysisController:
         providers: list[AudioAnalysisProvider],
     ) -> set[str]:
         """Call start_analysis on each provider, returning IDs of those that accepted."""
+        self._mark_analysis_activity()
         provider_ids: set[str] = set()
         for provider in providers:
             try:
@@ -1050,6 +1060,31 @@ class AudioAnalysisController:
         # Cancel providers directly: a task cancelled before it first runs has no finally to run.
         self._cancel_providers(session_key)
         self.logger.debug("Stopped realtime analysis session %s", session_key)
+
+    def _mark_analysis_activity(self) -> None:
+        """Record analysis activity and ensure the idle-model monitor is running."""
+        self._last_analysis_activity = time.monotonic()
+        if self._idle_unload_task is None or self._idle_unload_task.done():
+            self._idle_unload_task = self.mass.create_task(self._monitor_idle_models())
+
+    async def _monitor_idle_models(self) -> None:
+        """Unload heavy models once no analysis has run for MODEL_IDLE_UNLOAD_SECONDS."""
+        while True:
+            await asyncio.sleep(MODEL_IDLE_CHECK_INTERVAL_SECONDS)
+            if self._active_sessions:
+                # Keep the timer fresh while analysis is running.
+                self._last_analysis_activity = time.monotonic()
+                continue
+            if time.monotonic() - self._last_analysis_activity < MODEL_IDLE_UNLOAD_SECONDS:
+                continue
+            await self._unload_idle_models()
+            return  # stop until the next analysis restarts the monitor
+
+    async def _unload_idle_models(self) -> None:
+        """Free heavy models on every provider that supports unloading them."""
+        for provider in self.providers:
+            if provider.has_unloadable_models:
+                await provider.unload_idle_models()
 
     async def _distribute_chunk(
         self,

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -198,17 +198,18 @@ class AudioAnalysisController:
 
     async def close(self) -> None:
         """Drain in-flight sessions and chunk workers on shutdown."""
-        if self._idle_unload_task is not None and not self._idle_unload_task.done():
-            self._idle_unload_task.cancel()
-        workers = list(self._workers.values())
+        tasks = list(self._workers.values())
         self._workers.clear()
-        for worker in workers:
-            if not worker.done():
-                worker.cancel()
+        if self._idle_unload_task is not None:
+            tasks.append(self._idle_unload_task)
+            self._idle_unload_task = None
+        for task in tasks:
+            if not task.done():
+                task.cancel()
         for session_key in list(self._active_sessions):
             self._cancel_providers(session_key)
-        if workers:
-            await asyncio.gather(*workers, return_exceptions=True)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
         if self.analysis_executor is not None:
             # A running CPU-bound thread can't be cancelled, so shut down without waiting on it.
             self.analysis_executor.shutdown(wait=False, cancel_futures=True)
@@ -1083,8 +1084,12 @@ class AudioAnalysisController:
     async def _unload_idle_models(self) -> None:
         """Free heavy models on every provider that supports unloading them."""
         for provider in self.providers:
-            if provider.has_unloadable_models:
+            if not provider.has_unloadable_models:
+                continue
+            try:
                 await provider.unload_idle_models()
+            except Exception as err:
+                self.logger.warning("Failed to unload models for %s: %s", provider.name, err)
 
     async def _distribute_chunk(
         self,

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -457,8 +457,12 @@ class AudioBuffer:
         # skip AudioSource — it's an open-ended live stream so analysis would never finalize
         # (radio still runs analysis; the analyzer caps it at 10 minutes)
         if seek_position_ms == 0 and streamdetails.media_type != MediaType.AUDIO_SOURCE:
-            # audio analysis providers (loudness, beat tracking, key detection, etc.)
-            await mass.streams.audio_analysis.start_analysis(audio_buffer, streamdetails)
+            # audio analysis providers (loudness, beat tracking, key detection, etc.).
+            # Fire-and-forget: analysis setup — including a possible model (re)load — must never
+            # delay the buffer fill. The analysis worker reads the retained chunks once ready.
+            mass.create_task(
+                mass.streams.audio_analysis.start_analysis(audio_buffer, streamdetails)
+            )
 
         # start filling from the media stream (seek in seconds for FFmpeg)
         audio_source = mass.streams.audio.get_media_stream(

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -94,6 +94,10 @@ class AudioAnalysisProvider(Provider):
     # start_analysis. None means no limit. Providers that accumulate whole-track state set it.
     max_analysis_duration: float | None = None
 
+    # Whether this provider holds heavy ML models that can be unloaded while idle and reloaded
+    # on demand. Providers that load such models set this True (see _load_models/_free_models).
+    has_unloadable_models: bool = False
+
     def __init__(
         self,
         mass: MusicAssistant,
@@ -104,6 +108,9 @@ class AudioAnalysisProvider(Provider):
         """Initialize AudioAnalysisProvider."""
         super().__init__(mass, manifest, config, supported_features)
         self._sessions: dict[str, AnalysisSessionData] = {}
+        # Serializes (re)loading of heavy models so concurrent session starts load them once.
+        self._models_lock = asyncio.Lock()
+        self._models_loaded = False
 
     async def start_analysis(
         self,
@@ -139,6 +146,8 @@ class AudioAnalysisProvider(Provider):
             media_type=streamdetails.media_type,
         )
         if stored_version is not None and stored_version >= self.analysis_version:
+            return False
+        if self.has_unloadable_models and not await self.ensure_models_loaded():
             return False
         self._sessions[session_id] = AnalysisSessionData(
             streamdetails=streamdetails,
@@ -218,10 +227,40 @@ class AudioAnalysisProvider(Provider):
         self._sessions.pop(session_id, None)
 
     async def unload(self, is_removed: bool = False) -> None:
-        """Handle unload, cancelling any active analysis sessions."""
+        """Handle unload, cancelling any active analysis sessions and freeing models."""
         for session_id in list(self._sessions):
             await self.cancel(session_id)
+        async with self._models_lock:
+            self._free_models()
+            self._models_loaded = False
         await super().unload(is_removed)
+
+    async def ensure_models_loaded(self) -> bool:
+        """
+        Load this provider's heavy models if they are not resident, returning success.
+
+        Safe to call from concurrent sessions: the models are loaded once. Returns False
+        when loading fails, so the caller can decline the session.
+        """
+        async with self._models_lock:
+            if self._models_loaded:
+                return True
+            try:
+                await self._load_models()
+            except Exception as err:
+                self.logger.error("Failed to load analysis models: %s", err, exc_info=err)
+                return False
+            self._models_loaded = True
+            return True
+
+    async def unload_idle_models(self) -> None:
+        """Free heavy models to reclaim memory while idle; the next analysis reloads them."""
+        async with self._models_lock:
+            if not self._models_loaded:
+                return
+            self._free_models()
+            self._models_loaded = False
+            self.logger.debug("Unloaded idle analysis models")
 
     @abstractmethod
     async def _start_analysis(
@@ -250,6 +289,14 @@ class AudioAnalysisProvider(Provider):
 
         :param session_id: The analysis session ID.
         """
+
+    async def _load_models(self) -> None:
+        """Load heavy models into memory. Override when has_unloadable_models is True."""
+        return
+
+    def _free_models(self) -> None:
+        """Drop references to heavy models so memory can be reclaimed. Override as needed."""
+        return
 
     async def _run_offloaded(self, func: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
         """

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -63,6 +63,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
     """Smart fades audio analysis provider using Beat This for beat tracking."""
 
     max_analysis_duration = ACCUMULATING_ANALYSIS_MAX_DURATION_SECONDS
+    has_unloadable_models = True
 
     def __init__(
         self,
@@ -77,17 +78,11 @@ class SmartFadesProvider(AudioAnalysisProvider):
         self._device = "cpu"
 
     async def handle_async_init(self) -> None:
-        """Handle async initialization of the provider."""
+        """Handle async initialization of the provider; idle models are reloaded on demand."""
         # Configure the inference runtime before loading any model (see the controller method).
         self.mass.streams.audio_analysis.ensure_inference_runtime_configured()
-        (
-            self._beat_this_model,
-            self._beat_this_post_processor,
-            self._skey_vqt,
-            self._skey_chromanet,
-            self._skey_crop,
-            self._spectral_centroid,
-        ) = await asyncio.to_thread(self._initialize_models)
+        await self._load_models()
+        self._models_loaded = True
 
     async def process_pcm_chunk(
         self,
@@ -130,6 +125,26 @@ class SmartFadesProvider(AudioAnalysisProvider):
             data.musical_key_feature_blocks.clear()
             data.features.reset()
         await super().cancel(session_id)
+
+    async def _load_models(self) -> None:
+        """Load the Beat This and S-KEY models into memory."""
+        (
+            self._beat_this_model,
+            self._beat_this_post_processor,
+            self._skey_vqt,
+            self._skey_chromanet,
+            self._skey_crop,
+            self._spectral_centroid,
+        ) = await asyncio.to_thread(self._initialize_models)
+
+    def _free_models(self) -> None:
+        """Release the Beat This and S-KEY models."""
+        self._beat_this_model = None
+        self._beat_this_post_processor = None
+        self._skey_vqt = None
+        self._skey_chromanet = None
+        self._skey_crop = None
+        self._spectral_centroid = None
 
     def _initialize_models(self) -> tuple[Any, ...]:
         """Initialize ML models (runs in a thread to avoid blocking the event loop)."""

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -327,6 +327,7 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
 
     analysis_version: int = 1
     max_analysis_duration = ACCUMULATING_ANALYSIS_MAX_DURATION_SECONDS
+    has_unloadable_models = True
 
     def __init__(
         self,
@@ -348,7 +349,7 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         Blocks the provider's setup until the model is loaded (first-run downloads
         ~500MB). On failure the exception propagates and the provider stays
         available=False, which the AudioAnalysisController already honors when
-        scheduling work.
+        scheduling work. While idle the model is later unloaded and reloaded on demand.
         """
         verify_system_meets_requirements(
             feature_name="Sonic Analysis",
@@ -358,21 +359,8 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         )
         # Configure the inference runtime before loading the model (see the controller method).
         self.mass.streams.audio_analysis.ensure_inference_runtime_configured()
-        (
-            self._clap_model,
-            self._clap_text_embeddings,
-            self._clap_prompt_order,
-        ) = await asyncio.to_thread(self._load_clap)
-        self.logger.info(
-            "CLAP model loaded; %d prompt pairs ready",
-            len(self._clap_prompt_order),
-        )
-
-    async def unload(self, is_removed: bool = False) -> None:
-        """Release the CLAP model."""
-        self._clap_model = None
-        self._clap_text_embeddings = None
-        await super().unload(is_removed)
+        await self._load_models()
+        self._models_loaded = True
 
     async def cancel(self, session_id: str) -> None:
         """Cancel pending CLAP inferences and free per-window buffers."""
@@ -420,6 +408,23 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
             session.overlap = post_audio[-OVERLAP_SAMPLES:].copy()
             if bf is not None:
                 merge_block_features(session.accumulated, bf)
+
+    async def _load_models(self) -> None:
+        """Load the CLAP model and prompt embeddings into memory."""
+        (
+            self._clap_model,
+            self._clap_text_embeddings,
+            self._clap_prompt_order,
+        ) = await asyncio.to_thread(self._load_clap)
+        self.logger.info(
+            "CLAP model loaded; %d prompt pairs ready",
+            len(self._clap_prompt_order),
+        )
+
+    def _free_models(self) -> None:
+        """Release the CLAP model and prompt embeddings."""
+        self._clap_model = None
+        self._clap_text_embeddings = None
 
     def _load_clap(
         self,

--- a/tests/controllers/streams/test_audio_analysis_controller.py
+++ b/tests/controllers/streams/test_audio_analysis_controller.py
@@ -82,6 +82,12 @@ async def _await_tasks(mock_mass: MagicMock) -> None:
     while awaited < len(mock_mass._created_tasks):
         pending = mock_mass._created_tasks[awaited:]
         awaited = len(mock_mass._created_tasks)
+        for task in pending:
+            # The idle-model monitor is a long-lived loop, not a one-shot; cancel it rather
+            # than block here waiting for it to finish.
+            coro = task.get_coro()
+            if coro is not None and "_monitor_idle_models" in getattr(coro, "__qualname__", ""):
+                task.cancel()
         await asyncio.gather(*pending, return_exceptions=True)
 
 
@@ -364,6 +370,62 @@ async def test_realtime_session_cap_is_per_queue(
         if not task.done():
             task.cancel()
     await asyncio.gather(*mock_mass._created_tasks, return_exceptions=True)
+
+
+def _unloadable_provider() -> MagicMock:
+    prov = MagicMock(spec=AudioAnalysisProvider)
+    prov.has_unloadable_models = True
+    prov.available = True
+    prov.unload_idle_models = AsyncMock()
+    return prov
+
+
+@pytest.mark.asyncio
+async def test_idle_monitor_unloads_models_when_idle(
+    controller: AudioAnalysisController,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no active sessions past the idle timeout, unloadable providers are unloaded."""
+    prov = _unloadable_provider()
+    monkeypatch.setattr(controller.__class__, "providers", property(lambda _self: [prov]))
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.audio_analysis.MODEL_IDLE_CHECK_INTERVAL_SECONDS", 0.01
+    )
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.audio_analysis.MODEL_IDLE_UNLOAD_SECONDS", 0.0
+    )
+
+    controller._mark_analysis_activity()  # starts the monitor
+    assert controller._idle_unload_task is not None
+    await asyncio.wait_for(controller._idle_unload_task, timeout=2.0)
+
+    prov.unload_idle_models.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_idle_monitor_keeps_models_while_sessions_active(
+    controller: AudioAnalysisController,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Models are not unloaded while an analysis session is still active."""
+    prov = _unloadable_provider()
+    monkeypatch.setattr(controller.__class__, "providers", property(lambda _self: [prov]))
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.audio_analysis.MODEL_IDLE_CHECK_INTERVAL_SECONDS", 0.01
+    )
+    monkeypatch.setattr(
+        "music_assistant.controllers.streams.audio_analysis.MODEL_IDLE_UNLOAD_SECONDS", 0.0
+    )
+
+    controller._active_sessions["sess"] = {"prov"}
+    controller._mark_analysis_activity()
+    await asyncio.sleep(0.05)  # several monitor ticks
+
+    prov.unload_idle_models.assert_not_called()
+
+    assert controller._idle_unload_task is not None
+    controller._idle_unload_task.cancel()
+    await asyncio.gather(controller._idle_unload_task, return_exceptions=True)
 
 
 # -- Edge cases --

--- a/tests/models/test_audio_analysis_provider.py
+++ b/tests/models/test_audio_analysis_provider.py
@@ -330,3 +330,72 @@ async def test_run_offloaded_releases_permit_if_scheduling_fails() -> None:
         await provider._run_offloaded(lambda: "x")
 
     assert not semaphore.locked()  # permit released despite the failure
+
+
+@pytest.mark.asyncio
+async def test_ensure_models_loaded_loads_once() -> None:
+    """Concurrent ensure_models_loaded calls load the heavy models a single time."""
+    provider = _make_provider()
+    provider.has_unloadable_models = True
+    calls = 0
+
+    async def _load() -> None:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.01)
+
+    provider._load_models = _load  # type: ignore[method-assign]
+
+    results = await asyncio.gather(*(provider.ensure_models_loaded() for _ in range(5)))
+
+    assert all(results)
+    assert calls == 1
+    assert provider._models_loaded is True
+
+
+@pytest.mark.asyncio
+async def test_unload_idle_models_frees_then_reloads() -> None:
+    """unload_idle_models frees the models; the next ensure reloads them."""
+    provider = _make_provider()
+    provider.has_unloadable_models = True
+    load_calls = 0
+    free_calls = 0
+
+    async def _load() -> None:
+        nonlocal load_calls
+        load_calls += 1
+
+    def _free() -> None:
+        nonlocal free_calls
+        free_calls += 1
+
+    provider._load_models = _load  # type: ignore[method-assign]
+    provider._free_models = _free  # type: ignore[method-assign]
+
+    await provider.ensure_models_loaded()
+    await provider.unload_idle_models()
+    assert free_calls == 1
+    assert provider._models_loaded is False
+
+    await provider.ensure_models_loaded()
+    assert load_calls == 2  # reloaded on demand
+    assert provider._models_loaded is True
+
+
+@pytest.mark.asyncio
+async def test_start_analysis_rejects_when_model_load_fails() -> None:
+    """A provider whose model load fails declines the session instead of starting it."""
+    provider = _make_provider()
+    provider.has_unloadable_models = True
+    provider._start_analysis = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    async def _load() -> None:
+        raise RuntimeError("model load boom")
+
+    provider._load_models = _load  # type: ignore[method-assign]
+    streamdetails = MagicMock()
+    streamdetails.duration = 120
+
+    assert await provider.start_analysis("s", streamdetails, MagicMock()) is False
+    provider._start_analysis.assert_not_awaited()
+    assert provider._models_loaded is False


### PR DESCRIPTION
# What does this implement/fix?

The CLAP (sonic analysis) and Beat This (smart fades) models stay resident the whole time those providers are enabled — roughly 1 GB — even when nothing is playing. This frees them after a stretch with no analysis and reloads them on demand, so an idle server gives the memory back.

- The base `AudioAnalysisProvider` gains `ensure_models_loaded` / `unload_idle_models` lifecycle hooks (load-once lock); the torch providers implement `_load_models` / `_free_models`. Loudness is unaffected (no model).
- The controller unloads unloadable providers after `MODEL_IDLE_UNLOAD_SECONDS` (5 min) with no active analysis, and restarts the monitor on the next session. The timeout is long enough that gaps between tracks never thrash the reload.
- Analysis setup runs fire-and-forget from the audio buffer, so a model reload can never delay the buffer fill or playback; the reload happens off the playback path.

On the nightly/prod images jemalloc (background thread + page decay) returns the freed pages to the OS within ~10s, so this is a real RSS reduction, not just a Python-heap one. Streaming-time memory is unchanged — this targets the idle footprint.

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
