### PR TITLE
Add support for podcast chapters in Audiobookshelf

### DIFF
--- a/music_assistant/providers/audiobookshelf/manifest.json
+++ b/music_assistant/providers/audiobookshelf/manifest.json
@@ -6,7 +6,7 @@
   "description": "Stream audiobooks and podcasts from your personal Audiobookshelf server.",
   "codeowners": ["@fmunkes"],
   "credits": ["[aioaudiobookshelf](https://github.com/music-assistant/aioaudiobookshelf)"],
-  "requirements": ["aioaudiobookshelf==0.1.21"],
+  "requirements": ["aioaudiobookshelf==0.1.22"],
   "documentation": "https://music-assistant.io/music-providers/audiobookshelf",
   "multi_instance": true
 }

--- a/music_assistant/providers/audiobookshelf/parsers.py
+++ b/music_assistant/providers/audiobookshelf/parsers.py
@@ -255,6 +255,17 @@ def parse_podcast_episode(
         mass_episode.resume_position_ms = int(media_progress.current_time * 1000)
         mass_episode.fully_played = media_progress.is_finished
 
+    if episode.chapters:
+        mass_episode.metadata.chapters = [
+            MediaItemChapter(
+                position=position,
+                name=chapter.title,
+                start=chapter.start,
+                end=chapter.end,
+            )
+            for position, chapter in enumerate(episode.chapters, 1)
+        ]
+
     return mass_episode
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3,7 +3,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 Brotli>=1.0.9
-aioaudiobookshelf==0.1.21
+aioaudiobookshelf==0.1.22
 aiodns>=3.2.0
 aiofiles==24.1.0
 aiohttp==3.14.1


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Adds support for podcast episode chapters to the Audiobookshelf provider. Also as a result of https://github.com/music-assistant/server/pull/4444 , but not to be backported.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
