### PR TITLE
Document provider_mappings database structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,18 @@ MA stores its data in `$HOME/.musicassistant/`. When debugging locally:
 
 - **Logs:** `$HOME/.musicassistant/musicassistant.log` (current), `musicassistant.log.1`, `.log.2`, etc. for older rotated logs.
 - **Database:** `$HOME/.musicassistant/library.db` — query via `sqlite3`. **Only execute SELECT queries** — never write to a live database.
+
+### Database Structure
+
+#### `provider_mappings` table
+
+Critical structure for resolving tracks between library and external providers:
+
+- `item_id` (integer): **ALWAYS the library database ID** — this is the key for lookups
+- `provider_domain` (string): The external provider identifier (e.g., `"spotify"`, `"apple_music"`, `"tidal"`)
+- `provider_item_id` (string): The external provider's ID for this item
+- `media_type` (string): Type of media item (`"track"`, `"album"`, `"artist"`, `"playlist"`)
+
+**Important:** `provider_domain='library'` **never exists** in this table. Library items are identified by checking `track.provider == 'library'` where `track.item_id` is the library DB ID directly.
+
+For streaming provider tracks with library mappings, the `item_id` field in `provider_mappings` **IS** the library DB ID — use this to query genres, metadata, etc. from the library database.

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -877,19 +877,23 @@ class SmartPlaylistProvider(PluginProvider):
         if not tracks:
             return
 
-        # Build map of library_track_id -> list of track objects in single pass
-        # Check provider_mappings for library presence (tracks from Spotify/etc may also be in library)
         track_id_to_tracks: dict[int, list[Track]] = {}
         for t in tracks:
             if t.metadata and t.metadata.genres:
                 continue
-            for mapping in t.provider_mappings or ():
-                if mapping.provider_domain == "library" and str(mapping.item_id).isdigit():
-                    track_id = int(mapping.item_id)
-                    if track_id not in track_id_to_tracks:
-                        track_id_to_tracks[track_id] = []
-                    track_id_to_tracks[track_id].append(t)
-                    break
+            if t.provider == "library" and str(t.item_id).isdigit():
+                track_id = int(t.item_id)
+                if track_id not in track_id_to_tracks:
+                    track_id_to_tracks[track_id] = []
+                track_id_to_tracks[track_id].append(t)
+            elif t.provider_mappings:
+                for mapping in t.provider_mappings:
+                    if str(mapping.item_id).isdigit():
+                        track_id = int(mapping.item_id)
+                        if track_id not in track_id_to_tracks:
+                            track_id_to_tracks[track_id] = []
+                        track_id_to_tracks[track_id].append(t)
+                        break
         if not track_id_to_tracks:
             return
 
@@ -924,16 +928,21 @@ class SmartPlaylistProvider(PluginProvider):
 
         required_ids = set(required_genre_ids)
 
-        # Build map of library_track_id -> list of track objects
         track_id_to_tracks: dict[int, list[Track]] = {}
         for track in tracks:
-            for mapping in track.provider_mappings or ():
-                if mapping.provider_domain == "library" and str(mapping.item_id).isdigit():
-                    track_id = int(mapping.item_id)
-                    if track_id not in track_id_to_tracks:
-                        track_id_to_tracks[track_id] = []
-                    track_id_to_tracks[track_id].append(track)
-                    break
+            if track.provider == "library" and str(track.item_id).isdigit():
+                track_id = int(track.item_id)
+                if track_id not in track_id_to_tracks:
+                    track_id_to_tracks[track_id] = []
+                track_id_to_tracks[track_id].append(track)
+            elif track.provider_mappings:
+                for mapping in track.provider_mappings:
+                    if str(mapping.item_id).isdigit():
+                        track_id = int(mapping.item_id)
+                        if track_id not in track_id_to_tracks:
+                            track_id_to_tracks[track_id] = []
+                        track_id_to_tracks[track_id].append(track)
+                        break
 
         if not track_id_to_tracks:
             return []

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -915,6 +915,57 @@ class SmartPlaylistProvider(PluginProvider):
                 for genre in genres:
                     track.metadata.genres.add(genre.name)
 
+    async def _filter_tracks_with_all_genres(
+        self, tracks: list[Track], required_genre_ids: list[int]
+    ) -> list[Track]:
+        """Filter tracks to only those that have ALL required genre IDs in the database."""
+        if not tracks or not required_genre_ids:
+            return tracks
+
+        required_ids = set(required_genre_ids)
+
+        # Build map of library_track_id -> list of track objects
+        track_id_to_tracks: dict[int, list[Track]] = {}
+        for track in tracks:
+            for mapping in track.provider_mappings or ():
+                if mapping.provider_domain == "library" and str(mapping.item_id).isdigit():
+                    track_id = int(mapping.item_id)
+                    if track_id not in track_id_to_tracks:
+                        track_id_to_tracks[track_id] = []
+                    track_id_to_tracks[track_id].append(track)
+                    break
+
+        if not track_id_to_tracks:
+            return []
+
+        # Fetch genres for all track IDs in parallel
+        # With typical limits (20-50 tracks), this results in 100-250 parallel DB calls
+        # which is acceptable. Only at very high limits would we approach the 2000 max.
+        track_ids = list(track_id_to_tracks.keys())
+        genre_results = await asyncio.gather(
+            *(
+                self.mass.music.genres.get_genres_for_media_item(MediaType.TRACK, track_id)
+                for track_id in track_ids
+            )
+        )
+
+        # Build set of track IDs that have all required genres
+        matching_track_ids: set[int] = set()
+        for track_id, genres in zip(track_ids, genre_results, strict=True):
+            track_genre_ids = {
+                int(g.item_id) for g in genres if g.item_id and str(g.item_id).isdigit()
+            }
+            if required_ids.issubset(track_genre_ids):
+                matching_track_ids.add(track_id)
+
+        # Return tracks that match, preserving original order
+        result: list[Track] = []
+        for track_id in track_ids:
+            if track_id in matching_track_ids:
+                result.extend(track_id_to_tracks[track_id])
+
+        return result
+
     async def _recently_played_keys(self, dedup_hours: int) -> set[tuple[str, str]]:
         """
         Return ``(provider, item_id)`` keys of tracks fully played within dedup_hours.
@@ -974,6 +1025,10 @@ class SmartPlaylistProvider(PluginProvider):
             limit=min(rules.limit * 5, 2000),
             user_provider_filter=user_provider_filter,
         )
+
+        # When multiple genres are specified with AND logic, filter to tracks that have ALL genres
+        if has_genre and len(rules.genre_ids) > 1:
+            base_tracks = await self._filter_tracks_with_all_genres(base_tracks, rules.genre_ids)
 
         if not has_artist and not has_album:
             return base_tracks

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -1870,23 +1870,28 @@ async def test_filter_tracks_with_all_genres_filters_correctly() -> None:
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
-    # Create mock tracks with library provider mappings
-    track_1 = _make_mock_track("1", uri="library://track/1")
-    track_1_mapping = MagicMock()
-    track_1_mapping.provider_domain = "library"
-    track_1_mapping.item_id = "101"
-    track_1.provider_mappings = [track_1_mapping]
+    # Create mock tracks:
+    # Track 1: Library track (direct)
+    track_1 = _make_mock_track("1", uri="library://track/101")
+    track_1.provider = "library"
+    track_1.item_id = "101"
 
-    track_2 = _make_mock_track("2", uri="library://track/2")
+    # Track 2: Spotify track with library mapping (item_id is library DB ID)
+    track_2 = _make_mock_track("2", uri="spotify://track/abc")
+    track_2.provider = "spotify"
+    track_2.item_id = "abc"
     track_2_mapping = MagicMock()
-    track_2_mapping.provider_domain = "library"
-    track_2_mapping.item_id = "102"
+    track_2_mapping.provider_domain = "spotify"
+    track_2_mapping.item_id = "102"  # This is the library DB ID
     track_2.provider_mappings = [track_2_mapping]
 
-    track_3 = _make_mock_track("3", uri="library://track/3")
+    # Track 3: Apple Music track with library mapping
+    track_3 = _make_mock_track("3", uri="apple_music://track/xyz")
+    track_3.provider = "apple_music"
+    track_3.item_id = "xyz"
     track_3_mapping = MagicMock()
-    track_3_mapping.provider_domain = "library"
-    track_3_mapping.item_id = "103"
+    track_3_mapping.provider_domain = "apple_music"
+    track_3_mapping.item_id = "103"  # This is the library DB ID
     track_3.provider_mappings = [track_3_mapping]
 
     tracks = [track_1, track_2, track_3]
@@ -1919,9 +1924,9 @@ async def test_filter_tracks_with_all_genres_filters_correctly() -> None:
     # Only tracks 1 and 3 should be returned (have both genres 10 and 20)
     assert len(result) == 2
     result_uris = {t.uri for t in result}
-    assert "library://track/1" in result_uris
-    assert "library://track/3" in result_uris
-    assert "library://track/2" not in result_uris
+    assert "library://track/101" in result_uris
+    assert "apple_music://track/xyz" in result_uris
+    assert "spotify://track/abc" not in result_uris
 
 
 @pytest.mark.asyncio
@@ -1935,21 +1940,23 @@ async def test_filter_tracks_with_all_genres_preserves_order() -> None:
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
     # Create tracks in specific order: 103, 101, 102
-    track_3 = _make_mock_track("3", uri="library://track/3")
-    track_3_mapping = MagicMock()
-    track_3_mapping.provider_domain = "library"
-    track_3_mapping.item_id = "103"
-    track_3.provider_mappings = [track_3_mapping]
+    track_3 = _make_mock_track("3", uri="library://track/103")
+    track_3.provider = "library"
+    track_3.item_id = "103"
 
-    track_1 = _make_mock_track("1", uri="library://track/1")
+    track_1 = _make_mock_track("1", uri="spotify://track/abc")
+    track_1.provider = "spotify"
+    track_1.item_id = "abc"
     track_1_mapping = MagicMock()
-    track_1_mapping.provider_domain = "library"
+    track_1_mapping.provider_domain = "spotify"
     track_1_mapping.item_id = "101"
     track_1.provider_mappings = [track_1_mapping]
 
-    track_2 = _make_mock_track("2", uri="library://track/2")
+    track_2 = _make_mock_track("2", uri="apple_music://track/xyz")
+    track_2.provider = "apple_music"
+    track_2.item_id = "xyz"
     track_2_mapping = MagicMock()
-    track_2_mapping.provider_domain = "library"
+    track_2_mapping.provider_domain = "apple_music"
     track_2_mapping.item_id = "102"
     track_2.provider_mappings = [track_2_mapping]
 
@@ -1969,9 +1976,9 @@ async def test_filter_tracks_with_all_genres_preserves_order() -> None:
 
     # Order should be preserved: track 3, track 1, track 2
     assert len(result) == 3
-    assert result[0].uri == "library://track/3"
-    assert result[1].uri == "library://track/1"
-    assert result[2].uri == "library://track/2"
+    assert result[0].uri == "library://track/103"
+    assert result[1].uri == "spotify://track/abc"
+    assert result[2].uri == "apple_music://track/xyz"
 
 
 @pytest.mark.asyncio
@@ -1984,11 +1991,9 @@ async def test_filter_tracks_with_all_genres_handles_non_numeric_genre_ids() -> 
     config.get_value.return_value = "GLOBAL"
     plugin = SmartPlaylistProvider(mass, manifest, config, set())
 
-    track_1 = _make_mock_track("1", uri="library://track/1")
-    track_1_mapping = MagicMock()
-    track_1_mapping.provider_domain = "library"
-    track_1_mapping.item_id = "101"
-    track_1.provider_mappings = [track_1_mapping]
+    track_1 = _make_mock_track("1", uri="library://track/101")
+    track_1.provider = "library"
+    track_1.item_id = "101"
 
     tracks = [track_1]
 
@@ -2008,4 +2013,4 @@ async def test_filter_tracks_with_all_genres_handles_non_numeric_genre_ids() -> 
     result = await plugin._filter_tracks_with_all_genres(cast("Any", tracks), [10, 20])
 
     assert len(result) == 1
-    assert result[0].uri == "library://track/1"
+    assert result[0].uri == "library://track/101"

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -1853,3 +1853,159 @@ async def test_refresh_ai_description_skips_flush_when_unchanged(tmp_path: Any) 
     await plugin._refresh_ai_description("abc")
 
     cast("Any", plugin)._flush_rules_to_disk.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Genre AND logic filtering tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_filter_tracks_with_all_genres_filters_correctly() -> None:
+    """_filter_tracks_with_all_genres returns only tracks that have ALL required genres."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    # Create mock tracks with library provider mappings
+    track_1 = _make_mock_track("1", uri="library://track/1")
+    track_1_mapping = MagicMock()
+    track_1_mapping.provider_domain = "library"
+    track_1_mapping.item_id = "101"
+    track_1.provider_mappings = [track_1_mapping]
+
+    track_2 = _make_mock_track("2", uri="library://track/2")
+    track_2_mapping = MagicMock()
+    track_2_mapping.provider_domain = "library"
+    track_2_mapping.item_id = "102"
+    track_2.provider_mappings = [track_2_mapping]
+
+    track_3 = _make_mock_track("3", uri="library://track/3")
+    track_3_mapping = MagicMock()
+    track_3_mapping.provider_domain = "library"
+    track_3_mapping.item_id = "103"
+    track_3.provider_mappings = [track_3_mapping]
+
+    tracks = [track_1, track_2, track_3]
+
+    # Mock genres for each track:
+    # Track 101: has genres 10 and 20 (matches requirement)
+    # Track 102: has only genre 10 (missing 20, should be filtered out)
+    # Track 103: has genres 10, 20, and 30 (matches requirement with extra genre)
+    async def mock_get_genres(_media_type: Any, media_id: int) -> list[MagicMock]:
+        genre_10 = MagicMock()
+        genre_10.item_id = "10"
+        genre_20 = MagicMock()
+        genre_20.item_id = "20"
+        genre_30 = MagicMock()
+        genre_30.item_id = "30"
+
+        if media_id == 101:
+            return [genre_10, genre_20]
+        if media_id == 102:
+            return [genre_10]
+        if media_id == 103:
+            return [genre_10, genre_20, genre_30]
+        return []
+
+    cast("Any", plugin.mass.music.genres).get_genres_for_media_item = mock_get_genres
+
+    # Require genres 10 AND 20
+    result = await plugin._filter_tracks_with_all_genres(cast("Any", tracks), [10, 20])
+
+    # Only tracks 1 and 3 should be returned (have both genres 10 and 20)
+    assert len(result) == 2
+    result_uris = {t.uri for t in result}
+    assert "library://track/1" in result_uris
+    assert "library://track/3" in result_uris
+    assert "library://track/2" not in result_uris
+
+
+@pytest.mark.asyncio
+async def test_filter_tracks_with_all_genres_preserves_order() -> None:
+    """_filter_tracks_with_all_genres preserves the original track order."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    # Create tracks in specific order: 103, 101, 102
+    track_3 = _make_mock_track("3", uri="library://track/3")
+    track_3_mapping = MagicMock()
+    track_3_mapping.provider_domain = "library"
+    track_3_mapping.item_id = "103"
+    track_3.provider_mappings = [track_3_mapping]
+
+    track_1 = _make_mock_track("1", uri="library://track/1")
+    track_1_mapping = MagicMock()
+    track_1_mapping.provider_domain = "library"
+    track_1_mapping.item_id = "101"
+    track_1.provider_mappings = [track_1_mapping]
+
+    track_2 = _make_mock_track("2", uri="library://track/2")
+    track_2_mapping = MagicMock()
+    track_2_mapping.provider_domain = "library"
+    track_2_mapping.item_id = "102"
+    track_2.provider_mappings = [track_2_mapping]
+
+    tracks = [track_3, track_1, track_2]
+
+    # All three tracks have both required genres
+    async def mock_get_genres(_media_type: Any, _media_id: int) -> list[MagicMock]:
+        genre_10 = MagicMock()
+        genre_10.item_id = "10"
+        genre_20 = MagicMock()
+        genre_20.item_id = "20"
+        return [genre_10, genre_20]
+
+    cast("Any", plugin.mass.music.genres).get_genres_for_media_item = mock_get_genres
+
+    result = await plugin._filter_tracks_with_all_genres(cast("Any", tracks), [10, 20])
+
+    # Order should be preserved: track 3, track 1, track 2
+    assert len(result) == 3
+    assert result[0].uri == "library://track/3"
+    assert result[1].uri == "library://track/1"
+    assert result[2].uri == "library://track/2"
+
+
+@pytest.mark.asyncio
+async def test_filter_tracks_with_all_genres_handles_non_numeric_genre_ids() -> None:
+    """_filter_tracks_with_all_genres ignores genres with non-numeric IDs."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    track_1 = _make_mock_track("1", uri="library://track/1")
+    track_1_mapping = MagicMock()
+    track_1_mapping.provider_domain = "library"
+    track_1_mapping.item_id = "101"
+    track_1.provider_mappings = [track_1_mapping]
+
+    tracks = [track_1]
+
+    # Return a mix of numeric and non-numeric genre IDs
+    async def mock_get_genres(_media_type: Any, _media_id: int) -> list[MagicMock]:
+        genre_10 = MagicMock()
+        genre_10.item_id = "10"
+        genre_20 = MagicMock()
+        genre_20.item_id = "20"
+        genre_invalid = MagicMock()
+        genre_invalid.item_id = "bandcamp:123-456"  # non-numeric
+        return [genre_10, genre_20, genre_invalid]
+
+    cast("Any", plugin.mass.music.genres).get_genres_for_media_item = mock_get_genres
+
+    # Should still match because track has genres 10 and 20 (ignoring the invalid one)
+    result = await plugin._filter_tracks_with_all_genres(cast("Any", tracks), [10, 20])
+
+    assert len(result) == 1
+    assert result[0].uri == "library://track/1"


### PR DESCRIPTION
# What does this implement/fix?

Adds critical documentation about the `provider_mappings` database table structure to AGENTS.md to help prevent AI-generated code from making incorrect assumptions about the schema.

This addresses a pattern where Copilot (both in code generation and PR reviews) incorrectly suggests using `provider_domain='library'` which never exists in the database.

## Changes

Added a "Database Structure" section under "Debugging" in AGENTS.md documenting:
- `provider_mappings` table schema
- `item_id` is ALWAYS the library DB ID
- `provider_domain` identifies external providers (spotify, apple_music, etc.)
- `provider_domain='library'` never exists
- Library items are identified via `track.provider=='library'`

**Related issue (if applicable):**

- Related to #4459 (where this incorrect pattern was discovered)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.