### PR TITLE
Add AirPlay DACP replay tests and verbose traffic capture

### DIFF
--- a/music_assistant/providers/airplay/provider.py
+++ b/music_assistant/providers/airplay/provider.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import socket
 from contextlib import suppress
 from ipaddress import ip_address
@@ -12,6 +14,7 @@ from music_assistant_models.enums import PlaybackState
 from zeroconf import ServiceStateChange
 from zeroconf.asyncio import AsyncServiceInfo
 
+from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.datetime import utc
 from music_assistant.helpers.util import (
     get_ip_pton,
@@ -283,6 +286,18 @@ class AirPlayProvider(PlayerProvider):
                 path,
                 body,
             )
+            # machine-parseable capture of raw DACP traffic for building replay test fixtures
+            if self.logger.isEnabledFor(VERBOSE_LOG_LEVEL):
+                capture = {
+                    "player": player.name if player else None,
+                    "active_remote": active_remote,
+                    "method": headers_split[0].split(" ", 1)[0],
+                    "path": path,
+                    "headers": headers,
+                    "body": body,
+                    "raw_b64": base64.b64encode(raw_request).decode("ascii"),
+                }
+                self.logger.log(VERBOSE_LOG_LEVEL, "AIRPLAY_DACP_CAPTURE %s", json.dumps(capture))
             if not player:
                 return
             if player.protocol_parent_id and (

--- a/tests/providers/airplay/dacp/__init__.py
+++ b/tests/providers/airplay/dacp/__init__.py
@@ -1,0 +1,1 @@
+"""Replay-based tests for the AirPlay DACP handler."""

--- a/tests/providers/airplay/dacp/conftest.py
+++ b/tests/providers/airplay/dacp/conftest.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -24,13 +22,6 @@ _PLAYER_CMDS = (
 )
 
 
-def _consume_coro(coro: Any = None, *args: Any, **kwargs: Any) -> MagicMock:  # noqa: ARG001
-    """Stand-in for mass.create_task: close any coroutine arg to avoid warnings."""
-    if asyncio.iscoroutine(coro):
-        coro.close()
-    return MagicMock()
-
-
 @pytest.fixture
 def mock_mass() -> MagicMock:
     """Create a mock MusicAssistant instance for the AirPlay provider."""
@@ -44,7 +35,6 @@ def mock_mass() -> MagicMock:
     mass.players.all_players = MagicMock(return_value=[])
     mass.player_queues = MagicMock()
     mass.player_queues.set_shuffle = AsyncMock()
-    mass.create_task = _consume_coro
     mass.call_later = MagicMock()
     mass.cancel_timer = MagicMock()
     mass.config.get_raw_player_config_value = MagicMock(return_value=False)

--- a/tests/providers/airplay/dacp/conftest.py
+++ b/tests/providers/airplay/dacp/conftest.py
@@ -1,0 +1,143 @@
+"""Fixtures for DACP replay tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.enums import PlaybackState
+
+from music_assistant.providers.airplay.provider import AirPlayProvider
+
+_PLAYER_CMDS = (
+    "cmd_play",
+    "cmd_pause",
+    "cmd_play_pause",
+    "cmd_stop",
+    "cmd_next_track",
+    "cmd_previous_track",
+    "cmd_volume_up",
+    "cmd_volume_down",
+    "cmd_ungroup",
+)
+
+
+def _consume_coro(coro: Any = None, *args: Any, **kwargs: Any) -> MagicMock:  # noqa: ARG001
+    """Stand-in for mass.create_task: close any coroutine arg to avoid warnings."""
+    if asyncio.iscoroutine(coro):
+        coro.close()
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_mass() -> MagicMock:
+    """Create a mock MusicAssistant instance for the AirPlay provider."""
+    mass = MagicMock()
+    mass.players = MagicMock()
+    for name in _PLAYER_CMDS:
+        setattr(mass.players, name, AsyncMock())
+    mass.players.get_active_queue = MagicMock(
+        return_value=MagicMock(queue_id="q1", shuffle_enabled=False)
+    )
+    mass.players.all_players = MagicMock(return_value=[])
+    mass.player_queues = MagicMock()
+    mass.player_queues.set_shuffle = AsyncMock()
+    mass.create_task = _consume_coro
+    mass.call_later = MagicMock()
+    mass.cancel_timer = MagicMock()
+    mass.config.get_raw_player_config_value = MagicMock(return_value=False)
+    return mass
+
+
+@pytest.fixture
+def manifest_mock() -> MagicMock:
+    """Return a mock provider manifest."""
+    manifest = MagicMock()
+    manifest.domain = "airplay"
+    manifest.name = "AirPlay"
+    return manifest
+
+
+@pytest.fixture
+def config_mock() -> MagicMock:
+    """Return a mock provider config (GLOBAL log level so construction doesn't fail)."""
+    config = MagicMock()
+    config.instance_id = "airplay_test"
+    config.get_value = MagicMock(return_value="GLOBAL")
+    return config
+
+
+@pytest.fixture
+def airplay_provider(
+    mock_mass: MagicMock, manifest_mock: MagicMock, config_mock: MagicMock
+) -> AirPlayProvider:
+    """
+    Build a real AirPlayProvider backed by the mock mass.
+
+    handle_async_init (DACP server / zeroconf) is intentionally not called; only the
+    request handler is exercised. The default logger level keeps VERBOSE capture off.
+    """
+    return AirPlayProvider(mock_mass, manifest_mock, config_mock)
+
+
+def make_player(  # noqa: PLR0913
+    mass: MagicMock,
+    *,
+    active_remote: str = "123",
+    player_id: str = "ap123",
+    playing: bool = True,
+    manufacturer: str = "Test",
+    synced_to: str | None = None,
+    transitioning: bool = False,
+    stream_connected: bool = True,
+    prevent_playback: bool = False,
+    has_session: bool = True,
+    has_stream: bool = True,
+) -> MagicMock:
+    """
+    Make the mock mass return a single mock AirPlay player, and return it.
+
+    Each call replaces the mass player list, so calling it twice does not yield two
+    players.
+
+    :param mass: The mock_mass fixture the provider looks players up through.
+    :param active_remote: Active-Remote id the player's stream answers to.
+    :param player_id: Player id used in dispatched commands.
+    :param playing: Whether the player reports PLAYING (else IDLE).
+    :param manufacturer: Device manufacturer ("Apple" triggers ignore-volume).
+    :param synced_to: Parent player id when synced, else None.
+    :param transitioning: Value of player._transitioning.
+    :param stream_connected: Whether the stream reports connected.
+    :param prevent_playback: Initial stream.prevent_playback flag.
+    :param has_session: Whether the stream has an active session.
+    :param has_stream: Whether the player has a stream at all.
+    """
+    player = MagicMock()
+    player.player_id = player_id
+    player.name = "Test Player"
+    player.protocol_parent_id = None
+    player.synced_to = synced_to
+    player._transitioning = transitioning
+    state = PlaybackState.PLAYING if playing else PlaybackState.IDLE
+    player.playback_state = state
+    player.state.playback_state = state
+    player.state.active_group = None
+    player.device_info.manufacturer = manufacturer
+    player.volume_muted = False
+    player.volume_level = 50
+    if has_stream:
+        stream = MagicMock()
+        stream.active_remote_id = active_remote
+        stream.running = True
+        stream.connected = stream_connected
+        stream.prevent_playback = prevent_playback
+        stream.session = MagicMock() if has_session else None
+        stream.stop = AsyncMock()
+        stream.send_cli_command = AsyncMock()
+        player.stream = stream
+    else:
+        player.stream = None
+    mass.players.all_players.return_value = [player]
+    return player

--- a/tests/providers/airplay/dacp/helpers.py
+++ b/tests/providers/airplay/dacp/helpers.py
@@ -1,0 +1,75 @@
+"""Helpers for replaying DACP requests through the AirPlay handler."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from music_assistant.providers.airplay.provider import AirPlayProvider
+
+
+def build_dacp_request(
+    path: str,
+    active_remote: str | None = "123",
+    *,
+    method: str = "POST",
+    body: str = "",
+    headers: dict[str, str] | None = None,
+) -> bytes:
+    """
+    Build raw DACP request bytes for replay.
+
+    :param path: Request path, e.g. "/ctrl-int/1/play".
+    :param active_remote: Active-Remote header value; omitted from the request when None.
+    :param method: HTTP method.
+    :param body: Request body.
+    :param headers: Extra headers to include.
+    """
+    hdrs: dict[str, str] = {}
+    if active_remote is not None:
+        hdrs["Active-Remote"] = active_remote
+    if headers:
+        hdrs.update(headers)
+    lines = [f"{method} {path} HTTP/1.1"]
+    lines += [f"{key}: {value}" for key, value in hdrs.items()]
+    request = "\r\n".join(lines) + "\r\n\r\n" + body
+    return request.encode("utf-8")
+
+
+def load_capture(path: str) -> list[bytes]:
+    """
+    Parse AIRPLAY_DACP_CAPTURE lines from a verbose log file into raw request bytes.
+
+    Parses real-device capture logs for future replay fixtures; landed ahead of its
+    first consumer (the capture-mode task).
+
+    :param path: Path to a log file containing AIRPLAY_DACP_CAPTURE lines.
+    """
+    marker = "AIRPLAY_DACP_CAPTURE "
+    requests: list[bytes] = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            if marker not in line:
+                continue
+            payload = json.loads(line.split(marker, 1)[1])
+            requests.append(base64.b64decode(payload["raw_b64"]))
+    return requests
+
+
+async def replay(provider: AirPlayProvider, raw: bytes) -> bytes:
+    """
+    Feed raw request bytes through the real DACP handler and return the response bytes.
+
+    :param provider: Real AirPlayProvider instance (built with a mock mass).
+    :param raw: Raw DACP request bytes.
+    """
+    reader = asyncio.StreamReader()
+    reader.feed_data(raw)
+    reader.feed_eof()
+    writer = MagicMock()
+    writer.drain = AsyncMock()
+    writer.wait_closed = AsyncMock()
+    await provider._handle_dacp_request(reader, writer)
+    return writer.write.call_args.args[0] if writer.write.called else b""

--- a/tests/providers/airplay/dacp/test_dacp_compliance.py
+++ b/tests/providers/airplay/dacp/test_dacp_compliance.py
@@ -1,0 +1,26 @@
+"""Replay-based DACP compliance tests for the AirPlay handler."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from music_assistant.providers.airplay.provider import AirPlayProvider
+
+from .conftest import make_player
+from .helpers import build_dacp_request, replay
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_unknown_active_remote_is_ignored(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """A request whose Active-Remote matches no player must be a no-op (and not crash)."""
+    make_player(mock_mass, active_remote="123")
+    raw = build_dacp_request("/ctrl-int/1/play", active_remote="999")
+
+    await replay(airplay_provider, raw)
+
+    mock_mass.players.cmd_play.assert_not_called()

--- a/tests/providers/airplay/dacp/test_dacp_compliance.py
+++ b/tests/providers/airplay/dacp/test_dacp_compliance.py
@@ -243,6 +243,25 @@ async def test_prevent_playback_zero_schedules_reset(
     )
 
 
+async def test_denon_transient_prevent_playback_pair_keeps_stream(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """
+    A transient prevent-playback=1/=0 burst during RAOP setup must not tear down the stream.
+
+    Regression for a Denon AVR-X2700H that emits this pair while the stream is still being
+    established (https://github.com/music-assistant/support/issues/5033).
+    """
+    player = make_player(mock_mass, synced_to=None, stream_connected=False)
+
+    await replay(airplay_provider, build_dacp_request(_PREVENT_1))
+    await replay(airplay_provider, build_dacp_request(_PREVENT_0))
+
+    player.stream.stop.assert_not_called()
+    mock_mass.players.cmd_ungroup.assert_not_called()
+    assert player.stream.prevent_playback is False
+
+
 async def test_empty_request_returns_early(
     airplay_provider: AirPlayProvider, mock_mass: MagicMock
 ) -> None:

--- a/tests/providers/airplay/dacp/test_dacp_compliance.py
+++ b/tests/providers/airplay/dacp/test_dacp_compliance.py
@@ -24,3 +24,308 @@ async def test_unknown_active_remote_is_ignored(
     await replay(airplay_provider, raw)
 
     mock_mass.players.cmd_play.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("path", "cmd"),
+    [
+        ("/ctrl-int/1/playpause", "cmd_play_pause"),
+        ("/ctrl-int/1/stop", "cmd_stop"),
+        ("/ctrl-int/1/nextitem", "cmd_next_track"),
+        ("/ctrl-int/1/previtem", "cmd_previous_track"),
+        ("/ctrl-int/1/volumeup", "cmd_volume_up"),
+        ("/ctrl-int/1/volumedown", "cmd_volume_down"),
+    ],
+)
+async def test_transport_commands_dispatch(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock, path: str, cmd: str
+) -> None:
+    """Simple transport paths dispatch the matching player command with the player id."""
+    player = make_player(mock_mass)
+    await replay(airplay_provider, build_dacp_request(path))
+    getattr(mock_mass.players, cmd).assert_called_once_with(player.player_id)
+
+
+async def test_play_when_not_playing_dispatches_play(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """/play starts playback when the player is not already playing."""
+    player = make_player(mock_mass, playing=False)
+    await replay(airplay_provider, build_dacp_request("/ctrl-int/1/play"))
+    mock_mass.players.cmd_play.assert_called_once_with(player.player_id)
+
+
+async def test_play_when_already_playing_is_ignored(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """/play is a confirmation echo and must be ignored when already playing."""
+    make_player(mock_mass, playing=True)
+    await replay(airplay_provider, build_dacp_request("/ctrl-int/1/play"))
+    mock_mass.players.cmd_play.assert_not_called()
+
+
+async def test_pause_when_playing_dispatches_pause(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """/pause pauses when the player is playing."""
+    player = make_player(mock_mass, playing=True)
+    await replay(airplay_provider, build_dacp_request("/ctrl-int/1/pause"))
+    mock_mass.players.cmd_pause.assert_called_once_with(player.player_id)
+
+
+async def test_pause_when_not_playing_is_ignored(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """/pause does nothing when the player is not playing."""
+    make_player(mock_mass, playing=False)
+    await replay(airplay_provider, build_dacp_request("/ctrl-int/1/pause"))
+    mock_mass.players.cmd_pause.assert_not_called()
+
+
+async def test_shuffle_songs_toggles_queue_shuffle(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """/shuffle_songs flips the active queue's shuffle state."""
+    make_player(mock_mass)
+    await replay(airplay_provider, build_dacp_request("/ctrl-int/1/shuffle_songs"))
+    mock_mass.player_queues.set_shuffle.assert_called_once_with("q1", True)
+
+
+async def test_discrete_pause_schedules_debounced_pause(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """/discrete-pause while playing schedules a debounced cmd_pause (not an immediate one)."""
+    player = make_player(mock_mass, playing=True)
+    await replay(airplay_provider, build_dacp_request("/ctrl-int/1/discrete-pause"))
+
+    mock_mass.players.cmd_pause.assert_not_called()
+    mock_mass.call_later.assert_called_once_with(
+        1.0,
+        mock_mass.players.cmd_pause,
+        player.player_id,
+        task_id=f"debounced_pause_{player.player_id}",
+    )
+
+
+async def test_discrete_pause_when_not_playing_does_nothing(
+    airplay_provider: AirPlayProvider,
+    mock_mass: MagicMock,
+) -> None:
+    """/discrete-pause is ignored when the player is not playing."""
+    make_player(mock_mass, playing=False)
+    await replay(airplay_provider, build_dacp_request("/ctrl-int/1/discrete-pause"))
+    mock_mass.call_later.assert_not_called()
+
+
+async def test_prevent_playback_cancels_pending_discrete_pause(
+    airplay_provider: AirPlayProvider,
+    mock_mass: MagicMock,
+) -> None:
+    """device-prevent-playback=1 cancels the debounced pause timer for the player."""
+    player = make_player(mock_mass, playing=True)
+    await replay(
+        airplay_provider,
+        build_dacp_request("/ctrl-int/1/setproperty?device-prevent-playback=1"),
+    )
+    mock_mass.cancel_timer.assert_any_call(f"debounced_pause_{player.player_id}")
+
+
+async def test_device_volume_updates_volume(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """dmcp.device-volume in dB updates the player volume via the converted 0-100 value."""
+    player = make_player(mock_mass)
+    # -15 dB maps to 50 on the 0-100 scale
+    raw = build_dacp_request("/ctrl-int/1/setproperty?dmcp.device-volume=-15.000000")
+    await replay(airplay_provider, raw)
+    player.update_volume_from_device.assert_called_once_with(50)
+
+
+async def test_device_volume_mute_threshold_mutes(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """dmcp.device-volume at/below the mute threshold mutes the player and sends VOLUME=0."""
+    player = make_player(mock_mass)
+    raw = build_dacp_request("/ctrl-int/1/setproperty?dmcp.device-volume=-144.000000")
+    await replay(airplay_provider, raw)
+    assert player._attr_volume_muted is True
+    player.stream.send_cli_command.assert_called_once_with("VOLUME=0")
+
+
+async def test_device_volume_ignored_for_apple_device(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """Apple devices echo our own volume; dmcp.device-volume must be ignored for them."""
+    player = make_player(mock_mass, manufacturer="Apple")
+    raw = build_dacp_request("/ctrl-int/1/setproperty?dmcp.device-volume=-15.000000")
+    await replay(airplay_provider, raw)
+    player.update_volume_from_device.assert_not_called()
+
+
+async def test_dmcp_volume_button_updates_volume(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """dmcp.volume (hardware buttons) updates the player volume directly."""
+    player = make_player(mock_mass)
+    raw = build_dacp_request("/ctrl-int/1/setproperty?dmcp.volume=45")
+    await replay(airplay_provider, raw)
+    player.update_volume_from_device.assert_called_once_with(45)
+
+
+_PREVENT_1 = "/ctrl-int/1/setproperty?device-prevent-playback=1"
+_PREVENT_0 = "/ctrl-int/1/setproperty?device-prevent-playback=0"
+
+
+async def test_prevent_playback_stops_unsynced_stream(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """prevent-playback=1 on an established, unsynced stream stops that stream."""
+    player = make_player(mock_mass, synced_to=None)
+    await replay(airplay_provider, build_dacp_request(_PREVENT_1))
+    assert player.stream.prevent_playback is True
+    player.stream.stop.assert_called_once()
+    mock_mass.players.cmd_ungroup.assert_not_called()
+
+
+async def test_prevent_playback_ungroups_synced_player(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """prevent-playback=1 on a synced player ungroups instead of stopping the stream."""
+    player = make_player(mock_mass, synced_to="parent")
+    await replay(airplay_provider, build_dacp_request(_PREVENT_1))
+    mock_mass.players.cmd_ungroup.assert_called_once_with(player.player_id)
+    player.stream.stop.assert_not_called()
+
+
+async def test_prevent_playback_ignored_during_transition(
+    airplay_provider: AirPlayProvider,
+    mock_mass: MagicMock,
+) -> None:
+    """prevent-playback=1 during a stream transition is a stale message and ignored."""
+    player = make_player(mock_mass, transitioning=True)
+    await replay(airplay_provider, build_dacp_request(_PREVENT_1))
+    player.stream.stop.assert_not_called()
+    mock_mass.players.cmd_ungroup.assert_not_called()
+
+
+async def test_prevent_playback_ignored_when_stream_not_connected(
+    airplay_provider: AirPlayProvider,
+    mock_mass: MagicMock,
+) -> None:
+    """prevent-playback=1 before the stream is established (Denon transient) is ignored."""
+    player = make_player(mock_mass, stream_connected=False)
+    await replay(airplay_provider, build_dacp_request(_PREVENT_1))
+    player.stream.stop.assert_not_called()
+
+
+async def test_prevent_playback_ignored_when_already_set(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """A duplicate prevent-playback=1 while already preventing is ignored."""
+    player = make_player(mock_mass, prevent_playback=True)
+    await replay(airplay_provider, build_dacp_request(_PREVENT_1))
+    player.stream.stop.assert_not_called()
+
+
+async def test_prevent_playback_zero_schedules_reset(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """prevent-playback=0 schedules a debounced reset of the prevent_playback flag."""
+    player = make_player(mock_mass, prevent_playback=True)
+    await replay(airplay_provider, build_dacp_request(_PREVENT_0))
+    mock_mass.call_later.assert_called_once_with(
+        5,
+        setattr,
+        player.stream,
+        "prevent_playback",
+        False,
+        task_id=f"reset_prevent_playback_{player.player_id}",
+    )
+
+
+async def test_empty_request_returns_early(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """An empty request (e.g. Phorus PS10 ack) is handled without dispatching anything."""
+    make_player(mock_mass)
+    await replay(airplay_provider, b"")
+    mock_mass.players.cmd_play.assert_not_called()
+
+
+async def test_headers_only_request_does_not_crash(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """A request without a body terminator must parse and dispatch normally."""
+    player = make_player(mock_mass, playing=False)
+    raw = b"POST /ctrl-int/1/play HTTP/1.1\r\nActive-Remote: 123"
+    await replay(airplay_provider, raw)
+    mock_mass.players.cmd_play.assert_called_once_with(player.player_id)
+
+
+async def test_malformed_header_line_is_skipped(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """A header line without a colon is skipped rather than crashing the handler."""
+    player = make_player(mock_mass, playing=False)
+    raw = (
+        b"POST /ctrl-int/1/play HTTP/1.1\r\n"
+        b"garbage-line-without-colon\r\n"
+        b"Active-Remote: 123\r\n\r\n"
+    )
+    await replay(airplay_provider, raw)
+    mock_mass.players.cmd_play.assert_called_once_with(player.player_id)
+
+
+async def test_unknown_path_returns_204_without_command(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """An unrecognized path dispatches nothing but still returns HTTP 204."""
+    make_player(mock_mass)
+    response = await replay(airplay_provider, build_dacp_request("/ctrl-int/1/bogus"))
+    mock_mass.players.cmd_play.assert_not_called()
+    assert response.startswith(b"HTTP/1.0 204 No Content")
+
+
+async def test_handled_request_returns_204(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock
+) -> None:
+    """A handled request returns the spec-shaped HTTP 204 response."""
+    make_player(mock_mass)
+    response = await replay(airplay_provider, build_dacp_request("/ctrl-int/1/stop"))
+    assert response.startswith(b"HTTP/1.0 204 No Content")
+
+
+# These commands are documented in the community DACP spec
+# (https://openairplay.github.io/airplay-spec/audio/remote_control.html) but MA does
+# not implement them yet. The test locks in the current graceful no-op so the suite
+# covers the full spec without failing. When one is implemented, move it out of this
+# parametrize list into its own behavior test. See the spec doc "Known spec gaps".
+_UNHANDLED_SPEC_COMMANDS = [
+    "/ctrl-int/1/beginff",
+    "/ctrl-int/1/beginrew",
+    "/ctrl-int/1/mutetoggle",
+    "/ctrl-int/1/playresume",
+]
+
+
+@pytest.mark.parametrize("path", _UNHANDLED_SPEC_COMMANDS)
+async def test_documented_unhandled_commands_noop(
+    airplay_provider: AirPlayProvider, mock_mass: MagicMock, path: str
+) -> None:
+    """Spec commands MA does not implement dispatch nothing but still return HTTP 204."""
+    make_player(mock_mass)
+    response = await replay(airplay_provider, build_dacp_request(path))
+
+    players = mock_mass.players
+    for cmd in (
+        "cmd_play",
+        "cmd_pause",
+        "cmd_play_pause",
+        "cmd_stop",
+        "cmd_next_track",
+        "cmd_previous_track",
+        "cmd_volume_up",
+        "cmd_volume_down",
+    ):
+        getattr(players, cmd).assert_not_called()
+    assert response.startswith(b"HTTP/1.0 204 No Content")


### PR DESCRIPTION
# What does this implement/fix?

Our AirPlay support is reverse-engineered and depends on DACP control events sent by the player, but that handler had no test coverage. This adds a replay-based unit-test harness for the DACP handler, an initial suite of spec-compliance scenarios, and an opt-in capture log so future (mis)behaving devices can be turned into regression tests.

DACP has no official Apple spec; scenarios are derived from the community [unofficial AirPlay remote-control spec](https://openairplay.github.io/airplay-spec/audio/remote_control.html). MA acts as the DACP server (the speaker connects back and sends control requests), so tests replay raw requests through the real `_handle_dacp_request` and assert the dispatched command / flag change.

**Note:** the new capture line logs the full raw request (headers + body, base64) and is gated behind verbose logging (off by default). Users sharing verbose logs to build fixtures are sharing raw device traffic, which can include `Active-Remote`/device identifiers — worth sanitising before attaching to issues.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- Add a replay harness under `tests/providers/airplay/dacp/` (`helpers.py` request builder + `replay()` + `load_capture()`, `conftest.py` fixtures building a real `AirPlayProvider` over a mock mass).
- Add ~34 DACP compliance scenarios: transport commands, discrete-pause debounce, device-volume/mute, source-switching (`device-prevent-playback`), parsing robustness, and documented-but-unimplemented spec commands locked in as graceful no-ops.
- Add a `VERBOSE_LOG_LEVEL` `AIRPLAY_DACP_CAPTURE` log line (alongside the existing debug line) emitting the raw request as machine-parseable JSON, so real-device traffic can be captured into fixtures (parsed back by `load_capture`).

`load_capture` is intentional groundwork for the capture workflow and has no in-tree caller yet.

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes. <!-- pre-commit clean on changed files; run full suite before merge -->
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
