### PR TITLE
Fix complete config loss after power failure or unclean shutdown

### DIFF
--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -28,7 +28,12 @@ from music_assistant.controllers.config.migrations import migrate
 from music_assistant.controllers.config.players import PlayerConfigMixin
 from music_assistant.controllers.config.providers import ProviderConfigMixin
 from music_assistant.controllers.config.queues import PlayerQueueConfigMixin
-from music_assistant.helpers.json import JSON_DECODE_EXCEPTIONS, async_json_dumps, async_json_loads
+from music_assistant.helpers.json import (
+    JSON_DECODE_EXCEPTIONS,
+    async_json_dumps,
+    async_json_loads,
+    json_loads,
+)
 
 if TYPE_CHECKING:
     from music_assistant import MusicAssistant
@@ -234,14 +239,17 @@ class ConfigController(
             _file.flush()
             # fsync so a power failure can not leave a zero-length file behind (#5716)
             os.fsync(_file.fileno())
-        with contextlib.suppress(FileNotFoundError):
-            # never rotate an empty (crash-corrupted) file over a possibly good backup
-            if filename.stat().st_size > 0:
-                filename.replace(f"{self.filename}.backup")
+        with contextlib.suppress(FileNotFoundError, *JSON_DECODE_EXCEPTIONS):
+            # only rotate a parseable file to the backup, so a corrupt
+            # (crash leftover) file can never clobber a possibly good backup
+            json_loads(filename.read_bytes())
+            filename.replace(f"{self.filename}.backup")
         filename_temp.replace(filename)
-        # fsync the directory as well so the renames themselves survive a power failure
-        dir_fd = os.open(os.path.dirname(self.filename), os.O_RDONLY)
-        try:
-            os.fsync(dir_fd)
-        finally:
-            os.close(dir_fd)
+        # best effort: fsync the directory as well so the renames themselves
+        # survive a power failure (not supported on all platforms/filesystems)
+        with contextlib.suppress(OSError):
+            dir_fd = os.open(os.path.dirname(self.filename), os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -7,11 +7,11 @@ import base64
 import contextlib
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import aiofiles
-from aiofiles.os import wrap
 from cryptography.fernet import Fernet, InvalidToken
 from music_assistant_models import config_entries
 from music_assistant_models.errors import InvalidDataError
@@ -35,10 +35,6 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-isfile = wrap(os.path.isfile)
-remove = wrap(os.remove)
-rename = wrap(os.rename)
-
 
 class ConfigController(
     ProviderConfigMixin,
@@ -58,6 +54,7 @@ class ConfigController(
         self._data: dict[str, Any] = {}
         self.filename = os.path.join(self.mass.storage_path, "settings.json")
         self._timer_handle: asyncio.TimerHandle | None = None
+        self._save_lock = asyncio.Lock()
 
     async def setup(self) -> None:
         """Async initialize of controller."""
@@ -223,13 +220,28 @@ class ConfigController(
 
     async def _async_save(self) -> None:
         """Save persistent data to disk."""
-        filename_backup = f"{self.filename}.backup"
-        # make backup before we write a new file
-        if await isfile(self.filename):
-            with contextlib.suppress(FileNotFoundError):
-                await remove(filename_backup)
-            await rename(self.filename, filename_backup)
-
-        async with aiofiles.open(self.filename, "w", encoding="utf-8") as _file:
-            await _file.write(await async_json_dumps(self._data, indent=True))
+        async with self._save_lock:
+            json_data = await async_json_dumps(self._data, indent=True)
+            await asyncio.to_thread(self._save_to_disk, json_data)
         LOGGER.debug("Saved data to persistent storage")
+
+    def _save_to_disk(self, json_data: str) -> None:
+        """Atomically write the settings file to disk, rotating the previous one to backup."""
+        filename = Path(self.filename)
+        filename_temp = Path(f"{self.filename}.tmp")
+        with filename_temp.open("w", encoding="utf-8") as _file:
+            _file.write(json_data)
+            _file.flush()
+            # fsync so a power failure can not leave a zero-length file behind (#5716)
+            os.fsync(_file.fileno())
+        with contextlib.suppress(FileNotFoundError):
+            # never rotate an empty (crash-corrupted) file over a possibly good backup
+            if filename.stat().st_size > 0:
+                filename.replace(f"{self.filename}.backup")
+        filename_temp.replace(filename)
+        # fsync the directory as well so the renames themselves survive a power failure
+        dir_fd = os.open(os.path.dirname(self.filename), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)

--- a/tests/controllers/config/test_persistent_storage_save.py
+++ b/tests/controllers/config/test_persistent_storage_save.py
@@ -1,0 +1,87 @@
+"""
+Regression tests for persistent settings storage durability (support issue #5716).
+
+Users reported complete config loss after a power failure or unclean stop:
+both ``settings.json`` AND ``settings.json.backup`` ended up as zero-length
+files. The old save path renamed the live settings file to the backup and then
+rewrote ``settings.json`` in place, so a single crash inside the write window
+(or a failure during serialization) could destroy both generations at once.
+
+These tests pin down the safe behavior:
+- a failed save must leave the existing files on disk untouched
+- an empty/corrupt settings file must never be rotated over a good backup
+- a successful save rotates the previous file to the backup atomically
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from music_assistant.controllers.config.controller import ConfigController
+
+
+def _make_controller(tmp_path: Path) -> ConfigController:
+    mass = SimpleNamespace(storage_path=str(tmp_path))
+    return ConfigController(mass)  # type: ignore[arg-type]
+
+
+async def test_save_rotates_previous_file_to_backup(tmp_path: Path) -> None:
+    """A successful save keeps the previous generation as a valid backup."""
+    controller = _make_controller(tmp_path)
+    controller._data = {"generation": 1}
+    await controller._async_save()
+    controller._data = {"generation": 2}
+    await controller._async_save()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 2}
+    assert json.loads(Path(f"{controller.filename}.backup").read_text()) == {"generation": 1}
+    assert not os.path.isfile(f"{controller.filename}.tmp")
+
+
+async def test_failed_save_leaves_existing_files_untouched(tmp_path: Path) -> None:
+    """A save that fails mid-write may not corrupt the files already on disk."""
+    controller = _make_controller(tmp_path)
+    controller._data = {"generation": 1}
+    await controller._async_save()
+    controller._data = {"generation": 2}
+    await controller._async_save()
+
+    controller._data = {"generation": 3}
+    with (
+        patch(
+            "music_assistant.controllers.config.controller.async_json_dumps",
+            side_effect=RuntimeError("serialization failed"),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await controller._async_save()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 2}
+    assert json.loads(Path(f"{controller.filename}.backup").read_text()) == {"generation": 1}
+
+
+async def test_empty_settings_file_does_not_clobber_backup(tmp_path: Path) -> None:
+    """
+    A zero-length settings file (crash leftover) must never replace a good backup.
+
+    This is the exact scenario from issue #5716: after loading from the backup,
+    the first save used to rotate the empty main file over the backup, making
+    the loss permanent if anything went wrong before the new write completed.
+    """
+    controller = _make_controller(tmp_path)
+    Path(controller.filename).write_text("")
+    Path(f"{controller.filename}.backup").write_text(json.dumps({"recovered": True}))
+
+    await controller._load()
+    assert controller._data == {"recovered": True}
+
+    await controller._async_save()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"recovered": True}
+    assert json.loads(Path(f"{controller.filename}.backup").read_text()) == {"recovered": True}

--- a/tests/controllers/config/test_persistent_storage_save.py
+++ b/tests/controllers/config/test_persistent_storage_save.py
@@ -85,3 +85,31 @@ async def test_empty_settings_file_does_not_clobber_backup(tmp_path: Path) -> No
 
     assert json.loads(Path(controller.filename).read_text()) == {"recovered": True}
     assert json.loads(Path(f"{controller.filename}.backup").read_text()) == {"recovered": True}
+
+
+async def test_corrupt_settings_file_does_not_clobber_backup(tmp_path: Path) -> None:
+    """A non-empty but corrupt settings file (torn write) must never replace a good backup."""
+    controller = _make_controller(tmp_path)
+    Path(controller.filename).write_text('{"truncated": tr')
+    Path(f"{controller.filename}.backup").write_text(json.dumps({"recovered": True}))
+
+    await controller._load()
+    assert controller._data == {"recovered": True}
+
+    await controller._async_save()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"recovered": True}
+    assert json.loads(Path(f"{controller.filename}.backup").read_text()) == {"recovered": True}
+
+
+async def test_save_succeeds_when_directory_fsync_unsupported(tmp_path: Path) -> None:
+    """The best-effort directory fsync may not fail the save on unsupported platforms."""
+    controller = _make_controller(tmp_path)
+    controller._data = {"generation": 1}
+    with patch(
+        "music_assistant.controllers.config.controller.os.open",
+        side_effect=OSError("fsync on directory not supported"),
+    ):
+        await controller._async_save()
+
+    assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}


### PR DESCRIPTION
# What does this implement/fix?

Users reported complete loss of all Music Assistant configuration after a power failure or unclean shutdown: both `settings.json` and `settings.json.backup` ended up as zero-length files, forcing a full re-onboard.

The save path renamed the live `settings.json` to the backup and then rewrote `settings.json` in place, without fsync or atomic replace. Since saves happen frequently (5s debounce), a single power cut inside the kernel writeback window could destroy both generations at once — the backup was just the previous unsynced write. On the next boot MA started empty and immediately saved, making the loss permanent.

Changes:

- Write to a temp file, fsync it and atomically replace it into place, so a crash leaves either the old or the new file, never an empty one.
- Never rotate an empty (crash-corrupted) settings file over a possibly good backup, so recovery from the backup cannot be wiped out.
- fsync the directory so the renames themselves survive a power failure.
- Serialize saves with a lock to prevent interleaved rotate/write races between the debounced and immediate save paths.
- Regression tests covering the failed-save and empty-file scenarios.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5716

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
