### PR TITLE
Fix Squeezelite progress bar showing previous track position after track change

### DIFF
--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -437,6 +437,7 @@ class SqueezelitePlayer(Player):
             # We need this because some players (e.g. WiiM) keep sending increasing elapsed time
             self._attr_elapsed_time_last_updated = time.time()
         # Update current media if available
+        old_item_id = self._attr_current_media.queue_item_id if self._attr_current_media else None
         if self.client.current_media and (metadata := self.client.current_media.metadata):
             self._attr_current_media = PlayerMedia(
                 uri=metadata.get("item_id"),
@@ -450,6 +451,11 @@ class SqueezelitePlayer(Player):
             )
         else:
             self._attr_current_media = None
+        new_item_id = self._attr_current_media.queue_item_id if self._attr_current_media else None
+        if old_item_id is not None and new_item_id is not None and old_item_id != new_item_id:
+            # elapsed still reflects the previous track until the next STMt heartbeat (support#3704)
+            self._attr_elapsed_time = 0
+            self._attr_elapsed_time_last_updated = time.time()
 
     async def _handle_play_url_for_slimplayer(
         self,


### PR DESCRIPTION
# What does this implement/fix?

On a gapless track change, the Squeezelite player reported the **previous** track's position against the **new** track until the next heartbeat corrected it. In Home Assistant this showed up as `media_position` jumping to a value near the old track's duration (and the progress bar overshooting) right after a track switch — pausing/resuming was the only way to fix it.

Root cause: the slimproto `STMs` event flips `current_media` to the next track, but the elapsed time keeps reflecting the previous track until the next `STMt` heartbeat arrives (~1s later). The existing elapsed-time reset only fired on a non-playing→playing transition, so gapless track changes (which stay `PLAYING`) were missed.

Fix: reset elapsed time to 0 in `update_attributes` whenever the current queue item changes. Seek-within-track and pause/resume keep the same item id and are unaffected.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/3704
- https://github.com/music-assistant/support/issues/5416
- 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable. _(small, self-contained change — no test added)_
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
