### PR TITLE
Don't auto-start playback when an ADD/NEXT onto an idle queue enters dynamic mode

### DIFF
--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -716,25 +716,19 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         enabled implicitly: a dynamic queue is always a smart mix.
 
         :param queue_id: The queue entering dynamic mode.
-        :param option: The enqueue option that triggered the transition. PLAY/REPLACE (or an empty
-            queue) start playback on the rebuilt pool; ADD/NEXT/REPLACE_NEXT keep the current track
-            playing and only rebuild the tail behind it.
+        :param option: The enqueue option that triggered the transition. PLAY/REPLACE start playback
+            on the rebuilt pool; ADD/NEXT/REPLACE_NEXT stage it without starting playback (behind the
+            current track, or from the front of an idle/empty queue).
         """
         data = self._queue_data[queue_id]
         queue = data.queue
         # a dynamic queue is an always-on smart mix; reflect that in the (now locked) shuffle state
         queue.shuffle_enabled = True
         queue.smart_shuffle_active = self.is_smart_shuffle_active(queue)
-        if queue.current_index is None:
-            # nothing is playing yet (REPLACE cleared the queue, or it was empty): the pool becomes
-            # the whole queue and playback starts on it
-            insert_at = 0
-            start_playing = True
-        else:
-            insert_at = queue.current_index + 1
-            # PLAY/REPLACE restart playback on the rebuilt pool; ADD/NEXT/REPLACE_NEXT keep the
-            # current track playing and only rebuild the tail behind it
-            start_playing = option in (QueueOption.PLAY, QueueOption.REPLACE)
+        insert_at = 0 if queue.current_index is None else queue.current_index + 1
+        # PLAY/REPLACE start playback on the rebuilt pool; ADD/NEXT/REPLACE_NEXT only stage it and
+        # never start playback (an idle/empty queue stays idle on an add, just like the linear path)
+        start_playing = option in (QueueOption.PLAY, QueueOption.REPLACE)
         # drop the finite upcoming tail up front so the pool is sized and deduped against the kept
         # head only (the tail we are discarding must not exclude its own tracks from the new pool)
         data.items = data.items[:insert_at]
@@ -749,6 +743,9 @@ class QueueLoaderMixin(_PlayerQueuesBase):
         await self.load(queue_id, queue_items, insert_at_index=insert_at, keep_remaining=False)
         if start_playing:
             await self.play_index(queue_id, insert_at)
+        else:
+            # give an idle/empty queue a current item without starting playback
+            self._ensure_current_index(queue_id)
 
     async def _get_similar_tracks(
         self,

--- a/tests/controllers/player_queues/test_enqueue_options.py
+++ b/tests/controllers/player_queues/test_enqueue_options.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
-from music_assistant_models.enums import PlaybackState, QueueOption
+from music_assistant_models.enums import MediaType, PlaybackState, QueueOption
+from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
+from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.controllers.player_queues import PlayerQueuesController
 from music_assistant.controllers.player_queues.state import PlayerQueueData
@@ -31,6 +33,22 @@ def _items(queue_id: str, names: list[str]) -> list[QueueItem]:
     return [
         QueueItem(queue_id=queue_id, queue_item_id=name, name=name, duration=60) for name in names
     ]
+
+
+def _track(item_id: str) -> Track:
+    """Build a playable Track on the 'test' provider (mirrors the managed-pool test helper)."""
+    return Track(
+        item_id=item_id,
+        provider="test",
+        name=f"Track {item_id}",
+        duration=60,
+        artists=UniqueList(
+            [ItemMapping(item_id="a", provider="test", name="A", media_type=MediaType.ARTIST)]
+        ),
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+    )
 
 
 async def test_play_on_idle_queue_starts_at_first_item() -> None:
@@ -194,3 +212,79 @@ async def test_next_on_idle_queue_with_content_keeps_current_index() -> None:
     assert queue.current_index == 1
     assert [item.queue_item_id for item in items] == ["e0", "e1", "n0", "e2"]
     ctrl.play_index.assert_not_awaited()
+
+
+def _dynamic_controller() -> PlayerQueuesController:
+    """Build a bare controller wired to drive ``_enter_dynamic_mode`` with a stubbed managed pool."""
+    ctrl = _controller()
+    ctrl.get_next_item = Mock(return_value=None)  # type: ignore[method-assign]
+    ctrl.is_smart_shuffle_active = Mock(return_value=True)  # type: ignore[method-assign]
+    ctrl._managed_pool = Mock()
+    ctrl._managed_pool.fill = AsyncMock(return_value=[_track("p0"), _track("p1")])
+    return ctrl
+
+
+async def test_enter_dynamic_mode_add_on_idle_does_not_start_playback() -> None:
+    """ADD of a dynamic source onto an idle/empty queue stages the pool but does not start playing."""
+    ctrl = _dynamic_controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+
+    await ctrl._enter_dynamic_mode("q1", QueueOption.ADD)
+
+    # the pool is loaded and the current item is set, but playback is not started
+    items = ctrl._queue_data["q1"].items
+    assert {item.media_item.item_id for item in items if item.media_item is not None} == {
+        "p0",
+        "p1",
+    }
+    assert queue.current_index == 0
+    assert queue.current_item is not None
+    play_index.assert_not_awaited()
+
+
+async def test_enter_dynamic_mode_play_on_idle_starts_playback() -> None:
+    """PLAY of a dynamic source onto an idle/empty queue starts playback on the rebuilt pool."""
+    ctrl = _dynamic_controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+
+    await ctrl._enter_dynamic_mode("q1", QueueOption.PLAY)
+
+    assert len(ctrl._queue_data["q1"].items) == 2
+    play_index.assert_awaited_once_with("q1", 0)
+
+
+async def test_enter_dynamic_mode_add_on_active_keeps_current_and_rebuilds_tail() -> None:
+    """ADD of a dynamic source onto a playing queue rebuilds the tail without interrupting it."""
+    ctrl = _dynamic_controller()
+    play_index = AsyncMock()
+    ctrl.play_index = play_index  # type: ignore[method-assign]
+    existing = _items("q1", ["e0", "e1", "e2"])
+    queue = PlayerQueue(
+        queue_id="q1",
+        active=True,
+        display_name="Q1",
+        available=True,
+        items=len(existing),
+        state=PlaybackState.PLAYING,
+        current_index=1,
+        index_in_buffer=1,
+    )
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue, items=list(existing))}
+
+    await ctrl._enter_dynamic_mode("q1", QueueOption.ADD)
+
+    items = ctrl._queue_data["q1"].items
+    # the current track and history are kept; the finite tail behind it is replaced by the pool
+    assert [item.queue_item_id for item in items[:2]] == ["e0", "e1"]
+    assert {item.media_item.item_id for item in items[2:] if item.media_item is not None} == {
+        "p0",
+        "p1",
+    }
+    assert queue.current_index == 1
+    play_index.assert_not_awaited()


### PR DESCRIPTION
## What does this implement/fix?

Entering dynamic mode via ADD / NEXT / REPLACE_NEXT onto an **idle/empty** queue wrongly started playback. `_enter_dynamic_mode` keyed `start_playing` off `current_index is None` (empty queue → always start), so adding a dynamic playlist onto an idle queue began playing immediately — unlike adding a regular (finite) playlist, which correctly just stages the content.

Now `start_playing` follows the enqueue option (only PLAY/REPLACE start), matching the linear enqueue path: an ADD/NEXT/REPLACE_NEXT onto an idle/empty queue stages the pool and sets the current item via the shared `_ensure_current_index` helper, without starting playback. PLAY/REPLACE and the active-queue transition are unchanged.

Introduced in #4513 (dynamic mode is dev-only, so no stable backport).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
