### PR TITLE
Fix smart fades falling back to a hard cut when the incoming track is short

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/renderer.py
+++ b/music_assistant/controllers/streams/smart_fades/renderer.py
@@ -5,7 +5,8 @@ The renderer is the DJ's hands: it picks the tools from the filter toolset
 (``filters.py``) that realize a ``TransitionPlan``, and produces the
 ``CrossfadeTimingInfo`` breakdown.  This is the only place where bytes
 re-enter: the plan is sized in seconds, the renderer reconciles it with the
-actual buffer lengths for the timing bookkeeping.
+actual buffer lengths and drives both the acrossfade overlap and the timing
+bookkeeping from that one reconciled value.
 """
 
 from __future__ import annotations
@@ -51,11 +52,31 @@ class TransitionRenderer:
         :param pcm_format: PCM format of both input buffers and the output.
         :param fade_in_bytes_len: Length in bytes of the incoming track's head buffer.
         """
-        filters = self._build_filters(plan)
-        timing = self._build_timing(plan, pcm_format, fade_in_bytes_len)
+        fade_out_seconds = plan.fade_out_window - plan.tempo_plan.savings_until(
+            plan.fade_out_window
+        )
+        fade_in_seconds = fade_in_bytes_len / pcm_format.pcm_sample_size
+        fadein_trimmed = plan.fadein_trim_start or 0.0
+        # clamp CF to fit shorter inputs (defensive — normally full buffers)
+        crossfade_samples = int(
+            min(
+                plan.crossfade_duration,
+                fade_out_seconds,
+                max(0.0, fade_in_seconds - fadein_trimmed),
+            )
+            * pcm_format.sample_rate
+        )
+        crossfade_seconds = crossfade_samples / pcm_format.sample_rate
+        filters = self._build_filters(plan, crossfade_samples)
+        timing = CrossfadeTimingInfo(
+            pre_crossfade_duration=max(0.0, fade_out_seconds - crossfade_seconds),
+            crossfade_duration=crossfade_seconds,
+            fadein_trimmed_duration=fadein_trimmed,
+            post_crossfade_duration=max(0.0, fade_in_seconds - fadein_trimmed - crossfade_seconds),
+        )
         return filters, timing
 
-    def _build_filters(self, plan: TransitionPlan) -> list[Filter]:
+    def _build_filters(self, plan: TransitionPlan, crossfade_samples: int) -> list[Filter]:
         """Assemble the ordered filter chain from the plan."""
         filters: list[Filter] = []
         # FadeOutTrim must precede any time-stretch: its cut point is on the
@@ -76,9 +97,7 @@ class TransitionRenderer:
             )
         filters.append(self._sweep_filter(plan.eq_plan.fadeout))
         filters.append(self._sweep_filter(plan.eq_plan.fadein))
-        filters.append(
-            CrossfadeFilter(logger=self.logger, crossfade_duration=plan.crossfade_duration)
-        )
+        filters.append(CrossfadeFilter(logger=self.logger, crossfade_samples=crossfade_samples))
         return filters
 
     def _sweep_filter(self, spec: SweepSpec) -> FrequencySweepFilter:
@@ -93,29 +112,4 @@ class TransitionRenderer:
             poles=spec.poles,
             curve_type=spec.curve_type,
             stream_type=spec.stream_type,
-        )
-
-    def _build_timing(
-        self,
-        plan: TransitionPlan,
-        pcm_format: AudioFormat,
-        fade_in_bytes_len: int,
-    ) -> CrossfadeTimingInfo:
-        """Compute the PRE | CF | POST timing breakdown for the rendered mix."""
-        fade_out_seconds = plan.fade_out_window - plan.tempo_plan.savings_until(
-            plan.fade_out_window
-        )
-        fade_in_seconds = fade_in_bytes_len / pcm_format.pcm_sample_size
-        fadein_trimmed = plan.fadein_trim_start or 0.0
-        # clamp CF to fit shorter inputs (defensive — normally full buffers)
-        crossfade_duration = min(
-            plan.crossfade_duration,
-            fade_out_seconds,
-            max(0.0, fade_in_seconds - fadein_trimmed),
-        )
-        return CrossfadeTimingInfo(
-            pre_crossfade_duration=max(0.0, fade_out_seconds - crossfade_duration),
-            crossfade_duration=crossfade_duration,
-            fadein_trimmed_duration=fadein_trimmed,
-            post_crossfade_duration=max(0.0, fade_in_seconds - fadein_trimmed - crossfade_duration),
         )

--- a/tests/controllers/streams/smart_fades/test_renderer.py
+++ b/tests/controllers/streams/smart_fades/test_renderer.py
@@ -100,6 +100,30 @@ class TestTransitionRenderer:
         assert timing.crossfade_duration == pytest.approx(4.0)
         assert timing.post_crossfade_duration == 0.0
 
+    def test_short_fadein_clamps_acrossfade_overlap(self) -> None:
+        """
+        Regression: the acrossfade overlap must never exceed the audio it is fed.
+
+        acrossfade silently emits nothing (a hard cut) when its requested overlap
+        exceeds the incoming buffer, so the filter must use the same clamped,
+        frame-exact overlap as the timing info.
+        """
+        plan = _plan(crossfade_duration=10.0, fadein_trim_start=1.0)
+        filters, timing = TransitionRenderer(LOGGER).render(plan, PCM, _seconds(5))
+        crossfade = filters[-1]
+        assert isinstance(crossfade, CrossfadeFilter)
+        # 5s buffer minus the 1s trim leaves 4s of incoming audio
+        assert crossfade.crossfade_samples == 4 * PCM.sample_rate
+        assert timing.crossfade_duration == pytest.approx(4.0)
+
+    def test_full_buffers_render_plan_duration_as_samples(self) -> None:
+        """With full buffers the filter carries the plan duration, frame-exact."""
+        filters, timing = TransitionRenderer(LOGGER).render(_plan(), PCM, _seconds(45))
+        crossfade = filters[-1]
+        assert isinstance(crossfade, CrossfadeFilter)
+        assert crossfade.crossfade_samples == 10 * PCM.sample_rate
+        assert timing.crossfade_duration == pytest.approx(10.0)
+
     def test_stretch_savings_shorten_fadeout_accounting(self) -> None:
         """A speed-up ramp removes time from the rendered fade-out total."""
         plan = _plan(tempo_plan=TempoPlan(steps=[(30.0, 1.0), (35.0, 1.02)]))

--- a/tests/controllers/streams/test_smartfade_transition_timings.py
+++ b/tests/controllers/streams/test_smartfade_transition_timings.py
@@ -956,8 +956,10 @@ class TestStretchSavings:
         fade.build(_seconds(45), _seconds(45), PCM)
         assert fade.tempo_steps, "test requires the stretch to be active"
         sweep = self._fadeout_sweep(fade)
-        timing = fade.timing_info
-        input_duration = min(max(timing.crossfade_duration * 2.5, 8.0), fade.effective_end)
+        # mirror the planner's EQ window math from the plan value: timing_info's
+        # crossfade_duration is frame-quantized and can differ by <1 sample
+        assert fade.plan is not None
+        input_duration = min(max(fade.plan.crossfade_duration * 2.5, 8.0), fade.effective_end)
         input_start = max(0.0, fade.effective_end - input_duration)
         start_shift = _savings_until(fade, input_start)
         assert start_shift > 0.0, "fixture must place the EQ start inside the stretch window"


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4532, which deliberately preserved this pre-existing bug to stay functionally identical (also flagged by Copilot review there).

The smart fades renderer clamped the crossfade length to the actual buffer lengths in the timing bookkeeping, but built the ffmpeg `acrossfade` filter with the unclamped planned duration. When the incoming track's head buffer holds less audio than planned (tracks shorter than ~90s, or after a fade-in trim for beat alignment), `acrossfade` is asked for more overlap than it is fed and silently emits nothing — the transition becomes a hard cut, while `timing_info` claims a crossfade happened.

- Compute the clamp once in `render()` and drive both the `CrossfadeFilter` and `timing_info` from that single value
- Use the frame-exact `ns=` sample-count form (same as the `StandardCrossFade` hard-cut fix in #4253) so a fractional `d=` can never round past the buffer
- Add a regression test: short fade-in buffer → acrossfade overlap never exceeds the available audio and matches `timing_info`

**Related issue (if applicable):**

- n/a (flagged in review on #4532)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
