### PR TITLE
Avoid back-to-back artists in dynamic queues

### DIFF
--- a/music_assistant/controllers/player_queues/README.md
+++ b/music_assistant/controllers/player_queues/README.md
@@ -173,8 +173,10 @@ Two distinct refill paths share the same "running low" trigger:
   Each source contributes candidates by its fill mode — a dynamic playlist (a radio playlist or a
   provider station) yields its own self-managing batch (`DYNAMIC`), while a finite item mixed into
   the pool rotates its own unplayed tracks (`TRACKS`). Each top-up apportions slots across the
-  sources by weight, recency-gates every candidate, and prefers the least-recently-played. A "radio"
-  is just a dynamic playlist from the `radio_playlist` provider.
+  sources by weight, recency-gates every candidate, prefers the least-recently-played and nudges
+  recently-heard artists back, then spaces the assembled batch so no two adjacent tracks share an
+  artist (seam-aware against the current tail). A "radio" is just a dynamic playlist from the
+  `radio_playlist` provider.
 - **Autoplay** refills using the per-queue configured mode, owned by `autoplay.py`: similar tracks
   (seeded from the enqueued items), an infinite library mix (genre-biased, least-played), a chosen
   playlist, or an automatic mode that tries similar first and falls back to the library mix. The

--- a/music_assistant/controllers/player_queues/README.md
+++ b/music_assistant/controllers/player_queues/README.md
@@ -174,9 +174,9 @@ Two distinct refill paths share the same "running low" trigger:
   provider station) yields its own self-managing batch (`DYNAMIC`), while a finite item mixed into
   the pool rotates its own unplayed tracks (`TRACKS`). Each top-up apportions slots across the
   sources by weight, recency-gates every candidate, prefers the least-recently-played and nudges
-  recently-heard artists back, then spaces the assembled batch so no two adjacent tracks share an
-  artist (seam-aware against the current tail). A "radio" is just a dynamic playlist from the
-  `radio_playlist` provider.
+  recently-heard artists back, then best-effort spaces the assembled batch so adjacent tracks avoid
+  sharing an artist (seam-aware against the current tail). A "radio" is just a dynamic playlist from
+  the `radio_playlist` provider.
 - **Autoplay** refills using the per-queue configured mode, owned by `autoplay.py`: similar tracks
   (seeded from the enqueued items), an infinite library mix (genre-biased, least-played), a chosen
   playlist, or an automatic mode that tries similar first and falls back to the library mix. The

--- a/music_assistant/controllers/player_queues/helpers.py
+++ b/music_assistant/controllers/player_queues/helpers.py
@@ -145,3 +145,39 @@ def get_current_playback_speed(queue: PlayerQueue) -> float:
     if queue.current_item is None:
         return 1.0
     return float(queue.current_item.extra_attributes.get("playback_speed") or 1.0)
+
+
+# how many bounded passes to make separating directly-adjacent same-artist items
+ARTIST_REPAIR_PASSES = 4
+# how far ahead to look for a non-clashing item to swap in (keeps moves local so any
+# existing even spread is preserved)
+ARTIST_SWAP_WINDOW = 6
+
+
+def space_by_artist(artist_sets: list[set[str]], *, preceding: set[str] | None = None) -> list[int]:
+    """
+    Return an index order that best-effort keeps same-artist entries from sitting adjacent.
+
+    :param artist_sets: The lowercased artist-name set for each item, in its current order.
+    :param preceding: Artist names of the item that will sit directly before the first entry (the
+        seam with the already-queued tail); the first entry is kept clear of it too. None ignores it.
+    """
+    count = len(artist_sets)
+    order = list(range(count))
+    sets = list(artist_sets)
+    for _ in range(ARTIST_REPAIR_PASSES):
+        changed = False
+        # index -1 represents the preceding (seam) item, so the first entry is kept clear of it too
+        for index in range(-1, count - 1):
+            current = preceding if index == -1 else sets[index]
+            if not current or not current & sets[index + 1]:
+                continue
+            for target in range(index + 2, min(index + 2 + ARTIST_SWAP_WINDOW, count)):
+                if not current & sets[target]:
+                    order[index + 1], order[target] = order[target], order[index + 1]
+                    sets[index + 1], sets[target] = sets[target], sets[index + 1]
+                    changed = True
+                    break
+        if not changed:
+            break
+    return order

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -19,8 +19,9 @@ so a recently-heard track isn't pulled back in. A dynamic batch is offered least
 first and de-prioritizes tracks whose artist is within the artist-recency window (a soft nudge, not
 a hard exclusion, so a single-artist station still plays); a finite source keeps its own
 (materialized) order so it plays through coherently. Once the batch is assembled it is passed
-through a seam-aware artist-spacing pass so no two directly-adjacent tracks share an artist, and the
-first added track is kept clear of the currently-queued tail's last artist.
+through a seam-aware artist-spacing pass that best-effort keeps directly-adjacent tracks from
+sharing an artist, and the first added track is kept clear of the currently-queued tail's last
+artist.
 """
 
 from __future__ import annotations
@@ -506,7 +507,7 @@ def _ungated_fallback(
 
 def _space_tracks(tracks: list[Track], preceding: set[str] | None) -> list[Track]:
     """
-    Reorder the batch so no two directly-adjacent tracks share an artist.
+    Reorder the batch to best-effort keep directly-adjacent tracks from sharing an artist.
 
     :param tracks: The assembled batch to space.
     :param preceding: Artist names of the track that will sit directly before the batch (the seam

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -16,7 +16,11 @@ that is topped up as it plays down. Each source has a *fill mode*:
 Each top-up apportions slots across the sources by weight (per-base quota by default, so adding a
 source more than once weights it up) and gates every candidate against the shared ``RecencyEngine``
 so a recently-heard track isn't pulled back in. A dynamic batch is offered least-recently-played
-first; a finite source keeps its own (materialized) order so it plays through coherently.
+first and de-prioritizes tracks whose artist is within the artist-recency window (a soft nudge, not
+a hard exclusion, so a single-artist station still plays); a finite source keeps its own
+(materialized) order so it plays through coherently. Once the batch is assembled it is passed
+through a seam-aware artist-spacing pass so no two directly-adjacent tracks share an artist, and the
+first added track is kept clear of the currently-queued tail's last artist.
 """
 
 from __future__ import annotations
@@ -34,6 +38,7 @@ from music_assistant.controllers.player_queues.constants import (
     MANAGED_POOL_SOURCE_CAP,
     MANAGED_POOL_TARGET,
 )
+from music_assistant.controllers.player_queues.helpers import space_by_artist
 from music_assistant.helpers.track_filter import track_filter
 
 if TYPE_CHECKING:
@@ -139,8 +144,20 @@ class ManagedPool:
             if is_initial
             else max(MANAGED_POOL_TARGET - self._unplayed(queue), 0)
         )
+        # the batch is appended after the current tail, so keep its first track clear of the last
+        # queued item's artist (the seam the listener actually hears)
+        preceding = (
+            _track_artist_set(items[-1].media_item)
+            if items and isinstance(items[-1].media_item, Track)
+            else set()
+        )
         chosen = allocate_refill(
-            sources, slots=slots, pool_keys=pool_keys, snapshot=snapshot, windows=windows
+            sources,
+            slots=slots,
+            pool_keys=pool_keys,
+            snapshot=snapshot,
+            windows=windows,
+            preceding_artists=preceding,
         )
         # advance each finite source's deque: drop what was just dispatched, rotate recency-denied
         # tracks to the back, page in more if it is draining, and retire it once fully played
@@ -337,14 +354,17 @@ def allocate_refill(
     snapshot: RecencySnapshot,
     windows: RecencyWindows,
     weight_model: PoolWeightModel = POOL_WEIGHT_MODEL,
+    preceding_artists: set[str] | None = None,
 ) -> list[Track]:
     """
     Pick the next batch of tracks for the managed pool, weighted per source and recency-gated.
 
     Slots are apportioned across sources by weight; each source's candidates are hard-gated against
     the recency snapshot (a within-window track is excluded entirely). A dynamic batch is ordered
-    least-recently-played first; a finite (TRACKS) source keeps its own materialized order. If gating
-    leaves nothing, an ungated least-recently-played fallback is returned so playback never stalls.
+    least-recently-played first and de-prioritizes recently-heard artists; a finite (TRACKS) source
+    keeps its own materialized order. If gating leaves nothing, an ungated least-recently-played
+    fallback is returned so playback never stalls. The assembled batch is finally spaced so no two
+    adjacent tracks share an artist.
 
     :param sources: The queue's dynamic sources, each with its already-fetched candidate tracks.
     :param slots: How many tracks to add (0 or fewer returns nothing).
@@ -352,6 +372,8 @@ def allocate_refill(
     :param snapshot: The play-history snapshot to gate/score against.
     :param windows: The configured recency windows.
     :param weight_model: How to weight sources against each other.
+    :param preceding_artists: Artist names of the track that will sit directly before the batch (the
+        seam with the current tail); the first added track is kept clear of it.
     """
     if slots <= 0 or not sources:
         return []
@@ -384,7 +406,8 @@ def allocate_refill(
         chosen_set.add(track)
         taken[best_index] += 1
         pointers[best_index] += 1
-    return chosen or _ungated_fallback(sources, slots, pool_keys, snapshot)
+    batch = chosen or _ungated_fallback(sources, slots, pool_keys, snapshot)
+    return _space_tracks(batch, preceding_artists)
 
 
 def gate_tracks(
@@ -421,7 +444,8 @@ def _eligible(
     Return a source's candidates minus pool/recency-blocked ones.
 
     A finite (TRACKS) source keeps its materialized deque order so it plays through coherently; a
-    dynamic batch is ordered least-recently-played first.
+    dynamic batch is ordered fresh-artist first (recently-heard artists nudged back), then
+    least-recently-played.
     """
     # a deliberately-duplicated source uses the short repeat-gap, a singleton the long song window
     window = windows.duplicate_gap_seconds if source.multiplicity > 1 else windows.song_seconds
@@ -431,17 +455,25 @@ def _eligible(
             for track in source.candidates
             if track not in pool_keys and not snapshot.track_recent(track, window)
         ]
-    scored: list[tuple[int, int, Track]] = []
+    scored: list[tuple[int, int, int, Track]] = []
     for track in source.candidates:
         if track in pool_keys:
             continue
         last_played = snapshot.last_played(track)
         if window and last_played is not None and last_played >= snapshot.now - window:
             continue  # hard recency gate: a within-window track is excluded entirely
-        # never-played (None) sorts ahead of played; then oldest play first
-        scored.append((0 if last_played is None else 1, last_played or 0, track))
-    scored.sort(key=lambda entry: (entry[0], entry[1]))
-    return [track for _, _, track in scored]
+        # a within-artist-window track sorts behind fresh-artist ones (soft, so a single-artist
+        # station still plays); then never-played (None) ahead of played; then oldest play first
+        artist_recent = any(
+            snapshot.artist_recent(artist.name, windows.artist_seconds)
+            for artist in track.artists
+            if artist.name
+        )
+        scored.append(
+            (1 if artist_recent else 0, 0 if last_played is None else 1, last_played or 0, track)
+        )
+    scored.sort(key=lambda entry: (entry[0], entry[1], entry[2]))
+    return [entry[3] for entry in scored]
 
 
 def _weight(source: DynamicSource, weight_model: PoolWeightModel) -> int:
@@ -470,6 +502,23 @@ def _ungated_fallback(
         )
     )
     return pool[:slots]
+
+
+def _space_tracks(tracks: list[Track], preceding: set[str] | None) -> list[Track]:
+    """
+    Reorder the batch so no two directly-adjacent tracks share an artist.
+
+    :param tracks: The assembled batch to space.
+    :param preceding: Artist names of the track that will sit directly before the batch (the seam
+        with the current tail); the first track is kept clear of it too.
+    """
+    order = space_by_artist([_track_artist_set(track) for track in tracks], preceding=preceding)
+    return [tracks[index] for index in order]
+
+
+def _track_artist_set(track: Track) -> set[str]:
+    """Return the lowercased set of artist names for a track."""
+    return {artist.name.lower() for artist in track.artists if artist.name}
 
 
 def _uri(media_item: MediaItemType) -> str | None:

--- a/music_assistant/controllers/player_queues/smart_shuffle.py
+++ b/music_assistant/controllers/player_queues/smart_shuffle.py
@@ -32,6 +32,7 @@ from music_assistant.controllers.player_queues.constants import (
     SMART_SHUFFLE_ENABLED_DEFAULT,
     SMART_SHUFFLE_SONG_RECENCY_DEFAULT,
 )
+from music_assistant.controllers.player_queues.helpers import space_by_artist
 
 if TYPE_CHECKING:
     from music_assistant_models.player_queue import PlayerQueue
@@ -39,12 +40,6 @@ if TYPE_CHECKING:
 
     from music_assistant.controllers.music.recency import RecencySnapshot
     from music_assistant.controllers.player_queues.controller import PlayerQueuesController
-
-# how many bounded passes to make separating directly-adjacent same-artist items
-ARTIST_REPAIR_PASSES = 4
-# how far ahead to look for a non-clashing item to swap in (keeps moves local so the
-# even spread from the interleave is preserved)
-ARTIST_SWAP_WINDOW = 6
 
 
 class SmartShuffle:
@@ -165,31 +160,16 @@ def _interleave(bucket: list[QueueItem]) -> list[QueueItem]:
     return [item for _, item in positioned]
 
 
-def _space_artists(items: list[QueueItem]) -> list[QueueItem]:
-    """Best-effort separate directly-adjacent same-artist items with bounded local swaps."""
-    count = len(items)
-    if count <= 2:
-        return items
-    result = list(items)
-    artist_sets = [_artist_name_set(item) for item in result]
-    for _ in range(ARTIST_REPAIR_PASSES):
-        changed = False
-        for index in range(count - 1):
-            current = artist_sets[index]
-            if not current or not current & artist_sets[index + 1]:
-                continue
-            for target in range(index + 2, min(index + 2 + ARTIST_SWAP_WINDOW, count)):
-                if not current & artist_sets[target]:
-                    result[index + 1], result[target] = result[target], result[index + 1]
-                    artist_sets[index + 1], artist_sets[target] = (
-                        artist_sets[target],
-                        artist_sets[index + 1],
-                    )
-                    changed = True
-                    break
-        if not changed:
-            break
-    return result
+def _space_artists(items: list[QueueItem], *, preceding: set[str] | None = None) -> list[QueueItem]:
+    """
+    Best-effort separate directly-adjacent same-artist items.
+
+    :param items: The items to space.
+    :param preceding: Artist names of the item that will sit directly before the first item (the
+        seam with the already-queued tail); the first item is kept clear of it too. None ignores it.
+    """
+    order = space_by_artist([_artist_name_set(item) for item in items], preceding=preceding)
+    return [items[index] for index in order]
 
 
 def _song_key(item: QueueItem) -> tuple[str, str]:

--- a/tests/controllers/player_queues/test_managed_pool.py
+++ b/tests/controllers/player_queues/test_managed_pool.py
@@ -39,6 +39,29 @@ def _track(item_id: str) -> Track:
     )
 
 
+def _artist_track(item_id: str, artist: str) -> Track:
+    """Build a Track on the 'test' provider with the given single named artist."""
+    return Track(
+        item_id=item_id,
+        provider="test",
+        name=f"Track {item_id}",
+        duration=60,
+        artists=UniqueList(
+            [
+                ItemMapping(
+                    item_id=artist.lower(),
+                    provider="test",
+                    name=artist,
+                    media_type=MediaType.ARTIST,
+                )
+            ]
+        ),
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+    )
+
+
 def _source(
     candidate_ids: list[str],
     *,
@@ -54,11 +77,34 @@ def _source(
     )
 
 
-def _snapshot(played: dict[str, int] | None = None) -> RecencySnapshot:
-    """Build a snapshot marking the given track ids as played at the given timestamps."""
-    return RecencySnapshot(
-        now=NOW, song_ts={("test", item_id): ts for item_id, ts in (played or {}).items()}
+def _artist_source(
+    pairs: list[tuple[str, str]],
+    *,
+    multiplicity: int = 1,
+    fill_mode: DynamicFillMode = DynamicFillMode.TRACKS,
+) -> DynamicSource:
+    """Build a DynamicSource from (track_id, artist) pairs."""
+    return DynamicSource(
+        media_item=_track("seed"),
+        multiplicity=multiplicity,
+        fill_mode=fill_mode,
+        candidates=[_artist_track(item_id, artist) for item_id, artist in pairs],
     )
+
+
+def _snapshot(
+    played: dict[str, int] | None = None, *, artists_played: dict[str, int] | None = None
+) -> RecencySnapshot:
+    """Build a snapshot marking the given track ids (and artist names) as played."""
+    return RecencySnapshot(
+        now=NOW,
+        song_ts={("test", item_id): ts for item_id, ts in (played or {}).items()},
+        artist_ts={name.lower(): ts for name, ts in (artists_played or {}).items()},
+    )
+
+
+def _artists(tracks: list[Track]) -> list[str]:
+    return [track.artists[0].name for track in tracks]
 
 
 def _ids(tracks: list[Track]) -> list[str]:
@@ -246,3 +292,52 @@ def test_gate_tracks_fallback_when_all_recent() -> None:
     tracks = [_track("a"), _track("b")]
     snapshot = _snapshot({"a": NOW - HOUR, "b": NOW - 2 * HOUR})
     assert _ids(gate_tracks(tracks, snapshot, windows)) == ["a", "b"]
+
+
+def test_spaces_adjacent_same_artist() -> None:
+    """The assembled batch never places two same-artist tracks directly adjacent."""
+    windows = RecencyWindows(song_seconds=0)  # gate off; test ordering only
+    source = _artist_source(
+        [("a1", "A"), ("a2", "A"), ("a3", "A"), ("b1", "B"), ("c1", "C")],
+    )
+    result = allocate_refill(
+        [source], slots=5, pool_keys=set(), snapshot=_snapshot(), windows=windows
+    )
+    artists = _artists(result)
+    assert len(result) == 5  # spacing reorders, never drops
+    assert all(artists[i] != artists[i + 1] for i in range(len(artists) - 1))
+
+
+def test_seam_avoids_preceding_artist() -> None:
+    """The first added track is kept clear of the artist that plays right before the batch."""
+    windows = RecencyWindows(song_seconds=0)
+    source = _artist_source([("a1", "A"), ("b1", "B"), ("c1", "C")])
+    result = allocate_refill(
+        [source],
+        slots=3,
+        pool_keys=set(),
+        snapshot=_snapshot(),
+        windows=windows,
+        preceding_artists={"a"},
+    )
+    assert len(result) == 3
+    assert result[0].artists[0].name != "A"
+
+
+def test_artist_recency_deprioritized() -> None:
+    """A dynamic candidate whose artist is within the artist window sorts behind fresh ones."""
+    windows = RecencyWindows(song_seconds=0, artist_seconds=1800)
+    source = _artist_source([("r1", "Recent"), ("f1", "Fresh")], fill_mode=DynamicFillMode.DYNAMIC)
+    snapshot = _snapshot(artists_played={"Recent": NOW - 600})
+    result = allocate_refill([source], slots=2, pool_keys=set(), snapshot=snapshot, windows=windows)
+    # the fresh-artist track leads even though it appears later in the candidate list
+    assert _artists(result) == ["Fresh", "Recent"]
+
+
+def test_artist_recency_not_hard_excluded() -> None:
+    """A within-window artist is only nudged back, never dropped (single-artist stations still play)."""
+    windows = RecencyWindows(song_seconds=0, artist_seconds=1800)
+    source = _artist_source([("a1", "A"), ("a2", "A")], fill_mode=DynamicFillMode.DYNAMIC)
+    snapshot = _snapshot(artists_played={"A": NOW - 600})
+    result = allocate_refill([source], slots=5, pool_keys=set(), snapshot=snapshot, windows=windows)
+    assert len(result) == 2  # both kept despite the artist being recently heard

--- a/tests/controllers/player_queues/test_player_queues_helpers.py
+++ b/tests/controllers/player_queues/test_player_queues_helpers.py
@@ -242,18 +242,18 @@ class TestHandlePlayAction:
 class TestSpaceByArtist:
     """Tests for space_by_artist."""
 
-    def test_separates_adjacent_same_artist(self) -> None:
-        """Directly-adjacent same-artist entries are pulled apart, dropping nothing."""
-        sets = [{"a"}, {"a"}, {"b"}, {"c"}]
+    def test_separates_adjacent_shared_artist(self) -> None:
+        """Adjacent entries sharing an artist are pulled apart (by intersection), dropping nothing."""
+        sets = [{"a"}, {"a", "b"}, {"b"}, {"c"}]
         spaced = [sets[index] for index in space_by_artist(sets)]
         assert sorted(spaced, key=sorted) == sorted(sets, key=sorted)
-        assert all(spaced[i] != spaced[i + 1] for i in range(len(spaced) - 1))
+        assert all(not (spaced[i] & spaced[i + 1]) for i in range(len(spaced) - 1))
 
     def test_honours_preceding_seam(self) -> None:
-        """The first entry is kept clear of the preceding (seam) artist set."""
-        sets = [{"a"}, {"b"}, {"c"}]
+        """The first entry shares no artist with the preceding (seam) set."""
+        sets = [{"a", "b"}, {"c"}, {"d"}]
         order = space_by_artist(sets, preceding={"a"})
-        assert sets[order[0]] != {"a"}
+        assert not (sets[order[0]] & {"a"})
 
     def test_identity_when_already_clear(self) -> None:
         """With no clashes and no seam, the order is left untouched."""

--- a/tests/controllers/player_queues/test_player_queues_helpers.py
+++ b/tests/controllers/player_queues/test_player_queues_helpers.py
@@ -16,6 +16,7 @@ from music_assistant.controllers.player_queues.helpers import (
     get_current_playback_speed,
     handle_play_action,
     has_dynamic_source,
+    space_by_artist,
 )
 from music_assistant.controllers.player_queues.state import PlayerQueueData
 
@@ -236,3 +237,28 @@ class TestHandlePlayAction:
             await _boom(cast("PlayerQueuesController", ctrl), "q1")
         assert queue.extra_attributes[ATTR_PLAY_ACTION_IN_PROGRESS] is False
         assert ctrl._queue_data["q1"].play_action_refcount == 0
+
+
+class TestSpaceByArtist:
+    """Tests for space_by_artist."""
+
+    def test_separates_adjacent_same_artist(self) -> None:
+        """Directly-adjacent same-artist entries are pulled apart, dropping nothing."""
+        sets = [{"a"}, {"a"}, {"b"}, {"c"}]
+        spaced = [sets[index] for index in space_by_artist(sets)]
+        assert sorted(spaced, key=sorted) == sorted(sets, key=sorted)
+        assert all(spaced[i] != spaced[i + 1] for i in range(len(spaced) - 1))
+
+    def test_honours_preceding_seam(self) -> None:
+        """The first entry is kept clear of the preceding (seam) artist set."""
+        sets = [{"a"}, {"b"}, {"c"}]
+        order = space_by_artist(sets, preceding={"a"})
+        assert sets[order[0]] != {"a"}
+
+    def test_identity_when_already_clear(self) -> None:
+        """With no clashes and no seam, the order is left untouched."""
+        assert space_by_artist([{"a"}, {"b"}, {"c"}]) == [0, 1, 2]
+
+    def test_empty_input(self) -> None:
+        """An empty input yields an empty order."""
+        assert space_by_artist([]) == []


### PR DESCRIPTION
# What does this implement/fix?

A dynamic queue (a radio or dynamic playlist) is filled by the managed pool, which only weighted its sources and gated on *song* recency. It never spaced by artist and ignored the artist-recency window, so a station could play the same artist back-to-back — most visibly the currently-playing track followed by another track from the same artist.

This wires the artist rules that smart shuffle already applies to finite queues into the dynamic pool:

- Order each refill fresh-artist first, softly nudging recently-heard artists (within the configured artist-recency window) toward the back — a soft de-prioritisation, not a hard exclusion, so a single-artist station still plays.
- Space the assembled batch (across all sources) so no two directly-adjacent tracks share an artist, including the seam with the track that is currently playing.
- Share the spacing algorithm via `helpers.space_by_artist`, used by both smart shuffle and the managed pool.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
