### PR TITLE
Prevent SSRF via attacker-controlled WebRTC HTTP proxy path

### DIFF
--- a/music_assistant/controllers/webserver/remote_access/gateway.py
+++ b/music_assistant/controllers/webserver/remote_access/gateway.py
@@ -648,7 +648,8 @@ class WebRTCGateway:
         # Handle both ws:// and wss:// schemes.
         parsed = urlparse(self.local_ws_url)
         http_scheme = "https" if parsed.scheme == "wss" else "http"
-        local_http_url = f"{http_scheme}://{parsed.netloc}{path}"
+        # Keep `path` as a URI path so an `@`/`//` prefix can't repoint the host (SSRF).
+        local_http_url = f"{http_scheme}://{parsed.netloc}/{path.lstrip('/')}"
 
         self.logger.debug("HTTP proxy request: %s %s", method, local_http_url)
 

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -2,6 +2,7 @@
 
 import base64
 from unittest.mock import AsyncMock, Mock, patch
+from urllib.parse import urlparse
 
 import pytest
 from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection
@@ -386,3 +387,51 @@ async def test_create_peer_connection_with_certificate() -> None:
         assert certificates[0] is certificate
     finally:
         await pc.close()
+
+
+@pytest.mark.parametrize(
+    "malicious_path",
+    [
+        "@evil.com",  # netloc becomes basic-auth creds, evil.com becomes the host
+        "//evil.com",  # protocol-relative URL pointing at another host
+        "@evil.com/foo",
+        "//evil.com/foo",
+    ],
+)
+async def test_http_proxy_request_cannot_change_host(
+    mock_certificate: Mock, malicious_path: str
+) -> None:
+    """An attacker-controlled proxy path must never change the target host (SSRF guard)."""
+    mock_session = Mock()
+    captured_url: dict[str, str] = {}
+
+    def fake_request(_method: str, url: str, **_kwargs: object) -> AsyncMock:
+        captured_url["url"] = url
+        response = AsyncMock()
+        response.status = 200
+        response.headers = {}
+        response.read = AsyncMock(return_value=b"")
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=response)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    mock_session.request = fake_request
+
+    gateway = WebRTCGateway(
+        http_session=mock_session,
+        remote_id="TEST-REMOTE-ID",
+        certificate=mock_certificate,
+        local_ws_url="ws://localhost:8095/ws",
+    )
+    session = WebRTCSession(session_id="s1", peer_connection=Mock())
+
+    await gateway._handle_http_proxy_request(
+        session, {"id": "1", "method": "GET", "path": malicious_path}
+    )
+
+    parsed = urlparse(captured_url["url"])
+    assert parsed.hostname == "localhost"
+    assert parsed.port == 8095
+    assert parsed.username is None
+    assert "evil.com" not in (parsed.netloc or "")


### PR DESCRIPTION
# What does this implement/fix?

The WebRTC remote-access gateway proxies HTTP requests to the local MA server on behalf of remote clients. The target URL was built by concatenating an attacker-controlled `path` directly onto the local netloc, without a separating `/`. A `path` starting with `@` (e.g. `@evil.com`) turned `http://localhost:8095` into HTTP Basic-Auth credentials and made `evil.com` the real host, and a protocol-relative `//evil.com` similarly redirected the request. Any client with a valid remote id (obtainable by a guest) could make the server issue HTTP requests to arbitrary hosts (SSRF).

The fix always inserts a `/` after the local netloc and strips leading slashes from the client path, so `path` can only ever be interpreted as a URI path and the destination host cannot be altered.

**Related issue (if applicable):**

Security assessment finding: 4.11.3 Calls to external systems (WebRTC HTTP proxy path)

## Changes

- Force the proxy `path` to be a URI path only: build the local URL as `{scheme}://{netloc}/{path.lstrip('/')}` in `_handle_http_proxy_request`.
- Add a parametrized regression test asserting `@evil.com` and `//evil.com` paths cannot change the target host.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
