### PR TITLE
Play finite sources in a dynamic queue through once instead of recycling them

### DIFF
--- a/music_assistant/controllers/player_queues/constants.py
+++ b/music_assistant/controllers/player_queues/constants.py
@@ -57,6 +57,10 @@ SMART_SHUFFLE_DUPLICATE_GAP_OPTIONS = (0, 3600, 7200, 10800, 14400, 21600, 28800
 # near the end instead of enqueuing thousands of tracks.
 MANAGED_POOL_TARGET = 25
 MANAGED_POOL_MAX = 50
+# A finite (TRACKS) source is materialized into its own deque and dequeued progressively. This caps
+# how many of its tracks are held in memory at once; a larger source pages the remainder in as the
+# deque drains, so a huge playlist or a bulk manual enqueue can't balloon internal state.
+MANAGED_POOL_SOURCE_CAP = 250
 
 CACHE_CATEGORY_PLAYER_QUEUE_STATE = 0
 CACHE_CATEGORY_PLAYER_QUEUE_ITEMS = 1

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1391,6 +1391,7 @@ class PlayerQueuesController(CoreController):
         self._play_action_refcount.pop(player_id, None)
         self._last_counted_play.pop(player_id, None)
         self._source_items.pop(player_id, None)
+        self._managed_pool.forget(player_id)
 
     async def load_next_queue_item(
         self,
@@ -2918,6 +2919,10 @@ class PlayerQueuesController(CoreController):
         else:
             self._source_items.pop(queue.queue_id, None)
         queue.sources = [ItemMapping.from_item(item) for item in items]
+        # release any materialized finite-source state whose source is no longer present
+        self._managed_pool.retain(
+            queue.queue_id, {item.uri for item in items if item.uri is not None}
+        )
 
     def _restore_source_items(self, queue: PlayerQueue) -> list[MediaItemType]:
         """

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -4,16 +4,24 @@ Managed dynamic pool for the Player Queues controller.
 A queue with one or more *dynamic sources* (its ``sources``) is kept as a small bounded pool
 that is topped up as it plays down. Each source has a *fill mode*:
 
-- ``DYNAMIC`` — a dynamic playlist's own self-managing batch (a radio playlist, a station);
-- ``TRACKS`` — the source's own unplayed tracks (a playlist/album/artist mixed into the pool).
+- ``DYNAMIC`` — a dynamic playlist's own self-managing batch (a radio playlist, a station): a fresh
+  batch is pulled every refill, so it never runs dry;
+- ``TRACKS`` — a finite source (a playlist/album/artist mixed into the pool): its tracks are
+  materialized once into a per-source deque and dequeued progressively, so the source plays through
+  once and then drops out rather than recycling the same tracks as they age out of the recency
+  window. A recency-denied track rotates to the back of its deque (a fair second chance) instead of
+  being dropped, and the deque is bounded (paging in more as it drains) so a huge source can't
+  balloon internal state.
 
 Each top-up apportions slots across the sources by weight (per-base quota by default, so adding a
-source more than once weights it up), gates every candidate against the shared ``RecencyEngine`` so
-a recently-heard track isn't pulled back in, and prefers the least-recently-played candidates.
+source more than once weights it up) and gates every candidate against the shared ``RecencyEngine``
+so a recently-heard track isn't pulled back in. A dynamic batch is offered least-recently-played
+first; a finite source keeps its own (materialized) order so it plays through coherently.
 """
 
 from __future__ import annotations
 
+from collections import deque
 from contextlib import suppress
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -22,7 +30,10 @@ from typing import TYPE_CHECKING
 from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.media_items import Playlist, Track
 
-from music_assistant.controllers.player_queues.constants import MANAGED_POOL_TARGET
+from music_assistant.controllers.player_queues.constants import (
+    MANAGED_POOL_SOURCE_CAP,
+    MANAGED_POOL_TARGET,
+)
 from music_assistant.helpers.track_filter import track_filter
 
 if TYPE_CHECKING:
@@ -65,6 +76,24 @@ class DynamicSource:
     candidates: list[Track] = field(default_factory=list)
 
 
+@dataclass(slots=True)
+class _MaterializedSource:
+    """
+    A finite (TRACKS) source materialized once and dequeued progressively across refills.
+
+    ``tracks`` holds the not-yet-dispatched tracks (bounded by ``MANAGED_POOL_SOURCE_CAP``);
+    ``dispatched`` records the item ids already handed to the queue so they are never re-offered and
+    so a larger-than-cap source can page the rest in without repeats; ``fully_paged`` is True once
+    the source has no further tracks to page in (it is exhausted when ``tracks`` is then empty).
+    """
+
+    media_item: MediaItemType
+    multiplicity: int
+    tracks: deque[Track]
+    dispatched: set[str]
+    fully_paged: bool
+
+
 class ManagedPoolHelper:
     """Build and top up a queue's bounded managed pool from its dynamic sources."""
 
@@ -77,6 +106,8 @@ class ManagedPoolHelper:
         self.queues = queues
         self.mass = queues.mass
         self.logger = queues.logger.getChild("managed_pool")
+        # finite-source materialized state, keyed by queue id then source uri; see _MaterializedSource
+        self._materialized: dict[str, dict[str, _MaterializedSource]] = {}
 
     async def fill(self, queue_id: str, *, is_initial: bool) -> list[Track]:
         """
@@ -108,9 +139,34 @@ class ManagedPoolHelper:
             if is_initial
             else max(MANAGED_POOL_TARGET - self._unplayed(queue), 0)
         )
-        return allocate_refill(
+        chosen = allocate_refill(
             sources, slots=slots, pool_keys=pool_keys, snapshot=snapshot, windows=windows
         )
+        # advance each finite source's deque: drop what was just dispatched, rotate recency-denied
+        # tracks to the back, page in more if it is draining, and retire it once fully played
+        await self._reconcile_tracks(queue_id, sources, chosen, snapshot, windows)
+        return chosen
+
+    def forget(self, queue_id: str) -> None:
+        """Drop all materialized finite-source state for a queue (it was cleared or removed)."""
+        self._materialized.pop(queue_id, None)
+
+    def retain(self, queue_id: str, uris: set[str]) -> None:
+        """
+        Prune materialized finite-source state down to the queue's current source uris.
+
+        Called whenever the queue's sources change so an exhausted/removed source releases its
+        materialized tracks instead of lingering until the queue is torn down.
+
+        :param queue_id: The queue whose sources changed.
+        :param uris: The uris of the sources the queue still has.
+        """
+        if not (materialized := self._materialized.get(queue_id)):
+            return
+        for uri in [uri for uri in materialized if uri not in uris]:
+            del materialized[uri]
+        if not materialized:
+            self._materialized.pop(queue_id, None)
 
     async def _collect_sources(
         self, queue_id: str, *, include_dynamic: bool
@@ -134,14 +190,23 @@ class ManagedPoolHelper:
             items.setdefault(uri, item)
         if not items:
             return []
+        materialized = self._materialized.setdefault(queue_id, {})
         sources: list[DynamicSource] = []
         for uri, media_item in items.items():
             if isinstance(media_item, Playlist) and media_item.is_dynamic:
                 fill_mode = DynamicFillMode.DYNAMIC
                 candidates = await self._fetch_dynamic(media_item)
             else:
+                # a finite source is materialized once, then its deque feeds (and is advanced by)
+                # every refill so it plays through instead of recycling tracks that age out
                 fill_mode = DynamicFillMode.TRACKS
-                candidates = await self._fetch_tracks(media_item)
+                source = materialized.get(uri)
+                if source is None:
+                    source = await self._materialize(media_item, counts[uri])
+                    materialized[uri] = source
+                else:
+                    source.multiplicity = counts[uri]
+                candidates = list(source.tracks)
             sources.append(
                 DynamicSource(
                     media_item=media_item,
@@ -168,6 +233,92 @@ class ManagedPoolHelper:
             return [track for track in tracks if isinstance(track, Track) and track.available]
         return []
 
+    async def _materialize(
+        self, media_item: MediaItemType, multiplicity: int
+    ) -> _MaterializedSource:
+        """Fetch a finite source's tracks once into a bounded deque for progressive dequeue."""
+        tracks = await self._fetch_tracks(media_item)
+        return _MaterializedSource(
+            media_item=media_item,
+            multiplicity=multiplicity,
+            tracks=deque(tracks[:MANAGED_POOL_SOURCE_CAP]),
+            dispatched=set(),
+            # everything fetched already fits: there is nothing more to page in beyond this deque
+            fully_paged=len(tracks) <= MANAGED_POOL_SOURCE_CAP,
+        )
+
+    async def _reconcile_tracks(
+        self,
+        queue_id: str,
+        sources: list[DynamicSource],
+        chosen: list[Track],
+        snapshot: RecencySnapshot,
+        windows: RecencyWindows,
+    ) -> None:
+        """Advance each finite source's deque for what this refill took, then page/retire it."""
+        materialized = self._materialized.get(queue_id)
+        if not materialized:
+            return
+        chosen_ids = {track.item_id for track in chosen}
+        exhausted: list[str] = []
+        for source in sources:
+            if source.fill_mode != DynamicFillMode.TRACKS:
+                continue
+            if not (uri := _uri(source.media_item)) or (mat := materialized.get(uri)) is None:
+                continue
+            # a duplicated source repeats on the short gap, a singleton on the long song window
+            window = windows.duplicate_gap_seconds if mat.multiplicity > 1 else windows.song_seconds
+            kept: deque[Track] = deque()
+            denied: deque[Track] = deque()
+            for track in mat.tracks:
+                if track.item_id in chosen_ids:
+                    mat.dispatched.add(track.item_id)  # handed to the queue: never offer it again
+                elif window and snapshot.track_recent(track, window):
+                    denied.append(track)  # too recent for now: a fair second chance, at the back
+                else:
+                    kept.append(track)
+            kept.extend(denied)
+            mat.tracks = kept
+            if len(mat.tracks) < MANAGED_POOL_TARGET and not mat.fully_paged:
+                await self._page_in(mat)
+            if not mat.tracks and mat.fully_paged:
+                exhausted.append(uri)
+        for uri in exhausted:
+            materialized.pop(uri, None)
+        if not materialized:
+            self._materialized.pop(queue_id, None)
+        if exhausted:
+            self._retire_sources(queue_id, exhausted)
+
+    async def _page_in(self, mat: _MaterializedSource) -> None:
+        """Pull the next as-yet-unseen tracks from a larger-than-cap source as its deque drains."""
+        have = {track.item_id for track in mat.tracks}
+        for track in await self._fetch_tracks(mat.media_item):
+            if len(mat.tracks) >= MANAGED_POOL_SOURCE_CAP:
+                break
+            if track.item_id in mat.dispatched or track.item_id in have:
+                continue
+            mat.tracks.append(track)
+            have.add(track.item_id)
+        # could not refill toward the cap: every remaining track has been seen, so it is fully paged
+        if len(mat.tracks) < MANAGED_POOL_SOURCE_CAP:
+            mat.fully_paged = True
+
+    def _retire_sources(self, queue_id: str, uris: list[str]) -> None:
+        """Drop fully-played finite sources from the queue so only live sources remain."""
+        queue = self.queues._queues.get(queue_id)
+        if queue is None:
+            return
+        retire = set(uris)
+        remaining = [
+            item for item in self.queues._source_items.get(queue_id, []) if _uri(item) not in retire
+        ]
+        self.queues._store_sources(queue, remaining)
+        self.logger.debug(
+            "Finite source(s) exhausted on queue %s; %d source(s) remain", queue_id, len(remaining)
+        )
+        self.queues.signal_update(queue_id)
+
     def _unplayed(self, queue: PlayerQueue) -> int:
         """Return how many not-yet-played items remain in the queue."""
         items = self.queues._queue_items.get(queue.queue_id, [])
@@ -189,9 +340,9 @@ def allocate_refill(
     Pick the next batch of tracks for the managed pool, weighted per source and recency-gated.
 
     Slots are apportioned across sources by weight; each source's candidates are hard-gated against
-    the recency snapshot (a within-window track is excluded entirely) and ordered least-recently-
-    played first. If gating leaves nothing, an ungated least-recently-played fallback is returned so
-    playback never stalls.
+    the recency snapshot (a within-window track is excluded entirely). A dynamic batch is ordered
+    least-recently-played first; a finite (TRACKS) source keeps its own materialized order. If gating
+    leaves nothing, an ungated least-recently-played fallback is returned so playback never stalls.
 
     :param sources: The queue's dynamic sources, each with its already-fetched candidate tracks.
     :param slots: How many tracks to add (0 or fewer returns nothing).
@@ -264,9 +415,20 @@ def _eligible(
     snapshot: RecencySnapshot,
     windows: RecencyWindows,
 ) -> list[Track]:
-    """Return a source's candidates minus pool/recency-blocked ones, least-recently-played first."""
+    """
+    Return a source's candidates minus pool/recency-blocked ones.
+
+    A finite (TRACKS) source keeps its materialized deque order so it plays through coherently; a
+    dynamic batch is ordered least-recently-played first.
+    """
     # a deliberately-duplicated source uses the short repeat-gap, a singleton the long song window
     window = windows.duplicate_gap_seconds if source.multiplicity > 1 else windows.song_seconds
+    if source.fill_mode == DynamicFillMode.TRACKS:
+        return [
+            track
+            for track in source.candidates
+            if track not in pool_keys and not snapshot.track_recent(track, window)
+        ]
     scored: list[tuple[int, int, Track]] = []
     for track in source.candidates:
         if track in pool_keys:

--- a/tests/controllers/player_queues/test_managed_pool.py
+++ b/tests/controllers/player_queues/test_managed_pool.py
@@ -158,12 +158,21 @@ def test_singleton_window_vs_duplicate_gap() -> None:
 
 
 def test_least_recently_played_first() -> None:
-    """Within a source, never-played sorts first, then oldest play before most recent."""
+    """A dynamic batch is ordered never-played first, then oldest play before most recent."""
     windows = RecencyWindows(song_seconds=0)  # gate off so we only test ordering
-    source = _source(["recent", "old", "never"])
+    source = _source(["recent", "old", "never"], fill_mode=DynamicFillMode.DYNAMIC)
     snapshot = _snapshot({"recent": NOW - 10, "old": NOW - 100_000})
     result = allocate_refill([source], slots=3, pool_keys=set(), snapshot=snapshot, windows=windows)
     assert _ids(result) == ["never", "old", "recent"]
+
+
+def test_tracks_mode_preserves_candidate_order() -> None:
+    """A finite (TRACKS) source keeps its materialized order instead of re-sorting by recency."""
+    windows = RecencyWindows(song_seconds=0)  # gate off so we only test ordering
+    source = _source(["recent", "old", "never"], fill_mode=DynamicFillMode.TRACKS)
+    snapshot = _snapshot({"recent": NOW - 10, "old": NOW - 100_000})
+    result = allocate_refill([source], slots=3, pool_keys=set(), snapshot=snapshot, windows=windows)
+    assert _ids(result) == ["recent", "old", "never"]
 
 
 def test_pool_keys_excluded() -> None:

--- a/tests/integration/test_managed_pool_e2e.py
+++ b/tests/integration/test_managed_pool_e2e.py
@@ -14,15 +14,18 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import Playlist
 from music_assistant_models.queue_item import QueueItem
 
 from music_assistant.constants import DB_TABLE_PLAYLOG
+from music_assistant.controllers.player_queues import managed_pool
 from music_assistant.controllers.player_queues.constants import (
     MANAGED_POOL_MAX,
     MANAGED_POOL_TARGET,
 )
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.music_provider import MusicProvider
+from music_assistant.providers.radio_playlist import radio_playlist_uri
 
 from .conftest import demo_players, wait_for
 
@@ -140,3 +143,144 @@ async def test_refill_dedupes_only_active_tail_not_played_history(e2e_mass: Musi
     assert "0_0_5" not in ids
     # but already-played history is not permanently excluded (no recency block in play here)
     assert any(f"0_0_{i}" in ids for i in range(5))
+
+
+@pytest.mark.asyncio
+async def test_finite_source_materializes_and_plays_through_once(
+    e2e_mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A finite source is materialized once and dequeued progressively until it is exhausted."""
+    # shrink the per-refill target so a single 20-track album is dequeued over several refills
+    monkeypatch.setattr(managed_pool, "MANAGED_POOL_TARGET", 5)
+    queue_id = demo_players(e2e_mass)[0].player_id
+    test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
+    assert test_prov is not None
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    queue.userid = TEST_USER
+
+    album = await test_prov.get_album("0_0")  # tracks 0_0_0 .. 0_0_19
+    e2e_mass.player_queues._source_items[queue_id] = cast("list[MediaItemType]", [album])
+
+    played: list[str] = []
+    fills = 0
+    # generous guard; a 20-track album drains in ~4 refills at the patched target of 5
+    while e2e_mass.player_queues._source_items.get(queue_id) and fills < 20:
+        pool = await e2e_mass.player_queues._managed_pool.fill(queue_id, is_initial=(fills == 0))
+        played += [track.item_id for track in pool]
+        fills += 1
+
+    # progressive: it took several refills, not one dump of the whole album
+    assert fills > 1
+    # plays through once: every album track exactly once, never recycled as tracks age out
+    assert sorted(played) == sorted(f"0_0_{i}" for i in range(20))
+    # exhausted: the source is retired from the queue and its materialized state is released
+    assert not e2e_mass.player_queues._source_items.get(queue_id)
+    assert queue_id not in e2e_mass.player_queues._managed_pool._materialized
+
+
+@pytest.mark.asyncio
+async def test_recency_denied_track_rotates_to_back_not_dropped(e2e_mass: MusicAssistant) -> None:
+    """A recency-denied finite-source track is kept for a fair second chance, not dropped."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
+    assert test_prov is not None
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    queue.userid = TEST_USER
+
+    album = await test_prov.get_album("0_0")  # tracks 0_0_0 .. 0_0_19
+    uri = album.uri
+    assert uri is not None
+    e2e_mass.player_queues._source_items[queue_id] = cast("list[MediaItemType]", [album])
+
+    # 5 tracks played a day ago -> within the 1-week song window -> recency-denied this round
+    now = int(time.time())
+    denied = [f"0_0_{i}" for i in range(5)]
+    for item_id in denied:
+        await _insert_play(e2e_mass, item_id, now - DAY, TEST_USER)
+
+    pool = await e2e_mass.player_queues._managed_pool.fill(queue_id, is_initial=True)
+    ids = [track.item_id for track in pool]
+
+    # the denied tracks are not handed to the queue this round ...
+    assert not any(item_id in ids for item_id in denied)
+    mat = e2e_mass.player_queues._managed_pool._materialized[queue_id][uri]
+    remaining = [track.item_id for track in mat.tracks]
+    # ... but they are kept (rotated to the back of the deque), not dropped
+    assert remaining[-len(denied) :] == denied
+    # the 15 playable tracks were dispatched; the source is not yet exhausted
+    assert mat.dispatched == {f"0_0_{i}" for i in range(5, 20)}
+    assert e2e_mass.player_queues._source_items.get(queue_id)
+
+    # once the recency block lifts, the held tracks get their second chance and the source exhausts
+    await e2e_mass.music.database.delete(
+        DB_TABLE_PLAYLOG, {"provider": "test", "userid": TEST_USER}
+    )
+    pool2 = await e2e_mass.player_queues._managed_pool.fill(queue_id, is_initial=False)
+    ids2 = sorted(track.item_id for track in pool2)
+
+    assert ids2 == sorted(denied)
+    assert not e2e_mass.player_queues._source_items.get(queue_id)
+
+
+@pytest.mark.asyncio
+async def test_large_finite_source_is_paged_and_bounded(
+    e2e_mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A source larger than the per-source cap is paged in as it drains, bounding internal state."""
+    # a cap far below the album size forces paging: the deque must never hold the whole album
+    monkeypatch.setattr(managed_pool, "MANAGED_POOL_SOURCE_CAP", 5)
+    queue_id = demo_players(e2e_mass)[0].player_id
+    test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
+    assert test_prov is not None
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    queue.userid = TEST_USER
+
+    album = await test_prov.get_album("0_0")  # 20 tracks, well over the patched cap of 5
+    uri = album.uri
+    assert uri is not None
+    e2e_mass.player_queues._source_items[queue_id] = cast("list[MediaItemType]", [album])
+
+    played: list[str] = []
+    max_held = 0
+    fills = 0
+    while e2e_mass.player_queues._source_items.get(queue_id) and fills < 20:
+        pool = await e2e_mass.player_queues._managed_pool.fill(queue_id, is_initial=False)
+        played += [track.item_id for track in pool]
+        if mat := e2e_mass.player_queues._managed_pool._materialized.get(queue_id, {}).get(uri):
+            max_held = max(max_held, len(mat.tracks))
+        fills += 1
+
+    # bounded: the materialized deque never held more than the per-source cap at once
+    assert max_held <= 5
+    # paged correctly: every track played exactly once despite being fetched in chunks
+    assert sorted(played) == sorted(f"0_0_{i}" for i in range(20))
+    assert not e2e_mass.player_queues._source_items.get(queue_id)
+
+
+@pytest.mark.asyncio
+async def test_dynamic_source_is_not_materialized(e2e_mass: MusicAssistant) -> None:
+    """A dynamic-playlist source self-manages and is never materialized; only finite ones are."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
+    assert test_prov is not None
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    queue.userid = TEST_USER
+
+    # a dynamic radio playlist (self-managing) mixed with a finite album (materialized)
+    seed = await test_prov.get_track("4_4_0")
+    radio = await e2e_mass.music.get_item_by_uri(radio_playlist_uri(seed))
+    assert isinstance(radio, Playlist)
+    assert radio.is_dynamic
+    album = await test_prov.get_album("0_0")
+    e2e_mass.player_queues._source_items[queue_id] = cast("list[MediaItemType]", [radio, album])
+
+    pool = await e2e_mass.player_queues._managed_pool.fill(queue_id, is_initial=False)
+
+    assert pool  # both sources feed the bounded pool
+    materialized = e2e_mass.player_queues._managed_pool._materialized.get(queue_id, {})
+    assert album.uri in materialized  # the finite source is materialized into a deque
+    assert radio.uri not in materialized  # the dynamic playlist is left to self-manage


### PR DESCRIPTION
A finite source (a regular album, artist or playlist) mixed into a dynamic queue used the managed pool's `TRACKS` fill mode, which re-fetched **all** of the source's tracks on every refill. Once a track aged out of the recency window it became eligible again, so the source could keep recycling its tracks indefinitely instead of playing through and finishing. This refines that path so a finite source plays through once and then drops out. (Pre-existing `TRACKS`-mode limitation, not introduced by #4498.)

- Materialize each finite source's tracks once into a per-source deque in the managed-pool state and dequeue it progressively across refills, instead of re-fetching the whole source every time.
- A recency-denied track rotates to the back of its deque for a fair later chance rather than being dropped; the source is retired only once every one of its tracks has played.
- Bound the materialized state with a per-source cap (`MANAGED_POOL_SOURCE_CAP`), paging more tracks in as the deque drains, so a huge playlist or a bulk track enqueue can't balloon memory.
- A finite source now plays through in its own (materialized) order; dynamic-playlist sources are unchanged — they keep self-managing via `get_playlist_tracks`.
- Release a source's materialized state when it is removed/exhausted or the queue is cleared.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
