### PR TITLE
Enforce role hierarchy for API command access control

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -859,7 +859,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             provider_instance_id_or_domain=provider_instance_id_or_domain,
         )
 
-    @api_command("music/favorites/add_item")
+    @api_command("music/favorites/add_item", required_role="user")
     async def add_item_to_favorites(
         self,
         item: str | MediaItemType | ItemMapping,
@@ -911,7 +911,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 continue
             await provider.set_favorite(prov_mapping.item_id, full_item.media_type, True)
 
-    @api_command("music/favorites/remove_item")
+    @api_command("music/favorites/remove_item", required_role="user")
     async def remove_item_from_favorites(
         self,
         media_type: MediaType,
@@ -935,7 +935,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 continue
             self.mass.create_task(provider.set_favorite(prov_mapping.item_id, media_type, False))
 
-    @api_command("music/library/remove_item")
+    @api_command("music/library/remove_item", required_role="user")
     async def remove_item_from_library(
         self, media_type: MediaType, library_item_id: str | int, recursive: bool = True
     ) -> None:
@@ -962,7 +962,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         # remove from library
         await ctrl.remove_item_from_library(library_item_id, recursive)
 
-    @api_command("music/library/add_item")
+    @api_command("music/library/add_item", required_role="user")
     async def add_item_to_library(
         self, item: str | MediaItemType | ItemMapping, overwrite_existing: bool = False
     ) -> MediaItemType:
@@ -1844,7 +1844,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 mappings_added = True
         return mappings_added
 
-    @api_command("music/add_provider_mapping")
+    @api_command("music/add_provider_mapping", required_role="user")
     async def add_provider_mapping(
         self, media_type: MediaType, db_id: str, mapping: ProviderMapping
     ) -> None:
@@ -1852,7 +1852,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         ctrl = self.get_controller(media_type)
         await ctrl.add_provider_mappings(db_id, [mapping])
 
-    @api_command("music/remove_provider_mapping")
+    @api_command("music/remove_provider_mapping", required_role="user")
     async def remove_provider_mapping(
         self, media_type: MediaType, db_id: str, mapping: ProviderMapping
     ) -> None:
@@ -1860,7 +1860,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         ctrl = self.get_controller(media_type)
         await ctrl.remove_provider_mapping(db_id, mapping.provider_instance, mapping.item_id)
 
-    @api_command("music/match_providers")
+    @api_command("music/match_providers", required_role="user")
     async def match_providers(self, media_type: MediaType, db_id: str) -> None:
         """Search for mappings on all providers for the given library item."""
         ctrl = self.get_controller(media_type)

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -218,7 +218,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             ],
         )
 
-    @api_command("music/sync")
+    @api_command("music/sync", required_role="user")
     async def start_sync(
         self,
         media_types: list[MediaType] | None = None,

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -73,16 +73,22 @@ class PlaylistController(MediaControllerBase[Playlist]):
         super().__init__(mass)
         # register (extra) api handlers
         api_base = self.api_base
-        self.mass.register_api_command(f"music/{api_base}/create_playlist", self.create_playlist)
+        self.mass.register_api_command(
+            f"music/{api_base}/create_playlist", self.create_playlist, required_role="user"
+        )
         self.mass.register_api_command("music/playlists/playlist_tracks", self.tracks)
         self.mass.register_api_command(
-            "music/playlists/add_playlist_tracks", self.add_playlist_tracks
+            "music/playlists/add_playlist_tracks", self.add_playlist_tracks, required_role="user"
         )
         self.mass.register_api_command(
-            "music/playlists/remove_playlist_tracks", self.remove_playlist_tracks
+            "music/playlists/remove_playlist_tracks",
+            self.remove_playlist_tracks,
+            required_role="user",
         )
         self.mass.register_api_command("music/playlists/export_playlist", self.export_playlist)
-        self.mass.register_api_command("music/playlists/import_playlist", self.import_playlist)
+        self.mass.register_api_command(
+            "music/playlists/import_playlist", self.import_playlist, required_role="user"
+        )
 
     async def tracks(
         self,

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -42,7 +42,9 @@ class RadioController(MediaControllerBase[Radio]):
         api_base = self.api_base
         self.mass.register_api_command(f"music/{api_base}/radio_versions", self.versions)
         self.mass.register_api_command(f"music/{api_base}/export_radios", self.export_radios)
-        self.mass.register_api_command(f"music/{api_base}/import_radios", self.import_radios)
+        self.mass.register_api_command(
+            f"music/{api_base}/import_radios", self.import_radios, required_role="user"
+        )
 
     async def export_radios(self) -> str:
         """Export all library radio stations to M3U8 format."""

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -43,7 +43,7 @@ from music_assistant.controllers.webserver.helpers.ssl import (
     format_certificate_info,
     verify_ssl_certificate,
 )
-from music_assistant.helpers.api import parse_arguments
+from music_assistant.helpers.api import has_required_role, parse_arguments
 from music_assistant.helpers.json import json_dumps, json_loads
 from music_assistant.helpers.redirect_validation import is_allowed_redirect_url
 from music_assistant.helpers.util import format_ip_for_url, get_ip_addresses
@@ -547,10 +547,10 @@ class WebserverController(CoreController):
 
             # Set user in context and check role
             set_current_user(user)
-            if handler.required_role == "admin" and user.role != UserRole.ADMIN:
+            if not has_required_role(user.role, handler.required_role):
                 return web.Response(
                     status=403,
-                    text="Admin access required",
+                    text="Insufficient permissions",
                 )
 
         try:

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -18,7 +18,7 @@ from music_assistant_models.api import (
     MessageType,
     SuccessResultMessage,
 )
-from music_assistant_models.auth import AuthProviderType, User, UserRole
+from music_assistant_models.auth import AuthProviderType, User
 from music_assistant_models.enums import EventType
 from music_assistant_models.errors import (
     AuthenticationRequired,
@@ -32,7 +32,7 @@ from music_assistant_models.media_items.metadata import IMAGE_PROXY_ID_RESOLVER
 from music_assistant_models.translations import TRANSLATION_RESOLVER
 
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER, VERBOSE_LOG_LEVEL
-from music_assistant.helpers.api import APICommandHandler, parse_arguments
+from music_assistant.helpers.api import APICommandHandler, has_required_role, parse_arguments
 
 from .helpers.auth_middleware import (
     is_request_from_ingress,
@@ -225,17 +225,16 @@ class WebsocketClientHandler:
             set_sendspin_player_id(self._sendspin_player_id)
 
             # Check role if required
-            if handler.required_role == "admin":
-                if self._authenticated_user.role != UserRole.ADMIN:
-                    await self._send_message(
-                        ErrorResultMessage(
-                            msg.message_id,
-                            InsufficientPermissions.error_code,
-                            "Admin access required",
-                            translation_key="insufficient_permissions",
-                        )
+            if not has_required_role(self._authenticated_user.role, handler.required_role):
+                await self._send_message(
+                    ErrorResultMessage(
+                        msg.message_id,
+                        InsufficientPermissions.error_code,
+                        "Insufficient permissions",
+                        translation_key="insufficient_permissions",
                     )
-                    return
+                )
+                return
 
         # schedule task to handle the command
         self.mass.create_task(self._run_handler(handler, msg))

--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -15,6 +15,7 @@ from types import NoneType, UnionType
 from typing import Any, TypeVar, Union, get_args, get_origin, get_type_hints
 
 from mashumaro.exceptions import MissingField
+from music_assistant_models.auth import UserRole
 from music_assistant_models.media_items.media_item import MediaItem
 
 from music_assistant.helpers.util import try_parse_bool
@@ -22,6 +23,26 @@ from music_assistant.helpers.util import try_parse_bool
 LOGGER = logging.getLogger(__name__)
 
 _F = TypeVar("_F", bound=Callable[..., Any])
+
+# Role privilege levels; higher satisfies a lower required_role.
+ROLE_LEVELS: dict[UserRole, int] = {
+    UserRole.GUEST: 0,
+    UserRole.USER: 1,
+    UserRole.ADMIN: 2,
+}
+
+
+def has_required_role(user_role: UserRole, required_role: str | None) -> bool:
+    """
+    Check whether a user's role satisfies a command's required role.
+
+    :param user_role: The role of the authenticated user.
+    :param required_role: The command's required role ("admin", "user") or None for any role.
+    """
+    if required_role is None:
+        return True
+    return ROLE_LEVELS.get(user_role, 0) >= ROLE_LEVELS.get(UserRole(required_role), 0)
+
 
 # Cache for resolved type alias strings to avoid repeated imports
 _TYPE_ALIAS_CACHE: dict[str, Any] = {}

--- a/tests/test_role_hierarchy.py
+++ b/tests/test_role_hierarchy.py
@@ -1,0 +1,34 @@
+"""Tests for the role hierarchy used by API command access control."""
+
+import pytest
+from music_assistant_models.auth import UserRole
+
+from music_assistant.helpers.api import ROLE_LEVELS, has_required_role
+
+
+def test_role_levels_ordering() -> None:
+    """Guest is the lowest privileged role, admin the highest."""
+    assert ROLE_LEVELS[UserRole.GUEST] < ROLE_LEVELS[UserRole.USER]
+    assert ROLE_LEVELS[UserRole.USER] < ROLE_LEVELS[UserRole.ADMIN]
+
+
+@pytest.mark.parametrize(
+    ("user_role", "required_role", "expected"),
+    [
+        # required_role=None: any authenticated user (including guest) is allowed
+        (UserRole.GUEST, None, True),
+        (UserRole.USER, None, True),
+        (UserRole.ADMIN, None, True),
+        # required_role="user": guest rejected, user and admin allowed
+        (UserRole.GUEST, "user", False),
+        (UserRole.USER, "user", True),
+        (UserRole.ADMIN, "user", True),
+        # required_role="admin": only admin allowed
+        (UserRole.GUEST, "admin", False),
+        (UserRole.USER, "admin", False),
+        (UserRole.ADMIN, "admin", True),
+    ],
+)
+def test_has_required_role(user_role: UserRole, required_role: str | None, expected: bool) -> None:
+    """A user's role must be at least the required role level to be granted access."""
+    assert has_required_role(user_role, required_role) is expected


### PR DESCRIPTION
# What does this implement/fix?

API command access control only special-cased `required_role="admin"`. There was no role hierarchy, so commands marked `required_role="user"` were not enforced at all and a GUEST was treated identically to a USER. This let guests call user-level commands (e.g. `party/url`) plus sensitive shared library and provider-mapping commands.

This introduces a central role hierarchy (`GUEST < USER < ADMIN`) and applies it at both enforcement points, so a user's role level must be `>=` the command's required role. It also tags the clearly-sensitive shared library/provider-mapping commands as `required_role="user"`.

## Changes

- Add `ROLE_LEVELS` and `has_required_role()` helper in `helpers/api.py`.
- Replace the `required_role == "admin"` checks in `webserver/controller.py` (HTTP, 403) and `webserver/websocket_client.py` (WS, `InsufficientPermissions`) with the hierarchy check.
- Tag `music/add_provider_mapping`, `music/remove_provider_mapping`, `music/match_providers`, `music/library/add_item`, `music/library/remove_item`, `music/favorites/add_item`, `music/favorites/remove_item` with `required_role="user"`.
- Tag the remaining shared-library mutation commands with `required_role="user"` as well: `music/playlists/create_playlist`, `music/playlists/add_playlist_tracks`, `music/playlists/remove_playlist_tracks`, `music/playlists/import_playlist`, `music/radios/import_radios` and `music/sync`.
- Add `tests/test_role_hierarchy.py` covering the hierarchy (guest rejected from `user`, user/admin allowed; guest still allowed when no role required).

Playback/queue commands are intentionally left untagged so guests keep the party experience; tightening those is recommended as follow-up.

Security assessment finding: 3.1 Vertical access controls

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

