### PR TITLE
Restrict the image palette API to an opaque image id

### DIFF
--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -31,8 +31,9 @@ from music_assistant_models.media_items import (
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.api import api_command
-from music_assistant.helpers.colors import get_palette, get_palette_for_url
+from music_assistant.helpers.colors import get_palette
 from music_assistant.helpers.images import (
+    _extract_imageproxy_id,
     create_collage,
     create_thumb_hash,
     detect_image_content_format,
@@ -233,21 +234,27 @@ class ImageProxyMixin:
         return image.path
 
     @api_command("metadata/get_image_palette")
-    async def get_image_palette(self, image: MediaItemImage | str) -> MediaItemPalette | None:
+    async def get_image_palette(self, image_id: str) -> MediaItemPalette | None:
         """
-        Get the color palette extracted from an image.
+        Get the color palette extracted from a (proxied) image.
 
         The palette follows the Sendspin color@v1 spec (primary, accent, on_dark,
         on_light, background_dark and background_light). Results are cached, so
         repeated requests for the same image are cheap.
 
-        :param image: A MediaItemImage to read colors from, or an image URL (either a
-            direct URL or an imageproxy URL as produced by `get_image_url`).
+        :param image_id: The opaque imageproxy image id (the ``proxy_id`` field on a
+            ``MediaItemImage``, or the id segment of an ``/imageproxy/<id>`` URL). It
+            is resolved to the image the server registered for that id; unknown ids
+            yield None. Arbitrary URLs or paths are intentionally not accepted.
         """
-        if not isinstance(image, MediaItemImage):
-            return await get_palette_for_url(self.mass, image)
+        # resolving guarantees we only read an image the server registered, so a
+        # caller can never coerce this into fetching an arbitrary URL/path
+        resolved = await self.resolve_image_id(_extract_imageproxy_id(image_id) or image_id)
+        if resolved is None:
+            return None
+        provider, path = resolved
         try:
-            return await get_palette(self.mass, image.path, image.provider)
+            return await get_palette(self.mass, path, provider)
         except MediaNotFoundError, OSError:
             return None
 

--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -33,7 +33,6 @@ from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.colors import get_palette
 from music_assistant.helpers.images import (
-    _extract_imageproxy_id,
     create_collage,
     create_thumb_hash,
     detect_image_content_format,
@@ -243,13 +242,10 @@ class ImageProxyMixin:
         repeated requests for the same image are cheap.
 
         :param image_id: The opaque imageproxy image id (the ``proxy_id`` field on a
-            ``MediaItemImage``, or the id segment of an ``/imageproxy/<id>`` URL). It
-            is resolved to the image the server registered for that id; unknown ids
-            yield None. Arbitrary URLs or paths are intentionally not accepted.
+            ``MediaItemImage``). Resolved to the image registered for that id; an
+            unknown id yields None.
         """
-        # resolving guarantees we only read an image the server registered, so a
-        # caller can never coerce this into fetching an arbitrary URL/path
-        resolved = await self.resolve_image_id(_extract_imageproxy_id(image_id) or image_id)
+        resolved = await self.resolve_image_id(image_id)
         if resolved is None:
             return None
         provider, path = resolved

--- a/tests/controllers/metadata/test_metadata.py
+++ b/tests/controllers/metadata/test_metadata.py
@@ -40,20 +40,23 @@ async def test_get_image_palette_resolves_registered_id(
     assert calls["get_palette"] == ("cover.jpg", "spotify")
 
 
-async def test_get_image_palette_accepts_imageproxy_url(
+async def test_get_image_palette_rejects_imageproxy_url(
     metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An /imageproxy/<id> URL is accepted by extracting and resolving its id."""
-    palette = MediaItemPalette(primary=(4, 5, 6))
+    """Only a bare image id is accepted; a full /imageproxy/<id> URL yields None."""
+    fetched = False
 
     async def fake_get_palette(_mass: object, _path: str, _provider: str) -> MediaItemPalette:
-        return palette
+        nonlocal fetched
+        fetched = True
+        return MediaItemPalette(primary=(4, 5, 6))
 
     monkeypatch.setattr("music_assistant.controllers.metadata.images.get_palette", fake_get_palette)
 
     image_id = metadata_controller.compute_image_id("filesystem", "/x.jpg")
     url = f"http://mass.local/imageproxy/{image_id}?size=256"
-    assert await metadata_controller.get_image_palette(url) is palette
+    assert await metadata_controller.get_image_palette(url) is None
+    assert fetched is False
 
 
 async def test_get_image_palette_rejects_unregistered_input(

--- a/tests/controllers/metadata/test_metadata.py
+++ b/tests/controllers/metadata/test_metadata.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from music_assistant_models.enums import ImageType
-from music_assistant_models.media_items import MediaItemImage, MediaItemPalette
+from music_assistant_models.media_items import MediaItemPalette
 
 from music_assistant.controllers.metadata import MetaDataController
 
@@ -23,10 +22,10 @@ async def metadata_controller(mass_minimal: MusicAssistant) -> MetaDataControlle
     return controller
 
 
-async def test_get_image_palette_dispatches_by_input_type(
+async def test_get_image_palette_resolves_registered_id(
     metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A MediaItemImage resolves by (path, provider); a plain URL goes via get_palette_for_url."""
+    """A registered image id resolves to its (provider, path) and yields its palette."""
     palette = MediaItemPalette(primary=(1, 2, 3))
     calls: dict[str, object] = {}
 
@@ -34,32 +33,57 @@ async def test_get_image_palette_dispatches_by_input_type(
         calls["get_palette"] = (path, provider)
         return palette
 
-    async def fake_get_palette_for_url(_mass: object, url: str) -> MediaItemPalette:
-        calls["get_palette_for_url"] = url
+    monkeypatch.setattr("music_assistant.controllers.metadata.images.get_palette", fake_get_palette)
+
+    image_id = metadata_controller.compute_image_id("spotify", "cover.jpg")
+    assert await metadata_controller.get_image_palette(image_id) is palette
+    assert calls["get_palette"] == ("cover.jpg", "spotify")
+
+
+async def test_get_image_palette_accepts_imageproxy_url(
+    metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An /imageproxy/<id> URL is accepted by extracting and resolving its id."""
+    palette = MediaItemPalette(primary=(4, 5, 6))
+
+    async def fake_get_palette(_mass: object, _path: str, _provider: str) -> MediaItemPalette:
         return palette
 
     monkeypatch.setattr("music_assistant.controllers.metadata.images.get_palette", fake_get_palette)
-    monkeypatch.setattr(
-        "music_assistant.controllers.metadata.images.get_palette_for_url",
-        fake_get_palette_for_url,
-    )
 
-    image = MediaItemImage(type=ImageType.THUMB, path="cover.jpg", provider="spotify")
-    assert await metadata_controller.get_image_palette(image) is palette
-    assert calls["get_palette"] == ("cover.jpg", "spotify")
+    image_id = metadata_controller.compute_image_id("filesystem", "/x.jpg")
+    url = f"http://mass.local/imageproxy/{image_id}?size=256"
+    assert await metadata_controller.get_image_palette(url) is palette
 
-    assert await metadata_controller.get_image_palette("https://example/cover.jpg") is palette
-    assert calls["get_palette_for_url"] == "https://example/cover.jpg"
+
+async def test_get_image_palette_rejects_unregistered_input(
+    metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unknown ids and arbitrary URLs yield None and never trigger a fetch (no SSRF)."""
+    fetched = False
+
+    async def fake_get_palette(_mass: object, _path: str, _provider: str) -> MediaItemPalette:
+        nonlocal fetched
+        fetched = True
+        return MediaItemPalette(primary=(0, 0, 0))
+
+    monkeypatch.setattr("music_assistant.controllers.metadata.images.get_palette", fake_get_palette)
+
+    # an id that was never registered
+    assert await metadata_controller.get_image_palette("0" * 64) is None
+    # an arbitrary URL must not be resolved or fetched
+    assert await metadata_controller.get_image_palette("http://169.254.169.254/latest") is None
+    assert fetched is False
 
 
 async def test_get_image_palette_returns_none_for_unreadable_image(
     metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An image whose data can't be read yields None instead of raising."""
+    """A registered image whose data can't be read yields None instead of raising."""
 
     async def boom(_mass: object, path: str, _provider: str) -> MediaItemPalette:
         raise FileNotFoundError(path)
 
     monkeypatch.setattr("music_assistant.controllers.metadata.images.get_palette", boom)
-    image = MediaItemImage(type=ImageType.THUMB, path="missing.jpg", provider="filesystem")
-    assert await metadata_controller.get_image_palette(image) is None
+    image_id = metadata_controller.compute_image_id("filesystem", "missing.jpg")
+    assert await metadata_controller.get_image_palette(image_id) is None


### PR DESCRIPTION
# What does this implement/fix?

`metadata/get_image_palette` accepted an arbitrary URL/path string (and a `MediaItemImage` carrying one) and fetched it server-side — an authenticated SSRF surface, in the same spirit as the legacy `/imageproxy?path=` endpoint removed in #4544. It now accepts **only an opaque image id**, which is resolved back to the `(provider, path)` the server registered for that id; unknown ids and arbitrary URLs return `None` without any fetch.

Both input forms were exploitable (a crafted `MediaItemImage.path` too), so the whole input now goes through the image-id map and a caller can never point it at an internal/arbitrary target. `get_palette_for_url` is left as-is for internal callers (the players controller passes server-derived URLs, including local-provider art on private IPs, which must keep working).

No client is affected: the frontend and mobile app both read the palette off the queue item and don't call this command. Dev-only — the command isn't exposed in `stable`.

**Related issue (if applicable):**

- Follow-up to #4544

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
