### PR TITLE
Add played_only parameter to library_items methods

### DIFF
--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -121,6 +121,7 @@ class AlbumsController(MediaControllerBase[Album]):
         order_by: str = "sort_name",
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
+        played_only: bool = False,
         album_types: list[AlbumType] | None = None,
         **kwargs: Any,
     ) -> list[Album]:
@@ -180,6 +181,7 @@ class AlbumsController(MediaControllerBase[Album]):
             extra_query_parts=extra_query_parts,
             extra_query_params=extra_query_params,
             extra_join_parts=extra_join_parts,
+            played_only=played_only,
             in_library_only=True,
         )
 

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -105,6 +105,7 @@ class ArtistsController(MediaControllerBase[Artist]):
         order_by: str = "sort_name",
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
+        played_only: bool = False,
         album_artists_only: bool = False,
         artist_type: ArtistType | None = None,
         **kwargs: Any,
@@ -141,6 +142,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             provider_filter=self._ensure_provider_filter(provider),
             extra_query_parts=extra_query_parts,
             extra_query_params=extra_query_params,
+            played_only=played_only,
             in_library_only=True,
         )
 

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -112,6 +112,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         order_by: str = "sort_name",
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
+        played_only: bool = False,
         without_collections: bool | None = None,
         **kwargs: Any,
     ) -> list[Audiobook]:
@@ -144,6 +145,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             provider_filter=self._ensure_provider_filter(provider),
             extra_query_parts=extra_query_parts,
             extra_query_params=extra_query_params,
+            played_only=played_only,
             in_library_only=True,
         )
         if search and len(result) < 25 and not offset:

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -286,6 +286,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         order_by: str = "sort_name",
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
+        played_only: bool = False,
         **kwargs: Any,
     ) -> list[ItemCls]:
         """
@@ -298,6 +299,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
+        :param played_only: Only include items that have been played (last_played IS NOT NULL).
         """
         items = await self.get_library_items_by_query(
             favorite=favorite,
@@ -307,6 +309,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             order_by=order_by,
             provider_filter=self._ensure_provider_filter(provider),
             genre_ids=genre,
+            played_only=played_only,
             in_library_only=True,
         )
         if (
@@ -938,6 +941,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         extra_query_params: dict[str, Any] | None = None,
         extra_join_parts: list[str] | None = None,
         genre_ids: int | list[int] | None = None,
+        played_only: bool = False,
         in_library_only: bool = False,
     ) -> list[ItemCls]:
         """Fetch MediaItem records from database by building the query."""
@@ -956,6 +960,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 search=search,
                 genre_ids=genre_ids,
                 provider_filter=provider_filter,
+                played_only=played_only,
                 limit=limit,
                 in_library_only=in_library_only,
             )
@@ -969,6 +974,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 search=search,
                 genre_ids=genre_ids,
                 provider_filter=provider_filter,
+                played_only=played_only,
                 in_library_only=in_library_only,
             )
         # build and execute final query
@@ -1095,7 +1101,8 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         search: str | None,
         genre_ids: list[int] | None,
         provider_filter: list[str] | None,
-        limit: int,
+        played_only: bool = False,
+        limit: int = 500,
         in_library_only: bool = False,
     ) -> None:
         """Build a fast random subquery with all filters applied."""
@@ -1111,6 +1118,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             search=search,
             genre_ids=genre_ids,
             provider_filter=provider_filter,
+            played_only=played_only,
             in_library_only=in_library_only,
         )
 
@@ -1141,6 +1149,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         search: str | None,
         genre_ids: list[int] | None,
         provider_filter: list[str] | None,
+        played_only: bool = False,
         in_library_only: bool = False,
     ) -> None:
         """Apply search, favorite, and provider filters."""
@@ -1151,6 +1160,9 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         if favorite is not None:
             query_parts.append(f"{self.db_table}.favorite = :favorite")
             query_params["favorite"] = favorite
+        # handle played_only filter
+        if played_only:
+            query_parts.append(f"{self.db_table}.last_played IS NOT NULL")
         # handle genre filter
         if genre_ids:
             query_params["genre_ids"] = genre_ids

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -299,7 +299,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
-        :param played_only: Only include items that have been played (last_played IS NOT NULL).
+        :param played_only: Only include items that have been played (last_played > 0).
         """
         items = await self.get_library_items_by_query(
             favorite=favorite,
@@ -1162,7 +1162,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             query_params["favorite"] = favorite
         # handle played_only filter
         if played_only:
-            query_parts.append(f"{self.db_table}.last_played IS NOT NULL")
+            query_parts.append(f"{self.db_table}.last_played > 0")
         # handle genre filter
         if genre_ids:
             query_params["genre_ids"] = genre_ids

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -318,6 +318,7 @@ class GenreController(MediaControllerBase[Genre]):
                 offset=offset,
                 favorite=favorite,
                 order_by=order_by,
+                played_only=played_only,
                 hide_empty=hide_empty,
                 media_type=media_type,
                 content_type=content_type,

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -234,7 +234,7 @@ class GenreController(MediaControllerBase[Genre]):
         FROM (SELECT * FROM {DB_TABLE_GENRES} WHERE is_excluded = 0) AS {DB_TABLE_GENRES}"""
         return query, {}
 
-    async def library_items(
+    async def library_items(  # noqa: PLR0913
         self,
         favorite: bool | None = None,
         search: str | None = None,
@@ -243,6 +243,7 @@ class GenreController(MediaControllerBase[Genre]):
         order_by: str = "sort_name",
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
+        played_only: bool = False,
         hide_empty: bool | None = None,
         media_type: MediaType | None = None,
         content_type: str | None = None,
@@ -306,6 +307,7 @@ class GenreController(MediaControllerBase[Genre]):
             order_by=order_by,
             extra_query_params=extra_params,
             extra_query_parts=extra_parts,
+            played_only=played_only,
         )
         if kwargs.get("_localized_fallback", True) and search and not items:
             # retry with the canonical name behind a localized query, so genres are findable

--- a/music_assistant/controllers/music/media/podcasts.py
+++ b/music_assistant/controllers/music/media/podcasts.py
@@ -54,6 +54,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
         order_by: str = "sort_name",
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
+        played_only: bool = False,
         **kwargs: Any,
     ) -> list[Podcast]:
         """
@@ -75,6 +76,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
             offset=offset,
             order_by=order_by,
             provider_filter=self._ensure_provider_filter(provider),
+            played_only=played_only,
             in_library_only=True,
         )
         if search and len(result) < 25 and not offset:

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -183,6 +183,7 @@ class TracksController(MediaControllerBase[Track]):
         order_by: str = "sort_name",
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
+        played_only: bool = False,
         **kwargs: Any,
     ) -> list[Track]:
         """
@@ -225,6 +226,7 @@ class TracksController(MediaControllerBase[Track]):
             extra_query_parts=extra_query_parts,
             extra_query_params=extra_query_params,
             extra_join_parts=extra_join_parts,
+            played_only=played_only,
             in_library_only=True,
         )
         if search and len(result) < 25 and not offset:


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a `played_only` parameter to the `library_items()` method across all media controllers, allowing efficient SQL-level filtering for items that have been played at least once (i.e., `last_played IS NOT NULL`).

**Related issue (if applicable):**

- Addresses review comment from @OzGav on PR #3890

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

## Details

### Changes

- **Base Controller** (`media/base.py`):
  - Added `played_only: bool = False` parameter to `library_items()`
  - Added `played_only` parameter to `get_library_items_by_query()`
  - Updated `_apply_filters()` to add `last_played IS NOT NULL` SQL clause when `played_only=True`
  - Updated `_apply_random_subquery()` to thread `played_only` parameter

- **All Media Controllers** (tracks, albums, artists, podcasts, audiobooks, genres):
  - Updated `library_items()` signatures to include `played_only` parameter
  - Thread parameter through to `get_library_items_by_query()` calls

### Motivation

This addresses a review comment from @OzGav on PR #3890 (Recommendations plugin). The plugin needs to efficiently fetch items like "Forgotten Tracks" (items added over 90 days ago and last played over 90 days ago), which requires filtering out items that have never been played (`last_played IS NULL`).

The current workaround in #3890 fetches results with `order_by` DESC, filters for `last_played IS NOT NULL` in Python, reverses the list, and slices to the requested limit. This is inefficient, especially for libraries with many never-played items.

With this PR, the workaround can be replaced with:
```python
items = await controller.library_items(
    limit=limit,
    order_by="last_played",
    played_only=True,  # Efficient SQL-level filter
    favorite=favorite,
)
```

### Notes

- This is a **prerequisite PR** for #3890 (Recommendations plugin)
- The parameter defaults to `False` to preserve existing behavior
- All pre-commit checks pass (except pre-existing mypy error in hue_entertainment unrelated to this change)