### PR TITLE
Use radio playlists in the MCP play_media tool

### DIFF
--- a/music_assistant/providers/fastmcp_server/tools/playback.py
+++ b/music_assistant/providers/fastmcp_server/tools/playback.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
+from music_assistant_models.media_items import BrowseFolder
 
+from ...radio_playlist import radio_playlist_uri
 from ..tags import Tag
 from ._common import TIMEOUT_MUTATION, TIMEOUT_QUERY
 
@@ -180,10 +183,10 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
     async def play_media(
         queue_id: str,
         uri: str,
-        radio_mode: bool = False,
+        radio: bool = False,
     ) -> None:
         """
-        Load and start playing an album, track, playlist, or radio station on a player queue.
+        Load and start playing an artist, album, track, playlist, or radio station on a queue.
 
         Replaces whatever the queue was playing. Use ``playback_play_index`` to start an
         item that is already in the queue. Returns nothing.
@@ -194,10 +197,19 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
             or radio station to play, of the form
             ``<provider>://<media_type>/<id>`` (e.g. as found on
             ``TrackBrief.uri`` / ``AlbumBrief.uri`` / ...).
-        :param radio_mode: When ``True``, Music Assistant fills the queue with
-            similar items after the requested URI plays.
+        :param radio: When ``True``, play an endless "radio" seeded from ``uri``
+            instead of just the item itself. Music Assistant builds a dynamic
+            playlist from the seed (artist, album, track, playlist or genre),
+            mixing in its own tracks and continuously refilling the queue with
+            similar tracks.
         """
-        await mass.player_queues.play_media(queue_id, uri, radio_mode=radio_mode)
+        if radio:
+            seed = await mass.music.get_item_by_uri(uri)
+            if isinstance(seed, BrowseFolder):
+                msg = f"Cannot start a radio from a browse folder: {uri!r}"
+                raise ToolError(msg)
+            uri = radio_playlist_uri(seed)
+        await mass.player_queues.play_media(queue_id, uri)
 
     @sub.tool(
         tags={Tag.CONTROL_PLAYBACK},

--- a/music_assistant/providers/fastmcp_server/tools/playback.py
+++ b/music_assistant/providers/fastmcp_server/tools/playback.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
+from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.media_items import BrowseFolder
 
 from ...radio_playlist import radio_playlist_uri
@@ -204,7 +205,11 @@ def build_playback_server(mass: MusicAssistant) -> FastMCP:
             similar tracks.
         """
         if radio:
-            seed = await mass.music.get_item_by_uri(uri)
+            try:
+                seed = await mass.music.get_item_by_uri(uri)
+            except MusicAssistantError as err:
+                msg = f"Could not resolve URI for radio: {uri!r} ({err})"
+                raise ToolError(msg) from err
             if isinstance(seed, BrowseFolder):
                 msg = f"Cannot start a radio from a browse folder: {uri!r}"
                 raise ToolError(msg)

--- a/tests/providers/fastmcp_server/test_playback_tool.py
+++ b/tests/providers/fastmcp_server/test_playback_tool.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import contextlib
 from collections.abc import Iterator
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+from music_assistant_models.media_items import BrowseFolder
 
 from music_assistant.providers.fastmcp_server.tools import build_playback_server
 
@@ -47,3 +50,46 @@ async def test_play_pause_calls_player_queues_play_pause(
     async with Client(mounted_playback) as client:
         await client.call_tool("playback_play_pause", {"queue_id": "player1"})
     mock_mass.player_queues.play_pause.assert_awaited_once_with("player1")
+
+
+async def test_play_media_enqueues_uri_directly(mock_mass: Any, mounted_playback: FastMCP) -> None:
+    """``playback_play_media`` plays the given URI as-is (no radio)."""
+    async with Client(mounted_playback) as client:
+        await client.call_tool(
+            "playback_play_media",
+            {"queue_id": "player1", "uri": "spotify://track/abc"},
+        )
+    mock_mass.music.get_item_by_uri.assert_not_awaited()
+    mock_mass.player_queues.play_media.assert_awaited_once_with("player1", "spotify://track/abc")
+
+
+async def test_play_media_radio_enqueues_radio_playlist_uri(
+    mock_mass: Any, mounted_playback: FastMCP
+) -> None:
+    """``radio=True`` resolves the seed and enqueues its radio_playlist:// dynamic playlist."""
+    seed = MagicMock()
+    seed.uri = "spotify://artist/abc"
+    mock_mass.music.get_item_by_uri.return_value = seed
+    async with Client(mounted_playback) as client:
+        await client.call_tool(
+            "playback_play_media",
+            {"queue_id": "player1", "uri": "spotify://artist/abc", "radio": True},
+        )
+    mock_mass.music.get_item_by_uri.assert_awaited_once_with("spotify://artist/abc")
+    mock_mass.player_queues.play_media.assert_awaited_once_with(
+        "player1", "radio_playlist://playlist/spotify://artist/abc"
+    )
+
+
+async def test_play_media_radio_rejects_browse_folder(
+    mock_mass: Any, mounted_playback: FastMCP
+) -> None:
+    """A browse folder is not a playable radio seed; the tool rejects it cleanly."""
+    mock_mass.music.get_item_by_uri.return_value = MagicMock(spec=BrowseFolder)
+    async with Client(mounted_playback) as client:
+        with pytest.raises(ToolError, match="browse folder"):
+            await client.call_tool(
+                "playback_play_media",
+                {"queue_id": "player1", "uri": "library://browse/x", "radio": True},
+            )
+    mock_mass.player_queues.play_media.assert_not_awaited()

--- a/tests/providers/fastmcp_server/test_playback_tool.py
+++ b/tests/providers/fastmcp_server/test_playback_tool.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 from fastmcp import Client, FastMCP
 from fastmcp.exceptions import ToolError
+from music_assistant_models.errors import MediaNotFoundError
 from music_assistant_models.media_items import BrowseFolder
 
 from music_assistant.providers.fastmcp_server.tools import build_playback_server
@@ -91,5 +92,19 @@ async def test_play_media_radio_rejects_browse_folder(
             await client.call_tool(
                 "playback_play_media",
                 {"queue_id": "player1", "uri": "library://browse/x", "radio": True},
+            )
+    mock_mass.player_queues.play_media.assert_not_awaited()
+
+
+async def test_play_media_radio_resolution_failure_raises_tool_error(
+    mock_mass: Any, mounted_playback: FastMCP
+) -> None:
+    """A failed seed lookup surfaces as a clean ToolError, not a raw MA error."""
+    mock_mass.music.get_item_by_uri.side_effect = MediaNotFoundError("nope")
+    async with Client(mounted_playback) as client:
+        with pytest.raises(ToolError, match="Could not resolve URI for radio"):
+            await client.call_tool(
+                "playback_play_media",
+                {"queue_id": "player1", "uri": "spotify://track/missing", "radio": True},
             )
     mock_mass.player_queues.play_media.assert_not_awaited()


### PR DESCRIPTION
The `play_media` tool in the MCP server still exposed a `radio_mode` flag. Since #4498 that flag is deprecated — `play_media` logs a deprecation warning and internally translates it into a `radio_playlist://` dynamic playlist. This updates the tool to use the radio-playlist concept directly, so the MCP path no longer relies on the deprecated flag.

The tool now takes a `radio` flag instead: when set, it resolves the requested item and enqueues its `radio_playlist://` dynamic playlist (built via `radio_playlist_uri`), which the queue treats like any other dynamic playlist.

- Drop the deprecated `radio_mode` param from `playback_play_media`; add a `radio` flag
- When `radio=True`, enqueue the resolved item's `radio_playlist://` dynamic playlist
- Reject a non-playable seed (browse folder) with a clear error
- Add tests for the direct-play, radio and browse-folder paths

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
