### PR TITLE
Audiobookshelf: tolerate out-of-range podcast episode dates

### DIFF
--- a/music_assistant/providers/audiobookshelf/parsers.py
+++ b/music_assistant/providers/audiobookshelf/parsers.py
@@ -215,8 +215,9 @@ def parse_podcast_episode(
     release_date: datetime | None = None
     if episode.published_at is not None:
         position = -episode.published_at
-        # abs published_at is ms epoch
-        release_date = from_utc_timestamp(episode.published_at / 1000)
+        # abs published_at is ms epoch; leave the date unset if it is out of range
+        with suppress(ValueError, OverflowError, OSError):
+            release_date = from_utc_timestamp(episode.published_at / 1000)
     else:
         position = 0
         if fallback_episode_cnt is not None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A podcast episode with an out-of-range `published_at` (an epoch that parses to a year beyond 1..9999) raised `ValueError` while building the release date, which aborted the whole podcast sync and the recommendations fetch and dropped every episode from the provider. Leave the date unset for such values so the episode still imports and the sync continues.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5727

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
