### PR TITLE
Replace obfuscated app_vars with build-time secret injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,14 @@ jobs:
 
           print(f"✅ Updated pyproject.toml version to ${{ inputs.version }}")
 
+      - name: Provision app secrets
+        env:
+          TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+        run: |
+          curl -fsSL -H "Authorization: token ${TOKEN}" \
+            https://raw.githubusercontent.com/music-assistant/appvars/main/app_secrets.json \
+            -o music_assistant/helpers/app_secrets.json
+
       - name: Build python package
         run: >-
           python3 -m build

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ music_assistant/testrun.sh
 build/
 dist/
 venv/
+
+# Bundled app credentials - injected at build time, or a maintainer's local copy. Never commit.
+music_assistant/helpers/app_secrets.json
+app_vars.json
 .venv
 .venv*
 .mypy_cache/

--- a/music_assistant/helpers/app_vars.py
+++ b/music_assistant/helpers/app_vars.py
@@ -1,5 +1,146 @@
-# pylint: skip-file
-# fmt: off
-# flake8: noqa
-# ruff: noqa
-(lambda __g: [(lambda __mod: [[[None for __g['app_var'], app_var.__name__ in [(lambda index: (lambda __l: [[AV(aap(__l['var'].encode()).decode()) for __l['var'] in [(vars.split('acb2')[__l['index']][::(-1)])]][0] for __l['index'] in [(index)]][0])({}), 'app_var')]][0] for __g['vars'] in [('3YTNyUDOyQTOacb2=EmN5M2YjdzMhljYzYzYhlDMmFGNlVTOmNDZwMzNxYzNacb2=UDMzEGOyADO1QWO5kDNygTMlJGN5QzNzIWOmZTOiVmMacb2yMTNzITNacb2=UDZhJmMldTZ3QTY4IjZ3kTNxYjN0czNwI2YxkTM5MjNacb2==QMh5WOmZnewM2d4UDblRzZacb20QzMwAjNacb2=QzNiRTO3EjMjFzMldjY3QTMwEDMwADMiNWZ5UWO3UWMacb2RZzQiB1UvlDZWhzQ1xEZy5Uek9UM0UkdwRjVapUStcHaidVeklHSuRWe2tmYUFULVF3R0JkV092Ny1kQHpHVnl1Yx5WdPd2bydle1cmcJhVeTxmbN1kL54EVNFzYq1UNZpnTzUkaPlWUYlFcKNET6VEVOBTQ65UerpnT49maJdHaYpVa3lWSy0URSRzcVF1RsZlVIpUaPlWTzMGcKlXZuElZpFVMWtkSp9UaBhVZwo0QMl2aU9UR4BjTTpkeSNlRrlkNJNkWwRXbJNXSp5UMJpXVGpUaPl2YHJGaKlXZacb2==QVnRlQFFHa5sEckJ1UEJkNacb2=0DOHRla6N3YJZjTxFUVlhmTWFTYrh2czkTUjFETilUS5oFci52NZ1GU1VGeacb2=ETO1YDNzgzMacb2=kjN4IDZ0MTNhRWZ1EDZkdDNxMGNjlDZzY2M3AzMjhDZacb2=AjN2kjN2QTM4Y2MiF2Y1gzNzYmZhRGM0QzY3M2N1YGZacb2==wcCllUFRTaEllN')]][0] for __g['aap'] in [(__mod.b64decode)]][0])(__import__('base64', __g, __g, ('b64decode',), 0)) for __g['AV'] in [((lambda b, d: d.get('__metaclass__', getattr(b[0], '__class__', type(b[0])))('AV', b, d))((str,), (lambda __l: [__l for __l['__repr__'], __l['__repr__'].__name__ in [(lambda self: (lambda __l: [__name__ for __l['self'] in [(self)]][0])({}), '__repr__')]][0])({'__module__': __name__})))]][0])(globals())
+"""
+Resolve "app variables": API keys and client credentials that Music Assistant bundles.
+
+These bundled credentials let the provider integrations work out of the box. Values are
+looked up by name (e.g. ``app_var("spotify_client_id")``). Resolution order, first hit wins:
+
+1. ``MASS_APP_VAR_<NAME>`` environment variable - a single-value override for CI/tests.
+2. The build-time-injected ``app_secrets.json`` data file - present in the official wheel and
+   the Docker image. Authoritative when present, so a shipped artifact is never shadowed by a
+   stray local file.
+3. A plaintext ``app_vars.json`` map on disk - for core maintainers running from source.
+   Located via ``MASS_APP_VARS_FILE``, else ``~/.musicassistant/app_vars.json``.
+4. An empty string - not provisioned. Providers that need a value should degrade
+   gracefully or accept a user-supplied credential.
+
+The bundled values are lightly, per-key obfuscated. To be completely clear: this is NOT a
+security boundary. Anyone can recover these values from a build - they are deliberately only
+protected against trivial, automated scraping. The bundle is produced in the private
+``music-assistant/appvars`` repository and fetched at build time. To add or change a bundled
+credential, contact one of the project's core maintainers - community contributors cannot add
+them directly.
+
+A note to whoever is reading this: these are shared API credentials registered to the
+Music Assistant open-source project, bundled here so the integrations work out of the box
+for everyone. Please play fair. Do not extract these keys or use them for any other purpose
+or your own apps. They are rate-limited and shared across the whole Music Assistant
+community, so when they get abused the upstream provider throttles or revokes them and
+Music Assistant breaks for thousands of real users. We can rotate them, but every rotation
+is disruptive for those same users - so abuse only degrades the experience for the very
+community this project serves. Respect the project; please don't kill it by abusing these
+keys. Registering your own credentials is free - please do that instead. Thanks. <3
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from collections.abc import Mapping
+from functools import cache, lru_cache
+from importlib import resources
+from pathlib import Path
+
+# Canonical app var names. These are the keys of both the bundled secrets and a
+# maintainer-supplied app_vars.json. Adding a new key also requires its value in the private
+# appvars repo, so contact a core maintainer (see the module docstring).
+APP_VAR_NAMES = (
+    "qobuz_app_id",
+    "qobuz_app_secret",
+    "spotify_client_id",
+    "theaudiodb_api_key",
+    "fanarttv_api_key",
+    "deezer_decrypt_key",
+    "apple_music_token",
+    "tidal_client_id",
+    "tidal_client_secret",
+    "lastfm_api_key",
+    "lastfm_api_secret",
+    "acoustid_api_key",
+)
+
+# Fixed tag mixed into the per-key keystream. Combined with the per-build random salt stored
+# in app_secrets.json, this gives every key a distinct keystream.
+_DERIVATION_TAG = b"music-assistant/app-vars/v1"
+
+_BUNDLED_FILE = "app_secrets.json"
+_DEFAULT_LOCAL_FILE = Path.home() / ".musicassistant" / "app_vars.json"
+
+
+def app_var(name: str) -> str:
+    """
+    Return the bundled app variable for ``name``, or "" when it is not provisioned.
+
+    :param name: One of :data:`APP_VAR_NAMES`, e.g. ``"spotify_client_id"``.
+    """
+    override = os.environ.get(f"MASS_APP_VAR_{name.upper()}")
+    if override:
+        return override
+    bundled = _bundled()
+    if bundled is not None and name in bundled:
+        return bundled[name]
+    local = _local_secrets()
+    if name in local:
+        return local[name]
+    return ""
+
+
+@lru_cache(maxsize=1)
+def _bundled() -> Mapping[str, str] | None:
+    raw = _bundled_text()
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw)
+        salt = base64.b64decode(data["salt"])
+        return {
+            name: _codec(salt, name, base64.b64decode(token)).decode()
+            for name, token in data["secrets"].items()
+        }
+    except ValueError, KeyError, TypeError, AttributeError:
+        # A corrupt/incomplete bundle must not crash startup; fall through instead.
+        return None
+
+
+def _bundled_text() -> str | None:
+    try:
+        return (resources.files(__package__) / _BUNDLED_FILE).read_text(encoding="utf-8")
+    except FileNotFoundError, OSError, ModuleNotFoundError:
+        return None
+
+
+def _local_secrets() -> Mapping[str, str]:
+    path = os.environ.get("MASS_APP_VARS_FILE")
+    target = Path(path) if path else _DEFAULT_LOCAL_FILE
+    return _read_json_map(str(target))
+
+
+@cache
+def _read_json_map(path: str) -> Mapping[str, str]:
+    file = Path(path)
+    if not file.is_file():
+        return {}
+    try:
+        data = json.loads(file.read_text(encoding="utf-8"))
+    except OSError, ValueError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(key): str(value) for key, value in data.items()}
+
+
+def _codec(salt: bytes, name: str, data: bytes) -> bytes:
+    keystream = _keystream(salt, name, len(data))
+    return bytes(byte ^ key for byte, key in zip(data, keystream, strict=True))
+
+
+def _keystream(salt: bytes, name: str, length: int) -> bytes:
+    seed = b"\x00".join((salt, name.encode(), _DERIVATION_TAG))
+    out = bytearray()
+    counter = 0
+    while len(out) < length:
+        out += hmac.new(seed, counter.to_bytes(4, "big"), hashlib.sha256).digest()
+        counter += 1
+    return bytes(out[:length])

--- a/music_assistant/providers/acoustid_lookup/provider.py
+++ b/music_assistant/providers/acoustid_lookup/provider.py
@@ -20,7 +20,7 @@ from music_assistant_models.errors import (
 )
 
 from music_assistant.controllers.cache import use_cache
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.compare import create_safe_string
 from music_assistant.helpers.datetime import utc_timestamp
 from music_assistant.helpers.tags import write_identifier_tags
@@ -234,7 +234,7 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
         user_key = self.config.get_value(CONF_API_KEY)
         if isinstance(user_key, str) and user_key:
             return user_key
-        return str(app_var(14))
+        return str(app_var("acoustid_api_key"))
 
     async def _start_analysis(
         self,

--- a/music_assistant/providers/apple_music/constants.py
+++ b/music_assistant/providers/apple_music/constants.py
@@ -2,7 +2,7 @@
 
 from music_assistant_models.enums import ProviderFeature
 
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 
 SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_ARTISTS,
@@ -26,7 +26,7 @@ SUPPORTED_FEATURES = {
     ProviderFeature.FAVORITE_PLAYLISTS_EDIT,
 }
 
-MUSIC_APP_TOKEN = app_var(8)
+MUSIC_APP_TOKEN = app_var("apple_music_token")
 WIDEVINE_BASE_PATH = "/usr/local/bin/widevine_cdm"
 DECRYPT_CLIENT_ID_FILENAME = "client_id.bin"
 DECRYPT_PRIVATE_KEY_FILENAME = "private_key.pem"

--- a/music_assistant/providers/deezer/streaming.py
+++ b/music_assistant/providers/deezer/streaming.py
@@ -21,7 +21,7 @@ from music_assistant_models.errors import AudioError, MediaNotFoundError
 from music_assistant_models.media_items import AudioFormat, MediaItemType
 from music_assistant_models.streamdetails import StreamDetails
 
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.datetime import utc_timestamp
 
 from .gw_client import DeezerGWError
@@ -366,7 +366,7 @@ class DeezerStreamingManager:
 
     def _get_blowfish_key(self, track_id: str) -> str:
         """Get blowfish key to decrypt a chunk of a track."""
-        secret = app_var(5)
+        secret = app_var("deezer_decrypt_key")
         id_md5 = self._md5(track_id)
         return "".join(
             chr(ord(id_md5[i]) ^ ord(id_md5[i + 16]) ^ ord(secret[i])) for i in range(16)

--- a/music_assistant/providers/fanarttv/__init__.py
+++ b/music_assistant/providers/fanarttv/__init__.py
@@ -11,7 +11,7 @@ from music_assistant_models.enums import ConfigEntryType, ExternalID, ImageType,
 from music_assistant_models.media_items import MediaItemImage, MediaItemMetadata, UniqueList
 
 from music_assistant.controllers.cache import use_cache
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.throttle_retry import Throttler
 from music_assistant.models.metadata_provider import MetadataProvider
 
@@ -186,10 +186,10 @@ class FanartTvMetadataProvider(MetadataProvider):
         """Get data from api."""
         url = f"http://webservice.fanart.tv/v3/{endpoint}"
         headers = {
-            "api-key": app_var(4),
+            "api-key": app_var("fanarttv_api_key"),
         }
         if client_key := self.config.get_value(CONF_CLIENT_KEY):
-            headers["client_key"] = client_key
+            headers["client_key"] = str(client_key)
         async with (
             self.throttler,
             self.mass.http_session_no_ssl.get(

--- a/music_assistant/providers/lastfm_recommendations/api_client.py
+++ b/music_assistant/providers/lastfm_recommendations/api_client.py
@@ -13,12 +13,12 @@ from music_assistant_models.errors import (
     ResourceTemporarilyUnavailable,
 )
 
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.throttle_retry import ThrottlerManager
 from music_assistant.providers.lastfm_recommendations.constants import CONF_API_KEY
 
 # Built-in Last.fm API key (read-only access, no secret needed)
-_DEFAULT_API_KEY: str = app_var(12)
+_DEFAULT_API_KEY: str = app_var("lastfm_api_key")
 
 if TYPE_CHECKING:
     import logging

--- a/music_assistant/providers/lastfm_scrobble/__init__.py
+++ b/music_assistant/providers/lastfm_scrobble/__init__.py
@@ -19,7 +19,7 @@ from music_assistant_models.enums import ConfigEntryType, EventType, MediaType, 
 from music_assistant_models.errors import LoginFailed, SetupFailedError
 
 from music_assistant.constants import MASS_LOGGER_NAME
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.auth import AuthenticationHelper
 from music_assistant.helpers.scrobbler import ScrobblerConfig, ScrobblerHelper
 from music_assistant.mass import MusicAssistant
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
     from music_assistant_models.provider import ProviderManifest
 
 # Built-in Last.fm API credentials (not available for Libre.fm)
-_DEFAULT_API_KEY: str = app_var(12)
-_DEFAULT_API_SECRET: str = app_var(13)
+_DEFAULT_API_KEY: str = app_var("lastfm_api_key")
+_DEFAULT_API_SECRET: str = app_var("lastfm_api_secret")
 
 
 # we don't have any special supported features (yet)

--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -50,7 +50,7 @@ from music_assistant.constants import (
     VARIOUS_ARTISTS_NAME,
 )
 from music_assistant.controllers.cache import use_cache
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.throttle_retry import (
     ThrottlerManager,
@@ -867,7 +867,7 @@ class QobuzProvider(MusicProvider):
         """Get data from api."""
         self.logger.debug("Handling GET request to %s", endpoint)
         url = f"https://www.qobuz.com/api.json/0.2/{endpoint}"
-        headers = {"X-App-Id": app_var(0)}
+        headers = {"X-App-Id": app_var("qobuz_app_id")}
         locale = self.mass.metadata.locale.replace("_", "-")
         language = locale.split("-")[0]
         headers["Accept-Language"] = f"{locale}, {language};q=0.9, *;q=0.5"
@@ -884,11 +884,13 @@ class QobuzProvider(MusicProvider):
             for key in keys:
                 signing_data += f"{key}{kwargs[key]}"
             request_ts = str(time.time())
-            request_sig = signing_data + request_ts + app_var(1)
-            request_sig = str(hashlib.md5(request_sig.encode()).hexdigest())
+            request_sig = signing_data + request_ts + app_var("qobuz_app_secret")
+            # Qobuz signs API requests with MD5; usedforsecurity=False as this is mandated by
+            # their API, not a security measure on our side.
+            request_sig = str(hashlib.md5(request_sig.encode(), usedforsecurity=False).hexdigest())
             kwargs["request_ts"] = request_ts
             kwargs["request_sig"] = request_sig
-            kwargs["app_id"] = app_var(0)
+            kwargs["app_id"] = app_var("qobuz_app_id")
             kwargs["user_auth_token"] = await self._auth_token()
         async with (
             self.mass.http_session.get(url, headers=headers, params=kwargs) as response,
@@ -938,7 +940,7 @@ class QobuzProvider(MusicProvider):
         if not data:
             data = {}
         url = f"https://www.qobuz.com/api.json/0.2/{endpoint}"
-        params["app_id"] = app_var(0)
+        params["app_id"] = app_var("qobuz_app_id")
         auth_token = await self._auth_token()
         if auth_token is None:
             msg = "Authentication token is required"

--- a/music_assistant/providers/spotify/__init__.py
+++ b/music_assistant/providers/spotify/__init__.py
@@ -9,7 +9,7 @@ from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError, LoginFailed
 
 from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 
 from .constants import (
     CALLBACK_REDIRECT_URL,
@@ -65,7 +65,9 @@ async def _handle_auth_actions(
         return
 
     if action == CONF_ACTION_AUTH:
-        refresh_token = await pkce_auth_flow(mass, cast("str", values["session_id"]), app_var(2))
+        refresh_token = await pkce_auth_flow(
+            mass, cast("str", values["session_id"]), app_var("spotify_client_id")
+        )
         values[CONF_REFRESH_TOKEN_GLOBAL] = refresh_token
         values[CONF_REFRESH_TOKEN_DEV] = None  # Clear dev token on new global auth
         values[CONF_CLIENT_ID] = None  # Clear client ID on new global auth

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -47,7 +47,7 @@ from music_assistant_models.streamdetails import StreamDetails
 from orjson import JSONDecodeError
 
 from music_assistant.controllers.cache import use_cache
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.json import json_loads
 from music_assistant.helpers.process import check_output
 from music_assistant.helpers.throttle_retry import ThrottlerManager, throttle_with_retries
@@ -828,7 +828,7 @@ class SpotifyProvider(MusicProvider):
         try:
             auth_info = await get_spotify_token(
                 self.mass.http_session,
-                app_var(2),  # Always use MA's global client ID
+                app_var("spotify_client_id"),  # Always use MA's global client ID
                 cast("str", refresh_token),
                 "global",
             )

--- a/music_assistant/providers/theaudiodb/__init__.py
+++ b/music_assistant/providers/theaudiodb/__init__.py
@@ -27,7 +27,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.controllers.cache import use_cache
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 from music_assistant.helpers.compare import compare_strings
 from music_assistant.helpers.throttle_retry import Throttler
 from music_assistant.models.metadata_provider import MetadataProvider
@@ -431,7 +431,7 @@ class AudioDbMetadataProvider(MetadataProvider):
     @use_cache(86400 * 90, persistent=True)  # Cache for 90 days
     async def _get_data(self, endpoint: str, **kwargs: Any) -> dict[str, Any] | None:
         """Get data from api."""
-        url = f"https://theaudiodb.com/api/v1/json/{app_var(3)}/{endpoint}"
+        url = f"https://theaudiodb.com/api/v1/json/{app_var('theaudiodb_api_key')}/{endpoint}"
         async with (
             self.throttler,
             self.mass.http_session.get(url, params=kwargs, ssl=False) as response,

--- a/music_assistant/providers/tidal/auth_manager.py
+++ b/music_assistant/providers/tidal/auth_manager.py
@@ -13,7 +13,7 @@ import pkce
 from music_assistant_models.enums import EventType
 from music_assistant_models.errors import LoginFailed
 
-from music_assistant.helpers.app_vars import app_var  # type: ignore[attr-defined]
+from music_assistant.helpers.app_vars import app_var
 
 from .constants import AUTH_URL, LOGIN_URL, REDIRECT_URI, SESSIONS_URL
 
@@ -141,7 +141,7 @@ class TidalAuthManager:
         if not refresh_token:
             return False
 
-        client_id = self._auth_info.get("client_id", app_var(9))
+        client_id = self._auth_info.get("client_id", app_var("tidal_client_id"))
 
         data = {
             "refresh_token": refresh_token,
@@ -197,8 +197,8 @@ class TidalAuthManager:
         auth_params = {
             "code_verifier": code_verifier,
             "client_unique_key": client_unique_key,
-            "client_id": app_var(9),
-            "client_secret": app_var(10),
+            "client_id": app_var("tidal_client_id"),
+            "client_secret": app_var("tidal_client_secret"),
             "quality": quality,
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ platforms = ["any"]
 zip-safe = false
 
 [tool.setuptools.package-data]
-music_assistant = ["py.typed"]
+music_assistant = ["py.typed", "helpers/app_secrets.json"]
 
 [tool.ruff]
 fix = true
@@ -143,7 +143,6 @@ enable_error_code = [
   "truthy-iterable",
 ]
 exclude = [
-  '^music_assistant/helpers/app_vars.py',
   '^music_assistant/providers/sonic_analysis/vendored_clap/.*$',
 ]
 extra_checks = false

--- a/tests/helpers/test_app_vars.py
+++ b/tests/helpers/test_app_vars.py
@@ -1,0 +1,100 @@
+"""Tests for the app_vars resolver."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from music_assistant.helpers import app_vars as app_vars_module
+from music_assistant.helpers.app_vars import APP_VAR_NAMES, app_var
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> Iterator[None]:
+    """Reset the module-level lookup caches around every test."""
+    app_vars_module._bundled.cache_clear()
+    app_vars_module._read_json_map.cache_clear()
+    yield
+    app_vars_module._bundled.cache_clear()
+    app_vars_module._read_json_map.cache_clear()
+
+
+def _bundle_blob(salt: bytes, values: dict[str, str]) -> str:
+    """Build an app_secrets.json blob the way the generator does."""
+    secrets = {
+        name: base64.b64encode(app_vars_module._codec(salt, name, value.encode())).decode()
+        for name, value in values.items()
+    }
+    return json.dumps({"salt": base64.b64encode(salt).decode(), "secrets": secrets})
+
+
+def test_unprovisioned_returns_empty(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """With no override, no bundle and no file, an app var resolves to ''."""
+    monkeypatch.delenv("MASS_APP_VAR_SPOTIFY_CLIENT_ID", raising=False)
+    monkeypatch.setattr(app_vars_module, "_bundled", lambda: None)
+    monkeypatch.setenv("MASS_APP_VARS_FILE", str(tmp_path / "does_not_exist.json"))
+    assert app_var("spotify_client_id") == ""
+
+
+def test_unknown_key_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unknown name resolves to '' rather than raising."""
+    monkeypatch.delenv("MASS_APP_VAR_NOPE_NOT_A_KEY", raising=False)
+    monkeypatch.setattr(app_vars_module, "_bundled", lambda: None)
+    assert app_var("nope_not_a_key") == ""
+
+
+def test_env_override_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A MASS_APP_VAR_<NAME> override beats a value present in a local file."""
+    file = tmp_path / "app_vars.json"
+    file.write_text(json.dumps({"spotify_client_id": "from_file"}), encoding="utf-8")
+    monkeypatch.setattr(app_vars_module, "_bundled", lambda: None)
+    monkeypatch.setenv("MASS_APP_VARS_FILE", str(file))
+    monkeypatch.setenv("MASS_APP_VAR_SPOTIFY_CLIENT_ID", "from_env")
+    assert app_var("spotify_client_id") == "from_env"
+
+
+def test_local_json_file_via_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A maintainer's app_vars.json is read when pointed at by MASS_APP_VARS_FILE."""
+    file = tmp_path / "app_vars.json"
+    file.write_text(json.dumps({"tidal_client_id": "abc123"}), encoding="utf-8")
+    monkeypatch.delenv("MASS_APP_VAR_TIDAL_CLIENT_ID", raising=False)
+    monkeypatch.setattr(app_vars_module, "_bundled", lambda: None)
+    monkeypatch.setenv("MASS_APP_VARS_FILE", str(file))
+    assert app_var("tidal_client_id") == "abc123"
+
+
+def test_default_local_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When MASS_APP_VARS_FILE is unset, the default data-dir location is used."""
+    file = tmp_path / "app_vars.json"
+    file.write_text(json.dumps({"qobuz_app_id": "default_loc"}), encoding="utf-8")
+    monkeypatch.delenv("MASS_APP_VARS_FILE", raising=False)
+    monkeypatch.delenv("MASS_APP_VAR_QOBUZ_APP_ID", raising=False)
+    monkeypatch.setattr(app_vars_module, "_bundled", lambda: None)
+    monkeypatch.setattr(app_vars_module, "_DEFAULT_LOCAL_FILE", file)
+    assert app_var("qobuz_app_id") == "default_loc"
+
+
+def test_bundled_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real app_secrets.json blob parses and decodes back to the original values."""
+    salt = os.urandom(16)
+    values = {name: f"value-for-{name}" for name in APP_VAR_NAMES}
+    monkeypatch.setattr(app_vars_module, "_bundled_text", lambda: _bundle_blob(salt, values))
+    for name, expected in values.items():
+        monkeypatch.delenv(f"MASS_APP_VAR_{name.upper()}", raising=False)
+        assert app_var(name) == expected
+
+
+def test_corrupt_bundle_does_not_crash(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A malformed bundle resolves to None (and '') instead of raising."""
+    monkeypatch.delenv("MASS_APP_VAR_SPOTIFY_CLIENT_ID", raising=False)
+    monkeypatch.setenv("MASS_APP_VARS_FILE", str(tmp_path / "does_not_exist.json"))
+    for blob in ("{ not valid json", json.dumps({"secrets": {}}), json.dumps({"salt": "!!"})):
+        app_vars_module._bundled.cache_clear()
+        monkeypatch.setattr(app_vars_module, "_bundled_text", lambda blob=blob: blob)
+        assert app_vars_module._bundled() is None
+        assert app_var("spotify_client_id") == ""


### PR DESCRIPTION
# What does this implement/fix?

Removes the obfuscated, committed `app_vars.py` one-liner (the base64/`acb2` blob that keeps getting reported as malware / hardcoded secrets, e.g. #4464) and replaces it with build-time secret injection.

- `app_var()` now looks values up by name (`app_var("spotify_client_id")`) instead of by index.
- No secret material in the public source tree anymore. The real values live in the private `appvars` repo, which builds an obfuscated `app_secrets.json` data file. The release workflow downloads that file (via the existing `PRIVILEGED_GITHUB_TOKEN`, same mechanism as the Widevine files) and bundles it into the wheel; `app_vars.py` decodes it at runtime. No generator or remote code runs in the server build. Docker installs that same wheel, so no Dockerfile change.
- Running from raw source degrades gracefully (empty values); maintainers can point `MASS_APP_VARS_FILE` at their `appvars` checkout, or drop `~/.musicassistant/app_vars.json`.

This is deliberately light, per-key obfuscation — **not** a security boundary; see the note in `app_vars.py`.

> [!IMPORTANT]
> `app_secrets.json` is already committed to the `appvars` repo `main`. Keep this as a draft until a nightly build confirms keys ship in the artifact, so no release goes out key-less.

## Types of changes

- [x] Maintenance / chore — `maintenance`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
