### PR TITLE
Fix discover page not loading due to MusicBrainz recommendation scan

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -18,6 +18,10 @@ DYNAMIC_RADIO_DYNAMIC_TARGET: Final[int] = 50
 
 CACHE_CATEGORY_SEARCH_RESULTS: Final[int] = 10
 
+# max time to wait for a single provider's recommendations before skipping it,
+# so one slow provider can never block the whole discover page
+RECOMMENDATIONS_PROVIDER_TIMEOUT: Final[int] = 30
+
 DATABASE_CLEANUP_TASK_ID: Final[str] = "music_database_cleanup"
 PROVIDER_MAPPING_CORRECTION_TASK_ID: Final[str] = "music_provider_mapping_correction"
 MUSIC_SYNC_COMPLETION_CHECK_TASK_ID: Final[str] = "music_sync_completion_check"

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -64,6 +64,7 @@ from music_assistant.controllers.music.constants import (
     MUSIC_SYNC_COMPLETION_CHECK_TASK_ID,
     PROVIDER_MAPPING_CORRECTION_TASK_ID,
     RADIO_TRACK_MAX_DURATION_SECS,
+    RECOMMENDATIONS_PROVIDER_TIMEOUT,
 )
 from music_assistant.controllers.music.database import MusicDatabaseSetupMixin
 from music_assistant.controllers.music.helpers import sort_search_result
@@ -2313,7 +2314,14 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
     ) -> list[RecommendationFolder]:
         """Return recommendations from a provider."""
         try:
-            return await provider.recommendations()
+            async with asyncio.timeout(RECOMMENDATIONS_PROVIDER_TIMEOUT):
+                return await provider.recommendations()
+        except TimeoutError:
+            self.logger.warning(
+                "Timeout while fetching recommendations from %s; skipping for this request",
+                provider.name,
+            )
+            return []
         except Exception as err:
             self.logger.warning(
                 "Error while fetching recommendations from %s: %s",

--- a/music_assistant/providers/musicbrainz/provider.py
+++ b/music_assistant/providers/musicbrainz/provider.py
@@ -86,6 +86,17 @@ class MusicbrainzProvider(MetadataProvider):
         self._api_client = MusicBrainzAPIClient(self.mass)
         self._recommendations = MusicBrainzRecommendationManager(self)
 
+    async def loaded_in_mass(self) -> None:
+        """Call after the provider has been loaded."""
+        await super().loaded_in_mass()
+        # Warm the recommendation cache in the background so the discover page is never
+        # blocked by the (rate-limited) initial MusicBrainz library scan.
+        self._recommendations.schedule_refresh()
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Handle unload/close of the provider."""
+        self._recommendations.cancel()
+
     async def recommendations(self) -> list[RecommendationFolder]:
         """Return birthday/memorial recommendation folders."""
         return await self._recommendations.get_recommendations()

--- a/music_assistant/providers/musicbrainz/recommendations.py
+++ b/music_assistant/providers/musicbrainz/recommendations.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from datetime import datetime, time, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import ExternalID
 from music_assistant_models.media_items import (
+    Artist,
     BrowseFolder,
     ItemMapping,
     MediaItemType,
@@ -17,11 +18,9 @@ from music_assistant_models.media_items import (
 from music_assistant.helpers.datetime import utc as datetime_utc
 
 if TYPE_CHECKING:
-    from music_assistant_models.media_items import Artist
-
     from .provider import MusicbrainzProvider
 
-# Cache key for the precomputed recommendation folders (namespaced per provider instance).
+# Cache key for the precomputed matches (namespaced per provider instance).
 RECOMMENDATIONS_CACHE_KEY = "birthday_memoriam_recommendations"
 
 
@@ -34,87 +33,83 @@ class MusicBrainzRecommendationManager:
         self.logger = provider.logger
         self.mass = provider.mass
         self._refresh_task_id = f"{provider.instance_id}_recommendations_refresh"
-        self._daily_task_id = f"{provider.instance_id}_recommendations_daily"
 
     async def get_recommendations(self) -> list[RecommendationFolder]:
         """
-        Return the precomputed birthday/in-memoriam recommendation folders.
+        Return the birthday/in-memoriam recommendation folders.
 
-        The result is served from cache so the discover page is never blocked by the
-        rate-limited MusicBrainz library scan; the scan runs in the background and
-        populates the cache (see :meth:`schedule_refresh`).
+        Served from cache so the discover page is never blocked by the rate-limited
+        MusicBrainz library scan. If the cache has expired, the last-known-good result
+        is served immediately (stale-while-revalidate) while a fresh scan runs in the
+        background; day labels are derived against the current day on every read, so
+        stale data stays correctly labelled and entries that fell out of the window are
+        dropped.
         """
-        cached: list[RecommendationFolder] | None = await self.mass.cache.get(
+        matches = await self.mass.cache.get(
+            RECOMMENDATIONS_CACHE_KEY, provider=self.provider.instance_id, default=None
+        )
+        if matches is not None:
+            return self._folders_from_matches(matches)
+        # Nothing fresh: refresh in the background and serve stale data if we have any.
+        self.schedule_refresh()
+        stale = await self.mass.cache.get(
             RECOMMENDATIONS_CACHE_KEY,
             provider=self.provider.instance_id,
-            base_class=RecommendationFolder,
+            allow_expired_cache=True,
             default=None,
         )
-        if cached is not None:
-            return cached
-        # Nothing computed yet (first run or past the daily expiry): kick off the
-        # background scan and return empty for now; results appear on the next load.
-        self.schedule_refresh()
+        if stale is not None:
+            return self._folders_from_matches(stale)
         return []
 
     def schedule_refresh(self) -> None:
-        """Compute and cache the recommendation folders in the background (deduplicated)."""
+        """Scan the library and refresh the cached matches in the background (deduplicated)."""
         self.mass.create_task(self._refresh(), task_id=self._refresh_task_id)
 
     def cancel(self) -> None:
-        """Cancel any pending background refresh work (called on provider unload)."""
+        """Cancel any pending background refresh (called on provider unload)."""
         self.mass.cancel_task(self._refresh_task_id)
-        self.mass.cancel_timer(self._daily_task_id)
 
     # ------------------------------------------------------------------
     # background refresh
     # ------------------------------------------------------------------
 
     async def _refresh(self) -> None:
-        """Scan the library once, cache the resulting folders, and re-arm for tomorrow."""
+        """Scan the library once and cache the matched artists keyed by month/day."""
         try:
-            folders = await self._compute_folders()
+            matches = await self._scan_matches()
         except Exception as err:
             self.logger.warning("Failed to compute MusicBrainz recommendations: %s", err)
             return
-        # Expire at the next UTC midnight so the relative day labels (today/tomorrow/...)
-        # stay correct; the daily timer below repopulates the cache right after.
+        # Expire at the next UTC midnight so the fresh path recomputes daily; the entry
+        # survives cleanup (allow_expired_cache) so it can be served as stale fallback.
         await self.mass.cache.set(
             RECOMMENDATIONS_CACHE_KEY,
-            [folder.to_dict() for folder in folders],
+            [
+                {"kind": kind, "mmdd": mmdd, "artist": artist.to_dict()}
+                for kind, mmdd, artist in matches
+            ],
             expiration=self._seconds_until_next_utc_midnight() + 60,
             provider=self.provider.instance_id,
-        )
-        self.mass.call_later(
-            self._seconds_until_next_utc_midnight() + 60,
-            self.schedule_refresh,
-            task_id=self._daily_task_id,
+            allow_expired_cache=True,
         )
 
-    async def _compute_folders(self) -> list[RecommendationFolder]:
+    async def _scan_matches(self) -> list[tuple[str, str, Artist]]:
         """
-        Build recommendation folders for artists with dates in a configurable window.
+        Scan the library for artists whose birth/death day falls in the configured window.
 
-        Scans configurable days before today through configurable days after today,
-        fetching each library artist's MusicBrainz details once and bucketing it by
-        birthday (life-span ``begin``) and/or death day (life-span ``end``).
+        Each library artist's MusicBrainz details are fetched once; matches are returned
+        as ``(kind, MM-DD, artist)`` tuples (``kind`` is ``"birthday"`` or ``"memoriam"``)
+        so the read side can re-derive day offsets for the current day.
         """
-        today = datetime_utc().date()
         days_before_after = self._days_window()
         self.logger.info(
             "MusicBrainz recommendations: scanning %d days before/after today",
             days_before_after,
         )
+        window = set(self._offset_map())
 
-        # Map each MM-DD in the window to its day offset; the window never exceeds 31
-        # days so there are no month/day collisions.
-        mmdd_to_offset: dict[str, int] = {}
-        for offset in range(-days_before_after, days_before_after + 1):
-            target_date = today + timedelta(days=offset)
-            mmdd_to_offset[f"{target_date.month:02d}-{target_date.day:02d}"] = offset
-
-        birthdays: dict[int, list[Artist]] = {}
-        memoriam: dict[int, list[Artist]] = {}
+        matches: list[tuple[str, str, Artist]] = []
         scanned = 0
         async for artist in self.mass.music.artists.iter_library_items(order_by="name"):
             mbid = artist.get_external_id(ExternalID.MB_ARTIST)
@@ -131,36 +126,52 @@ class MusicBrainzRecommendationManager:
                 continue
             begin = life_span.begin
             # Only full "YYYY-MM-DD" dates are usable; partial dates like "1990" are skipped
-            if begin and len(begin) >= 10:
-                match_offset = mmdd_to_offset.get(begin[5:10])
-                if match_offset is not None:
-                    birthdays.setdefault(match_offset, []).append(artist)
+            if begin and len(begin) >= 10 and begin[5:10] in window:
+                matches.append(("birthday", begin[5:10], artist))
             end = life_span.end
-            if life_span.ended and end and len(end) >= 10:
-                match_offset = mmdd_to_offset.get(end[5:10])
-                if match_offset is not None:
-                    memoriam.setdefault(match_offset, []).append(artist)
+            if life_span.ended and end and len(end) >= 10 and end[5:10] in window:
+                matches.append(("memoriam", end[5:10], artist))
 
         self.logger.debug("Scanned %d library artist(s) with MB IDs", scanned)
+        return matches
 
+    # ------------------------------------------------------------------
+    # folder building
+    # ------------------------------------------------------------------
+
+    def _folders_from_matches(self, matches: list[dict[str, Any]]) -> list[RecommendationFolder]:
+        """Build recommendation folders from cached matches, labelled for the current day."""
+        offset_map = self._offset_map()
+        birthdays: dict[int, list[Artist]] = {}
+        memoriam: dict[int, list[Artist]] = {}
+        for entry in matches:
+            match_offset = offset_map.get(entry["mmdd"])
+            if match_offset is None:
+                # date is no longer in the window (cache is from another day)
+                continue
+            artist = Artist.from_dict(entry["artist"])
+            bucket = birthdays if entry["kind"] == "birthday" else memoriam
+            bucket.setdefault(match_offset, []).append(artist)
+
+        days_before_after = self._days_window()
         folders: list[RecommendationFolder] = []
         for offset in range(-days_before_after, days_before_after + 1):
             day_suffix = self._get_day_suffix(offset)
             day_params = self._get_day_params(offset)
-            if matching := birthdays.get(offset):
+            if artists := birthdays.get(offset):
                 folders.extend(
                     self._build_artist_folders(
-                        matching,
+                        artists,
                         folder_id_prefix=f"birthdays_{offset}",
                         translation_key=f"artist_birthdays_{day_suffix}",
                         icon="mdi-cake-variant",
                         translation_params=day_params,
                     )
                 )
-            if matching_mem := memoriam.get(offset):
+            if artists := memoriam.get(offset):
                 folders.extend(
                     self._build_artist_folders(
-                        matching_mem,
+                        artists,
                         folder_id_prefix=f"memoriam_{offset}",
                         translation_key=f"artist_memoriam_{day_suffix}",
                         icon="mdi-candle",
@@ -169,9 +180,46 @@ class MusicBrainzRecommendationManager:
                 )
         return folders
 
+    def _build_artist_folders(
+        self,
+        artists: list[Artist],
+        *,
+        folder_id_prefix: str,
+        translation_key: str,
+        icon: str,
+        translation_params: list[str] | None = None,
+    ) -> list[RecommendationFolder]:
+        """Return a single RecommendationFolder containing all given artists."""
+        if not artists:
+            return []
+        # Use translation_key as fallback name if translation is unavailable
+        fallback_name = translation_key.replace("_", " ").title()
+        return [
+            RecommendationFolder(
+                item_id=folder_id_prefix,
+                name=fallback_name,
+                provider=self.provider.instance_id,
+                translation_key=translation_key,
+                translation_params=translation_params,
+                icon=icon,
+                items=UniqueList[MediaItemType | ItemMapping | BrowseFolder](artists),
+                is_playable=False,
+            )
+        ]
+
     # ------------------------------------------------------------------
     # helpers
     # ------------------------------------------------------------------
+
+    def _offset_map(self) -> dict[str, int]:
+        """Return a mapping of each MM-DD in the current window to its day offset."""
+        today = datetime_utc().date()
+        days_before_after = self._days_window()
+        offset_map: dict[str, int] = {}
+        for offset in range(-days_before_after, days_before_after + 1):
+            target_date = today + timedelta(days=offset)
+            offset_map[f"{target_date.month:02d}-{target_date.day:02d}"] = offset
+        return offset_map
 
     def _days_window(self) -> int:
         """Return the validated number of days to scan before/after today."""
@@ -215,30 +263,3 @@ class MusicBrainzRecommendationManager:
         if day_offset in (-1, 0, 1):
             return None
         return [str(abs(day_offset))]
-
-    def _build_artist_folders(
-        self,
-        artists: list[Artist],
-        *,
-        folder_id_prefix: str,
-        translation_key: str,
-        icon: str,
-        translation_params: list[str] | None = None,
-    ) -> list[RecommendationFolder]:
-        """Return a single RecommendationFolder containing all given artists."""
-        if not artists:
-            return []
-        # Use translation_key as fallback name if translation is unavailable
-        fallback_name = translation_key.replace("_", " ").title()
-        return [
-            RecommendationFolder(
-                item_id=folder_id_prefix,
-                name=fallback_name,
-                provider=self.provider.instance_id,
-                translation_key=translation_key,
-                translation_params=translation_params,
-                icon=icon,
-                items=UniqueList[MediaItemType | ItemMapping | BrowseFolder](artists),
-                is_playable=False,
-            )
-        ]

--- a/music_assistant/providers/musicbrainz/recommendations.py
+++ b/music_assistant/providers/musicbrainz/recommendations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import ExternalID
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 
     from .provider import MusicbrainzProvider
 
+# Cache key for the precomputed recommendation folders (namespaced per provider instance).
+RECOMMENDATIONS_CACHE_KEY = "birthday_memoriam_recommendations"
+
 
 class MusicBrainzRecommendationManager:
     """Manages MusicBrainz-based recommendations (birthdays and memorials)."""
@@ -30,98 +33,162 @@ class MusicBrainzRecommendationManager:
         self.provider = provider
         self.logger = provider.logger
         self.mass = provider.mass
+        self._refresh_task_id = f"{provider.instance_id}_recommendations_refresh"
+        self._daily_task_id = f"{provider.instance_id}_recommendations_daily"
 
     async def get_recommendations(self) -> list[RecommendationFolder]:
         """
-        Return recommendation folders for artists with dates in a configurable window.
+        Return the precomputed birthday/in-memoriam recommendation folders.
 
-        Scans configurable days before today through configurable days after today.
-        Includes:
-        - Birthday artists (born on these days)
-        - In-memoriam artists (passed away on these days)
+        The result is served from cache so the discover page is never blocked by the
+        rate-limited MusicBrainz library scan; the scan runs in the background and
+        populates the cache (see :meth:`schedule_refresh`).
+        """
+        cached: list[RecommendationFolder] | None = await self.mass.cache.get(
+            RECOMMENDATIONS_CACHE_KEY,
+            provider=self.provider.instance_id,
+            base_class=RecommendationFolder,
+            default=None,
+        )
+        if cached is not None:
+            return cached
+        # Nothing computed yet (first run or past the daily expiry): kick off the
+        # background scan and return empty for now; results appear on the next load.
+        self.schedule_refresh()
+        return []
+
+    def schedule_refresh(self) -> None:
+        """Compute and cache the recommendation folders in the background (deduplicated)."""
+        self.mass.create_task(self._refresh(), task_id=self._refresh_task_id)
+
+    def cancel(self) -> None:
+        """Cancel any pending background refresh work (called on provider unload)."""
+        self.mass.cancel_task(self._refresh_task_id)
+        self.mass.cancel_timer(self._daily_task_id)
+
+    # ------------------------------------------------------------------
+    # background refresh
+    # ------------------------------------------------------------------
+
+    async def _refresh(self) -> None:
+        """Scan the library once, cache the resulting folders, and re-arm for tomorrow."""
+        try:
+            folders = await self._compute_folders()
+        except Exception as err:
+            self.logger.warning("Failed to compute MusicBrainz recommendations: %s", err)
+            return
+        # Expire at the next UTC midnight so the relative day labels (today/tomorrow/...)
+        # stay correct; the daily timer below repopulates the cache right after.
+        await self.mass.cache.set(
+            RECOMMENDATIONS_CACHE_KEY,
+            [folder.to_dict() for folder in folders],
+            expiration=self._seconds_until_next_utc_midnight() + 60,
+            provider=self.provider.instance_id,
+        )
+        self.mass.call_later(
+            self._seconds_until_next_utc_midnight() + 60,
+            self.schedule_refresh,
+            task_id=self._daily_task_id,
+        )
+
+    async def _compute_folders(self) -> list[RecommendationFolder]:
+        """
+        Build recommendation folders for artists with dates in a configurable window.
+
+        Scans configurable days before today through configurable days after today,
+        fetching each library artist's MusicBrainz details once and bucketing it by
+        birthday (life-span ``begin``) and/or death day (life-span ``end``).
         """
         today = datetime_utc().date()
-        folders: list[RecommendationFolder] = []
-
-        # Get config values with type safety and range validation
-        days_config = self.provider.config.get_value("recommendation_days", 3)
-        try:
-            days_before_after = int(str(days_config))
-        except TypeError, ValueError:
-            days_before_after = 3
-        days_before_after = max(1, min(15, days_before_after))
-
+        days_before_after = self._days_window()
         self.logger.info(
             "MusicBrainz recommendations: scanning %d days before/after today",
             days_before_after,
         )
 
-        # Build MBID → library-artist mapping once, shared across all artist checks
-        mbid_to_artist: dict[str, Artist] = {}
+        # Map each MM-DD in the window to its day offset; the window never exceeds 31
+        # days so there are no month/day collisions.
+        mmdd_to_offset: dict[str, int] = {}
+        for offset in range(-days_before_after, days_before_after + 1):
+            target_date = today + timedelta(days=offset)
+            mmdd_to_offset[f"{target_date.month:02d}-{target_date.day:02d}"] = offset
+
+        birthdays: dict[int, list[Artist]] = {}
+        memoriam: dict[int, list[Artist]] = {}
+        scanned = 0
         async for artist in self.mass.music.artists.iter_library_items(order_by="name"):
-            if mbid := artist.get_external_id(ExternalID.MB_ARTIST):
-                mbid_to_artist[mbid] = artist
+            mbid = artist.get_external_id(ExternalID.MB_ARTIST)
+            if not mbid:
+                continue
+            scanned += 1
+            try:
+                mb_artist = await self.provider.get_artist_details(mbid)
+            except Exception as err:
+                self.logger.debug("Skipping artist %s: %s", mbid, err)
+                continue
+            life_span = mb_artist.life_span
+            if not life_span:
+                continue
+            begin = life_span.begin
+            # Only full "YYYY-MM-DD" dates are usable; partial dates like "1990" are skipped
+            if begin and len(begin) >= 10:
+                match_offset = mmdd_to_offset.get(begin[5:10])
+                if match_offset is not None:
+                    birthdays.setdefault(match_offset, []).append(artist)
+            end = life_span.end
+            if life_span.ended and end and len(end) >= 10:
+                match_offset = mmdd_to_offset.get(end[5:10])
+                if match_offset is not None:
+                    memoriam.setdefault(match_offset, []).append(artist)
 
-        self.logger.debug("Library contains %d artist(s) with MB IDs", len(mbid_to_artist))
+        self.logger.debug("Scanned %d library artist(s) with MB IDs", scanned)
 
-        # Scan configurable day window
-        for day_offset in range(-days_before_after, days_before_after + 1):
-            target_date = today + timedelta(days=day_offset)
-            target_mmdd = f"{target_date.month:02d}-{target_date.day:02d}"
-
-            # Determine translation key suffix based on day offset
-            day_suffix = self._get_day_suffix(day_offset)
-            day_params = self._get_day_params(day_offset)
-
-            # --- birthdays ---
-            birthday_mbids = await self._find_artist_mbids_by_date(
-                mbid_to_artist, target_mmdd, date_field="begin"
-            )
-            if birthday_mbids:
-                matching = [mbid_to_artist[m] for m in birthday_mbids if m in mbid_to_artist]
-                self.logger.debug(
-                    "Birthday scan for %s (%s) found %d artist(s)",
-                    target_mmdd,
-                    day_suffix,
-                    len(matching),
-                )
+        folders: list[RecommendationFolder] = []
+        for offset in range(-days_before_after, days_before_after + 1):
+            day_suffix = self._get_day_suffix(offset)
+            day_params = self._get_day_params(offset)
+            if matching := birthdays.get(offset):
                 folders.extend(
                     self._build_artist_folders(
                         matching,
-                        folder_id_prefix=f"birthdays_{day_offset}",
+                        folder_id_prefix=f"birthdays_{offset}",
                         translation_key=f"artist_birthdays_{day_suffix}",
                         icon="mdi-cake-variant",
                         translation_params=day_params,
                     )
                 )
-
-            # --- in memoriam ---
-            memoriam_mbids = await self._find_artist_mbids_by_date(
-                mbid_to_artist, target_mmdd, date_field="end"
-            )
-            if memoriam_mbids:
-                matching_mem = [mbid_to_artist[m] for m in memoriam_mbids if m in mbid_to_artist]
-                self.logger.debug(
-                    "In-memoriam scan for %s (%s) found %d artist(s)",
-                    target_mmdd,
-                    day_suffix,
-                    len(matching_mem),
-                )
+            if matching_mem := memoriam.get(offset):
                 folders.extend(
                     self._build_artist_folders(
                         matching_mem,
-                        folder_id_prefix=f"memoriam_{day_offset}",
+                        folder_id_prefix=f"memoriam_{offset}",
                         translation_key=f"artist_memoriam_{day_suffix}",
                         icon="mdi-candle",
                         translation_params=day_params,
                     )
                 )
-
         return folders
 
     # ------------------------------------------------------------------
-    # artist date helpers
+    # helpers
     # ------------------------------------------------------------------
+
+    def _days_window(self) -> int:
+        """Return the validated number of days to scan before/after today."""
+        days_config = self.provider.config.get_value("recommendation_days", 3)
+        try:
+            days_before_after = int(str(days_config))
+        except TypeError, ValueError:
+            days_before_after = 3
+        return max(1, min(15, days_before_after))
+
+    def _seconds_until_next_utc_midnight(self) -> int:
+        """Return the number of seconds until the next UTC midnight (at least 60)."""
+        now = datetime_utc()
+        next_midnight = datetime.combine(
+            now.date() + timedelta(days=1), time.min, tzinfo=now.tzinfo
+        )
+        return max(60, int((next_midnight - now).total_seconds()))
 
     def _get_day_suffix(self, day_offset: int) -> str:
         """
@@ -148,38 +215,6 @@ class MusicBrainzRecommendationManager:
         if day_offset in (-1, 0, 1):
             return None
         return [str(abs(day_offset))]
-
-    async def _find_artist_mbids_by_date(
-        self,
-        mbid_to_artist: dict[str, Artist],
-        today_mmdd: str,
-        *,
-        date_field: str,
-    ) -> list[str]:
-        """
-        Return MBIDs of library artists whose MB life-span field matches today's month/day.
-
-        :param mbid_to_artist: Mapping of MB artist ID to library Artist.
-        :param today_mmdd: Today's month-day string in ``MM-DD`` format.
-        :param date_field: Either ``"begin"`` (birthday) or ``"end"`` (death day).
-        """
-        matched: list[str] = []
-        for mbid in mbid_to_artist:
-            try:
-                mb_artist = await self.provider.get_artist_details(mbid)
-            except Exception as err:
-                self.logger.debug("Skipping artist %s: %s", mbid, err)
-                continue
-            life_span = mb_artist.life_span
-            if not life_span:
-                continue
-            raw_date = life_span.begin if date_field == "begin" else life_span.end
-            # Only full "YYYY-MM-DD" dates are usable; partial dates like "1990" are skipped
-            if raw_date and len(raw_date) >= 10 and raw_date[5:10] == today_mmdd:
-                if date_field == "end" and not life_span.ended:
-                    continue
-                matched.append(mbid)
-        return matched
 
     def _build_artist_folders(
         self,

--- a/tests/providers/musicbrainz/test_recommendations.py
+++ b/tests/providers/musicbrainz/test_recommendations.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from collections.abc import AsyncIterator, Sequence
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 from music_assistant_models.enums import ExternalID
 from music_assistant_models.media_items import (
-    Album,
     Artist,
     MediaItemMetadata,
     ProviderMapping,
@@ -18,9 +17,11 @@ from music_assistant_models.media_items import (
 from music_assistant.providers.musicbrainz.models import (
     MusicBrainzArtist,
     MusicBrainzLifeSpan,
-    MusicBrainzReleaseGroup,
 )
-from music_assistant.providers.musicbrainz.recommendations import MusicBrainzRecommendationManager
+from music_assistant.providers.musicbrainz.recommendations import (
+    RECOMMENDATIONS_CACHE_KEY,
+    MusicBrainzRecommendationManager,
+)
 
 # ---------------------------------------------------------------------------
 # helpers
@@ -47,26 +48,6 @@ def _make_artist(
     return artist
 
 
-def _make_album(
-    item_id: str,
-    name: str,
-    mb_rg_id: str | None = None,
-    year: int | None = None,
-) -> Album:
-    """Return a minimal library Album, optionally with a MB release-group external-ID."""
-    pm = ProviderMapping(
-        item_id=item_id,
-        provider_domain="test",
-        provider_instance="test",
-    )
-    album = Album(item_id=item_id, provider="test", name=name, provider_mappings={pm})
-    if mb_rg_id:
-        album.add_external_id(ExternalID.MB_RELEASEGROUP, mb_rg_id)
-    if year is not None:
-        album.year = year
-    return album
-
-
 def _make_mb_artist(
     mbid: str, begin: str | None, end: str | None = None, ended: bool = False
 ) -> MusicBrainzArtist:
@@ -75,17 +56,21 @@ def _make_mb_artist(
     return MusicBrainzArtist(id=mbid, name="stub", sort_name="stub", life_span=life_span)
 
 
-def _make_mb_release_group(
-    rg_id: str, title: str, first_release_date: str | None
-) -> MusicBrainzReleaseGroup:
-    """Return a MusicBrainzReleaseGroup with the given first release date."""
-    return MusicBrainzReleaseGroup(id=rg_id, title=title, first_release_date=first_release_date)
-
-
-async def _async_iter(items: list[object]) -> AsyncIterator[object]:
+async def _async_iter(items: Sequence[object]) -> AsyncIterator[object]:
     """Yield items from a list as an async iterator."""
     for item in items:
         yield item
+
+
+def _today_mmdd() -> str:
+    """Return today's MM-DD string in UTC."""
+    today = datetime.now(UTC).date()
+    return f"{today.month:02d}-{today.day:02d}"
+
+
+def _set_library(provider_mock: Mock, artists: list[Artist]) -> None:
+    """Wire the library artist iterator on the provider mock."""
+    provider_mock.mass.music.artists.iter_library_items = Mock(return_value=_async_iter(artists))
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +86,8 @@ def provider_mock() -> Mock:
     provider.logger = Mock()
     provider.config.get_value = Mock(return_value=3)
     provider.mass = Mock()
+    provider.mass.create_task = Mock()
+    provider.mass.call_later = Mock()
     return provider
 
 
@@ -111,80 +98,75 @@ def manager(provider_mock: Mock) -> MusicBrainzRecommendationManager:
 
 
 # ---------------------------------------------------------------------------
-# _find_artist_mbids_by_date — begin (birthday)
+# _compute_folders — birthdays
 # ---------------------------------------------------------------------------
 
 
-async def test_find_birthday_mbids_matches_exact_date(
+async def test_compute_folders_birthday_match(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Artists whose birth date matches today's MM-DD are returned."""
-    today = datetime.now(UTC).date()
-    today_mmdd = f"{today.month:02d}-{today.day:02d}"
-
+    """Only artists whose full birth date matches today's MM-DD produce a folder."""
+    today_mmdd = _today_mmdd()
     mbid_match = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     mbid_no_match = "f59c5520-5f46-4d2c-b2c4-822eabf53419"
     mbid_year_only = "c3c82bdc-d9e7-4836-9746-c24ead47ca19"
 
-    mbid_to_artist = {
-        mbid_match: _make_artist("1", "Birthday Artist", mbid=mbid_match),
-        mbid_no_match: _make_artist("2", "Other Artist", mbid=mbid_no_match),
-        mbid_year_only: _make_artist("3", "Year-Only Artist", mbid=mbid_year_only),
-    }
+    _set_library(
+        provider_mock,
+        [
+            _make_artist("1", "Birthday Artist", mbid=mbid_match),
+            _make_artist("2", "Other Artist", mbid=mbid_no_match),
+            _make_artist("3", "Year-Only Artist", mbid=mbid_year_only),
+        ],
+    )
 
     async def fake_get_artist_details(mbid: str) -> MusicBrainzArtist:
-        match_date = f"1980-{today_mmdd}"
         dates = {
-            mbid_match: match_date,
+            mbid_match: f"1980-{today_mmdd}",
             mbid_no_match: "1975-01-15",
-            mbid_year_only: "1990",
+            mbid_year_only: "1990",  # partial date, must be skipped
         }
         return _make_mb_artist(mbid, dates[mbid])
 
     provider_mock.get_artist_details = fake_get_artist_details
 
-    result = await manager._find_artist_mbids_by_date(
-        mbid_to_artist, today_mmdd, date_field="begin"
-    )
+    folders = await manager._compute_folders()
 
-    assert result == [mbid_match]
+    birthday_folders = [f for f in folders if "birthdays" in (f.translation_key or "")]
+    assert len(birthday_folders) == 1
+    assert birthday_folders[0].translation_key == "artist_birthdays_today"
+    assert birthday_folders[0].translation_params is None
+    assert [a.name for a in birthday_folders[0].items] == ["Birthday Artist"]
 
 
-async def test_find_birthday_mbids_no_life_span(
+async def test_compute_folders_no_life_span(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
     """Artists with no life_span are silently skipped."""
-    today = datetime.now(UTC).date()
-    today_mmdd = f"{today.month:02d}-{today.day:02d}"
-
     mbid = "89ad4ac3-39f7-470e-963a-56509c546377"
-    mbid_to_artist = {mbid: _make_artist("1", "No Lifespan", mbid=mbid)}
-
+    _set_library(provider_mock, [_make_artist("1", "No Lifespan", mbid=mbid)])
     provider_mock.get_artist_details = AsyncMock(return_value=_make_mb_artist(mbid, None))
 
-    result = await manager._find_artist_mbids_by_date(
-        mbid_to_artist, today_mmdd, date_field="begin"
-    )
-
-    assert result == []
+    assert await manager._compute_folders() == []
 
 
-async def test_find_birthday_mbids_api_error_skipped(
+async def test_compute_folders_api_error_skipped(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
     """API errors for individual artists are swallowed; remaining artists still checked."""
-    today = datetime.now(UTC).date()
-    today_mmdd = f"{today.month:02d}-{today.day:02d}"
-
+    today_mmdd = _today_mmdd()
     mbid_error = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     mbid_ok = "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-    mbid_to_artist = {
-        mbid_error: _make_artist("1", "Error Artist", mbid=mbid_error),
-        mbid_ok: _make_artist("2", "OK Artist", mbid=mbid_ok),
-    }
+    _set_library(
+        provider_mock,
+        [
+            _make_artist("1", "Error Artist", mbid=mbid_error),
+            _make_artist("2", "OK Artist", mbid=mbid_ok),
+        ],
+    )
 
     async def fake_get_artist_details(mbid: str) -> MusicBrainzArtist:
         if mbid == mbid_error:
@@ -194,49 +176,44 @@ async def test_find_birthday_mbids_api_error_skipped(
 
     provider_mock.get_artist_details = fake_get_artist_details
 
-    result = await manager._find_artist_mbids_by_date(
-        mbid_to_artist, today_mmdd, date_field="begin"
-    )
-
-    assert result == [mbid_ok]
+    folders = await manager._compute_folders()
+    birthday_folders = [f for f in folders if "birthdays" in (f.translation_key or "")]
+    assert len(birthday_folders) == 1
+    assert [a.name for a in birthday_folders[0].items] == ["OK Artist"]
 
 
 # ---------------------------------------------------------------------------
-# _find_artist_mbids_by_date — end (in memoriam)
+# _compute_folders — in memoriam
 # ---------------------------------------------------------------------------
 
 
-async def test_find_memoriam_mbids_matches_death_date(
+async def test_compute_folders_memoriam_match(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Artists who passed away on today's date (ended=True) are returned."""
-    today = datetime.now(UTC).date()
-    today_mmdd = f"{today.month:02d}-{today.day:02d}"
-
+    """Artists who passed away on today's date (ended=True) produce a memoriam folder."""
+    today_mmdd = _today_mmdd()
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
-    mbid_to_artist = {mbid: _make_artist("1", "Late Artist", mbid=mbid)}
-
+    _set_library(provider_mock, [_make_artist("1", "Late Artist", mbid=mbid)])
     provider_mock.get_artist_details = AsyncMock(
         return_value=_make_mb_artist(mbid, begin="1933-01-01", end=f"2006-{today_mmdd}", ended=True)
     )
 
-    result = await manager._find_artist_mbids_by_date(mbid_to_artist, today_mmdd, date_field="end")
+    folders = await manager._compute_folders()
+    memoriam_folders = [f for f in folders if "memoriam" in (f.translation_key or "")]
+    assert len(memoriam_folders) == 1
+    assert memoriam_folders[0].translation_key == "artist_memoriam_today"
+    assert [a.name for a in memoriam_folders[0].items] == ["Late Artist"]
 
-    assert result == [mbid]
 
-
-async def test_find_memoriam_skips_living_artists(
+async def test_compute_folders_skips_living_artists(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
     """Artists where ended=False are not included even if end date matches."""
-    today = datetime.now(UTC).date()
-    today_mmdd = f"{today.month:02d}-{today.day:02d}"
-
+    today_mmdd = _today_mmdd()
     mbid = "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-    mbid_to_artist = {mbid: _make_artist("1", "Living Artist", mbid=mbid)}
-
+    _set_library(provider_mock, [_make_artist("1", "Living Artist", mbid=mbid)])
     # ended=False simulates a band that broke up but members are alive
     provider_mock.get_artist_details = AsyncMock(
         return_value=_make_mb_artist(
@@ -244,9 +221,48 @@ async def test_find_memoriam_skips_living_artists(
         )
     )
 
-    result = await manager._find_artist_mbids_by_date(mbid_to_artist, today_mmdd, date_field="end")
+    assert await manager._compute_folders() == []
 
-    assert result == []
+
+# ---------------------------------------------------------------------------
+# _compute_folders — empty / no match
+# ---------------------------------------------------------------------------
+
+
+async def test_compute_folders_empty_library(
+    manager: MusicBrainzRecommendationManager,
+    provider_mock: Mock,
+) -> None:
+    """Empty library returns no folders."""
+    _set_library(provider_mock, [])
+    assert await manager._compute_folders() == []
+
+
+async def test_compute_folders_no_mbid_artists_skipped(
+    manager: MusicBrainzRecommendationManager,
+    provider_mock: Mock,
+) -> None:
+    """Library artists without an MBID are not looked up and produce no folders."""
+    _set_library(provider_mock, [_make_artist("1", "No MBID Artist")])
+    provider_mock.get_artist_details = AsyncMock(side_effect=AssertionError("should not be called"))
+    assert await manager._compute_folders() == []
+
+
+async def test_compute_folders_no_birthday_match(
+    manager: MusicBrainzRecommendationManager,
+    provider_mock: Mock,
+) -> None:
+    """Library artist with MBID but a non-window birth date produces no folders."""
+    mbid = "c3c82bdc-d9e7-4836-9746-c24ead47ca19"
+    _set_library(provider_mock, [_make_artist("1", "Wrong Birthday", mbid=mbid)])
+    # a date ~6 months out is always outside the +/- window (max 15 days)
+    far = datetime.now(UTC).date() + timedelta(days=180)
+    other_mmdd = f"{far.month:02d}-{far.day:02d}"
+    provider_mock.get_artist_details = AsyncMock(
+        return_value=_make_mb_artist(mbid, f"1985-{other_mmdd}")
+    )
+
+    assert await manager._compute_folders() == []
 
 
 # ---------------------------------------------------------------------------
@@ -294,89 +310,86 @@ def test_build_artist_folders_empty_returns_empty(
 
 
 # ---------------------------------------------------------------------------
-# get_recommendations (integration)
+# get_recommendations — cache-backed hot path
 # ---------------------------------------------------------------------------
 
 
-async def test_get_recommendations_returns_folders_for_birthday_artists(
+async def test_get_recommendations_returns_cached(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Full flow: library artist with today's birthday produces a folder."""
-    today = datetime.now(UTC).date()
-    today_mmdd = f"{today.month:02d}-{today.day:02d}"
-
-    mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
-    birthday_artist = _make_artist("10", "Birthday Star", mbid=mbid, genres={"Pop"})
-
-    provider_mock.mass.music.artists.iter_library_items = Mock(
-        return_value=_async_iter([birthday_artist])
+    """A cached result is returned as-is without triggering a background refresh."""
+    cached = manager._build_artist_folders(
+        [_make_artist("1", "Cached Artist")],
+        folder_id_prefix="birthdays_0",
+        translation_key="artist_birthdays_today",
+        icon="mdi-cake-variant",
     )
-    provider_mock.mass.music.albums.iter_library_items = Mock(return_value=_async_iter([]))
+    provider_mock.mass.cache.get = AsyncMock(return_value=cached)
+
+    result = await manager.get_recommendations()
+
+    assert result == cached
+    provider_mock.mass.cache.get.assert_awaited_once()
+    provider_mock.mass.create_task.assert_not_called()
+
+
+async def test_get_recommendations_schedules_refresh_on_miss(
+    manager: MusicBrainzRecommendationManager,
+    provider_mock: Mock,
+) -> None:
+    """On a cache miss the hot path returns empty and schedules a background refresh."""
+    provider_mock.mass.cache.get = AsyncMock(return_value=None)
+
+    result = await manager.get_recommendations()
+
+    assert result == []
+    provider_mock.mass.create_task.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _refresh — background compute + cache write
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_computes_caches_and_rearms(
+    manager: MusicBrainzRecommendationManager,
+    provider_mock: Mock,
+) -> None:
+    """_refresh scans the library, stores serialized folders, and schedules the next run."""
+    today_mmdd = _today_mmdd()
+    mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
+    _set_library(provider_mock, [_make_artist("10", "Birthday Star", mbid=mbid)])
     provider_mock.get_artist_details = AsyncMock(
         return_value=_make_mb_artist(mbid, f"1990-{today_mmdd}")
     )
+    provider_mock.mass.cache.set = AsyncMock()
 
-    folders = await manager.get_recommendations()
+    await manager._refresh()
 
-    birthday_folders = [
-        f for f in folders if f.translation_key and "birthdays" in f.translation_key
-    ]
-    assert len(birthday_folders) == 1
-    assert birthday_folders[0].translation_key == "artist_birthdays_today"
-    assert birthday_folders[0].translation_params is None
-    assert len(birthday_folders[0].items) == 1
+    provider_mock.mass.cache.set.assert_awaited_once()
+    args, kwargs = provider_mock.mass.cache.set.call_args
+    assert args[0] == RECOMMENDATIONS_CACHE_KEY
+    # stored payload is a JSON-serializable list of folder dicts
+    stored = args[1]
+    assert isinstance(stored, list)
+    assert stored
+    assert isinstance(stored[0], dict)
+    assert kwargs["provider"] == "musicbrainz"
+    # next-day refresh re-armed
+    provider_mock.mass.call_later.assert_called_once()
 
 
-async def test_get_recommendations_empty_library(
+async def test_refresh_swallows_compute_errors(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Empty library returns no folders."""
-    provider_mock.mass.music.artists.iter_library_items = Mock(return_value=_async_iter([]))
-    provider_mock.mass.music.albums.iter_library_items = Mock(return_value=_async_iter([]))
-
-    folders = await manager.get_recommendations()
-
-    assert folders == []
-
-
-async def test_get_recommendations_no_mbid_artists_skipped(
-    manager: MusicBrainzRecommendationManager,
-    provider_mock: Mock,
-) -> None:
-    """Library artists without an MBID are not checked and produce no folders."""
-    artist_no_mbid = _make_artist("1", "No MBID Artist")
-
+    """A failure during the scan does not write the cache or raise."""
     provider_mock.mass.music.artists.iter_library_items = Mock(
-        return_value=_async_iter([artist_no_mbid])
+        side_effect=RuntimeError("library unavailable")
     )
-    provider_mock.mass.music.albums.iter_library_items = Mock(return_value=_async_iter([]))
+    provider_mock.mass.cache.set = AsyncMock()
 
-    folders = await manager.get_recommendations()
+    await manager._refresh()
 
-    assert folders == []
-
-
-async def test_get_recommendations_no_birthday_match(
-    manager: MusicBrainzRecommendationManager,
-    provider_mock: Mock,
-) -> None:
-    """Library artist with MBID but different birth date produces no folders."""
-    today = datetime.now(UTC).date()
-    today_mmdd = f"{today.month:02d}-{today.day:02d}"
-
-    mbid = "c3c82bdc-d9e7-4836-9746-c24ead47ca19"
-    artist = _make_artist("1", "Wrong Birthday", mbid=mbid, genres={"Rock"})
-
-    other_mmdd = "01-01" if today_mmdd != "01-01" else "01-02"
-
-    provider_mock.mass.music.artists.iter_library_items = Mock(return_value=_async_iter([artist]))
-    provider_mock.mass.music.albums.iter_library_items = Mock(return_value=_async_iter([]))
-    provider_mock.get_artist_details = AsyncMock(
-        return_value=_make_mb_artist(mbid, f"1985-{other_mmdd}")
-    )
-
-    folders = await manager.get_recommendations()
-
-    assert folders == []
+    provider_mock.mass.cache.set.assert_not_awaited()

--- a/tests/providers/musicbrainz/test_recommendations.py
+++ b/tests/providers/musicbrainz/test_recommendations.py
@@ -64,8 +64,18 @@ async def _async_iter(items: Sequence[object]) -> AsyncIterator[object]:
 
 def _today_mmdd() -> str:
     """Return today's MM-DD string in UTC."""
-    today = datetime.now(UTC).date()
-    return f"{today.month:02d}-{today.day:02d}"
+    return _mmdd_for_offset(0)
+
+
+def _mmdd_for_offset(offset: int) -> str:
+    """Return the MM-DD string for today + offset days (UTC)."""
+    target = datetime.now(UTC).date() + timedelta(days=offset)
+    return f"{target.month:02d}-{target.day:02d}"
+
+
+def _match_entry(kind: str, offset: int, artist: Artist) -> dict[str, object]:
+    """Return a cached-match dict as stored by _refresh."""
+    return {"kind": kind, "mmdd": _mmdd_for_offset(offset), "artist": artist.to_dict()}
 
 
 def _set_library(provider_mock: Mock, artists: list[Artist]) -> None:
@@ -98,15 +108,15 @@ def manager(provider_mock: Mock) -> MusicBrainzRecommendationManager:
 
 
 # ---------------------------------------------------------------------------
-# _compute_folders — birthdays
+# _scan_matches — birthdays
 # ---------------------------------------------------------------------------
 
 
-async def test_compute_folders_birthday_match(
+async def test_scan_matches_birthday(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Only artists whose full birth date matches today's MM-DD produce a folder."""
+    """Only artists whose full birth date matches a window MM-DD are returned."""
     today_mmdd = _today_mmdd()
     mbid_match = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     mbid_no_match = "f59c5520-5f46-4d2c-b2c4-822eabf53419"
@@ -120,27 +130,26 @@ async def test_compute_folders_birthday_match(
             _make_artist("3", "Year-Only Artist", mbid=mbid_year_only),
         ],
     )
+    far_mmdd = _mmdd_for_offset(180)
 
     async def fake_get_artist_details(mbid: str) -> MusicBrainzArtist:
         dates = {
             mbid_match: f"1980-{today_mmdd}",
-            mbid_no_match: "1975-01-15",
+            mbid_no_match: f"1975-{far_mmdd}",
             mbid_year_only: "1990",  # partial date, must be skipped
         }
         return _make_mb_artist(mbid, dates[mbid])
 
     provider_mock.get_artist_details = fake_get_artist_details
 
-    folders = await manager._compute_folders()
+    matches = await manager._scan_matches()
 
-    birthday_folders = [f for f in folders if "birthdays" in (f.translation_key or "")]
-    assert len(birthday_folders) == 1
-    assert birthday_folders[0].translation_key == "artist_birthdays_today"
-    assert birthday_folders[0].translation_params is None
-    assert [a.name for a in birthday_folders[0].items] == ["Birthday Artist"]
+    assert [(kind, mmdd, a.name) for kind, mmdd, a in matches] == [
+        ("birthday", today_mmdd, "Birthday Artist")
+    ]
 
 
-async def test_compute_folders_no_life_span(
+async def test_scan_matches_no_life_span(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
@@ -149,10 +158,10 @@ async def test_compute_folders_no_life_span(
     _set_library(provider_mock, [_make_artist("1", "No Lifespan", mbid=mbid)])
     provider_mock.get_artist_details = AsyncMock(return_value=_make_mb_artist(mbid, None))
 
-    assert await manager._compute_folders() == []
+    assert await manager._scan_matches() == []
 
 
-async def test_compute_folders_api_error_skipped(
+async def test_scan_matches_api_error_skipped(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
@@ -176,22 +185,20 @@ async def test_compute_folders_api_error_skipped(
 
     provider_mock.get_artist_details = fake_get_artist_details
 
-    folders = await manager._compute_folders()
-    birthday_folders = [f for f in folders if "birthdays" in (f.translation_key or "")]
-    assert len(birthday_folders) == 1
-    assert [a.name for a in birthday_folders[0].items] == ["OK Artist"]
+    matches = await manager._scan_matches()
+    assert [a.name for _, _, a in matches] == ["OK Artist"]
 
 
 # ---------------------------------------------------------------------------
-# _compute_folders — in memoriam
+# _scan_matches — in memoriam
 # ---------------------------------------------------------------------------
 
 
-async def test_compute_folders_memoriam_match(
+async def test_scan_matches_memoriam(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Artists who passed away on today's date (ended=True) produce a memoriam folder."""
+    """Artists who passed away on a window date (ended=True) are returned as memoriam."""
     today_mmdd = _today_mmdd()
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     _set_library(provider_mock, [_make_artist("1", "Late Artist", mbid=mbid)])
@@ -199,14 +206,11 @@ async def test_compute_folders_memoriam_match(
         return_value=_make_mb_artist(mbid, begin="1933-01-01", end=f"2006-{today_mmdd}", ended=True)
     )
 
-    folders = await manager._compute_folders()
-    memoriam_folders = [f for f in folders if "memoriam" in (f.translation_key or "")]
-    assert len(memoriam_folders) == 1
-    assert memoriam_folders[0].translation_key == "artist_memoriam_today"
-    assert [a.name for a in memoriam_folders[0].items] == ["Late Artist"]
+    matches = await manager._scan_matches()
+    assert [(kind, a.name) for kind, _, a in matches] == [("memoriam", "Late Artist")]
 
 
-async def test_compute_folders_skips_living_artists(
+async def test_scan_matches_skips_living_artists(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
@@ -221,48 +225,102 @@ async def test_compute_folders_skips_living_artists(
         )
     )
 
-    assert await manager._compute_folders() == []
+    assert await manager._scan_matches() == []
 
 
 # ---------------------------------------------------------------------------
-# _compute_folders — empty / no match
+# _scan_matches — empty / no match
 # ---------------------------------------------------------------------------
 
 
-async def test_compute_folders_empty_library(
+async def test_scan_matches_empty_library(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Empty library returns no folders."""
+    """Empty library returns no matches."""
     _set_library(provider_mock, [])
-    assert await manager._compute_folders() == []
+    assert await manager._scan_matches() == []
 
 
-async def test_compute_folders_no_mbid_artists_skipped(
+async def test_scan_matches_no_mbid_artists_skipped(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Library artists without an MBID are not looked up and produce no folders."""
+    """Library artists without an MBID are not looked up and produce no matches."""
     _set_library(provider_mock, [_make_artist("1", "No MBID Artist")])
     provider_mock.get_artist_details = AsyncMock(side_effect=AssertionError("should not be called"))
-    assert await manager._compute_folders() == []
+    assert await manager._scan_matches() == []
 
 
-async def test_compute_folders_no_birthday_match(
+async def test_scan_matches_out_of_window(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """Library artist with MBID but a non-window birth date produces no folders."""
+    """A birth date outside the +/- window is not matched."""
     mbid = "c3c82bdc-d9e7-4836-9746-c24ead47ca19"
     _set_library(provider_mock, [_make_artist("1", "Wrong Birthday", mbid=mbid)])
-    # a date ~6 months out is always outside the +/- window (max 15 days)
-    far = datetime.now(UTC).date() + timedelta(days=180)
-    other_mmdd = f"{far.month:02d}-{far.day:02d}"
     provider_mock.get_artist_details = AsyncMock(
-        return_value=_make_mb_artist(mbid, f"1985-{other_mmdd}")
+        return_value=_make_mb_artist(mbid, f"1985-{_mmdd_for_offset(180)}")
     )
 
-    assert await manager._compute_folders() == []
+    assert await manager._scan_matches() == []
+
+
+# ---------------------------------------------------------------------------
+# _folders_from_matches — labelling for the current day
+# ---------------------------------------------------------------------------
+
+
+def test_folders_from_matches_today_birthday(
+    manager: MusicBrainzRecommendationManager,
+) -> None:
+    """A birthday match for today produces a folder labelled for today."""
+    matches = [_match_entry("birthday", 0, _make_artist("1", "Star"))]
+    folders = manager._folders_from_matches(matches)
+
+    assert len(folders) == 1
+    assert folders[0].translation_key == "artist_birthdays_today"
+    assert folders[0].translation_params is None
+    assert [a.name for a in folders[0].items] == ["Star"]
+
+
+def test_folders_from_matches_future_offset(
+    manager: MusicBrainzRecommendationManager,
+) -> None:
+    """A match two days out is labelled with the in-N-days key and the day count param."""
+    matches = [_match_entry("birthday", 2, _make_artist("1", "Future Star"))]
+    folders = manager._folders_from_matches(matches)
+
+    assert len(folders) == 1
+    assert folders[0].translation_key == "artist_birthdays_in_n_days"
+    assert folders[0].translation_params == ["2"]
+
+
+def test_folders_from_matches_memoriam(
+    manager: MusicBrainzRecommendationManager,
+) -> None:
+    """A memoriam match for today produces a memoriam folder."""
+    matches = [_match_entry("memoriam", 0, _make_artist("1", "Late Star"))]
+    folders = manager._folders_from_matches(matches)
+
+    assert len(folders) == 1
+    assert folders[0].translation_key == "artist_memoriam_today"
+    assert [a.name for a in folders[0].items] == ["Late Star"]
+
+
+def test_folders_from_matches_out_of_window_dropped(
+    manager: MusicBrainzRecommendationManager,
+) -> None:
+    """Stale matches whose date is no longer in the current window are dropped."""
+    far = datetime.now(UTC).date() + timedelta(days=180)
+    matches = [
+        {
+            "kind": "birthday",
+            "mmdd": f"{far.month:02d}-{far.day:02d}",
+            "artist": _make_artist("1", "Stale Star").to_dict(),
+        }
+    ]
+    assert manager._folders_from_matches(matches) == []
 
 
 # ---------------------------------------------------------------------------
@@ -310,35 +368,48 @@ def test_build_artist_folders_empty_returns_empty(
 
 
 # ---------------------------------------------------------------------------
-# get_recommendations — cache-backed hot path
+# get_recommendations — cache-backed hot path (stale-while-revalidate)
 # ---------------------------------------------------------------------------
 
 
-async def test_get_recommendations_returns_cached(
+async def test_get_recommendations_returns_fresh(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """A cached result is returned as-is without triggering a background refresh."""
-    cached = manager._build_artist_folders(
-        [_make_artist("1", "Cached Artist")],
-        folder_id_prefix="birthdays_0",
-        translation_key="artist_birthdays_today",
-        icon="mdi-cake-variant",
-    )
-    provider_mock.mass.cache.get = AsyncMock(return_value=cached)
+    """A fresh cache hit is built into folders without triggering a refresh."""
+    matches = [_match_entry("birthday", 0, _make_artist("1", "Cached"))]
+    provider_mock.mass.cache.get = AsyncMock(return_value=matches)
 
     result = await manager.get_recommendations()
 
-    assert result == cached
+    assert len(result) == 1
+    assert result[0].translation_key == "artist_birthdays_today"
     provider_mock.mass.cache.get.assert_awaited_once()
     provider_mock.mass.create_task.assert_not_called()
 
 
-async def test_get_recommendations_schedules_refresh_on_miss(
+async def test_get_recommendations_serves_stale_and_schedules(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """On a cache miss the hot path returns empty and schedules a background refresh."""
+    """When nothing fresh is cached, stale data is served and a refresh is scheduled."""
+    matches = [_match_entry("birthday", 0, _make_artist("1", "Stale-but-shown"))]
+    # first (fresh) lookup misses, second (allow_expired) returns stale data
+    provider_mock.mass.cache.get = AsyncMock(side_effect=[None, matches])
+
+    result = await manager.get_recommendations()
+
+    assert len(result) == 1
+    assert [a.name for a in result[0].items] == ["Stale-but-shown"]
+    provider_mock.mass.create_task.assert_called_once()
+    assert provider_mock.mass.cache.get.await_count == 2
+
+
+async def test_get_recommendations_empty_when_no_cache(
+    manager: MusicBrainzRecommendationManager,
+    provider_mock: Mock,
+) -> None:
+    """With no cached data at all, the hot path returns empty and schedules a refresh."""
     provider_mock.mass.cache.get = AsyncMock(return_value=None)
 
     result = await manager.get_recommendations()
@@ -352,11 +423,11 @@ async def test_get_recommendations_schedules_refresh_on_miss(
 # ---------------------------------------------------------------------------
 
 
-async def test_refresh_computes_caches_and_rearms(
+async def test_refresh_scans_and_caches(
     manager: MusicBrainzRecommendationManager,
     provider_mock: Mock,
 ) -> None:
-    """_refresh scans the library, stores serialized folders, and schedules the next run."""
+    """_refresh scans the library and stores serialized matches with stale fallback enabled."""
     today_mmdd = _today_mmdd()
     mbid = "20ff3303-4fe2-4a47-a1b6-291e26aa3438"
     _set_library(provider_mock, [_make_artist("10", "Birthday Star", mbid=mbid)])
@@ -370,14 +441,13 @@ async def test_refresh_computes_caches_and_rearms(
     provider_mock.mass.cache.set.assert_awaited_once()
     args, kwargs = provider_mock.mass.cache.set.call_args
     assert args[0] == RECOMMENDATIONS_CACHE_KEY
-    # stored payload is a JSON-serializable list of folder dicts
     stored = args[1]
     assert isinstance(stored, list)
-    assert stored
-    assert isinstance(stored[0], dict)
+    assert stored[0]["kind"] == "birthday"
+    assert stored[0]["mmdd"] == today_mmdd
+    assert stored[0]["artist"]["name"] == "Birthday Star"
     assert kwargs["provider"] == "musicbrainz"
-    # next-day refresh re-armed
-    provider_mock.mass.call_later.assert_called_once()
+    assert kwargs["allow_expired_cache"] is True
 
 
 async def test_refresh_swallows_compute_errors(


### PR DESCRIPTION
# What does this implement/fix?

The discover page stopped loading on recent nightlies. The birthday/in-memoriam recommendations added in #3833 turned MusicBrainz into a recommendations provider, but its scan runs on the discover request itself: for every library artist with a MusicBrainz ID it fetches full artist details across a multi-day window, for both birth and death dates. MusicBrainz lookups are rate-limited to ~1/sec, so on a larger library the scan takes minutes — and because the recommendations controller awaits all providers together without a timeout, the whole discover page is blocked until it finishes. That's why the only sign in the logs is a stream of MusicBrainz rate-limit messages.

This moves the scan off the request path and adds a safety net so one slow provider can no longer block discover:

- MusicBrainz recommendations are now precomputed in a background task and served from cache, so `recommendations()` returns immediately. The cache is warmed on startup and refreshed once a day.
- The library scan is now single-pass — each artist is fetched once and bucketed by birthday and death day — instead of re-fetching per day and per date field.
- The result is cached until the next day so the relative labels (today / tomorrow / in N days) stay correct; the underlying MusicBrainz lookups remain cached and are reused on later refreshes, so the rate-limited work only happens once.
- Added a per-provider timeout in the recommendations controller so a single slow provider can never block the entire discover page again.
- Updated the MusicBrainz recommendation tests for the new background/caching behaviour.

**Related issue (if applicable):**

- Regression introduced by #3833

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
