### PR TITLE
Prevent a crash when a CPU can't execute on-device analysis

### DIFF
--- a/music_assistant/helpers/_ml_inference_probe.py
+++ b/music_assistant/helpers/_ml_inference_probe.py
@@ -1,0 +1,51 @@
+"""
+Out-of-process probe that verifies the CPU can execute on-device ML inference.
+
+Run as a short-lived subprocess by ``helpers.util.verify_cpu_supports_ml_inference()``; the
+process exit code carries the verdict. Running the inference here, in a throwaway process,
+means a CPU that faults on the vector instructions torch emits (common on virtual machines
+that do not pass the host CPU through) crashes only this probe -- never the server.
+"""
+
+from __future__ import annotations
+
+# Exit codes interpreted by the parent. A clean "no AVX2" rejection is distinct from a
+# native crash (which the parent sees as a negative, signal-valued return code) and from
+# any other exit (which the parent treats as inconclusive and lets through).
+PROBE_CAPABLE = 0
+PROBE_NO_AVX2 = 10
+
+
+def run_probe() -> int:
+    """Run representative inference kernels and return the verdict exit code."""
+    import torch  # noqa: PLC0415
+
+    if torch.backends.cpu.get_cpu_capability() in ("DEFAULT", "NO AVX"):
+        return PROBE_NO_AVX2
+
+    # Exercise the kernel families the analysis providers depend on -- a BLAS matmul, an
+    # FFT, a convolution and an fbgemm-quantized matmul (the path most likely to use an
+    # instruction a VM masks) -- on tiny tensors. The cost is the torch import, not the math.
+    torch.set_num_threads(1)
+    # Prefer fbgemm -- the x86 quantized backend the analysis models use and the one most
+    # likely to hit a masked instruction -- and fall back to qnnpack on ARM.
+    for engine in ("fbgemm", "qnnpack"):
+        if engine in torch.backends.quantized.supported_engines:
+            torch.backends.quantized.engine = engine
+            break
+    with torch.inference_mode():
+        matrix = torch.randn(64, 64)
+        torch.mm(matrix, matrix)
+        torch.stft(torch.randn(2048), n_fft=512, window=torch.hann_window(512), return_complex=True)
+        conv = torch.nn.Conv1d(1, 4, kernel_size=8)
+        conv(torch.randn(1, 1, 2048))
+        linear = torch.nn.Sequential(torch.nn.Linear(64, 64))
+        quantized = torch.ao.quantization.quantize_dynamic(  # type: ignore[no-untyped-call]
+            linear, {torch.nn.Linear}, dtype=torch.qint8
+        )
+        quantized(torch.randn(8, 64))
+    return PROBE_CAPABLE
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_probe())

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -10,6 +10,7 @@ import os
 import platform
 import re
 import shutil
+import signal
 import socket
 import sys
 import time
@@ -266,7 +267,7 @@ def is_arm() -> bool:
     return platform.machine().lower() in ("arm64", "aarch64", "armv8l", "armv7l")
 
 
-def verify_system_meets_requirements(
+async def verify_system_meets_requirements(
     *,
     feature_name: str,
     min_memory_gb: float = 0.0,
@@ -280,7 +281,7 @@ def verify_system_meets_requirements(
     :param min_memory_gb: Minimum total system RAM in GB (0 disables the check).
     :param min_cpu_cores: Minimum CPU core count (0 disables the check).
     :param require_ml_inference: When True, also verify the CPU can run on-device
-        torch inference (AVX2 on x86). Checked last, as it imports torch.
+        torch inference. Checked last, as it spawns a probe subprocess.
     :raises UnsupportedSystemError: If the system does not meet the requirements.
     """
     if shortfall := _resource_shortfall(min_memory_gb=min_memory_gb, min_cpu_cores=min_cpu_cores):
@@ -291,7 +292,7 @@ def verify_system_meets_requirements(
             translation_args=[feature_name, *translation_args],
         )
     if require_ml_inference:
-        verify_cpu_supports_ml_inference()
+        await verify_cpu_supports_ml_inference()
 
 
 def system_meets_requirements(
@@ -364,19 +365,38 @@ def _resource_shortfall(
     return None
 
 
-def verify_cpu_supports_ml_inference() -> None:
-    """
-    Verify the CPU can run on-device ML (torch) inference.
+# How long to wait for the out-of-process inference probe before treating it as
+# inconclusive. The probe only imports torch and runs a few tiny tensors, but a cold,
+# heavily loaded VM can be slow to start the interpreter, so keep this generous.
+_ML_INFERENCE_PROBE_TIMEOUT = 60.0
+# POSIX signals that mean the CPU could not execute the inference (the probe exits with the
+# negated signal number). Any of these disables the feature; other exits fail open.
+_ML_INFERENCE_FAULT_SIGNALS = frozenset(
+    {signal.SIGILL, signal.SIGSEGV, signal.SIGABRT, signal.SIGFPE}
+)
 
-    :raises UnsupportedSystemError: If this is an x86 CPU without AVX2 support, which
-        torch's FBGEMM quantized backend requires.
+
+async def verify_cpu_supports_ml_inference() -> None:
+    """
+    Verify the CPU can actually execute on-device ML (torch) inference.
+
+    Runs a representative inference in a throwaway subprocess, so a CPU that reports a
+    capability it cannot actually execute (common on virtual machines without host CPU
+    passthrough) crashes the probe instead of the server. Inconclusive probe results fail
+    open, so a probe malfunction never blocks a capable host.
+
+    :raises UnsupportedSystemError: If the CPU lacks AVX2, or reports it but cannot execute
+        the required instructions.
     """
     if platform.machine().lower() not in ("x86_64", "amd64", "i386", "i686", "x86"):
         # non-x86 (ARM) machines run quantized inference via QNNPACK instead of FBGEMM
         return
-    import torch  # noqa: PLC0415
+    from music_assistant.helpers import _ml_inference_probe  # noqa: PLC0415
 
-    if torch.backends.cpu.get_cpu_capability() in ("DEFAULT", "NO AVX"):
+    returncode = await _run_ml_inference_probe()
+    if returncode == _ml_inference_probe.PROBE_CAPABLE:
+        return
+    if returncode == _ml_inference_probe.PROBE_NO_AVX2:
         raise UnsupportedSystemError(
             "On-device audio analysis requires a CPU with AVX2 support "
             "(Intel Haswell / AMD Zen or newer). This CPU does not support AVX2. "
@@ -384,6 +404,51 @@ def verify_cpu_supports_ml_inference() -> None:
             "CPU type to 'host' may expose AVX2 to the guest.",
             translation_key="unsupported_system_avx2",
         )
+    if returncode is not None and returncode < 0 and -returncode in _ML_INFERENCE_FAULT_SIGNALS:
+        raise UnsupportedSystemError(
+            "On-device audio analysis cannot run on this CPU: it reports AVX2 support but "
+            "fails to execute the required instructions. This is common on virtual machines "
+            "without host CPU passthrough -- if you are running in a VM (e.g. Proxmox or "
+            "TrueNAS), set the CPU type to 'host'.",
+            translation_key="unsupported_system_ml_inference_failed",
+        )
+    # Inconclusive: the probe could not be spawned, timed out, was OOM-killed, or exited for
+    # an unexpected reason. Assume the host is capable rather than block a working setup.
+    LOGGER.warning(
+        "On-device ML inference capability probe was inconclusive (exit code %s); "
+        "assuming this CPU is capable",
+        returncode,
+    )
+
+
+async def _run_ml_inference_probe() -> int | None:
+    """
+    Run the inference probe subprocess and return its exit code.
+
+    Returns None when the probe could not be started or did not finish in time; otherwise
+    the process return code (negative if a signal killed it).
+    """
+    from music_assistant.helpers import _ml_inference_probe  # noqa: PLC0415
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            _ml_inference_probe.__file__,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except OSError as err:
+        LOGGER.warning("Could not start the ML inference capability probe: %s", err)
+        return None
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=_ML_INFERENCE_PROBE_TIMEOUT)
+    except TimeoutError:
+        proc.kill()
+        with suppress(ProcessLookupError):
+            await proc.wait()
+        LOGGER.warning("The ML inference capability probe timed out")
+        return None
+    return proc.returncode
 
 
 keyword_pattern = re.compile("title=|artist=")

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -431,9 +431,12 @@ async def _run_ml_inference_probe() -> int | None:
     from music_assistant.helpers import _ml_inference_probe  # noqa: PLC0415
 
     try:
+        # Run with -m, not by file path: a path run puts the probe's own directory on
+        # sys.path, which would shadow the stdlib (e.g. helpers/logging.py over logging).
         proc = await asyncio.create_subprocess_exec(
             sys.executable,
-            _ml_inference_probe.__file__,
+            "-m",
+            _ml_inference_probe.__name__,
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
         )

--- a/music_assistant/providers/smart_fades/__init__.py
+++ b/music_assistant/providers/smart_fades/__init__.py
@@ -43,7 +43,7 @@ async def setup(
     """Set up the Smart Fades provider."""
     # Gate before importing the provider module so the heavy torch/beat_this stack is
     # never imported on a host that does not meet the minimal requirements.
-    verify_system_meets_requirements(
+    await verify_system_meets_requirements(
         feature_name="Smart Fades",
         min_memory_gb=MIN_RAM_GB,
         min_cpu_cores=MIN_CPU_CORES,

--- a/music_assistant/providers/sonic_analysis/__init__.py
+++ b/music_assistant/providers/sonic_analysis/__init__.py
@@ -351,7 +351,7 @@ class SonicAnalysisProvider(AudioAnalysisProvider):
         available=False, which the AudioAnalysisController already honors when
         scheduling work. While idle the model is later unloaded and reloaded on demand.
         """
-        verify_system_meets_requirements(
+        await verify_system_meets_requirements(
             feature_name="Sonic Analysis",
             min_memory_gb=MIN_RAM_GB,
             min_cpu_cores=MIN_CPU_CORES,

--- a/music_assistant/strings.json
+++ b/music_assistant/strings.json
@@ -1035,6 +1035,7 @@
     "unsupported_system_cpu_cores": "This system does not meet the minimal requirements for {0}: at least {1} CPU cores are required ({2} detected).",
     "unsupported_system_memory": "This system does not meet the minimal requirements for {0}: at least {1}GB of RAM is required ({2}GB detected).",
     "unsupported_system_avx2": "On-device audio analysis requires a CPU with AVX2 support (Intel Haswell / AMD Zen or newer). This CPU does not support AVX2. If you are running in a virtual machine (e.g. Proxmox), changing the CPU type to 'host' may expose AVX2 to the guest.",
+    "unsupported_system_ml_inference_failed": "On-device audio analysis cannot run on this CPU: it reports AVX2 support but fails to execute the required instructions. This is common on virtual machines without host CPU passthrough -- if you are running in a VM (e.g. Proxmox or TrueNAS), set the CPU type to 'host'.",
     "player_unavailable": "The player is not available.",
     "player_command_failed": "The command to the player failed.",
     "invalid_command": "Invalid or unsupported command.",

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -229,6 +229,7 @@
   "common.errors.unsupported_system_avx2": "On-device audio analysis requires a CPU with AVX2 support (Intel Haswell / AMD Zen or newer). This CPU does not support AVX2. If you are running in a virtual machine (e.g. Proxmox), changing the CPU type to 'host' may expose AVX2 to the guest.",
   "common.errors.unsupported_system_cpu_cores": "This system does not meet the minimal requirements for {0}: at least {1} CPU cores are required ({2} detected).",
   "common.errors.unsupported_system_memory": "This system does not meet the minimal requirements for {0}: at least {1}GB of RAM is required ({2}GB detected).",
+  "common.errors.unsupported_system_ml_inference_failed": "On-device audio analysis cannot run on this CPU: it reports AVX2 support but fails to execute the required instructions. This is common on virtual machines without host CPU passthrough -- if you are running in a VM (e.g. Proxmox or TrueNAS), set the CPU type to 'host'.",
   "common.media.audiobook_genre.arts_and_entertainment.description": "Audiobooks on the arts, media and entertainment, from film and music to the performing and visual arts.",
   "common.media.audiobook_genre.arts_and_entertainment.name": "Arts & Entertainment",
   "common.media.audiobook_genre.biography_and_memoir.description": "Life stories — biographies and memoirs of notable people and personal accounts of lived experience.",

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -1,8 +1,9 @@
 """Tests for utility/helper functions."""
 
+import signal
 from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType
@@ -14,7 +15,7 @@ from music_assistant_models.errors import (
 from yarl import URL
 from zeroconf import InterfaceChoice, IPVersion
 
-from music_assistant.helpers import uri, util
+from music_assistant.helpers import _ml_inference_probe, uri, util
 from music_assistant.helpers.aiohttp_client import encoded_request_url
 
 
@@ -404,42 +405,95 @@ def test_get_zeroconf_args_all_interfaces() -> None:
 
 
 @pytest.mark.parametrize(
-    ("machine", "capability", "should_raise"),
+    ("capability", "expected"),
     [
-        ("x86_64", "DEFAULT", True),
-        ("AMD64", "DEFAULT", True),
-        ("x86_64", "NO AVX", True),
-        ("x86_64", "AVX2", False),
-        ("x86_64", "AVX512", False),
-        # a future torch capability string we don't know about yet must fail open
-        ("x86_64", "AVX10", False),
+        ("DEFAULT", _ml_inference_probe.PROBE_NO_AVX2),
+        ("NO AVX", _ml_inference_probe.PROBE_NO_AVX2),
+        ("AVX2", _ml_inference_probe.PROBE_CAPABLE),
+        ("AVX512", _ml_inference_probe.PROBE_CAPABLE),
     ],
 )
-def test_verify_cpu_supports_ml_inference_x86(
-    machine: str, capability: str, should_raise: bool
+def test_ml_inference_probe_run_probe(capability: str, expected: int) -> None:
+    """The probe rejects a no-AVX2 CPU cleanly and otherwise runs the kernels to completion."""
+    with patch("torch.backends.cpu.get_cpu_capability", return_value=capability):
+        assert _ml_inference_probe.run_probe() == expected
+
+
+@pytest.mark.parametrize(
+    ("returncode", "translation_key"),
+    [
+        (_ml_inference_probe.PROBE_CAPABLE, None),
+        (_ml_inference_probe.PROBE_NO_AVX2, "unsupported_system_avx2"),
+        (-signal.SIGILL, "unsupported_system_ml_inference_failed"),
+        (-signal.SIGSEGV, "unsupported_system_ml_inference_failed"),
+        (-signal.SIGABRT, "unsupported_system_ml_inference_failed"),
+        (-signal.SIGKILL, None),  # external/OOM kill is not a CPU fault -> fail open
+        (1, None),  # unexpected clean exit -> fail open
+        (None, None),  # spawn failure or timeout -> fail open
+    ],
+)
+async def test_verify_cpu_supports_ml_inference_x86(
+    returncode: int | None, translation_key: str | None
 ) -> None:
-    """x86 CPUs require AVX2/AVX512 for torch's FBGEMM quantized inference."""
+    """On x86 the probe verdict vetoes only on no-AVX2 or a fatal signal; anything else fails open."""
     with (
-        patch("music_assistant.helpers.util.platform.machine", return_value=machine),
-        patch("torch.backends.cpu.get_cpu_capability", return_value=capability),
-    ):
-        if should_raise:
-            with pytest.raises(SetupFailedError):
-                util.verify_cpu_supports_ml_inference()
-        else:
-            util.verify_cpu_supports_ml_inference()
-
-
-def test_verify_cpu_supports_ml_inference_arm() -> None:
-    """ARM machines pass without consulting torch (QNNPACK backend works there)."""
-    with (
-        patch("music_assistant.helpers.util.platform.machine", return_value="aarch64"),
+        patch("music_assistant.helpers.util.platform.machine", return_value="x86_64"),
         patch(
-            "torch.backends.cpu.get_cpu_capability",
-            side_effect=AssertionError("torch must not be consulted on ARM"),
+            "music_assistant.helpers.util._run_ml_inference_probe",
+            AsyncMock(return_value=returncode),
         ),
     ):
-        util.verify_cpu_supports_ml_inference()
+        if translation_key is not None:
+            with pytest.raises(UnsupportedSystemError) as err:
+                await util.verify_cpu_supports_ml_inference()
+            assert err.value.translation_key == translation_key
+            assert err.value.translation_args == []
+        else:
+            await util.verify_cpu_supports_ml_inference()
+
+
+async def test_verify_cpu_supports_ml_inference_arm() -> None:
+    """ARM machines pass without spawning the probe (QNNPACK backend works there)."""
+    with (
+        patch("music_assistant.helpers.util.platform.machine", return_value="aarch64"),
+        patch("music_assistant.helpers.util._run_ml_inference_probe", AsyncMock()) as probe,
+    ):
+        await util.verify_cpu_supports_ml_inference()
+    probe.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("returncode", "expected"),
+    [
+        (-signal.SIGILL, -signal.SIGILL),
+        (0, 0),
+    ],
+)
+async def test_run_ml_inference_probe_returncode(returncode: int, expected: int) -> None:
+    """The probe runner reports the subprocess exit code (negative when a signal killed it)."""
+    proc = AsyncMock()
+    proc.wait = AsyncMock(return_value=returncode)
+    proc.returncode = returncode
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        assert await util._run_ml_inference_probe() == expected
+
+
+async def test_run_ml_inference_probe_spawn_failure() -> None:
+    """A spawn failure is reported as None so the caller fails open."""
+    with patch("asyncio.create_subprocess_exec", AsyncMock(side_effect=OSError("boom"))):
+        assert await util._run_ml_inference_probe() is None
+
+
+async def test_run_ml_inference_probe_timeout() -> None:
+    """A probe that overruns the timeout is killed and reported as None."""
+    proc = AsyncMock()
+    proc.kill = MagicMock()
+    with (
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+        patch("asyncio.wait_for", AsyncMock(side_effect=TimeoutError)),
+    ):
+        assert await util._run_ml_inference_probe() is None
+    proc.kill.assert_called_once()
 
 
 def test_unsupported_system_error_is_setup_failed() -> None:
@@ -457,7 +511,7 @@ def test_unsupported_system_error_is_setup_failed() -> None:
         (1, 0, False),  # 0 disables the check
     ],
 )
-def test_verify_system_meets_requirements_cpu(
+async def test_verify_system_meets_requirements_cpu(
     cpu_cores: int, min_cpu_cores: int, should_raise: bool
 ) -> None:
     """The CPU-core gate raises UnsupportedSystemError below the minimum."""
@@ -467,9 +521,13 @@ def test_verify_system_meets_requirements_cpu(
     ):
         if should_raise:
             with pytest.raises(UnsupportedSystemError):
-                util.verify_system_meets_requirements(feature_name="X", min_cpu_cores=min_cpu_cores)
+                await util.verify_system_meets_requirements(
+                    feature_name="X", min_cpu_cores=min_cpu_cores
+                )
         else:
-            util.verify_system_meets_requirements(feature_name="X", min_cpu_cores=min_cpu_cores)
+            await util.verify_system_meets_requirements(
+                feature_name="X", min_cpu_cores=min_cpu_cores
+            )
 
 
 @pytest.mark.parametrize(
@@ -487,7 +545,7 @@ def test_verify_system_meets_requirements_cpu(
         (2.0, 0.0, False),  # 0 disables the check
     ],
 )
-def test_verify_system_meets_requirements_memory(
+async def test_verify_system_meets_requirements_memory(
     total_gb: float, min_memory_gb: float, should_raise: bool
 ) -> None:
     """The RAM gate raises below the minimum (within tolerance) but fails open when unknown (0.0)."""
@@ -497,9 +555,13 @@ def test_verify_system_meets_requirements_memory(
     ):
         if should_raise:
             with pytest.raises(UnsupportedSystemError):
-                util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)
+                await util.verify_system_meets_requirements(
+                    feature_name="X", min_memory_gb=min_memory_gb
+                )
         else:
-            util.verify_system_meets_requirements(feature_name="X", min_memory_gb=min_memory_gb)
+            await util.verify_system_meets_requirements(
+                feature_name="X", min_memory_gb=min_memory_gb
+            )
 
 
 @pytest.mark.parametrize(
@@ -520,30 +582,35 @@ def test_meets_memory_target(total_gb: float, target_gb: float, expected: bool) 
     assert util.meets_memory_target(total_gb, target_gb) is expected
 
 
-def test_verify_system_meets_requirements_ml_inference() -> None:
-    """require_ml_inference adds the AVX2 capability check after the RAM/CPU checks."""
+async def test_verify_system_meets_requirements_ml_inference() -> None:
+    """require_ml_inference runs the capability probe after the RAM/CPU checks."""
     with (
         patch("music_assistant.helpers.util.os.process_cpu_count", return_value=16),
         patch("music_assistant.helpers.util.get_total_system_memory", return_value=64.0),
         patch("music_assistant.helpers.util.platform.machine", return_value="x86_64"),
-        patch("torch.backends.cpu.get_cpu_capability", return_value="DEFAULT"),
+        patch(
+            "music_assistant.helpers.util._run_ml_inference_probe",
+            AsyncMock(return_value=_ml_inference_probe.PROBE_NO_AVX2),
+        ),
     ):
-        # capable RAM/CPU but no AVX2: only raises when the ML inference check is requested
+        # capable RAM/CPU but the probe rejects: only raises when the ML check is requested
         with pytest.raises(UnsupportedSystemError):
-            util.verify_system_meets_requirements(
+            await util.verify_system_meets_requirements(
                 feature_name="X", min_cpu_cores=4, min_memory_gb=8.0, require_ml_inference=True
             )
-        util.verify_system_meets_requirements(feature_name="X", min_cpu_cores=4, min_memory_gb=8.0)
+        await util.verify_system_meets_requirements(
+            feature_name="X", min_cpu_cores=4, min_memory_gb=8.0
+        )
 
 
-def test_unsupported_system_error_translation() -> None:
+async def test_unsupported_system_error_translation() -> None:
     """Each raise path carries the right translation key + ordered args (feature name first)."""
     with (
         patch("music_assistant.helpers.util.os.process_cpu_count", return_value=2),
         patch("music_assistant.helpers.util.get_total_system_memory", return_value=64.0),
         pytest.raises(UnsupportedSystemError) as cpu_err,
     ):
-        util.verify_system_meets_requirements(feature_name="Smart Fades", min_cpu_cores=4)
+        await util.verify_system_meets_requirements(feature_name="Smart Fades", min_cpu_cores=4)
     assert cpu_err.value.translation_key == "unsupported_system_cpu_cores"
     assert cpu_err.value.translation_args == ["Smart Fades", 4, 2]
 
@@ -552,16 +619,19 @@ def test_unsupported_system_error_translation() -> None:
         patch("music_assistant.helpers.util.get_total_system_memory", return_value=2.0),
         pytest.raises(UnsupportedSystemError) as mem_err,
     ):
-        util.verify_system_meets_requirements(feature_name="Smart Fades", min_memory_gb=8.0)
+        await util.verify_system_meets_requirements(feature_name="Smart Fades", min_memory_gb=8.0)
     assert mem_err.value.translation_key == "unsupported_system_memory"
     assert mem_err.value.translation_args == ["Smart Fades", "8", "2.0"]
 
     with (
         patch("music_assistant.helpers.util.platform.machine", return_value="x86_64"),
-        patch("torch.backends.cpu.get_cpu_capability", return_value="DEFAULT"),
+        patch(
+            "music_assistant.helpers.util._run_ml_inference_probe",
+            AsyncMock(return_value=_ml_inference_probe.PROBE_NO_AVX2),
+        ),
         pytest.raises(UnsupportedSystemError) as avx_err,
     ):
-        util.verify_cpu_supports_ml_inference()
+        await util.verify_cpu_supports_ml_inference()
     assert avx_err.value.translation_key == "unsupported_system_avx2"
     assert avx_err.value.translation_args == []
 

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -1,6 +1,8 @@
 """Tests for utility/helper functions."""
 
 import signal
+import subprocess
+import sys
 from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -404,19 +406,32 @@ def test_get_zeroconf_args_all_interfaces() -> None:
     assert "192.168.1.10" in result["interfaces"]
 
 
-@pytest.mark.parametrize(
-    ("capability", "expected"),
-    [
-        ("DEFAULT", _ml_inference_probe.PROBE_NO_AVX2),
-        ("NO AVX", _ml_inference_probe.PROBE_NO_AVX2),
-        ("AVX2", _ml_inference_probe.PROBE_CAPABLE),
-        ("AVX512", _ml_inference_probe.PROBE_CAPABLE),
-    ],
-)
-def test_ml_inference_probe_run_probe(capability: str, expected: int) -> None:
-    """The probe rejects a no-AVX2 CPU cleanly and otherwise runs the kernels to completion."""
+@pytest.mark.parametrize("capability", ["DEFAULT", "NO AVX"])
+def test_ml_inference_probe_rejects_no_avx2(capability: str) -> None:
+    """A no-AVX2 CPU is rejected before any kernel runs (safe to check in-process)."""
     with patch("torch.backends.cpu.get_cpu_capability", return_value=capability):
-        assert _ml_inference_probe.run_probe() == expected
+        assert _ml_inference_probe.run_probe() == _ml_inference_probe.PROBE_NO_AVX2
+
+
+def test_ml_inference_probe_subprocess_runs_to_a_clean_verdict() -> None:
+    """
+    End-to-end: the probe runs out-of-process and exits with a defined verdict, never a crash.
+
+    Spawning a subprocess (rather than calling run_probe() inline) is the same isolation the
+    production check relies on, so a hypothetical native crash on a misconfigured host fails
+    this one test instead of taking down the session. On an x86 host with AVX2 this exercises
+    the kernels and returns PROBE_CAPABLE; elsewhere it returns PROBE_NO_AVX2.
+    """
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-m", _ml_inference_probe.__name__],
+        capture_output=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode in (
+        _ml_inference_probe.PROBE_CAPABLE,
+        _ml_inference_probe.PROBE_NO_AVX2,
+    ), result.stderr.decode()
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/sonic_analysis/test_clap_background_load.py
+++ b/tests/providers/sonic_analysis/test_clap_background_load.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -70,6 +71,16 @@ def _make_streamdetails(
     sd.provider = "test_provider"
     sd.duration = duration
     return sd
+
+
+@pytest.fixture(autouse=True)
+def _stub_ml_inference_gate() -> Generator[None]:
+    """Stub the hardware gate so these unit tests never spawn the real capability probe."""
+    with patch(
+        "music_assistant.providers.sonic_analysis.verify_system_meets_requirements",
+        new=AsyncMock(),
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Smart Fades and Sonic Analysis run on-device torch ML inference. On some CPUs — notably virtual machines that report AVX2 but don't pass the host CPU through (e.g. TrueNAS/Proxmox without a `host` CPU type) — the first inference executes an instruction the CPU can't actually run and crashes the **whole server** with a native signal (the log just ends, sometimes with a leaked-semaphore warning). Our gate only reads the CPU's *advertised* capability, which those hosts pass, so the feature loads and then takes the server down on first playback.

This verifies the capability up front by running a representative inference in a short-lived subprocess. An incapable host disables the feature cleanly with a clear message instead of crashing — the probe runs in a child process, so a native fault kills only the probe, and it fails open on any inconclusive result so it never blocks a capable host.

**Changes:**

- Add an out-of-process capability probe (`helpers/_ml_inference_probe.py`) exercising the kernel families analysis uses (matmul, FFT, conv, fbgemm-quantized matmul).
- `verify_cpu_supports_ml_inference()` now runs the probe and maps a fatal signal or missing AVX2 to a clean `UnsupportedSystemError`; every other outcome fails open.
- Add a distinct error message for the "reports AVX2 but can't execute it" case.
- Make `verify_system_meets_requirements()` async and await it in the Smart Fades / Sonic Analysis setup paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
