### PR TITLE
Handle expired/revoked Spotify refresh tokens and missing rotation - stable branch

### DIFF
--- a/music_assistant/providers/spotify/helpers.py
+++ b/music_assistant/providers/spotify/helpers.py
@@ -75,14 +75,20 @@ async def get_spotify_token(
         ) as response:
             if response.status != 200:
                 err = await response.text()
-                if "revoked" in err:
-                    raise LoginFailed(f"Token revoked for {session_name}: {err}")
+                # invalid_grant means the refresh token is revoked or expired (Spotify
+                # enforces a 6-month lifetime); retrying won't recover it, so fail now and
+                # let the caller clear the stored token and prompt re-authentication.
+                if "invalid_grant" in err or "revoked" in err:
+                    raise LoginFailed(f"Refresh token no longer valid for {session_name}: {err}")
                 # the token failed to refresh, we allow one retry
                 await asyncio.sleep(2)
                 continue
             # if we reached this point, the token has been successfully refreshed
             auth_info: dict[str, Any] = await response.json()
             auth_info["expires_at"] = int(auth_info["expires_in"] + time.time())
+            # Spotify only returns a refresh_token when it rotates one; when the response
+            # omits it, keep using the existing token (per Spotify's refresh-token docs).
+            auth_info.setdefault("refresh_token", refresh_token)
             return auth_info
 
     raise LoginFailed(f"Failed to refresh {session_name} access token: {err}")

--- a/music_assistant/providers/spotify/provider.py
+++ b/music_assistant/providers/spotify/provider.py
@@ -872,8 +872,8 @@ class SpotifyProvider(MusicProvider):
             )
             self.logger.debug("Successfully refreshed global access token")
         except LoginFailed as err:
-            if "revoked" in str(err):
-                # clear refresh token if it's invalid
+            if "revoked" in str(err) or "invalid_grant" in str(err):
+                # clear refresh token if it's revoked or expired
                 self._update_config_value(CONF_REFRESH_TOKEN_GLOBAL, None)
                 if self.available:
                     self.unload_with_error(str(err))
@@ -933,8 +933,8 @@ class SpotifyProvider(MusicProvider):
             )
             self.logger.debug("Successfully refreshed developer access token")
         except LoginFailed as err:
-            if "revoked" in str(err):
-                # clear refresh token if it's invalid
+            if "revoked" in str(err) or "invalid_grant" in str(err):
+                # clear refresh token if it's revoked or expired
                 self._update_config_value(CONF_REFRESH_TOKEN_DEV, None)
                 self._update_config_value(CONF_CLIENT_ID, None)
             # Don't unload - we can still use the global session


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Stable branch version of https://github.com/music-assistant/server/pull/4494

Sources:
https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration
https://developer.spotify.com/documentation/web-api/tutorials/refreshing-tokens

Spotify has changed how refresh tokens work: they no longer always return a new refresh token when you refresh an access token, and they've introduced a 6-month expiry on them. The first change was crashing setup with a custom client ID (KeyError: 'refresh_token'), leaving the provider stuck in "requires attention". We now keep using the existing token when Spotify doesn't send a new one (as their docs instruct).

For the second change, an expired token now returns invalid_grant, which we treat as unrecoverable, clearing the stored credentials and prompting re-authentication rather than silently failing to refresh.

**Related issue (if applicable):**

- related issue https://github.com/orgs/music-assistant/discussions/5719

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
