### PR TITLE
Fix AirPlay receiver advertising on the wrong network interface

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -937,6 +937,24 @@ async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
     return await asyncio.to_thread(call)
 
 
+def interface_name_for_ip(ip: str) -> str | None:
+    """
+    Return the name of the network interface that holds the given IP, or None.
+
+    Used to map a bind/publish IP to its interface name for components that select
+    their mDNS/zeroconf advertisement interface by name (e.g. shairport-sync and
+    go-librespot), so the advertisement stays on the intended network.
+
+    :param ip: The IPv4/IPv6 address to look up.
+    """
+    for adapter in ifaddr.get_adapters():
+        for ip_config in adapter.ips:
+            addr = ip_config.ip if isinstance(ip_config.ip, str) else ip_config.ip[0]
+            if addr == ip:
+                return adapter.name
+    return None
+
+
 async def get_primary_ip_address() -> str | None:
     """Return the primary IP address of the system."""
 

--- a/music_assistant/providers/airplay_receiver/__init__.py
+++ b/music_assistant/providers/airplay_receiver/__init__.py
@@ -46,6 +46,7 @@ from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 from music_assistant.constants import CONF_ENTRY_WARN_PREVIEW, VERBOSE_LOG_LEVEL
 from music_assistant.helpers.named_pipe import AsyncNamedPipeWriter
 from music_assistant.helpers.process import AsyncProcess, check_output
+from music_assistant.helpers.util import interface_name_for_ip
 from music_assistant.models.plugin import PluginProvider
 from music_assistant.providers.airplay_receiver.helpers import get_shairport_sync_binary
 from music_assistant.providers.airplay_receiver.metadata import MetadataReader
@@ -469,6 +470,7 @@ class AirPlayReceiverProvider(PluginProvider):
         config_content = config_content.replace("{METADATA_PIPE}", self.metadata_pipe.path)
         config_content = config_content.replace("{AUDIO_PIPE}", self.audio_pipe.path)
         config_content = config_content.replace("{PORT}", str(self.airplay_port))
+        config_content = config_content.replace("{INTERFACE_LINE}", self._get_mdns_interface_line())
 
         # Set default volume based on default player's current volume if available
         # Convert player volume (0-100) to AirPlay volume (-30.0 to 0.0 dB)
@@ -487,6 +489,27 @@ class AirPlayReceiverProvider(PluginProvider):
                 f.write(config_content)
 
         await asyncio.to_thread(_write_config)
+
+    def _get_mdns_interface_line(self) -> str:
+        """
+        Build the shairport-sync ``general.interface`` directive, or an empty string.
+
+        When the stream server is bound to a specific interface (not 0.0.0.0), pin
+        the AirPlay mDNS advertisement to that same interface so the receiver is
+        announced on the intended network instead of an unrelated one (e.g. a
+        Docker bridge). Returns an empty string to advertise on all interfaces.
+        """
+        bind_ip = self.mass.streams.bind_ip
+        if not bind_ip or bind_ip == "0.0.0.0":
+            return ""
+        iface_name = interface_name_for_ip(bind_ip)
+        if not iface_name:
+            self.logger.debug(
+                "No interface found for stream bind IP %s; advertising on all interfaces",
+                bind_ip,
+            )
+            return ""
+        return f'\tinterface = "{iface_name}";\n'
 
     async def _setup_pipes_and_config(self) -> None:
         """

--- a/music_assistant/providers/airplay_receiver/bin/shairport-sync.conf
+++ b/music_assistant/providers/airplay_receiver/bin/shairport-sync.conf
@@ -8,8 +8,10 @@ general =
 	output_backend = "pipe";
 	default_airplay_volume = {DEFAULT_VOLUME};
 	port = {PORT};
-	// Using tinysvcmdns (embedded mDNS, no external daemon required)
-};
+	// Using tinysvcmdns (embedded mDNS, no external daemon required).
+	// The line below is filled in with an `interface = "..."` directive when the
+	// stream server is bound to a specific interface, else it is left empty.
+{INTERFACE_LINE}};
 
 metadata =
 {

--- a/music_assistant/providers/spotify_connect/__init__.py
+++ b/music_assistant/providers/spotify_connect/__init__.py
@@ -37,11 +37,11 @@ from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 
 from music_assistant.constants import CONF_ENTRY_WARN_PREVIEW
 from music_assistant.helpers.process import AsyncProcess
-from music_assistant.helpers.util import select_free_port
+from music_assistant.helpers.util import interface_name_for_ip, select_free_port
 from music_assistant.models.plugin import PluginProvider
 
 from .client import GoLibrespotClient
-from .helpers import generate_device_id, get_go_librespot_binary, interface_name_for_ip
+from .helpers import generate_device_id, get_go_librespot_binary
 
 if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigValueType, ProviderConfig

--- a/music_assistant/providers/spotify_connect/helpers.py
+++ b/music_assistant/providers/spotify_connect/helpers.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import hashlib
 import shutil
 
-import ifaddr
-
 GO_LIBRESPOT_BINARY = "go-librespot"
 
 
@@ -42,21 +40,3 @@ def generate_device_id(instance_id: str) -> str:
     :param instance_id: The provider instance id.
     """
     return hashlib.sha256(instance_id.encode()).hexdigest()[:40]
-
-
-def interface_name_for_ip(ip: str) -> str | None:
-    """
-    Return the name of the network interface that holds the given IP, or None.
-
-    go-librespot selects which interfaces to advertise the Spotify Connect device
-    on by interface name, so callers map the streams server's bind IP to its
-    interface to keep the advertisement on the right network.
-
-    :param ip: The IPv4/IPv6 address to look up.
-    """
-    for adapter in ifaddr.get_adapters():
-        for ip_config in adapter.ips:
-            addr = ip_config.ip if isinstance(ip_config.ip, str) else ip_config.ip[0]
-            if addr == ip:
-                return adapter.name
-    return None

--- a/tests/helpers/test_helpers.py
+++ b/tests/helpers/test_helpers.py
@@ -332,6 +332,7 @@ def _make_mock_adapter(
     :param ipv6_addrs: List of (address, flowinfo, scope_id) tuples for IPv6.
     """
     adapter = MagicMock()
+    adapter.name = name
     adapter.nice_name = name
     ips = []
     for addr in ipv4_addrs or []:
@@ -404,6 +405,34 @@ def test_get_zeroconf_args_all_interfaces() -> None:
     assert result["ip_version"] == IPVersion.All
     assert isinstance(result["interfaces"], list)
     assert "192.168.1.10" in result["interfaces"]
+
+
+def test_interface_name_for_ip_ipv4_match() -> None:
+    """An IPv4 address returns the name of the interface that holds it."""
+    adapters = [
+        _make_mock_adapter("lo", ["127.0.0.1"]),
+        _make_mock_adapter("eth0", ["192.168.1.10"]),
+    ]
+    with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+        assert util.interface_name_for_ip("192.168.1.10") == "eth0"
+
+
+def test_interface_name_for_ip_ipv6_match() -> None:
+    """An IPv6 address (stored as an (addr, flowinfo, scope_id) tuple) resolves by its address."""
+    adapters = [
+        _make_mock_adapter("eth0", ipv6_addrs=[("fd00::1", 0, 2)]),
+    ]
+    with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+        assert util.interface_name_for_ip("fd00::1") == "eth0"
+
+
+def test_interface_name_for_ip_no_match() -> None:
+    """An address that no interface holds returns None."""
+    adapters = [
+        _make_mock_adapter("eth0", ["192.168.1.10"]),
+    ]
+    with patch("music_assistant.helpers.util.ifaddr.get_adapters", return_value=adapters):
+        assert util.interface_name_for_ip("10.0.0.1") is None
 
 
 @pytest.mark.parametrize("capability", ["DEFAULT", "NO AVX"])


### PR DESCRIPTION
# What does this implement/fix?

The AirPlay Receiver plugin runs shairport-sync with embedded mDNS (tinysvcmdns), which advertised the AirPlay service on all interfaces. On multi-homed hosts — most commonly a Docker container running on the host network — this could announce an internal, unreachable address such as a Docker bridge IP (e.g. `172.29.0.1`), so senders discovered the receiver on the wrong network.

The provider passed no interface configuration to shairport-sync at all, so none of the existing network settings reached it. This mirrors the fix already in the Spotify Connect provider: when the stream server is bound to a specific interface, pin the receiver's mDNS advertisement to that same interface.

Changes:

- AirPlay Receiver: emit shairport-sync's `general.interface` directive derived from the stream server's bind IP, so the service is advertised on the intended network. Left empty (advertise on all interfaces) when the bind IP is `0.0.0.0`.
- Promote the `interface_name_for_ip` helper out of the Spotify Connect provider into `helpers/util.py` and share it between both providers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
