### PR TITLE
Bump aioslimproto to 3.1.9

### DIFF
--- a/music_assistant/providers/squeezelite/manifest.json
+++ b/music_assistant/providers/squeezelite/manifest.json
@@ -8,7 +8,7 @@
   "credits": [
     "[aioslimproto](https://github.com/music-assistant/aioslimproto)"
   ],
-  "requirements": ["aioslimproto==3.1.8"],
+  "requirements": ["aioslimproto==3.1.9"],
   "documentation": "https://music-assistant.io/player-support/squeezelite/",
   "multi_instance": false,
   "builtin": false

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -14,7 +14,7 @@ aiojellyfin==0.14.1
 aiomusiccast==0.15.0
 aiortc>=1.6.0
 aiosendspin[server]==6.1.1
-aioslimproto==3.1.8
+aioslimproto==3.1.9
 aiosonos==0.1.12
 aiosqlite==0.22.1
 aiovban==1.1.0


### PR DESCRIPTION
# What does this implement/fix?

Bumps `aioslimproto` from 3.1.8 to 3.1.9 (the squeezelite provider dependency).

Notable upstream changes in 3.1.9:
- Reset elapsed time when a new stream starts
- Tolerate additional args in `_handle_serverstatus`
- CI / internal dependency bumps

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`
