### PR TITLE
Prevent providers picking the same port when starting concurrently

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -873,11 +873,10 @@ _select_free_port_lock = asyncio.Lock()
 
 async def select_free_port(range_start: int, range_end: int) -> int:
     """
-    Find and reserve an available port within the given range.
+    Find and reserve a free port within the given range.
 
-    The returned port is briefly reserved in-process so concurrent or successive
-    callers don't get handed the same port before it has been bound (binding
-    frequently happens asynchronously after this call returns).
+    The returned port is reserved so concurrent or successive callers are not
+    handed the same port.
 
     :param range_start: First port (inclusive) of the range to search.
     :param range_end: Port to stop before (exclusive) when searching the range.

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import socket
 import sys
+import time
 import unicodedata
 import urllib.error
 import urllib.request
@@ -858,11 +859,41 @@ async def is_port_in_use(port: int) -> bool:
     return await asyncio.to_thread(_is_port_in_use)
 
 
+# In-process reservations for ports handed out by select_free_port. Provider
+# instances (and reloads) frequently call select_free_port at nearly the same
+# moment and only bind the returned port asynchronously afterwards, so a port
+# that was just handed out is not yet detectable as "in use". Keeping a
+# short-lived reservation per returned port stops concurrent/successive callers
+# from picking the same one. Reservations expire automatically after the grace
+# period so the range is never permanently exhausted across reloads.
+_PORT_RESERVATION_TTL = 60.0
+_reserved_ports: dict[int, float] = {}
+_select_free_port_lock = asyncio.Lock()
+
+
 async def select_free_port(range_start: int, range_end: int) -> int:
-    """Automatically find available port within range."""
-    for port in range(range_start, range_end):
-        if not await is_port_in_use(port):
-            return port
+    """
+    Find and reserve an available port within the given range.
+
+    The returned port is briefly reserved in-process so concurrent or successive
+    callers don't get handed the same port before it has been bound (binding
+    frequently happens asynchronously after this call returns).
+
+    :param range_start: First port (inclusive) of the range to search.
+    :param range_end: Port to stop before (exclusive) when searching the range.
+    """
+    async with _select_free_port_lock:
+        now = time.monotonic()
+        # drop expired reservations so their ports become reusable again
+        for reserved_port, deadline in list(_reserved_ports.items()):
+            if deadline <= now:
+                del _reserved_ports[reserved_port]
+        for port in range(range_start, range_end):
+            if port in _reserved_ports:
+                continue
+            if not await is_port_in_use(port):
+                _reserved_ports[port] = now + _PORT_RESERVATION_TTL
+                return port
     msg = "No free port available"
     raise OSError(msg)
 

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -1,10 +1,13 @@
 """Tests for music_assistant.helpers.util networking helpers."""
 
+import asyncio
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
 
-from music_assistant.helpers.util import get_source_ip_for_target
+from music_assistant.helpers import util
+from music_assistant.helpers.util import get_source_ip_for_target, select_free_port
 
 
 class TestGetSourceIpForTarget:
@@ -48,3 +51,32 @@ class TestGetSourceIpForTarget:
             sock.connect.side_effect = OSError("no route to host")
             result = await get_source_ip_for_target("10.10.20.31", bind_ip="0.0.0.0", publish_ip="")
         assert result == "0.0.0.0"
+
+
+class TestSelectFreePort:
+    """select_free_port hands out distinct ports even under concurrent calls."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_reservations(self) -> Iterator[None]:
+        """Ensure no port reservation state leaks between tests."""
+        util._reserved_ports.clear()
+        yield
+        util._reserved_ports.clear()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_calls_get_distinct_ports(self) -> None:
+        """Instances starting simultaneously must not be handed the same port."""
+        # All ports report free, mimicking instances that haven't bound yet.
+        with patch("music_assistant.helpers.util.is_port_in_use", return_value=False):
+            ports = await asyncio.gather(*(select_free_port(38800, 38900) for _ in range(5)))
+        assert len(set(ports)) == len(ports)
+
+    @pytest.mark.asyncio
+    async def test_expired_reservation_is_reusable(self) -> None:
+        """A reservation past its TTL is released so the port can be handed out again."""
+        with patch("music_assistant.helpers.util.is_port_in_use", return_value=False):
+            first = await select_free_port(38800, 38900)
+            # force the reservation to look expired so the next call can reuse it
+            util._reserved_ports[first] = 0.0
+            second = await select_free_port(38800, 38900)
+        assert first == second


### PR DESCRIPTION
# What does this implement/fix?

When multiple provider instances of the same domain start at nearly the same moment (e.g. several Spotify Connect plugins on boot), each one calls `select_free_port` and scans the range from the start. The returned port is only bound *asynchronously* afterwards (go-librespot binds it later in its daemon task), so at selection time none of the ports are in use yet and every instance is handed the same port — leaving all but one daemon failing to start.

`select_free_port` now reserves each handed-out port in-process so concurrent and successive callers never receive the same port before it has been bound. Reservations expire after a short grace period so the range is never permanently exhausted across reloads. This fixes every provider using the helper (Spotify Connect, SiriusXM, AirPlay).

**Related issue (if applicable):**

- related issue music-assistant/support#5731

## Changes

- Reserve ports handed out by `select_free_port` under a lock, with a short TTL so they auto-release.
- Add tests covering concurrent selection (distinct ports) and reservation expiry (port reuse).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.