### PR TITLE
Add playlist metadata infrastructure to MetadataProvider

### DIFF
--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -13,9 +13,8 @@ from contextlib import suppress
 from dataclasses import replace
 from time import time
 from typing import TYPE_CHECKING, cast
-from uuid import uuid4
 
-from music_assistant_models.enums import AlbumType, ImageType, MediaType, ProviderFeature
+from music_assistant_models.enums import AlbumType, MediaType, ProviderFeature
 from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.helpers import get_global_cache_value
 from music_assistant_models.media_items import Album, Artist, MediaItemImage, Track
@@ -369,36 +368,33 @@ class MetadataEnrichmentMixin:
         playlist_genres_filtered = {genre for genre, count in playlist_genres.items() if count > 5}
         playlist_genres_filtered = set(list(playlist_genres_filtered)[:8])
         playlist.metadata.genres.update(playlist_genres_filtered)
-        # create collage images
-        cur_images: list[MediaItemImage] = playlist.metadata.images or []
-        new_images = []
-        # thumb image
-        thumb_image = next((x for x in cur_images if x.type == ImageType.THUMB), None)
-        if not thumb_image or self._collage_images_dir in thumb_image.path:
-            img_filename = thumb_image.path if thumb_image else f"{uuid4().hex}_thumb.jpg"
-            if collage_thumb_image := await self.create_collage_image(
-                all_playlist_tracks_images, img_filename
-            ):
-                new_images.append(collage_thumb_image)
-        elif thumb_image:
-            # just use old image
-            new_images.append(thumb_image)
-        # fanart image
-        fanart_image = next((x for x in cur_images if x.type == ImageType.FANART), None)
-        if not fanart_image or self._collage_images_dir in fanart_image.path:
-            img_filename = fanart_image.path if fanart_image else f"{uuid4().hex}_fanart.jpg"
-            if collage_fanart_image := await self.create_collage_image(
-                all_playlist_tracks_images, img_filename, fanart=True
-            ):
-                new_images.append(collage_fanart_image)
-        elif fanart_image:
-            # just use old image
-            new_images.append(fanart_image)
-        playlist.metadata.images = UniqueList(new_images) if new_images else None
+
+        # Collect metadata from metadata providers (e.g. playlist_metadata)
+        for provider in self.providers:
+            if ProviderFeature.PLAYLIST_METADATA not in provider.supported_features:
+                continue
+            try:
+                if prov_metadata := await provider.get_playlist_metadata(playlist):
+                    playlist.metadata.update(prov_metadata)
+                    self.logger.debug(
+                        "Retrieved playlist metadata from provider %s for %s",
+                        provider.name,
+                        playlist.name,
+                    )
+            except Exception as err:
+                self.logger.warning(
+                    "Error retrieving playlist metadata from provider %s for %s: %s",
+                    provider.name,
+                    playlist.name,
+                    err,
+                    exc_info=err if self.logger.isEnabledFor(10) else None,
+                )
         # set timestamp, used to determine when this function was last called
         playlist.metadata.last_refresh = int(time())
         # update final item in library database
-        await self.mass.music.playlists.update_item_in_library(playlist.item_id, playlist)
+        await self.mass.music.playlists.update_item_in_library(
+            playlist.item_id, playlist, overwrite=True
+        )
 
     async def _update_audiobook_metadata(
         self, audiobook: Audiobook, force_refresh: bool = False

--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -18,7 +18,6 @@ from music_assistant_models.enums import AlbumType, MediaType, ProviderFeature
 from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.helpers import get_global_cache_value
 from music_assistant_models.media_items import Album, Artist, MediaItemImage, Track
-from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
 from music_assistant.helpers.compare import compare_strings
@@ -32,6 +31,7 @@ if TYPE_CHECKING:
 
     from music_assistant_models.config_entries import CoreConfig
     from music_assistant_models.media_items import Audiobook, Playlist, Podcast
+    from music_assistant_models.unique_list import UniqueList
 
     from music_assistant import MusicAssistant
     from music_assistant.models.metadata_provider import MetadataProvider

--- a/music_assistant/models/metadata_provider.py
+++ b/music_assistant/models/metadata_provider.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
         Album,
         Artist,
         MediaItemMetadata,
+        Playlist,
         RecommendationFolder,
         Track,
     )
@@ -45,6 +46,12 @@ class MetadataProvider(Provider):
     async def get_track_metadata(self, track: Track) -> MediaItemMetadata | None:
         """Retrieve metadata for a track on this Metadata provider."""
         if ProviderFeature.TRACK_METADATA in self.supported_features:
+            raise NotImplementedError
+        return None
+
+    async def get_playlist_metadata(self, playlist: Playlist) -> MediaItemMetadata | None:
+        """Retrieve metadata for a playlist on this Metadata provider."""
+        if ProviderFeature.PLAYLIST_METADATA in self.supported_features:
             raise NotImplementedError
         return None
 


### PR DESCRIPTION
# What does this implement/fix?

Adds infrastructure to MetadataProvider for collecting playlist metadata from providers using the standard pattern. This enables providers to generate custom artwork, genres, and descriptions for library playlists.

**Key changes:**
- Add `get_playlist_metadata()` method to `MetadataProvider` base class
- Update `enrichment.py` to iterate providers with `ProviderFeature.PLAYLIST_METADATA` 
- Return `MediaItemMetadata` with images wrapped in `UniqueList` following existing pattern
- Use ProviderFeature flag instead of legacy `hasattr()` check

This infrastructure enables the new `playlist_metadata` provider (#3786) and future providers to contribute metadata through the standard MetadataProvider pattern.

**Related issue (if applicable):** N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes (waiting for models#279 — mypy expects PLAYLIST_METADATA).
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable (waiting for models#279).
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

**Depends on:** music-assistant/models#279 (adds `PLAYLIST_METADATA` to `ProviderFeature` enum)

**Enables:** #3786 (playlist_metadata provider implementation)