### PR TITLE
Only expose container items as player queue sources

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import asyncio
 import random
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import shortuuid
 from music_assistant_models.enums import (
@@ -97,6 +97,20 @@ if TYPE_CHECKING:
     from music_assistant.constants import PlaylistPlayableItem
     from music_assistant.controllers.music.recency import RecencyWindows
     from music_assistant.models.player import Player
+
+
+# the container media types worth surfacing as a queue "source" for clients to display. Individual
+# items (single tracks, radio streams, podcast episodes, live audio sources, ...) carry no grouping
+# and only clutter the "playing from" representation, so they are omitted from the wire `sources`.
+_WIRE_SOURCE_MEDIA_TYPES: Final = frozenset(
+    {
+        MediaType.ARTIST,
+        MediaType.ALBUM,
+        MediaType.PLAYLIST,
+        MediaType.PODCAST,
+        MediaType.AUDIOBOOK,
+    }
+)
 
 
 class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeederMixin):
@@ -1484,10 +1498,15 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         """
         self._queue_data[queue.queue_id].source_items = items
         # keep every occurrence server-side (a source added more than once weights it up in the
-        # managed pool), but expose each distinct source only once on the wire for clients to show
+        # managed pool), but expose only the distinct container sources on the wire for clients to
+        # show. Individual items (tracks, radio streams, podcast episodes, ...) are omitted; see
+        # `_WIRE_SOURCE_MEDIA_TYPES`. Autoplay/pool refill reads the full `source_items` above, not
+        # this projected list, so it is unaffected.
         seen: set[str] = set()
         sources: list[ItemMapping] = []
         for item in items:
+            if item.media_type not in _WIRE_SOURCE_MEDIA_TYPES:
+                continue
             mapping = ItemMapping.from_item(item)
             if mapping.uri and mapping.uri in seen:
                 continue

--- a/tests/controllers/player_queues/test_enqueue_options.py
+++ b/tests/controllers/player_queues/test_enqueue_options.py
@@ -12,7 +12,15 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock
 
 from music_assistant_models.enums import MediaType, PlaybackState, QueueOption
-from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track
+from music_assistant_models.media_items import (
+    Album,
+    ItemMapping,
+    MediaItemType,
+    Podcast,
+    ProviderMapping,
+    Radio,
+    Track,
+)
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 from music_assistant_models.unique_list import UniqueList
@@ -45,6 +53,42 @@ def _track(item_id: str) -> Track:
         artists=UniqueList(
             [ItemMapping(item_id="a", provider="test", name="A", media_type=MediaType.ARTIST)]
         ),
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _album(item_id: str) -> Album:
+    """Build an Album on the 'test' provider (a container source, kept in the wire `sources`)."""
+    return Album(
+        item_id=item_id,
+        provider="test",
+        name=f"Album {item_id}",
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _podcast(item_id: str) -> Podcast:
+    """Build a Podcast on the 'test' provider (a container source, kept in the wire `sources`)."""
+    return Podcast(
+        item_id=item_id,
+        provider="test",
+        name=f"Podcast {item_id}",
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _radio(item_id: str) -> Radio:
+    """Build a Radio on the 'test' provider (an individual item, omitted from the wire `sources`)."""
+    return Radio(
+        item_id=item_id,
+        provider="test",
+        name=f"Radio {item_id}",
         provider_mappings={
             ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
         },
@@ -359,7 +403,7 @@ def test_store_sources_dedupes_wire_sources_keeps_internal_multiplicity() -> Non
     ctrl._managed_pool = Mock()
     queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
     ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
-    a, b = _track("a"), _track("b")
+    a, b = _album("a"), _album("b")
 
     # "a" added twice (multiplicity 2), "b" once
     ctrl.store_sources(queue, [a, b, a])
@@ -368,3 +412,21 @@ def test_store_sources_dedupes_wire_sources_keeps_internal_multiplicity() -> Non
     assert ctrl._queue_data["q1"].source_items == [a, b, a]
     # wire list clients see is deduped to the distinct sources, order preserved
     assert [mapping.uri for mapping in queue.sources] == [a.uri, b.uri]
+
+
+def test_store_sources_keeps_only_container_types_on_wire() -> None:
+    """Container sources reach the wire `sources`; individual items are omitted (kept server-side)."""
+    ctrl = _controller()
+    ctrl._managed_pool = Mock()
+    queue = PlayerQueue(queue_id="q1", active=True, display_name="Q1", available=True, items=0)
+    ctrl._queue_data = {"q1": PlayerQueueData(queue=queue)}
+    album, podcast = _album("al"), _podcast("po")
+    track, radio = _track("t"), _radio("r")
+    items: list[MediaItemType] = [album, track, podcast, radio]
+
+    ctrl.store_sources(queue, items)
+
+    # the full set (incl. the individual items) is retained server-side for pool weighting / seeds
+    assert ctrl._queue_data["q1"].source_items == items
+    # but only the container sources are shown to clients, in original order
+    assert [mapping.uri for mapping in queue.sources] == [album.uri, podcast.uri]


### PR DESCRIPTION
# What does this implement/fix?

The player controller exposes what the user enqueued to API clients via `PlayerQueue.sources` (a list of `ItemMapping`s), so a client can show which playlist/album/artist is currently playing. It also included every individually-enqueued track, which made that "playing from" representation noisy — a queue built from single tracks showed a long list of track names instead of a clean set of sources.

This projects only container media types onto the wire `sources`. The full source set is still kept server-side in `source_items`, so nothing that reads it — autoplay when the queue runs out, the managed pool's per-source weighting, dynamic refill — is affected.

## Changes

- `store_sources` now filters `queue.sources` to container types only (artist, album, playlist, podcast, audiobook) via a new `_WIRE_SOURCE_MEDIA_TYPES` allowlist; individual items (tracks, radio streams, podcast episodes, live audio sources, ...) are omitted.
- Server-side `source_items` (and `enqueued_media_items`) are left untouched — autoplay and the managed pool read those, not the projected wire list.
- Added tests covering the projection: containers are kept (in order, deduped), individual items are retained server-side but omitted from the wire.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
