### PR TITLE
Subsonic: Convert provider to StreamType.HTTP

### DIFF
--- a/music_assistant/providers/opensubsonic/__init__.py
+++ b/music_assistant/providers/opensubsonic/__init__.py
@@ -14,7 +14,6 @@ from .sonic_provider import (
     CONF_ENABLE_LEGACY_AUTH,
     CONF_ENABLE_PODCASTS,
     CONF_NEW_ALBUMS,
-    CONF_OVERRIDE_OFFSET,
     CONF_PAGE_SIZE,
     CONF_PLAYED_ALBUMS,
     CONF_RAW_FILE,
@@ -100,12 +99,6 @@ async def get_config_entries(
         ),
         ConfigEntry(
             key=CONF_ENABLE_LEGACY_AUTH,
-            type=ConfigEntryType.BOOLEAN,
-            required=True,
-            default_value=False,
-        ),
-        ConfigEntry(
-            key=CONF_OVERRIDE_OFFSET,
             type=ConfigEntryType.BOOLEAN,
             required=True,
             default_value=False,

--- a/music_assistant/providers/opensubsonic/manifest.json
+++ b/music_assistant/providers/opensubsonic/manifest.json
@@ -6,7 +6,7 @@
   "description": "Stream music from your OpenSubsonic compatible server — your own cloud jukebox.",
   "codeowners": ["@khers"],
   "credits": ["[py-opensonic](https://github.com/khers/py-opensonic)"],
-  "requirements": ["py-opensonic==10.0.0"],
+  "requirements": ["py-opensonic==10.1.0"],
   "documentation": "https://music-assistant.io/music-providers/subsonic/",
   "multi_instance": true
 }

--- a/music_assistant/providers/opensubsonic/sonic_provider.py
+++ b/music_assistant/providers/opensubsonic/sonic_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from asyncio import TaskGroup
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+from urllib.parse import urlencode
 
 from libopensonic import AsyncConnection as SonicConnection
 from libopensonic.errors import (
@@ -77,7 +78,6 @@ if TYPE_CHECKING:
 CONF_BASE_URL = "baseURL"
 CONF_ENABLE_PODCASTS = "enable_podcasts"
 CONF_ENABLE_LEGACY_AUTH = "enable_legacy_auth"
-CONF_OVERRIDE_OFFSET = "override_transcode_offest"
 CONF_RECO_FAVES = "recommend_favorites"
 CONF_NEW_ALBUMS = "recommend_new"
 CONF_PLAYED_ALBUMS = "recommend_played"
@@ -97,8 +97,6 @@ class OpenSonicProvider(MusicProvider):
 
     conn: SonicConnection
     _enable_podcasts: bool = True
-    _seek_support: bool = False
-    _ignore_offset: bool = False
     _show_faves: bool = True
     _show_new: bool = True
     _show_played: bool = True
@@ -138,16 +136,14 @@ class OpenSonicProvider(MusicProvider):
                 translation_args=[self.config.get_value(CONF_BASE_URL)],
             ) from e
         self._enable_podcasts = bool(self.config.get_value(CONF_ENABLE_PODCASTS))
-        self._ignore_offset = bool(self.config.get_value(CONF_OVERRIDE_OFFSET))
         try:
             extensions: list[OpenSubsonicExtension] = await self.conn.get_open_subsonic_extensions()
             for entry in extensions:
-                if entry.name == "transcodeOffset" and not self._ignore_offset:
-                    self._seek_support = True
                 if entry.name == "songLyrics":
                     self._id_lyrics = True
+                    break
         except OSError:
-            self.logger.info("Server does not support transcodeOffset, seeking in player provider")
+            self.logger.info("Failed to query server for OpenSubsonic extensions")
         self._show_faves = bool(self.config.get_value(CONF_RECO_FAVES))
         self._show_new = bool(self.config.get_value(CONF_NEW_ALBUMS))
         self._show_played = bool(self.config.get_value(CONF_PLAYED_ALBUMS))
@@ -679,24 +675,22 @@ class OpenSonicProvider(MusicProvider):
             msg = f"Unsupported media type encountered '{media_type}'"
             raise UnsupportedFeaturedException(msg)
 
-        if mime_type and mime_type.endswith("mp4"):
-            self.logger.warning(
-                "Due to the streaming method used by the subsonic API, M4A files "
-                "may fail. See provider documentation for more information."
-            )
-
-        # We believe that reporting the container type here is causing playback problems and ffmpeg
-        # should be capable of guessing the correct container type for any media supported by
-        # OpenSubsonic servers. Better to let ffmpeg figure things out than tell it something
-        # confusing. We still go through the effort of figuring out what the server thinks the
-        # container is to warn about M4A files.
-        mime_type = "?"
+        # The stream URL carries no query string; id/auth/format all travel in the POST body
+        # so they never end up in proxy logs, server logs, or a `ps aux` listing. ffmpeg is
+        # handed the URL as its input and re-sends this same body on every Range-based reconnect
+        # it issues while seeking, so seeking is handled entirely by ffmpeg's own demuxer rather
+        # than the transcodeOffset extension.
+        fmat = "raw" if self._raw_file else None
+        url, params = self.conn.get_stream_url(item.id, tformat=fmat, estimate_length=True)
+        # ffmpeg's -post_data is a binary AVOption: it must be given as a hex string of the
+        # raw bytes, a plain string value is silently rejected ("Invalid argument").
+        post_data = urlencode(params).encode().hex()
 
         return StreamDetails(
             item_id=item.id,
             provider=self.instance_id,
             allow_seek=True,
-            can_seek=self._seek_support,
+            can_seek=True,
             media_type=media_type,
             audio_format=AudioFormat(
                 content_type=ContentType.try_parse(mime_type),
@@ -704,7 +698,16 @@ class OpenSonicProvider(MusicProvider):
                 bit_depth=item.bit_depth or 16,
                 channels=item.channel_count or 2,
             ),
-            stream_type=StreamType.CUSTOM,
+            stream_type=StreamType.HTTP,
+            path=url,
+            extra_input_args=[
+                "-method",
+                "POST",
+                "-content_type",
+                "application/x-www-form-urlencoded",
+                "-post_data",
+                post_data,
+            ],
             duration=item.duration or 0,
         )
 
@@ -790,32 +793,6 @@ class OpenSonicProvider(MusicProvider):
                 )
         # If we get here, there is no bookmark
         return (False, 0, None)
-
-    async def get_audio_stream(
-        self, streamdetails: StreamDetails, seek_position: int = 0
-    ) -> AsyncGenerator[bytes]:
-        """Provide a generator for the stream data."""
-        # ignore seek position if the server does not support it
-        # in that case we let the core handle seeking
-        if not self._seek_support:
-            seek_position = 0
-
-        self.logger.debug("Streaming %s", streamdetails.item_id)
-        fmat = "raw" if self._raw_file else None
-
-        try:
-            resp = await self.conn.stream(
-                streamdetails.item_id, time_offset=seek_position, estimate_length=True, tformat=fmat
-            )
-        except DataNotFoundError as err:
-            msg = f"Item '{streamdetails.item_id}' not found"
-            raise MediaNotFoundError(msg) from err
-        self.logger.debug("starting stream of item '%s'", streamdetails.item_id)
-        async with resp:
-            async for chunk in resp.content.iter_chunked(40960):
-                yield bytes(chunk)
-
-        self.logger.debug("Done streaming %s", streamdetails.item_id)
 
     async def _get_podcast_channel_async(self, chan_id: str) -> PodcastChannel | None:
         if cache := await self.mass.cache.get(

--- a/music_assistant/providers/opensubsonic/strings.json
+++ b/music_assistant/providers/opensubsonic/strings.json
@@ -28,10 +28,6 @@
       "label": "Enable Legacy Auth",
       "description": "Enable OpenSubsonic \"legacy\" auth support"
     },
-    "override_transcode_offest": {
-      "label": "Force Player Provider Seek",
-      "description": "Some Subsonic implementations advertise that they support seeking when they do not always. If seeking does not work for you, enable this."
-    },
     "recommend_favorites": {
       "label": "Recommend Favorites",
       "description": "Should favorited (starred) items be included as recommendations."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1335,8 +1335,6 @@
   "provider.opensubsonic.config_entries.enable_legacy_auth.label": "Enable Legacy Auth",
   "provider.opensubsonic.config_entries.enable_podcasts.description": "Should the provider query for podcasts as well as music?",
   "provider.opensubsonic.config_entries.enable_podcasts.label": "Enable Podcasts",
-  "provider.opensubsonic.config_entries.override_transcode_offest.description": "Some Subsonic implementations advertise that they support seeking when they do not always. If seeking does not work for you, enable this.",
-  "provider.opensubsonic.config_entries.override_transcode_offest.label": "Force Player Provider Seek",
   "provider.opensubsonic.config_entries.pagination_size.description": "When enumerating items from the server, how many should be in each request. Smaller will require more requests but is better for low bandwidth connections. The Open Subsonic spec says the max value for this is 500 items.",
   "provider.opensubsonic.config_entries.pagination_size.label": "Number of items included per server request.",
   "provider.opensubsonic.config_entries.password.description": "The password associated with the username",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -60,7 +60,7 @@ pkce==1.0.3
 plexapi==4.18.1
 podcastparser==0.6.11
 propcache>=0.2.1
-py-opensonic==10.0.0
+py-opensonic==10.1.0
 pyacoustid==1.3.0
 pyamplipi==0.4.12
 pyblu==2.0.8

--- a/scripts/lint_baselines/private_methods_not_last.txt
+++ b/scripts/lint_baselines/private_methods_not_last.txt
@@ -54,7 +54,7 @@ music_assistant/providers/nicovideo/converters/track.py	1
 music_assistant/providers/nicovideo/helpers/hls_seek_optimizer.py	1
 music_assistant/providers/nicovideo/services/search.py	1
 music_assistant/providers/nugs/__init__.py	3
-music_assistant/providers/opensubsonic/sonic_provider.py	29
+music_assistant/providers/opensubsonic/sonic_provider.py	28
 music_assistant/providers/orf_radiothek/__init__.py	9
 music_assistant/providers/pandora/provider.py	6
 music_assistant/providers/party/__init__.py	6


### PR DESCRIPTION
Most of the complications we are seeing with seeking from subsonic based server come down to not allowing the tool which understands the container/codec in use to request precise byte ranges. If we can convert to the HTTP stream type this problem goes away. The only possible challenge here is the POST body for the server needs to be hex encoded before handing to ffmpeg or the process rejects the additional items.

Lightly tested localy, but working on my setup so right after a big release is the perfect time to roll it out.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5210

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
