### PR TITLE
Extend podcast

### DIFF
--- a/music_assistant/helpers/podcast_parsers.py
+++ b/music_assistant/helpers/podcast_parsers.py
@@ -7,13 +7,14 @@ from typing import TYPE_CHECKING, Any
 
 import podcastparser
 from aiohttp.client import ClientError, ClientTimeout
-from music_assistant_models.enums import ContentType, ImageType, MediaType
+from music_assistant_models.enums import ContentType, ImageType, LinkType, MediaType
 from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import (
     AudioFormat,
     ItemMapping,
     MediaItemChapter,
     MediaItemImage,
+    MediaItemLink,
     Podcast,
     PodcastEpisode,
     ProviderMapping,
@@ -212,6 +213,19 @@ def parse_podcast_episode(
     if description := episode.get("description"):
         mass_episode.metadata.description = description
 
+    # explicit flag (itunes:explicit); only set when the feed actually declared it
+    explicit = episode.get("explicit")
+    if explicit is not None:
+        mass_episode.metadata.explicit = bool(explicit)
+
+    # episode webpage (the item <link>)
+    if link := episode.get("link"):
+        mass_episode.metadata.links = {MediaItemLink(type=LinkType.WEBSITE, url=link)}
+
+    # hosts/guests (podcast:person), mapped to performer names
+    if performers := parse_podcast_persons(episode.get("persons")):
+        mass_episode.metadata.performers = set(performers)
+
     # inline chapters (Podlove Simple Chapters, parsed by podcastparser)
     if chapters := episode.get("chapters"):
         _chapters = []
@@ -240,6 +254,34 @@ def parse_podcast_episode(
         )
 
     return mass_episode
+
+
+def parse_podcast_persons(persons: Any) -> list[str]:
+    """
+    Extract performer names from a Podcasting 2.0 ``podcast:person`` collection.
+
+    Accepts the persons list as produced by podcastparser (feeds) or by the Podcast
+    Index API; both expose a ``name`` per entry. Roles, links and images are dropped
+    (no corresponding metadata field). Order is preserved and duplicate names
+    (case-insensitive, trimmed) are removed. Any non-list input yields no names, so
+    callers can pass a raw ``.get("persons")`` without guarding.
+
+    :param persons: The raw persons collection, or any value (non-lists yield []).
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    if not isinstance(persons, list):
+        return names
+    for person in persons:
+        name = person.get("name") if isinstance(person, dict) else person
+        if not isinstance(name, str) or not (name := name.strip()):
+            continue
+        key = name.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        names.append(name)
+    return names
 
 
 def _coerce_seconds(value: Any) -> float | None:
@@ -287,19 +329,26 @@ def parse_chapters_from_json(data: dict[str, Any]) -> list[MediaItemChapter]:
 async def enrich_episode_chapters(
     *,
     session: aiohttp.ClientSession,
-    episode: dict[str, Any],
+    chapters_json_url: str | None,
     mass_episode: PodcastEpisode,
 ) -> None:
     """
     Attach ``podcast:chapters`` (external JSON) to an episode lacking inline chapters.
 
-    Chapter data is supplementary: any fetch/parse failure is logged and ignored so
-    it can never break episode resolution or playback. Intended for the single-episode
-    path only, to avoid a network request per episode when listing a whole podcast.
+    Transport-agnostic: the caller supplies the chapters JSON URL directly (e.g.
+    podcastparser's ``chapters_json_url`` or the Podcast Index API ``chaptersUrl``),
+    so any podcast provider can reuse it. Chapter data is supplementary: any
+    fetch/parse failure is logged and ignored so it can never break episode
+    resolution or playback. Intended for the single-episode path only, to avoid a
+    network request per episode when listing a whole podcast.
+
+    :param session: The aiohttp session used for the best-effort fetch.
+    :param chapters_json_url: The Podcasting 2.0 chapters JSON URL, or None to skip.
+    :param mass_episode: The episode to enrich; untouched if it already has chapters.
     """
     if mass_episode.metadata.chapters:
         return
-    url = episode.get("chapters_json_url")
+    url = chapters_json_url
     if not url:
         return
     # the Mozilla UA mirrors get_podcastparser_dict: some podcast hosts/CDNs reject

--- a/music_assistant/helpers/podcast_parsers.py
+++ b/music_assistant/helpers/podcast_parsers.py
@@ -173,6 +173,13 @@ def parse_podcast_episode(
     if episode_published == 0:
         episode_published = None
 
+    # prefer the explicit itunes:episode number for ordering (parity with podcast_index);
+    # fall back to the feed enumeration order when the feed omits it
+    episode_number = episode.get("number")
+    episode_position = (
+        episode_number if isinstance(episode_number, int) and episode_number > 0 else episode_cnt
+    )
+
     try:
         stream_url, guid = get_stream_url_and_guid_from_episode(episode=episode)
     except ValueError:
@@ -188,7 +195,7 @@ def parse_podcast_episode(
         provider=instance_id,
         name=episode_title,
         duration=int(episode_duration),
-        position=episode_cnt,
+        position=episode_position,
         podcast=ItemMapping(
             item_id=prov_podcast_id,
             provider=instance_id,

--- a/music_assistant/helpers/podcast_parsers.py
+++ b/music_assistant/helpers/podcast_parsers.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import UTC, datetime
 from io import BytesIO
+from math import isfinite
 from typing import TYPE_CHECKING, Any
 
 import podcastparser
@@ -228,15 +229,17 @@ def parse_podcast_episode(
 
     # inline chapters (Podlove Simple Chapters, parsed by podcastparser)
     if chapters := episode.get("chapters"):
-        _chapters = []
-        for cnt, chapter in enumerate(chapters):
+        _chapters: list[MediaItemChapter] = []
+        for chapter in chapters:
             if not isinstance(chapter, dict):
                 continue
             title = chapter.get("title")
             start = chapter.get("start")
             # start may legitimately be 0 (opening chapter), so test against None
             if title and start is not None:
-                _chapters.append(MediaItemChapter(position=cnt + 1, name=title, start=start))
+                _chapters.append(
+                    MediaItemChapter(position=len(_chapters) + 1, name=title, start=start)
+                )
         if _chapters:
             mass_episode.metadata.chapters = _chapters
 
@@ -261,10 +264,9 @@ def parse_podcast_persons(persons: Any) -> list[str]:
     Extract performer names from a Podcasting 2.0 ``podcast:person`` collection.
 
     Accepts the persons list as produced by podcastparser (feeds) or by the Podcast
-    Index API; both expose a ``name`` per entry. Roles, links and images are dropped
-    (no corresponding metadata field). Order is preserved and duplicate names
-    (case-insensitive, trimmed) are removed. Any non-list input yields no names, so
-    callers can pass a raw ``.get("persons")`` without guarding.
+    Index API. Returns the display names de-duplicated (case-insensitive) in feed
+    order; any non-list input yields no names, so callers can pass a raw
+    ``.get("persons")`` without guarding.
 
     :param persons: The raw persons collection, or any value (non-lists yield []).
     """
@@ -289,9 +291,10 @@ def _coerce_seconds(value: Any) -> float | None:
     if value is None:
         return None
     try:
-        return float(value)
+        seconds = float(value)
     except TypeError, ValueError:
         return None
+    return seconds if isfinite(seconds) else None
 
 
 def parse_chapters_from_json(data: dict[str, Any]) -> list[MediaItemChapter]:
@@ -313,7 +316,7 @@ def parse_chapters_from_json(data: dict[str, Any]) -> list[MediaItemChapter]:
             continue
         title = raw_chapter.get("title")
         start = _coerce_seconds(raw_chapter.get("startTime"))
-        if not title or start is None:
+        if not isinstance(title, str) or not title or start is None:
             continue
         chapters.append(
             MediaItemChapter(
@@ -351,10 +354,12 @@ async def enrich_episode_chapters(
     url = chapters_json_url
     if not url:
         return
-    # the Mozilla UA mirrors get_podcastparser_dict: some podcast hosts/CDNs reject
-    # non-browser agents (music-assistant/support#3596), and chapter JSON is served
-    # from the same infrastructure. TimeoutError (raised on total-timeout) is not a
-    # ClientError, so it must be caught explicitly to keep this enrichment best-effort.
+    # send a browser UA: some podcast hosts/CDNs reject non-browser agents
+    # (music-assistant/support#3596). Chapter data is supplementary, so unlike
+    # get_podcastparser_dict we make a single best-effort attempt with no UA-less retry.
+    # TimeoutError (raised on total-timeout) is not a ClientError, so catch it explicitly
+    # to keep this enrichment best-effort. The parse stays inside the try so a malformed
+    # document can never break episode resolution either.
     try:
         async with session.get(
             url,
@@ -363,8 +368,7 @@ async def enrich_episode_chapters(
             timeout=_CHAPTERS_FETCH_TIMEOUT,
         ) as response:
             data = await response.json(content_type=None)
+        if isinstance(data, dict) and (chapters := parse_chapters_from_json(data)):
+            mass_episode.metadata.chapters = chapters
     except (ClientError, TimeoutError, ValueError, TypeError) as err:
         LOGGER.warning("Failed to fetch podcast chapters from %s: %s", url, err)
-        return
-    if isinstance(data, dict) and (chapters := parse_chapters_from_json(data)):
-        mass_episode.metadata.chapters = chapters

--- a/music_assistant/providers/gpodder/__init__.py
+++ b/music_assistant/providers/gpodder/__init__.py
@@ -603,7 +603,7 @@ class GPodder(MusicProvider):
             if guid_or_stream_url in (guid, stream_url):
                 await enrich_episode_chapters(
                     session=self.mass.http_session,
-                    episode=episode,
+                    chapters_json_url=episode.get("chapters_json_url"),
                     mass_episode=mass_episode,
                 )
                 return

--- a/music_assistant/providers/itunes_podcasts/__init__.py
+++ b/music_assistant/providers/itunes_podcasts/__init__.py
@@ -327,7 +327,7 @@ class ITunesPodcastsProvider(MusicProvider):
             if guid_or_stream_url == _guid_or_stream_url:
                 await enrich_episode_chapters(
                     session=self.mass.http_session,
-                    episode=episode,
+                    chapters_json_url=episode.get("chapters_json_url"),
                     mass_episode=mass_episode,
                 )
                 return mass_episode

--- a/music_assistant/providers/podcast_index/helpers.py
+++ b/music_assistant/providers/podcast_index/helpers.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
-from music_assistant_models.enums import ContentType, ImageType, MediaType
+from music_assistant_models.enums import ContentType, ImageType, LinkType, MediaType
 from music_assistant_models.errors import (
     InvalidDataError,
     LoginFailed,
@@ -18,11 +18,14 @@ from music_assistant_models.media_items import (
     AudioFormat,
     ItemMapping,
     MediaItemImage,
+    MediaItemLink,
     Podcast,
     PodcastEpisode,
     ProviderMapping,
     UniqueList,
 )
+
+from music_assistant.helpers.podcast_parsers import parse_podcast_persons
 
 from .constants import API_BASE_URL
 
@@ -198,6 +201,14 @@ def parse_episode_from_data(
     # Add metadata
     episode.metadata.description = episode_data.get("description", "")
     episode.metadata.explicit = bool(episode_data.get("explicit", 0))
+
+    # hosts/guests (Podcast Index persons array), mapped to performer names
+    if performers := parse_podcast_persons(episode_data.get("persons")):
+        episode.metadata.performers = set(performers)
+
+    # episode webpage
+    if link := episode_data.get("link"):
+        episode.metadata.links = {MediaItemLink(type=LinkType.WEBSITE, url=link)}
 
     date_published = episode_data.get("datePublished")
     if date_published:

--- a/music_assistant/providers/podcast_index/provider.py
+++ b/music_assistant/providers/podcast_index/provider.py
@@ -25,6 +25,7 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.cache import use_cache
+from music_assistant.helpers.podcast_parsers import enrich_episode_chapters
 from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
@@ -301,6 +302,14 @@ class PodcastIndexProvider(MusicProvider):
                     episode_data, podcast_id, 0, self.instance_id, self.domain
                 )
                 if episode:
+                    # single-episode path only: fetch external podcast:chapters JSON
+                    # (Podcasting 2.0) when present, to avoid a request per episode
+                    # during full-podcast listing
+                    await enrich_episode_chapters(
+                        session=self.mass.http_session,
+                        chapters_json_url=episode_data.get("chaptersUrl"),
+                        mass_episode=episode,
+                    )
                     return episode
 
         except ProviderUnavailableError, InvalidDataError:

--- a/music_assistant/providers/podcast_index/provider.py
+++ b/music_assistant/providers/podcast_index/provider.py
@@ -291,27 +291,16 @@ class PodcastIndexProvider(MusicProvider):
 
         Uses the efficient episodes/byid endpoint for direct episode retrieval.
         """
+        episode_data: dict[str, Any] | None = None
+        episode: PodcastEpisode | None = None
         try:
             podcast_id, episode_id = prov_episode_id.split("|", 1)
-
             response = await self._api_request("episodes/byid", params={"id": episode_id})
             episode_data = response.get("episode")
-
             if episode_data:
                 episode = parse_episode_from_data(
                     episode_data, podcast_id, 0, self.instance_id, self.domain
                 )
-                if episode:
-                    # single-episode path only: fetch external podcast:chapters JSON
-                    # (Podcasting 2.0) when present, to avoid a request per episode
-                    # during full-podcast listing
-                    await enrich_episode_chapters(
-                        session=self.mass.http_session,
-                        chapters_json_url=episode_data.get("chaptersUrl"),
-                        mass_episode=episode,
-                    )
-                    return episode
-
         except ProviderUnavailableError, InvalidDataError:
             # Re-raise these specific errors
             raise
@@ -321,7 +310,19 @@ class PodcastIndexProvider(MusicProvider):
         except Exception as err:
             self.logger.warning("Unexpected error getting episode %s: %s", prov_episode_id, err)
 
-        raise MediaNotFoundError(f"Episode {prov_episode_id} not found")
+        if episode is None or episode_data is None:
+            raise MediaNotFoundError(f"Episode {prov_episode_id} not found")
+
+        # single-episode path only: fetch external podcast:chapters JSON (Podcasting 2.0)
+        # when present, to avoid a request per episode during full-podcast listing. Runs
+        # outside the resolution try so a best-effort chapter failure can never surface as
+        # the episode itself being not found.
+        await enrich_episode_chapters(
+            session=self.mass.http_session,
+            chapters_json_url=episode_data.get("chaptersUrl"),
+            mass_episode=episode,
+        )
+        return episode
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """

--- a/music_assistant/providers/podcastfeed/__init__.py
+++ b/music_assistant/providers/podcastfeed/__init__.py
@@ -154,7 +154,7 @@ class PodcastMusicprovider(MusicProvider):
                 if mass_episode := self._parse_episode(episode, idx):
                     await enrich_episode_chapters(
                         session=self.mass.http_session,
-                        episode=episode,
+                        chapters_json_url=episode.get("chapters_json_url"),
                         mass_episode=mass_episode,
                     )
                     return mass_episode

--- a/tests/helpers/test_podcast_parsers.py
+++ b/tests/helpers/test_podcast_parsers.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp.client import ClientError
+from music_assistant_models.enums import LinkType
 
 from music_assistant.helpers.podcast_parsers import (
     enrich_episode_chapters,
     parse_chapters_from_json,
     parse_podcast_episode,
+    parse_podcast_persons,
 )
 
 if TYPE_CHECKING:
@@ -210,7 +212,7 @@ async def test_enrich_fetches_json_chapters() -> None:
     session = _FakeSession(payload={"chapters": [{"startTime": 0, "title": "Intro"}]})
     await enrich_episode_chapters(
         session=cast("aiohttp.ClientSession", session),
-        episode={"chapters_json_url": "https://example.com/ch.json"},
+        chapters_json_url="https://example.com/ch.json",
         mass_episode=mass_episode,
     )
     assert mass_episode.metadata.chapters is not None
@@ -224,7 +226,7 @@ async def test_enrich_swallows_fetch_error() -> None:
     session = _FakeSession(error=ClientError("boom"))
     await enrich_episode_chapters(
         session=cast("aiohttp.ClientSession", session),
-        episode={"chapters_json_url": "https://example.com/ch.json"},
+        chapters_json_url="https://example.com/ch.json",
         mass_episode=mass_episode,
     )
     assert mass_episode.metadata.chapters is None
@@ -237,7 +239,7 @@ async def test_enrich_swallows_timeout() -> None:
     session = _FakeSession(error=TimeoutError())
     await enrich_episode_chapters(
         session=cast("aiohttp.ClientSession", session),
-        episode={"chapters_json_url": "https://example.com/ch.json"},
+        chapters_json_url="https://example.com/ch.json",
         mass_episode=mass_episode,
     )
     assert mass_episode.metadata.chapters is None
@@ -250,9 +252,86 @@ async def test_enrich_skips_when_inline_chapters_present() -> None:
     session = _FakeSession(payload={"chapters": [{"startTime": 5, "title": "FromJson"}]})
     await enrich_episode_chapters(
         session=cast("aiohttp.ClientSession", session),
-        episode={"chapters_json_url": "https://example.com/ch.json"},
+        chapters_json_url="https://example.com/ch.json",
         mass_episode=mass_episode,
     )
     assert session.calls == 0
     assert mass_episode.metadata.chapters is not None
     assert [c.name for c in mass_episode.metadata.chapters] == ["Inline"]
+
+
+async def test_enrich_skips_when_no_url() -> None:
+    """A falsy chapters URL is a no-op: no fetch, no chapters."""
+    mass_episode = _parse(_episode())
+    assert mass_episode is not None
+    session = _FakeSession(payload={"chapters": [{"startTime": 0, "title": "Intro"}]})
+    await enrich_episode_chapters(
+        session=cast("aiohttp.ClientSession", session),
+        chapters_json_url=None,
+        mass_episode=mass_episode,
+    )
+    assert session.calls == 0
+    assert mass_episode.metadata.chapters is None
+
+
+# --- episode webpage, explicit flag, performers ----------------------------------------------
+
+
+def test_episode_link_maps_to_website_link() -> None:
+    """An item <link> becomes a WEBSITE link on the episode metadata."""
+    mass_episode = _parse(_episode(link="https://example.com/ep1"))
+    assert mass_episode is not None
+    assert mass_episode.metadata.links is not None
+    link = next(iter(mass_episode.metadata.links))
+    assert (link.type, link.url) == (LinkType.WEBSITE, "https://example.com/ep1")
+
+
+def test_episode_missing_link_leaves_links_unset() -> None:
+    """Without an item <link>, metadata.links stays None."""
+    mass_episode = _parse(_episode())
+    assert mass_episode is not None
+    assert mass_episode.metadata.links is None
+
+
+def test_episode_explicit_only_set_when_declared() -> None:
+    """The explicit flag is set from the feed value, and left untouched when absent."""
+    explicit_ep = _parse(_episode(explicit=True))
+    assert explicit_ep is not None
+    assert explicit_ep.metadata.explicit is True
+    not_explicit = _parse(_episode(explicit=False))
+    assert not_explicit is not None
+    assert not_explicit.metadata.explicit is False
+    # absent key must not coerce to False over the model default
+    unknown = _parse(_episode())
+    assert unknown is not None
+    assert unknown.metadata.explicit is None
+
+
+def test_episode_performers_from_persons() -> None:
+    """podcast:person entries land on metadata.performers as names."""
+    mass_episode = _parse(
+        _episode(persons=[{"name": "Jane Host", "role": "host"}, {"name": "Joe Guest"}])
+    )
+    assert mass_episode is not None
+    assert mass_episode.metadata.performers == {"Jane Host", "Joe Guest"}
+
+
+# --- parse_podcast_persons -------------------------------------------------------------------
+
+
+def test_parse_podcast_persons_dedupes_and_trims() -> None:
+    """Names are trimmed, de-duplicated case-insensitively, and order-preserved."""
+    persons = [{"name": "  Alice "}, {"name": "alice"}, {"name": "Bob"}]
+    assert parse_podcast_persons(persons) == ["Alice", "Bob"]
+
+
+def test_parse_podcast_persons_skips_blank_and_malformed() -> None:
+    """Blank names, missing names, and non-dict/non-str entries are skipped."""
+    persons = [{"name": ""}, {"role": "host"}, {"name": 123}, "Carol", 7]
+    assert parse_podcast_persons(persons) == ["Carol"]
+
+
+def test_parse_podcast_persons_non_list_returns_empty() -> None:
+    """Any non-list input yields no names, so callers need not guard."""
+    assert parse_podcast_persons(None) == []
+    assert parse_podcast_persons("nope") == []

--- a/tests/helpers/test_podcast_parsers.py
+++ b/tests/helpers/test_podcast_parsers.py
@@ -134,6 +134,23 @@ def test_podcast_reference_falls_back_to_episode_title() -> None:
     assert mass_episode.podcast.name == "Some Episode"
 
 
+# --- episode position (itunes:episode number) -----------------------------------------------
+
+
+def test_episode_position_uses_itunes_episode_number() -> None:
+    """A declared itunes:episode number drives the episode position over the feed order."""
+    mass_episode = _parse(_episode(number=5))
+    assert mass_episode is not None
+    assert mass_episode.position == 5
+
+
+def test_episode_position_falls_back_to_feed_order() -> None:
+    """Without an episode number, position falls back to the feed enumeration order (cnt=1)."""
+    mass_episode = _parse(_episode())
+    assert mass_episode is not None
+    assert mass_episode.position == 1
+
+
 # --- inline (Podlove Simple Chapters) --------------------------------------------------------
 
 

--- a/tests/helpers/test_podcast_parsers.py
+++ b/tests/helpers/test_podcast_parsers.py
@@ -202,6 +202,23 @@ def test_parse_chapters_from_json_malformed_returns_empty() -> None:
     assert parse_chapters_from_json({"chapters": "nope"}) == []
 
 
+def test_parse_chapters_from_json_skips_malformed_values() -> None:
+    """Non-numeric/non-finite startTimes and non-string titles are dropped, not stored."""
+    data = {
+        "chapters": [
+            {"startTime": "01:30", "title": "non-numeric start"},
+            {"startTime": float("nan"), "title": "nan start"},
+            {"startTime": float("inf"), "title": "inf start"},
+            {"startTime": 10, "title": {"x": 1}},
+            {"startTime": 20, "title": 123},
+            {"startTime": 30, "title": "kept", "endTime": float("nan")},
+        ]
+    }
+    chapters = parse_chapters_from_json(data)
+    # only the well-formed entry survives, and its non-finite endTime collapses to None
+    assert [(c.name, c.start, c.end) for c in chapters] == [("kept", 30.0, None)]
+
+
 # --- chapter enrichment (external JSON fetch) ------------------------------------------------
 
 
@@ -271,6 +288,34 @@ async def test_enrich_skips_when_no_url() -> None:
         mass_episode=mass_episode,
     )
     assert session.calls == 0
+    assert mass_episode.metadata.chapters is None
+
+
+async def test_enrich_ignores_non_dict_payload() -> None:
+    """A JSON payload that is not an object (e.g. a list) leaves the episode without chapters."""
+    mass_episode = _parse(_episode())
+    assert mass_episode is not None
+    session = _FakeSession(payload=[{"startTime": 0, "title": "Intro"}])
+    await enrich_episode_chapters(
+        session=cast("aiohttp.ClientSession", session),
+        chapters_json_url="https://example.com/ch.json",
+        mass_episode=mass_episode,
+    )
+    assert session.calls == 1
+    assert mass_episode.metadata.chapters is None
+
+
+async def test_enrich_ignores_empty_chapters_payload() -> None:
+    """A document whose chapters all filter out leaves metadata.chapters as None."""
+    mass_episode = _parse(_episode())
+    assert mass_episode is not None
+    session = _FakeSession(payload={"chapters": []})
+    await enrich_episode_chapters(
+        session=cast("aiohttp.ClientSession", session),
+        chapters_json_url="https://example.com/ch.json",
+        mass_episode=mass_episode,
+    )
+    assert session.calls == 1
     assert mass_episode.metadata.chapters is None
 
 

--- a/tests/providers/gpodder/__init__.py
+++ b/tests/providers/gpodder/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the gpodder provider."""

--- a/tests/providers/gpodder/test_chapter_enrichment.py
+++ b/tests/providers/gpodder/test_chapter_enrichment.py
@@ -1,0 +1,107 @@
+"""Tests for gpodder external chapter enrichment on the single-episode path."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.helpers.podcast_parsers import parse_podcast_episode
+from music_assistant.providers.gpodder import GPodder
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items import PodcastEpisode
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    async def json(self, **kwargs: Any) -> Any:
+        return self._payload
+
+
+class _FakeGetContext:
+    def __init__(self, session: _FakeSession) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> _FakeResponse:
+        return _FakeResponse(self._session.payload)
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+
+class _FakeSession:
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+        self.calls = 0
+
+    def get(self, url: str, **kwargs: Any) -> _FakeGetContext:
+        self.calls += 1
+        return _FakeGetContext(self)
+
+
+def _mass_episode() -> PodcastEpisode:
+    """Build a resolved episode with no chapters, as the enrichment input."""
+    episode = parse_podcast_episode(
+        episode={
+            "title": "Episode 1",
+            "enclosures": [{"url": "https://example.com/ep1.mp3"}],
+            "guid": "guid-1",
+        },
+        prov_podcast_id="pod-1",
+        episode_cnt=1,
+        instance_id="gpodder--test",
+        domain="gpodder",
+    )
+    assert episode is not None
+    return episode
+
+
+def _provider(podcast: dict[str, Any], session: _FakeSession) -> MagicMock:
+    """Build a gpodder provider stub sufficient for _enrich_episode_chapters."""
+    provider = MagicMock()
+    provider._cache_get_podcast = AsyncMock(return_value=podcast)
+    provider.mass.http_session = session
+    return provider
+
+
+async def _enrich(provider: MagicMock, guid_or_stream_url: str, episode: PodcastEpisode) -> None:
+    await GPodder._enrich_episode_chapters(
+        cast("GPodder", provider), "pod-1", guid_or_stream_url, episode
+    )
+
+
+async def test_enriches_matching_episode_and_skips_enclosure_less() -> None:
+    """An enclosure-less raw episode is skipped; the matching one's chapters are fetched."""
+    podcast = {
+        "episodes": [
+            # enclosure-less: get_stream_url_and_guid_from_episode raises ValueError -> skipped
+            {"enclosures": []},
+            {
+                "enclosures": [{"url": "https://example.com/ep1.mp3"}],
+                "guid": "guid-1",
+                "chapters_json_url": "https://example.com/ch.json",
+            },
+        ]
+    }
+    session = _FakeSession(payload={"chapters": [{"startTime": 0, "title": "Intro"}]})
+    mass_episode = _mass_episode()
+    await _enrich(_provider(podcast, session), "guid-1", mass_episode)
+    assert session.calls == 1
+    assert mass_episode.metadata.chapters is not None
+    assert [c.name for c in mass_episode.metadata.chapters] == ["Intro"]
+
+
+async def test_no_matching_episode_performs_no_fetch() -> None:
+    """When no raw episode matches the id, nothing is fetched and chapters stay None."""
+    podcast = {
+        "episodes": [
+            {"enclosures": [{"url": "https://example.com/other.mp3"}], "guid": "other"},
+        ]
+    }
+    session = _FakeSession(payload={"chapters": [{"startTime": 0, "title": "Intro"}]})
+    mass_episode = _mass_episode()
+    await _enrich(_provider(podcast, session), "guid-1", mass_episode)
+    assert session.calls == 0
+    assert mass_episode.metadata.chapters is None

--- a/tests/providers/podcast_index/__init__.py
+++ b/tests/providers/podcast_index/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Podcast Index provider."""

--- a/tests/providers/podcast_index/test_episode_metadata.py
+++ b/tests/providers/podcast_index/test_episode_metadata.py
@@ -1,0 +1,127 @@
+"""Tests for Podcast Index episode metadata (persons/links) and chapter enrichment."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant_models.enums import LinkType
+
+from music_assistant.providers.podcast_index.helpers import parse_episode_from_data
+from music_assistant.providers.podcast_index.provider import PodcastIndexProvider
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items import PodcastEpisode
+
+
+def _episode_data(**overrides: Any) -> dict[str, Any]:
+    """Return minimal Podcast Index episode API data with a valid enclosure."""
+    data: dict[str, Any] = {
+        "id": 123,
+        "title": "Episode 1",
+        "enclosureUrl": "https://example.com/ep1.mp3",
+        "enclosureType": "audio/mpeg",
+    }
+    data.update(overrides)
+    return data
+
+
+def _parse(data: dict[str, Any]) -> PodcastEpisode | None:
+    return parse_episode_from_data(data, "feed-1", 0, "podcast_index--test", "podcast_index")
+
+
+# --- parse_episode_from_data: persons / links ------------------------------------------------
+
+
+def test_persons_map_to_performers() -> None:
+    """The API persons array becomes performer names on the episode metadata."""
+    episode = _parse(
+        _episode_data(persons=[{"name": "Jane Host", "role": "host"}, {"name": "Joe Guest"}])
+    )
+    assert episode is not None
+    assert episode.metadata.performers == {"Jane Host", "Joe Guest"}
+
+
+def test_link_maps_to_website_link() -> None:
+    """The API episode link becomes a WEBSITE link."""
+    episode = _parse(_episode_data(link="https://example.com/ep1"))
+    assert episode is not None
+    assert episode.metadata.links is not None
+    link = next(iter(episode.metadata.links))
+    assert (link.type, link.url) == (LinkType.WEBSITE, "https://example.com/ep1")
+
+
+def test_missing_persons_and_link_leave_metadata_unset() -> None:
+    """Without persons/link, performers and links stay None and parsing still succeeds."""
+    episode = _parse(_episode_data())
+    assert episode is not None
+    assert episode.metadata.performers is None
+    assert episode.metadata.links is None
+
+
+# --- chapter enrichment on the single-episode path -------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    async def json(self, **kwargs: Any) -> Any:
+        return self._payload
+
+
+class _FakeGetContext:
+    def __init__(self, session: _FakeSession) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> _FakeResponse:
+        return _FakeResponse(self._session.payload)
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+
+class _FakeSession:
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+        self.calls = 0
+
+    def get(self, url: str, **kwargs: Any) -> _FakeGetContext:
+        self.calls += 1
+        return _FakeGetContext(self)
+
+
+def _provider(episode_data: dict[str, Any], session: _FakeSession) -> MagicMock:
+    """Build a provider stub sufficient for get_podcast_episode's single lookup."""
+    provider = MagicMock()
+    provider.instance_id = "podcast_index--test"
+    provider.domain = "podcast_index"
+    provider.logger = MagicMock()
+    provider.mass.http_session = session
+    provider._api_request = AsyncMock(return_value={"episode": episode_data})
+    return provider
+
+
+async def _call_get_episode(provider: MagicMock, prov_episode_id: str) -> PodcastEpisode:
+    # bypass the @use_cache wrapper to drive the real method directly
+    func = PodcastIndexProvider.get_podcast_episode.__wrapped__
+    return await func(cast("PodcastIndexProvider", provider), prov_episode_id)
+
+
+async def test_get_podcast_episode_enriches_chapters() -> None:
+    """A chaptersUrl on the single-episode path populates metadata.chapters."""
+    session = _FakeSession(payload={"chapters": [{"startTime": 0, "title": "Intro"}]})
+    provider = _provider(_episode_data(chaptersUrl="https://example.com/ch.json"), session)
+    episode = await _call_get_episode(provider, "feed-1|123")
+    assert session.calls == 1
+    assert episode.metadata.chapters is not None
+    assert [c.name for c in episode.metadata.chapters] == ["Intro"]
+
+
+async def test_get_podcast_episode_without_chapters_url() -> None:
+    """No chaptersUrl: the episode resolves normally with no chapters and no fetch."""
+    session = _FakeSession(payload={"chapters": [{"startTime": 0, "title": "Intro"}]})
+    provider = _provider(_episode_data(), session)
+    episode = await _call_get_episode(provider, "feed-1|123")
+    assert session.calls == 0
+    assert episode.metadata.chapters is None

--- a/tests/providers/podcast_index/test_episode_metadata.py
+++ b/tests/providers/podcast_index/test_episode_metadata.py
@@ -104,8 +104,9 @@ def _provider(episode_data: dict[str, Any], session: _FakeSession) -> MagicMock:
 
 async def _call_get_episode(provider: MagicMock, prov_episode_id: str) -> PodcastEpisode:
     # bypass the @use_cache wrapper to drive the real method directly
-    func = PodcastIndexProvider.get_podcast_episode.__wrapped__
-    return await func(cast("PodcastIndexProvider", provider), prov_episode_id)
+    func: Any = PodcastIndexProvider.get_podcast_episode.__wrapped__  # type: ignore[attr-defined]
+    result = await func(cast("PodcastIndexProvider", provider), prov_episode_id)
+    return cast("PodcastEpisode", result)
 
 
 async def test_get_podcast_episode_enriches_chapters() -> None:


### PR DESCRIPTION
# What does this implement/fix?

What does this implement/fix? Explain your changes.

Builds on #4444 (podcast episode descriptions/chapters/parent-podcast name) by turning the episode metadata mapping into a transport-agnostic helper toolkit, so any podcast provider — not just the RSS/podcastparser ones — can expose the same rich metadata when its source has it. Podcast Index is wired up as the first non-feed adopter.

- Generalized chapter enrichment. enrich_episode_chapters now takes a chapters_json_url: str | None directly instead of being coupled to a podcastparser episode dict, so it can be reused by any provider. The external-fetch path stays strictly best-effort (capped timeout, context-managed request, failures logged and swallowed) and now also runs the JSON parse inside the guard so a malformed chapters document can never break episode resolution.
- Performers from podcast:person. New parse_podcast_persons() maps a Podcasting 2.0 podcast:person collection (RSS feeds) or the Podcast Index persons array onto deduplicated performer names. parse_podcast_episode now also sets performers, episode links (the item <link>), and explicit (only when the feed actually declares it).
- Podcast Index parity. parse_episode_from_data maps persons → performers and link → links; get_podcast_episode fetches Podcasting 2.0 chapters from the API chaptersUrl on the single-episode path only (no per-episode request during listing), and the enrichment call was moved outside the broad try so a best-effort chapter failure can no longer surface as MediaNotFoundError.
- Stable episode ordering. parse_podcast_episode now uses the explicit itunes:episode number for the episode position (parity with Podcast Index), falling back to feed enumeration order when the feed omits it.
- Hardening. parse_chapters_from_json rejects non-string titles and non-finite start/end times; contiguous chapter numbering across the inline and JSON paths.
- Adds unit tests for the new helpers (persons parsing, the generalized enrich signature incl. no-url/timeout/bad-JSON/non-dict/empty payloads, the new episode fields) and for Podcast Index chapter enrichment + persons/link mapping.


**Related issue (if applicable):**


## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
