### PR TITLE
Remove Home Assistant musllinux wheel index from package install

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -58,8 +58,6 @@ from dataclasses import fields, is_dataclass
 
 LOGGER = logging.getLogger(__name__)
 
-HA_WHEELS = "https://wheels.home-assistant.io/musllinux/"
-
 T = TypeVar("T")
 CALLBACK_TYPE = Callable[[], None]
 
@@ -1183,7 +1181,7 @@ def empty_queue[T](q: asyncio.Queue[T]) -> None:
 async def install_package(package: str) -> None:
     """Install package with pip, raise when install failed."""
     LOGGER.debug("Installing python package %s", package)
-    args = ["uv", "pip", "install", "--no-cache", "--find-links", HA_WHEELS, package]
+    args = ["uv", "pip", "install", "--no-cache", package]
     return_code, output = await check_output(*args)
     if return_code != 0:
         msg = f"Failed to install package {package}\n{output.decode()}"


### PR DESCRIPTION
# What does this implement/fix?

The YouTube Music provider hot-loads `yt-dlp[default]` via pip at runtime. The install passed `--find-links https://wheels.home-assistant.io/musllinux/`, an index that only serves Alpine/musl wheels. We dropped Alpine long ago, so this index adds nothing but a hard dependency on `wheels.home-assistant.io`. When that host returned HTTP 522 (seen on the latest nightly) the yt-dlp install failed entirely and the provider errored with "This provider requires attention".

This removes the wheel index so `uv pip install` resolves straight from PyPI.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Changes

- Removed `--find-links <HA musllinux wheels>` from the runtime `uv pip install` call in `install_package()`.
- Removed the now-unused `HA_WHEELS` constant.

Note: this affects all hot-loaded packages, not just yt-dlp — the wheel index was applied globally. That's intended now that Alpine is gone.

## Checklist

- [ ] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
