### PR TITLE
Allow Don't stop the music with metadata/plugin similar-track providers

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -426,9 +426,8 @@ class PlayerQueuesController(CoreController):
     @api_command("player_queues/dont_stop_the_music")
     def set_dont_stop_the_music(self, queue_id: str, dont_stop_the_music_enabled: bool) -> None:
         """Configure Don't stop the music setting on the queue."""
-        providers_available_with_similar_tracks = any(
-            ProviderFeature.SIMILAR_TRACKS in provider.supported_features
-            for provider in self.mass.music.providers
+        providers_available_with_similar_tracks = bool(
+            self.mass.get_providers_supporting_feature(ProviderFeature.SIMILAR_TRACKS)
         )
         if dont_stop_the_music_enabled and not providers_available_with_similar_tracks:
             raise UnsupportedFeaturedException(

--- a/tests/core/test_dont_stop_the_music.py
+++ b/tests/core/test_dont_stop_the_music.py
@@ -1,0 +1,35 @@
+"""Tests for the Don't stop the music availability check."""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.errors import UnsupportedFeaturedException
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+
+
+def _fake_controller(similar_tracks_providers: list[object]) -> MagicMock:
+    fake = MagicMock()
+    fake.mass.get_providers_supporting_feature.return_value = similar_tracks_providers
+    # keep the trailing radio-fill branch out of the way
+    queue = MagicMock()
+    queue.enqueued_media_items = []
+    fake._queues = {"q1": queue}
+    return fake
+
+
+def test_dont_stop_the_music_rejected_without_similar_tracks_provider() -> None:
+    """Enabling the feature raises when no provider can supply similar tracks."""
+    fake = _fake_controller([])
+    with pytest.raises(UnsupportedFeaturedException):
+        PlayerQueuesController.set_dont_stop_the_music(
+            cast("PlayerQueuesController", fake), "q1", True
+        )
+
+
+def test_dont_stop_the_music_enabled_by_plugin_provider() -> None:
+    """A plugin/metadata similar-tracks provider (e.g. sonic_similarity) enables the feature."""
+    fake = _fake_controller([MagicMock()])
+    PlayerQueuesController.set_dont_stop_the_music(cast("PlayerQueuesController", fake), "q1", True)
+    assert fake._queues["q1"].dont_stop_the_music_enabled is True


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The autoplay config gated the 'similar' mode on music providers only, so a similar-tracks source that is a metadata or plugin provider (e.g. sonic_similarity) could not enable it, even though the runtime fetch path already consults those providers. Gate on get_providers_supporting_feature instead, matching the fetch path.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5752

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
