### PR TITLE
Fix min/max volume scaling lost on protocol/external volume redirect

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -3757,15 +3757,20 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                     f"Player control {control_name} is not available"
                 )
             assert player_control.volume_set is not None
-            await player_control.volume_set(volume_level)
+            # forward the already-scaled device volume; the external control sets the
+            # raw device volume and does not apply min/max scaling of its own
+            await player_control.volume_set(device_volume)
             return
         if protocol_player := self.get_player(player.state.volume_control):
-            # redirect to protocol player volume control
+            # redirect to protocol player volume control.
+            # forward the already-scaled device volume so the min/max limits configured
+            # on this (user-facing) player are honored; the protocol player has no
+            # limits of its own, so its scaling is an identity pass-through.
             self.logger.debug(
                 "Redirecting volume command to protocol player %s",
                 protocol_player.provider.manifest.name,
             )
-            await self._handle_cmd_volume_set(protocol_player.player_id, volume_level)
+            await self._handle_cmd_volume_set(protocol_player.player_id, device_volume)
             return
 
     async def _handle_play_media(self, player_id: str, media: PlayerMedia) -> None:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
 from music_assistant_models.enums import EventType, PlaybackState, PlayerFeature, PlayerType
 from music_assistant_models.errors import InvalidDataError, UnsupportedFeaturedException
 from music_assistant_models.player import PlayerSource
@@ -899,6 +900,91 @@ class TestMirrorsParentMedia:
         """A self-referential active_group/synced_to is not a real parent, so resolve locally."""
         player = self._fake_player(player_id="p1", synced_to="p1", active_group="p1")
         assert controller._mirrors_parent_media(player) is False  # type: ignore[arg-type]
+
+
+class TestVolumeScalingOnRedirect:
+    """min/max volume scaling must survive a redirect to a protocol player or external control."""
+
+    @staticmethod
+    def _volume_player(
+        player_id: str,
+        volume_control: str,
+        volume_set: AsyncMock | None = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            player_id=player_id,
+            type=PlayerType.PLAYER,
+            protocol_parent_id=None,
+            extra_data={},
+            volume_control=volume_control,
+            volume_set=volume_set or AsyncMock(),
+            update_state=MagicMock(),
+            provider=MagicMock(),
+            state=SimpleNamespace(
+                name=player_id,
+                volume_control=volume_control,
+                volume_muted=False,
+                mute_control=PLAYER_CONTROL_NONE,
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_protocol_redirect_forwards_scaled_volume(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """A volume command redirected to a protocol player honors the user-facing max_volume."""
+
+        def _conf(player_id: str, key: str, default: object = None) -> object:
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                # user-facing player caps at 50, the protocol player has no limits of its own
+                return 50 if player_id == "user_player" else 100
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_conf)
+
+        protocol = self._volume_player("protocol_player", PLAYER_CONTROL_NATIVE)
+        user = self._volume_player("user_player", "protocol_player")
+        players = {"user_player": user, "protocol_player": protocol}
+
+        with (
+            patch.object(controller, "get_player", side_effect=players.get),
+            patch.object(controller, "_get_active_audio_source", return_value=None),
+        ):
+            controller._controls = {}
+            await controller._handle_cmd_volume_set("user_player", 100)
+
+        # logical 100 with a max_volume of 50 must reach the protocol player as 50, not the raw 100
+        protocol.volume_set.assert_awaited_once_with(50)
+
+    @pytest.mark.asyncio
+    async def test_external_control_redirect_forwards_scaled_volume(
+        self, controller: PlayerController, mock_mass: MagicMock
+    ) -> None:
+        """A volume command redirected to an external control honors the user-facing max_volume."""
+
+        def _conf(_player_id: str, key: str, default: object = None) -> object:
+            if key == "min_volume":
+                return 0
+            if key == "max_volume":
+                return 50
+            return default if default is not None else "auto"
+
+        mock_mass.config.get_raw_player_config_value = MagicMock(side_effect=_conf)
+
+        control = SimpleNamespace(name="External Amp", supports_volume=True, volume_set=AsyncMock())
+        user = self._volume_player("user_player", "ext_control")
+        players = {"user_player": user}
+
+        with (
+            patch.object(controller, "get_player", side_effect=players.get),
+            patch.object(controller, "_get_active_audio_source", return_value=None),
+        ):
+            controller._controls = {"ext_control": control}  # type: ignore[dict-item]
+            await controller._handle_cmd_volume_set("user_player", 100)
+
+        control.volume_set.assert_awaited_once_with(50)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **_NOTE:_**  Bugfix with the help of Opus4.8

# What does this implement/fix?

When a player's volume command was redirected to a linked protocol player (e.g. a non-Google Chromecast soundbar wrapped in a UniversalPlayer) or to an external PlayerControl, the already-scaled device volume was discarded and the raw logical volume was forwarded instead. The protocol redirect then re-scaled against the protocol player's own (default 0-100) limits, so the user-facing player's min/max volume config was ignored on write — even though it was correctly honored on read, producing an asymmetry where reading the volume worked but setting it did not.

Forward the already-scaled device_volume in both the external-control and protocol-redirect branches so the min/max limits configured on the user-facing player are honored. The protocol player has no limits of its own, so its scaling is an identity pass-through.

**Related issue (if applicable):**

- Not reported yet

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
