### PR TITLE
Fix deezer parse_streamable returning Any from a bool function

### DIFF
--- a/music_assistant/providers/deezer/parsers.py
+++ b/music_assistant/providers/deezer/parsers.py
@@ -162,7 +162,7 @@ def _track_available(
         return False
     if media.rights.sub is None:
         return False
-    return media.rights.sub.available
+    return bool(media.rights.sub.available)
 
 
 def parse_track(


### PR DESCRIPTION
# What does this implement/fix?

GraphQL-typed media.rights.sub.available is Any, so the helper returned Any from a function declared to return bool. Wrap it in bool() to satisfy the declared return type (clears a mypy no-any-return).

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
