### PR TITLE
Fix audiobook release_date parsed but never stored

### DIFF
--- a/music_assistant/providers/audible/audible_helper.py
+++ b/music_assistant/providers/audible/audible_helper.py
@@ -721,7 +721,8 @@ class AudibleHelper:
         book.metadata.languages = UniqueList([audiobook_data.get("language") or ""])
         if release_date := audiobook_data.get("release_date"):
             with suppress(ValueError):
-                datetime.strptime(release_date, "%Y-%m-%d").astimezone(UTC)
+                parsed_date = datetime.strptime(release_date, "%Y-%m-%d").astimezone(UTC)
+                book.metadata.release_date = parsed_date
 
         # Set review if available
         reviews = audiobook_data.get("editorial_reviews", [])


### PR DESCRIPTION
# What does this implement/fix?

_process_audiobook_item parsed audiobook_data["release_date"] into a datetime but discarded the result, so metadata.release_date was never set on audiobooks. Assign the parsed value to book.metadata.release_date.


**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
