### PR TITLE
Honour play-next under shuffle and set the current item when enqueuing onto an empty queue

### DIFF
--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -103,12 +103,30 @@ class QueueLoaderMixin(_PlayerQueuesBase):
             return
         # handle next: add item(s) in the index next to the playing/loaded/buffered index
         if option == QueueOption.NEXT:
-            await self.load(
-                queue_id,
-                queue_items=queue_items,
-                insert_at_index=insert_at_index,
-                shuffle=shuffle,
-            )
+            if shuffle:
+                # honour "play next" under shuffle: the first new item goes right after the
+                # buffered index so it plays next, the rest of the batch is shuffled into the tail
+                # behind it. insert_at_index is the first un-buffered slot, so the track the player
+                # already prepared for crossfade is left untouched.
+                await self.load(
+                    queue_id,
+                    queue_items=queue_items[:1],
+                    insert_at_index=insert_at_index,
+                )
+                await self.load(
+                    queue_id,
+                    queue_items=queue_items[1:],
+                    insert_at_index=insert_at_index + 1,
+                    shuffle=True,
+                )
+            else:
+                await self.load(
+                    queue_id,
+                    queue_items=queue_items,
+                    insert_at_index=insert_at_index,
+                    shuffle=shuffle,
+                )
+            self._ensure_current_index(queue_id)
             return
         if option == QueueOption.REPLACE_NEXT:
             await self.load(
@@ -118,6 +136,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                 keep_remaining=False,
                 shuffle=shuffle,
             )
+            self._ensure_current_index(queue_id)
             return
         # handle play: replace current loaded/playing index with new item(s)
         if option == QueueOption.PLAY:
@@ -152,13 +171,24 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                 # managed-pool tracks are already ordered in a pattern we want to keep
                 shuffle=queue.shuffle_enabled and not managed_pool,
             )
-            # handle edgecase, queue is empty and items are only added (not played)
-            # mark first item as new index
-            if queue.current_index is None:
-                queue.current_index = 0
-                queue.current_item = self.get_item(queue_id, 0)
-                queue.items = len(queue_items)
-                self.signal_update(queue_id)
+            self._ensure_current_index(queue_id)
+
+    def _ensure_current_index(self, queue_id: str) -> None:
+        """
+        Point the current index at the first item when the queue does not have one yet.
+
+        NEXT/ADD/REPLACE_NEXT stage items without starting playback; on an empty queue there is no
+        current index, so set it to the first item to give the queue a current item. A queue that
+        already has content keeps its current index untouched (its items are inserted after it).
+
+        :param queue_id: The queue to update.
+        """
+        queue = self._queue_data[queue_id].queue
+        if queue.current_index is not None:
+            return
+        queue.current_index = 0
+        queue.current_item = self.get_item(queue_id, 0)
+        self.signal_update(queue_id)
 
     async def _load_item(
         self,

--- a/tests/controllers/player_queues/test_enqueue_options.py
+++ b/tests/controllers/player_queues/test_enqueue_options.py
@@ -75,3 +75,122 @@ async def test_play_on_active_queue_inserts_after_current() -> None:
     # inserted right after the current/buffered index (2) and playback jumps there
     assert ctrl._queue_data["q1"].items[3] is new_items[0]
     play_index.assert_awaited_once_with("q1", 3)
+
+
+async def test_next_shuffle_pins_first_item_and_shuffles_rest() -> None:
+    """NEXT with shuffle on pins the first new item after the buffered index, shuffles the rest."""
+    ctrl = _controller()
+    ctrl.play_index = AsyncMock()  # type: ignore[method-assign]
+    ctrl.get_next_item = Mock(return_value=None)  # type: ignore[method-assign]
+    # keep the shuffle deterministic-enough: pure random of the "rest", first item stays pinned
+    ctrl._smart_shuffle = Mock()
+    ctrl._smart_shuffle.is_enabled = Mock(return_value=False)
+    existing = _items("q1", ["e0", "e1", "e2"])
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=len(existing),
+        state=PlaybackState.PLAYING,
+        current_index=0,
+        index_in_buffer=0,
+        shuffle_enabled=True,
+    )
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue, items=list(existing))}
+    new_items = _items("q1", ["n0", "n1"])
+
+    await ctrl._enqueue_with_option("q1", new_items, QueueOption.NEXT, managed_pool=False)
+
+    items = ctrl._queue_data["q1"].items
+    # the first new item is pinned right after the buffered index (0) so it plays next
+    assert items[0] is existing[0]
+    assert items[1] is new_items[0]
+    # the rest of the batch and the existing unplayed tail are shuffled together behind it
+    assert {item.queue_item_id for item in items[2:]} == {"n1", "e1", "e2"}
+    ctrl.play_index.assert_not_awaited()
+
+
+async def test_next_shuffle_single_item_keeps_tail_order() -> None:
+    """A single-item NEXT inserts at the buffered index+1 without re-arranging the tail."""
+    ctrl = _controller()
+    ctrl.play_index = AsyncMock()  # type: ignore[method-assign]
+    ctrl.get_next_item = Mock(return_value=None)  # type: ignore[method-assign]
+    existing = _items("q1", ["e0", "e1", "e2"])
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=len(existing),
+        state=PlaybackState.PLAYING,
+        current_index=0,
+        index_in_buffer=0,
+        shuffle_enabled=True,
+    )
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue, items=list(existing))}
+    new_items = _items("q1", ["n0"])
+
+    await ctrl._enqueue_with_option("q1", new_items, QueueOption.NEXT, managed_pool=False)
+
+    # inserted right after the buffered index; the existing tail keeps its order (no reshuffle)
+    assert [item.queue_item_id for item in ctrl._queue_data["q1"].items] == ["e0", "n0", "e1", "e2"]
+    ctrl.play_index.assert_not_awaited()
+
+
+async def test_next_on_empty_queue_sets_current_index_without_playing() -> None:
+    """NEXT onto an empty queue stages the items and points the current index at the first one."""
+    ctrl = _controller()
+    ctrl.play_index = AsyncMock()  # type: ignore[method-assign]
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    items = _items("q1", ["a", "b", "c"])
+
+    await ctrl._enqueue_with_option("q1", items, QueueOption.NEXT, managed_pool=False)
+
+    assert [item.queue_item_id for item in ctrl._queue_data["q1"].items] == ["a", "b", "c"]
+    assert queue.current_index == 0
+    assert queue.current_item is items[0]
+    ctrl.play_index.assert_not_awaited()
+
+
+async def test_replace_next_on_empty_queue_sets_current_index_without_playing() -> None:
+    """REPLACE_NEXT onto an empty queue stages the items and sets the current index."""
+    ctrl = _controller()
+    ctrl.play_index = AsyncMock()  # type: ignore[method-assign]
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    items = _items("q1", ["a", "b"])
+
+    await ctrl._enqueue_with_option("q1", items, QueueOption.REPLACE_NEXT, managed_pool=False)
+
+    assert [item.queue_item_id for item in ctrl._queue_data["q1"].items] == ["a", "b"]
+    assert queue.current_index == 0
+    assert queue.current_item is items[0]
+    ctrl.play_index.assert_not_awaited()
+
+
+async def test_next_on_idle_queue_with_content_keeps_current_index() -> None:
+    """NEXT on an idle queue that has content leaves the current index and inserts after it."""
+    ctrl = _controller()
+    ctrl.play_index = AsyncMock()  # type: ignore[method-assign]
+    existing = _items("q1", ["e0", "e1", "e2"])
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=len(existing),
+        state=PlaybackState.IDLE,
+        current_index=1,
+    )
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue, items=list(existing))}
+    new_items = _items("q1", ["n0"])
+
+    await ctrl._enqueue_with_option("q1", new_items, QueueOption.NEXT, managed_pool=False)
+
+    items = ctrl._queue_data["q1"].items
+    # current index is untouched; the new item is inserted right after it
+    assert queue.current_index == 1
+    assert [item.queue_item_id for item in items] == ["e0", "e1", "n0", "e2"]
+    ctrl.play_index.assert_not_awaited()


### PR DESCRIPTION
## What does this implement/fix?

Two enqueue-behaviour fixes for when shuffle is on / the queue is empty:

- **NEXT under shuffle** now honours "play next": the first new item is pinned right after the buffered index so it actually plays next, and the rest of the batch is smart-shuffled into the tail behind it. Previously the whole batch was shuffled into the tail, so a "play next" item could land anywhere. The already-buffered (crossfade-prepped) track is left untouched.
- **NEXT / REPLACE_NEXT onto an empty queue** now point the current index at the first item (mirroring ADD) so the queue has a current item, without starting playback. The existing ADD edge-case is factored into a shared helper so all three stay consistent.

Single items are unchanged (inserted at their slot, no tail re-arrange) and dynamic-mode (managed pool) is unaffected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
