### PR TITLE
Dedupe the queue's sources list so a repeated source shows once

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -1488,7 +1488,18 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         :param items: The full source media items; an empty list clears the queue's sources.
         """
         self._queue_data[queue.queue_id].source_items = items
-        queue.sources = [ItemMapping.from_item(item) for item in items]
+        # keep every occurrence server-side (a source added more than once weights it up in the
+        # managed pool), but expose each distinct source only once on the wire for clients to show
+        seen: set[str] = set()
+        sources: list[ItemMapping] = []
+        for item in items:
+            mapping = ItemMapping.from_item(item)
+            if mapping.uri and mapping.uri in seen:
+                continue
+            if mapping.uri:
+                seen.add(mapping.uri)
+            sources.append(mapping)
+        queue.sources = sources
         # release any materialized finite-source state whose source is no longer present
         self._managed_pool.retain(
             queue.queue_id, {item.uri for item in items if item.uri is not None}

--- a/tests/controllers/player_queues/test_enqueue_options.py
+++ b/tests/controllers/player_queues/test_enqueue_options.py
@@ -351,3 +351,20 @@ async def test_enter_dynamic_mode_rebuilds_from_buffer_index() -> None:
         "p1",
     }
     play_index.assert_not_awaited()
+
+
+def test_store_sources_dedupes_wire_sources_keeps_internal_multiplicity() -> None:
+    """The wire `sources` list is deduped per source; the server keeps every occurrence."""
+    ctrl = _controller()
+    ctrl._managed_pool = Mock()
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    a, b = _track("a"), _track("b")
+
+    # "a" added twice (multiplicity 2), "b" once
+    ctrl.store_sources(queue, [a, b, a])
+
+    # server-side list keeps every occurrence (drives the managed-pool weighting)
+    assert ctrl._queue_data["q1"].source_items == [a, b, a]
+    # wire list clients see is deduped to the distinct sources, order preserved
+    assert [mapping.uri for mapping in queue.sources] == [a.uri, b.uri]


### PR DESCRIPTION
## What does this implement/fix?

A source added to a dynamic queue more than once is recorded once per occurrence server-side — that multiplicity is what weights it up in the managed pool. But the wire-facing `sources` list projected every occurrence too, so a repeatedly-added source showed up duplicated in clients (e.g. "based on your selection: Qmusic Top 40, Infinite Mix (library), Infinite Mix (library)").

`store_sources` now dedupes the projected `sources` by URI (order preserved) while keeping the full list server-side in `source_items`, so the managed-pool weighting is unchanged and clients see each distinct source once.

Follow-up to #4522.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
