### PR TITLE
Detect stalled source streams when the connection drops mid-playback

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -866,6 +866,11 @@ INTERNAL_PCM_FORMAT = AudioFormat(
     channels=2,  # static for flow stream, dynamic for anything else
 )
 
+# Seconds without a new chunk before the source is treated as stalled (above ffmpeg's ~15s reconnect window).
+STREAM_STALL_TIMEOUT: Final[int] = 20
+# Longer budget for the first chunk to allow for connect + probe.
+STREAM_START_TIMEOUT: Final[int] = 30
+
 # extra data / extra attributes keys
 ATTR_FAKE_POWER: Final[str] = "fake_power"
 ATTR_FAKE_VOLUME: Final[str] = "fake_volume_level"

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -65,6 +65,8 @@ from music_assistant.constants import (
     FLOW_MODE_SAMPLE_RATE_SMART,
     INTERNAL_PCM_FORMAT,
     MASS_LOGGER_NAME,
+    STREAM_STALL_TIMEOUT,
+    STREAM_START_TIMEOUT,
     VERBOSE_LOG_LEVEL,
 )
 from music_assistant.controllers.streams.audio_analysis import (
@@ -544,7 +546,19 @@ class StreamsAudio:
                 )
             stream_start = mass.loop.time()
             chunk_size = calculate_content_length(pcm_format, chunk_seconds)
-            async for chunk in ffmpeg_proc.iter_chunked(chunk_size):
+            chunk_iter = ffmpeg_proc.iter_chunked(chunk_size)
+            while True:
+                # Time the read, not the yield: catches a stalled source, ignores backpressure.
+                read_timeout = (
+                    STREAM_START_TIMEOUT if not first_chunk_received else STREAM_STALL_TIMEOUT
+                )
+                try:
+                    async with asyncio.timeout(read_timeout):
+                        chunk = await anext(chunk_iter)
+                except StopAsyncIteration:
+                    break
+                except TimeoutError as err:
+                    raise AudioError(f"Source stalled: no audio for {read_timeout}s") from err
                 if not first_chunk_received:
                     # At this point ffmpeg has started and should now know the codec used
                     # for encoding the audio.

--- a/tests/controllers/streams/test_get_media_stream.py
+++ b/tests/controllers/streams/test_get_media_stream.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.enums import ContentType, MediaType, StreamType
+from music_assistant_models.errors import AudioError
 from music_assistant_models.media_items import AudioFormat
 from music_assistant_models.streamdetails import StreamDetails
 
@@ -99,6 +101,65 @@ def _make_streamdetails(
 async def _drain(gen: AsyncGenerator[bytes]) -> None:
     async for _ in gen:
         pass
+
+
+class _StallingFFMpeg(_FakeFFMpeg):
+    """FFMpeg double whose read never produces a chunk (frozen source)."""
+
+    async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes]:
+        await asyncio.Event().wait()  # blocks until the watchdog cancels the read
+        yield b""  # unreachable
+
+
+class _SlowConsumerFFMpeg(_FakeFFMpeg):
+    """FFMpeg double that hands over chunks instantly when asked."""
+
+    async def iter_chunked(self, _chunk_size: int) -> AsyncGenerator[bytes]:
+        for _ in range(3):
+            yield b"\x00\x01" * 256
+
+
+def _flac_streamdetails() -> StreamDetails:
+    return _make_streamdetails(
+        audio_format=AudioFormat(
+            content_type=ContentType.FLAC,
+            codec_type=ContentType.FLAC,
+            sample_rate=44100,
+            bit_depth=16,
+            channels=2,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_raises_when_source_stalls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source that stops producing audio is surfaced as an AudioError."""
+    monkeypatch.setattr(audio_mod, "FFMpeg", _StallingFFMpeg)
+    monkeypatch.setattr(audio_mod, "STREAM_START_TIMEOUT", 0.1)
+    monkeypatch.setattr(audio_mod, "STREAM_STALL_TIMEOUT", 0.1)
+
+    audio = _make_audio_controller()
+    with pytest.raises(AudioError):
+        await _drain(audio.get_media_stream(_flac_streamdetails(), _make_pcm_format()))
+
+
+@pytest.mark.asyncio
+async def test_get_media_stream_does_not_stall_on_slow_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A consumer slower than the stall timeout must not trip the watchdog."""
+    monkeypatch.setattr(audio_mod, "FFMpeg", _SlowConsumerFFMpeg)
+    monkeypatch.setattr(audio_mod, "STREAM_START_TIMEOUT", 0.1)
+    monkeypatch.setattr(audio_mod, "STREAM_STALL_TIMEOUT", 0.1)
+
+    audio = _make_audio_controller()
+    chunks = 0
+    async for _ in audio.get_media_stream(_flac_streamdetails(), _make_pcm_format()):
+        chunks += 1
+        await asyncio.sleep(0.3)  # downstream waits far longer than the stall timeout
+    assert chunks == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

When an internet source (e.g. Qobuz) stops delivering audio mid-stream — a dropped connection or a frozen link — ffmpeg neither errors nor exits, it just blocks indefinitely. The stream coroutine kept waiting while playback elapsed-time advanced on wall-clock, so the UI showed progress (and even skipped tracks) while the player was silent.

This adds a read watchdog in `get_media_stream` so a stalled source is detected and surfaced as a stream error instead of hanging silently.

- Bound only the time spent waiting for the next chunk (`anext`), never the `yield` — so the watchdog fires on a stalled source but not while we trickle-buffer and wait for the player to drain its buffer.
- On timeout, raise `AudioError`, which the existing callers already turn into `streamdetails.stream_error`.
- Add `STREAM_STALL_TIMEOUT` (20s, above ffmpeg's own ~15s reconnect window) and `STREAM_START_TIMEOUT` (30s, extra room for connect + probe).
- Covers every source type, since they all funnel through `iter_chunked`.

**Related issue (if applicable):**

- https://github.com/music-assistant/support/issues/3528

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
