### PR TITLE
Revert squeezelite-local media_position workaround (#4504)

### DIFF
--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -437,7 +437,6 @@ class SqueezelitePlayer(Player):
             # We need this because some players (e.g. WiiM) keep sending increasing elapsed time
             self._attr_elapsed_time_last_updated = time.time()
         # Update current media if available
-        old_item_id = self._attr_current_media.queue_item_id if self._attr_current_media else None
         if self.client.current_media and (metadata := self.client.current_media.metadata):
             self._attr_current_media = PlayerMedia(
                 uri=metadata.get("item_id"),
@@ -451,11 +450,6 @@ class SqueezelitePlayer(Player):
             )
         else:
             self._attr_current_media = None
-        new_item_id = self._attr_current_media.queue_item_id if self._attr_current_media else None
-        if old_item_id is not None and new_item_id is not None and old_item_id != new_item_id:
-            # elapsed still reflects the previous track until the next STMt heartbeat (support#3704)
-            self._attr_elapsed_time = 0
-            self._attr_elapsed_time_last_updated = time.time()
 
     async def _handle_play_url_for_slimplayer(
         self,


### PR DESCRIPTION
# What does this implement/fix?

Reverts #4504, which reset the Squeezelite player's elapsed time on a queue-item
change to work around the progress bar showing the previous track's position
after a track change (support#3704).

That workaround was in the wrong layer and didn't actually fix the issue: Home
Assistant derives `media_position` from the **queue's** `elapsed_time`, not the
player's, and the player-level reset was clobbered by the next `STMt` heartbeat.

## Root cause & real fix

The bug is Squeezelite-specific. `aioslimproto` never reset its elapsed baseline
when a new stream started (and kept reporting the flushed stream's trailing
heartbeats), so after a seek or gapless track change the client reported the
previous track's position. Other players (Sonos, Chromecast) reset per stream
and are unaffected — verified live.

Fixed at the source, with the client relaying the corrected value to consumers:

- aioslimproto: https://github.com/music-assistant/aioslimproto/pull/530
- client: https://github.com/music-assistant/client/pull/194

This PR just removes the now-superseded provider-local workaround.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/3704

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. _(pure revert — no test needed)_
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.