### PR TITLE
Bounded managed pool for radio mode

### DIFF
--- a/music_assistant/controllers/music/recency.py
+++ b/music_assistant/controllers/music/recency.py
@@ -61,10 +61,9 @@ class RecencySnapshot:
 
     def last_played(self, item: MediaItemType) -> int | None:
         """
-        Return the most recent play timestamp for the track, or None if not in the snapshot.
+        Return the most recent play timestamp for the track, or None if it has no play recorded.
 
-        Matched across the track's own ``(provider, item_id)`` and all of its provider mappings;
-        used for least-recently-played ordering (a missing timestamp sorts as least recent).
+        Matched across the track's own ``(provider, item_id)`` and all of its provider mappings.
 
         :param item: The track (or queue media item) to look up.
         """

--- a/music_assistant/controllers/music/recency.py
+++ b/music_assistant/controllers/music/recency.py
@@ -56,15 +56,27 @@ class RecencySnapshot:
         """
         if not within_seconds:
             return False
-        cutoff = self.now - within_seconds
+        timestamp = self.last_played(item)
+        return timestamp is not None and timestamp >= self.now - within_seconds
+
+    def last_played(self, item: MediaItemType) -> int | None:
+        """
+        Return the most recent play timestamp for the track, or None if not in the snapshot.
+
+        Matched across the track's own ``(provider, item_id)`` and all of its provider mappings;
+        used for least-recently-played ordering (a missing timestamp sorts as least recent).
+
+        :param item: The track (or queue media item) to look up.
+        """
+        timestamps = []
         timestamp = self.song_ts.get((item.provider, item.item_id))
-        if timestamp is not None and timestamp >= cutoff:
-            return True
+        if timestamp is not None:
+            timestamps.append(timestamp)
         for mapping in getattr(item, "provider_mappings", None) or ():
             timestamp = self.song_ts.get((mapping.provider_instance, mapping.item_id))
-            if timestamp is not None and timestamp >= cutoff:
-                return True
-        return False
+            if timestamp is not None:
+                timestamps.append(timestamp)
+        return max(timestamps) if timestamps else None
 
     def artist_recent(self, name: str, within_seconds: int | None) -> bool:
         """

--- a/music_assistant/controllers/player_queues/constants.py
+++ b/music_assistant/controllers/player_queues/constants.py
@@ -53,5 +53,13 @@ SMART_SHUFFLE_SONG_RECENCY_OPTIONS = (
 SMART_SHUFFLE_ARTIST_RECENCY_OPTIONS = (0, 300, 900, 1800, 3600, 7200)
 SMART_SHUFFLE_DUPLICATE_GAP_OPTIONS = (0, 3600, 7200, 10800, 14400, 21600, 28800, 43200, 86400)
 
+# Managed-pool (radio) sizing: a radio-flagged enqueue turns the whole queue into a small
+# bounded pool of dynamic sources, topped up near the end instead of enqueuing thousands.
+MANAGED_POOL_TARGET = 25
+MANAGED_POOL_MAX = 50
+# how many similar candidates to fetch per SIMILAR source on each (re)fill
+POOL_PER_SOURCE_FETCH = 50
+
 CACHE_CATEGORY_PLAYER_QUEUE_STATE = 0
 CACHE_CATEGORY_PLAYER_QUEUE_ITEMS = 1
+CACHE_CATEGORY_PLAYER_QUEUE_POOL = 2

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -2595,7 +2595,9 @@ class PlayerQueuesController(CoreController):
         # recency-gated. fill() already sizes the batch to the pool target; the tail cap below is a
         # defensive ceiling so the unplayed tail never grows past MANAGED_POOL_MAX.
         pool_tracks = await self._managed_pool.fill(queue_id, is_initial=False)
-        unplayed = max(len(self._queue_items[queue_id]) - ((queue.current_index or 0) + 1), 0)
+        # keep the unplayed tail within the bounded pool size (no current_index => nothing played yet)
+        played = 0 if queue.current_index is None else queue.current_index + 1
+        unplayed = max(len(self._queue_items[queue_id]) - played, 0)
         headroom = max(MANAGED_POOL_MAX - unplayed, 0)
         queue_items = [
             QueueItem.from_media_item(queue_id, x) for x in pool_tracks[:headroom] if x.available

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -2206,9 +2206,12 @@ class PlayerQueuesController(CoreController):
         else:
             queue.radio_source += radio_source
         queue.is_dynamic = is_radio_source_dynamic(queue.radio_source)
-        self._managed_pool.register(
-            queue_id, queue.radio_source, similar_uris, replace=replace_sources
-        )
+        # only track fill modes when the queue actually has dynamic sources; a plain enqueue leaves
+        # radio_source empty and shouldn't write a cache entry (a REPLACE already cleared any prior)
+        if queue.radio_source:
+            self._managed_pool.register(
+                queue_id, queue.radio_source, similar_uris, replace=replace_sources
+            )
 
         if already_managed and not media_items:
             # Sources were registered onto an already-active managed pool (no tracks to dump): keep

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -107,6 +107,7 @@ from music_assistant.controllers.player_queues.constants import (
     CONF_SMART_SHUFFLE_SONG_RECENCY,
     ENQUEUE_SELECT_ALBUM_DEFAULT_VALUE,
     ENQUEUE_SELECT_ARTIST_DEFAULT_VALUE,
+    MANAGED_POOL_MAX,
     SMART_SHUFFLE_ARTIST_RECENCY_DEFAULT,
     SMART_SHUFFLE_ARTIST_RECENCY_OPTIONS,
     SMART_SHUFFLE_DUPLICATE_GAP_DEFAULT,
@@ -122,6 +123,7 @@ from music_assistant.controllers.player_queues.helpers import (
     is_radio_source_dynamic,
     sort_tracks,
 )
+from music_assistant.controllers.player_queues.managed_pool import ManagedPoolHelper, gate_tracks
 from music_assistant.controllers.player_queues.smart_shuffle import SmartShuffleHelper
 from music_assistant.controllers.streams.audio_buffer import AudioBuffer
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
@@ -183,6 +185,7 @@ class PlayerQueuesController(CoreController):
         self._flow_buffer_completed: dict[str, str] = {}
         self._autoplay = AutoplayHelper(self)
         self._smart_shuffle = SmartShuffleHelper(self)
+        self._managed_pool = ManagedPoolHelper(self)
         self.manifest.name = "Player Queues controller"
         self.manifest.description = (
             "Music Assistant's core controller which manages the queues for all players."
@@ -735,6 +738,7 @@ class PlayerQueuesController(CoreController):
         queue = self._queues[queue_id]
         queue.radio_source = []
         queue.is_dynamic = False
+        self._managed_pool.forget(queue_id, drop_cache=True)
         if queue.state != PlaybackState.IDLE and not skip_stop:
             self.mass.create_task(self.stop(queue_id))
         queue.current_index = None
@@ -1214,6 +1218,7 @@ class PlayerQueuesController(CoreController):
         target_queue.autoplay_enabled = source_queue.autoplay_enabled
         target_queue.radio_source = source_queue.radio_source
         target_queue.is_dynamic = source_queue.is_dynamic
+        self._managed_pool.transfer(source_queue_id, target_queue_id)
         target_queue.smart_shuffle_active = self.is_smart_shuffle_active(target_queue)
         target_queue.enqueued_media_items = source_queue.enqueued_media_items
         target_queue.resume_pos = source_resume_pos
@@ -1254,6 +1259,8 @@ class PlayerQueuesController(CoreController):
                 # recalculate is_dynamic after radio_source is restored from cache
                 # (old cache entries won't have is_dynamic set)
                 queue.is_dynamic = is_radio_source_dynamic(queue.radio_source)
+                # restore the per-source fill modes (SIMILAR vs rotate-own-tracks)
+                await self._managed_pool.restore(queue_id, queue.radio_source)
                 prev_items = await self.mass.cache.get(
                     key=queue_id,
                     provider=self.domain,
@@ -1381,6 +1388,7 @@ class PlayerQueuesController(CoreController):
         self._transitioning_players.discard(player_id)
         self._play_action_refcount.pop(player_id, None)
         self._last_counted_play.pop(player_id, None)
+        self._managed_pool.forget(player_id, drop_cache=permanent)
 
     async def load_next_queue_item(
         self,
@@ -2077,8 +2085,16 @@ class PlayerQueuesController(CoreController):
         if option not in (QueueOption.ADD, QueueOption.NEXT):
             queue.enqueued_media_items.clear()
 
+        # Decide whether this enqueue manages a bounded radio pool. radio_mode starts a fresh pool;
+        # an ADD/NEXT onto an already-active pool keeps managing it. A REPLACE cleared radio_source
+        # above, so it always exits managed mode and behaves as a normal queue.
+        already_managed = bool(queue.radio_source) and option in (QueueOption.ADD, QueueOption.NEXT)
+        managed_pool = radio_mode or already_managed
+
         media_items: list[MediaItemType] = []
         radio_source: list[MediaItemType] = []
+        # URIs of sources enqueued with the radio flag (SIMILAR fill mode); the rest rotate tracks
+        similar_uris: set[str] = set()
         # resolve all media items
         for item in media_list:
             try:
@@ -2123,11 +2139,8 @@ class PlayerQueuesController(CoreController):
                     queue.enqueued_media_items.append(media_item)
                     if len(queue.enqueued_media_items) > 10:
                         queue.enqueued_media_items.pop(0)
-                    if (
-                        isinstance(media_item, Playlist)
-                        and media_item.is_dynamic
-                        and not radio_mode
-                    ):
+                    if isinstance(media_item, Playlist) and media_item.is_dynamic:
+                        # a dynamic playlist/station is always a self-managing radio source
                         radio_source.append(media_item)
 
                 # handle default enqueue option if needed
@@ -2149,12 +2162,9 @@ class PlayerQueuesController(CoreController):
                         self.clear(queue_id, skip_stop=True)
 
                 # collect media_items to play
-                if radio_mode:
-                    # Type guard for mypy - only add full MediaItemType to radio_source
-                    if not isinstance(media_item, (ItemMapping, BrowseFolder)):
-                        radio_source.append(media_item)
-                elif isinstance(media_item, Playlist) and media_item.is_dynamic:
-                    # Dynamic playlists supply their own tracks on demand; fetch first batch now.
+                if isinstance(media_item, Playlist) and media_item.is_dynamic:
+                    # Dynamic playlists/stations supply their own tracks on demand and keep their
+                    # self-managing refill path even inside a managed pool; fetch first batch now.
                     self.mass.create_task(
                         self.mass.music.mark_item_played(
                             media_item, userid=queue.userid, queue_id=queue_id, user_initiated=True
@@ -2162,6 +2172,14 @@ class PlayerQueuesController(CoreController):
                     )
                     initial_tracks = await self.get_playlist_tracks(media_item, start_item=None)
                     media_items += initial_tracks
+                elif managed_pool:
+                    # Managed-pool mode: keep the item as a dynamic source instead of dumping all
+                    # its tracks (the bounded pool is built once below). The radio flag marks the
+                    # source SIMILAR (fetch base+similar); otherwise it rotates its own tracks.
+                    if not isinstance(media_item, (ItemMapping, BrowseFolder)):
+                        radio_source.append(media_item)
+                        if radio_mode and media_item.uri:
+                            similar_uris.add(media_item.uri)
                 else:
                     # Convert start_item to string URI if needed
                     start_item_uri: str | None = None
@@ -2182,17 +2200,32 @@ class PlayerQueuesController(CoreController):
                 self.logger.warning("Skipping %s: %s", item, str(err))
 
         # overwrite or append radio source items
-        if option not in (QueueOption.ADD, QueueOption.NEXT):
+        replace_sources = option not in (QueueOption.ADD, QueueOption.NEXT)
+        if replace_sources:
             queue.radio_source = radio_source
         else:
             queue.radio_source += radio_source
         queue.is_dynamic = is_radio_source_dynamic(queue.radio_source)
-        # Use collected media items to calculate the radio if radio mode is on
-        if radio_mode:
-            radio_tracks = await self._get_radio_tracks(
-                queue_id=queue_id, is_initial_radio_mode=True
-            )
-            media_items = list(radio_tracks)
+        self._managed_pool.register(
+            queue_id, queue.radio_source, similar_uris, replace=replace_sources
+        )
+
+        if already_managed and not media_items:
+            # Sources were registered onto an already-active managed pool (no tracks to dump): keep
+            # the playing pool intact and let it be topped up, incorporating the new sources.
+            self.signal_update(queue_id)
+            if queue.current_index is not None and (queue.items - queue.current_index) < 5:
+                task_id = f"fill_radio_tracks_{queue_id}"
+                self.mass.call_later(5, self._fill_radio_tracks, queue_id, task_id=task_id)
+            return
+
+        # Build the bounded managed pool (instead of dumping all source tracks) for a fresh radio
+        # start, so radio actually fires instead of enqueuing thousands of items. A dynamic
+        # station yields no pool tracks (it self-manages), so keep its own already-fetched tracks.
+        if managed_pool and not already_managed:
+            pool_tracks = await self._managed_pool.fill(queue_id, is_initial=True)
+            if pool_tracks:
+                media_items = list(pool_tracks)
 
         # only add valid/available items
         queue_items: list[QueueItem] = [
@@ -2204,8 +2237,8 @@ class PlayerQueuesController(CoreController):
         if not queue_items:
             raise MediaNotFoundError("No playable items found")
 
-        # load the items into the queue
-        await self._enqueue_with_option(queue_id, queue_items, option, radio_mode)
+        # load the items into the queue (managed-pool tracks are already ordered, so don't reshuffle)
+        await self._enqueue_with_option(queue_id, queue_items, option, managed_pool)
 
     async def _enqueue_with_option(
         self,
@@ -2526,9 +2559,16 @@ class PlayerQueuesController(CoreController):
             set_current_user(playback_user)
             try:
                 dynamic_tracks = await self.get_playlist_tracks(dynamic_playlist, start_item=None)
-                queue_items = [
-                    QueueItem.from_media_item(queue_id, x) for x in dynamic_tracks if x.available
-                ]
+                # route the station batch through the recency engine (ungated fallback keeps the
+                # station playing if everything was recently heard)
+                windows = self._smart_shuffle._windows(queue_id)
+                snapshot = await self.mass.music.recency.snapshot(windows, userid=queue.userid)
+                gated = gate_tracks(
+                    [track for track in dynamic_tracks if isinstance(track, Track)],
+                    snapshot,
+                    windows,
+                )
+                queue_items = [QueueItem.from_media_item(queue_id, x) for x in gated if x.available]
                 if not queue_items:
                     self.logger.warning(
                         "Dynamic playlist %s returned no playable tracks for queue %s",
@@ -2551,9 +2591,17 @@ class PlayerQueuesController(CoreController):
                     err,
                 )
             return
-        radio_tracks = await self._get_radio_tracks(queue_id=queue_id, is_initial_radio_mode=False)
-        # fill queue - filter out unavailable items
-        queue_items = [QueueItem.from_media_item(queue_id, x) for x in radio_tracks if x.available]
+        # Managed pool: top up from the queue's dynamic sources, weighted per source and
+        # recency-gated. fill() already sizes the batch to the pool target; the tail cap below is a
+        # defensive ceiling so the unplayed tail never grows past MANAGED_POOL_MAX.
+        pool_tracks = await self._managed_pool.fill(queue_id, is_initial=False)
+        unplayed = max(len(self._queue_items[queue_id]) - ((queue.current_index or 0) + 1), 0)
+        headroom = max(MANAGED_POOL_MAX - unplayed, 0)
+        queue_items = [
+            QueueItem.from_media_item(queue_id, x) for x in pool_tracks[:headroom] if x.available
+        ]
+        if not queue_items:
+            return
         await self.load(
             queue_id,
             queue_items,
@@ -2605,6 +2653,13 @@ class PlayerQueuesController(CoreController):
                 "Autoplay failed to fetch tracks for queue %s: %s", queue.display_name, err
             )
             return
+        # route the autoplay batch through the recency engine so a recently-heard track isn't
+        # immediately re-added (ungated fallback keeps autoplay going if everything is recent)
+        windows = self._smart_shuffle._windows(queue_id)
+        snapshot = await self.mass.music.recency.snapshot(windows, userid=queue.userid)
+        tracks = gate_tracks(
+            [track for track in tracks if isinstance(track, Track)], snapshot, windows
+        )
         queue_items = [QueueItem.from_media_item(queue_id, x) for x in tracks if x.available]
         if not queue_items:
             self.logger.info("Autoplay found no new tracks to add for queue %s", queue.display_name)

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -2173,9 +2173,9 @@ class PlayerQueuesController(CoreController):
                     initial_tracks = await self.get_playlist_tracks(media_item, start_item=None)
                     media_items += initial_tracks
                 elif managed_pool:
-                    # Managed-pool mode: keep the item as a dynamic source instead of dumping all
-                    # its tracks (the bounded pool is built once below). The radio flag marks the
-                    # source SIMILAR (fetch base+similar); otherwise it rotates its own tracks.
+                    # Managed-pool mode: keep the item as a dynamic source (the bounded pool is
+                    # built from these sources below). The radio flag marks it SIMILAR (base +
+                    # similar); otherwise it rotates its own tracks.
                     if not isinstance(media_item, (ItemMapping, BrowseFolder)):
                         radio_source.append(media_item)
                         if radio_mode and media_item.uri:
@@ -2214,17 +2214,16 @@ class PlayerQueuesController(CoreController):
             )
 
         if already_managed and not media_items:
-            # Sources were registered onto an already-active managed pool (no tracks to dump): keep
-            # the playing pool intact and let it be topped up, incorporating the new sources.
+            # new sources were added to an already-active pool: leave the playing pool intact and
+            # let the next top-up incorporate them
             self.signal_update(queue_id)
             if queue.current_index is not None and (queue.items - queue.current_index) < 5:
                 task_id = f"fill_radio_tracks_{queue_id}"
                 self.mass.call_later(5, self._fill_radio_tracks, queue_id, task_id=task_id)
             return
 
-        # Build the bounded managed pool (instead of dumping all source tracks) for a fresh radio
-        # start, so radio actually fires instead of enqueuing thousands of items. A dynamic
-        # station yields no pool tracks (it self-manages), so keep its own already-fetched tracks.
+        # Build the bounded managed pool for a fresh radio start. A dynamic station yields no pool
+        # tracks (it self-manages), so keep its own already-fetched tracks in that case.
         if managed_pool and not already_managed:
             pool_tracks = await self._managed_pool.fill(queue_id, is_initial=True)
             if pool_tracks:

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -185,7 +185,7 @@ class ManagedPoolHelper:
         :param is_initial: True when seeding a fresh pool, False when topping up an existing one.
         """
         queue = self.queues._queues[queue_id]
-        sources = await self._collect_sources(queue_id, queue, is_initial=is_initial)
+        sources = await self._collect_sources(queue_id, queue)
         if not sources:
             return []
         windows = self.queues._smart_shuffle._windows(queue_id)
@@ -204,9 +204,7 @@ class ManagedPoolHelper:
             sources, slots=slots, pool_keys=pool_keys, snapshot=snapshot, windows=windows
         )
 
-    async def _collect_sources(
-        self, queue_id: str, queue: PlayerQueue, *, is_initial: bool
-    ) -> list[DynamicSource]:
+    async def _collect_sources(self, queue_id: str, queue: PlayerQueue) -> list[DynamicSource]:
         """Group the queue's radio_source into dynamic sources and fetch each one's candidates."""
         # multiplicity = how often a source was added; dynamic playlists/stations self-manage and
         # are handled by the dedicated dynamic-playlist refill path, so skip them here.
@@ -226,9 +224,7 @@ class ManagedPoolHelper:
         for uri, media_item in items.items():
             fill_mode = self.fill_mode(queue_id, uri)
             if fill_mode == DynamicFillMode.SIMILAR:
-                candidates = await self._fetch_similar(
-                    media_item, is_initial=is_initial, preferred=preferred
-                )
+                candidates = await self._fetch_similar(media_item, preferred=preferred)
             else:
                 candidates = await self._fetch_tracks(media_item, preferred=preferred)
             sources.append(
@@ -242,13 +238,22 @@ class ManagedPoolHelper:
         return sources
 
     async def _fetch_similar(
-        self, media_item: MediaItemType, *, is_initial: bool, preferred: list[str] | None
+        self, media_item: MediaItemType, *, preferred: list[str] | None
     ) -> list[Track]:
-        """Fetch base + similar tracks for a SIMILAR source via the dynamic-radio machinery."""
+        """
+        Fetch base + similar tracks for a SIMILAR source via the dynamic-radio machinery.
+
+        Base (original) tracks are always requested so the pool keeps a steady original+similar
+        mix; the recency gate and already-in-pool dedup drop them once they are stale or used,
+        leaving similar-only when no base track can still be honoured.
+
+        :param media_item: The dynamic source to fetch base + similar tracks for.
+        :param preferred: Preferred provider instance ids for the similar lookup.
+        """
         with suppress(MusicAssistantError):
             return await self.mass.music.get_dynamic_radio_tracks(
                 [media_item],
-                include_base_tracks=is_initial,
+                include_base_tracks=True,
                 target_size=POOL_PER_SOURCE_FETCH,
                 preferred_provider_instances=preferred,
             )

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -1,0 +1,435 @@
+"""
+Managed dynamic pool for the Player Queues controller.
+
+A radio-flagged enqueue turns the whole queue into a small, bounded *managed pool* fed by one or
+more *dynamic sources* instead of enqueuing thousands of tracks (so radio never fires). The pool is
+topped up near the end. Each dynamic source has a *fill mode*:
+
+- ``SIMILAR`` — generate base + similar/discovery tracks (set today by the ``radio_mode`` flag);
+- ``TRACKS`` — rotate the source's own unplayed tracks (a normal playlist/album/artist mixed in).
+
+Refills are apportioned across the sources by weight (per-base quota by default — multiplicity is
+the explicit "more often" knob), every candidate is gated against the shared ``RecencyEngine`` so a
+recently-heard song can't be pulled back in, and the least-recently-played candidates are preferred.
+
+The public/model surface (``radio_mode`` param, ``radio_source`` field) is the unchanged bridge to
+this internal model: a queue is in managed-pool mode when its ``radio_source`` is non-empty.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.media_items import Playlist, Track
+
+from music_assistant.controllers.player_queues.constants import (
+    CACHE_CATEGORY_PLAYER_QUEUE_POOL,
+    MANAGED_POOL_TARGET,
+    POOL_PER_SOURCE_FETCH,
+)
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items import MediaItemType
+    from music_assistant_models.player_queue import PlayerQueue
+
+    from music_assistant.controllers.music.recency import RecencySnapshot, RecencyWindows
+    from music_assistant.controllers.player_queues.controller import PlayerQueuesController
+
+
+class PoolWeightModel(StrEnum):
+    """How refill slots are apportioned across the queue's dynamic sources."""
+
+    # equal share per source, scaled only by multiplicity (times added) — size-independent
+    PER_BASE_QUOTA = "per_base_quota"
+    # share scales with the source's candidate count as well as its multiplicity
+    SIZE_MULTIPLICITY = "size_multiplicity"
+
+
+class DynamicFillMode(StrEnum):
+    """How a dynamic source contributes tracks to the managed pool."""
+
+    SIMILAR = "similar"
+    TRACKS = "tracks"
+
+
+# the shipped default; SIZE_MULTIPLICITY is a one-line switch if the feel needs revisiting
+POOL_WEIGHT_MODEL = PoolWeightModel.PER_BASE_QUOTA
+
+# media types that only make sense as similar-seeds (rotating their "own tracks" is degenerate)
+_SIMILAR_MEDIA_TYPES = (
+    MediaType.TRACK,
+    MediaType.ARTIST,
+    MediaType.ALBUM,
+    MediaType.RADIO,
+    MediaType.GENRE,
+)
+
+
+@dataclass(slots=True)
+class DynamicSource:
+    """A single base item feeding the managed pool, with its multiplicity, fill mode + candidates."""
+
+    media_item: MediaItemType
+    multiplicity: int
+    fill_mode: DynamicFillMode
+    candidates: list[Track] = field(default_factory=list)
+
+
+class ManagedPoolHelper:
+    """Build and top up a queue's bounded managed pool from its dynamic sources."""
+
+    def __init__(self, queues: PlayerQueuesController) -> None:
+        """
+        Initialize the managed pool helper.
+
+        :param queues: The owning player queues controller.
+        """
+        self.queues = queues
+        self.mass = queues.mass
+        self.logger = queues.logger.getChild("managed_pool")
+        # queue_id -> set of source URIs whose fill mode is SIMILAR (default, absent = TRACKS)
+        self._similar_sources: dict[str, set[str]] = {}
+
+    def fill_mode(self, queue_id: str, uri: str | None) -> DynamicFillMode:
+        """
+        Return the fill mode for a source URI in the given queue.
+
+        :param queue_id: The queue the source belongs to.
+        :param uri: The source's URI.
+        """
+        if uri and uri in self._similar_sources.get(queue_id, ()):
+            return DynamicFillMode.SIMILAR
+        return DynamicFillMode.TRACKS
+
+    def register(
+        self,
+        queue_id: str,
+        radio_source: list[MediaItemType],
+        similar_uris: set[str],
+        *,
+        replace: bool,
+    ) -> None:
+        """
+        Record the fill modes for a queue's dynamic sources and persist them.
+
+        :param queue_id: The queue being (re)configured.
+        :param radio_source: The queue's full list of dynamic sources after this enqueue.
+        :param similar_uris: URIs of sources enqueued with the radio flag (SIMILAR fill mode).
+        :param replace: True to replace the existing fill modes, False to merge (ADD/NEXT).
+        """
+        valid = {uri for item in radio_source if (uri := _uri(item))}
+        existing = set() if replace else self._similar_sources.get(queue_id, set())
+        self._similar_sources[queue_id] = (existing | similar_uris) & valid
+        self._persist(queue_id)
+
+    async def restore(self, queue_id: str, radio_source: list[MediaItemType]) -> None:
+        """
+        Restore the fill modes for a queue from cache after a restart.
+
+        Falls back to deriving them from each source's media type when no cache entry exists
+        (e.g. queues persisted before this feature).
+
+        :param queue_id: The queue being restored.
+        :param radio_source: The queue's restored dynamic sources.
+        """
+        valid = {uri for item in radio_source if (uri := _uri(item))}
+        stored = await self.mass.cache.get(
+            key=queue_id,
+            provider=self.queues.domain,
+            category=CACHE_CATEGORY_PLAYER_QUEUE_POOL,
+        )
+        if stored is not None:
+            self._similar_sources[queue_id] = {uri for uri in stored if uri in valid}
+        else:
+            self._similar_sources[queue_id] = {
+                uri for item in radio_source if _derive_similar(item) and (uri := _uri(item))
+            }
+
+    def forget(self, queue_id: str, *, drop_cache: bool) -> None:
+        """
+        Drop the in-memory fill modes for a queue (and optionally its cache entry).
+
+        :param queue_id: The queue to forget.
+        :param drop_cache: True to also delete the persisted entry (queue cleared/removed).
+        """
+        self._similar_sources.pop(queue_id, None)
+        if drop_cache:
+            self.mass.create_task(
+                self.mass.cache.delete(
+                    key=queue_id,
+                    provider=self.queues.domain,
+                    category=CACHE_CATEGORY_PLAYER_QUEUE_POOL,
+                )
+            )
+
+    def transfer(self, source_queue_id: str, target_queue_id: str) -> None:
+        """
+        Copy a queue's fill modes onto another queue (used when a queue is transferred).
+
+        :param source_queue_id: The queue currently holding the dynamic sources.
+        :param target_queue_id: The queue receiving them.
+        """
+        self._similar_sources[target_queue_id] = set(self._similar_sources.get(source_queue_id, ()))
+        self._persist(target_queue_id)
+
+    async def fill(self, queue_id: str, *, is_initial: bool) -> list[Track]:
+        """
+        Build (or top up) the managed pool and return the tracks to add.
+
+        :param queue_id: The queue to fill.
+        :param is_initial: True when seeding a fresh pool, False when topping up an existing one.
+        """
+        queue = self.queues._queues[queue_id]
+        sources = await self._collect_sources(queue_id, queue, is_initial=is_initial)
+        if not sources:
+            return []
+        windows = self.queues._smart_shuffle._windows(queue_id)
+        snapshot = await self.mass.music.recency.snapshot(windows, userid=queue.userid)
+        pool_keys = {
+            item.media_item
+            for item in self.queues._queue_items[queue_id]
+            if isinstance(item.media_item, Track)
+        }
+        slots = (
+            MANAGED_POOL_TARGET
+            if is_initial
+            else max(MANAGED_POOL_TARGET - self._unplayed(queue), 0)
+        )
+        return allocate_refill(
+            sources, slots=slots, pool_keys=pool_keys, snapshot=snapshot, windows=windows
+        )
+
+    async def _collect_sources(
+        self, queue_id: str, queue: PlayerQueue, *, is_initial: bool
+    ) -> list[DynamicSource]:
+        """Group the queue's radio_source into dynamic sources and fetch each one's candidates."""
+        # multiplicity = how often a source was added; dynamic playlists/stations self-manage and
+        # are handled by the dedicated dynamic-playlist refill path, so skip them here.
+        counts: dict[str, int] = {}
+        items: dict[str, MediaItemType] = {}
+        for item in queue.radio_source:
+            if isinstance(item, Playlist) and item.is_dynamic:
+                continue
+            if not (uri := _uri(item)):
+                continue
+            counts[uri] = counts.get(uri, 0) + 1
+            items.setdefault(uri, item)
+        if not items:
+            return []
+        preferred = await self._preferred_providers(queue)
+        sources: list[DynamicSource] = []
+        for uri, media_item in items.items():
+            fill_mode = self.fill_mode(queue_id, uri)
+            if fill_mode == DynamicFillMode.SIMILAR:
+                candidates = await self._fetch_similar(
+                    media_item, is_initial=is_initial, preferred=preferred
+                )
+            else:
+                candidates = await self._fetch_tracks(media_item, preferred=preferred)
+            sources.append(
+                DynamicSource(
+                    media_item=media_item,
+                    multiplicity=counts[uri],
+                    fill_mode=fill_mode,
+                    candidates=candidates,
+                )
+            )
+        return sources
+
+    async def _fetch_similar(
+        self, media_item: MediaItemType, *, is_initial: bool, preferred: list[str] | None
+    ) -> list[Track]:
+        """Fetch base + similar tracks for a SIMILAR source via the dynamic-radio machinery."""
+        with suppress(MusicAssistantError):
+            return await self.mass.music.get_dynamic_radio_tracks(
+                [media_item],
+                include_base_tracks=is_initial,
+                target_size=POOL_PER_SOURCE_FETCH,
+                preferred_provider_instances=preferred,
+            )
+        return []
+
+    async def _fetch_tracks(
+        self, media_item: MediaItemType, *, preferred: list[str] | None
+    ) -> list[Track]:
+        """Fetch a TRACKS source's own (playable) tracks via its media controller."""
+        controller = self.mass.music.get_controller(media_item.media_type)
+        with suppress(MusicAssistantError):
+            tracks = await controller.radio_mode_base_tracks(media_item, preferred)  # type: ignore[arg-type]
+            return [track for track in tracks if isinstance(track, Track) and track.available]
+        return []
+
+    async def _preferred_providers(self, queue: PlayerQueue) -> list[str] | None:
+        """Return the queue owner's preferred provider instances, if any."""
+        if (
+            queue.userid
+            and (user := await self.mass.webserver.auth.get_user(queue.userid))
+            and user.provider_filter
+        ):
+            return user.provider_filter
+        return None
+
+    def _unplayed(self, queue: PlayerQueue) -> int:
+        """Return how many not-yet-played items remain in the queue."""
+        items = self.queues._queue_items.get(queue.queue_id, [])
+        if queue.current_index is None:
+            return len(items)
+        return max(len(items) - (queue.current_index + 1), 0)
+
+    def _persist(self, queue_id: str) -> None:
+        """Persist the queue's SIMILAR-source URIs so fill modes survive a restart."""
+        self.mass.create_task(
+            self.mass.cache.set(
+                key=queue_id,
+                data=sorted(self._similar_sources.get(queue_id, ())),
+                provider=self.queues.domain,
+                category=CACHE_CATEGORY_PLAYER_QUEUE_POOL,
+            )
+        )
+
+
+def allocate_refill(
+    sources: list[DynamicSource],
+    *,
+    slots: int,
+    pool_keys: set[Track],
+    snapshot: RecencySnapshot,
+    windows: RecencyWindows,
+    weight_model: PoolWeightModel = POOL_WEIGHT_MODEL,
+) -> list[Track]:
+    """
+    Pick the next batch of tracks for the managed pool, weighted per source and recency-gated.
+
+    Slots are apportioned across sources by weight; each source's candidates are hard-gated against
+    the recency snapshot (a within-window track is excluded entirely) and ordered least-recently-
+    played first. If gating leaves nothing, an ungated least-recently-played fallback is returned so
+    playback never stalls.
+
+    :param sources: The queue's dynamic sources, each with its already-fetched candidate tracks.
+    :param slots: How many tracks to add (0 or fewer returns nothing).
+    :param pool_keys: Tracks already in the queue, to avoid immediate repeats.
+    :param snapshot: The play-history snapshot to gate/score against.
+    :param windows: The configured recency windows.
+    :param weight_model: How to weight sources against each other.
+    """
+    if slots <= 0 or not sources:
+        return []
+    eligible = [_eligible(source, pool_keys, snapshot, windows) for source in sources]
+    weights = [max(_weight(source, weight_model), 0) for source in sources]
+    total_weight = sum(weights) or len(sources)
+    shares = [slots * (weight or 0) / total_weight for weight in weights]
+    taken = [0.0] * len(sources)
+    pointers = [0] * len(sources)
+    chosen: list[Track] = []
+    chosen_set: set[Track] = set()
+    for _ in range(slots):
+        best_index = -1
+        best_deficit = 0.0
+        for index in range(len(sources)):
+            # skip candidates already chosen for another source this round
+            while pointers[index] < len(eligible[index]) and (
+                eligible[index][pointers[index]] in chosen_set
+            ):
+                pointers[index] += 1
+            if pointers[index] >= len(eligible[index]):
+                continue
+            deficit = shares[index] - taken[index]
+            if best_index == -1 or deficit > best_deficit:
+                best_index, best_deficit = index, deficit
+        if best_index == -1:
+            break
+        track = eligible[best_index][pointers[best_index]]
+        chosen.append(track)
+        chosen_set.add(track)
+        taken[best_index] += 1
+        pointers[best_index] += 1
+    return chosen or _ungated_fallback(sources, slots, pool_keys, snapshot)
+
+
+def gate_tracks(
+    tracks: list[Track],
+    snapshot: RecencySnapshot,
+    windows: RecencyWindows,
+    *,
+    duplicate: bool = False,
+) -> list[Track]:
+    """
+    Drop tracks played within the recency window, keeping the original order.
+
+    Falls back to the ungated list when every track is blocked, so a refill never returns empty.
+
+    :param tracks: The candidate tracks to filter.
+    :param snapshot: The play-history snapshot to gate against.
+    :param windows: The configured recency windows.
+    :param duplicate: True to gate on the duplicate repeat-gap instead of the song window.
+    """
+    window = windows.duplicate_gap_seconds if duplicate else windows.song_seconds
+    if not window:
+        return list(tracks)
+    kept = [track for track in tracks if not snapshot.track_recent(track, window)]
+    return kept or list(tracks)
+
+
+def _eligible(
+    source: DynamicSource,
+    pool_keys: set[Track],
+    snapshot: RecencySnapshot,
+    windows: RecencyWindows,
+) -> list[Track]:
+    """Return a source's candidates minus pool/recency-blocked ones, least-recently-played first."""
+    # a deliberately-duplicated source uses the short repeat-gap, a singleton the long song window
+    window = windows.duplicate_gap_seconds if source.multiplicity > 1 else windows.song_seconds
+    scored: list[tuple[int, int, Track]] = []
+    for track in source.candidates:
+        if track in pool_keys:
+            continue
+        last_played = snapshot.last_played(track)
+        if window and last_played is not None and last_played >= snapshot.now - window:
+            continue  # hard recency gate: a within-window track is excluded entirely
+        # never-played (None) sorts ahead of played; then oldest play first
+        scored.append((0 if last_played is None else 1, last_played or 0, track))
+    scored.sort(key=lambda entry: (entry[0], entry[1]))
+    return [track for _, _, track in scored]
+
+
+def _weight(source: DynamicSource, weight_model: PoolWeightModel) -> int:
+    """Return a source's refill weight under the configured weight model."""
+    if weight_model == PoolWeightModel.SIZE_MULTIPLICITY:
+        return max(len(source.candidates), 1) * source.multiplicity
+    return source.multiplicity
+
+
+def _ungated_fallback(
+    sources: list[DynamicSource], slots: int, pool_keys: set[Track], snapshot: RecencySnapshot
+) -> list[Track]:
+    """Return the globally least-recently-played candidates, ignoring the recency gate."""
+    seen: set[Track] = set()
+    pool: list[Track] = []
+    for source in sources:
+        for track in source.candidates:
+            if track in pool_keys or track in seen:
+                continue
+            seen.add(track)
+            pool.append(track)
+    pool.sort(
+        key=lambda track: (
+            0 if snapshot.last_played(track) is None else 1,
+            snapshot.last_played(track) or 0,
+        )
+    )
+    return pool[:slots]
+
+
+def _derive_similar(media_item: MediaItemType) -> bool:
+    """Return whether a source defaults to SIMILAR fill mode based on its media type."""
+    return media_item.media_type in _SIMILAR_MEDIA_TYPES
+
+
+def _uri(media_item: MediaItemType) -> str | None:
+    """Return a media item's URI, or None when it has none."""
+    return getattr(media_item, "uri", None)

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -23,7 +23,6 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
-from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.media_items import Playlist, Track
 
@@ -59,15 +58,6 @@ class DynamicFillMode(StrEnum):
 
 # the shipped default; SIZE_MULTIPLICITY is a one-line switch if the feel needs revisiting
 POOL_WEIGHT_MODEL = PoolWeightModel.PER_BASE_QUOTA
-
-# media types that only make sense as similar-seeds (rotating their "own tracks" is degenerate)
-_SIMILAR_MEDIA_TYPES = (
-    MediaType.TRACK,
-    MediaType.ARTIST,
-    MediaType.ALBUM,
-    MediaType.RADIO,
-    MediaType.GENRE,
-)
 
 
 @dataclass(slots=True)
@@ -131,8 +121,9 @@ class ManagedPoolHelper:
         """
         Restore the fill modes for a queue from cache after a restart.
 
-        Falls back to deriving them from each source's media type when no cache entry exists
-        (e.g. queues persisted before this feature).
+        When no cache entry exists (a queue persisted before this feature) every radio_source item
+        was a similar/discovery seed, so all (non-station) sources default to SIMILAR to preserve
+        that pre-feature radio behaviour after an upgrade.
 
         :param queue_id: The queue being restored.
         :param radio_source: The queue's restored dynamic sources.
@@ -147,7 +138,9 @@ class ManagedPoolHelper:
             self._similar_sources[queue_id] = {uri for uri in stored if uri in valid}
         else:
             self._similar_sources[queue_id] = {
-                uri for item in radio_source if _derive_similar(item) and (uri := _uri(item))
+                uri
+                for item in radio_source
+                if not (isinstance(item, Playlist) and item.is_dynamic) and (uri := _uri(item))
             }
 
     def forget(self, queue_id: str, *, drop_cache: bool) -> None:
@@ -428,11 +421,6 @@ def _ungated_fallback(
         )
     )
     return pool[:slots]
-
-
-def _derive_similar(media_item: MediaItemType) -> bool:
-    """Return whether a source defaults to SIMILAR fill mode based on its media type."""
-    return media_item.media_type in _SIMILAR_MEDIA_TYPES
 
 
 def _uri(media_item: MediaItemType) -> str | None:

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -1,19 +1,15 @@
 """
 Managed dynamic pool for the Player Queues controller.
 
-A radio-flagged enqueue turns the whole queue into a small, bounded *managed pool* fed by one or
-more *dynamic sources* instead of enqueuing thousands of tracks (so radio never fires). The pool is
-topped up near the end. Each dynamic source has a *fill mode*:
+A queue with one or more *dynamic sources* (its ``radio_source``) is kept as a small bounded pool
+that is topped up as it plays down. Each source has a *fill mode*:
 
-- ``SIMILAR`` — generate base + similar/discovery tracks (set today by the ``radio_mode`` flag);
-- ``TRACKS`` — rotate the source's own unplayed tracks (a normal playlist/album/artist mixed in).
+- ``SIMILAR`` — base + similar/discovery tracks (radio sources);
+- ``TRACKS`` — the source's own unplayed tracks (a playlist/album/artist mixed into the pool).
 
-Refills are apportioned across the sources by weight (per-base quota by default — multiplicity is
-the explicit "more often" knob), every candidate is gated against the shared ``RecencyEngine`` so a
-recently-heard song can't be pulled back in, and the least-recently-played candidates are preferred.
-
-The public/model surface (``radio_mode`` param, ``radio_source`` field) is the unchanged bridge to
-this internal model: a queue is in managed-pool mode when its ``radio_source`` is non-empty.
+Each top-up apportions slots across the sources by weight (per-base quota by default, so adding a
+source more than once weights it up), gates every candidate against the shared ``RecencyEngine`` so
+a recently-heard track isn't pulled back in, and prefers the least-recently-played candidates.
 """
 
 from __future__ import annotations
@@ -234,16 +230,14 @@ class ManagedPoolHelper:
         self, media_item: MediaItemType, *, preferred: list[str] | None
     ) -> list[Track]:
         """
-        Fetch base + similar tracks for a SIMILAR source via the dynamic-radio machinery.
+        Return base + similar tracks for a SIMILAR source.
 
-        Base (original) tracks are always requested so the pool keeps a steady original+similar
-        mix; the recency gate and already-in-pool dedup drop them once they are stale or used,
-        leaving similar-only when no base track can still be honoured.
-
-        :param media_item: The dynamic source to fetch base + similar tracks for.
+        :param media_item: The dynamic source to fetch tracks for.
         :param preferred: Preferred provider instance ids for the similar lookup.
         """
         with suppress(MusicAssistantError):
+            # always include the base tracks so the pool keeps a steady original+similar mix; the
+            # recency gate and in-pool dedup drop them once stale or already queued
             return await self.mass.music.get_dynamic_radio_tracks(
                 [media_item],
                 include_base_tracks=True,

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -179,10 +179,12 @@ class ManagedPoolHelper:
             return []
         windows = self.queues._smart_shuffle._windows(queue_id)
         snapshot = await self.mass.music.recency.snapshot(windows, userid=queue.userid)
+        # dedupe only against the active (current + unplayed) tail; played history is left out so
+        # recency, not permanent exclusion, decides when a track may return
+        items = self.queues._queue_items[queue_id]
+        start = queue.current_index if queue.current_index is not None else 0
         pool_keys = {
-            item.media_item
-            for item in self.queues._queue_items[queue_id]
-            if isinstance(item.media_item, Track)
+            item.media_item for item in items[start:] if isinstance(item.media_item, Track)
         }
         slots = (
             MANAGED_POOL_TARGET

--- a/music_assistant/providers/test/__init__.py
+++ b/music_assistant/providers/test/__init__.py
@@ -75,6 +75,7 @@ SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_TRACKS,
     ProviderFeature.LIBRARY_PODCASTS,
     ProviderFeature.LIBRARY_AUDIOBOOKS,
+    ProviderFeature.SIMILAR_TRACKS,
 }
 
 
@@ -196,6 +197,28 @@ class TestProvider(MusicProvider):
             track_number=int(track_idx),
         )
 
+    async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
+        """Return a deterministic set of similar tracks (the catalogue neighbours of the seed)."""
+        num_artists = self.config.get_value(CONF_KEY_NUM_ARTISTS) or 5
+        num_albums = self.config.get_value(CONF_KEY_NUM_ALBUMS) or 5
+        num_tracks = self.config.get_value(CONF_KEY_NUM_TRACKS) or 20
+        assert isinstance(num_artists, int)
+        assert isinstance(num_albums, int)
+        assert isinstance(num_tracks, int)
+        total = num_artists * num_albums * num_tracks
+        artist_idx, album_idx, track_idx = (int(part) for part in prov_track_id.split("_", 3))
+        seed_ordinal = (artist_idx * num_albums + album_idx) * num_tracks + track_idx
+        # walk the catalogue starting just after the seed so the result is stable and seed-excluded
+        similar: list[Track] = []
+        for step in range(1, total):
+            if len(similar) >= limit:
+                break
+            ordinal = (seed_ordinal + step) % total
+            artist, remainder = divmod(ordinal, num_albums * num_tracks)
+            album, track = divmod(remainder, num_tracks)
+            similar.append(await self.get_track(f"{artist}_{album}_{track}"))
+        return similar
+
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """Get full artist details by id."""
         genre = random.Random(prov_artist_id).choice(DEFAULT_GENRES)
@@ -234,6 +257,16 @@ class TestProvider(MusicProvider):
             },
             metadata=MediaItemMetadata(images=UniqueList([DEFAULT_THUMB]), genres={genre}),
         )
+
+    async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
+        """Get all tracks for the given album id."""
+        num_tracks = self.config.get_value(CONF_KEY_NUM_TRACKS) or 20
+        assert isinstance(num_tracks, int)
+        artist_idx, album_idx = prov_album_id.split("_", 2)
+        return [
+            await self.get_track(f"{artist_idx}_{album_idx}_{track_idx}")
+            for track_idx in range(num_tracks)
+        ]
 
     async def get_podcast(self, prov_podcast_id: str) -> Podcast:
         """Get full podcast details by id."""

--- a/tests/controllers/player_queues/test_managed_pool.py
+++ b/tests/controllers/player_queues/test_managed_pool.py
@@ -1,0 +1,239 @@
+"""Tests for the managed-pool refill allocator (player_queues/managed_pool.py)."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track
+from music_assistant_models.unique_list import UniqueList
+
+from music_assistant.controllers.music.recency import RecencySnapshot, RecencyWindows
+from music_assistant.controllers.player_queues.managed_pool import (
+    DynamicFillMode,
+    DynamicSource,
+    PoolWeightModel,
+    allocate_refill,
+    gate_tracks,
+)
+
+NOW = 1_000_000_000
+HOUR = 3600
+WEEK = 7 * 24 * HOUR
+GAP = 3 * HOUR
+
+
+def _track(item_id: str) -> Track:
+    """Build a Track on the 'test' provider with a single artist and provider mapping."""
+    return Track(
+        item_id=item_id,
+        provider="test",
+        name=f"Track {item_id}",
+        duration=60,
+        artists=UniqueList(
+            [ItemMapping(item_id="a", provider="test", name="A", media_type=MediaType.ARTIST)]
+        ),
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _source(
+    candidate_ids: list[str],
+    *,
+    multiplicity: int = 1,
+    fill_mode: DynamicFillMode = DynamicFillMode.TRACKS,
+) -> DynamicSource:
+    """Build a DynamicSource with the given candidate track ids."""
+    return DynamicSource(
+        media_item=_track("seed"),
+        multiplicity=multiplicity,
+        fill_mode=fill_mode,
+        candidates=[_track(cid) for cid in candidate_ids],
+    )
+
+
+def _snapshot(played: dict[str, int] | None = None) -> RecencySnapshot:
+    """Build a snapshot marking the given track ids as played at the given timestamps."""
+    return RecencySnapshot(
+        now=NOW, song_ts={("test", item_id): ts for item_id, ts in (played or {}).items()}
+    )
+
+
+def _ids(tracks: list[Track]) -> list[str]:
+    return [track.item_id for track in tracks]
+
+
+def test_empty_slots_returns_empty() -> None:
+    """Asking for zero (or fewer) slots returns nothing."""
+    source = _source(["a", "b"])
+    assert (
+        allocate_refill(
+            [source], slots=0, pool_keys=set(), snapshot=_snapshot(), windows=RecencyWindows()
+        )
+        == []
+    )
+
+
+def test_no_sources_returns_empty() -> None:
+    """No sources returns nothing."""
+    assert (
+        allocate_refill(
+            [], slots=5, pool_keys=set(), snapshot=_snapshot(), windows=RecencyWindows()
+        )
+        == []
+    )
+
+
+def test_per_base_quota_equal_share() -> None:
+    """Two equally-weighted sources split the slots evenly, regardless of catalogue size."""
+    sources = [
+        _source([f"a{i}" for i in range(20)]),
+        _source([f"b{i}" for i in range(20)]),
+    ]
+    result = allocate_refill(
+        sources, slots=10, pool_keys=set(), snapshot=_snapshot(), windows=RecencyWindows()
+    )
+    counts = Counter("a" if tid.startswith("a") else "b" for tid in _ids(result))
+    assert counts["a"] == 5
+    assert counts["b"] == 5
+
+
+def test_multiplicity_increases_share() -> None:
+    """A source added 3x gets ~3x the slots of one added once (per-base quota)."""
+    sources = [
+        _source([f"a{i}" for i in range(20)], multiplicity=1),
+        _source([f"b{i}" for i in range(20)], multiplicity=3),
+    ]
+    result = allocate_refill(
+        sources, slots=8, pool_keys=set(), snapshot=_snapshot(), windows=RecencyWindows()
+    )
+    counts = Counter("a" if tid.startswith("a") else "b" for tid in _ids(result))
+    assert counts["b"] == 6
+    assert counts["a"] == 2
+
+
+def test_size_multiplicity_weights_by_catalogue_size() -> None:
+    """Under SIZE_MULTIPLICITY, the larger-catalogue source dominates the pool."""
+    sources = [
+        _source(["a0", "a1"], multiplicity=1),
+        _source([f"b{i}" for i in range(20)], multiplicity=1),
+    ]
+    result = allocate_refill(
+        sources,
+        slots=11,
+        pool_keys=set(),
+        snapshot=_snapshot(),
+        windows=RecencyWindows(),
+        weight_model=PoolWeightModel.SIZE_MULTIPLICITY,
+    )
+    counts = Counter("a" if tid.startswith("a") else "b" for tid in _ids(result))
+    # weights 2 vs 20 -> b takes the lion's share; a is capped by its 2 candidates
+    assert counts["b"] > counts["a"]
+    assert counts["a"] <= 2
+
+
+def test_repeat_gap_hard_exclusion() -> None:
+    """A duplicated source's candidate played within the repeat-gap is excluded entirely."""
+    windows = RecencyWindows(song_seconds=WEEK, duplicate_gap_seconds=GAP)
+    sources = [_source(["hot", "cold"], multiplicity=2)]
+    snapshot = _snapshot({"hot": NOW - HOUR, "cold": NOW - 10 * HOUR})
+    result = allocate_refill(sources, slots=10, pool_keys=set(), snapshot=snapshot, windows=windows)
+    assert "hot" not in _ids(result)
+    assert "cold" in _ids(result)
+
+
+def test_singleton_window_vs_duplicate_gap() -> None:
+    """A track 5h old is buried as a singleton (week window) but fresh as a duplicate (3h gap)."""
+    windows = RecencyWindows(song_seconds=WEEK, duplicate_gap_seconds=GAP)
+    singleton = _source(["s"], multiplicity=1)
+    duplicate = _source(["d"], multiplicity=2)
+    snapshot = _snapshot({"s": NOW - 5 * HOUR, "d": NOW - 5 * HOUR})
+    result = allocate_refill(
+        [singleton, duplicate], slots=10, pool_keys=set(), snapshot=snapshot, windows=windows
+    )
+    assert "s" not in _ids(result)
+    assert "d" in _ids(result)
+
+
+def test_least_recently_played_first() -> None:
+    """Within a source, never-played sorts first, then oldest play before most recent."""
+    windows = RecencyWindows(song_seconds=0)  # gate off so we only test ordering
+    source = _source(["recent", "old", "never"])
+    snapshot = _snapshot({"recent": NOW - 10, "old": NOW - 100_000})
+    result = allocate_refill([source], slots=3, pool_keys=set(), snapshot=snapshot, windows=windows)
+    assert _ids(result) == ["never", "old", "recent"]
+
+
+def test_pool_keys_excluded() -> None:
+    """A candidate already in the pool is never re-added."""
+    source = _source(["a", "b", "c"])
+    in_pool = _track("b")
+    result = allocate_refill(
+        [source], slots=10, pool_keys={in_pool}, snapshot=_snapshot(), windows=RecencyWindows()
+    )
+    assert "b" not in _ids(result)
+    assert set(_ids(result)) == {"a", "c"}
+
+
+def test_never_exceeds_slots() -> None:
+    """The result never contains more than the requested number of slots."""
+    source = _source([f"a{i}" for i in range(50)])
+    result = allocate_refill(
+        [source], slots=7, pool_keys=set(), snapshot=_snapshot(), windows=RecencyWindows()
+    )
+    assert len(result) == 7
+
+
+def test_no_duplicates_across_sources() -> None:
+    """A track offered by two sources is added only once."""
+    shared = [f"x{i}" for i in range(10)]
+    sources = [_source(shared), _source(shared)]
+    result = allocate_refill(
+        sources, slots=10, pool_keys=set(), snapshot=_snapshot(), windows=RecencyWindows()
+    )
+    assert len(_ids(result)) == len(set(_ids(result)))
+
+
+def test_all_gated_falls_back_ungated() -> None:
+    """When every candidate is within the window, the ungated least-recently-played set is used."""
+    windows = RecencyWindows(song_seconds=WEEK)
+    source = _source(["a", "b", "c"])
+    snapshot = _snapshot({"a": NOW - HOUR, "b": NOW - 2 * HOUR, "c": NOW - 3 * HOUR})
+    result = allocate_refill([source], slots=2, pool_keys=set(), snapshot=snapshot, windows=windows)
+    # all are recent, but playback must not stall: the two least-recently-played come back
+    assert _ids(result) == ["c", "b"]
+
+
+def test_deterministic() -> None:
+    """Same inputs yield an identical allocation (the allocator uses no randomness)."""
+    sources = [
+        _source([f"a{i}" for i in range(10)], multiplicity=2),
+        _source([f"b{i}" for i in range(10)]),
+    ]
+    snapshot = _snapshot({"a3": NOW - 10, "b1": NOW - 20})
+    windows = RecencyWindows(song_seconds=WEEK, duplicate_gap_seconds=GAP)
+    first = _ids(
+        allocate_refill(sources, slots=6, pool_keys=set(), snapshot=snapshot, windows=windows)
+    )
+    second = _ids(
+        allocate_refill(sources, slots=6, pool_keys=set(), snapshot=snapshot, windows=windows)
+    )
+    assert first == second
+
+
+def test_gate_tracks_drops_recent() -> None:
+    """gate_tracks drops tracks played within the song window, keeping order."""
+    windows = RecencyWindows(song_seconds=WEEK)
+    tracks = [_track("a"), _track("b"), _track("c")]
+    snapshot = _snapshot({"b": NOW - HOUR})
+    assert _ids(gate_tracks(tracks, snapshot, windows)) == ["a", "c"]
+
+
+def test_gate_tracks_fallback_when_all_recent() -> None:
+    """gate_tracks returns the ungated list when every track is within the window."""
+    windows = RecencyWindows(song_seconds=WEEK)
+    tracks = [_track("a"), _track("b")]
+    snapshot = _snapshot({"a": NOW - HOUR, "b": NOW - 2 * HOUR})
+    assert _ids(gate_tracks(tracks, snapshot, windows)) == ["a", "b"]

--- a/tests/integration/test_managed_pool_e2e.py
+++ b/tests/integration/test_managed_pool_e2e.py
@@ -1,0 +1,111 @@
+"""
+End-to-end tests for the bounded managed radio pool through the real queue controller + DB.
+
+Boots a hermetic MusicAssistant (fake `test` music provider + demo players) and exercises:
+- a radio-flagged enqueue turning the whole queue into a small bounded pool (not the whole library);
+- a refill drawing from the queue's dynamic sources, weighted per source (multiplicity) and
+  hard-gated against the playlog recency windows.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from music_assistant_models.enums import MediaType
+
+from music_assistant.constants import DB_TABLE_PLAYLOG
+from music_assistant.controllers.player_queues.constants import (
+    MANAGED_POOL_MAX,
+    MANAGED_POOL_TARGET,
+)
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
+
+from .conftest import demo_players, wait_for
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items import ItemMapping, MediaItemType
+
+HOUR = 3600
+DAY = 24 * HOUR
+TEST_USER = "e2e-user"
+
+
+async def _insert_play(mass: MusicAssistant, item_id: str, timestamp: int, userid: str) -> None:
+    """Insert a fully-played track row into the playlog for the given user."""
+    await mass.music.database.insert(
+        DB_TABLE_PLAYLOG,
+        {
+            "item_id": item_id,
+            "provider": "test",
+            "media_type": MediaType.TRACK.value,
+            "name": f"Track {item_id}",
+            "timestamp": timestamp,
+            "fully_played": True,
+            "seconds_played": 60,
+            "userid": userid,
+            "user_initiated": True,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_radio_enqueue_builds_bounded_pool(e2e_mass: MusicAssistant) -> None:
+    """A radio-flagged enqueue turns the queue into a small bounded pool, not the whole library."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
+    assert test_prov is not None
+    seed = await test_prov.get_track("0_0_0")
+
+    await e2e_mass.player_queues.play_media(
+        queue_id, cast("MediaItemType | ItemMapping | str", seed), radio_mode=True
+    )
+
+    assert await wait_for(lambda: len(e2e_mass.player_queues.items(queue_id)) > 1), (
+        "radio pool never populated"
+    )
+    items = e2e_mass.player_queues.items(queue_id)
+    # bounded: a single-track radio yields ~target items, never the full 500-track library
+    assert 1 < len(items) <= MANAGED_POOL_MAX
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    assert queue.radio_source  # the seed is kept as a dynamic source
+
+
+@pytest.mark.asyncio
+async def test_refill_gates_recent_and_weights_by_multiplicity(e2e_mass: MusicAssistant) -> None:
+    """A managed-pool refill excludes recently-played tracks and favours the higher-multiplicity source."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
+    assert test_prov is not None
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    queue.userid = TEST_USER
+
+    # two albums (20 tracks each) as TRACKS sources; the second is added twice (multiplicity 2)
+    album_single = await test_prov.get_album("0_0")  # tracks 0_0_0 .. 0_0_19
+    album_double = await test_prov.get_album("1_0")  # tracks 1_0_0 .. 1_0_19
+    queue.radio_source = cast("list[MediaItemType]", [album_single, album_double, album_double])
+    e2e_mass.player_queues._managed_pool.register(queue_id, queue.radio_source, set(), replace=True)
+
+    # singleton album: 5 tracks played a day ago -> within the 1-week song window -> hard-gated
+    now = int(time.time())
+    gated = [f"0_0_{i}" for i in range(5)]
+    for item_id in gated:
+        await _insert_play(e2e_mass, item_id, now - DAY, TEST_USER)
+    # duplicated album: 5 tracks played 5h ago -> outside the 3h repeat-gap -> allowed
+    for i in range(5):
+        await _insert_play(e2e_mass, f"1_0_{i}", now - 5 * HOUR, TEST_USER)
+
+    pool = await e2e_mass.player_queues._managed_pool.fill(queue_id, is_initial=True)
+    ids = [track.item_id for track in pool]
+
+    assert 0 < len(pool) <= MANAGED_POOL_TARGET
+    # recency hard gate: the within-window singleton tracks are excluded entirely
+    assert not any(item_id in ids for item_id in gated)
+    # per-base quota: the album added twice contributes more than the one added once
+    single_count = sum(1 for tid in ids if tid.startswith("0_0_"))
+    double_count = sum(1 for tid in ids if tid.startswith("1_0_"))
+    assert double_count > single_count

--- a/tests/integration/test_managed_pool_e2e.py
+++ b/tests/integration/test_managed_pool_e2e.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 from music_assistant_models.enums import MediaType
+from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.constants import DB_TABLE_PLAYLOG
 from music_assistant.controllers.player_queues.constants import (
@@ -109,3 +110,33 @@ async def test_refill_gates_recent_and_weights_by_multiplicity(e2e_mass: MusicAs
     single_count = sum(1 for tid in ids if tid.startswith("0_0_"))
     double_count = sum(1 for tid in ids if tid.startswith("1_0_"))
     assert double_count > single_count
+
+
+@pytest.mark.asyncio
+async def test_refill_dedupes_only_active_tail_not_played_history(e2e_mass: MusicAssistant) -> None:
+    """A track in the played history can return on refill; only the current+unplayed tail is deduped."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
+    assert test_prov is not None
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    queue.userid = TEST_USER
+
+    album = await test_prov.get_album("0_0")  # tracks 0_0_0 .. 0_0_19
+    queue.radio_source = cast("list[MediaItemType]", [album])
+    e2e_mass.player_queues._managed_pool.register(queue_id, queue.radio_source, set(), replace=True)
+
+    # simulate a queue with played history: 0_0_0..0_0_4 already played, 0_0_5 is the current track
+    queue_items = [
+        QueueItem.from_media_item(queue_id, await test_prov.get_track(f"0_0_{i}")) for i in range(6)
+    ]
+    e2e_mass.player_queues._queue_items[queue_id] = queue_items
+    queue.current_index = 5
+
+    pool = await e2e_mass.player_queues._managed_pool.fill(queue_id, is_initial=False)
+    ids = [track.item_id for track in pool]
+
+    # the active (current) track isn't duplicated into the upcoming pool
+    assert "0_0_5" not in ids
+    # but already-played history is not permanently excluded (no recency block in play here)
+    assert any(f"0_0_{i}" in ids for i in range(5))


### PR DESCRIPTION
# What does this implement/fix?

Radio mode used to dump *every* track from your sources straight into the queue — add a big playlist (and a top40 a few times) and you'd end up with a queue thousands of tracks long where you only ever heard the front, and radio barely kicked in.

Now a radio-flagged play turns the queue into a small, self-refreshing mix (~25 tracks) that tops itself up as you listen, so it stays fresh for as long as you keep playing instead of running off one giant static list. You can mix sources: flag a playlist/artist/track for radio to hear it *plus* similar discoveries, or add other playlists alongside to keep them in the rotation. Add something more than once and it turns up more often, and tracks you've just heard won't come straight back around.

- Bounded, continuously topped-up pool instead of enqueuing everything up front
- Mix multiple sources in one queue; radio sources keep a steady "originals + similar" blend
- Recently-played tracks are held back (reuses the existing smart-shuffle recency windows)
- No new settings, and normal (non-radio) playback is unchanged

**Related issue (if applicable):**

- Follows up the smart-shuffle work (#4475).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
