### PR TITLE
Fix first queued item being skipped when playing onto an idle queue (backport)

### DIFF
--- a/music_assistant/controllers/player_queues.py
+++ b/music_assistant/controllers/player_queues.py
@@ -1552,13 +1552,16 @@ class PlayerQueuesController(CoreController):
             return
         # handle play: replace current loaded/playing index with new item(s)
         if option == QueueOption.PLAY:
+            # an idle/empty queue has no current item to insert after, so insert at and
+            # start from the very first index instead of skipping past it
+            play_at_index = 0 if queue.current_index is None else insert_at_index
             await self.load(
                 queue_id,
                 queue_items=queue_items,
-                insert_at_index=insert_at_index,
+                insert_at_index=play_at_index,
                 shuffle=shuffle,
             )
-            next_index = min(insert_at_index, len(self._queue_items[queue_id]) - 1)
+            next_index = min(play_at_index, len(self._queue_items[queue_id]) - 1)
             await self.play_index(queue_id, next_index)
             return
         # handle add: add/append item(s) to the remaining queue items

--- a/tests/core/test_player_queues_enqueue_options.py
+++ b/tests/core/test_player_queues_enqueue_options.py
@@ -1,0 +1,77 @@
+"""
+Tests for the enqueue-option handling in the player-queues controller.
+
+These exercise ``PlayerQueuesController._enqueue_with_option`` against a bare controller
+instance. The real ``load`` and ``update_items`` run so the insert position is verified
+end-to-end; only the side-effecting ``play_index`` and ``signal_update`` are stubbed out.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+from music_assistant_models.enums import PlaybackState, QueueOption
+from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.queue_item import QueueItem
+
+from music_assistant.controllers.player_queues import PlayerQueuesController
+
+
+def _controller() -> PlayerQueuesController:
+    """Create a bare controller instance with the noisy ``signal_update`` stubbed out."""
+    ctrl = PlayerQueuesController.__new__(PlayerQueuesController)
+    ctrl.signal_update = Mock()  # type: ignore[method-assign]
+    return ctrl
+
+
+def _items(queue_id: str, names: list[str]) -> list[QueueItem]:
+    """Build a list of simple queue items with the given names."""
+    return [
+        QueueItem(queue_id=queue_id, queue_item_id=name, name=name, duration=60) for name in names
+    ]
+
+
+async def test_play_on_idle_queue_starts_at_first_item() -> None:
+    """PLAY with multiple items onto an idle/empty queue plays the first item, not the second."""
+    ctrl = _controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queues = {"q1": queue}
+    ctrl._queue_items = {"q1": []}
+    items = _items("q1", ["a", "b", "c"])
+
+    await ctrl._enqueue_with_option("q1", items, QueueOption.PLAY, radio_mode=False)
+
+    # the items are loaded from the very start and playback begins at the first one
+    assert ctrl._queue_items["q1"][0] is items[0]
+    assert len(ctrl._queue_items["q1"]) == 3
+    play_index.assert_awaited_once_with("q1", 0)
+
+
+async def test_play_on_active_queue_inserts_after_current() -> None:
+    """PLAY on an active queue keeps inserting right after the current index and jumps to it."""
+    ctrl = _controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    ctrl.get_next_item = Mock(return_value=None)  # type: ignore[method-assign]
+    existing = _items("q1", ["e0", "e1", "e2"])
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=len(existing),
+        state=PlaybackState.PLAYING,
+        current_index=2,
+        index_in_buffer=2,
+    )
+    ctrl._queues = {"q1": queue}
+    ctrl._queue_items = {"q1": list(existing)}
+    new_items = _items("q1", ["n0", "n1"])
+
+    await ctrl._enqueue_with_option("q1", new_items, QueueOption.PLAY, radio_mode=False)
+
+    # inserted right after the current/buffered index (2) and playback jumps there
+    assert ctrl._queue_items["q1"][3] is new_items[0]
+    play_index.assert_awaited_once_with("q1", 3)


### PR DESCRIPTION
## What does this implement/fix?

Manual backport of #4514 to `stable` (the auto-backport can't apply — `dev` has the fully refactored player-queues package, incompatible with stable's single-module controller).

`PLAY` onto an idle or empty queue started playback at the **second** enqueued item instead of the first. On an idle queue `current_index` is `None`, so `insert_at_index` resolved to `1` and `play_index()` jumped past index `0` — skipping the first track whenever several items were enqueued at once (e.g. playing an album or a multi-track selection onto a stopped player).

`PLAY` now inserts at and starts from index `0` when the queue is idle/empty. Active-queue behaviour is unchanged (insert right after the current/buffered index and jump to it), and the `NEXT` / `ADD` / `REPLACE_NEXT` branches are untouched.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
