### PR TITLE
Fix QUIC/HTTP-3 debug log spam caused by urllib3-future override

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+# Keep urllib3-future from hijacking the urllib3 namespace (see pyproject.toml).
+env:
+  URLLIB3_NO_OVERRIDE: "1"
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+# Keep urllib3-future from hijacking the urllib3 namespace (see pyproject.toml).
+env:
+  URLLIB3_NO_OVERRIDE: "1"
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,11 @@ RUN uv venv $VIRTUAL_ENV
 # because we do not have to install dependencies at runtime
 # --index-strategy: allow PyPI packages when also using the PyTorch extra index
 # https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes
+# Keep urllib3-future from hijacking the urllib3 namespace (see pyproject.toml).
+ENV URLLIB3_NO_OVERRIDE=1
 RUN uv pip install \
     --index-strategy unsafe-best-match \
+    --no-binary urllib3-future \
     -r requirements_all.txt
 
 # Install PyAV from pre-built wheel (built against system FFmpeg in base image)

--- a/music_assistant/__main__.py
+++ b/music_assistant/__main__.py
@@ -135,6 +135,8 @@ def setup_logger(data_path: str, level: str = "DEBUG") -> logging.Logger:
     logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
     logging.getLogger("numba").setLevel(logging.WARNING)
     logging.getLogger("torio._extension.utils").setLevel(logging.WARNING)
+    logging.getLogger("quic").setLevel(logging.WARNING)
+    logging.getLogger("http3").setLevel(logging.WARNING)
 
     # Add a filter to suppress slow callback warnings from buffered audio streaming
     # These warnings are expected when audio buffers fill up and producers wait for consumers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,11 @@ explicit = true
 name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
 
+[tool.uv]
+# Build urllib3-future (pulled in via niquests) from source so URLLIB3_NO_OVERRIDE=1 set during
+# installs takes effect, stopping it from hijacking the stock urllib3 namespace server-wide.
+no-binary-package = ["urllib3-future"]
+
 [tool.uv.sources]
 torch = {index = "pytorch-cpu"}
 torchaudio = {index = "pytorch-cpu"}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,6 +29,8 @@ uv pip install -e "."
 uv pip install -e ".[test]"
 # --index-strategy: allow PyPI packages when also using the PyTorch extra index
 # https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes
+# Keep urllib3-future from hijacking the urllib3 namespace (see pyproject.toml).
+export URLLIB3_NO_OVERRIDE=1
 [[ -f requirements_all.txt ]] && uv pip install --index-strategy unsafe-best-match -r requirements_all.txt
 
 


### PR DESCRIPTION
# What does this implement/fix?

Debug logs were being flooded by `[quic]` / `[http3]` messages (QUIC handshakes, loss-detection, keepalive PINGs) and Google sockets were being leaked.

Root cause: the `qqmusic` provider pulls `niquests`, which depends on `urllib3-future`. Its prebuilt wheel ships a `urllib3` package that overrides stock urllib3 **server-wide**, silently upgrading all HTTP traffic (e.g. YouTube Music via `requests`) to its HTTP/3 stack — even when qqmusic isn't loaded. That HTTP/3 layer is what emits the noise and leaks connections.

Fix: install `urllib3-future` from source with `URLLIB3_NO_OVERRIDE=1` so it stays in its own `urllib3_future` namespace (niquests still uses it; everything else keeps stock urllib3). Plus a defensive level bump for the `quic`/`http3` loggers.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
