### PR TITLE
Honour the queue's recency windows in provider dynamic stations

### DIFF
--- a/music_assistant/helpers/track_filter.py
+++ b/music_assistant/helpers/track_filter.py
@@ -50,6 +50,24 @@ def get_track_filter() -> TrackFilter | None:
     return _CURRENT_TRACK_FILTER.get()
 
 
+def filter_tracks(tracks: list[Track]) -> list[Track]:
+    """
+    Drop tracks the active best-effort filter would reject, keeping all if that empties the list.
+
+    A dynamic-playlist generator calls this on its assembled candidate tracks so the consumer's
+    recency/queue filter can pre-skip tracks it would discard anyway. It is a no-op when no filter
+    is published and never turns a non-empty list into an empty one, so the consumer stays
+    authoritative. Generators should over-generate where they can so filtering still leaves enough.
+
+    :param tracks: The candidate tracks to filter.
+    """
+    active_filter = get_track_filter()
+    if active_filter is None:
+        return tracks
+    kept = [track for track in tracks if active_filter.allows(track)]
+    return kept or tracks
+
+
 @contextmanager
 def track_filter(include: Callable[[Track], bool]) -> Iterator[TrackFilter]:
     """

--- a/music_assistant/providers/apple_music/media.py
+++ b/music_assistant/providers/apple_music/media.py
@@ -15,6 +15,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.controllers.cache import use_cache
+from music_assistant.helpers.track_filter import filter_tracks
 
 from .helpers.utils import is_catalog_id, is_library_id
 from .parsers import (
@@ -238,7 +239,7 @@ class AppleMusicMediaManager:
                     fresh_id,
                 )
                 tracks = await self._fetch_station_tracks(fresh_id)
-        return tracks
+        return filter_tracks(tracks)
 
     async def _fetch_station_tracks(self, station_id: str) -> list[Track]:
         """Fetch tracks for a station ID from the Apple Music API."""

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -71,6 +71,7 @@ from music_assistant.helpers.playlists import (
 )
 from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.tags import AudioTags, async_parse_tags
+from music_assistant.helpers.track_filter import filter_tracks, get_track_filter
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.music_provider import MusicProvider
 
@@ -1169,24 +1170,30 @@ class BuiltinProvider(MusicProvider):
 
     async def _get_builtin_playlist_infinite_mix(self) -> list[Track]:
         """Return 25 random library tracks for the Infinite Mix dynamic playlist."""
-        result: list[Track] = []
-        for idx, track in enumerate(
-            await self.mass.music.tracks.library_items(limit=25, order_by="random"), 1
-        ):
-            track.position = idx
-            result.append(track)
-        return result
+        return await self._infinite_mix_tracks(favorite=None)
 
     async def _get_builtin_playlist_infinite_mix_favorites(self) -> list[Track]:
         """Return 25 random favorited tracks for the Infinite Mix (favorites) dynamic playlist."""
-        result: list[Track] = []
-        for idx, track in enumerate(
-            await self.mass.music.tracks.library_items(favorite=True, limit=25, order_by="random"),
-            1,
-        ):
+        return await self._infinite_mix_tracks(favorite=True)
+
+    async def _infinite_mix_tracks(self, *, favorite: bool | None) -> list[Track]:
+        """
+        Return up to 25 random (optionally favorited) library tracks for an Infinite Mix.
+
+        :param favorite: Restrict to favorited tracks when True; all library tracks when None.
+        """
+        # over-fetch when a recency filter is published so dropping recently-played tracks still
+        # leaves a full mix; the pool is trimmed back to the mix size after filtering
+        limit = 25 * 3 if get_track_filter() is not None else 25
+        candidates = list(
+            await self.mass.music.tracks.library_items(
+                favorite=favorite, limit=limit, order_by="random"
+            )
+        )
+        tracks = filter_tracks(candidates)[:25]
+        for idx, track in enumerate(tracks, 1):
             track.position = idx
-            result.append(track)
-        return result
+        return tracks
 
     async def _get_builtin_playlist_tracks(
         self, builtin_playlist_id: str

--- a/music_assistant/providers/deezer/browse.py
+++ b/music_assistant/providers/deezer/browse.py
@@ -28,6 +28,7 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.controllers.cache import use_cache
+from music_assistant.helpers.track_filter import filter_tracks
 
 from .constants import (
     BROWSE_ALL_FLOWS,
@@ -938,7 +939,7 @@ class DeezerBrowseManager:
                 if ft.track is not None and ft.track.id not in seen:
                     seen.add(ft.track.id)
                     tracks.append(parse_track(self.provider, ft.track))
-        return tracks
+        return filter_tracks(tracks)
 
     @use_cache(3600)
     async def _get_recommended_tracks(self) -> list[Track]:
@@ -985,7 +986,7 @@ class DeezerBrowseManager:
                 if ft.track is not None and ft.track.id not in seen:
                     seen.add(ft.track.id)
                     tracks.append(parse_track(self.provider, ft.track))
-        return tracks
+        return filter_tracks(tracks)
 
     @use_cache(3600)
     async def _get_smart_tracklist_tracks(self, tracklist_id: str) -> list[Track]:
@@ -1033,9 +1034,9 @@ class DeezerBrowseManager:
         tracklist = group.suggested_tracklist.tracklist
         if tracklist is None:
             return []
-        return [
-            parse_track(self.provider, edge.node) for edge in tracklist.tracks.edges if edge.node
-        ]
+        return filter_tracks(
+            [parse_track(self.provider, edge.node) for edge in tracklist.tracks.edges if edge.node]
+        )
 
     async def _get_shaker_curated_tracks(self, group_id: str) -> list[Track]:
         """

--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -50,6 +50,7 @@ from music_assistant_models.streamdetails import StreamDetails
 
 from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
 from music_assistant.controllers.cache import use_cache
+from music_assistant.helpers.track_filter import filter_tracks
 from music_assistant.models.music_provider import MusicProvider
 
 from .constants import (
@@ -1751,7 +1752,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
                 break
             if no_new_rounds >= 2:
                 break
-        return result
+        return filter_tracks(result)
 
     async def _get_heart_mode_seed(self) -> tuple[str, str, str | None] | None:
         """Resolve heart mode seed ids as (seed_song_id, playlist_id, image_url)."""
@@ -1844,7 +1845,7 @@ class NeteaseCloudMusicProvider(MusicProvider):
                 continue
             with suppress(InvalidDataError):
                 result.append(self._parse_track(song_obj))
-        return result
+        return filter_tracks(result)
 
     async def _build_dynamic_radio_folder(self) -> RecommendationFolder | None:
         """Build recommendation folder with dynamic playlist items."""

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -52,7 +52,6 @@ from music_assistant.constants import (
     DYNAMIC_PLAYLIST_SAMPLE_SIZE,
 )
 from music_assistant.controllers.cache import use_cache
-from music_assistant.controllers.music.recency import RecencyWindows
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.security import is_safe_name
 from music_assistant.helpers.track_filter import filter_tracks
@@ -665,7 +664,8 @@ class SmartPlaylistProvider(PluginProvider):
             if rules.excluded_genre_ids:
                 await self._enrich_tracks_with_db_genres(tracks)
 
-        # Apply exclusions and dedup regardless of source mode
+        # Apply exclusions regardless of source mode. Recency (don't repeat recently-played) is
+        # no longer handled here: the player queue owns it globally for dynamic playlists.
         excluded_genre_names, excl_album_type_ids = await asyncio.gather(
             self._resolve_excluded_genre_names(rules),
             self._get_album_ids_for_types(rules.excluded_album_types)
@@ -676,29 +676,6 @@ class SmartPlaylistProvider(PluginProvider):
             tracks, rules, excluded_genre_names, excl_album_type_ids or None
         )
         tracks = self._deduplicate_tracks(tracks)
-        if rules.dedup_hours is not None:
-            deduped = await self._apply_dedup(tracks, rules.dedup_hours)
-            if len(deduped) >= rules.limit:
-                tracks = deduped
-            elif deduped:
-                # Pool partially exhausted: fill remainder with least-recently-played tracks
-                # so playback never stops when the dedup window covers most of the library.
-                deduped_uris = {t.uri for t in deduped}
-                played_remainder = sorted(
-                    (t for t in tracks if t.uri not in deduped_uris),
-                    # last_played is 0 for non-library (streaming) tracks; treat 0 as
-                    # "most recent" so just-played streaming tracks aren't filled first.
-                    key=lambda t: t.last_played or float("inf"),
-                )
-                tracks = deduped + played_remainder[: rules.limit - len(deduped)]
-            else:
-                # All matching tracks were played recently — ignore dedup entirely so
-                # the playlist never goes empty.
-                self.logger.debug(
-                    "dedup_hours=%d exhausted the full track pool; ignoring dedup",
-                    rules.dedup_hours,
-                )
-
         random.shuffle(tracks)
         return tracks[: rules.limit]
 
@@ -1009,21 +986,6 @@ class SmartPlaylistProvider(PluginProvider):
                 result.extend(track_id_to_tracks[track_id])
 
         return result
-
-    async def _apply_dedup(self, tracks: list[Track], dedup_hours: int) -> list[Track]:
-        """
-        Filter out tracks fully played within dedup_hours (scoped to the current user).
-
-        Uses the shared recency engine, whose membership test resolves a track across its
-        provider mappings and its own (provider, item_id) so both library and streaming plays
-        are matched. The engine resolves the current user (the queue owner's context is
-        restored during refills), keeping the dedup window per user.
-        """
-        window = dedup_hours * 3600
-        snapshot = await self.mass.music.recency.snapshot(RecencyWindows(song_seconds=window))
-        if not snapshot.song_ts:
-            return list(tracks)
-        return [track for track in tracks if not snapshot.track_recent(track, window)]
 
     async def _evaluate_and(
         self,

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -55,6 +55,7 @@ from music_assistant.controllers.cache import use_cache
 from music_assistant.controllers.music.recency import RecencyWindows
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.security import is_safe_name
+from music_assistant.helpers.track_filter import filter_tracks
 from music_assistant.helpers.uri import parse_uri
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.smart_playlist.helpers import (
@@ -275,7 +276,10 @@ class SmartPlaylistProvider(PluginProvider):
         user_provider_filter = (
             tuple(sorted(user.provider_filter)) if user and user.provider_filter else ()
         )
-        return await self._cached_dynamic_sample(resolved_id, user_provider_filter)
+        # Filter the cached sample at the boundary (not inside the cached evaluation) so a
+        # recency-filtered batch from a queue refill never gets cached and served to browse.
+        sample = await self._cached_dynamic_sample(resolved_id, user_provider_filter)
+        return filter_tracks(sample)
 
     @use_cache(
         expiration=DYNAMIC_SAMPLE_CACHE_EXPIRATION,

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -125,7 +125,6 @@ class SmartPlaylistRules:
     excluded_album_names: dict[int, str] = field(default_factory=dict)
     excluded_genre_ids: list[int] = field(default_factory=list)
     excluded_genre_names: dict[int, str] = field(default_factory=dict)
-    dedup_hours: int | None = None
     album_types: list[str] = field(default_factory=list)
     excluded_album_types: list[str] = field(default_factory=list)
     explicit: bool | None = None
@@ -173,7 +172,6 @@ class SmartPlaylistRules:
             "excluded_album_names": {str(k): v for k, v in self.excluded_album_names.items()},
             "excluded_genre_ids": self.excluded_genre_ids,
             "excluded_genre_names": {str(k): v for k, v in self.excluded_genre_names.items()},
-            "dedup_hours": self.dedup_hours,
             "album_types": self.album_types,
             "excluded_album_types": self.excluded_album_types,
             "explicit": self.explicit,
@@ -224,7 +222,6 @@ class SmartPlaylistRules:
             excluded_genre_names=_coerce_int_keyed_dict(
                 data.get("excluded_genre_names"), "excluded_genre_names"
             ),
-            dedup_hours=_coerce_optional_int(data.get("dedup_hours"), "dedup_hours"),
             album_types=_coerce_str_list(data.get("album_types"), "album_types"),
             excluded_album_types=_coerce_str_list(
                 data.get("excluded_album_types"), "excluded_album_types"
@@ -271,8 +268,6 @@ class SmartPlaylistRules:
             parts.append(f"Excl. genres: {', '.join(names)}")
         if self.excluded_track_uris:
             parts.append(f"Excl. {len(self.excluded_track_uris)} track(s)")
-        if self.dedup_hours is not None:
-            parts.append(f"No repeat within {self.dedup_hours}h")
         if self.album_types:
             parts.append(f"Album types: {', '.join(self.album_types)}")
         if self.excluded_album_types:
@@ -316,10 +311,6 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
     total_seeds = len(rules.all_seed_uris())
     if total_seeds > MAX_SEEDS:
         msg = f"Too many seeds: {total_seeds} > {MAX_SEEDS}"
-        raise InvalidDataError(msg)
-    if rules.dedup_hours is not None and not (1 <= rules.dedup_hours <= 2160):
-        # 2160h == 90 days, matching the playlog retention window the dedup relies on.
-        msg = f"dedup_hours must be between 1 and 2160, got {rules.dedup_hours}"
         raise InvalidDataError(msg)
     valid_album_types = {t.value for t in AlbumType}
     for at in rules.album_types:

--- a/tests/helpers/test_track_filter.py
+++ b/tests/helpers/test_track_filter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from music_assistant_models.media_items import ProviderMapping, Track
 
-from music_assistant.helpers.track_filter import get_track_filter, track_filter
+from music_assistant.helpers.track_filter import filter_tracks, get_track_filter, track_filter
 
 
 def _track(item_id: str) -> Track:
@@ -46,3 +46,29 @@ def test_nested_filters_restore_outer() -> None:
         with track_filter(lambda _track: False) as inner:
             assert get_track_filter() is inner
         assert get_track_filter() is outer
+
+
+def test_filter_tracks_without_filter_returns_input_unchanged() -> None:
+    """With no filter published, filter_tracks is a no-op and returns the same list object."""
+    tracks = [_track("a"), _track("b")]
+    assert filter_tracks(tracks) is tracks
+
+
+def test_filter_tracks_drops_rejected_and_preserves_order() -> None:
+    """filter_tracks drops tracks the active filter rejects, keeping the rest in order."""
+    a, b, c = _track("a"), _track("b"), _track("c")
+    with track_filter(lambda track: track.item_id != "b"):
+        assert filter_tracks([a, b, c]) == [a, c]
+
+
+def test_filter_tracks_never_empties_a_nonempty_list() -> None:
+    """When the filter would reject every track, the original list is kept (best-effort)."""
+    a, b = _track("a"), _track("b")
+    with track_filter(lambda _track: False):
+        assert filter_tracks([a, b]) == [a, b]
+
+
+def test_filter_tracks_empty_input_stays_empty() -> None:
+    """An empty candidate list stays empty regardless of the filter."""
+    with track_filter(lambda _track: False):
+        assert filter_tracks([]) == []

--- a/tests/providers/builtin/test_infinite_mix.py
+++ b/tests/providers/builtin/test_infinite_mix.py
@@ -4,8 +4,9 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from music_assistant_models.media_items import Track
+from music_assistant_models.media_items import ProviderMapping, Track
 
+from music_assistant.helpers.track_filter import track_filter
 from music_assistant.providers.builtin import BuiltinProvider
 from music_assistant.providers.builtin.constants import (
     ALL_FAVORITE_TRACKS,
@@ -90,7 +91,9 @@ async def test_infinite_mix_returns_25_tracks_with_positions() -> None:
 
     result = await provider._get_builtin_playlist_infinite_mix()
 
-    provider.mass.music.tracks.library_items.assert_called_once_with(limit=25, order_by="random")
+    provider.mass.music.tracks.library_items.assert_called_once_with(
+        favorite=None, limit=25, order_by="random"
+    )
     assert len(result) == 25
     for expected_pos, track in enumerate(result, 1):
         assert track.position == expected_pos
@@ -122,3 +125,56 @@ async def test_infinite_mix_empty_library_returns_empty_list() -> None:
     result = await provider._get_builtin_playlist_infinite_mix()
 
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _infinite_mix_tracks — recency track filter
+# ---------------------------------------------------------------------------
+
+
+def _real_tracks(item_ids: list[str]) -> list[Track]:
+    """Return real Track objects so a filter predicate can read item_id."""
+    return [
+        Track(
+            item_id=item_id,
+            provider="test",
+            name=item_id,
+            provider_mappings={
+                ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+            },
+        )
+        for item_id in item_ids
+    ]
+
+
+@pytest.mark.asyncio
+async def test_infinite_mix_over_fetches_and_drops_filtered_tracks() -> None:
+    """With a recency filter active, the mix over-fetches (3x) and drops rejected tracks."""
+    provider = _make_provider()
+    pool = _real_tracks([str(i) for i in range(75)])
+    provider.mass.music.tracks.library_items = AsyncMock(return_value=pool)  # type: ignore[method-assign]
+
+    # reject odd-numbered tracks; the even ones remain and are trimmed back to the mix size
+    with track_filter(lambda track: int(track.item_id) % 2 == 0):
+        result = await provider._get_builtin_playlist_infinite_mix()
+
+    provider.mass.music.tracks.library_items.assert_called_once_with(
+        favorite=None, limit=75, order_by="random"
+    )
+    assert len(result) == 25
+    assert all(int(track.item_id) % 2 == 0 for track in result)
+    for expected_pos, track in enumerate(result, 1):
+        assert track.position == expected_pos
+
+
+@pytest.mark.asyncio
+async def test_infinite_mix_filter_rejecting_all_falls_back_to_pool() -> None:
+    """If the filter rejects every track, the mix still returns a full batch (never empty)."""
+    provider = _make_provider()
+    pool = _real_tracks([str(i) for i in range(75)])
+    provider.mass.music.tracks.library_items = AsyncMock(return_value=pool)  # type: ignore[method-assign]
+
+    with track_filter(lambda _track: False):
+        result = await provider._get_builtin_playlist_infinite_mix()
+
+    assert len(result) == 25

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -15,6 +15,7 @@ from music_assistant_models.media_items.metadata import MediaItemMetadata
 
 from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
 from music_assistant.controllers.music.recency import RecencySnapshot
+from music_assistant.helpers.track_filter import track_filter
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.smart_playlist import (
     CONF_AI_DESCRIPTIONS,
@@ -2078,3 +2079,50 @@ async def test_filter_tracks_with_all_genres_handles_non_numeric_genre_ids() -> 
 
     assert len(result) == 1
     assert result[0].uri == "library://track/101"
+
+
+# ---------------------------------------------------------------------------
+# get_playlist_tracks — recency track filter (dynamic playlists only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dynamic_playlist_applies_recency_filter() -> None:
+    """A dynamic smart playlist drops filter-rejected tracks at the boundary."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    rules = SmartPlaylistRules(is_dynamic=True)
+    cast("Any", plugin)._resolve_rules_for_playlist_id = AsyncMock(return_value=("42", rules))
+    sample = [_make_mock_track("keep"), _make_mock_track("drop")]
+    cast("Any", plugin)._cached_dynamic_sample = AsyncMock(return_value=sample)
+
+    with track_filter(lambda track: track.item_id != "drop"):
+        result = await plugin.get_playlist_tracks("42")
+
+    assert [track.item_id for track in result] == ["keep"]
+
+
+@pytest.mark.asyncio
+async def test_static_playlist_ignores_recency_filter() -> None:
+    """A non-dynamic smart playlist is evaluated as-is and never recency-filtered."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    rules = SmartPlaylistRules(is_dynamic=False)
+    cast("Any", plugin)._resolve_rules_for_playlist_id = AsyncMock(return_value=("42", rules))
+    evaluated = [_make_mock_track("keep"), _make_mock_track("drop")]
+    cast("Any", plugin)._evaluate_rules = AsyncMock(return_value=evaluated)
+
+    with track_filter(lambda track: track.item_id != "drop"):
+        result = await plugin.get_playlist_tracks("42")
+
+    assert [track.item_id for track in result] == ["keep", "drop"]

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -14,7 +14,6 @@ from music_assistant_models.media_items import Genre, Playlist, ProviderMapping,
 from music_assistant_models.media_items.metadata import MediaItemMetadata
 
 from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
-from music_assistant.controllers.music.recency import RecencySnapshot
 from music_assistant.helpers.track_filter import track_filter
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.smart_playlist import (
@@ -465,26 +464,6 @@ class TestNewValidation:
         )
         plugin._validate_rules(rules)  # should not raise
 
-    def test_dedup_hours_out_of_range_raises(self) -> None:
-        """dedup_hours outside 1-2160 raises InvalidDataError."""
-        plugin = self._make_plugin()
-        with pytest.raises(InvalidDataError, match="dedup_hours"):
-            plugin._validate_rules(SmartPlaylistRules(dedup_hours=0))
-        with pytest.raises(InvalidDataError, match="dedup_hours"):
-            plugin._validate_rules(SmartPlaylistRules(dedup_hours=9000))
-
-    def test_dedup_hours_valid_passes(self) -> None:
-        """dedup_hours within 1-2160 does not raise."""
-        plugin = self._make_plugin()
-        plugin._validate_rules(SmartPlaylistRules(dedup_hours=24))  # should not raise
-
-    def test_dedup_hours_above_retention_raises(self) -> None:
-        """dedup_hours beyond the 90-day (2160h) playlog retention raises."""
-        plugin = self._make_plugin()
-        with pytest.raises(InvalidDataError, match="dedup_hours"):
-            plugin._validate_rules(SmartPlaylistRules(dedup_hours=2161))
-        plugin._validate_rules(SmartPlaylistRules(dedup_hours=2160))  # boundary, should not raise
-
 
 @pytest.mark.asyncio
 async def test_seed_mode_uses_tracks_from_seeds() -> None:
@@ -582,113 +561,6 @@ async def test_exclusion_filters_out_excluded_uri() -> None:
     rules = SmartPlaylistRules(excluded_track_uris=["library://track/2"], limit=10)
     result = await plugin._evaluate_rules(rules)
     assert all(t.uri != "library://track/2" for t in result)
-
-
-def _recency_snapshot(*played_keys: tuple[str, str]) -> RecencySnapshot:
-    """Build a snapshot whose given (provider_instance, item_id) keys are recently played."""
-    now = 1_000_000_000
-    return RecencySnapshot(now=now, song_ts=dict.fromkeys(played_keys, now))
-
-
-@pytest.mark.asyncio
-async def test_dedup_removes_recently_played() -> None:
-    """Tracks present in the playlog within dedup_hours are excluded; others are kept."""
-    mass = MagicMock()
-    mass.music.recency.snapshot = AsyncMock(return_value=_recency_snapshot(("library", "1")))
-    manifest = MagicMock()
-    manifest.domain = "smart_playlist"
-    config = MagicMock()
-    config.get_value.return_value = "GLOBAL"
-    plugin = SmartPlaylistProvider(mass, manifest, config, set())
-
-    recent = _make_mock_track("1", "library://track/1")
-    old = _make_mock_track("2", "library://track/2")
-    never = _make_mock_track("3", "library://track/3")
-
-    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[recent, old, never])
-
-    rules = SmartPlaylistRules(dedup_hours=1, limit=2)  # limit <= non-recent count
-    result = await plugin._evaluate_rules(rules)
-    uris = {t.uri for t in result}
-    assert "library://track/1" not in uris
-    assert "library://track/2" in uris
-    assert "library://track/3" in uris
-
-
-@pytest.mark.asyncio
-async def test_dedup_removes_recently_played_streaming_track() -> None:
-    """A non-library (streaming) track in the playlog is excluded via its provider mapping."""
-    mass = MagicMock()
-    mass.music.recency.snapshot = AsyncMock(return_value=_recency_snapshot(("spotify--abc", "s1")))
-    manifest = MagicMock()
-    manifest.domain = "smart_playlist"
-    config = MagicMock()
-    config.get_value.return_value = "GLOBAL"
-    plugin = SmartPlaylistProvider(mass, manifest, config, set())
-
-    played = _make_mock_track("s1", "spotify://track/s1", provider_instance="spotify--abc")
-    fresh = _make_mock_track("s2", "spotify://track/s2", provider_instance="spotify--abc")
-    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[played, fresh])
-
-    rules = SmartPlaylistRules(dedup_hours=1, limit=1)
-    result = await plugin._evaluate_rules(rules)
-    uris = {t.uri for t in result}
-    assert "spotify://track/s1" not in uris
-    assert "spotify://track/s2" in uris
-
-
-@pytest.mark.asyncio
-async def test_dedup_fallback_when_pool_exhausted() -> None:
-    """When all tracks were recently played, dedup is ignored and the full pool is returned."""
-    mass = MagicMock()
-    tracks = [_make_mock_track(str(i), f"library://track/{i}") for i in range(5)]
-    mass.music.recency.snapshot = AsyncMock(
-        return_value=_recency_snapshot(*[("library", str(i)) for i in range(5)])
-    )
-    manifest = MagicMock()
-    manifest.domain = "smart_playlist"
-    config = MagicMock()
-    config.get_value.return_value = "GLOBAL"
-    plugin = SmartPlaylistProvider(mass, manifest, config, set())
-
-    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=tracks)
-
-    rules = SmartPlaylistRules(dedup_hours=1, limit=5)
-    result = await plugin._evaluate_rules(rules)
-    # Pool exhausted → fallback to full pool
-    assert len(result) == 5
-
-
-@pytest.mark.asyncio
-async def test_dedup_partial_fill_prefers_old_library_over_streaming() -> None:
-    """Partial-exhaustion fill must not rank streaming tracks (last_played=0) as oldest."""
-    mass = MagicMock()
-    mass.music.recency.snapshot = AsyncMock(
-        return_value=_recency_snapshot(("library", "lo"), ("spotify--abc", "sn"))
-    )
-    manifest = MagicMock()
-    manifest.domain = "smart_playlist"
-    config = MagicMock()
-    config.get_value.return_value = "GLOBAL"
-    plugin = SmartPlaylistProvider(mass, manifest, config, set())
-
-    never = _make_mock_track("n", "library://track/n")  # not in playlog -> survives dedup
-    lib_old = _make_mock_track("lo", "library://track/lo")
-    lib_old.last_played = 100  # genuinely old play
-    stream_new = _make_mock_track("sn", "spotify://track/sn", provider_instance="spotify--abc")
-    stream_new.last_played = 0  # streaming track: no library timestamp
-
-    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[never, lib_old, stream_new])
-
-    # limit=2: `never` fills one slot, the remaining slot is filled from the
-    # recently-played remainder; the old library track should win over the
-    # just-played streaming track.
-    rules = SmartPlaylistRules(dedup_hours=1, limit=2)
-    result = await plugin._evaluate_rules(rules)
-    uris = {t.uri for t in result}
-    assert "library://track/n" in uris
-    assert "library://track/lo" in uris
-    assert "spotify://track/sn" not in uris
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
#4498 added a best-effort recency filter that the player queue publishes during dynamic-playlist generation, letting generators pre-skip recently-played tracks while a queue tops up. Only the new `radio_playlist` provider honoured it. This wires the same filter into the other providers that generate their own dynamic playlists/stations, so their stations respect the queue's recency windows the same way. It also drops the smart playlist's own recency setting, now that the queue owns recency centrally.

- New shared `filter_tracks()` helper in `track_filter.py` — drops tracks the published filter rejects, but never empties a non-empty result (the queue stays authoritative).
- Apple Music stations, Deezer Flow/Mix, and NetEase Personal FM / Heart Mode now drop recently-played tracks when topping up.
- Built-in Infinite Mix over-fetches while a filter is active so it still returns a full mix after filtering.
- Smart playlists filter the dynamic sample at the queue boundary, so the cached browse sample stays unfiltered.
- Remove the now-redundant smart playlist `dedup_hours` rule (and its dedup pass) — recency is handled by the queue; stored values are simply ignored.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
