### PR TITLE
Enable Don't Stop the Music mode for metadata/plugin similar-track providers

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -314,9 +314,10 @@ class PlayerQueuesController(CoreController):
         :param playlist_options: Library playlists to offer for the 'playlist' autoplay mode.
             Only populated when serving the entries to the UI; the parse path can omit it.
         """
-        similar_tracks_available = any(
-            ProviderFeature.SIMILAR_TRACKS in provider.supported_features
-            for provider in self.mass.music.providers
+        # Match the runtime fetch path: similar tracks can also come from metadata/plugin
+        # providers (e.g. sonic_similarity), so gate on all types, not music providers alone.
+        similar_tracks_available = bool(
+            self.mass.get_providers_supporting_feature(ProviderFeature.SIMILAR_TRACKS)
         )
         autoplay_entries = [
             ConfigEntry(

--- a/tests/controllers/player_queues/test_autoplay.py
+++ b/tests/controllers/player_queues/test_autoplay.py
@@ -189,7 +189,7 @@ async def test_get_playlist_tracks_without_config_returns_empty() -> None:
 def test_get_queue_config_entries_categories_and_dependencies() -> None:
     """Autoplay and crossfade entries land in their own categories with the playlist depends_on."""
     fake = MagicMock()
-    fake.mass.music.providers = []
+    fake.mass.get_providers_supporting_feature.return_value = []
     fake.mass.streams.smart_fades_available = False
 
     entries = PlayerQueuesController.get_queue_config_entries(cast("PlayerQueuesController", fake))
@@ -214,3 +214,19 @@ def test_get_queue_config_entries_categories_and_dependencies() -> None:
         opt for opt in by_key["autoplay_mode"].options if opt.value == AutoplayMode.SIMILAR.value
     )
     assert similar_option.disabled is True
+
+
+def test_get_queue_config_entries_similar_enabled_by_plugin_provider() -> None:
+    """The 'similar' option is enabled when any provider (incl. a plugin) supplies similar tracks."""
+    fake = MagicMock()
+    # mirror a sonic_similarity-style plugin: only surfaces via get_providers_supporting_feature
+    fake.mass.get_providers_supporting_feature.return_value = [MagicMock()]
+    fake.mass.streams.smart_fades_available = False
+
+    entries = PlayerQueuesController.get_queue_config_entries(cast("PlayerQueuesController", fake))
+    by_key = {entry.key: entry for entry in entries}
+
+    similar_option = next(
+        opt for opt in by_key["autoplay_mode"].options if opt.value == AutoplayMode.SIMILAR.value
+    )
+    assert similar_option.disabled is False


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The autoplay config gated the 'similar' mode on music providers only, so a similar-tracks source that is a metadata or plugin provider (e.g. sonic_similarity) could not enable it, even though the runtime fetch path already consults those providers. Gate on get_providers_supporting_feature instead, matching the fetch path.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5752

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
