### PR TITLE
Fix the podcast's title not being used in Audiobookshelf's episode parser

### DIFF
--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -519,6 +519,7 @@ for more details.
                     parse_podcast_episode(
                         episode=item.episode,
                         prov_podcast_id=item.library_item.id_,
+                        prov_podcast_name=item.library_item.media.metadata.title,
                         fallback_episode_cnt=None,
                         instance_id=self.instance_id,
                         domain=self.domain,
@@ -1129,13 +1130,16 @@ for more details.
                                 continue
                             _cover_path = None
                             _cover_version = None
+                            _podcast_title = None
                             if isinstance(entity, ShelfLibraryItemMinifiedPodcast):
                                 _cover_path = entity.media.cover_path
                                 _cover_version = entity.updated_at
+                                _podcast_title = entity.media.metadata.title
                             # we only have a PodcastEpisode here, with limited information
                             item = parse_podcast_episode(
                                 episode=entity.recent_episode,
                                 prov_podcast_id=podcast_id,
+                                prov_podcast_name=_podcast_title,
                                 instance_id=self.instance_id,
                                 domain=self.domain,
                                 token=self._client.token,

--- a/music_assistant/providers/audiobookshelf/__init__.py
+++ b/music_assistant/providers/audiobookshelf/__init__.py
@@ -711,6 +711,7 @@ for more details.
             mass_episode = parse_podcast_episode(
                 episode=abs_episode,
                 prov_podcast_id=prov_podcast_id,
+                prov_podcast_name=abs_podcast.media.metadata.title,
                 fallback_episode_cnt=episode_cnt,
                 instance_id=self.instance_id,
                 domain=self.domain,
@@ -741,6 +742,7 @@ for more details.
                 return parse_podcast_episode(
                     episode=abs_episode,
                     prov_podcast_id=prov_podcast_id,
+                    prov_podcast_name=abs_podcast.media.metadata.title,
                     fallback_episode_cnt=episode_cnt,
                     instance_id=self.instance_id,
                     domain=self.domain,

--- a/music_assistant/providers/audiobookshelf/parsers.py
+++ b/music_assistant/providers/audiobookshelf/parsers.py
@@ -165,7 +165,7 @@ def parse_podcast_episode(
     *,
     episode: AbsPodcastEpisode | AbsPodcastEpisodeExpanded,
     prov_podcast_id: str,
-    prov_podcast_name: str | None = None,
+    prov_podcast_name: str | None,
     fallback_episode_cnt: int | None = None,
     instance_id: str,
     domain: str,

--- a/music_assistant/providers/audiobookshelf/parsers.py
+++ b/music_assistant/providers/audiobookshelf/parsers.py
@@ -165,6 +165,7 @@ def parse_podcast_episode(
     *,
     episode: AbsPodcastEpisode | AbsPodcastEpisodeExpanded,
     prov_podcast_id: str,
+    prov_podcast_name: str | None = None,
     fallback_episode_cnt: int | None = None,
     instance_id: str,
     domain: str,
@@ -185,6 +186,7 @@ def parse_podcast_episode(
     A PodcastEpisode has only limited information, and is currently only used
     within the recommendations.
     """
+    # ruff: noqa: PLR0913 (too many arguments)
     episode_id = f"{prov_podcast_id} {episode.id_}"
 
     if isinstance(episode, AbsPodcastEpisodeExpanded):
@@ -231,7 +233,7 @@ def parse_podcast_episode(
         podcast=ItemMapping(
             item_id=prov_podcast_id,
             provider=instance_id,
-            name=episode.title,
+            name=prov_podcast_name or episode.title,
             media_type=MediaType.PODCAST,
         ),
         provider_mappings=provider_mappings,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Use the podcast's title in the ItemMapping of an Episode when parsing episodes in ABS. Related: PR https://github.com/music-assistant/server/pull/4444

I disabled the too-many-arguments of ruff in the parse episode. The ABS provider needs to see a refactor, and that will come after I added the author/ narrator support to the frontend and ABS (and the local filesystem provider)

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
