### PR TITLE
Fix lrclib plain lyrics written to the synced-LRC field

### DIFF
--- a/music_assistant/providers/lrclib/__init__.py
+++ b/music_assistant/providers/lrclib/__init__.py
@@ -138,7 +138,7 @@ class LrclibProvider(MetadataProvider):
 
             if plain_lyrics:
                 metadata = MediaItemMetadata()
-                metadata.lrc_lyrics = plain_lyrics
+                metadata.lyrics = plain_lyrics
 
                 self.logger.debug("Found plain lyrics for %s by %s", track.name, artist_name)
                 return metadata


### PR DESCRIPTION
# What does this implement/fix?

The plain-lyrics fallback assigned plainLyrics to metadata.lrc_lyrics (the synchronized-LRC field) instead of metadata.lyrics, so un-timestamped lyrics were exposed as synced LRC and metadata.lyrics was never populated.


<!-- Quick description and explanation of changes. -->

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
