### PR TITLE
Improve Hue entertainment start reliability for slow DTLS handshakes

### DIFF
--- a/music_assistant/providers/hue_entertainment/bridge.py
+++ b/music_assistant/providers/hue_entertainment/bridge.py
@@ -46,6 +46,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from hue_entertainment import EntertainmentArea
+    from hue_entertainment.api import HueEntertainmentAPI
 
     from music_assistant.providers.sendspin.provider import SendspinProvider
 
@@ -62,6 +63,11 @@ _RENDER_PERIOD_S = 1.0 / _RENDER_RATE_HZ
 # (channel rise/decay, bass baseline) are tuned for ~20 Hz spectrum input; the
 # DTLS render loop runs faster and interpolates.
 _VISUALIZER_RATE_HZ = 20
+
+# Session start retries when the bridge is slow to complete the DTLS handshake.
+_ENTERTAINMENT_START_ATTEMPTS = 6
+_ENTERTAINMENT_START_BACKOFF_S = 1.5
+_ENTERTAINMENT_STALE_COOLDOWN_S = 1.0
 
 
 class HueEntertainmentBridge:
@@ -262,7 +268,8 @@ class HueEntertainmentBridge:
         # entertainment stream active.
         adopted = False
         try:
-            for attempt in range(3):
+            await self._clear_stale_entertainment(hue_api)
+            for attempt in range(_ENTERTAINMENT_START_ATTEMPTS):
                 try:
                     await session.start(self.area.id)
                     self._session = session
@@ -278,11 +285,13 @@ class HueEntertainmentBridge:
                         self.area.name,
                         err,
                     )
-                    if attempt < 2:
-                        await asyncio.sleep(0.5)
+                    if attempt + 1 < _ENTERTAINMENT_START_ATTEMPTS:
+                        await asyncio.sleep(_ENTERTAINMENT_START_BACKOFF_S)
 
             self.logger.error(
-                "Failed to start entertainment for '%s' after 3 attempts", self.area.name
+                "Failed to start entertainment for '%s' after %d attempts",
+                self.area.name,
+                _ENTERTAINMENT_START_ATTEMPTS,
             )
         finally:
             self._entertainment_starting = False
@@ -422,6 +431,25 @@ class HueEntertainmentBridge:
         finally:
             if self._is_streaming:
                 self._render_handle = self.mass.loop.call_later(_RENDER_PERIOD_S, self._render_tick)
+
+    async def _clear_stale_entertainment(self, hue_api: HueEntertainmentAPI) -> None:
+        """
+        Stop entertainment left active on the bridge from a prior failed handshake.
+
+        :param hue_api: Authenticated Hue REST client for this bridge.
+        """
+        try:
+            status, _rid = await hue_api.get_entertainment_status(self.area.id)
+        except Exception:
+            return
+        if status != "active":
+            return
+        self.logger.info(
+            "Entertainment area '%s' still active on bridge, clearing before DTLS",
+            self.area.name,
+        )
+        await hue_api.stop_entertainment(self.area.id)
+        await asyncio.sleep(_ENTERTAINMENT_STALE_COOLDOWN_S)
 
 
 class HueEntertainmentBridgeManager:

--- a/music_assistant/providers/hue_entertainment/manifest.json
+++ b/music_assistant/providers/hue_entertainment/manifest.json
@@ -5,7 +5,7 @@
   "name": "Hue Lights Sync",
   "description": "Sync Philips Hue lights to music using Entertainment Mode.",
   "codeowners": ["@music-assistant"],
-  "requirements": ["hue-entertainment==0.1.1"],
+  "requirements": ["hue-entertainment==0.1.2"],
   "documentation": "https://music-assistant.io/plugins/hue-entertainment/",
   "multi_instance": true,
   "builtin": false,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ fastmcp==3.3.1
 getmac==0.9.5
 gql[all]==4.0.0
 hass-client==1.2.3
-hue-entertainment==0.1.1
+hue-entertainment==0.1.2
 huggingface-hub==1.12.0
 ibroadcastaio==0.6.0
 ifaddr==0.2.0


### PR DESCRIPTION
# What does this implement/fix?

Hue entertainment streaming intermittently failed to start because the DTLS handshake timed out waiting for ServerHello (~5 s) after REST `start_entertainment` succeeded. The bridge often misses the first cookie ClientHello; a single short retry loop was not enough.

This PR:
- Clears stale bridge entertainment state via `get_entertainment_status` before starting DTLS
- Increases start attempts (6) with 1.5 s backoff between full start cycles
- Bumps `hue-entertainment` to **0.1.2** ([music-assistant/hue-entertainment#1](https://github.com/music-assistant/hue-entertainment/pull/1) merged and released — includes cookie ClientHello resend and `get_entertainment_status`)

**Related issue (if applicable):**

- N/A (debugged on personal dev environment)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.


Made with [Cursor](https://cursor.com)