### PR TITLE
Turn a queue with any dynamic source into one bounded smart-shuffled pool

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -203,6 +203,10 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
     async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
         """Configure shuffle setting on the the queue."""
         queue = self._queue_data[queue_id].queue
+        if queue.is_dynamic:
+            # a dynamic queue is an always-on, recency-orchestrated smart mix; manual shuffle
+            # (and plain linear order) have no meaning here so the toggle is locked
+            raise InvalidCommand("Cannot change shuffle while the queue is in dynamic mode")
         if queue.shuffle_enabled == shuffle_enabled:
             return  # no change
         queue.shuffle_enabled = shuffle_enabled
@@ -232,12 +236,13 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         """
         Return whether smart shuffle is currently in effect for the queue.
 
-        Radio mode implies smart selection, so it always counts as active; otherwise smart shuffle
-        is active when shuffle is on and the per-queue smart-shuffle setting is enabled.
+        A dynamic queue is always an orchestrated smart mix (the managed pool), so it always counts
+        as active; otherwise smart shuffle is active when shuffle is on and the per-queue
+        smart-shuffle setting is enabled.
 
         :param queue: The queue to evaluate.
         """
-        if queue.sources:
+        if queue.is_dynamic:
             return True
         return queue.shuffle_enabled and self._smart_shuffle.is_enabled(queue.queue_id)
 
@@ -251,7 +256,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         if (
             queue.autoplay_enabled
             and queue.enqueued_media_items
-            and not queue.sources
+            and not queue.is_dynamic
             and queue.current_index is not None
             and (queue.items - queue.current_index) < 5
         ):
@@ -268,6 +273,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
     def set_repeat(self, queue_id: str, repeat_mode: RepeatMode) -> None:
         """Configure repeat setting on the the queue."""
         queue = self._queue_data[queue_id].queue
+        if queue.is_dynamic:
+            # a dynamic queue is an always-on flowing mix of its sources; repeat has no meaning here
+            raise InvalidCommand("Cannot change repeat while the queue is in dynamic mode")
         if queue.repeat_mode == repeat_mode:
             return  # no change
         queue.repeat_mode = repeat_mode

--- a/music_assistant/controllers/player_queues/playback_tracker.py
+++ b/music_assistant/controllers/player_queues/playback_tracker.py
@@ -284,8 +284,8 @@ class PlaybackTrackerMixin(_PlayerQueuesBase):
             running_low = (
                 queue.current_index is not None and (queue.items - queue.current_index) < 5
             )
-            if queue.sources and running_low:
-                # an active dynamic source (incl. dynamic playlists/stations) keeps itself going
+            if queue.is_dynamic and running_low:
+                # a dynamic queue tops up its bounded managed pool from its (dynamic + finite) sources
                 task_id = f"fill_dynamic_tracks_{queue_id}"
                 self.mass.call_later(5, self._fill_dynamic_tracks, queue_id, task_id=task_id)
             elif queue.autoplay_enabled and queue.enqueued_media_items and running_low:

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -510,11 +510,11 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         if option not in (QueueOption.ADD, QueueOption.NEXT):
             queue.enqueued_media_items.clear()
 
-        # An ADD/NEXT onto a queue that already has dynamic sources keeps feeding its bounded pool;
-        # any other enqueue is not managed here (a REPLACE clears the sources above, and a dynamic
-        # playlist self-manages its own refills).
-        already_managed = bool(queue.sources) and option in (QueueOption.ADD, QueueOption.NEXT)
-        managed_pool = already_managed
+        # An ADD/NEXT onto a queue that is already a managed pool (has a dynamic source) keeps
+        # feeding that pool; any other enqueue starts fresh (a REPLACE clears the sources above,
+        # and a dynamic playlist self-manages its own refills). A finite-only queue has sources
+        # recorded too, so this keys off is_dynamic rather than bool(queue.sources).
+        already_dynamic = queue.is_dynamic and option in (QueueOption.ADD, QueueOption.NEXT)
 
         media_items: list[MediaItemType] = []
         source_items: list[MediaItemType] = []
@@ -586,23 +586,36 @@ class QueueLoaderMixin(_PlayerQueuesBase):
 
                 # collect media_items to play
                 if isinstance(media_item, Playlist) and media_item.is_dynamic:
-                    # Dynamic playlists/stations supply their own tracks on demand and keep their
-                    # self-managing refill path even inside a managed pool; fetch first batch now.
+                    # a dynamic playlist/station supplies its own tracks on demand; mark it played
                     self.mass.create_task(
                         self.mass.music.mark_item_played(
                             media_item, userid=queue.userid, queue_id=queue_id, user_initiated=True
                         )
                     )
-                    initial_tracks = await self._media_resolver.get_playlist_tracks(
-                        media_item, start_item=None
-                    )
-                    media_items += initial_tracks
-                elif managed_pool:
-                    # Managed-pool mode: keep the item as a dynamic source; the bounded pool is
-                    # built from these sources below (a finite source rotates its own tracks).
+                    if already_dynamic:
+                        # feed the already-active pool with this playlist's next self-managed batch
+                        media_items += await self._media_resolver.get_playlist_tracks(
+                            media_item, start_item=None
+                        )
+                    # otherwise the queue is entering dynamic mode below: the managed pool seeds the
+                    # first batch from all sources, so there is no need to fetch a batch here
+                elif already_dynamic:
+                    # feed the already-active pool: keep the finite item as a (materialized) source
                     if not isinstance(media_item, (ItemMapping, BrowseFolder)):
                         source_items.append(media_item)
                 else:
+                    # not (yet) a managed pool: record the finite parent as a source (kept for a
+                    # later dynamic transition and for similar/autoplay seeds) and expand it into
+                    # the linear queue
+                    if not isinstance(
+                        media_item, (ItemMapping, BrowseFolder)
+                    ) and media_item.media_type in (
+                        MediaType.TRACK,
+                        MediaType.ALBUM,
+                        MediaType.PLAYLIST,
+                        MediaType.ARTIST,
+                    ):
+                        source_items.append(media_item)
                     # Convert start_item to string URI if needed
                     start_item_uri: str | None = None
                     if isinstance(start_item, str):
@@ -630,7 +643,15 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         source_items = self._queue_data[queue_id].source_items
         queue.is_dynamic = has_dynamic_source(source_items)
 
-        if already_managed and not media_items:
+        if queue.is_dynamic and not already_dynamic:
+            # this enqueue introduced a dynamic source into a queue that wasn't a managed pool yet:
+            # rebuild the upcoming tail into a bounded, recency-orchestrated mix over ALL sources
+            # (existing finite content becomes materialized TRACKS seed(s), the added dynamic
+            # playlist(s) DYNAMIC seed(s)) instead of leaving a linear tail in front of the pool.
+            await self._enter_dynamic_mode(queue_id, option)
+            return
+
+        if already_dynamic and not media_items:
             # new sources were added to an already-active pool: leave the playing pool intact and
             # let the next top-up incorporate them
             self.signal_update(queue_id)
@@ -650,7 +671,49 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             raise MediaNotFoundError("No playable items found")
 
         # load the items into the queue (managed-pool tracks are already ordered, so don't reshuffle)
-        await self._enqueue_with_option(queue_id, queue_items, option, managed_pool)
+        await self._enqueue_with_option(queue_id, queue_items, option, already_dynamic)
+
+    async def _enter_dynamic_mode(self, queue_id: str, option: QueueOption | None) -> None:
+        """
+        Rebuild a queue's upcoming tail into a bounded managed pool as it enters dynamic mode.
+
+        Keeps the current track and everything before it, drops the (finite) upcoming tail, and
+        replaces it with a bounded, recency-orchestrated mix of all the queue's sources (finite
+        sources materialized as TRACKS seeds, dynamic playlists as DYNAMIC seeds). Shuffle is
+        enabled implicitly: a dynamic queue is always a smart mix.
+
+        :param queue_id: The queue entering dynamic mode.
+        :param option: The enqueue option that triggered the transition. PLAY/REPLACE (or an empty
+            queue) rebuild from the front and start playback; ADD/NEXT keep the current track playing
+            and only rebuild the tail behind it.
+        """
+        data = self._queue_data[queue_id]
+        queue = data.queue
+        # a dynamic queue is an always-on smart mix; reflect that in the (now locked) shuffle state
+        queue.shuffle_enabled = True
+        queue.smart_shuffle_active = self.is_smart_shuffle_active(queue)
+        if queue.current_index is not None and option in (QueueOption.ADD, QueueOption.NEXT):
+            # keep the current track + history playing; rebuild only the tail behind it
+            insert_at = queue.current_index + 1
+            start_playing = False
+        else:
+            # fresh start (PLAY/REPLACE or an empty queue): the pool becomes the whole upcoming queue
+            insert_at = queue.current_index + 1 if queue.current_index is not None else 0
+            start_playing = True
+        # drop the finite upcoming tail up front so the pool is sized and deduped against the kept
+        # head only (the tail we are discarding must not exclude its own tracks from the new pool)
+        data.items = data.items[:insert_at]
+        queue.items = len(data.items)
+        pool_tracks = await self._managed_pool.fill(queue_id, is_initial=False)
+        queue_items = [
+            QueueItem.from_media_item(queue_id, track) for track in pool_tracks if track.available
+        ]
+        if not queue_items:
+            raise MediaNotFoundError("No playable items found")
+        # the managed pool already interleaved the sources in a recency-aware order; load as-is
+        await self.load(queue_id, queue_items, insert_at_index=insert_at, keep_remaining=False)
+        if start_playing:
+            await self.play_index(queue_id, insert_at)
 
     async def _get_similar_tracks(
         self,

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -684,22 +684,24 @@ class QueueLoaderMixin(_PlayerQueuesBase):
 
         :param queue_id: The queue entering dynamic mode.
         :param option: The enqueue option that triggered the transition. PLAY/REPLACE (or an empty
-            queue) rebuild from the front and start playback; ADD/NEXT keep the current track playing
-            and only rebuild the tail behind it.
+            queue) start playback on the rebuilt pool; ADD/NEXT/REPLACE_NEXT keep the current track
+            playing and only rebuild the tail behind it.
         """
         data = self._queue_data[queue_id]
         queue = data.queue
         # a dynamic queue is an always-on smart mix; reflect that in the (now locked) shuffle state
         queue.shuffle_enabled = True
         queue.smart_shuffle_active = self.is_smart_shuffle_active(queue)
-        if queue.current_index is not None and option in (QueueOption.ADD, QueueOption.NEXT):
-            # keep the current track + history playing; rebuild only the tail behind it
-            insert_at = queue.current_index + 1
-            start_playing = False
-        else:
-            # fresh start (PLAY/REPLACE or an empty queue): the pool becomes the whole upcoming queue
-            insert_at = queue.current_index + 1 if queue.current_index is not None else 0
+        if queue.current_index is None:
+            # nothing is playing yet (REPLACE cleared the queue, or it was empty): the pool becomes
+            # the whole queue and playback starts on it
+            insert_at = 0
             start_playing = True
+        else:
+            insert_at = queue.current_index + 1
+            # PLAY/REPLACE restart playback on the rebuilt pool; ADD/NEXT/REPLACE_NEXT keep the
+            # current track playing and only rebuild the tail behind it
+            start_playing = option in (QueueOption.PLAY, QueueOption.REPLACE)
         # drop the finite upcoming tail up front so the pool is sized and deduped against the kept
         # head only (the tail we are discarding must not exclude its own tracks from the new pool)
         data.items = data.items[:insert_at]

--- a/tests/integration/test_dynamic_mode_e2e.py
+++ b/tests/integration/test_dynamic_mode_e2e.py
@@ -1,0 +1,159 @@
+"""
+End-to-end tests for a queue entering "dynamic mode" through the real queue controller.
+
+Boots a hermetic MusicAssistant (fake `test` provider + demo players) and exercises the
+source-recording and finite->dynamic transition: playing a finite source records it as a source
+even while the queue stays linear, and introducing a dynamic source rebuilds the upcoming tail
+into a bounded, smart-shuffled managed pool over ALL the queue's sources. Shuffle and repeat are
+locked (implicit) while the queue is dynamic.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from music_assistant_models.enums import QueueOption, RepeatMode
+from music_assistant_models.errors import InvalidCommand
+from music_assistant_models.media_items import Playlist
+
+from music_assistant.controllers.player_queues import managed_pool
+from music_assistant.controllers.player_queues.constants import MANAGED_POOL_MAX
+from music_assistant.mass import MusicAssistant
+from music_assistant.models.music_provider import MusicProvider
+from music_assistant.providers.radio_playlist import radio_playlist_uri
+
+from .conftest import demo_players, wait_for
+
+if TYPE_CHECKING:
+    from music_assistant_models.media_items import Album, ItemMapping, MediaItemType
+
+
+async def _play_finite_album(mass: MusicAssistant, queue_id: str, album_id: str = "0_0") -> Album:
+    """Play a finite album linearly and wait until it is the active (non-dynamic) queue."""
+    test_prov = cast("MusicProvider", mass.get_provider("test"))
+    assert test_prov is not None
+    album = await test_prov.get_album(album_id)  # 20 tracks: <album_id>_0 .. <album_id>_19
+    await mass.player_queues.play_media(queue_id, cast("MediaItemType | ItemMapping | str", album))
+    assert await wait_for(
+        lambda: (q := mass.player_queues.get(queue_id)) is not None and q.current_index is not None
+    ), "album never started playing"
+    return album
+
+
+async def _add_dynamic_playlist(mass: MusicAssistant, queue_id: str, seed_id: str = "4_4_0") -> str:
+    """Add a dynamic radio playlist (seeded from a track) to the queue and return its uri."""
+    test_prov = cast("MusicProvider", mass.get_provider("test"))
+    assert test_prov is not None
+    seed = await test_prov.get_track(seed_id)
+    uri = radio_playlist_uri(seed)
+    await mass.player_queues.play_media(queue_id, uri, option=QueueOption.ADD)
+    return uri
+
+
+@pytest.mark.asyncio
+async def test_finite_source_recorded_even_while_linear(e2e_mass: MusicAssistant) -> None:
+    """Playing a finite album records it as a source, but the queue stays linear (not dynamic)."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    album = await _play_finite_album(e2e_mass, queue_id)
+
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    # a finite-only queue is NOT dynamic even though its source is recorded ...
+    assert queue.is_dynamic is False
+    # ... and the whole album is enqueued linearly (no bounded pool yet)
+    assert len(e2e_mass.player_queues.items(queue_id)) == 20
+    # the finite source is recorded server-side and projected onto the wire `sources`
+    data = e2e_mass.player_queues._queue_data[queue_id]
+    assert [item.uri for item in data.source_items] == [album.uri]
+    assert [mapping.uri for mapping in queue.sources] == [album.uri]
+
+
+@pytest.mark.asyncio
+async def test_source_items_records_finite_and_dynamic(e2e_mass: MusicAssistant) -> None:
+    """Adding a dynamic playlist to a finite queue records BOTH the finite and dynamic sources."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    album = await _play_finite_album(e2e_mass, queue_id)
+    await _add_dynamic_playlist(e2e_mass, queue_id)
+
+    data = e2e_mass.player_queues._queue_data[queue_id]
+    source_uris = {item.uri for item in data.source_items}
+    # the finite album is still a source, now mixed with the dynamic playlist
+    assert album.uri in source_uris
+    assert any(isinstance(item, Playlist) and item.is_dynamic for item in data.source_items)
+
+
+@pytest.mark.asyncio
+async def test_finite_then_dynamic_rebuilds_tail_into_bounded_pool(
+    e2e_mass: MusicAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Adding a dynamic source collapses the finite tail into a bounded mix of all sources."""
+    # shrink the pool target so the collapse is visible against a 20-track album
+    monkeypatch.setattr(managed_pool, "MANAGED_POOL_TARGET", 10)
+    queue_id = demo_players(e2e_mass)[0].player_id
+    await _play_finite_album(e2e_mass, queue_id)
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    assert queue.current_item is not None
+    playing_id = queue.current_item.media_item.item_id if queue.current_item.media_item else None
+    assert playing_id == "0_0_0"
+
+    await _add_dynamic_playlist(e2e_mass, queue_id)
+
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    assert queue.current_index is not None
+    # the queue is now a managed pool ...
+    assert queue.is_dynamic is True
+    items = e2e_mass.player_queues.items(queue_id)
+    tail_ids = [
+        item.media_item.item_id for item in items[queue.current_index + 1 :] if item.media_item
+    ]
+    # ... whose upcoming tail is bounded, not the whole 20-track album left in front of the pool
+    assert 0 < len(tail_ids) <= MANAGED_POOL_MAX
+    all_ids = [item.media_item.item_id for item in items if item.media_item]
+    assert len([tid for tid in all_ids if tid.startswith("0_0_")]) < 20
+    # the current track is kept playing across the rebuild
+    assert queue.current_item is not None
+    assert queue.current_item.media_item is not None
+    assert queue.current_item.media_item.item_id == "0_0_0"
+    # the bounded mix draws from BOTH the finite album (0_0_*) and the dynamic playlist (others)
+    assert any(tid.startswith("0_0_") for tid in tail_ids)
+    assert any(not tid.startswith("0_0_") for tid in tail_ids)
+
+
+@pytest.mark.asyncio
+async def test_entering_dynamic_mode_enables_smart_shuffle(e2e_mass: MusicAssistant) -> None:
+    """Transitioning into dynamic mode auto-enables (implicit) shuffle + smart shuffle."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    await _play_finite_album(e2e_mass, queue_id)
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    # a plain linear album starts with shuffle off and smart shuffle inactive
+    assert queue.shuffle_enabled is False
+    assert queue.smart_shuffle_active is False
+
+    await _add_dynamic_playlist(e2e_mass, queue_id)
+
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    assert queue.is_dynamic is True
+    # dynamic mode is an always-on smart mix; the state reflects that
+    assert queue.shuffle_enabled is True
+    assert queue.smart_shuffle_active is True
+
+
+@pytest.mark.asyncio
+async def test_shuffle_and_repeat_locked_while_dynamic(e2e_mass: MusicAssistant) -> None:
+    """Shuffle and repeat toggles are rejected while the queue is in dynamic mode."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    await _play_finite_album(e2e_mass, queue_id)
+    await _add_dynamic_playlist(e2e_mass, queue_id)
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    assert queue.is_dynamic is True
+
+    with pytest.raises(InvalidCommand):
+        await e2e_mass.player_queues.set_shuffle(queue_id, False)
+    with pytest.raises(InvalidCommand):
+        e2e_mass.player_queues.set_repeat(queue_id, RepeatMode.ALL)

--- a/tests/integration/test_dynamic_mode_e2e.py
+++ b/tests/integration/test_dynamic_mode_e2e.py
@@ -144,6 +144,36 @@ async def test_entering_dynamic_mode_enables_smart_shuffle(e2e_mass: MusicAssist
 
 
 @pytest.mark.asyncio
+async def test_replace_next_dynamic_keeps_current_track_playing(e2e_mass: MusicAssistant) -> None:
+    """REPLACE_NEXT with a dynamic source rebuilds the tail without interrupting the current track."""
+    queue_id = demo_players(e2e_mass)[0].player_id
+    await _play_finite_album(e2e_mass, queue_id)
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    assert queue.current_item is not None
+    assert queue.current_item.media_item is not None
+    playing_before = queue.current_item.media_item.item_id
+
+    test_prov = cast("MusicProvider", e2e_mass.get_provider("test"))
+    assert test_prov is not None
+    seed = await test_prov.get_track("4_4_0")
+    await e2e_mass.player_queues.play_media(
+        queue_id, radio_playlist_uri(seed), option=QueueOption.REPLACE_NEXT
+    )
+
+    queue = e2e_mass.player_queues.get(queue_id)
+    assert queue is not None
+    assert queue.is_dynamic is True
+    # the current track keeps playing across the tail rebuild (REPLACE_NEXT does not jump playback)
+    assert queue.current_item is not None
+    assert queue.current_item.media_item is not None
+    assert queue.current_item.media_item.item_id == playing_before
+    # the upcoming tail was replaced by the managed pool
+    assert queue.current_index is not None
+    assert len(e2e_mass.player_queues.items(queue_id)) > queue.current_index + 1
+
+
+@pytest.mark.asyncio
 async def test_shuffle_and_repeat_locked_while_dynamic(e2e_mass: MusicAssistant) -> None:
     """Shuffle and repeat toggles are rejected while the queue is in dynamic mode."""
     queue_id = demo_players(e2e_mass)[0].player_id


### PR DESCRIPTION
A queue could already mix finite sources (albums/playlists) with dynamic sources (radio playlists/stations) into a bounded managed pool, but only when a dynamic source was present from the start. Playing a finite playlist A and *then* adding a dynamic playlist B left the queue in a half-state: B became a dynamic source and `is_dynamic` flipped true, but A's already-expanded tracks stayed linearly in front of B's pool, and `is_smart_shuffle_active` reported a smart mix that wasn't actually smart-ordered. This completes dynamic mode so a queue with **one or more** dynamic sources is always a single bounded, smart-shuffled managed pool over **all** of its sources.

- Record every parent source added to a queue — finite *and* dynamic — on `PlayerQueueData.source_items` (projected onto `queue.sources`), not just dynamic playlists. Playing playlist A now records A as a source before any dynamic source exists.
- When an enqueue introduces a dynamic source into a queue that isn't a managed pool yet, rebuild the queue *after the current index* into a full dynamic pool: keep the current track and everything before it, feed the existing finite content in as materialize-once `TRACKS` seed(s) and the added dynamic playlist(s) as `DYNAMIC` seed(s), and let the managed pool interleave them (recency-aware, weighted). A's long tail collapses to a bounded mix, refilled at the tail — nothing is lost, A's tracks just become a seed pool interleaved with B over time.
- Auto-enable shuffle + smart shuffle when a queue enters dynamic mode, so `is_smart_shuffle_active` genuinely reflects the ordering.
- Reject `set_shuffle` / `set_repeat` with `InvalidCommand` while a queue is dynamic — the pool is always an orchestrated smart mix, so manual shuffle/linear/repeat have no meaning (the frontend hides these controls; the server enforces it defensively).

"Dynamic mode" now keys off `is_dynamic` (a dynamic source is present) rather than "has any source", so a finite-only queue with recorded sources stays a plain linear queue and keeps using autoplay instead of the managed-pool refill. For linear listening, play a playlist without adding a dynamic source.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`
