### PR TITLE
Fix negative elapsed_time crashing clients

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -72,6 +72,11 @@ if TYPE_CHECKING:
     from .player_provider import PlayerProvider
 
 
+def _clamp_elapsed_time(elapsed_time: float | None) -> float | None:
+    """Return elapsed_time clamped to a non-negative value."""
+    return max(0.0, elapsed_time) if elapsed_time is not None else None
+
+
 class Player(ABC):
     """
     Base representation of a Player within the Music Assistant Server.
@@ -196,7 +201,7 @@ class Player(ABC):
     @property
     def elapsed_time(self) -> float | None:
         """Return the elapsed time in (fractional) seconds of the current track (if any)."""
-        return self._attr_elapsed_time
+        return _clamp_elapsed_time(self._attr_elapsed_time)
 
     @property
     def elapsed_time_last_updated(self) -> float | None:
@@ -873,8 +878,10 @@ class Player(ABC):
         if self.elapsed_time is None or self.elapsed_time_last_updated is None:
             return None
         if self.playback_state == PlaybackState.PLAYING:
-            return self.elapsed_time + (time.time() - self.elapsed_time_last_updated)
-        return self.elapsed_time
+            return _clamp_elapsed_time(
+                self.elapsed_time + (time.time() - self.elapsed_time_last_updated)
+            )
+        return _clamp_elapsed_time(self.elapsed_time)
 
     @cached_property
     @final

--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -222,7 +222,7 @@ class DLNAPlayer(Player):
         prev_state = self._attr_playback_state
         self.set_current_media(uri=url, clear_all=True)
         self._attr_playback_state = PlaybackState.PLAYING
-        self._attr_elapsed_time = -1
+        self._attr_elapsed_time = 0
         self._attr_elapsed_time_last_updated = time.time()
         try:
             await self.device.async_set_transport_uri(url, title, didl_metadata)

--- a/tests/controllers/players/test_player_protocol_state.py
+++ b/tests/controllers/players/test_player_protocol_state.py
@@ -123,6 +123,25 @@ class TestFinalPlaybackStateWithActiveProtocol:
 
         assert player.state.playback_state == PlaybackState.PLAYING
 
+    def test_negative_elapsed_time_is_clamped(
+        self,
+        provider: MockProvider,
+        controller: PlayerController,
+    ) -> None:
+        """A negative provider elapsed time is clamped at the elapsed_time accessor."""
+        player = MockPlayer(provider, "player_1", "Test Player")
+        player._attr_playback_state = PlaybackState.PAUSED
+        player._attr_elapsed_time = -1.0
+        player._attr_elapsed_time_last_updated = time.time()
+
+        controller._players = {"player_1": player}
+
+        player.update_state(signal_event=False)
+
+        assert player.elapsed_time == 0
+        assert player.corrected_elapsed_time == 0
+        assert player.state.elapsed_time == 0
+
 
 def _audio_source_queue(elapsed: float, updated: float) -> MagicMock:
     """Build a mock queue whose current item is an AudioSource carrying a source clock."""


### PR DESCRIPTION
# What does this implement/fix?

DLNA's play_media set an optimistic elapsed_time sentinel of -1 while position was unknown. The desktop app would panic converting the resulting
 negative corrected_elapsed_time to a Duration. It has been fixed, but
we shouldn't emit negative elapsed_time.

- dlna: use 0 instead of -1 for the optimistic elapsed_time placeholder (0 is correct for a freshly started stream).
- player: clamp elapsed_time at the elapsed_time accessor so no negative value reaches any consumer (PlayerState, queue, and live readers), and guard corrected_elapsed_time against the realtime/clock-skew edge.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/desktop-app/issues/89

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
