### PR TITLE
Document provider_mappings database structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,17 +64,18 @@ MA stores its data in `$HOME/.musicassistant/`. When debugging locally:
 - **Logs:** `$HOME/.musicassistant/musicassistant.log` (current), `musicassistant.log.1`, `.log.2`, etc. for older rotated logs.
 - **Database:** `$HOME/.musicassistant/library.db` — query via `sqlite3`. **Only execute SELECT queries** — never write to a live database.
 
-### Database Structure
+### Provider Mappings
 
-#### `provider_mappings` table
+Every `MediaItem` (track, album, artist, playlist) has a `provider_mappings` attribute containing mappings between library items and external providers:
 
-Critical structure for resolving tracks between library and external providers:
+- `item_id` (str): The external provider's item ID (e.g., `"spotify--track123"`)
+- `provider_domain` (str): The external provider identifier (e.g., `"spotify"`, `"apple_music"`, `"tidal"`)
+- `provider_instance` (str): Optional provider instance ID if multiple instances of same provider exist
+- `media_type` (MediaType): Type of media item (track, album, artist, playlist)
 
-- `item_id` (integer): **ALWAYS the library database ID** — this is the key for lookups
-- `provider_domain` (string): The external provider identifier (e.g., `"spotify"`, `"apple_music"`, `"tidal"`)
-- `provider_item_id` (string): The external provider's ID for this item
-- `media_type` (string): Type of media item (`"track"`, `"album"`, `"artist"`, `"playlist"`)
+**Important patterns:**
 
-**Important:** `provider_domain='library'` **never exists** in this table. Library items are identified by checking `track.provider == 'library'` where `track.item_id` is the library DB ID directly.
-
-For streaming provider tracks with library mappings, the `item_id` field in `provider_mappings` **IS** the library DB ID — use this to query genres, metadata, etc. from the library database.
+- Library items are identified by `item.provider == "library"` where `item.item_id` is the library DB ID
+- `provider_domain='library'` **never exists** in provider_mappings — library items don't have mappings to themselves
+- To resolve a provider item to its library equivalent, use: `await mass.music.tracks.get_library_item_by_prov_id(item_id, provider_instance_id_or_domain)`
+- Never assume you can use `mapping.item_id` directly as a library DB ID — always use the resolution method above

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,16 +66,19 @@ MA stores its data in `$HOME/.musicassistant/`. When debugging locally:
 
 ### Provider Mappings
 
-Every `MediaItem` (track, album, artist, playlist) has a `provider_mappings` attribute containing mappings between library items and external providers:
+Every `MediaItem` (track, album, artist, playlist) has a `provider_mappings` attribute containing the exact mappings of the item on (each) provider. For a MediaItem that comes from a musicprovider directly, this will usually contain one single ID-mapping (although it is possible that a provider has multiple mappings). For library items, this will contain all mappings of all providers connected to the item.
 
-- `item_id` (str): The external provider's item ID (e.g., `"spotify--track123"`)
-- `provider_domain` (str): The external provider identifier (e.g., `"spotify"`, `"apple_music"`, `"tidal"`)
-- `provider_instance` (str): Optional provider instance ID if multiple instances of same provider exist
-- `media_type` (MediaType): Type of media item (track, album, artist, playlist)
+The ProviderMapping has this structure:
+
+- `item_id` (str): The music provider's item ID (e.g., `"spotify--track123"`)
+- `provider_domain` (str): The musicprovider's domain (e.g., `"spotify"`, `"apple_music"`, `"tidal"`)
+- `provider_instance` (str): The provider instance ID (to handle multiple instances of the same provider).
+- some more details such as the quality (relevant in case of album or track)
 
 **Important patterns:**
 
+- A media item itself also has an item_id and provider attribute. For an item that comes straight from the musicprovider itself (so not from the MA library) the provider attribute will be set to the instance_id of that provider.
 - Library items are identified by `item.provider == "library"` where `item.item_id` is the library DB ID
 - `provider_domain='library'` **never exists** in provider_mappings — library items don't have mappings to themselves
-- To resolve a provider item to its library equivalent, use: `await mass.music.tracks.get_library_item_by_prov_id(item_id, provider_instance_id_or_domain)`
+- To resolve a provider item to its library equivalent, use: `await mass.music.<mediatype>.get_library_item_by_prov_id(item_id, provider_instance_id_or_domain)`
 - Never assume you can use `mapping.item_id` directly as a library DB ID — always use the resolution method above

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,18 @@ MA stores its data in `$HOME/.musicassistant/`. When debugging locally:
 
 - **Logs:** `$HOME/.musicassistant/musicassistant.log` (current), `musicassistant.log.1`, `.log.2`, etc. for older rotated logs.
 - **Database:** `$HOME/.musicassistant/library.db` — query via `sqlite3`. **Only execute SELECT queries** — never write to a live database.
+
+### Database Structure
+
+#### `provider_mappings` table
+
+Critical structure for resolving tracks between library and external providers:
+
+- `item_id` (integer): **ALWAYS the library database ID** — this is the key for lookups
+- `provider_domain` (string): The external provider identifier (e.g., `"spotify"`, `"apple_music"`, `"tidal"`)
+- `provider_item_id` (string): The external provider's ID for this item
+- `media_type` (string): Type of media item (`"track"`, `"album"`, `"artist"`, `"playlist"`)
+
+**Important:** `provider_domain='library'` **never exists** in this table. Library items are identified by checking `track.provider == 'library'` where `track.item_id` is the library DB ID directly.
+
+For streaming provider tracks with library mappings, the `item_id` field in `provider_mappings` **IS** the library DB ID — use this to query genres, metadata, etc. from the library database.


### PR DESCRIPTION
## What does this implement/fix?

Adds critical documentation about the `provider_mappings` database table structure to AGENTS.md to help prevent AI-generated code from making incorrect assumptions about the schema.

This addresses a pattern where Copilot (both in code generation and PR reviews) incorrectly suggests using `provider_domain='library'` which never exists in the database.

## Changes

Added a "Database Structure" section under "Debugging" in AGENTS.md documenting:
- `provider_mappings` table schema
- `item_id` is ALWAYS the library DB ID
- `provider_domain` identifies external providers (spotify, apple_music, etc.)
- `provider_domain='library'` never exists
- Library items are identified via `track.provider=='library'`

**Related issue (if applicable):**
- Related to #4459 (where this incorrect pattern was discovered)

## Types of changes
- [x] Documentation only — `documentation`

## Checklist
- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's AI Policy https://github.com/music-assistant/.github/blob/main/AI_POLICY.md for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.