### PR TITLE
Catch only MusicAssistantError in playlist metadata enrichment

### DIFF
--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -15,7 +15,7 @@ from time import time
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.enums import AlbumType, MediaType, ProviderFeature
-from music_assistant_models.errors import MediaNotFoundError
+from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.helpers import get_global_cache_value
 from music_assistant_models.media_items import Album, Artist, MediaItemImage, Track
 
@@ -381,7 +381,7 @@ class MetadataEnrichmentMixin:
                         provider.name,
                         playlist.name,
                     )
-            except Exception as err:
+            except MusicAssistantError as err:
                 self.logger.warning(
                     "Error retrieving playlist metadata from provider %s for %s: %s",
                     provider.name,

--- a/tests/controllers/metadata/test_playlist_metadata_integration.py
+++ b/tests/controllers/metadata/test_playlist_metadata_integration.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.enums import ImageType, ProviderFeature
+from music_assistant_models.errors import ProviderUnavailableError
 from music_assistant_models.media_items import MediaItemImage, Playlist, ProviderMapping, Track
 from music_assistant_models.media_items.metadata import MediaItemMetadata
 from music_assistant_models.unique_list import UniqueList
@@ -88,18 +89,20 @@ async def test_update_playlist_metadata_calls_provider(tmp_path: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_update_playlist_metadata_handles_provider_exception(tmp_path: Any) -> None:
-    """_update_playlist_metadata should handle exceptions from providers gracefully."""
+    """_update_playlist_metadata should handle MusicAssistantError exceptions from providers gracefully."""
     enrichment = MetadataEnrichmentMixin()
     enrichment.logger = MagicMock()
     enrichment.mass = MagicMock()
     enrichment._collage_images_dir = str(tmp_path / "collage")
     enrichment.create_collage_image = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
-    # Mock metadata provider that raises exception
+    # Mock metadata provider that raises MusicAssistantError
     provider = MagicMock()
     provider.name = "playlist_metadata"
     provider.supported_features = {ProviderFeature.PLAYLIST_METADATA}
-    provider.get_playlist_metadata = AsyncMock(side_effect=RuntimeError("Test error"))
+    provider.get_playlist_metadata = AsyncMock(
+        side_effect=ProviderUnavailableError("Test provider unavailable")
+    )
     enrichment.providers = [provider]  # type: ignore[misc]
 
     playlist = _make_playlist()


### PR DESCRIPTION
# What does this implement/fix?

Replace bare `except Exception` with `except MusicAssistantError` in the playlist metadata enrichment loop. This catches only known errors (MediaNotFoundError, ProviderUnavailableError, etc.) derived from MusicAssistantError while allowing unexpected errors to propagate for debugging.

**Related issue (if applicable):**

- Follow-up to #4460 as suggested by @marcelveldt in https://github.com/music-assistant/server/pull/4460#discussion_r3488585882

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.