### PR TITLE
Add duration and last_played filters to Smart Playlist

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import os
 import random
+import time
 import uuid as _uuid
 from collections.abc import Callable
 from contextlib import suppress
@@ -671,6 +672,19 @@ class SmartPlaylistProvider(PluginProvider):
                 allowed_album_ids = await self._get_album_ids_for_types(rules.album_types)
                 tracks = self._filter_by_album_ids(tracks, allowed_album_ids)
 
+            # Apply duration filters
+            if rules.min_duration is not None:
+                tracks = [t for t in tracks if t.duration and t.duration >= rules.min_duration]
+            if rules.max_duration is not None:
+                tracks = [t for t in tracks if t.duration and t.duration <= rules.max_duration]
+
+            # Apply last_played filter (tracks not played in X days)
+            if rules.last_played_before_days is not None:
+                threshold_timestamp = int(time.time()) - (rules.last_played_before_days * 86400)
+                tracks = [
+                    t for t in tracks if t.last_played == 0 or t.last_played < threshold_timestamp
+                ]
+
             # In non-seed mode, _evaluate_and/_evaluate_or already query by genre_ids.
             # Only enrich if excluded_genre_ids is set (needs track.metadata.genres).
             if rules.excluded_genre_ids:
@@ -750,6 +764,20 @@ class SmartPlaylistProvider(PluginProvider):
         if rules.album_types:
             allowed_album_ids = await self._get_album_ids_for_types(rules.album_types)
             tracks = self._filter_by_album_ids(tracks, allowed_album_ids)
+
+        # Apply duration filters in seed mode
+        if rules.min_duration is not None:
+            tracks = [t for t in tracks if t.duration and t.duration >= rules.min_duration]
+        if rules.max_duration is not None:
+            tracks = [t for t in tracks if t.duration and t.duration <= rules.max_duration]
+
+        # Apply last_played filter in seed mode
+        if rules.last_played_before_days is not None:
+            threshold_timestamp = int(time.time()) - (rules.last_played_before_days * 86400)
+            tracks = [
+                t for t in tracks if t.last_played == 0 or t.last_played < threshold_timestamp
+            ]
+
         return tracks
 
     def _apply_exclusions(

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -129,6 +129,44 @@ def _filter_by_explicit(tracks: list[Track], explicit_rule: bool | None) -> list
     return tracks
 
 
+def _filter_by_duration(
+    tracks: list[Track], min_duration: int | None, max_duration: int | None
+) -> list[Track]:
+    """
+    Filter tracks based on duration bounds.
+
+    :param tracks: List of tracks to filter.
+    :param min_duration: Minimum duration in seconds (None = no minimum).
+    :param max_duration: Maximum duration in seconds (None = no maximum).
+    :return: Filtered list of tracks.
+    """
+    if min_duration is not None:
+        tracks = [t for t in tracks if t.duration and t.duration >= min_duration]
+    if max_duration is not None:
+        tracks = [t for t in tracks if t.duration and t.duration <= max_duration]
+    return tracks
+
+
+def _filter_by_last_played(tracks: list[Track], value: int | None, unit: str | None) -> list[Track]:
+    """
+    Filter tracks not played within a specified time period.
+
+    :param tracks: List of tracks to filter.
+    :param value: Time value (None = no filter).
+    :param unit: Time unit: "hours", "days", "weeks", "months" (None = no filter).
+    :return: Filtered list of tracks not played in the specified period (includes never-played).
+    """
+    if value is None or unit is None:
+        return tracks
+
+    # Convert to seconds based on unit
+    seconds_per_unit = {"hours": 3600, "days": 86400, "weeks": 604800, "months": 2592000}
+    seconds = value * seconds_per_unit.get(unit, 86400)  # Default to days if unknown
+
+    threshold_timestamp = int(time.time()) - seconds
+    return [t for t in tracks if not t.last_played or t.last_played < threshold_timestamp]
+
+
 class SmartPlaylistProvider(PluginProvider):
     """Smart Playlist plugin provider for Music Assistant."""
 
@@ -672,18 +710,11 @@ class SmartPlaylistProvider(PluginProvider):
                 allowed_album_ids = await self._get_album_ids_for_types(rules.album_types)
                 tracks = self._filter_by_album_ids(tracks, allowed_album_ids)
 
-            # Apply duration filters
-            if rules.min_duration is not None:
-                tracks = [t for t in tracks if t.duration and t.duration >= rules.min_duration]
-            if rules.max_duration is not None:
-                tracks = [t for t in tracks if t.duration and t.duration <= rules.max_duration]
-
-            # Apply last_played filter (tracks not played in X days)
-            if rules.last_played_before_days is not None:
-                threshold_timestamp = int(time.time()) - (rules.last_played_before_days * 86400)
-                tracks = [
-                    t for t in tracks if t.last_played == 0 or t.last_played < threshold_timestamp
-                ]
+            # Apply duration and last_played filters
+            tracks = _filter_by_duration(tracks, rules.min_duration, rules.max_duration)
+            tracks = _filter_by_last_played(
+                tracks, rules.last_played_before_value, rules.last_played_before_unit
+            )
 
             # In non-seed mode, _evaluate_and/_evaluate_or already query by genre_ids.
             # Only enrich if excluded_genre_ids is set (needs track.metadata.genres).
@@ -765,20 +796,11 @@ class SmartPlaylistProvider(PluginProvider):
             allowed_album_ids = await self._get_album_ids_for_types(rules.album_types)
             tracks = self._filter_by_album_ids(tracks, allowed_album_ids)
 
-        # Apply duration filters in seed mode
-        if rules.min_duration is not None:
-            tracks = [t for t in tracks if t.duration and t.duration >= rules.min_duration]
-        if rules.max_duration is not None:
-            tracks = [t for t in tracks if t.duration and t.duration <= rules.max_duration]
-
-        # Apply last_played filter in seed mode
-        if rules.last_played_before_days is not None:
-            threshold_timestamp = int(time.time()) - (rules.last_played_before_days * 86400)
-            tracks = [
-                t for t in tracks if t.last_played == 0 or t.last_played < threshold_timestamp
-            ]
-
-        return tracks
+        # Apply duration and last_played filters in seed mode
+        tracks = _filter_by_duration(tracks, rules.min_duration, rules.max_duration)
+        return _filter_by_last_played(
+            tracks, rules.last_played_before_value, rules.last_played_before_unit
+        )
 
     def _apply_exclusions(
         self,

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -130,7 +130,8 @@ class SmartPlaylistRules:
     explicit: bool | None = None
     min_duration: int | None = None
     max_duration: int | None = None
-    last_played_before_days: int | None = None
+    last_played_before_value: int | None = None
+    last_played_before_unit: str | None = None  # "hours", "days", "weeks", "months"
 
     def all_seed_uris(self) -> list[str]:
         """Return every seed URI across the four seed lists, deduplicated, original order."""
@@ -180,7 +181,8 @@ class SmartPlaylistRules:
             "explicit": self.explicit,
             "min_duration": self.min_duration,
             "max_duration": self.max_duration,
-            "last_played_before_days": self.last_played_before_days,
+            "last_played_before_value": self.last_played_before_value,
+            "last_played_before_unit": self.last_played_before_unit,
         }
 
     @classmethod
@@ -235,9 +237,10 @@ class SmartPlaylistRules:
             explicit=_coerce_optional_bool(data.get("explicit"), "explicit"),
             min_duration=_coerce_optional_int(data.get("min_duration"), "min_duration"),
             max_duration=_coerce_optional_int(data.get("max_duration"), "max_duration"),
-            last_played_before_days=_coerce_optional_int(
-                data.get("last_played_before_days"), "last_played_before_days"
+            last_played_before_value=_coerce_optional_int(
+                data.get("last_played_before_value"), "last_played_before_value"
             ),
+            last_played_before_unit=data.get("last_played_before_unit"),
         )
 
     def human_readable(self) -> str:
@@ -289,8 +292,8 @@ class SmartPlaylistRules:
             parts.append(year_range)
         if duration_range := self._format_duration_range():
             parts.append(duration_range)
-        if self.last_played_before_days is not None:
-            parts.append(f"Not played in {self.last_played_before_days} days")
+        if last_played_str := self._format_last_played():
+            parts.append(last_played_str)
         if not parts:
             return "No rules (all library tracks)"
         connector = f" {self.logic} "
@@ -315,6 +318,13 @@ class SmartPlaylistRules:
         if self.max_duration is not None:
             return f"Duration: ≤{self.max_duration}s"
         return None
+
+    def _format_last_played(self) -> str | None:
+        """Format last played filter as human-readable string."""
+        if self.last_played_before_value is None or self.last_played_before_unit is None:
+            return None
+        unit_display = self.last_played_before_unit  # hours, days, weeks, months
+        return f"Not played in {self.last_played_before_value} {unit_display}"
 
 
 def validate_rules(rules: SmartPlaylistRules) -> None:
@@ -364,8 +374,23 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
     ):
         msg = f"min_duration must be <= max_duration, got {rules.min_duration}>{rules.max_duration}"
         raise InvalidDataError(msg)
-    if rules.last_played_before_days is not None and rules.last_played_before_days < 1:
-        msg = f"last_played_before_days must be >= 1, got {rules.last_played_before_days}"
+
+    # Validate last_played fields
+    if (rules.last_played_before_value is None) != (rules.last_played_before_unit is None):
+        msg = (
+            "last_played_before_value and last_played_before_unit must both be set or both be None"
+        )
+        raise InvalidDataError(msg)
+    if rules.last_played_before_value is not None and rules.last_played_before_value < 1:
+        msg = f"last_played_before_value must be >= 1, got {rules.last_played_before_value}"
+        raise InvalidDataError(msg)
+    if rules.last_played_before_unit is not None and rules.last_played_before_unit not in (
+        "hours",
+        "days",
+        "weeks",
+        "months",
+    ):
+        msg = f"last_played_before_unit must be hours/days/weeks/months, got {rules.last_played_before_unit}"
         raise InvalidDataError(msg)
 
 

--- a/music_assistant/providers/smart_playlist/helpers.py
+++ b/music_assistant/providers/smart_playlist/helpers.py
@@ -128,6 +128,9 @@ class SmartPlaylistRules:
     album_types: list[str] = field(default_factory=list)
     excluded_album_types: list[str] = field(default_factory=list)
     explicit: bool | None = None
+    min_duration: int | None = None
+    max_duration: int | None = None
+    last_played_before_days: int | None = None
 
     def all_seed_uris(self) -> list[str]:
         """Return every seed URI across the four seed lists, deduplicated, original order."""
@@ -175,6 +178,9 @@ class SmartPlaylistRules:
             "album_types": self.album_types,
             "excluded_album_types": self.excluded_album_types,
             "explicit": self.explicit,
+            "min_duration": self.min_duration,
+            "max_duration": self.max_duration,
+            "last_played_before_days": self.last_played_before_days,
         }
 
     @classmethod
@@ -227,6 +233,11 @@ class SmartPlaylistRules:
                 data.get("excluded_album_types"), "excluded_album_types"
             ),
             explicit=_coerce_optional_bool(data.get("explicit"), "explicit"),
+            min_duration=_coerce_optional_int(data.get("min_duration"), "min_duration"),
+            max_duration=_coerce_optional_int(data.get("max_duration"), "max_duration"),
+            last_played_before_days=_coerce_optional_int(
+                data.get("last_played_before_days"), "last_played_before_days"
+            ),
         )
 
     def human_readable(self) -> str:
@@ -274,17 +285,36 @@ class SmartPlaylistRules:
             parts.append(f"Excl. album types: {', '.join(self.excluded_album_types)}")
         if self.min_popularity is not None:
             parts.append(f"Min. popularity: {self.min_popularity}")
-        if self.year_from is not None or self.year_to is not None:
-            if self.year_from is not None and self.year_to is not None:
-                parts.append(f"Year: {self.year_from}-{self.year_to}")
-            elif self.year_from is not None:
-                parts.append(f"Year: from {self.year_from}")
-            else:
-                parts.append(f"Year: to {self.year_to}")
+        if year_range := self._format_year_range():
+            parts.append(year_range)
+        if duration_range := self._format_duration_range():
+            parts.append(duration_range)
+        if self.last_played_before_days is not None:
+            parts.append(f"Not played in {self.last_played_before_days} days")
         if not parts:
             return "No rules (all library tracks)"
         connector = f" {self.logic} "
         return connector.join(parts)
+
+    def _format_year_range(self) -> str | None:
+        """Format year filter as human-readable string."""
+        if self.year_from is not None and self.year_to is not None:
+            return f"Year: {self.year_from}-{self.year_to}"
+        if self.year_from is not None:
+            return f"Year: from {self.year_from}"
+        if self.year_to is not None:
+            return f"Year: to {self.year_to}"
+        return None
+
+    def _format_duration_range(self) -> str | None:
+        """Format duration filter as human-readable string."""
+        if self.min_duration is not None and self.max_duration is not None:
+            return f"Duration: {self.min_duration}-{self.max_duration}s"
+        if self.min_duration is not None:
+            return f"Duration: ≥{self.min_duration}s"
+        if self.max_duration is not None:
+            return f"Duration: ≤{self.max_duration}s"
+        return None
 
 
 def validate_rules(rules: SmartPlaylistRules) -> None:
@@ -321,6 +351,22 @@ def validate_rules(rules: SmartPlaylistRules) -> None:
         if at not in valid_album_types:
             msg = f"Invalid excluded_album_types value: {at!r}. Must be one of {sorted(valid_album_types)}"
             raise InvalidDataError(msg)
+    if rules.min_duration is not None and rules.min_duration < 0:
+        msg = f"min_duration must be >= 0, got {rules.min_duration}"
+        raise InvalidDataError(msg)
+    if rules.max_duration is not None and rules.max_duration < 0:
+        msg = f"max_duration must be >= 0, got {rules.max_duration}"
+        raise InvalidDataError(msg)
+    if (
+        rules.min_duration is not None
+        and rules.max_duration is not None
+        and rules.min_duration > rules.max_duration
+    ):
+        msg = f"min_duration must be <= max_duration, got {rules.min_duration}>{rules.max_duration}"
+        raise InvalidDataError(msg)
+    if rules.last_played_before_days is not None and rules.last_played_before_days < 1:
+        msg = f"last_played_before_days must be >= 1, got {rules.last_played_before_days}"
+        raise InvalidDataError(msg)
 
 
 async def read_json(path: str) -> dict[str, Any]:

--- a/music_assistant/providers/smart_playlist/manifest.json
+++ b/music_assistant/providers/smart_playlist/manifest.json
@@ -3,10 +3,10 @@
   "stage": "experimental",
   "domain": "smart_playlist",
   "name": "Smart Playlists",
-  "description": "Create dynamic or fixed playlists based on rules like genres, artists, albums, favorites and similar tracks.",
+  "description": "Create dynamic or fixed playlists based on rules: genres, artists, albums, favorites, similar tracks, release year, album type, explicit content, track duration, and rediscover forgotten tracks by filtering out recently played music.",
   "codeowners": ["@dmoo500"],
   "requirements": [],
-  "documentation": "",
+  "documentation": "https://music-assistant.io/features/smart-playlists/",
   "multi_instance": false,
   "builtin": false,
   "icon": "playlist-star"

--- a/music_assistant/providers/smart_playlist/strings.json
+++ b/music_assistant/providers/smart_playlist/strings.json
@@ -13,7 +13,7 @@
     }
   },
   "manifest": {
-    "description": "Create dynamic or fixed playlists based on rules like genres, artists, albums, favorites and similar tracks."
+    "description": "Create dynamic or fixed playlists based on rules: genres, artists, albums, favorites, similar tracks, release year, album type, explicit content, track duration, and rediscover forgotten tracks by filtering out recently played music."
   },
   "errors": {
     "invalid_name": "{0} is not a valid playlist name."

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1592,7 +1592,7 @@
   "provider.smart_playlist.config_entries.ai_descriptions.description": "When a provider with AI support is available, use it to write a natural-language description for each smart playlist. Falls back to a plain rules summary when no AI provider is available.",
   "provider.smart_playlist.config_entries.ai_descriptions.label": "Generate descriptions with AI",
   "provider.smart_playlist.errors.invalid_name": "{0} is not a valid playlist name.",
-  "provider.smart_playlist.manifest.description": "Create dynamic or fixed playlists based on rules like genres, artists, albums, favorites and similar tracks.",
+  "provider.smart_playlist.manifest.description": "Create dynamic or fixed playlists based on rules: genres, artists, albums, favorites, similar tracks, release year, album type, explicit content, track duration, and rediscover forgotten tracks by filtering out recently played music.",
   "provider.smart_playlist.media.recommendations.smart_playlists.name": "Smart Playlists",
   "provider.snapcast.config_entries.snapcast_server_built_in_buffer_size.label": "Snapserver buffer size",
   "provider.snapcast.config_entries.snapcast_server_built_in_chunk_ms.label": "Snapserver chunk size",

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -167,6 +167,28 @@ class TestSmartPlaylistRules:
         assert rules.excluded_artist_names == {}
         assert rules.excluded_album_names == {}
 
+    def test_duration_fields_round_trip(self) -> None:
+        """min_duration and max_duration survive serialization."""
+        original = SmartPlaylistRules(min_duration=180, max_duration=600)
+        recovered = SmartPlaylistRules.from_dict(original.to_dict())
+        assert recovered.min_duration == 180
+        assert recovered.max_duration == 600
+
+    def test_last_played_field_round_trip(self) -> None:
+        """last_played_before_days survives serialization."""
+        original = SmartPlaylistRules(last_played_before_days=30)
+        recovered = SmartPlaylistRules.from_dict(original.to_dict())
+        assert recovered.last_played_before_days == 30
+
+    def test_from_dict_null_duration_fields_treated_as_none(self) -> None:
+        """from_dict treats null for duration fields as None."""
+        rules = SmartPlaylistRules.from_dict(
+            {"min_duration": None, "max_duration": None, "last_played_before_days": None}
+        )
+        assert rules.min_duration is None
+        assert rules.max_duration is None
+        assert rules.last_played_before_days is None
+
 
 # ---------------------------------------------------------------------------
 # Plugin validation tests
@@ -226,6 +248,42 @@ class TestRuleValidation:
         with pytest.raises(InvalidDataError, match="Too many seeds"):
             plugin._validate_rules(rules)
 
+    def test_negative_min_duration_raises(self) -> None:
+        """Negative min_duration raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(min_duration=-10)
+        with pytest.raises(InvalidDataError, match="min_duration"):
+            plugin._validate_rules(rules)
+
+    def test_negative_max_duration_raises(self) -> None:
+        """Negative max_duration raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(max_duration=-5)
+        with pytest.raises(InvalidDataError, match="max_duration"):
+            plugin._validate_rules(rules)
+
+    def test_min_duration_greater_than_max_raises(self) -> None:
+        """min_duration > max_duration raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(min_duration=600, max_duration=300)
+        with pytest.raises(InvalidDataError, match="min_duration.*max_duration"):
+            plugin._validate_rules(rules)
+
+    def test_last_played_before_days_zero_raises(self) -> None:
+        """last_played_before_days < 1 raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(last_played_before_days=0)
+        with pytest.raises(InvalidDataError, match="last_played_before_days"):
+            plugin._validate_rules(rules)
+
+    def test_valid_duration_and_last_played_pass(self) -> None:
+        """Valid duration and last_played values do not raise."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(
+            min_duration=180, max_duration=600, last_played_before_days=30
+        )
+        plugin._validate_rules(rules)  # should not raise
+
 
 # ---------------------------------------------------------------------------
 # Persistence tests  (using tmp_path, no real MA instance needed)
@@ -278,6 +336,8 @@ def _make_mock_track(
     favorite: bool = False,
     popularity: int | None = None,
     provider_instance: str = "library",
+    duration: int | None = None,
+    last_played: int = 0,
 ) -> MagicMock:
     """Build a minimal mock Track object."""
     track = MagicMock()
@@ -285,6 +345,8 @@ def _make_mock_track(
     track.uri = uri
     track.name = f"Track {item_id}"
     track.favorite = favorite
+    track.duration = duration
+    track.last_played = last_played
 
     mapping = MagicMock()
     mapping.provider_instance = provider_instance
@@ -442,6 +504,130 @@ async def test_limit_is_respected() -> None:
     rules = SmartPlaylistRules(limit=5)
     result = await plugin._evaluate_rules(rules)
     assert len(result) <= 5
+
+
+@pytest.mark.asyncio
+async def test_duration_filter_min_only() -> None:
+    """Tracks shorter than min_duration are filtered out."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    short_track = _make_mock_track("1", uri="library://track/1", duration=120)  # 2 minutes
+    long_track = _make_mock_track("2", uri="library://track/2", duration=300)  # 5 minutes
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[short_track, long_track])
+
+    rules = SmartPlaylistRules(min_duration=180, logic=LOGIC_AND, limit=10)  # 3 minutes min
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" not in uris  # too short
+    assert "library://track/2" in uris
+
+
+@pytest.mark.asyncio
+async def test_duration_filter_max_only() -> None:
+    """Tracks longer than max_duration are filtered out."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    short_track = _make_mock_track("1", uri="library://track/1", duration=120)  # 2 minutes
+    long_track = _make_mock_track("2", uri="library://track/2", duration=600)  # 10 minutes
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[short_track, long_track])
+
+    rules = SmartPlaylistRules(max_duration=300, logic=LOGIC_AND, limit=10)  # 5 minutes max
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris
+    assert "library://track/2" not in uris  # too long
+
+
+@pytest.mark.asyncio
+async def test_duration_filter_between() -> None:
+    """Only tracks within min_duration and max_duration pass."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    too_short = _make_mock_track("1", uri="library://track/1", duration=120)  # 2 min
+    just_right = _make_mock_track("2", uri="library://track/2", duration=240)  # 4 min
+    too_long = _make_mock_track("3", uri="library://track/3", duration=600)  # 10 min
+    cast("Any", plugin)._get_library_tracks = AsyncMock(
+        return_value=[too_short, just_right, too_long]
+    )
+
+    rules = SmartPlaylistRules(
+        min_duration=180, max_duration=300, logic=LOGIC_AND, limit=10
+    )  # 3-5 minutes
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" not in uris  # too short
+    assert "library://track/2" in uris  # perfect
+    assert "library://track/3" not in uris  # too long
+
+
+@pytest.mark.asyncio
+async def test_duration_filter_skips_tracks_without_duration() -> None:
+    """Tracks with duration=None are excluded when duration filter is active."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    no_duration = _make_mock_track("1", uri="library://track/1", duration=None)
+    has_duration = _make_mock_track("2", uri="library://track/2", duration=240)
+    cast("Any", plugin)._get_library_tracks = AsyncMock(
+        return_value=[no_duration, has_duration]
+    )
+
+    rules = SmartPlaylistRules(min_duration=180, logic=LOGIC_AND, limit=10)
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" not in uris  # no duration
+    assert "library://track/2" in uris
+
+
+@pytest.mark.asyncio
+async def test_last_played_filter() -> None:
+    """Tracks played recently are filtered out."""
+    import time
+
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    now = int(time.time())
+    never_played = _make_mock_track("1", uri="library://track/1", last_played=0)
+    played_recently = _make_mock_track("2", uri="library://track/2", last_played=now - 86400)  # 1 day ago
+    played_long_ago = _make_mock_track(
+        "3", uri="library://track/3", last_played=now - (60 * 86400)
+    )  # 60 days ago
+    cast("Any", plugin)._get_library_tracks = AsyncMock(
+        return_value=[never_played, played_recently, played_long_ago]
+    )
+
+    rules = SmartPlaylistRules(
+        last_played_before_days=30, logic=LOGIC_AND, limit=10
+    )  # Not played in last 30 days
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris  # never played = included
+    assert "library://track/2" not in uris  # played 1 day ago = excluded
+    assert "library://track/3" in uris  # played 60 days ago = included
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -266,7 +267,7 @@ class TestRuleValidation:
         """min_duration > max_duration raises InvalidDataError."""
         plugin = self._make_plugin()
         rules = SmartPlaylistRules(min_duration=600, max_duration=300)
-        with pytest.raises(InvalidDataError, match="min_duration.*max_duration"):
+        with pytest.raises(InvalidDataError, match=r"min_duration.*max_duration"):
             plugin._validate_rules(rules)
 
     def test_last_played_before_days_zero_raises(self) -> None:
@@ -279,9 +280,7 @@ class TestRuleValidation:
     def test_valid_duration_and_last_played_pass(self) -> None:
         """Valid duration and last_played values do not raise."""
         plugin = self._make_plugin()
-        rules = SmartPlaylistRules(
-            min_duration=180, max_duration=600, last_played_before_days=30
-        )
+        rules = SmartPlaylistRules(min_duration=180, max_duration=600, last_played_before_days=30)
         plugin._validate_rules(rules)  # should not raise
 
 
@@ -587,9 +586,7 @@ async def test_duration_filter_skips_tracks_without_duration() -> None:
 
     no_duration = _make_mock_track("1", uri="library://track/1", duration=None)
     has_duration = _make_mock_track("2", uri="library://track/2", duration=240)
-    cast("Any", plugin)._get_library_tracks = AsyncMock(
-        return_value=[no_duration, has_duration]
-    )
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=[no_duration, has_duration])
 
     rules = SmartPlaylistRules(min_duration=180, logic=LOGIC_AND, limit=10)
     result = await plugin._evaluate_rules(rules)
@@ -601,8 +598,6 @@ async def test_duration_filter_skips_tracks_without_duration() -> None:
 @pytest.mark.asyncio
 async def test_last_played_filter() -> None:
     """Tracks played recently are filtered out."""
-    import time
-
     mass = MagicMock()
     manifest = MagicMock()
     manifest.domain = "smart_playlist"
@@ -612,7 +607,9 @@ async def test_last_played_filter() -> None:
 
     now = int(time.time())
     never_played = _make_mock_track("1", uri="library://track/1", last_played=0)
-    played_recently = _make_mock_track("2", uri="library://track/2", last_played=now - 86400)  # 1 day ago
+    played_recently = _make_mock_track(
+        "2", uri="library://track/2", last_played=now - 86400
+    )  # 1 day ago
     played_long_ago = _make_mock_track(
         "3", uri="library://track/3", last_played=now - (60 * 86400)
     )  # 60 days ago

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -176,19 +176,26 @@ class TestSmartPlaylistRules:
         assert recovered.max_duration == 600
 
     def test_last_played_field_round_trip(self) -> None:
-        """last_played_before_days survives serialization."""
-        original = SmartPlaylistRules(last_played_before_days=30)
+        """last_played_before_value and last_played_before_unit survive serialization."""
+        original = SmartPlaylistRules(last_played_before_value=30, last_played_before_unit="days")
         recovered = SmartPlaylistRules.from_dict(original.to_dict())
-        assert recovered.last_played_before_days == 30
+        assert recovered.last_played_before_value == 30
+        assert recovered.last_played_before_unit == "days"
 
     def test_from_dict_null_duration_fields_treated_as_none(self) -> None:
-        """from_dict treats null for duration fields as None."""
+        """from_dict treats null for duration and last_played fields as None."""
         rules = SmartPlaylistRules.from_dict(
-            {"min_duration": None, "max_duration": None, "last_played_before_days": None}
+            {
+                "min_duration": None,
+                "max_duration": None,
+                "last_played_before_value": None,
+                "last_played_before_unit": None,
+            }
         )
         assert rules.min_duration is None
         assert rules.max_duration is None
-        assert rules.last_played_before_days is None
+        assert rules.last_played_before_value is None
+        assert rules.last_played_before_unit is None
 
 
 # ---------------------------------------------------------------------------
@@ -270,18 +277,44 @@ class TestRuleValidation:
         with pytest.raises(InvalidDataError, match=r"min_duration.*max_duration"):
             plugin._validate_rules(rules)
 
-    def test_last_played_before_days_zero_raises(self) -> None:
-        """last_played_before_days < 1 raises InvalidDataError."""
+    def test_last_played_before_value_zero_raises(self) -> None:
+        """last_played_before_value < 1 raises InvalidDataError."""
         plugin = self._make_plugin()
-        rules = SmartPlaylistRules(last_played_before_days=0)
-        with pytest.raises(InvalidDataError, match="last_played_before_days"):
+        rules = SmartPlaylistRules(last_played_before_value=0, last_played_before_unit="days")
+        with pytest.raises(InvalidDataError, match="last_played_before_value"):
             plugin._validate_rules(rules)
 
     def test_valid_duration_and_last_played_pass(self) -> None:
         """Valid duration and last_played values do not raise."""
         plugin = self._make_plugin()
-        rules = SmartPlaylistRules(min_duration=180, max_duration=600, last_played_before_days=30)
+        rules = SmartPlaylistRules(
+            min_duration=180,
+            max_duration=600,
+            last_played_before_value=30,
+            last_played_before_unit="days",
+        )
         plugin._validate_rules(rules)  # should not raise
+
+    def test_last_played_invalid_unit_raises(self) -> None:
+        """Invalid last_played_before_unit raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(last_played_before_value=10, last_played_before_unit="years")
+        with pytest.raises(InvalidDataError, match="last_played_before_unit"):
+            plugin._validate_rules(rules)
+
+    def test_last_played_only_value_set_raises(self) -> None:
+        """Only last_played_before_value set (no unit) raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(last_played_before_value=10, last_played_before_unit=None)
+        with pytest.raises(InvalidDataError, match="last_played"):
+            plugin._validate_rules(rules)
+
+    def test_last_played_only_unit_set_raises(self) -> None:
+        """Only last_played_before_unit set (no value) raises InvalidDataError."""
+        plugin = self._make_plugin()
+        rules = SmartPlaylistRules(last_played_before_value=None, last_played_before_unit="days")
+        with pytest.raises(InvalidDataError, match="last_played"):
+            plugin._validate_rules(rules)
 
 
 # ---------------------------------------------------------------------------
@@ -617,9 +650,30 @@ async def test_last_played_filter() -> None:
         return_value=[never_played, played_recently, played_long_ago]
     )
 
+    # Test with days unit
     rules = SmartPlaylistRules(
-        last_played_before_days=30, logic=LOGIC_AND, limit=10
+        last_played_before_value=30, last_played_before_unit="days", logic=LOGIC_AND, limit=10
     )  # Not played in last 30 days
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris  # never played = included
+    assert "library://track/2" not in uris  # played 1 day ago = excluded
+    assert "library://track/3" in uris  # played 60 days ago = included
+
+    # Test with hours unit
+    rules = SmartPlaylistRules(
+        last_played_before_value=12, last_played_before_unit="hours", logic=LOGIC_AND, limit=10
+    )  # Not played in last 12 hours
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris  # never played = included
+    assert "library://track/2" in uris  # played 1 day ago = included
+    assert "library://track/3" in uris  # played 60 days ago = included
+
+    # Test with weeks unit
+    rules = SmartPlaylistRules(
+        last_played_before_value=2, last_played_before_unit="weeks", logic=LOGIC_AND, limit=10
+    )  # Not played in last 2 weeks
     result = await plugin._evaluate_rules(rules)
     uris = [t.uri for t in result]
     assert "library://track/1" in uris  # never played = included


### PR DESCRIPTION
# What does this implement/fix?

Adds two new filter options to Smart Playlist:
- **Duration filter**: Filter tracks by length using MM:SS time format (e.g., 2:30 to 5:00)
- **Last played filter**: Filter tracks not played within a specified time period (hours, days, weeks, or months)

Both filters work at Python level after SQL query, consistent with existing Smart Playlist architecture.

**Related discussions:**
- https://github.com/orgs/music-assistant/discussions/5649 (Duration/track length filter) ✅ fully implemented
- https://github.com/orgs/music-assistant/discussions/5539 (Not played in X time period) ✅ fully implemented with hours/days/weeks/months support

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

## Implementation Details

### Backend Changes
- Extended `SmartPlaylistRules` dataclass with duration and last_played fields
- Duration: `min_duration` and `max_duration` (in seconds)
- Last played: `last_played_before_value` and `last_played_before_unit` (hours/days/weeks/months)
- Added validation for new fields in `validate_rules()`
- Implemented Python-level filtering with helper functions `_filter_by_duration()` and `_filter_by_last_played()`
- Updated manifest.json with documentation URL and enhanced description

### Filter Behavior
- **Duration**: Filters tracks by length in seconds. Both min and max are optional - leave blank to have open-ended ranges.
- **Last played**: Filters tracks not played within a specified time period. Supports hours, days, weeks, and months. Never-played tracks are always included in the result.

### Testing
- Added 11 unit tests covering serialization, validation, and filtering logic
- Tests verify both fields work independently and together
- Tests cover all time units (hours, days, weeks, months)
- Tests validate edge cases (NULL handling, invalid units, partial field specification)

## Frontend PR
music-assistant/frontend#1998
