### PR TITLE
iBroadcast mapping issue with album id's and possible other id's

### DIFF
--- a/music_assistant/providers/ibroadcast/manifest.json
+++ b/music_assistant/providers/ibroadcast/manifest.json
@@ -6,7 +6,7 @@
   "description": "Stream your personal iBroadcast music collection from anywhere.",
   "codeowners": ["@robsonke"],
   "credits": ["[ibroadcastaio](https://github.com/robsonke/ibroadcastaio)"],
-  "requirements": ["ibroadcastaio==0.6.0"],
+  "requirements": ["ibroadcastaio==0.8.0"],
   "documentation": "https://music-assistant.io/music-providers/ibroadcast/",
   "multi_instance": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -41,7 +41,7 @@ gql[all]==4.0.0
 hass-client==1.2.3
 hue-entertainment==0.1.1
 huggingface-hub==1.12.0
-ibroadcastaio==0.6.0
+ibroadcastaio==0.8.0
 ifaddr==0.2.0
 liblistenbrainz==0.7.0
 librosa==0.11.0


### PR DESCRIPTION
# What does this implement/fix?

Fixes an issue where albums were skipped during the sync process. This was caused by an int/string type issue, probably caused by a breaking API change at iBroadcast's side.
Next to that, overall housekeeping upgrades in the lib.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
