### PR TITLE
Give playback priority over realtime audio analysis (backport #4449 + #4451)

### DIFF
--- a/music_assistant/controllers/streams/README.md
+++ b/music_assistant/controllers/streams/README.md
@@ -73,11 +73,11 @@ Supporting modules in `helpers/`:
 
 ### Key Methods
 
-- `AudioBuffer.get_buffer()` - Static factory that creates or reuses a buffer. Reads config, determines mode, attaches analyze callbacks, starts filling
+- `AudioBuffer.get_buffer()` - Static factory that creates or reuses a buffer. Reads config, determines mode, starts the analysis reader, starts filling
 - `AudioBuffer.get_stream()` - Get processed audio with optional filters/resampling applied
-- `AudioBuffer.get_raw_stream()` - Get unprocessed raw PCM audio
+- `AudioBuffer.get_raw_stream()` - Get unprocessed raw PCM audio (playback consumer)
+- `AudioBuffer.read_chunk_for_analysis()` - Read one chunk for a passive analysis reader without mutating the buffer; raises when the chunk has been evicted (reader fell behind)
 - `AudioBuffer.fill()` - Start filling from an async generator of PCM chunks
-- `AudioBuffer.register_chunk_callback()` - Register a callback to observe chunks as they are buffered
 - `AudioBuffer.ready` - Event set when enough chunks are buffered past the seek point (threshold-based)
 
 ### Buffer Lifecycle
@@ -85,7 +85,7 @@ Supporting modules in `helpers/`:
 ```
 1. _load_item() fetches stream details, creates buffer with wait_ready=True
 2. Buffer starts filling from get_media_stream() in background
-3. Analyze callbacks (loudness, smart fades) process chunks as they arrive
+3. Analysis (loudness, smart fades) reads the same buffer in parallel, at lower priority
 4. Player requests stream -> get_queue_item_stream() calls buffer.get_stream()
 5. ~30s before track end: _prepare_next_audio_buffer() pre-fills next track
 6. _cleanup_stale_queue_buffers() clears old buffers to free memory

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -54,6 +54,10 @@ CHUNK_HANG_GUARD_SECONDS = 120.0
 # OS nice value for analysis worker threads (Linux): keeps analysis below playback so the
 # scheduler favors the event loop and ffmpeg under contention.
 ANALYSIS_THREAD_NICE = 10
+# Cap on concurrent realtime analysis sessions (the playing track plus the preloaded next).
+# Rapid track skipping would otherwise spawn an analysis per abandoned track; the oldest is
+# evicted to keep the count bounded.
+REALTIME_ANALYSIS_MAX_SESSIONS = 2
 FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
     "filesystem_local",
     "filesystem_smb",
@@ -155,6 +159,9 @@ class AudioAnalysisController:
         self.logger = self.mass.logger.getChild("audio_analysis")
         self._active_sessions: dict[str, set[str]] = {}
         self._workers: dict[str, asyncio.Task[None]] = {}
+        # Realtime session key -> queue id, insertion-ordered, so the session cap is applied
+        # per queue (concurrent queues don't evict each other's still-playing analysis).
+        self._session_queues: dict[str, str] = {}
         self._inference_runtime_configured = False
         # Kept alive to persist the process-wide native BLAS thread cap (set in
         # ensure_inference_runtime_configured); never used as a context manager.
@@ -308,18 +315,22 @@ class AudioAnalysisController:
             self.logger.debug("No providers accepted analysis for %s", session_key)
             return
 
+        # Bound concurrent realtime sessions per queue, evicting the oldest in this queue (the
+        # current track and its preloaded next are the youngest, so they survive a burst of
+        # skips). Scoping per queue keeps simultaneous queues from evicting each other.
+        queue_id = streamdetails.queue_id or session_key
+        in_queue = [key for key, qid in self._session_queues.items() if qid == queue_id]
+        for stale_key in in_queue[: max(0, len(in_queue) - REALTIME_ANALYSIS_MAX_SESSIONS + 1)]:
+            self._evict_realtime_session(stale_key)
+
         self._active_sessions[session_key] = provider_ids
+        self._session_queues[session_key] = queue_id
         worker = self.mass.create_task(self._buffer_reader_worker(session_key, audio_buffer))
         self._workers[session_key] = worker
 
         def _on_cancel() -> None:
-            # Buffer torn down (track skipped / inactivity). Cancel the reader and its providers
-            # here: a task cancelled before it first runs never executes its body (no finally).
-            self.logger.debug("Cancelling analysis session %s", session_key)
-            self._workers.pop(session_key, None)
-            if not worker.done():
-                worker.cancel()
-            self._cancel_providers(session_key)
+            # Buffer torn down (track skipped / inactivity) — free the session.
+            self._evict_realtime_session(session_key)
 
         audio_buffer.register_cancel_callback(_on_cancel)
 
@@ -1029,6 +1040,16 @@ class AudioAnalysisController:
             if provider and isinstance(provider, AudioAnalysisProvider) and provider.available:
                 self.mass.create_task(provider.cancel(session_key))
 
+    def _evict_realtime_session(self, session_key: str) -> None:
+        """Stop a realtime analysis worker and cancel its providers, freeing the session slot."""
+        self._session_queues.pop(session_key, None)
+        worker = self._workers.pop(session_key, None)
+        if worker is not None and not worker.done():
+            worker.cancel()
+        # Cancel providers directly: a task cancelled before it first runs has no finally to run.
+        self._cancel_providers(session_key)
+        self.logger.debug("Stopped realtime analysis session %s", session_key)
+
     async def _distribute_chunk(
         self,
         session_key: str,
@@ -1117,6 +1138,7 @@ class AudioAnalysisController:
                 cursor += 1
         finally:
             self._workers.pop(session_key, None)
+            self._session_queues.pop(session_key, None)
             if completed:
                 self._finalize_providers(session_key)
             else:

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -7,8 +7,10 @@ import contextlib
 import dataclasses
 import logging
 import os
+import sys
 import time
 from collections.abc import AsyncGenerator, Iterable, Mapping
+from concurrent.futures import ThreadPoolExecutor
 from math import inf
 from typing import TYPE_CHECKING, Any
 
@@ -25,12 +27,16 @@ from music_assistant.constants import (
     LOUDNESS_MEASUREMENT_MIN_LUFS,
     MASS_LOGGER_NAME,
 )
+from music_assistant.controllers.streams.audio_buffer import AudioBufferDiscarded, AudioBufferEOF
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.datetime import local_clock_time_to_utc
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.helpers.util import is_arm
 from music_assistant.models.audio_analysis import AudioAnalysisData
-from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
+from music_assistant.models.audio_analysis_provider import (
+    AudioAnalysisProvider,
+    InstrumentedSemaphore,
+)
 from music_assistant.models.music_provider import MusicProvider
 
 LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
@@ -41,21 +47,13 @@ BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300
 BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER = 1.5
 # Per-run wall-clock cap; in-flight tracks finish, new ones defer to the next run.
 BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
-# Per-chunk dispatch interval bounds. One PCM chunk = one audio-second of decoded data:
-# the floor is the fastest pace allowed; the ceiling is both the slowest pace and the
-# per-chunk processing timeout that evicts unresponsive providers.
-#
-# Live analysis is paced to ~5x real-time, never faster, on every machine. The buffer fills
-# far ahead of playback (a whole track decodes in seconds), and draining that burst at full
-# speed only spikes CPU — at 5x the analysis still completes well ahead of the crossfade
-# point. The ceiling is generous enough that legitimately slow, serialized per-chunk work on a
-# small box isn't mistaken for a hung provider. A companion half-the-cores concurrency cap
-# (analysis_semaphore) keeps analysis off the rest of the box on every machine.
-REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR = 0.200
-REAL_TIME_PACE_INTERVAL_SECONDS_CEILING = 2.0
-BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR = 0.250
-BACKGROUND_PACE_INTERVAL_SECONDS_CEILING = 4.0
-ANALYSIS_QUEUE_MAXSIZE = 30
+# Per-chunk processing ceiling for live and background analysis; a provider that exceeds it is
+# treated as stuck and evicted. Generous because analysis runs one offload at a time while a
+# player streams, so a chunk may wait behind other work before it computes.
+CHUNK_HANG_GUARD_SECONDS = 120.0
+# OS nice value for analysis worker threads (Linux): keeps analysis below playback so the
+# scheduler favors the event loop and ffmpeg under contention.
+ANALYSIS_THREAD_NICE = 10
 FILESYSTEM_PROVIDER_DOMAINS: tuple[str, ...] = (
     "filesystem_local",
     "filesystem_smb",
@@ -134,6 +132,19 @@ def _merged_from_rows(
     return merged if found else None
 
 
+def _nice_analysis_worker() -> None:
+    """
+    Lower the OS scheduling priority of the calling analysis worker thread.
+
+    Runs once per worker thread (ThreadPoolExecutor initializer). Linux-only, where the nice
+    value is per-thread and so affects just this pool; a no-op on other platforms.
+    """
+    if sys.platform != "linux" or not hasattr(os, "setpriority"):
+        return
+    with contextlib.suppress(OSError):
+        os.setpriority(os.PRIO_PROCESS, 0, ANALYSIS_THREAD_NICE)
+
+
 class AudioAnalysisController:
     """Controller that distributes PCM chunks to all registered AudioAnalysisProviders."""
 
@@ -151,7 +162,13 @@ class AudioAnalysisController:
         # Bounds how many analysis offloads run concurrently to half the cores; created in
         # ensure_inference_runtime_configured once the core count is known (None until then),
         # and honored by AudioAnalysisProvider._run_offloaded.
-        self.analysis_semaphore: asyncio.Semaphore | None = None
+        self.analysis_semaphore: InstrumentedSemaphore | None = None
+        # Held by an analysis offload while any player streams, capping analysis to one offload
+        # at a time; honored by AudioAnalysisProvider._run_offloaded.
+        self.analysis_solo_lock: asyncio.Lock | None = None
+        # Niced worker pool that runs analysis offloads, so the lower priority applies to
+        # analysis threads only; created in ensure_inference_runtime_configured.
+        self.analysis_executor: ThreadPoolExecutor | None = None
 
     def setup(self) -> None:
         """Register the nightly background scan task."""
@@ -176,6 +193,10 @@ class AudioAnalysisController:
             self._cancel_providers(session_key)
         if workers:
             await asyncio.gather(*workers, return_exceptions=True)
+        if self.analysis_executor is not None:
+            # A running CPU-bound thread can't be cancelled, so shut down without waiting on it.
+            self.analysis_executor.shutdown(wait=False, cancel_futures=True)
+            self.analysis_executor = None
 
     def ensure_inference_runtime_configured(self) -> None:
         """
@@ -215,9 +236,18 @@ class AudioAnalysisController:
         # never occupies the whole box and starves playback/the host — slow and steady on any
         # machine. Applies to every host; honored by AudioAnalysisProvider._run_offloaded.
         concurrency_cap = max(1, self._cpu_count() // 2)
-        self.analysis_semaphore = asyncio.Semaphore(concurrency_cap)
+        self.analysis_semaphore = InstrumentedSemaphore(concurrency_cap)
+        self.analysis_solo_lock = asyncio.Lock()
+        # Niced pool sized to the idle cap plus headroom; the semaphore and solo lock bound
+        # how many of its threads run at once.
+        self.analysis_executor = ThreadPoolExecutor(
+            max_workers=max(2, self._cpu_count()),
+            thread_name_prefix="analysis",
+            initializer=_nice_analysis_worker,
+        )
         self.logger.info(
-            "AudioAnalysis runtime: torch intra=%d interop=%d, blas<=%d, analysis concurrency<=%d, nnpack=%s",
+            "AudioAnalysis runtime: torch intra=%d interop=%d, blas<=%d, "
+            "analysis concurrency<=%d (1 while a player streams), nnpack=%s",
             torch.get_num_threads(),
             torch.get_num_interop_threads(),
             budget,
@@ -236,6 +266,15 @@ class AudioAnalysisController:
             if isinstance(prov, AudioAnalysisProvider) and prov.available
         ]
 
+    @property
+    def smart_fades_provider_available(self) -> bool:
+        """Return whether the smart fades audio analysis provider is loaded and available."""
+        return any(prov.domain == SMART_FADES_ANALYSIS_DOMAIN for prov in self.providers)
+
+    def playback_active(self) -> bool:
+        """Return whether a queue stream is actively serving a player right now."""
+        return self.streams.output_stream_active()
+
     async def start_analysis(
         self,
         audio_buffer: AudioBuffer,
@@ -244,7 +283,7 @@ class AudioAnalysisController:
         """
         Start analysis session for a track across all providers.
 
-        :param audio_buffer: The AudioBuffer to observe for PCM chunks.
+        :param audio_buffer: The shared playback AudioBuffer the analysis reads PCM from.
         :param streamdetails: The stream details for the item being analyzed.
         """
         providers = self.providers
@@ -270,52 +309,18 @@ class AudioAnalysisController:
             return
 
         self._active_sessions[session_key] = provider_ids
-        queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=ANALYSIS_QUEUE_MAXSIZE)
-        self._workers[session_key] = self.mass.create_task(
-            self._chunk_worker(
-                session_key,
-                queue,
-                min_interval=REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR,
-                max_interval=REAL_TIME_PACE_INTERVAL_SECONDS_CEILING,
-            )
-        )
-
-        finalized = False
-
-        async def _on_chunk(position_seconds: int, pcm_data: bytes, is_last_chunk: bool) -> None:  # noqa: ARG001
-            nonlocal finalized
-            if finalized or session_key not in self._active_sessions:
-                return
-            if is_last_chunk:
-                finalized = True
-                # The terminator must always land or the worker blocks forever on get().
-                # Sole producer, no await before put_nowait, so evicting to make room is race-free.
-                if queue.full():
-                    with contextlib.suppress(asyncio.QueueEmpty):
-                        queue.get_nowait()
-                queue.put_nowait(None)
-                self.mass.create_task(_finalize_session())
-                return
-            # Awaited inline by the audio producer — drop rather than ever block playback.
-            with contextlib.suppress(asyncio.QueueFull):
-                queue.put_nowait(pcm_data)
-
-        async def _finalize_session() -> None:
-            """Await the worker, then dispatch finalize to each provider."""
-            worker = self._workers.pop(session_key, None)
-            if worker is not None:
-                with contextlib.suppress(asyncio.CancelledError):
-                    await worker
-            self._finalize_providers(session_key)
+        worker = self.mass.create_task(self._buffer_reader_worker(session_key, audio_buffer))
+        self._workers[session_key] = worker
 
         def _on_cancel() -> None:
+            # Buffer torn down (track skipped / inactivity). Cancel the reader and its providers
+            # here: a task cancelled before it first runs never executes its body (no finally).
             self.logger.debug("Cancelling analysis session %s", session_key)
-            worker = self._workers.pop(session_key, None)
-            if worker is not None:
+            self._workers.pop(session_key, None)
+            if not worker.done():
                 worker.cancel()
             self._cancel_providers(session_key)
 
-        audio_buffer.register_chunk_callback(_on_chunk)
         audio_buffer.register_cancel_callback(_on_cancel)
 
     async def set_audio_analysis(
@@ -770,16 +775,12 @@ class AudioAnalysisController:
         self,
         streamdetails: StreamDetails,
         providers: list[AudioAnalysisProvider],
-        min_interval: float = BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR,
-        max_interval: float = BACKGROUND_PACE_INTERVAL_SECONDS_CEILING,
     ) -> None:
         """
         Run a single track through the streaming pipeline using ffmpeg as the source.
 
         :param streamdetails: Stream details for the track being analyzed.
         :param providers: Audio analysis providers to dispatch chunks to.
-        :param min_interval: Floor on wall-seconds between consecutive chunk dispatches.
-        :param max_interval: Ceiling on wall-seconds between consecutive chunk dispatches.
         """
         session_key = streamdetails.uri
         if session_key in self._active_sessions:
@@ -796,13 +797,7 @@ class AudioAnalysisController:
 
         try:
             await asyncio.wait_for(
-                self._run_background_streaming_inner(
-                    session_key,
-                    streamdetails,
-                    providers,
-                    min_interval=min_interval,
-                    max_interval=max_interval,
-                ),
+                self._run_background_streaming_inner(session_key, streamdetails, providers),
                 timeout=timeout_seconds,
             )
         except asyncio.CancelledError:
@@ -835,8 +830,6 @@ class AudioAnalysisController:
         session_key: str,
         streamdetails: StreamDetails,
         providers: list[AudioAnalysisProvider],
-        min_interval: float = BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR,
-        max_interval: float = BACKGROUND_PACE_INTERVAL_SECONDS_CEILING,
     ) -> None:
         """
         Inner body of _run_background_streaming_for_track, wrapped by wait_for.
@@ -844,8 +837,6 @@ class AudioAnalysisController:
         :param session_key: Active-session key for this track.
         :param streamdetails: Stream details for the track being analyzed.
         :param providers: Audio analysis providers to dispatch chunks to.
-        :param min_interval: Floor on wall-seconds between consecutive chunk dispatches.
-        :param max_interval: Ceiling on wall-seconds between consecutive chunk dispatches.
         """
         if not isinstance(streamdetails.path, str) or not streamdetails.path:
             return
@@ -865,16 +856,11 @@ class AudioAnalysisController:
         self._active_sessions[session_key] = accepted
 
         audio_source = self.mass.streams.audio.get_media_stream(streamdetails, pcm_format)
-        next_allowed = time.monotonic()
         async for chunk in audio_source:
             if session_key not in self._active_sessions:
                 # all providers evicted — bail early
                 break
-            now = time.monotonic()
-            if now < next_allowed:
-                await asyncio.sleep(next_allowed - now)
-            await self._distribute_chunk(session_key, chunk, max_interval=max_interval)
-            next_allowed = time.monotonic() + min_interval
+            await self._distribute_chunk(session_key, chunk, max_interval=CHUNK_HANG_GUARD_SECONDS)
         if session_key in self._active_sessions:
             self._finalize_providers(session_key)
 
@@ -1047,7 +1033,7 @@ class AudioAnalysisController:
         self,
         session_key: str,
         pcm_data: bytes,
-        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_CEILING,
+        max_interval: float = CHUNK_HANG_GUARD_SECONDS,
     ) -> None:
         """
         Fan a single PCM chunk to every provider in the session.
@@ -1094,37 +1080,47 @@ class AudioAnalysisController:
             if not provider_ids:
                 self._active_sessions.pop(session_key, None)
 
-    async def _chunk_worker(
-        self,
-        session_key: str,
-        queue: asyncio.Queue[bytes | None],
-        min_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_FLOOR,
-        max_interval: float = REAL_TIME_PACE_INTERVAL_SECONDS_CEILING,
-    ) -> None:
+    async def _buffer_reader_worker(self, session_key: str, audio_buffer: AudioBuffer) -> None:
         """
-        Background worker that processes queued PCM chunks via _distribute_chunk.
+        Read PCM straight from the shared playback buffer and distribute it to providers.
+
+        Reads at its own pace from the buffer's retained window. On clean end-of-stream the
+        providers are finalized; if the reader falls a full window behind playback (the chunk
+        it needs has been evicted) or the buffer is torn down first, the session is dropped.
 
         :param session_key: Active-session key for this worker.
-        :param queue: Queue receiving raw PCM chunks from the live producer.
-        :param min_interval: Floor on wall-seconds between consecutive chunk dispatches.
-        :param max_interval: Ceiling on wall-seconds between consecutive chunk dispatches.
+        :param audio_buffer: The shared playback buffer to read PCM from.
         """
-        next_allowed = time.monotonic()
-        while True:
-            chunk = await queue.get()
-            if chunk is None:
-                break
-            if session_key not in self._active_sessions:
-                break
-            now = time.monotonic()
-            if now < next_allowed:
-                await asyncio.sleep(next_allowed - now)
-            await self._distribute_chunk(session_key, chunk, max_interval=max_interval)
-            next_allowed = time.monotonic() + min_interval
-            if session_key not in self._active_sessions:
-                # all providers evicted by _distribute_chunk
-                self._workers.pop(session_key, None)
-                break
+        cursor = audio_buffer.first_buffered_chunk
+        completed = False
+        try:
+            while session_key in self._active_sessions:
+                try:
+                    chunk = await audio_buffer.read_chunk_for_analysis(cursor)
+                except AudioBufferEOF:
+                    completed = True
+                    break
+                except AudioBufferDiscarded:
+                    self.logger.debug(
+                        "Analysis fell behind the playback buffer for %s (chunk %d evicted); "
+                        "dropping session",
+                        session_key,
+                        cursor,
+                    )
+                    break
+                except Exception as err:
+                    self.logger.debug("Analysis read failed for %s: %s", session_key, err)
+                    break
+                await self._distribute_chunk(
+                    session_key, chunk, max_interval=CHUNK_HANG_GUARD_SECONDS
+                )
+                cursor += 1
+        finally:
+            self._workers.pop(session_key, None)
+            if completed:
+                self._finalize_providers(session_key)
+            else:
+                self._cancel_providers(session_key)
 
     def _cpu_count(self) -> int:
         """Return the CPU core count available to this process (fallback 4 when unknown)."""

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 import time
 from collections import deque
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Callable
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
@@ -42,16 +42,20 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.audio_buffer")
 
-# Callback signature for chunk observers: (chunk_position_seconds, pcm_data, is_last_chunk)
-# When is_last_chunk is True, pcm_data is empty and no more chunks will follow.
-ChunkCallback = Callable[[int, bytes, bool], Awaitable[None]]
-
 # Callback signature for cancel observers: invoked when the buffer is cancelled/cleared.
 CancelCallback = Callable[[], None]
 
 
 class AudioBufferEOF(Exception):
     """Exception raised when the audio buffer reaches end-of-file."""
+
+
+class AudioBufferDiscarded(Exception):
+    """
+    Raised when a passive (analysis) reader requests a chunk evicted from the retained window.
+
+    Means the reader is a full window behind playback, so its session is dropped.
+    """
 
 
 class AudioBuffer:
@@ -97,7 +101,6 @@ class AudioBuffer:
         self._cancelled = False
         self._producer_error: Exception | None = None
         self.ready = asyncio.Event()
-        self._chunk_callbacks: list[ChunkCallback] = []
         self._cancel_callbacks: list[CancelCallback] = []
 
     # -- Properties --
@@ -129,19 +132,12 @@ class AudioBuffer:
         """Return number of seconds of audio currently available."""
         return len(self._chunks)
 
+    @property
+    def first_buffered_chunk(self) -> int:
+        """Return the chunk number of the oldest chunk still retained in the buffer."""
+        return self._discarded_chunks
+
     # -- Public methods --
-
-    def register_chunk_callback(self, callback: ChunkCallback) -> None:
-        """
-        Register a callback to receive raw PCM chunks as they are buffered.
-
-        The callback receives (chunk_position_seconds, pcm_data, is_last_chunk).
-        When is_last_chunk is True, pcm_data is empty and no more chunks will follow.
-        Callbacks must be non-blocking.
-
-        :param callback: Callable receiving (position_seconds, pcm_data, is_last_chunk).
-        """
-        self._chunk_callbacks.append(callback)
 
     def register_cancel_callback(self, callback: CancelCallback) -> None:
         """
@@ -204,6 +200,34 @@ class AudioBuffer:
                 chunk_number += 1
             except AudioBufferEOF:
                 break
+
+    async def read_chunk_for_analysis(self, chunk_number: int) -> bytes:
+        """
+        Return one PCM chunk for a passive (analysis) reader, waiting until it is available.
+
+        A read-only accessor: it leaves the buffer untouched — no discard, no producer-space
+        signalling, no inactivity-timer reset — so an analysis reader never affects playback's
+        buffering.
+
+        :param chunk_number: Absolute chunk index to read.
+        :raises AudioBufferEOF: the stream ended before this chunk.
+        :raises AudioBufferDiscarded: the chunk has been evicted from the retained window (the
+            reader is a full window behind playback) or the buffer was torn down.
+        """
+        async with self._data_available:
+            while True:
+                if self.cancelled:
+                    raise AudioBufferDiscarded
+                if chunk_number < self._discarded_chunks:
+                    raise AudioBufferDiscarded
+                index = chunk_number - self._discarded_chunks
+                if index < len(self._chunks):
+                    return self._chunks[index]
+                if self._producer_error:
+                    raise self._producer_error
+                if self._eof_received:
+                    raise AudioBufferEOF
+                await self._data_available.wait()
 
     async def get_stream(
         self,
@@ -310,7 +334,6 @@ class AudioBuffer:
             self._cancelled = True
             self._producer_error = None
             self.ready.clear()
-            self._chunk_callbacks.clear()
             self._cancel_callbacks.clear()
             self._data_available.notify_all()
             self._space_available.notify_all()
@@ -464,7 +487,6 @@ class AudioBuffer:
 
         Waits for space when the buffer is full (backpressure).
         """
-        chunk_position = -1
         async with self._lock:
             if self._cancelled:
                 return
@@ -497,18 +519,6 @@ class AudioBuffer:
 
             self._data_available.notify_all()
 
-        # notify chunk callbacks outside the lock
-        if chunk_position >= 0 and self._chunk_callbacks:
-            failed: list[ChunkCallback] = []
-            for callback in self._chunk_callbacks:
-                try:
-                    await callback(chunk_position, chunk, False)
-                except Exception:
-                    LOGGER.exception("Chunk callback failed, removing it")
-                    failed.append(callback)
-            for cb in failed:
-                self._chunk_callbacks.remove(cb)
-
     async def _set_eof(self) -> None:
         """Signal that no more data will be added to the buffer."""
         async with self._lock:
@@ -522,14 +532,6 @@ class AudioBuffer:
                 self.ready.set()
             self._data_available.notify_all()
             self._space_available.notify_all()
-
-        # notify chunk callbacks of EOF (empty bytes with is_last_chunk=True)
-        total_chunks = self._discarded_chunks + len(self._chunks)
-        for callback in list(self._chunk_callbacks):
-            try:
-                await callback(total_chunks, b"", True)
-            except Exception:
-                LOGGER.exception("Chunk callback failed at EOF")
 
     async def _get(self, chunk_number: int = 0) -> bytes:
         """

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -153,11 +153,19 @@ class StreamsController(CoreController):
         self._bind_ip: str = "0.0.0.0"
         self.audio = StreamsAudio(mass)
         self._audio_analysis = AudioAnalysisController(self)
+        # Number of queue streams (single item or flow) actively serving a player right now.
+        # Audio analysis reads this (via audio_analysis.playback_active) to yield CPU while a
+        # queue stream is live. Announcements are a separate path that never runs analysis.
+        self._active_output_streams = 0
 
     @property
     def audio_analysis(self) -> AudioAnalysisController:
         """Return the AudioAnalysisController instance."""
         return self._audio_analysis
+
+    def output_stream_active(self) -> bool:
+        """Return whether a queue stream (single item or flow) is actively serving a player."""
+        return self._active_output_streams > 0
 
     @property
     def base_url(self) -> str:
@@ -746,37 +754,43 @@ class StreamsController(CoreController):
                 )
             first_chunk_received = False
             bytes_sent = 0
-            async for chunk in audio_bytes:
-                try:
-                    await resp.write(chunk)
-                    bytes_sent += len(chunk)
-                    if not first_chunk_received:
-                        first_chunk_received = True
-                        # inform the queue that the track is now loaded in the buffer
-                        # so for example the next track can be enqueued
-                        self.mass.player_queues.track_loaded_in_buffer(
-                            queue_item.queue_id, queue_item.queue_item_id
-                        )
-                except (BrokenPipeError, ConnectionResetError, ConnectionError) as err:
-                    if (
-                        first_chunk_received
-                        and not player.stop_called
-                        and queue_item.streamdetails.duration  # ignore for radio streams
-                    ):
-                        # Player disconnected (unexpected) after receiving at least some data
-                        # This could indicate buffering issues, network problems,
-                        # or player-specific issues.
-                        self.logger.warning(
-                            "Player %s disconnected prematurely from stream for %s (%s) - "
-                            "error: %s, sent %d bytes, content_length=%s",
-                            queue.display_name,
-                            queue_item.name,
-                            queue_item.uri,
-                            err.__class__.__name__,
-                            bytes_sent,
-                            resp.content_length,
-                        )
-                    break
+            # Mark this player as actively streaming so audio analysis yields CPU to playback
+            # for the duration of the transfer (see audio_analysis.playback_active).
+            self._active_output_streams += 1
+            try:
+                async for chunk in audio_bytes:
+                    try:
+                        await resp.write(chunk)
+                        bytes_sent += len(chunk)
+                        if not first_chunk_received:
+                            first_chunk_received = True
+                            # inform the queue that the track is now loaded in the buffer
+                            # so for example the next track can be enqueued
+                            self.mass.player_queues.track_loaded_in_buffer(
+                                queue_item.queue_id, queue_item.queue_item_id
+                            )
+                    except (BrokenPipeError, ConnectionResetError, ConnectionError) as err:
+                        if (
+                            first_chunk_received
+                            and not player.stop_called
+                            and queue_item.streamdetails.duration  # ignore for radio streams
+                        ):
+                            # Player disconnected (unexpected) after receiving at least some data
+                            # This could indicate buffering issues, network problems,
+                            # or player-specific issues.
+                            self.logger.warning(
+                                "Player %s disconnected prematurely from stream for %s (%s) - "
+                                "error: %s, sent %d bytes, content_length=%s",
+                                queue.display_name,
+                                queue_item.name,
+                                queue_item.uri,
+                                err.__class__.__name__,
+                                bytes_sent,
+                                resp.content_length,
+                            )
+                        break
+            finally:
+                self._active_output_streams -= 1
             if queue_item.streamdetails.stream_error:
                 self.logger.error(
                     "Error streaming QueueItem %s (%s) to %s",
@@ -829,7 +843,7 @@ class StreamsController(CoreController):
                         exc_info=True,
                     )
 
-    async def serve_queue_flow_stream(self, request: web.Request) -> web.StreamResponse:
+    async def serve_queue_flow_stream(self, request: web.Request) -> web.StreamResponse:  # noqa: PLR0915
         """Stream Queue Flow audio to player."""
         self._log_request(request)
         queue_id = request.match_info["queue_id"]
@@ -913,53 +927,61 @@ class StreamsController(CoreController):
         # such as channels mixing, DSP, resampling and, only if needed, encoding to lossy formats
         self.logger.debug("Start serving Queue flow audio stream for %s", queue.display_name)
 
-        async for chunk in get_ffmpeg_stream(
-            audio_input=self.audio.get_queue_flow_stream(
-                queue=queue, start_queue_item=start_queue_item, pcm_format=flow_pcm_format
-            ),
-            input_format=flow_pcm_format,
-            output_format=output_format,
-            filter_params=self.audio.get_player_filter_params(
-                player.player_id, flow_pcm_format, output_format
-            ),
-            # we need to slowly feed the music to avoid the player stopping and later
-            # restarting (or completely failing) the audio stream by keeping the buffer short.
-            # this is reported to be an issue especially with Chromecast players.
-            # see for example: https://github.com/music-assistant/support/issues/3717
-            # allow buffer ahead of a few seconds and read rest in (near) realtime
-            extra_input_args=["-readrate", "1.1", "-readrate_initial_burst", "5"],
-            chunk_size=icy_meta_interval if enable_icy else calculate_content_length(output_format),
-        ):
-            try:
-                await resp.write(chunk)
-            except BrokenPipeError, ConnectionResetError, ConnectionError:
-                # race condition
-                break
-
-            if not enable_icy:
-                continue
-
-            # if icy metadata is enabled, send the icy metadata after the chunk
-            if (
-                # use current item here and not buffered item, otherwise
-                # the icy metadata will be too much ahead
-                (current_item := queue.current_item)
-                and current_item.streamdetails
-                and current_item.streamdetails.stream_title
+        # Mark this player as actively streaming so audio analysis yields CPU to playback
+        # for the duration of the flow stream (see audio_analysis.playback_active).
+        self._active_output_streams += 1
+        try:
+            async for chunk in get_ffmpeg_stream(
+                audio_input=self.audio.get_queue_flow_stream(
+                    queue=queue, start_queue_item=start_queue_item, pcm_format=flow_pcm_format
+                ),
+                input_format=flow_pcm_format,
+                output_format=output_format,
+                filter_params=self.audio.get_player_filter_params(
+                    player.player_id, flow_pcm_format, output_format
+                ),
+                # we need to slowly feed the music to avoid the player stopping and later
+                # restarting (or completely failing) the audio stream by keeping the buffer short.
+                # this is reported to be an issue especially with Chromecast players.
+                # see for example: https://github.com/music-assistant/support/issues/3717
+                # allow buffer ahead of a few seconds and read rest in (near) realtime
+                extra_input_args=["-readrate", "1.1", "-readrate_initial_burst", "5"],
+                chunk_size=icy_meta_interval
+                if enable_icy
+                else calculate_content_length(output_format),
             ):
-                title = current_item.streamdetails.stream_title
-            elif queue and current_item and current_item.name:
-                title = current_item.name
-            else:
-                title = "Music Assistant"
-            metadata = f"StreamTitle='{title}';".encode()
-            if icy_preference == "full" and current_item and current_item.image:
-                metadata += f"StreamURL='{current_item.image.path}'".encode()
-            while len(metadata) % 16 != 0:
-                metadata += b"\x00"
-            length = len(metadata)
-            length_b = chr(int(length / 16)).encode()
-            await resp.write(length_b + metadata)
+                try:
+                    await resp.write(chunk)
+                except BrokenPipeError, ConnectionResetError, ConnectionError:
+                    # race condition
+                    break
+
+                if not enable_icy:
+                    continue
+
+                # if icy metadata is enabled, send the icy metadata after the chunk
+                if (
+                    # use current item here and not buffered item, otherwise
+                    # the icy metadata will be too much ahead
+                    (current_item := queue.current_item)
+                    and current_item.streamdetails
+                    and current_item.streamdetails.stream_title
+                ):
+                    title = current_item.streamdetails.stream_title
+                elif queue and current_item and current_item.name:
+                    title = current_item.name
+                else:
+                    title = "Music Assistant"
+                metadata = f"StreamTitle='{title}';".encode()
+                if icy_preference == "full" and current_item and current_item.image:
+                    metadata += f"StreamURL='{current_item.image.path}'".encode()
+                while len(metadata) % 16 != 0:
+                    metadata += b"\x00"
+                length = len(metadata)
+                length_b = chr(int(length / 16)).encode()
+                await resp.write(length_b + metadata)
+        finally:
+            self._active_output_streams -= 1
 
         return resp
 

--- a/music_assistant/models/audio_analysis_provider.py
+++ b/music_assistant/models/audio_analysis_provider.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import functools
+import time
 from abc import abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeVar
 
@@ -11,7 +14,7 @@ from .provider import Provider
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import Any
+    from typing import Any, Literal
 
     from music_assistant_models.config_entries import ProviderConfig
     from music_assistant_models.enums import ProviderFeature
@@ -23,6 +26,45 @@ if TYPE_CHECKING:
     from music_assistant.models.audio_analysis import AudioAnalysisData
 
 _T = TypeVar("_T")
+
+# DEBUG-log offloads that wait longer than this (seconds) for a permit -- time
+# spent queued behind the concurrency cap rather than computing.
+_PERMIT_WAIT_DEBUG_THRESHOLD = 0.5
+
+# Providers that accumulate whole-track feature state (beat grids, per-chunk VQT, CLAP windows)
+# cap analysis at this duration. Multi-hour mixes/audiobooks would hold hundreds of MB of
+# feature state and tie up the scan for hours, and smart crossfade/similarity carry no meaning
+# at that length. Providers opt in by setting max_analysis_duration.
+ACCUMULATING_ANALYSIS_MAX_DURATION_SECONDS = 1800.0
+
+
+# Subclass rather than wrap so existing isinstance(..., asyncio.Semaphore) checks keep
+# working, and keep the counters here so callers read contention state without touching
+# asyncio internals (_value/_waiters).
+class InstrumentedSemaphore(asyncio.Semaphore):
+    """asyncio.Semaphore that also exposes live in_flight/capacity/waiters counts."""
+
+    def __init__(self, value: int) -> None:
+        """Initialize with ``value`` permits."""
+        super().__init__(value)
+        self.capacity = value
+        self.in_flight = 0
+        self.waiters = 0
+
+    async def acquire(self) -> Literal[True]:
+        """Acquire a permit."""
+        self.waiters += 1
+        try:
+            acquired = await super().acquire()
+        finally:
+            self.waiters -= 1
+        self.in_flight += 1
+        return acquired
+
+    def release(self) -> None:
+        """Release a permit."""
+        self.in_flight -= 1
+        super().release()
 
 
 @dataclass
@@ -47,6 +89,10 @@ class AudioAnalysisProvider(Provider):
     # their algorithm changes significantly. The base class compares this against
     # the stored version to decide whether to re-analyze a track.
     analysis_version: int = 1
+
+    # Maximum track duration (seconds) this provider will analyze; longer tracks are skipped by
+    # start_analysis. None means no limit. Providers that accumulate whole-track state set it.
+    max_analysis_duration: float | None = None
 
     def __init__(
         self,
@@ -74,6 +120,18 @@ class AudioAnalysisProvider(Provider):
         :param streamdetails: The stream details for the item being analyzed.
         :param audio_format: PCM format of the audio stream.
         """
+        if (
+            self.max_analysis_duration is not None
+            and streamdetails.duration
+            and streamdetails.duration > self.max_analysis_duration
+        ):
+            self.logger.debug(
+                "Skipping analysis for %s: %.0fs exceeds the %.0fs limit",
+                streamdetails.uri,
+                streamdetails.duration,
+                self.max_analysis_duration,
+            )
+            return False
         stored_version = await self.mass.streams.audio_analysis.get_audio_analysis_version(
             streamdetails.item_id,
             streamdetails.provider,
@@ -195,42 +253,84 @@ class AudioAnalysisProvider(Provider):
 
     async def _run_offloaded(self, func: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
         """
-        Run a blocking analysis function in a worker thread, bounded by the CPU cap.
+        Run a blocking analysis function on the niced analysis thread pool.
 
-        The AudioAnalysisController caps how many of these run at once (half the cores) so
-        analysis never occupies the whole box; when no cap is configured this is a plain
-        asyncio.to_thread call. Route all CPU-heavy analysis work through this.
+        Route all CPU-heavy analysis work through this. The controller's semaphore caps
+        concurrency, and while any player is streaming the solo lock holds analysis to one
+        offload at a time so it stays below playback. Falls back to asyncio.to_thread when the
+        controller has no pool configured.
 
-        The permit is held until the worker thread actually finishes, even if the awaiting
-        coroutine is cancelled (e.g. a provider evicted on timeout, or a cancelled session):
-        asyncio.to_thread cannot stop a running thread, so releasing on cancellation would let
-        extra threads keep running and exceed the cap on exactly the hosts it protects.
+        The slot (semaphore permit and solo lock) is held until the worker thread finishes,
+        even if the awaiting coroutine is cancelled: the thread keeps running, so it must keep
+        counting against the caps.
 
         :param func: The blocking callable to run off the event loop.
         :param args: Positional arguments passed to func.
         :param kwargs: Keyword arguments passed to func.
         """
-        semaphore = self.mass.streams.audio_analysis.analysis_semaphore
+        controller = self.mass.streams.audio_analysis
+        semaphore = controller.analysis_semaphore
         if not isinstance(semaphore, asyncio.Semaphore):
             return await asyncio.to_thread(func, *args, **kwargs)
 
+        # While a player streams, take the solo lock so analysis runs one offload at a time:
+        # the GIL serializes Python execution, so concurrent inference starves the playback
+        # loop. Idle, the semaphore alone caps concurrency and background work uses spare cores.
+        solo = getattr(controller, "analysis_solo_lock", None)
+        solo_lock = solo if isinstance(solo, asyncio.Lock) else None
+        take_solo = False
+        if solo_lock is not None:
+            try:
+                take_solo = bool(controller.playback_active())
+            except Exception:
+                take_solo = False
+
+        solo_held = False
+
         def _release(done: asyncio.Future[_T]) -> None:
+            if solo_held and solo_lock is not None:
+                solo_lock.release()
             semaphore.release()
             # Retrieve any exception so a cancelled awaiter doesn't leave it unretrieved.
             if not done.cancelled():
                 done.exception()
 
+        wait_start = time.monotonic()
         await semaphore.acquire()
         try:
-            future: asyncio.Future[_T] = asyncio.ensure_future(
-                asyncio.to_thread(func, *args, **kwargs)
+            if take_solo and solo_lock is not None:
+                await solo_lock.acquire()
+                solo_held = True
+        except BaseException:
+            # Cancelled (or failed) waiting for the solo lock — give the permit back.
+            semaphore.release()
+            raise
+        wait_seconds = time.monotonic() - wait_start
+        if wait_seconds >= _PERMIT_WAIT_DEBUG_THRESHOLD and isinstance(
+            semaphore, InstrumentedSemaphore
+        ):
+            self.logger.debug(
+                "Analysis offload waited %.1fs for a slot (%d/%d permits in use, %d queued)",
+                wait_seconds,
+                semaphore.in_flight,
+                semaphore.capacity,
+                semaphore.waiters,
             )
+        executor = getattr(controller, "analysis_executor", None)
+        try:
+            if isinstance(executor, ThreadPoolExecutor):
+                loop = asyncio.get_running_loop()
+                future: asyncio.Future[_T] = asyncio.ensure_future(
+                    loop.run_in_executor(executor, functools.partial(func, *args, **kwargs))
+                )
+            else:
+                future = asyncio.ensure_future(asyncio.to_thread(func, *args, **kwargs))
         except Exception:
-            # Scheduling the worker failed (e.g. the loop is shutting down) — release the
-            # permit we just took so it isn't leaked, which would shrink the cap over time.
+            # Scheduling failed (e.g. loop shutting down) — release the slot so it isn't leaked.
+            if solo_held and solo_lock is not None:
+                solo_lock.release()
             semaphore.release()
             raise
         future.add_done_callback(_release)
-        # shield: if this coroutine is cancelled, the thread (and the permit) lives on until
-        # the work completes, rather than freeing the permit while the thread still runs.
+        # shield: a cancelled awaiter leaves the thread and its slot held until the work finishes.
         return await asyncio.shield(future)

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -17,7 +17,10 @@ from torchaudio.transforms import SpectralCentroid
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.util import is_arm
 from music_assistant.models.audio_analysis import AudioAnalysisData
-from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
+from music_assistant.models.audio_analysis_provider import (
+    ACCUMULATING_ANALYSIS_MAX_DURATION_SECONDS,
+    AudioAnalysisProvider,
+)
 
 from .dbn_postprocessor import DBNDownBeatTracker
 from .feature_extractor import AdvancedBeatFeatureExtractor
@@ -58,6 +61,8 @@ class SmartFadesData:
 
 class SmartFadesProvider(AudioAnalysisProvider):
     """Smart fades audio analysis provider using Beat This for beat tracking."""
+
+    max_analysis_duration = ACCUMULATING_ANALYSIS_MAX_DURATION_SECONDS
 
     def __init__(
         self,

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -19,6 +19,7 @@ from music_assistant.helpers.util import (
 )
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.models.audio_analysis_provider import (
+    ACCUMULATING_ANALYSIS_MAX_DURATION_SECONDS,
     AnalysisSessionData,
     AudioAnalysisProvider,
 )
@@ -328,6 +329,7 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
     """Audio analysis provider running librosa scalars + CLAP zero-shot per track."""
 
     analysis_version: int = 1
+    max_analysis_duration = ACCUMULATING_ANALYSIS_MAX_DURATION_SECONDS
 
     def __init__(
         self,

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import AsyncGenerator, Mapping
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -63,6 +64,35 @@ def test_ensure_inference_runtime_configured_is_idempotent() -> None:
         controller.ensure_inference_runtime_configured()
     set_threads.assert_called_once()
     blas_limits.assert_called_once()
+    if controller.analysis_executor is not None:
+        controller.analysis_executor.shutdown(wait=False)
+
+
+def test_ensure_inference_runtime_creates_solo_lock_and_executor() -> None:
+    """Runtime config creates the playback-priority solo lock and a dedicated worker pool."""
+    controller = _make_controller()
+    with (
+        patch("torch.set_num_threads"),
+        patch("torch.set_num_interop_threads"),
+        patch("threadpoolctl.threadpool_limits"),
+        patch("torch.backends.nnpack.set_flags"),
+    ):
+        controller.ensure_inference_runtime_configured()
+    try:
+        assert isinstance(controller.analysis_solo_lock, asyncio.Lock)
+        assert isinstance(controller.analysis_executor, ThreadPoolExecutor)
+    finally:
+        if controller.analysis_executor is not None:
+            controller.analysis_executor.shutdown(wait=False)
+
+
+def test_playback_active_delegates_to_streams() -> None:
+    """playback_active reflects the streams controller's active-output-stream gauge."""
+    controller = _make_controller()
+    controller.streams.output_stream_active = MagicMock(return_value=True)  # type: ignore[method-assign]
+    assert controller.playback_active() is True
+    controller.streams.output_stream_active = MagicMock(return_value=False)  # type: ignore[method-assign]
+    assert controller.playback_active() is False
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_audio_analysis_controller.py
+++ b/tests/core/test_audio_analysis_controller.py
@@ -4,19 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import unittest.mock
-from collections.abc import Coroutine
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.controllers.streams.audio_analysis import (
-    ANALYSIS_QUEUE_MAXSIZE,
-    AudioAnalysisController,
-)
-from music_assistant.controllers.streams.audio_buffer import AudioBuffer
+from music_assistant.controllers.streams.audio_analysis import AudioAnalysisController
+from music_assistant.controllers.streams.audio_buffer import AudioBuffer, AudioBufferDiscarded
 from music_assistant.models.audio_analysis_provider import (
     AnalysisSessionData,
     AudioAnalysisProvider,
@@ -49,11 +44,10 @@ def _create_mock_provider(
 
 
 async def _send_chunks(audio_buffer: AudioBuffer, num_chunks: int) -> None:
-    """Deliver chunks and EOF directly via the registered callback."""
-    cb = audio_buffer._chunk_callbacks[0]
-    for i in range(num_chunks):
-        await cb(i, ONE_SECOND_CHUNK, False)
-    await cb(num_chunks, b"", True)
+    """Fill the buffer with PCM chunks then signal EOF; the analysis worker reads from it."""
+    for _ in range(num_chunks):
+        await audio_buffer._put(ONE_SECOND_CHUNK)
+    await audio_buffer._set_eof()
 
 
 @pytest.fixture
@@ -133,7 +127,7 @@ async def test_start_analysis_no_providers(
     """No providers available means no callbacks registered and no sessions."""
     mock_mass.get_providers.return_value = []
     await controller.start_analysis(audio_buffer, mock_stream_details)
-    assert len(audio_buffer._chunk_callbacks) == 0
+    assert len(audio_buffer._cancel_callbacks) == 0
     assert len(controller._active_sessions) == 0
 
 
@@ -149,8 +143,8 @@ async def test_start_analysis_duplicate_session(
 
     buf2 = AudioBuffer(TEST_PCM_FORMAT)
     await controller.start_analysis(buf2, mock_stream_details)
-    # No extra callbacks on the second buffer
-    assert len(buf2._chunk_callbacks) == 0
+    # No callbacks registered on the second buffer
+    assert len(buf2._cancel_callbacks) == 0
     # Still only one session
     assert len(controller._active_sessions) == 1
 
@@ -166,7 +160,7 @@ async def test_start_analysis_all_providers_fail(
     mock_provider.start_analysis.side_effect = RuntimeError("init failed")
     await controller.start_analysis(audio_buffer, mock_stream_details)
     assert len(controller._active_sessions) == 0
-    assert len(audio_buffer._chunk_callbacks) == 0
+    assert len(audio_buffer._cancel_callbacks) == 0
 
 
 # -- Happy path --
@@ -258,9 +252,8 @@ async def test_cancel_on_buffer_clear(
 ) -> None:
     """Clearing the buffer triggers provider.cancel."""
     await controller.start_analysis(audio_buffer, mock_stream_details)
-    cb = audio_buffer._chunk_callbacks[0]
-    await cb(0, ONE_SECOND_CHUNK, False)
-    await cb(1, ONE_SECOND_CHUNK, False)
+    await audio_buffer._put(ONE_SECOND_CHUNK)
+    await audio_buffer._put(ONE_SECOND_CHUNK)
     await audio_buffer.clear()
     await _await_tasks(mock_mass)
     session_key = "test_prov://track/test_123"
@@ -276,8 +269,7 @@ async def test_session_cleaned_up_after_cancel(
 ) -> None:
     """Internal dicts are empty after cancel."""
     await controller.start_analysis(audio_buffer, mock_stream_details)
-    cb = audio_buffer._chunk_callbacks[0]
-    await cb(0, ONE_SECOND_CHUNK, False)
+    await audio_buffer._put(ONE_SECOND_CHUNK)
     await audio_buffer.clear()
     await _await_tasks(mock_mass)
     assert len(controller._active_sessions) == 0
@@ -305,21 +297,31 @@ async def test_worker_cancelled_on_buffer_clear(
 
 
 @pytest.mark.asyncio
-async def test_finalized_guard_prevents_double_finalize(
+async def test_worker_drops_session_when_falling_behind(
     controller: AudioAnalysisController,
-    audio_buffer: AudioBuffer,
     mock_stream_details: MagicMock,
     mock_provider: MagicMock,
     mock_mass: MagicMock,
 ) -> None:
-    """Invoking the chunk callback with is_last_chunk=True twice only finalizes once."""
-    await controller.start_analysis(audio_buffer, mock_stream_details)
-    assert len(audio_buffer._chunk_callbacks) == 1
-    cb = audio_buffer._chunk_callbacks[0]
-    await cb(0, b"", True)
-    await cb(1, b"", True)
+    """If a chunk has been evicted before analysis reads it, the session is dropped, not finalized."""
+    # A buffer that yields one chunk, then reports the next as already evicted.
+    fake_buffer = MagicMock()
+    fake_buffer.pcm_format = TEST_PCM_FORMAT
+    fake_buffer.first_buffered_chunk = 0
+    fake_buffer.read_chunk_for_analysis = AsyncMock(
+        side_effect=[ONE_SECOND_CHUNK, AudioBufferDiscarded]
+    )
+
+    await controller.start_analysis(fake_buffer, mock_stream_details)
     await _await_tasks(mock_mass)
-    mock_provider.finalize.assert_called_once()
+
+    session_key = "test_prov://track/test_123"
+    # The one available chunk was processed; falling behind drops the session (cancel, no finalize).
+    mock_provider.process_pcm_chunk.assert_called_once()
+    mock_provider.cancel.assert_called_once_with(session_key)
+    mock_provider.finalize.assert_not_called()
+    assert session_key not in controller._active_sessions
+    assert session_key not in controller._workers
 
 
 @pytest.mark.asyncio
@@ -405,7 +407,7 @@ async def test_slow_provider_removed_after_timeout(
     mock_mass.get_provider = MagicMock(side_effect=_get_prov)
 
     with unittest.mock.patch(
-        "music_assistant.controllers.streams.audio_analysis.REAL_TIME_PACE_INTERVAL_SECONDS_CEILING",
+        "music_assistant.controllers.streams.audio_analysis.CHUNK_HANG_GUARD_SECONDS",
         0.1,
     ):
         await controller.start_analysis(audio_buffer, mock_stream_details)
@@ -458,6 +460,7 @@ async def test_provider_start_analysis_uses_media_type_for_version_gating() -> N
     provider._start_analysis = AsyncMock(return_value=True)
     provider.domain = "test_domain"
     provider.analysis_version = 1
+    provider.max_analysis_duration = None
 
     streamdetails = MagicMock()
     streamdetails.item_id = "shared_id"
@@ -497,86 +500,3 @@ async def test_finalize_swallows_finalize_exception_and_cleans_up() -> None:
 
     assert "test_session" not in provider._sessions
     provider.logger.error.assert_called_once()
-
-
-async def _cancel_created_tasks(mock_mass: MagicMock) -> None:
-    """Cancel and drain any tasks created during the test (cleanup helper)."""
-    for task in mock_mass._created_tasks:
-        if not task.done():
-            task.cancel()
-    await asyncio.gather(*mock_mass._created_tasks, return_exceptions=True)
-
-
-@pytest.mark.asyncio
-async def test_chunk_delivery_does_not_block_producer_when_queue_full(
-    controller: AudioAnalysisController,
-    audio_buffer: AudioBuffer,
-    mock_stream_details: MagicMock,
-    mock_mass: MagicMock,
-) -> None:
-    """
-    A full analysis queue must not stall the audio producer.
-
-    The chunk callback is awaited inline by the buffer, so it must return
-    promptly (dropping the chunk) when the worker cannot keep up — never wait.
-    """
-
-    # Replace the worker so the queue is never drained, guaranteeing it fills.
-    async def _never_drain(*_args: object, **_kwargs: object) -> None:
-        await asyncio.Event().wait()
-
-    controller._chunk_worker = _never_drain  # type: ignore[method-assign]
-
-    await controller.start_analysis(audio_buffer, mock_stream_details)
-    cb = audio_buffer._chunk_callbacks[0]
-    for i in range(ANALYSIS_QUEUE_MAXSIZE):
-        await cb(i, ONE_SECOND_CHUNK, False)
-
-    # The next chunk hits a full queue. It must return promptly, not block on it.
-    await asyncio.wait_for(cb(ANALYSIS_QUEUE_MAXSIZE, ONE_SECOND_CHUNK, False), timeout=1.0)
-
-    await _cancel_created_tasks(mock_mass)
-
-
-@pytest.mark.asyncio
-async def test_eof_sentinel_lands_even_when_queue_full(
-    controller: AudioAnalysisController,
-    audio_buffer: AudioBuffer,
-    mock_stream_details: MagicMock,
-    mock_mass: MagicMock,
-) -> None:
-    """
-    The EOF terminator must always reach the worker, even on a full queue.
-
-    The producer bursts the whole decoded buffer in, so the queue is full at EOF
-    for any track longer than the queue depth. A plain drop-on-full would lose the
-    sentinel and the worker would block forever on get(), leaking the session. The
-    callback evicts one chunk to guarantee the terminator lands; it must also still
-    return promptly, since it is awaited inline by the producer.
-    """
-    captured: dict[str, asyncio.Queue[bytes | None]] = {}
-
-    def _capture_and_never_drain(*args: Any, **_kwargs: Any) -> Coroutine[Any, Any, None]:
-        # Capture synchronously at the call site: _on_chunk no longer awaits, so the
-        # worker coroutine itself never gets a turn to run before we inspect the queue.
-        captured["queue"] = args[1]
-        return asyncio.sleep(3600)
-
-    controller._chunk_worker = _capture_and_never_drain  # type: ignore[method-assign]
-
-    await controller.start_analysis(audio_buffer, mock_stream_details)
-    cb = audio_buffer._chunk_callbacks[0]
-    for i in range(ANALYSIS_QUEUE_MAXSIZE):
-        await cb(i, ONE_SECOND_CHUNK, False)
-
-    # EOF on a full, undrained queue must return promptly (never block the producer).
-    await asyncio.wait_for(cb(ANALYSIS_QUEUE_MAXSIZE, b"", True), timeout=1.0)
-
-    # ...and the terminator must be present, not dropped, so the worker can stop.
-    queue = captured["queue"]
-    drained: list[bytes | None] = []
-    while not queue.empty():
-        drained.append(queue.get_nowait())
-    assert None in drained
-
-    await _cancel_created_tasks(mock_mass)

--- a/tests/core/test_audio_analysis_controller.py
+++ b/tests/core/test_audio_analysis_controller.py
@@ -10,7 +10,10 @@ import pytest
 from music_assistant_models.enums import ContentType, MediaType
 from music_assistant_models.media_items import AudioFormat
 
-from music_assistant.controllers.streams.audio_analysis import AudioAnalysisController
+from music_assistant.controllers.streams.audio_analysis import (
+    REALTIME_ANALYSIS_MAX_SESSIONS,
+    AudioAnalysisController,
+)
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer, AudioBufferDiscarded
 from music_assistant.models.audio_analysis_provider import (
     AnalysisSessionData,
@@ -291,6 +294,76 @@ async def test_worker_cancelled_on_buffer_clear(
     await audio_buffer.clear()
     await _await_tasks(mock_mass)
     assert worker.cancelled() or worker.done()
+
+
+@pytest.mark.asyncio
+async def test_realtime_sessions_capped_evicting_oldest(
+    controller: AudioAnalysisController,
+    mock_provider: MagicMock,
+    mock_mass: MagicMock,
+) -> None:
+    """Starting past the cap evicts the oldest realtime session and cancels its providers."""
+    keys: list[str] = []
+    for i in range(REALTIME_ANALYSIS_MAX_SESSIONS + 1):
+        sd = MagicMock()
+        sd.uri = f"test://track/{i}"
+        sd.provider = "test"
+        sd.item_id = f"t{i}"
+        sd.media_type = MediaType.TRACK
+        sd.queue_id = "queue-1"  # same queue, so the per-queue cap applies
+        keys.append(sd.uri)
+        await controller.start_analysis(AudioBuffer(TEST_PCM_FORMAT), sd)
+
+    # Only the cap's worth survive; the oldest was evicted, the newest kept.
+    assert len(controller._workers) == REALTIME_ANALYSIS_MAX_SESSIONS
+    assert keys[0] not in controller._workers
+    assert keys[0] not in controller._active_sessions
+    assert keys[-1] in controller._workers
+    mock_provider.cancel.assert_any_call(keys[0])
+
+    # Drain the pending reader/cancel tasks so nothing leaks past the test.
+    for task in mock_mass._created_tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*mock_mass._created_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_realtime_session_cap_is_per_queue(
+    controller: AudioAnalysisController,
+    mock_provider: MagicMock,
+    mock_mass: MagicMock,
+) -> None:
+    """Concurrent queues are capped independently; one queue's burst can't evict another's."""
+
+    async def _start(uri: str, queue_id: str) -> None:
+        sd = MagicMock()
+        sd.uri = uri
+        sd.provider = "test"
+        sd.item_id = uri
+        sd.media_type = MediaType.TRACK
+        sd.queue_id = queue_id
+        await controller.start_analysis(AudioBuffer(TEST_PCM_FORMAT), sd)
+
+    # Fill two queues to the cap each (interleaved).
+    for i in range(REALTIME_ANALYSIS_MAX_SESSIONS):
+        await _start(f"a://{i}", "queueA")
+        await _start(f"b://{i}", "queueB")
+
+    # Both queues are fully populated and nothing was evicted across queues.
+    assert len(controller._workers) == 2 * REALTIME_ANALYSIS_MAX_SESSIONS
+    mock_provider.cancel.assert_not_called()
+
+    # One more in queueA evicts queueA's oldest only; queueB is untouched.
+    await _start("a://new", "queueA")
+    assert "a://0" not in controller._workers
+    assert "b://0" in controller._workers
+    mock_provider.cancel.assert_called_once_with("a://0")
+
+    for task in mock_mass._created_tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*mock_mass._created_tasks, return_exceptions=True)
 
 
 # -- Edge cases --

--- a/tests/core/test_audio_buffer.py
+++ b/tests/core/test_audio_buffer.py
@@ -13,6 +13,7 @@ from music_assistant_models.media_items import AudioFormat
 
 from music_assistant.controllers.streams.audio_buffer import (
     AudioBuffer,
+    AudioBufferDiscarded,
     AudioBufferEOF,
 )
 from music_assistant.controllers.streams.constants import (
@@ -305,68 +306,70 @@ async def test_seek_in_raw_stream() -> None:
     assert chunks[0] == _make_chunk(5)
 
 
-# -- Chunk callbacks --
+# -- Analysis reader (read_chunk_for_analysis) --
 
 
 @pytest.mark.asyncio
-async def test_chunk_callback_receives_data() -> None:
-    """Registered callbacks receive chunks with position."""
-    received: list[tuple[int, bytes, bool]] = []
-
-    async def _callback(position: int, data: bytes, is_last_chunk: bool) -> None:
-        received.append((position, data, is_last_chunk))
-
+async def test_read_chunk_for_analysis_returns_buffered_chunk() -> None:
+    """A passive reader gets a retained chunk without discarding it."""
     buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
-    buf.register_chunk_callback(_callback)
-    buf.fill(_make_source(3), source_name="test")
-    await asyncio.sleep(0.1)
+    await buf._put(_make_chunk(0))
+    await buf._put(_make_chunk(1))
 
-    # 3 data chunks + 1 EOF signal
-    assert len(received) == 4
-    assert received[0][0] == 0
-    assert received[1][0] == 1
-    assert received[2][0] == 2
-    # EOF signal has empty bytes and is_last_chunk=True
-    assert received[3][1] == b""
-    assert received[3][2] is True
-    # Data chunks have is_last_chunk=False
-    assert received[0][2] is False
+    assert await buf.read_chunk_for_analysis(0) == _make_chunk(0)
+    assert await buf.read_chunk_for_analysis(1) == _make_chunk(1)
+    # Reading must not have discarded anything — both chunks are still buffered.
+    assert buf.seconds_available == 2
+    assert buf.first_buffered_chunk == 0
 
 
 @pytest.mark.asyncio
-async def test_chunk_callback_eof_signal() -> None:
-    """Callback receives empty bytes on EOF."""
-    eof_positions: list[int] = []
-
-    async def _callback(position: int, _data: bytes, is_last_chunk: bool) -> None:
-        if is_last_chunk:
-            eof_positions.append(position)
-
+async def test_read_chunk_for_analysis_waits_then_returns() -> None:
+    """A reader ahead of the filled position waits until the chunk is produced."""
     buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
-    buf.register_chunk_callback(_callback)
-    buf.fill(_make_source(5), source_name="test")
-    await asyncio.sleep(0.1)
+    reader = asyncio.ensure_future(buf.read_chunk_for_analysis(0))
+    await asyncio.sleep(0.05)
+    assert not reader.done()  # nothing buffered yet
 
-    assert len(eof_positions) == 1
-    assert eof_positions[0] == 5  # total chunks
+    await buf._put(_make_chunk(0))
+    assert await asyncio.wait_for(reader, timeout=1.0) == _make_chunk(0)
 
 
 @pytest.mark.asyncio
-async def test_callbacks_cleared_on_clear() -> None:
-    """Callbacks are removed when buffer is cleared."""
-    call_count = 0
-
-    async def _callback(_position: int, _data: bytes, _is_last_chunk: bool) -> None:
-        nonlocal call_count
-        call_count += 1
-
+async def test_read_chunk_for_analysis_raises_eof_past_end() -> None:
+    """Reading past the last chunk of an ended stream raises AudioBufferEOF."""
     buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
-    buf.register_chunk_callback(_callback)
-    await buf._put(ONE_SECOND_CHUNK)
-    assert call_count == 1
+    await buf._put(_make_chunk(0))
+    await buf._set_eof()
 
+    assert await buf.read_chunk_for_analysis(0) == _make_chunk(0)
+    with pytest.raises(AudioBufferEOF):
+        await buf.read_chunk_for_analysis(1)
+
+
+@pytest.mark.asyncio
+async def test_read_chunk_for_analysis_raises_discarded_when_evicted() -> None:
+    """Requesting a chunk that has been evicted from the window raises AudioBufferDiscarded."""
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
+    await buf._put(_make_chunk(0))
+    # Simulate the playback consumer sliding the window past chunk 0.
+    buf._chunks.popleft()
+    buf._discarded_chunks += 1
+    assert buf.first_buffered_chunk == 1
+
+    with pytest.raises(AudioBufferDiscarded):
+        await buf.read_chunk_for_analysis(0)
+
+
+@pytest.mark.asyncio
+async def test_read_chunk_for_analysis_raises_discarded_on_clear() -> None:
+    """A reader blocked on a torn-down buffer is released with AudioBufferDiscarded."""
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
+    reader = asyncio.ensure_future(buf.read_chunk_for_analysis(0))
+    await asyncio.sleep(0.05)
     await buf.clear()
-    assert len(buf._chunk_callbacks) == 0
+    with pytest.raises(AudioBufferDiscarded):
+        await asyncio.wait_for(reader, timeout=1.0)
 
 
 # -- Buffer size limits --
@@ -537,54 +540,20 @@ async def test_raw_stream_with_seek_offset() -> None:
 
 
 @pytest.mark.asyncio
-async def test_failing_callback_does_not_break_fill() -> None:
-    """A failing chunk callback is removed without breaking the fill task."""
-    good_chunks: list[int] = []
-
-    async def _bad_callback(_position: int, _data: bytes, _is_last_chunk: bool) -> None:
-        msg = "callback error"
-        raise RuntimeError(msg)
-
-    async def _good_callback(position: int, data: bytes, is_last_chunk: bool) -> None:
-        if data and not is_last_chunk:
-            good_chunks.append(position)
-
-    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
-    buf.register_chunk_callback(_bad_callback)
-    buf.register_chunk_callback(_good_callback)
-    buf.fill(_make_source(3), source_name="test")
-    await asyncio.sleep(0.1)
-
-    # bad callback removed after first failure, good callback received all chunks
-    assert _bad_callback not in buf._chunk_callbacks
-    assert len(good_chunks) == 3
-
-
-@pytest.mark.asyncio
 async def test_clear_fires_cancel_callbacks() -> None:
-    """clear() fires cancel callbacks (not chunk callbacks) before removing them."""
-    chunk_received: list[bytes] = []
+    """clear() fires registered cancel callbacks before removing them."""
     cancel_called = False
-
-    async def _chunk_callback(_position: int, data: bytes, _is_last_chunk: bool) -> None:
-        chunk_received.append(data)
 
     def _cancel_callback() -> None:
         nonlocal cancel_called
         cancel_called = True
 
     buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
-    buf.register_chunk_callback(_chunk_callback)
     buf.register_cancel_callback(_cancel_callback)
     await buf._put(ONE_SECOND_CHUNK)
-    assert len(chunk_received) == 1  # data chunk
 
     await buf.clear()
-    # chunk callback should NOT have received anything extra from clear()
-    assert len(chunk_received) == 1
-    # cancel callback should have been called
     assert cancel_called is True
-    assert len(buf._chunk_callbacks) == 0
     assert len(buf._cancel_callbacks) == 0
 
 

--- a/tests/models/test_audio_analysis_provider.py
+++ b/tests/models/test_audio_analysis_provider.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from music_assistant.models.audio_analysis import AudioAnalysisData
-from music_assistant.models.audio_analysis_provider import AudioAnalysisProvider
+from music_assistant.models.audio_analysis_provider import (
+    AudioAnalysisProvider,
+    InstrumentedSemaphore,
+)
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat
@@ -124,10 +128,52 @@ async def test_finalize_swallows_post_analysis_exception() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_analysis_skips_tracks_over_max_duration() -> None:
+    """A provider with max_analysis_duration set rejects longer tracks before any DB/work."""
+    provider = _make_provider()
+    provider.max_analysis_duration = 1800.0
+    provider._start_analysis = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    streamdetails = MagicMock()
+    streamdetails.duration = 7200  # 2 hours
+
+    accepted = await provider.start_analysis("s", streamdetails, MagicMock())
+
+    assert accepted is False
+    provider._start_analysis.assert_not_awaited()
+    # The duration gate comes first, so the version lookup is skipped too.
+    version_lookup = provider.mass.streams.audio_analysis.get_audio_analysis_version
+    version_lookup.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_start_analysis_allows_tracks_under_max_duration() -> None:
+    """Tracks within the cap proceed to the provider's own _start_analysis."""
+    provider = _make_provider()
+    provider.max_analysis_duration = 1800.0
+    provider._start_analysis = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    streamdetails = MagicMock()
+    streamdetails.duration = 240
+
+    assert await provider.start_analysis("s", streamdetails, MagicMock()) is True
+    provider._start_analysis.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_analysis_no_duration_cap_by_default() -> None:
+    """With max_analysis_duration unset, even a very long track is accepted."""
+    provider = _make_provider()
+    provider._start_analysis = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    streamdetails = MagicMock()
+    streamdetails.duration = 99999
+
+    assert await provider.start_analysis("s", streamdetails, MagicMock()) is True
+
+
+@pytest.mark.asyncio
 async def test_run_offloaded_acquires_semaphore_when_present() -> None:
     """_run_offloaded holds the controller's analysis semaphore while the work runs."""
     provider = _make_provider()
-    semaphore = asyncio.Semaphore(1)
+    semaphore = InstrumentedSemaphore(1)
     provider.mass.streams.audio_analysis.analysis_semaphore = semaphore
 
     def _work() -> bool:
@@ -152,7 +198,7 @@ async def test_run_offloaded_without_cap_runs_plainly() -> None:
 async def test_run_offloaded_holds_permit_until_thread_finishes_on_cancel() -> None:
     """Cancelling the awaiter must not free the permit while the worker thread is still running."""
     provider = _make_provider()
-    semaphore = asyncio.Semaphore(1)
+    semaphore = InstrumentedSemaphore(1)
     provider.mass.streams.audio_analysis.analysis_semaphore = semaphore
 
     started = threading.Event()
@@ -182,10 +228,96 @@ async def test_run_offloaded_holds_permit_until_thread_finishes_on_cancel() -> N
 
 
 @pytest.mark.asyncio
+async def test_run_offloaded_serializes_to_one_while_streaming() -> None:
+    """While a player is streaming, offloads run one at a time even if the semaphore allows more."""
+    provider = _make_provider()
+    ctrl = provider.mass.streams.audio_analysis
+    ctrl.analysis_semaphore = InstrumentedSemaphore(4)  # plenty of permits
+    ctrl.analysis_solo_lock = asyncio.Lock()
+    ctrl.analysis_executor = None  # fall back to asyncio.to_thread
+    ctrl.playback_active = MagicMock(return_value=True)  # type: ignore[method-assign]
+
+    first_started = threading.Event()
+    first_may_finish = threading.Event()
+    second_started = threading.Event()
+
+    def _first() -> str:
+        first_started.set()
+        first_may_finish.wait(timeout=5)
+        return "first"
+
+    def _second() -> str:
+        second_started.set()
+        return "second"
+
+    t1 = asyncio.create_task(provider._run_offloaded(_first))
+    assert await asyncio.to_thread(first_started.wait, 5)
+
+    # The second offload must block on the solo lock while the first holds it.
+    t2 = asyncio.create_task(provider._run_offloaded(_second))
+    await asyncio.sleep(0.1)
+    assert not second_started.is_set()
+
+    first_may_finish.set()
+    assert await t1 == "first"
+    assert await t2 == "second"
+    assert second_started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_run_offloaded_runs_concurrently_when_idle() -> None:
+    """With no player streaming, the solo lock is not taken and offloads overlap up to the cap."""
+    provider = _make_provider()
+    ctrl = provider.mass.streams.audio_analysis
+    ctrl.analysis_semaphore = InstrumentedSemaphore(4)
+    ctrl.analysis_solo_lock = asyncio.Lock()
+    ctrl.analysis_executor = None
+    ctrl.playback_active = MagicMock(return_value=False)  # type: ignore[method-assign]
+
+    first_started = threading.Event()
+    first_may_finish = threading.Event()
+    second_started = threading.Event()
+
+    def _first() -> str:
+        first_started.set()
+        first_may_finish.wait(timeout=5)
+        return "first"
+
+    def _second() -> str:
+        second_started.set()
+        return "second"
+
+    t1 = asyncio.create_task(provider._run_offloaded(_first))
+    assert await asyncio.to_thread(first_started.wait, 5)
+    t2 = asyncio.create_task(provider._run_offloaded(_second))
+    # Idle: the second offload runs without waiting for the first to finish.
+    assert await asyncio.to_thread(second_started.wait, 5)
+
+    first_may_finish.set()
+    await asyncio.gather(t1, t2)
+
+
+@pytest.mark.asyncio
+async def test_run_offloaded_uses_dedicated_executor_when_present() -> None:
+    """Offloads run on the controller's dedicated (niced) analysis pool when configured."""
+    provider = _make_provider()
+    ctrl = provider.mass.streams.audio_analysis
+    ctrl.analysis_semaphore = InstrumentedSemaphore(1)
+    ctrl.analysis_solo_lock = None  # not an asyncio.Lock -> solo step skipped
+    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="analysis")
+    ctrl.analysis_executor = executor
+    try:
+        thread_name = await provider._run_offloaded(lambda: threading.current_thread().name)
+    finally:
+        executor.shutdown(wait=False)
+    assert thread_name.startswith("analysis")
+
+
+@pytest.mark.asyncio
 async def test_run_offloaded_releases_permit_if_scheduling_fails() -> None:
     """A failure to schedule the worker must release the permit, not leak it."""
     provider = _make_provider()
-    semaphore = asyncio.Semaphore(1)
+    semaphore = InstrumentedSemaphore(1)
     provider.mass.streams.audio_analysis.analysis_semaphore = semaphore
 
     with (

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -132,6 +132,7 @@ async def test_beat_detection(provider: SmartFadesProvider, mass_mock: Mock) -> 
     stream_details.queue_id = "test"
     stream_details.uri = "test://120bpm"
     stream_details.media_type = MediaType.TRACK
+    stream_details.duration = 120
 
     session_id = "test:test:test_120bpm"
     await provider.start_analysis(session_id, stream_details, audio_format)
@@ -193,6 +194,7 @@ async def test_extended_analysis_fields(provider: SmartFadesProvider, mass_mock:
     stream_details.queue_id = "test"
     stream_details.uri = "test://120bpm"
     stream_details.media_type = MediaType.TRACK
+    stream_details.duration = 120
 
     session_id = "test:test:test_120bpm_extended"
     await provider.start_analysis(session_id, stream_details, audio_format)
@@ -260,6 +262,7 @@ async def test_finalize_returns_audio_analysis_data(provider: SmartFadesProvider
     stream_details.queue_id = "test"
     stream_details.uri = "test://finalize_return"
     stream_details.media_type = MediaType.TRACK
+    stream_details.duration = 120
 
     session_id = "test:test:test_finalize_return"
     await provider.start_analysis(session_id, stream_details, audio_format)
@@ -292,6 +295,7 @@ async def test_finalize_returns_none_on_early_exit(provider: SmartFadesProvider)
     stream_details.queue_id = "test"
     stream_details.uri = "test://finalize_none"
     stream_details.media_type = MediaType.TRACK
+    stream_details.duration = 120
 
     session_id = "test:test:test_finalize_none"
     await provider.start_analysis(session_id, stream_details, audio_format)


### PR DESCRIPTION
Manual backport of #4449 and #4451 to `stable`.

`stable` already shipped #4442 (live audio analysis as a passive observer), but that approach made the playback stalls worse in practice. These two follow-ups replace it with the mechanism that's now validated on nightly:

- **#4449** — playback gets priority over realtime analysis: a solo lock holds analysis to one offload while any player is streaming, analysis runs on a dedicated niced thread pool, and the buffer-reader drops behind rather than blocking playback.
- **#4451** — caps concurrent realtime analysis sessions to 2 per queue, evicting the oldest, so a burst of track skips can't spawn an analysis per abandoned track.

Notes on the backport:
- Auto-backport couldn't apply these (the analysis subsystem diverged from `dev`). Conflicts were resolved by hand to match `dev`'s final state; the `controller.py` hot-path hunks land in regions untouched by the stable-only i18n/crossfade divergence.
- Analysis tests pass (133) and the touched files are ruff/mypy clean.