### PR TITLE
Clarify supported installation methods in README

### DIFF
--- a/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
+++ b/.github/workflows/RELEASE_WORKFLOW_GUIDE.md
@@ -96,11 +96,7 @@ Special thanks to the following contributors who helped with this release:
 @contributor1, @contributor2, @contributor3, @frontenddev, @serverdev, @translator
 ```
 
-### 3. PyPI Publish (`pypi-publish` job)
-- ✅ **Only runs for stable releases**
-- ✅ Publishes the package to PyPI using the configured token
-
-### 4. Docker Image Build (`build-and-push-container-image` job)
+### 3. Docker Image Build (`build-and-push-container-image` job)
 - ✅ Builds multi-platform Docker images (amd64 + arm64)
 - ✅ Uses the correct base image version for the channel
 - ✅ Tags images appropriately based on the channel:
@@ -120,7 +116,7 @@ Special thanks to the following contributors who helped with this release:
 - `ghcr.io/music-assistant/server:X.Y.Z.devN`
 - `ghcr.io/music-assistant/server:nightly`
 
-### 5. Update Add-on Repository (`update-addon-repository` job)
+### 4. Update Add-on Repository (`update-addon-repository` job)
 - ✅ Determines the correct add-on folder based on channel:
   - **Stable**: `music_assistant`
   - **Beta**: `music_assistant_beta`
@@ -163,7 +159,6 @@ Channel: stable
 ```
 This will:
 - Create release `2.1.0` (not a prerelease)
-- Publish to PyPI
 - Tag Docker images with `2.1.0`, `2.1`, `2`, `stable`, and `latest`
 
 ### Creating a Beta Release
@@ -173,7 +168,6 @@ Channel: beta
 ```
 This will:
 - Create release `2.2.0.b1` (marked as prerelease)
-- Skip PyPI publish
 - Tag Docker images with `2.2.0.b1` and `beta`
 
 ### Creating a Nightly Release
@@ -183,7 +177,6 @@ Channel: nightly
 ```
 This will:
 - Create release `2.2.0.dev20251023` (marked as prerelease)
-- Skip PyPI publish
 - Tag Docker images with `2.2.0.dev20251023` and `nightly`
 
 ## Troubleshooting
@@ -191,10 +184,6 @@ This will:
 ### Workflow Fails During Validation
 - Check that your version number matches the format for the selected channel
 - Ensure the version doesn't already exist as a tag
-
-### PyPI Publish Fails
-- Verify the `PYPI_TOKEN` secret is configured correctly
-- Check that the version doesn't already exist on PyPI
 
 ### Docker Build Fails
 - Check that the base image version exists

--- a/README.md
+++ b/README.md
@@ -20,17 +20,28 @@ ____________
 
 ## Running the server
 
-Music Assistant can be operated as a complete standalone product but it is actually tailored to use side by side with Home Assistant, it is meant with automation in mind, hence our recommended installation method is to run the server as a Home assistant Add-on.
+Music Assistant can be operated as a complete standalone product but it is actually tailored to use side by side with Home Assistant, it is meant with automation in mind, hence our recommended installation method is to run the server as a Home Assistant app.
 
 
-### Installation Instructions
+### Supported installation methods
 
-See here https://music-assistant.io/installation/
+The only officially supported ways to run the Music Assistant server are:
+
+- **Home Assistant app** (recommended) — see https://music-assistant.io/installation/
+- **Docker container** — `ghcr.io/music-assistant/server`
+
+Both bundle every system dependency the server needs. Although Music Assistant's main code is Python, it depends on external/OS components — a recent **ffmpeg (6.1+)** with a specific codec set, native libraries (e.g. jemalloc and CIFS/NFS client libraries) and a few bundled binaries — which a plain PyPI/`pip` install can't provide. The server is therefore **not published to PyPI**; run it via the app or container above.
 
 [repository-badge]: https://img.shields.io/badge/Add%20repository%20to%20my-Home%20Assistant-41BDF5?logo=home-assistant&style=for-the-badge
 [repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon
 
-Note that although Music Assistant's main code is written in python, it has multiple dependencies on external/OS components such as ffmpeg and custom binaries and it is therefore not possible to run it as standalone pypi package. The only available installation method to run the Music Assistant server is by running the Docker container or the Home Assistant add-on.
+### Running from source (development)
+
+For local development you provide the system dependencies yourself — **Python 3.14+** and **ffmpeg 6.1+** are required.
+
+- `scripts/setup.sh` — create the virtualenv and install dependencies and pre-commit hooks
+- `python -m music_assistant --log-level debug` — run the server locally (listens on http://localhost:8095)
+- `pytest` runs the tests; `pre-commit run --all-files` runs the linters
 
 ---
 


### PR DESCRIPTION
# What does this implement/fix?

Clarifies the supported installation methods in the README, now that the server isn't published to PyPI:

- Official methods are the Home Assistant app (recommended) and the Docker container — both bundle all required system dependencies.
- Explicit note that pip/PyPI isn't a supported route, and why (ffmpeg + native libraries + bundled binaries).
- A short "running from source (development)" section.
- Also removes the stale PyPI-publish references from `RELEASE_WORKFLOW_GUIDE.md`.

## Types of changes

- [x] Documentation only — `documentation`
