### PR TITLE
Fix smart playlist genre AND logic

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -888,8 +888,12 @@ class SmartPlaylistProvider(PluginProvider):
                 track_id_to_tracks[track_id].append(t)
             elif t.provider_mappings:
                 for mapping in t.provider_mappings:
-                    if str(mapping.item_id).isdigit():
-                        track_id = int(mapping.item_id)
+                    if library_track := await self.mass.music.tracks.get_library_item_by_prov_id(
+                        item_id=mapping.item_id,
+                        provider_instance_id_or_domain=mapping.provider_instance
+                        or mapping.provider_domain,
+                    ):
+                        track_id = int(library_track.item_id)
                         if track_id not in track_id_to_tracks:
                             track_id_to_tracks[track_id] = []
                         track_id_to_tracks[track_id].append(t)
@@ -937,8 +941,12 @@ class SmartPlaylistProvider(PluginProvider):
                 track_id_to_tracks[track_id].append(track)
             elif track.provider_mappings:
                 for mapping in track.provider_mappings:
-                    if str(mapping.item_id).isdigit():
-                        track_id = int(mapping.item_id)
+                    if library_track := await self.mass.music.tracks.get_library_item_by_prov_id(
+                        item_id=mapping.item_id,
+                        provider_instance_id_or_domain=mapping.provider_instance
+                        or mapping.provider_domain,
+                    ):
+                        track_id = int(library_track.item_id)
                         if track_id not in track_id_to_tracks:
                             track_id_to_tracks[track_id] = []
                         track_id_to_tracks[track_id].append(track)

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -915,6 +915,57 @@ class SmartPlaylistProvider(PluginProvider):
                 for genre in genres:
                     track.metadata.genres.add(genre.name)
 
+    async def _filter_tracks_with_all_genres(
+        self, tracks: list[Track], required_genre_ids: list[int]
+    ) -> list[Track]:
+        """Filter tracks to only those that have ALL required genre IDs in the database."""
+        if not tracks or not required_genre_ids:
+            return tracks
+
+        required_ids = set(required_genre_ids)
+
+        # Build map of library_track_id -> list of track objects
+        track_id_to_tracks: dict[int, list[Track]] = {}
+        for track in tracks:
+            for mapping in track.provider_mappings or ():
+                if mapping.provider_domain == "library" and str(mapping.item_id).isdigit():
+                    track_id = int(mapping.item_id)
+                    if track_id not in track_id_to_tracks:
+                        track_id_to_tracks[track_id] = []
+                    track_id_to_tracks[track_id].append(track)
+                    break
+
+        if not track_id_to_tracks:
+            return []
+
+        # Fetch genres for all track IDs in parallel
+        # With typical limits (20-50 tracks), this results in 100-250 parallel DB calls
+        # which is acceptable. Only at very high limits would we approach the 2000 max.
+        track_ids = list(track_id_to_tracks.keys())
+        genre_results = await asyncio.gather(
+            *(
+                self.mass.music.genres.get_genres_for_media_item(MediaType.TRACK, track_id)
+                for track_id in track_ids
+            )
+        )
+
+        # Build set of track IDs that have all required genres
+        matching_track_ids: set[int] = set()
+        for track_id, genres in zip(track_ids, genre_results, strict=True):
+            track_genre_ids = {
+                int(g.item_id) for g in genres if g.item_id and str(g.item_id).isdigit()
+            }
+            if required_ids.issubset(track_genre_ids):
+                matching_track_ids.add(track_id)
+
+        # Return tracks that match, preserving original order
+        result: list[Track] = []
+        for track_id in track_ids:
+            if track_id in matching_track_ids:
+                result.extend(track_id_to_tracks[track_id])
+
+        return result
+
     async def _apply_dedup(self, tracks: list[Track], dedup_hours: int) -> list[Track]:
         """
         Filter out tracks fully played within dedup_hours (scoped to the current user).
@@ -958,6 +1009,10 @@ class SmartPlaylistProvider(PluginProvider):
             limit=min(rules.limit * 5, 2000),
             user_provider_filter=user_provider_filter,
         )
+
+        # When multiple genres are specified with AND logic, filter to tracks that have ALL genres
+        if has_genre and len(rules.genre_ids) > 1:
+            base_tracks = await self._filter_tracks_with_all_genres(base_tracks, rules.genre_ids)
 
         if not has_artist and not has_album:
             return base_tracks

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -867,6 +867,64 @@ class SmartPlaylistProvider(PluginProvider):
                     genre_id_to_name[genre_id] = genre.name
         return {v.lower() for v in genre_id_to_name.values() if v}
 
+    async def _build_track_id_map(
+        self,
+        tracks: list[Track],
+        skip_tracks_with_genres: bool = False,
+    ) -> dict[int, list[Track]]:
+        """
+        Build mapping of library track ID to track objects, resolving provider tracks to library.
+
+        :param tracks: Tracks to process
+        :param skip_tracks_with_genres: Skip tracks that already have genre metadata
+        :return: Mapping of library track ID to list of track objects
+        """
+        track_id_to_tracks: dict[int, list[Track]] = {}
+        provider_track_tasks: list[tuple[Track, str, str]] = []
+
+        for track in tracks:
+            if skip_tracks_with_genres and track.metadata and track.metadata.genres:
+                continue
+
+            if track.provider == "library" and str(track.item_id).isdigit():
+                track_id = int(track.item_id)
+                if track_id not in track_id_to_tracks:
+                    track_id_to_tracks[track_id] = []
+                track_id_to_tracks[track_id].append(track)
+            elif track.provider_mappings:
+                for mapping in track.provider_mappings:
+                    provider_track_tasks.append(
+                        (
+                            track,
+                            mapping.item_id,
+                            mapping.provider_instance or mapping.provider_domain,
+                        )
+                    )
+                    break
+
+        # Resolve all provider tracks to library tracks in parallel
+        if provider_track_tasks:
+            library_tracks = await asyncio.gather(
+                *(
+                    self.mass.music.tracks.get_library_item_by_prov_id(
+                        item_id=item_id,
+                        provider_instance_id_or_domain=provider_instance_or_domain,
+                    )
+                    for _, item_id, provider_instance_or_domain in provider_track_tasks
+                )
+            )
+
+            for (track, _, _), library_track in zip(
+                provider_track_tasks, library_tracks, strict=True
+            ):
+                if library_track:
+                    track_id = int(library_track.item_id)
+                    if track_id not in track_id_to_tracks:
+                        track_id_to_tracks[track_id] = []
+                    track_id_to_tracks[track_id].append(track)
+
+        return track_id_to_tracks
+
     async def _enrich_tracks_with_db_genres(self, tracks: list[Track]) -> None:
         """
         Enrich library tracks with genre data from the database.
@@ -877,27 +935,7 @@ class SmartPlaylistProvider(PluginProvider):
         if not tracks:
             return
 
-        track_id_to_tracks: dict[int, list[Track]] = {}
-        for t in tracks:
-            if t.metadata and t.metadata.genres:
-                continue
-            if t.provider == "library" and str(t.item_id).isdigit():
-                track_id = int(t.item_id)
-                if track_id not in track_id_to_tracks:
-                    track_id_to_tracks[track_id] = []
-                track_id_to_tracks[track_id].append(t)
-            elif t.provider_mappings:
-                for mapping in t.provider_mappings:
-                    if library_track := await self.mass.music.tracks.get_library_item_by_prov_id(
-                        item_id=mapping.item_id,
-                        provider_instance_id_or_domain=mapping.provider_instance
-                        or mapping.provider_domain,
-                    ):
-                        track_id = int(library_track.item_id)
-                        if track_id not in track_id_to_tracks:
-                            track_id_to_tracks[track_id] = []
-                        track_id_to_tracks[track_id].append(t)
-                        break
+        track_id_to_tracks = await self._build_track_id_map(tracks, skip_tracks_with_genres=True)
         if not track_id_to_tracks:
             return
 
@@ -932,26 +970,7 @@ class SmartPlaylistProvider(PluginProvider):
 
         required_ids = set(required_genre_ids)
 
-        track_id_to_tracks: dict[int, list[Track]] = {}
-        for track in tracks:
-            if track.provider == "library" and str(track.item_id).isdigit():
-                track_id = int(track.item_id)
-                if track_id not in track_id_to_tracks:
-                    track_id_to_tracks[track_id] = []
-                track_id_to_tracks[track_id].append(track)
-            elif track.provider_mappings:
-                for mapping in track.provider_mappings:
-                    if library_track := await self.mass.music.tracks.get_library_item_by_prov_id(
-                        item_id=mapping.item_id,
-                        provider_instance_id_or_domain=mapping.provider_instance
-                        or mapping.provider_domain,
-                    ):
-                        track_id = int(library_track.item_id)
-                        if track_id not in track_id_to_tracks:
-                            track_id_to_tracks[track_id] = []
-                        track_id_to_tracks[track_id].append(track)
-                        break
-
+        track_id_to_tracks = await self._build_track_id_map(tracks)
         if not track_id_to_tracks:
             return []
 

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -877,19 +877,23 @@ class SmartPlaylistProvider(PluginProvider):
         if not tracks:
             return
 
-        # Build map of library_track_id -> list of track objects in single pass
-        # Check provider_mappings for library presence (tracks from Spotify/etc may also be in library)
         track_id_to_tracks: dict[int, list[Track]] = {}
         for t in tracks:
             if t.metadata and t.metadata.genres:
                 continue
-            for mapping in t.provider_mappings or ():
-                if mapping.provider_domain == "library" and str(mapping.item_id).isdigit():
-                    track_id = int(mapping.item_id)
-                    if track_id not in track_id_to_tracks:
-                        track_id_to_tracks[track_id] = []
-                    track_id_to_tracks[track_id].append(t)
-                    break
+            if t.provider == "library" and str(t.item_id).isdigit():
+                track_id = int(t.item_id)
+                if track_id not in track_id_to_tracks:
+                    track_id_to_tracks[track_id] = []
+                track_id_to_tracks[track_id].append(t)
+            elif t.provider_mappings:
+                for mapping in t.provider_mappings:
+                    if str(mapping.item_id).isdigit():
+                        track_id = int(mapping.item_id)
+                        if track_id not in track_id_to_tracks:
+                            track_id_to_tracks[track_id] = []
+                        track_id_to_tracks[track_id].append(t)
+                        break
         if not track_id_to_tracks:
             return
 
@@ -924,16 +928,21 @@ class SmartPlaylistProvider(PluginProvider):
 
         required_ids = set(required_genre_ids)
 
-        # Build map of library_track_id -> list of track objects
         track_id_to_tracks: dict[int, list[Track]] = {}
         for track in tracks:
-            for mapping in track.provider_mappings or ():
-                if mapping.provider_domain == "library" and str(mapping.item_id).isdigit():
-                    track_id = int(mapping.item_id)
-                    if track_id not in track_id_to_tracks:
-                        track_id_to_tracks[track_id] = []
-                    track_id_to_tracks[track_id].append(track)
-                    break
+            if track.provider == "library" and str(track.item_id).isdigit():
+                track_id = int(track.item_id)
+                if track_id not in track_id_to_tracks:
+                    track_id_to_tracks[track_id] = []
+                track_id_to_tracks[track_id].append(track)
+            elif track.provider_mappings:
+                for mapping in track.provider_mappings:
+                    if str(mapping.item_id).isdigit():
+                        track_id = int(mapping.item_id)
+                        if track_id not in track_id_to_tracks:
+                            track_id_to_tracks[track_id] = []
+                        track_id_to_tracks[track_id].append(track)
+                        break
 
         if not track_id_to_tracks:
             return []

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -1864,23 +1864,28 @@ async def test_filter_tracks_with_all_genres_filters_correctly() -> None:
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
-    # Create mock tracks with library provider mappings
-    track_1 = _make_mock_track("1", uri="library://track/1")
-    track_1_mapping = MagicMock()
-    track_1_mapping.provider_domain = "library"
-    track_1_mapping.item_id = "101"
-    track_1.provider_mappings = [track_1_mapping]
+    # Create mock tracks:
+    # Track 1: Library track (direct)
+    track_1 = _make_mock_track("1", uri="library://track/101")
+    track_1.provider = "library"
+    track_1.item_id = "101"
 
-    track_2 = _make_mock_track("2", uri="library://track/2")
+    # Track 2: Spotify track with library mapping (item_id is library DB ID)
+    track_2 = _make_mock_track("2", uri="spotify://track/abc")
+    track_2.provider = "spotify"
+    track_2.item_id = "abc"
     track_2_mapping = MagicMock()
-    track_2_mapping.provider_domain = "library"
-    track_2_mapping.item_id = "102"
+    track_2_mapping.provider_domain = "spotify"
+    track_2_mapping.item_id = "102"  # This is the library DB ID
     track_2.provider_mappings = [track_2_mapping]
 
-    track_3 = _make_mock_track("3", uri="library://track/3")
+    # Track 3: Apple Music track with library mapping
+    track_3 = _make_mock_track("3", uri="apple_music://track/xyz")
+    track_3.provider = "apple_music"
+    track_3.item_id = "xyz"
     track_3_mapping = MagicMock()
-    track_3_mapping.provider_domain = "library"
-    track_3_mapping.item_id = "103"
+    track_3_mapping.provider_domain = "apple_music"
+    track_3_mapping.item_id = "103"  # This is the library DB ID
     track_3.provider_mappings = [track_3_mapping]
 
     tracks = [track_1, track_2, track_3]
@@ -1913,9 +1918,9 @@ async def test_filter_tracks_with_all_genres_filters_correctly() -> None:
     # Only tracks 1 and 3 should be returned (have both genres 10 and 20)
     assert len(result) == 2
     result_uris = {t.uri for t in result}
-    assert "library://track/1" in result_uris
-    assert "library://track/3" in result_uris
-    assert "library://track/2" not in result_uris
+    assert "library://track/101" in result_uris
+    assert "apple_music://track/xyz" in result_uris
+    assert "spotify://track/abc" not in result_uris
 
 
 @pytest.mark.asyncio
@@ -1929,21 +1934,23 @@ async def test_filter_tracks_with_all_genres_preserves_order() -> None:
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
     # Create tracks in specific order: 103, 101, 102
-    track_3 = _make_mock_track("3", uri="library://track/3")
-    track_3_mapping = MagicMock()
-    track_3_mapping.provider_domain = "library"
-    track_3_mapping.item_id = "103"
-    track_3.provider_mappings = [track_3_mapping]
+    track_3 = _make_mock_track("3", uri="library://track/103")
+    track_3.provider = "library"
+    track_3.item_id = "103"
 
-    track_1 = _make_mock_track("1", uri="library://track/1")
+    track_1 = _make_mock_track("1", uri="spotify://track/abc")
+    track_1.provider = "spotify"
+    track_1.item_id = "abc"
     track_1_mapping = MagicMock()
-    track_1_mapping.provider_domain = "library"
+    track_1_mapping.provider_domain = "spotify"
     track_1_mapping.item_id = "101"
     track_1.provider_mappings = [track_1_mapping]
 
-    track_2 = _make_mock_track("2", uri="library://track/2")
+    track_2 = _make_mock_track("2", uri="apple_music://track/xyz")
+    track_2.provider = "apple_music"
+    track_2.item_id = "xyz"
     track_2_mapping = MagicMock()
-    track_2_mapping.provider_domain = "library"
+    track_2_mapping.provider_domain = "apple_music"
     track_2_mapping.item_id = "102"
     track_2.provider_mappings = [track_2_mapping]
 
@@ -1963,9 +1970,9 @@ async def test_filter_tracks_with_all_genres_preserves_order() -> None:
 
     # Order should be preserved: track 3, track 1, track 2
     assert len(result) == 3
-    assert result[0].uri == "library://track/3"
-    assert result[1].uri == "library://track/1"
-    assert result[2].uri == "library://track/2"
+    assert result[0].uri == "library://track/103"
+    assert result[1].uri == "spotify://track/abc"
+    assert result[2].uri == "apple_music://track/xyz"
 
 
 @pytest.mark.asyncio
@@ -1978,11 +1985,9 @@ async def test_filter_tracks_with_all_genres_handles_non_numeric_genre_ids() -> 
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
-    track_1 = _make_mock_track("1", uri="library://track/1")
-    track_1_mapping = MagicMock()
-    track_1_mapping.provider_domain = "library"
-    track_1_mapping.item_id = "101"
-    track_1.provider_mappings = [track_1_mapping]
+    track_1 = _make_mock_track("1", uri="library://track/101")
+    track_1.provider = "library"
+    track_1.item_id = "101"
 
     tracks = [track_1]
 
@@ -2002,4 +2007,4 @@ async def test_filter_tracks_with_all_genres_handles_non_numeric_genre_ids() -> 
     result = await plugin._filter_tracks_with_all_genres(cast("Any", tracks), [10, 20])
 
     assert len(result) == 1
-    assert result[0].uri == "library://track/1"
+    assert result[0].uri == "library://track/101"

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -1847,3 +1847,159 @@ async def test_refresh_ai_description_skips_flush_when_unchanged(tmp_path: Any) 
     await plugin._refresh_ai_description("abc")
 
     cast("Any", plugin)._flush_rules_to_disk.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Genre AND logic filtering tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_filter_tracks_with_all_genres_filters_correctly() -> None:
+    """_filter_tracks_with_all_genres returns only tracks that have ALL required genres."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    # Create mock tracks with library provider mappings
+    track_1 = _make_mock_track("1", uri="library://track/1")
+    track_1_mapping = MagicMock()
+    track_1_mapping.provider_domain = "library"
+    track_1_mapping.item_id = "101"
+    track_1.provider_mappings = [track_1_mapping]
+
+    track_2 = _make_mock_track("2", uri="library://track/2")
+    track_2_mapping = MagicMock()
+    track_2_mapping.provider_domain = "library"
+    track_2_mapping.item_id = "102"
+    track_2.provider_mappings = [track_2_mapping]
+
+    track_3 = _make_mock_track("3", uri="library://track/3")
+    track_3_mapping = MagicMock()
+    track_3_mapping.provider_domain = "library"
+    track_3_mapping.item_id = "103"
+    track_3.provider_mappings = [track_3_mapping]
+
+    tracks = [track_1, track_2, track_3]
+
+    # Mock genres for each track:
+    # Track 101: has genres 10 and 20 (matches requirement)
+    # Track 102: has only genre 10 (missing 20, should be filtered out)
+    # Track 103: has genres 10, 20, and 30 (matches requirement with extra genre)
+    async def mock_get_genres(_media_type: Any, media_id: int) -> list[MagicMock]:
+        genre_10 = MagicMock()
+        genre_10.item_id = "10"
+        genre_20 = MagicMock()
+        genre_20.item_id = "20"
+        genre_30 = MagicMock()
+        genre_30.item_id = "30"
+
+        if media_id == 101:
+            return [genre_10, genre_20]
+        if media_id == 102:
+            return [genre_10]
+        if media_id == 103:
+            return [genre_10, genre_20, genre_30]
+        return []
+
+    cast("Any", plugin.mass.music.genres).get_genres_for_media_item = mock_get_genres
+
+    # Require genres 10 AND 20
+    result = await plugin._filter_tracks_with_all_genres(cast("Any", tracks), [10, 20])
+
+    # Only tracks 1 and 3 should be returned (have both genres 10 and 20)
+    assert len(result) == 2
+    result_uris = {t.uri for t in result}
+    assert "library://track/1" in result_uris
+    assert "library://track/3" in result_uris
+    assert "library://track/2" not in result_uris
+
+
+@pytest.mark.asyncio
+async def test_filter_tracks_with_all_genres_preserves_order() -> None:
+    """_filter_tracks_with_all_genres preserves the original track order."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    # Create tracks in specific order: 103, 101, 102
+    track_3 = _make_mock_track("3", uri="library://track/3")
+    track_3_mapping = MagicMock()
+    track_3_mapping.provider_domain = "library"
+    track_3_mapping.item_id = "103"
+    track_3.provider_mappings = [track_3_mapping]
+
+    track_1 = _make_mock_track("1", uri="library://track/1")
+    track_1_mapping = MagicMock()
+    track_1_mapping.provider_domain = "library"
+    track_1_mapping.item_id = "101"
+    track_1.provider_mappings = [track_1_mapping]
+
+    track_2 = _make_mock_track("2", uri="library://track/2")
+    track_2_mapping = MagicMock()
+    track_2_mapping.provider_domain = "library"
+    track_2_mapping.item_id = "102"
+    track_2.provider_mappings = [track_2_mapping]
+
+    tracks = [track_3, track_1, track_2]
+
+    # All three tracks have both required genres
+    async def mock_get_genres(_media_type: Any, _media_id: int) -> list[MagicMock]:
+        genre_10 = MagicMock()
+        genre_10.item_id = "10"
+        genre_20 = MagicMock()
+        genre_20.item_id = "20"
+        return [genre_10, genre_20]
+
+    cast("Any", plugin.mass.music.genres).get_genres_for_media_item = mock_get_genres
+
+    result = await plugin._filter_tracks_with_all_genres(cast("Any", tracks), [10, 20])
+
+    # Order should be preserved: track 3, track 1, track 2
+    assert len(result) == 3
+    assert result[0].uri == "library://track/3"
+    assert result[1].uri == "library://track/1"
+    assert result[2].uri == "library://track/2"
+
+
+@pytest.mark.asyncio
+async def test_filter_tracks_with_all_genres_handles_non_numeric_genre_ids() -> None:
+    """_filter_tracks_with_all_genres ignores genres with non-numeric IDs."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    track_1 = _make_mock_track("1", uri="library://track/1")
+    track_1_mapping = MagicMock()
+    track_1_mapping.provider_domain = "library"
+    track_1_mapping.item_id = "101"
+    track_1.provider_mappings = [track_1_mapping]
+
+    tracks = [track_1]
+
+    # Return a mix of numeric and non-numeric genre IDs
+    async def mock_get_genres(_media_type: Any, _media_id: int) -> list[MagicMock]:
+        genre_10 = MagicMock()
+        genre_10.item_id = "10"
+        genre_20 = MagicMock()
+        genre_20.item_id = "20"
+        genre_invalid = MagicMock()
+        genre_invalid.item_id = "bandcamp:123-456"  # non-numeric
+        return [genre_10, genre_20, genre_invalid]
+
+    cast("Any", plugin.mass.music.genres).get_genres_for_media_item = mock_get_genres
+
+    # Should still match because track has genres 10 and 20 (ignoring the invalid one)
+    result = await plugin._filter_tracks_with_all_genres(cast("Any", tracks), [10, 20])
+
+    assert len(result) == 1
+    assert result[0].uri == "library://track/1"

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -1303,6 +1303,7 @@ async def test_enrich_tracks_with_db_genres_only_queries_library_tracks() -> Non
     )
 
     mass.music.genres.get_genres_for_media_item = AsyncMock()
+    mass.music.tracks.get_library_item_by_prov_id = AsyncMock(return_value=None)
 
     await plugin._enrich_tracks_with_db_genres([streaming_track])
 
@@ -1423,6 +1424,9 @@ async def test_enrich_tracks_with_db_genres_handles_duplicate_item_ids() -> None
     mass.music.genres.get_genres_for_media_item = AsyncMock(
         return_value=[rock_genre, alternative_genre]
     )
+    library_track = MagicMock()
+    library_track.item_id = "123"
+    mass.music.tracks.get_library_item_by_prov_id = AsyncMock(return_value=library_track)
 
     await plugin._enrich_tracks_with_db_genres([track1, track2])
 
@@ -1855,7 +1859,7 @@ async def test_refresh_ai_description_skips_flush_when_unchanged(tmp_path: Any) 
 
 
 @pytest.mark.asyncio
-async def test_filter_tracks_with_all_genres_filters_correctly() -> None:
+async def test_filter_tracks_with_all_genres_filters_correctly() -> None:  # noqa: PLR0915
     """_filter_tracks_with_all_genres returns only tracks that have ALL required genres."""
     mass = MagicMock()
     manifest = MagicMock()
@@ -1870,13 +1874,14 @@ async def test_filter_tracks_with_all_genres_filters_correctly() -> None:
     track_1.provider = "library"
     track_1.item_id = "101"
 
-    # Track 2: Spotify track with library mapping (item_id is library DB ID)
+    # Track 2: Spotify track with library mapping
     track_2 = _make_mock_track("2", uri="spotify://track/abc")
     track_2.provider = "spotify"
     track_2.item_id = "abc"
     track_2_mapping = MagicMock()
     track_2_mapping.provider_domain = "spotify"
-    track_2_mapping.item_id = "102"  # This is the library DB ID
+    track_2_mapping.provider_instance = None
+    track_2_mapping.item_id = "abc"  # Provider's item ID
     track_2.provider_mappings = [track_2_mapping]
 
     # Track 3: Apple Music track with library mapping
@@ -1885,10 +1890,27 @@ async def test_filter_tracks_with_all_genres_filters_correctly() -> None:
     track_3.item_id = "xyz"
     track_3_mapping = MagicMock()
     track_3_mapping.provider_domain = "apple_music"
-    track_3_mapping.item_id = "103"  # This is the library DB ID
+    track_3_mapping.provider_instance = None
+    track_3_mapping.item_id = "xyz"  # Provider's item ID
     track_3.provider_mappings = [track_3_mapping]
 
     tracks = [track_1, track_2, track_3]
+
+    # Mock get_library_item_by_prov_id to resolve provider items to library items
+    async def mock_get_library_item(
+        item_id: str, provider_instance_id_or_domain: str
+    ) -> MagicMock | None:
+        if provider_instance_id_or_domain == "spotify" and item_id == "abc":
+            lib_track = MagicMock()
+            lib_track.item_id = "102"  # Library DB ID
+            return lib_track
+        if provider_instance_id_or_domain == "apple_music" and item_id == "xyz":
+            lib_track = MagicMock()
+            lib_track.item_id = "103"  # Library DB ID
+            return lib_track
+        return None
+
+    cast("Any", plugin.mass.music.tracks).get_library_item_by_prov_id = mock_get_library_item
 
     # Mock genres for each track:
     # Track 101: has genres 10 and 20 (matches requirement)
@@ -1943,7 +1965,8 @@ async def test_filter_tracks_with_all_genres_preserves_order() -> None:
     track_1.item_id = "abc"
     track_1_mapping = MagicMock()
     track_1_mapping.provider_domain = "spotify"
-    track_1_mapping.item_id = "101"
+    track_1_mapping.provider_instance = None
+    track_1_mapping.item_id = "abc"  # Provider's item ID
     track_1.provider_mappings = [track_1_mapping]
 
     track_2 = _make_mock_track("2", uri="apple_music://track/xyz")
@@ -1951,10 +1974,27 @@ async def test_filter_tracks_with_all_genres_preserves_order() -> None:
     track_2.item_id = "xyz"
     track_2_mapping = MagicMock()
     track_2_mapping.provider_domain = "apple_music"
-    track_2_mapping.item_id = "102"
+    track_2_mapping.provider_instance = None
+    track_2_mapping.item_id = "xyz"  # Provider's item ID
     track_2.provider_mappings = [track_2_mapping]
 
     tracks = [track_3, track_1, track_2]
+
+    # Mock get_library_item_by_prov_id to resolve provider items to library items
+    async def mock_get_library_item(
+        item_id: str, provider_instance_id_or_domain: str
+    ) -> MagicMock | None:
+        if provider_instance_id_or_domain == "spotify" and item_id == "abc":
+            lib_track = MagicMock()
+            lib_track.item_id = "101"  # Library DB ID
+            return lib_track
+        if provider_instance_id_or_domain == "apple_music" and item_id == "xyz":
+            lib_track = MagicMock()
+            lib_track.item_id = "102"  # Library DB ID
+            return lib_track
+        return None
+
+    cast("Any", plugin.mass.music.tracks).get_library_item_by_prov_id = mock_get_library_item
 
     # All three tracks have both required genres
     async def mock_get_genres(_media_type: Any, _media_id: int) -> list[MagicMock]:


### PR DESCRIPTION
# What does this implement/fix?

When using 'Match all' (AND logic) with multiple genres in smart playlists, tracks that have ANY of the selected genres were returned instead of only tracks that have ALL of them.

## Fixes

1. **AND logic filtering:** The SQL query used `genre_id IN (10, 20)` which implements OR logic. Added post-filtering after the database query to ensure tracks have all required genre IDs when AND logic is used.

2. **Genre enrichment logic:** Corrected provider mapping resolution based on actual database structure:
   - Library tracks: Use `track.provider == "library"` with `track.item_id` as DB ID
   - Streaming tracks: Use `mapping.item_id` from `provider_mappings` as the library DB ID (not `provider_domain == "library"` which never exists in the database)

**Related issue (if applicable):**

- Fixes https://github.com/music-assistant/support/issues/5738

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.