### PR TITLE
Allow smart playlists through metadata enrichment

### DIFF
--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, cast
 from music_assistant_models.enums import AlbumType, MediaType, ProviderFeature
 from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.helpers import get_global_cache_value
-from music_assistant_models.media_items import Album, Artist, MediaItemImage, Track
+from music_assistant_models.media_items import Album, Artist, MediaItemImage, Track, UniqueList
 
 from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
 from music_assistant.helpers.compare import compare_strings
@@ -322,10 +322,11 @@ class MetadataEnrichmentMixin:
         self, playlist: Playlist, force_refresh: bool = False
     ) -> None:
         """Get/update rich metadata for a playlist."""
-        # dynamic playlists (e.g. Pandora stations, Apple Music stations) are
-        # provider-driven and endless: scanning "all" tracks for aggregate metadata
-        # doesn't make sense
-        if playlist.is_dynamic:
+        # Skip endless provider-driven playlists (radio stations), but allow smart playlists
+        has_smart_playlist_mapping = any(
+            pm.provider_domain == "smart_playlist" for pm in playlist.provider_mappings
+        )
+        if playlist.is_dynamic and not has_smart_playlist_mapping:
             return
         # collect metadata + create collage images
         # NOTE: we only do/allow this every REFRESH_INTERVAL
@@ -375,6 +376,15 @@ class MetadataEnrichmentMixin:
                 continue
             try:
                 if prov_metadata := await provider.get_playlist_metadata(playlist):
+                    # Remove fallback images before adding high-quality generated ones
+                    if prov_metadata.images:
+                        playlist.metadata.images = UniqueList(
+                            [
+                                img
+                                for img in playlist.metadata.images
+                                if img.provider != "smart_playlist"
+                            ]
+                        )
                     playlist.metadata.update(prov_metadata)
                     self.logger.debug(
                         "Retrieved playlist metadata from provider %s for %s",

--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -377,13 +377,14 @@ class MetadataEnrichmentMixin:
             try:
                 if prov_metadata := await provider.get_playlist_metadata(playlist):
                     # Remove fallback images before adding high-quality generated ones
-                    if prov_metadata.images:
-                        playlist.metadata.images = UniqueList(
-                            [
+                    if prov_metadata.images and playlist.metadata.images:
+                        playlist.metadata.images = (
+                            UniqueList(
                                 img
                                 for img in playlist.metadata.images
                                 if img.provider != "smart_playlist"
-                            ]
+                            )
+                            or None
                         )
                     playlist.metadata.update(prov_metadata)
                     self.logger.debug(

--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -321,12 +321,6 @@ class MetadataEnrichmentMixin:
         self, playlist: Playlist, force_refresh: bool = False
     ) -> None:
         """Get/update rich metadata for a playlist."""
-        # Skip endless provider-driven playlists (radio stations), but allow smart playlists
-        has_smart_playlist_mapping = any(
-            pm.provider_domain == "smart_playlist" for pm in playlist.provider_mappings
-        )
-        if playlist.is_dynamic and not has_smart_playlist_mapping:
-            return
         # collect metadata + create collage images
         # NOTE: we only do/allow this every REFRESH_INTERVAL
         needs_refresh = (time() - (playlist.metadata.last_refresh or 0)) > REFRESH_INTERVAL
@@ -375,16 +369,6 @@ class MetadataEnrichmentMixin:
                 continue
             try:
                 if prov_metadata := await provider.get_playlist_metadata(playlist):
-                    # Remove fallback images before adding high-quality generated ones
-                    if prov_metadata.images and playlist.metadata.images:
-                        playlist.metadata.images = (
-                            UniqueList(
-                                img
-                                for img in playlist.metadata.images
-                                if img.provider != "smart_playlist"
-                            )
-                            or None
-                        )
                     playlist.metadata.update(prov_metadata)
                     self.logger.debug(
                         "Retrieved playlist metadata from provider %s for %s",

--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
 
     from music_assistant_models.config_entries import CoreConfig
     from music_assistant_models.media_items import Audiobook, Playlist, Podcast
-    from music_assistant_models.unique_list import UniqueList
 
     from music_assistant import MusicAssistant
     from music_assistant.models.metadata_provider import MetadataProvider

--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, cast
 from music_assistant_models.enums import AlbumType, MediaType, ProviderFeature
 from music_assistant_models.errors import MediaNotFoundError, MusicAssistantError
 from music_assistant_models.helpers import get_global_cache_value
-from music_assistant_models.media_items import Album, Artist, MediaItemImage, Track, UniqueList
+from music_assistant_models.media_items import Album, Artist, MediaItemImage, Track
 
 from music_assistant.constants import VARIOUS_ARTISTS_MBID, VARIOUS_ARTISTS_NAME
 from music_assistant.helpers.compare import compare_strings
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
     from music_assistant_models.config_entries import CoreConfig
     from music_assistant_models.media_items import Audiobook, Playlist, Podcast
+    from music_assistant_models.unique_list import UniqueList
 
     from music_assistant import MusicAssistant
     from music_assistant.models.metadata_provider import MetadataProvider

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -372,11 +372,10 @@ class SmartPlaylistProvider(PluginProvider):
     async def _migrate_legacy_icon(self) -> None:
         """Remove legacy icon.svg from smart playlists (added by versions prior to PR #4447)."""
         try:
-            library_playlists = await self.mass.music.playlists.library_items(
-                provider=self.instance_id
-            )
             migrated_count = 0
-            for playlist in library_playlists:
+            async for playlist in self.mass.music.playlists.iter_library_items(
+                provider=self.instance_id
+            ):
                 if not playlist.metadata.images:
                     continue
 
@@ -389,7 +388,7 @@ class SmartPlaylistProvider(PluginProvider):
                 if len(old_images) != len(playlist.metadata.images):
                     playlist.metadata.images = UniqueList(old_images)
                     await self.mass.music.playlists.update_item_in_library(
-                        playlist.item_id, playlist
+                        playlist.item_id, playlist, overwrite=True
                     )
                     migrated_count += 1
                     self.logger.debug(

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -230,6 +230,7 @@ class SmartPlaylistProvider(PluginProvider):
         # Re-add playlists missing from the library (e.g. after a DB reset).
         self.mass.create_task(self._reconcile_library())
         # One-time migration: remove legacy icon.svg from smart playlists
+        # TODO: remove after 2.10 release
         self.mass.create_task(self._migrate_legacy_icon())
 
     async def unload(self, is_removed: bool = False) -> None:
@@ -371,14 +372,11 @@ class SmartPlaylistProvider(PluginProvider):
     async def _migrate_legacy_icon(self) -> None:
         """Remove legacy icon.svg from smart playlists (added by versions prior to PR #4447)."""
         try:
-            library_playlists = await self.mass.music.playlists.library_items()
+            library_playlists = await self.mass.music.playlists.library_items(
+                provider=self.instance_id
+            )
             migrated_count = 0
             for playlist in library_playlists:
-                if not any(
-                    m.provider_instance == self.instance_id for m in playlist.provider_mappings
-                ):
-                    continue
-
                 if not playlist.metadata.images:
                     continue
 

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -43,6 +43,7 @@ from music_assistant_models.media_items import (
     ProviderMapping,
     RecommendationFolder,
     Track,
+    UniqueList,
 )
 from music_assistant_models.media_items.metadata import MediaItemMetadata
 
@@ -228,6 +229,8 @@ class SmartPlaylistProvider(PluginProvider):
         )
         # Re-add playlists missing from the library (e.g. after a DB reset).
         self.mass.create_task(self._reconcile_library())
+        # One-time migration: remove legacy icon.svg from smart playlists
+        self.mass.create_task(self._migrate_legacy_icon())
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/close of the provider."""
@@ -364,6 +367,42 @@ class SmartPlaylistProvider(PluginProvider):
                 await self.mass.music.playlists.add_item_to_library(playlist)
             except Exception as exc:
                 self.logger.warning("Could not re-add smart playlist %s: %s", playlist_id, exc)
+
+    async def _migrate_legacy_icon(self) -> None:
+        """Remove legacy icon.svg from smart playlists (added by versions prior to PR #4447)."""
+        try:
+            library_playlists = await self.mass.music.playlists.library_items()
+            migrated_count = 0
+            for playlist in library_playlists:
+                if not any(
+                    m.provider_instance == self.instance_id for m in playlist.provider_mappings
+                ):
+                    continue
+
+                if not playlist.metadata.images:
+                    continue
+
+                old_images = [
+                    img
+                    for img in playlist.metadata.images
+                    if not (img.path == "icon.svg" and img.provider == self.instance_id)
+                ]
+
+                if len(old_images) != len(playlist.metadata.images):
+                    playlist.metadata.images = UniqueList(old_images)
+                    await self.mass.music.playlists.update_item_in_library(
+                        playlist.item_id, playlist
+                    )
+                    migrated_count += 1
+                    self.logger.debug(
+                        "Migrated smart playlist '%s' - removed legacy icon.svg", playlist.name
+                    )
+            if migrated_count > 0:
+                self.logger.info(
+                    "Migrated %d smart playlist(s) - removed legacy icon.svg", migrated_count
+                )
+        except Exception as exc:
+            self.logger.warning("Failed to migrate legacy icons: %s", exc)
 
     async def _on_media_item_deleted(self, event: MassEvent) -> None:
         """Remove the rules for a deleted smart playlist."""

--- a/tests/controllers/metadata/test_playlist_metadata_integration.py
+++ b/tests/controllers/metadata/test_playlist_metadata_integration.py
@@ -246,15 +246,13 @@ async def test_update_playlist_metadata_skips_dynamic_playlists(tmp_path: Any) -
         provider="pandora",
         name="Dynamic Station",
         is_dynamic=True,
-        provider_mappings=UniqueList(
-            [
-                ProviderMapping(
-                    item_id="dynamic_station_1",
-                    provider_domain="pandora",
-                    provider_instance="pandora_instance",
-                )
-            ]
-        ),
+        provider_mappings={
+            ProviderMapping(
+                item_id="dynamic_station_1",
+                provider_domain="pandora",
+                provider_instance="pandora_instance",
+            )
+        },
         metadata=MediaItemMetadata(),
     )
 
@@ -298,16 +296,14 @@ async def test_update_playlist_metadata_allows_smart_playlists(tmp_path: Any) ->
         item_id="smart_playlist_1",
         provider="library",
         name="Smart Playlist",
-        is_dynamic=True,  # Smart playlists are marked dynamic
-        provider_mappings=UniqueList(
-            [
-                ProviderMapping(
-                    item_id="smart_playlist_1",
-                    provider_domain="smart_playlist",
-                    provider_instance="smart_playlist",
-                )
-            ]
-        ),
+        is_dynamic=True,  # This test covers the dynamic smart-playlist exception path
+        provider_mappings={
+            ProviderMapping(
+                item_id="smart_playlist_1",
+                provider_domain="smart_playlist",
+                provider_instance="smart_playlist",
+            )
+        },
         metadata=MediaItemMetadata(),
     )
 

--- a/tests/controllers/metadata/test_playlist_metadata_integration.py
+++ b/tests/controllers/metadata/test_playlist_metadata_integration.py
@@ -246,13 +246,15 @@ async def test_update_playlist_metadata_skips_dynamic_playlists(tmp_path: Any) -
         provider="pandora",
         name="Dynamic Station",
         is_dynamic=True,
-        provider_mappings={
-            ProviderMapping(
-                item_id="dynamic_station_1",
-                provider_domain="pandora",
-                provider_instance="pandora_instance",
-            )
-        },
+        provider_mappings=UniqueList(
+            [
+                ProviderMapping(
+                    item_id="dynamic_station_1",
+                    provider_domain="pandora",
+                    provider_instance="pandora_instance",
+                )
+            ]
+        ),
         metadata=MediaItemMetadata(),
     )
 
@@ -297,13 +299,15 @@ async def test_update_playlist_metadata_allows_smart_playlists(tmp_path: Any) ->
         provider="library",
         name="Smart Playlist",
         is_dynamic=True,  # Smart playlists are marked dynamic
-        provider_mappings={
-            ProviderMapping(
-                item_id="smart_playlist_1",
-                provider_domain="smart_playlist",
-                provider_instance="smart_playlist",
-            )
-        },
+        provider_mappings=UniqueList(
+            [
+                ProviderMapping(
+                    item_id="smart_playlist_1",
+                    provider_domain="smart_playlist",
+                    provider_instance="smart_playlist",
+                )
+            ]
+        ),
         metadata=MediaItemMetadata(),
     )
 

--- a/tests/controllers/metadata/test_playlist_metadata_integration.py
+++ b/tests/controllers/metadata/test_playlist_metadata_integration.py
@@ -223,3 +223,95 @@ async def test_update_playlist_metadata_skips_providers_without_feature(tmp_path
 
     # Should have called update_item_in_library
     enrichment.mass.music.playlists.update_item_in_library.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_playlist_metadata_skips_dynamic_playlists(tmp_path: Any) -> None:
+    """_update_playlist_metadata should skip dynamic playlists (endless radio stations)."""
+    enrichment = MetadataEnrichmentMixin()
+    enrichment.logger = MagicMock()
+    enrichment.mass = MagicMock()
+    enrichment._collage_images_dir = str(tmp_path / "collage")
+
+    # Mock metadata provider
+    provider = MagicMock()
+    provider.name = "playlist_metadata"
+    provider.supported_features = {ProviderFeature.PLAYLIST_METADATA}
+    provider.get_playlist_metadata = AsyncMock()
+    enrichment.providers = [provider]  # type: ignore[misc]
+
+    # Create dynamic playlist (e.g., Pandora station, Apple Music station)
+    playlist = Playlist(
+        item_id="dynamic_station_1",
+        provider="pandora",
+        name="Dynamic Station",
+        is_dynamic=True,
+        provider_mappings={
+            ProviderMapping(
+                item_id="dynamic_station_1",
+                provider_domain="pandora",
+                provider_instance="pandora_instance",
+            )
+        },
+        metadata=MediaItemMetadata(),
+    )
+
+    await enrichment._update_playlist_metadata(playlist, force_refresh=True)
+
+    # Should not have called provider.get_playlist_metadata
+    provider.get_playlist_metadata.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_playlist_metadata_allows_smart_playlists(tmp_path: Any) -> None:
+    """_update_playlist_metadata should allow smart playlists despite is_dynamic=True."""
+    enrichment = MetadataEnrichmentMixin()
+    enrichment.logger = MagicMock()
+    enrichment.mass = MagicMock()
+    enrichment._collage_images_dir = str(tmp_path / "collage")
+    enrichment.create_collage_image = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    # Mock metadata provider
+    provider = MagicMock()
+    provider.name = "playlist_metadata"
+    provider.supported_features = {ProviderFeature.PLAYLIST_METADATA}
+    provider.get_playlist_metadata = AsyncMock(
+        return_value=MediaItemMetadata(
+            images=UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path="/fake/thumb.jpg",
+                        provider="playlist_metadata",
+                        remotely_accessible=False,
+                    )
+                ]
+            )
+        )
+    )
+    enrichment.providers = [provider]  # type: ignore[misc]
+
+    # Create smart playlist with is_dynamic=True
+    playlist = Playlist(
+        item_id="smart_playlist_1",
+        provider="library",
+        name="Smart Playlist",
+        is_dynamic=True,  # Smart playlists are marked dynamic
+        provider_mappings={
+            ProviderMapping(
+                item_id="smart_playlist_1",
+                provider_domain="smart_playlist",
+                provider_instance="smart_playlist",
+            )
+        },
+        metadata=MediaItemMetadata(),
+    )
+
+    enrichment.mass.music.playlists.tracks = _empty_tracks_iter
+    enrichment.mass.music.playlists.update_item_in_library = AsyncMock()
+
+    await enrichment._update_playlist_metadata(playlist, force_refresh=True)
+
+    # Should have called provider.get_playlist_metadata despite is_dynamic=True
+    provider.get_playlist_metadata.assert_called_once_with(playlist)
+    assert any(img.provider == "playlist_metadata" for img in (playlist.metadata.images or []))

--- a/tests/controllers/metadata/test_playlist_metadata_integration.py
+++ b/tests/controllers/metadata/test_playlist_metadata_integration.py
@@ -226,19 +226,40 @@ async def test_update_playlist_metadata_skips_providers_without_feature(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_update_playlist_metadata_skips_dynamic_playlists(tmp_path: Any) -> None:
-    """_update_playlist_metadata should skip dynamic playlists (endless radio stations)."""
+async def test_update_playlist_metadata_calls_providers_for_dynamic_playlists(
+    tmp_path: Any,
+) -> None:
+    """
+    _update_playlist_metadata should call providers even for dynamic playlists.
+
+    Providers decide themselves whether to return metadata (e.g., playlist_metadata
+    provider skips provider playlists via CONF_SKIP_PROVIDER_PLAYLISTS).
+    """
     enrichment = MetadataEnrichmentMixin()
     enrichment.logger = MagicMock()
     enrichment.mass = MagicMock()
     enrichment._collage_images_dir = str(tmp_path / "collage")
 
-    # Mock metadata provider
+    # Mock metadata provider that returns None for dynamic playlists
     provider = MagicMock()
     provider.name = "playlist_metadata"
     provider.supported_features = {ProviderFeature.PLAYLIST_METADATA}
-    provider.get_playlist_metadata = AsyncMock()
+    provider.get_playlist_metadata = AsyncMock(return_value=None)
     enrichment.providers = [provider]  # type: ignore[misc]
+
+    # Mock playlist tracks iterator (returns no tracks)
+    async def mock_tracks(
+        item_id: str,
+        provider: str,  # noqa: ARG001
+    ) -> AsyncIterator[Track]:
+        """Empty async generator."""
+        return
+        yield  # pragma: no cover
+
+    enrichment.mass.music.playlists.tracks = mock_tracks
+
+    # Mock update_item_in_library
+    enrichment.mass.music.playlists.update_item_in_library = AsyncMock()
 
     # Create dynamic playlist (e.g., Pandora station, Apple Music station)
     playlist = Playlist(
@@ -258,8 +279,8 @@ async def test_update_playlist_metadata_skips_dynamic_playlists(tmp_path: Any) -
 
     await enrichment._update_playlist_metadata(playlist, force_refresh=True)
 
-    # Should not have called provider.get_playlist_metadata
-    provider.get_playlist_metadata.assert_not_called()
+    # Provider should be called (provider decides whether to return metadata)
+    provider.get_playlist_metadata.assert_called_once_with(playlist)
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/metadata/test_playlist_metadata_integration.py
+++ b/tests/controllers/metadata/test_playlist_metadata_integration.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -249,12 +249,12 @@ async def test_update_playlist_metadata_calls_providers_for_dynamic_playlists(
 
     # Mock playlist tracks iterator (returns no tracks)
     async def mock_tracks(
-        item_id: str,
+        item_id: str,  # noqa: ARG001
         provider: str,  # noqa: ARG001
     ) -> AsyncIterator[Track]:
         """Empty async generator."""
-        return
-        yield  # pragma: no cover
+        if False:
+            yield  # type: ignore[unreachable]  # pragma: no cover
 
     enrichment.mass.music.playlists.tracks = mock_tracks
 

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -35,24 +35,24 @@ def _provider_mapping(item_id: str = "station_1") -> ProviderMapping:
 
 
 # --------------------------------------------------------------------------- #
-#  Metadata refresh scan processes all playlists (providers decide filtering)  #
+#  _update_playlist_metadata processes all playlists when called directly      #
 # --------------------------------------------------------------------------- #
 
 
 async def test_update_playlist_metadata_processes_dynamic_playlists() -> None:
-    """Dynamic playlists go through enrichment; providers decide whether to return metadata."""
+    """_update_playlist_metadata processes dynamic playlists; providers decide filtering."""
     mixin = MetadataEnrichmentMixin()
     mixin.mass = Mock()
     mixin.logger = Mock()
-    mixin.providers = []
+    mixin.providers = []  # type: ignore[misc]
 
     async def mock_tracks(
-        item_id: str,
+        item_id: str,  # noqa: ARG001
         provider: str,  # noqa: ARG001
     ) -> AsyncIterator[Track]:
         """Empty async generator."""
-        return
-        yield  # pragma: no cover
+        if False:
+            yield  # type: ignore[unreachable]  # pragma: no cover
 
     mixin.mass.music.playlists.tracks = mock_tracks
     mixin.mass.music.playlists.update_item_in_library = AsyncMock()
@@ -74,7 +74,7 @@ async def test_update_playlist_metadata_processes_dynamic_playlists() -> None:
 
 
 async def test_refresh_playlist_metadata_batch_query_excludes_dynamic_playlists() -> None:
-    """The metadata-refresh batch query filters out is_dynamic playlists at the DB level."""
+    """Batch query filters is_dynamic playlists; single updates process all playlists."""
     ctrl = _controller()
     mass = Mock()
     mass.music.playlists.get_library_items_by_query = AsyncMock(return_value=[])
@@ -84,6 +84,7 @@ async def test_refresh_playlist_metadata_batch_query_excludes_dynamic_playlists(
 
     _, kwargs = mass.music.playlists.get_library_items_by_query.call_args
     query_parts = kwargs["extra_query_parts"]
+    # Batch query should still filter dynamic playlists (automated refresh)
     assert any(f"{DB_TABLE_PLAYLISTS}.is_dynamic = 0" in part for part in query_parts)
 
 

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -46,6 +46,7 @@ async def test_update_playlist_metadata_skips_dynamic_playlists() -> None:
     mixin.logger = Mock()
     playlist = Mock()
     playlist.is_dynamic = True
+    playlist.provider_mappings = {_provider_mapping()}
 
     await mixin._update_playlist_metadata(playlist)
 

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, Mock, patch
 
 from music_assistant_models.enums import MediaType
-from music_assistant_models.media_items import ProviderMapping, UniqueList
+from music_assistant_models.media_items import ProviderMapping, Track, UniqueList
 
 from music_assistant.constants import DB_TABLE_PLAYLISTS
 from music_assistant.controllers.metadata import MetaDataController
@@ -35,23 +35,42 @@ def _provider_mapping(item_id: str = "station_1") -> ProviderMapping:
 
 
 # --------------------------------------------------------------------------- #
-#  Metadata refresh scan skips dynamic playlists                              #
+#  Metadata refresh scan processes all playlists (providers decide filtering)  #
 # --------------------------------------------------------------------------- #
 
 
-async def test_update_playlist_metadata_skips_dynamic_playlists() -> None:
-    """Dynamic playlists must not be scanned for aggregate track metadata."""
+async def test_update_playlist_metadata_processes_dynamic_playlists() -> None:
+    """Dynamic playlists go through enrichment; providers decide whether to return metadata."""
     mixin = MetadataEnrichmentMixin()
     mixin.mass = Mock()
     mixin.logger = Mock()
+    mixin.providers = []
+
+    async def mock_tracks(
+        item_id: str,
+        provider: str,  # noqa: ARG001
+    ) -> AsyncIterator[Track]:
+        """Empty async generator."""
+        return
+        yield  # pragma: no cover
+
+    mixin.mass.music.playlists.tracks = mock_tracks
+    mixin.mass.music.playlists.update_item_in_library = AsyncMock()
+
     playlist = Mock()
     playlist.is_dynamic = True
     playlist.provider_mappings = {_provider_mapping()}
+    playlist.provider = "pandora"
+    playlist.item_id = "test_dynamic"
+    playlist.name = "Test Dynamic Playlist"
+    playlist.metadata = Mock()
+    playlist.metadata.last_refresh = 0
+    playlist.metadata.genres = set()
 
-    await mixin._update_playlist_metadata(playlist)
+    await mixin._update_playlist_metadata(playlist, force_refresh=True)
 
-    mixin.mass.music.playlists.tracks.assert_not_called()
-    mixin.logger.debug.assert_not_called()
+    # Track scanning should happen (providers decide whether to use this data)
+    mixin.logger.debug.assert_called()
 
 
 async def test_refresh_playlist_metadata_batch_query_excludes_dynamic_playlists() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Fixes smart playlist artwork generation broken since PR #4326.

Smart playlists were incorrectly excluded from metadata enrichment by the `is_dynamic` check added in #4326. That PR was designed to skip endless provider-driven radio stations (Pandora, Apple Music stations) that don't have a meaningful "full track list" to scan. However, it inadvertently blocked smart playlists.

## Solution

Following @marcelveldt's architectural suggestion, this PR:

- **Removes the controller-level `is_dynamic` check** from `_update_playlist_metadata()` entirely
- **Delegates filtering to providers**: metadata providers now decide whether to return metadata for a given playlist
- **Preserves batch query filtering**: the automated metadata refresh still filters `is_dynamic = 0` at the DB level (dynamic playlists don't need regular automatic refreshes)
- **Migrates legacy icon.svg**: one-time migration removes icon.svg from smart playlists created before PR #4447, allowing generated artwork to display

This architectural approach is cleaner: instead of controller-level exceptions, providers implement their own skip logic (e.g., `playlist_metadata` provider checks `CONF_SKIP_PROVIDER_PLAYLISTS` config).

## Technical details

- Smart playlists have bounded track lists evaluated from library rules → can generate meaningful artwork
- Provider-driven radio (Pandora, Apple Music stations, Deezer Flow) are endless → `playlist_metadata` provider returns `None` for these
- Migration needed because old version of smart_playlist provider added icon.svg directly to metadata; `metadata.update()` merges lists instead of replacing, so icon.svg blocked generated artwork

**Related issue (if applicable):** Reported by user - smart playlists no longer generate artwork after #4326

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.