### PR TITLE
Mark Snapcast players offline when abruptly powered off

### DIFF
--- a/music_assistant/providers/snapcast/constants.py
+++ b/music_assistant/providers/snapcast/constants.py
@@ -32,6 +32,11 @@ SHIPPED_SNAPSERVER_CONFIG_FILE = (
     pathlib.Path(__file__).parent / "snapserver" / "snapserver.conf"
 ).resolve()
 
+# snapserver has no TCP keepalive (https://github.com/snapcast/snapcast/issues/995) and
+# never times out abruptly powered-off clients, so we poll lastSeen freshness ourselves.
+SNAPCLIENT_LIVENESS_POLL_INTERVAL = 5  # poll_interval (seconds) for snapcast players
+SNAPCLIENT_STALE_THRESHOLD = 15  # mark unavailable if lastSeen frozen this long (seconds)
+
 # Socket path template for control script communication
 # The {queue_id} placeholder will be replaced with the actual queue ID
 CONTROL_SOCKET_PATH_TEMPLATE = "/tmp/ma-snapcast-{queue_id}.sock"  # noqa: S108

--- a/music_assistant/providers/snapcast/player.py
+++ b/music_assistant/providers/snapcast/player.py
@@ -14,6 +14,10 @@ from propcache import under_cached_property as cached_property
 from music_assistant.constants import ATTR_ANNOUNCEMENT_IN_PROGRESS, CONF_ENTRY_HTTP_PROFILE_HIDDEN
 from music_assistant.helpers.util import is_valid_mac_address
 from music_assistant.models.player import Player
+from music_assistant.providers.snapcast.constants import (
+    SNAPCLIENT_LIVENESS_POLL_INTERVAL,
+    SNAPCLIENT_STALE_THRESHOLD,
+)
 from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
 from music_assistant.providers.sync_group.constants import SGP_PREFIX
 
@@ -73,6 +77,9 @@ class SnapCastPlayer(Player):
         self._poke_evt = asyncio.Event()
         self._state_update_lock = asyncio.Lock()
         self._last_tracked_state: TrackedPlayerState | None = None
+        # raw lastSeen value + monotonic time it last advanced (skew-proof liveness)
+        self._last_seen_raw: tuple[int, int] | None = None
+        self._last_seen_changed: float = 0.0
 
     @property
     def snap_provider(self) -> SnapCastProvider:
@@ -185,8 +192,16 @@ class SnapCastPlayer(Player):
             PlayerFeature.PLAY_ANNOUNCEMENT,
         }
         self._attr_can_group_with = {self.snap_provider.instance_id}
+        # poll to detect abruptly powered-off clients (see _is_alive)
+        self._attr_needs_poll = True
+        self._attr_poll_interval = SNAPCLIENT_LIVENESS_POLL_INTERVAL
         if not self._update_worker:
             self._update_worker = self.mass.create_task(self._player_update_worker)
+
+    async def poll(self) -> None:
+        """Poll the snapserver so abruptly powered-off clients are detected."""
+        await self.snap_provider.refresh_server_status()
+        self.poke_player_update()
 
     async def volume_set(self, volume_level: int) -> None:
         """Send VOLUME_SET command to given player."""
@@ -419,7 +434,7 @@ class SnapCastPlayer(Player):
             "_attr_name": self.snap_client.friendly_name,
             "_attr_volume_level": self.snap_client.volume,
             "_attr_volume_muted": self.snap_client.muted,
-            "_attr_available": self.snap_client.connected,
+            "_attr_available": self._is_alive(),
             "connected": self.snap_client.connected,
             "stream_id": snap_group.stream,
             "stream_status": snap_stream.status if snap_stream is not None else None,
@@ -526,6 +541,25 @@ class SnapCastPlayer(Player):
 
         # external snapcast stream
         return grp.stream or None
+
+    def _is_alive(self) -> bool:
+        """
+        Return whether the snapclient is connected and recently seen.
+
+        The snapserver advances lastSeen on every Time message a client sends
+        (~1/s while alive), but never marks an abruptly powered-off client
+        disconnected. We treat a connected client whose lastSeen has been frozen
+        longer than the threshold as gone.
+        """
+        now = self.mass.loop.time()
+        last_seen = self.snap_client._client.get("lastSeen")
+        ls = (last_seen["sec"], last_seen["usec"]) if last_seen else None
+        if ls != self._last_seen_raw:
+            self._last_seen_raw = ls
+            self._last_seen_changed = now
+        if not self.snap_client.connected:
+            return False
+        return (now - self._last_seen_changed) < SNAPCLIENT_STALE_THRESHOLD
 
     def _get_active_snapstream(self) -> SnapstreamProto | None:
         """Get active stream for given player_id."""

--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -41,6 +41,7 @@ from music_assistant.providers.snapcast.constants import (
     MASS_ANNOUNCEMENT_POSTFIX,
     MASS_STREAM_PREFIX,
     SHIPPED_SNAPSERVER_CONFIG_FILE,
+    SNAPCLIENT_LIVENESS_POLL_INTERVAL,
     SNAPWEB_DIR,
 )
 from music_assistant.providers.snapcast.ma_stream import SnapcastMAStream
@@ -79,6 +80,7 @@ class SnapCastProvider(PlayerProvider):
     _controlscript_available: bool
     _snapcast_ma_streams: dict[str, SnapcastMAStream]
     _snapcast_ma_streams_lock: asyncio.Lock
+    _last_status_refresh: float
 
     @property
     def queue_control_available(self) -> bool:
@@ -130,6 +132,7 @@ class SnapCastProvider(PlayerProvider):
             )
         self._snapcast_stream_idle_threshold = self.config.get_value(CONF_STREAM_IDLE_THRESHOLD)
         self._ids_map = bidict({})
+        self._last_status_refresh = 0.0
 
         self._snapcast_ma_streams = {}
         self._snapcast_ma_streams_lock = asyncio.Lock()
@@ -181,6 +184,25 @@ class SnapCastProvider(PlayerProvider):
 
         self._snapserver.stop()
         await self._stop_builtin_server()
+
+    async def refresh_server_status(self) -> None:
+        """
+        Refresh the full snapserver state, throttled to once per poll cycle.
+
+        Snapcast players all poll within the same controller pass; this collapses
+        that burst into a single Server.GetStatus so each client's lastSeen is
+        refreshed once per interval. Transient errors are ignored and retried.
+        """
+        now = self.mass.loop.time()
+        if now - self._last_status_refresh < SNAPCLIENT_LIVENESS_POLL_INTERVAL / 2:
+            return
+        self._last_status_refresh = now
+        try:
+            status, _ = await self._snapserver.status()
+            if isinstance(status, dict) and "server" in status:
+                self._snapserver.synchronize(status)
+        except Exception:
+            self.logger.debug("Snapserver status refresh failed", exc_info=True)
 
     async def _start_builtin_server(self) -> None:
         """Start the built-in Snapserver."""

--- a/tests/providers/snapcast/test_player_liveness.py
+++ b/tests/providers/snapcast/test_player_liveness.py
@@ -1,0 +1,71 @@
+"""Tests for Snapcast player liveness detection (abrupt power-off)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from music_assistant.providers.snapcast.constants import SNAPCLIENT_STALE_THRESHOLD
+from music_assistant.providers.snapcast.player import SnapCastPlayer
+
+
+class _Clock:
+    """Controllable monotonic clock stand-in for loop.time()."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def time(self) -> float:
+        """Return the current (fake) monotonic time."""
+        return self.now
+
+
+def _make_player(clock: _Clock, *, connected: bool, last_seen_sec: int) -> SnapCastPlayer:
+    player = SnapCastPlayer.__new__(SnapCastPlayer)
+    player._last_seen_raw = None
+    player._last_seen_changed = 0.0
+    player.mass = SimpleNamespace(loop=clock)
+    player.snap_client = SimpleNamespace(
+        connected=connected,
+        _client={"lastSeen": {"sec": last_seen_sec, "usec": 0}},
+    )
+    return player
+
+
+def test_alive_while_lastseen_advances() -> None:
+    """A connected client stays available as long as lastSeen keeps advancing."""
+    clock = _Clock()
+    player = _make_player(clock, connected=True, last_seen_sec=500)
+    assert player._is_alive() is True
+    for _ in range(5):
+        clock.now += SNAPCLIENT_STALE_THRESHOLD + 1
+        player.snap_client._client["lastSeen"]["sec"] += 1
+        assert player._is_alive() is True
+
+
+def test_becomes_unavailable_when_lastseen_frozen() -> None:
+    """A connected client whose lastSeen freezes flips to unavailable past the threshold."""
+    clock = _Clock()
+    player = _make_player(clock, connected=True, last_seen_sec=500)
+    assert player._is_alive() is True
+    clock.now += SNAPCLIENT_STALE_THRESHOLD - 1
+    assert player._is_alive() is True
+    clock.now += 2
+    assert player._is_alive() is False
+
+
+def test_disconnected_is_unavailable() -> None:
+    """A client reported disconnected by the server is unavailable regardless of lastSeen."""
+    clock = _Clock()
+    player = _make_player(clock, connected=False, last_seen_sec=500)
+    assert player._is_alive() is False
+
+
+def test_recovers_after_reconnect() -> None:
+    """A stale client becomes available again once lastSeen resumes advancing."""
+    clock = _Clock()
+    player = _make_player(clock, connected=True, last_seen_sec=500)
+    assert player._is_alive() is True
+    clock.now += SNAPCLIENT_STALE_THRESHOLD + 1
+    assert player._is_alive() is False
+    player.snap_client._client["lastSeen"]["sec"] += 1
+    assert player._is_alive() is True

--- a/tests/providers/snapcast/test_player_liveness.py
+++ b/tests/providers/snapcast/test_player_liveness.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 from music_assistant.providers.snapcast.constants import SNAPCLIENT_STALE_THRESHOLD
 from music_assistant.providers.snapcast.player import SnapCastPlayer
+
+if TYPE_CHECKING:
+    from music_assistant.mass import MusicAssistant
+    from music_assistant.providers.snapcast.snap_cntrl_proto import SnapclientProto
 
 
 class _Clock:
@@ -23,10 +28,13 @@ def _make_player(clock: _Clock, *, connected: bool, last_seen_sec: int) -> SnapC
     player = SnapCastPlayer.__new__(SnapCastPlayer)
     player._last_seen_raw = None
     player._last_seen_changed = 0.0
-    player.mass = SimpleNamespace(loop=clock)
-    player.snap_client = SimpleNamespace(
-        connected=connected,
-        _client={"lastSeen": {"sec": last_seen_sec, "usec": 0}},
+    player.mass = cast("MusicAssistant", SimpleNamespace(loop=clock))
+    player.snap_client = cast(
+        "SnapclientProto",
+        SimpleNamespace(
+            connected=connected,
+            _client={"lastSeen": {"sec": last_seen_sec, "usec": 0}},
+        ),
     )
     return player
 


### PR DESCRIPTION
# What does this implement/fix?

After 2.8.0, Snapcast players stay shown as **available even after the device is physically powered off**. The built-in snapserver never reports an abruptly powered-off client as disconnected (it has no TCP keepalive — see snapcast/snapcast#995), so the client's `connected` flag stays `true` indefinitely.

This detects liveness inside the Snapcast provider itself, using the server's per-client `lastSeen` timestamp (the server advances it on every Time message a live client sends, ~1/s). A connected client whose `lastSeen` stops advancing for ~15s is now treated as gone. Detection latency drops from ~12 min / never to ~15–20s. No cross-protocol dependency — aliveness stays within the provider.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5158

## Changes

- Snapcast players now opt into the player poll loop; `poll()` refreshes snapserver status (throttled to one `Server.GetStatus` per cycle).
- Availability is derived from `connected` **and** `lastSeen` freshness, using a skew-proof monotonic delta (works for external servers too).
- Added regression tests for the liveness state machine.

> Opened as **draft** to gather real-device testing from affected users before merge.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
