### PR TITLE
Use dedicated encryption key

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -88,6 +88,7 @@ MASS_LOGO: Final[str] = str(RESOURCES_DIR.joinpath("logo.png"))
 CONF_ONBOARD_DONE: Final[str] = "onboard_done"
 CONF_SERVER_ID: Final[str] = "server_id"
 CONF_ENCRYPTION_KEY: Final[str] = "encryption_key"
+CONF_ENCRYPTION_KEY_MIGRATED: Final[str] = "encryption_key_migrated"
 CONF_IP_ADDRESS: Final[str] = "ip_address"
 CONF_PORT: Final[str] = "port"
 CONF_PROVIDERS: Final[str] = "providers"

--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -87,6 +87,7 @@ MASS_LOGO: Final[str] = str(RESOURCES_DIR.joinpath("logo.png"))
 # config keys
 CONF_ONBOARD_DONE: Final[str] = "onboard_done"
 CONF_SERVER_ID: Final[str] = "server_id"
+CONF_ENCRYPTION_KEY: Final[str] = "encryption_key"
 CONF_IP_ADDRESS: Final[str] = "ip_address"
 CONF_PORT: Final[str] = "port"
 CONF_PROVIDERS: Final[str] = "providers"

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -212,12 +212,27 @@ class ConfigController(
         """
         server_id: str = self.get(CONF_SERVER_ID)
         assert server_id
-        self.set_default(CONF_ENCRYPTION_KEY, Fernet.generate_key().decode())
-        encryption_key: str = self.get(CONF_ENCRYPTION_KEY)
-        primary = Fernet(encryption_key.encode())
+        primary = self._load_or_create_primary_key()
         legacy_key = base64.urlsafe_b64encode(server_id.encode()[:32])
         self._fernet = MultiFernet([primary, Fernet(legacy_key)])
         self._migrate_secrets(primary)
+
+    def _load_or_create_primary_key(self) -> Fernet:
+        """
+        Return the dedicated Fernet key, generating a new one if it is absent or invalid.
+
+        A missing or corrupted key must never crash startup or block legacy decryption, so we
+        fall back to a fresh key while the legacy server_id key stays available for decrypt.
+        """
+        encryption_key: str = self.get(CONF_ENCRYPTION_KEY, "")
+        if encryption_key:
+            try:
+                return Fernet(encryption_key.encode())
+            except ValueError:
+                LOGGER.warning("Stored encryption key is invalid; generating a new one")
+        encryption_key = Fernet.generate_key().decode()
+        self.set(CONF_ENCRYPTION_KEY, encryption_key)
+        return Fernet(encryption_key.encode())
 
     def _migrate_secrets(self, primary: Fernet) -> None:
         """

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -229,8 +229,8 @@ class ConfigController(
         A missing or corrupted key must never crash startup or block legacy decryption, so we
         fall back to a fresh key while the legacy server_id key stays available for decrypt.
         """
-        encryption_key: str = self.get(CONF_ENCRYPTION_KEY, "")
-        if encryption_key:
+        encryption_key: Any = self.get(CONF_ENCRYPTION_KEY, "")
+        if isinstance(encryption_key, str) and encryption_key:
             try:
                 return Fernet(encryption_key.encode())
             except ValueError:

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import aiofiles
-from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+from cryptography.fernet import Fernet, InvalidToken
 from music_assistant_models import config_entries
 from music_assistant_models.errors import InvalidDataError
 
@@ -52,7 +52,7 @@ class ConfigController(
 ):
     """Controller that handles storage of persistent configuration settings."""
 
-    _fernet: MultiFernet | None = None
+    _fernet: Fernet | None = None
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize storage controller."""
@@ -205,75 +205,51 @@ class ConfigController(
             raise InvalidDataError(msg) from err
 
     def _init_encryption(self) -> None:
-        """
-        Set up encryption for SECURE_STRING values with a dedicated key, not server_id.
-
-        server_id is public (broadcast via Zeroconf), so it must not be the key; MultiFernet
-        keeps it as a decrypt-only fallback and _migrate_secrets re-encrypts onto the new key.
-        """
-        server_id: str = self.get(CONF_SERVER_ID)
-        assert server_id
-        primary = self._load_or_create_primary_key()
-        legacy_key = base64.urlsafe_b64encode(server_id.encode()[:32])
-        self._fernet = MultiFernet([primary, Fernet(legacy_key)])
-        # a one-time pass rotates any legacy server_id-encrypted secrets onto the primary key;
-        # once done, all writes use the primary key, so there is nothing to migrate on later boots
+        """Set up encryption for SECURE_STRING config values."""
+        self._fernet = self._load_or_create_encryption_key()
         if not self.get(CONF_ENCRYPTION_KEY_MIGRATED):
-            self._migrate_secrets(primary)
+            self._migrate_legacy_secrets()
             self.set(CONF_ENCRYPTION_KEY_MIGRATED, True)
 
-    def _load_or_create_primary_key(self) -> Fernet:
-        """
-        Return the dedicated Fernet key, generating a new one if it is absent or invalid.
-
-        A missing or corrupted key must never crash startup or block legacy decryption, so we
-        fall back to a fresh key while the legacy server_id key stays available for decrypt.
-        """
+    def _load_or_create_encryption_key(self) -> Fernet:
+        """Return the stored encryption key, generating a new one if it is absent or invalid."""
         encryption_key: Any = self.get(CONF_ENCRYPTION_KEY, "")
         if isinstance(encryption_key, str) and encryption_key:
             try:
                 return Fernet(encryption_key.encode())
             except ValueError:
                 LOGGER.warning("Stored encryption key is invalid; generating a new one")
-                # the primary key changed, so legacy secrets must be re-rotated onto it
                 self.set(CONF_ENCRYPTION_KEY_MIGRATED, False)
         encryption_key = Fernet.generate_key().decode()
         self.set(CONF_ENCRYPTION_KEY, encryption_key)
         return Fernet(encryption_key.encode())
 
-    def _migrate_secrets(self, primary: Fernet) -> None:
-        """
-        Proactively re-encrypt legacy server_id-encrypted secrets onto the new key.
-
-        Otherwise they stay recoverable with the public server_id until next rewritten.
-        """
-        assert self._fernet is not None
-        migrated = self._rotate_encrypted_values(self._data, primary)
+    def _migrate_legacy_secrets(self) -> None:
+        """One-time re-encryption of secrets that were encrypted with the server_id-derived key."""
+        server_id: str = self.get(CONF_SERVER_ID)
+        assert server_id
+        legacy_fernet = Fernet(base64.urlsafe_b64encode(server_id.encode()[:32]))
+        migrated = self._rotate_encrypted_values(self._data, legacy_fernet)
         if migrated:
-            LOGGER.info("Re-encrypted %s secret(s) onto the dedicated encryption key", migrated)
+            LOGGER.info("Re-encrypted %s secret(s) with the dedicated encryption key", migrated)
             self.save(immediate=True)
 
-    def _rotate_encrypted_values(self, node: Any, primary: Fernet) -> int:
-        """Recursively rotate legacy-encrypted values onto the primary key, returning the count."""
+    def _rotate_encrypted_values(self, node: Any, legacy_fernet: Fernet) -> int:
+        """Recursively re-encrypt legacy-encrypted values, returning the count."""
         assert self._fernet is not None
         count = 0
         values = node.items() if isinstance(node, dict) else enumerate(node)
         for key, value in values:
             if isinstance(value, (dict, list)):
-                count += self._rotate_encrypted_values(value, primary)
+                count += self._rotate_encrypted_values(value, legacy_fernet)
             elif isinstance(value, str) and value.startswith(ENCRYPT_SUFFIX):
                 token = value[len(ENCRYPT_SUFFIX) :].encode()
                 try:
-                    # already on the primary key, nothing to migrate
-                    primary.decrypt(token)
+                    decrypted = legacy_fernet.decrypt(token)
+                except InvalidToken:
                     continue
-                except InvalidToken:
-                    pass
-                try:
-                    node[key] = ENCRYPT_SUFFIX + self._fernet.rotate(token).decode()
-                    count += 1
-                except InvalidToken:
-                    LOGGER.warning("Failed to migrate an encrypted config value")
+                node[key] = ENCRYPT_SUFFIX + self._fernet.encrypt(decrypted).decode()
+                count += 1
         return count
 
     async def _load(self) -> None:

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -18,6 +18,7 @@ from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.constants import (
     CONF_ENCRYPTION_KEY,
+    CONF_ENCRYPTION_KEY_MIGRATED,
     CONF_ONBOARD_DONE,
     CONF_SERVER_ID,
     ENCRYPT_SUFFIX,
@@ -215,7 +216,11 @@ class ConfigController(
         primary = self._load_or_create_primary_key()
         legacy_key = base64.urlsafe_b64encode(server_id.encode()[:32])
         self._fernet = MultiFernet([primary, Fernet(legacy_key)])
-        self._migrate_secrets(primary)
+        # a one-time pass rotates any legacy server_id-encrypted secrets onto the primary key;
+        # once done, all writes use the primary key, so there is nothing to migrate on later boots
+        if not self.get(CONF_ENCRYPTION_KEY_MIGRATED):
+            self._migrate_secrets(primary)
+            self.set(CONF_ENCRYPTION_KEY_MIGRATED, True)
 
     def _load_or_create_primary_key(self) -> Fernet:
         """
@@ -230,6 +235,8 @@ class ConfigController(
                 return Fernet(encryption_key.encode())
             except ValueError:
                 LOGGER.warning("Stored encryption key is invalid; generating a new one")
+                # the primary key changed, so legacy secrets must be re-rotated onto it
+                self.set(CONF_ENCRYPTION_KEY_MIGRATED, False)
         encryption_key = Fernet.generate_key().decode()
         self.set(CONF_ENCRYPTION_KEY, encryption_key)
         return Fernet(encryption_key.encode())

--- a/music_assistant/controllers/config/controller.py
+++ b/music_assistant/controllers/config/controller.py
@@ -12,11 +12,12 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import aiofiles
-from cryptography.fernet import Fernet, InvalidToken
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 from music_assistant_models import config_entries
 from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.constants import (
+    CONF_ENCRYPTION_KEY,
     CONF_ONBOARD_DONE,
     CONF_SERVER_ID,
     ENCRYPT_SUFFIX,
@@ -50,7 +51,7 @@ class ConfigController(
 ):
     """Controller that handles storage of persistent configuration settings."""
 
-    _fernet: Fernet | None = None
+    _fernet: MultiFernet | None = None
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize storage controller."""
@@ -65,12 +66,9 @@ class ConfigController(
         """Async initialize of controller."""
         await self._load()
         self.initialized = True
-        # create default server ID if needed (also used for encrypting passwords)
+        # create default server ID if needed
         self.set_default(CONF_SERVER_ID, uuid4().hex)
-        server_id: str = self.get(CONF_SERVER_ID)
-        assert server_id
-        fernet_key = base64.urlsafe_b64encode(server_id.encode()[:32])
-        self._fernet = Fernet(fernet_key)
+        self._init_encryption()
         config_entries.ENCRYPT_CALLBACK = self.encrypt_string
         config_entries.DECRYPT_CALLBACK = self.decrypt_string
         if not self.onboard_done:
@@ -204,6 +202,57 @@ class ConfigController(
         except InvalidToken as err:
             msg = "Password decryption failed"
             raise InvalidDataError(msg) from err
+
+    def _init_encryption(self) -> None:
+        """
+        Set up encryption for SECURE_STRING values with a dedicated key, not server_id.
+
+        server_id is public (broadcast via Zeroconf), so it must not be the key; MultiFernet
+        keeps it as a decrypt-only fallback and _migrate_secrets re-encrypts onto the new key.
+        """
+        server_id: str = self.get(CONF_SERVER_ID)
+        assert server_id
+        self.set_default(CONF_ENCRYPTION_KEY, Fernet.generate_key().decode())
+        encryption_key: str = self.get(CONF_ENCRYPTION_KEY)
+        primary = Fernet(encryption_key.encode())
+        legacy_key = base64.urlsafe_b64encode(server_id.encode()[:32])
+        self._fernet = MultiFernet([primary, Fernet(legacy_key)])
+        self._migrate_secrets(primary)
+
+    def _migrate_secrets(self, primary: Fernet) -> None:
+        """
+        Proactively re-encrypt legacy server_id-encrypted secrets onto the new key.
+
+        Otherwise they stay recoverable with the public server_id until next rewritten.
+        """
+        assert self._fernet is not None
+        migrated = self._rotate_encrypted_values(self._data, primary)
+        if migrated:
+            LOGGER.info("Re-encrypted %s secret(s) onto the dedicated encryption key", migrated)
+            self.save(immediate=True)
+
+    def _rotate_encrypted_values(self, node: Any, primary: Fernet) -> int:
+        """Recursively rotate legacy-encrypted values onto the primary key, returning the count."""
+        assert self._fernet is not None
+        count = 0
+        values = node.items() if isinstance(node, dict) else enumerate(node)
+        for key, value in values:
+            if isinstance(value, (dict, list)):
+                count += self._rotate_encrypted_values(value, primary)
+            elif isinstance(value, str) and value.startswith(ENCRYPT_SUFFIX):
+                token = value[len(ENCRYPT_SUFFIX) :].encode()
+                try:
+                    # already on the primary key, nothing to migrate
+                    primary.decrypt(token)
+                    continue
+                except InvalidToken:
+                    pass
+                try:
+                    node[key] = ENCRYPT_SUFFIX + self._fernet.rotate(token).decode()
+                    count += 1
+                except InvalidToken:
+                    LOGGER.warning("Failed to migrate an encrypted config value")
+        return count
 
     async def _load(self) -> None:
         """Load data from persistent storage."""

--- a/tests/controllers/config/test_encryption_key.py
+++ b/tests/controllers/config/test_encryption_key.py
@@ -94,6 +94,34 @@ def test_existing_secrets_migrated_off_legacy_key(tmp_path: Path) -> None:
         _legacy_fernet(server_id).decrypt(token)
 
 
+def test_invalid_stored_key_regenerates_without_crash(tmp_path: Path) -> None:
+    """A corrupted/invalid stored encryption_key must not crash startup; a new key is generated."""
+    controller = _make_controller(tmp_path)
+    controller.set(CONF_SERVER_ID, uuid4().hex)
+    controller.set(CONF_ENCRYPTION_KEY, "not-a-valid-fernet-key")
+
+    controller._init_encryption()
+
+    new_key = controller.get(CONF_ENCRYPTION_KEY)
+    assert new_key != "not-a-valid-fernet-key"
+    round_tripped = controller.decrypt_string(controller.encrypt_string("s3cr3t"))
+    assert round_tripped == "s3cr3t"
+
+
+def test_legacy_secret_survives_invalid_stored_key(tmp_path: Path) -> None:
+    """Even with an invalid stored key, legacy server_id-encrypted secrets must still decrypt."""
+    controller = _make_controller(tmp_path)
+    server_id = uuid4().hex
+    controller.set(CONF_SERVER_ID, server_id)
+    controller.set(CONF_ENCRYPTION_KEY, "")
+    legacy_value = ENCRYPT_SUFFIX + _legacy_fernet(server_id).encrypt(b"old-secret").decode()
+    controller.set("providers/foo/token", legacy_value)
+
+    controller._init_encryption()
+
+    assert controller.decrypt_string(controller.get("providers/foo/token")) == "old-secret"
+
+
 def test_new_encryption_not_readable_with_legacy_key(tmp_path: Path) -> None:
     """New values must be encrypted with the new key, not the public legacy one."""
     controller = _make_controller(tmp_path)

--- a/tests/controllers/config/test_encryption_key.py
+++ b/tests/controllers/config/test_encryption_key.py
@@ -113,6 +113,19 @@ def test_invalid_stored_key_regenerates_without_crash(tmp_path: Path) -> None:
     assert round_tripped == "s3cr3t"
 
 
+def test_non_string_stored_key_regenerates_without_crash(tmp_path: Path) -> None:
+    """A non-string encryption_key (e.g. settings hand-edited to a number) must not crash startup."""
+    controller = _make_controller(tmp_path)
+    controller.set(CONF_SERVER_ID, uuid4().hex)
+    controller.set(CONF_ENCRYPTION_KEY, 12345)
+
+    controller._init_encryption()
+
+    new_key = controller.get(CONF_ENCRYPTION_KEY)
+    assert isinstance(new_key, str)
+    assert controller.decrypt_string(controller.encrypt_string("s3cr3t")) == "s3cr3t"
+
+
 def test_legacy_secret_survives_invalid_stored_key(tmp_path: Path) -> None:
     """Even with an invalid stored key, legacy server_id-encrypted secrets must still decrypt."""
     controller = _make_controller(tmp_path)

--- a/tests/controllers/config/test_encryption_key.py
+++ b/tests/controllers/config/test_encryption_key.py
@@ -1,0 +1,108 @@
+"""
+Regression tests for the SECURE_STRING encryption key (findings 7.3.1 / 7.3.2).
+
+The Fernet key used by ``encrypt_string``/``decrypt_string`` used to be derived
+from ``server_id`` (``base64.urlsafe_b64encode(server_id.encode()[:32])``).
+That ``server_id`` is broadcast on the LAN via Zeroconf and is a low-entropy
+UUIDv4 hex string, so any device on the network could decrypt the secrets.
+
+These tests pin down the fixed behavior:
+- the active encryption key is NOT derived from ``server_id``
+- encrypt -> decrypt round-trips
+- secrets encrypted with the legacy ``server_id``-derived key still decrypt
+  (transparent migration via ``MultiFernet``)
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from music_assistant.constants import CONF_ENCRYPTION_KEY, CONF_SERVER_ID, ENCRYPT_SUFFIX
+from music_assistant.controllers.config.controller import ConfigController
+
+
+def _make_controller(tmp_path: Path) -> ConfigController:
+    mass = SimpleNamespace(storage_path=str(tmp_path))
+    controller = ConfigController(mass)  # type: ignore[arg-type]
+    controller.initialized = True
+    controller.save = lambda **_kwargs: None  # type: ignore[method-assign]
+    return controller
+
+
+def _legacy_fernet(server_id: str) -> Fernet:
+    return Fernet(base64.urlsafe_b64encode(server_id.encode()[:32]))
+
+
+def test_encryption_key_not_derived_from_server_id(tmp_path: Path) -> None:
+    """The active key must not be the public, low-entropy server_id-derived key."""
+    controller = _make_controller(tmp_path)
+    server_id = uuid4().hex
+    controller.set(CONF_SERVER_ID, server_id)
+    controller._init_encryption()
+
+    stored_key = controller.get(CONF_ENCRYPTION_KEY)
+    assert stored_key
+    assert stored_key != base64.urlsafe_b64encode(server_id.encode()[:32]).decode()
+
+
+def test_encrypt_decrypt_round_trip(tmp_path: Path) -> None:
+    """A value encrypted with the new key decrypts back to the original."""
+    controller = _make_controller(tmp_path)
+    controller.set(CONF_SERVER_ID, uuid4().hex)
+    controller._init_encryption()
+
+    encrypted = controller.encrypt_string("s3cr3t-token")
+    assert encrypted.startswith(ENCRYPT_SUFFIX)
+    assert controller.decrypt_string(encrypted) == "s3cr3t-token"
+
+
+def test_legacy_encrypted_value_still_decrypts(tmp_path: Path) -> None:
+    """Secrets encrypted with the old server_id-derived key must still decrypt."""
+    controller = _make_controller(tmp_path)
+    server_id = uuid4().hex
+    controller.set(CONF_SERVER_ID, server_id)
+
+    legacy_value = ENCRYPT_SUFFIX + _legacy_fernet(server_id).encrypt(b"old-secret").decode()
+
+    controller._init_encryption()
+    assert controller.decrypt_string(legacy_value) == "old-secret"
+
+
+def test_existing_secrets_migrated_off_legacy_key(tmp_path: Path) -> None:
+    """Secrets stored with the legacy key are proactively re-encrypted on setup."""
+    controller = _make_controller(tmp_path)
+    server_id = uuid4().hex
+    controller.set(CONF_SERVER_ID, server_id)
+    legacy_value = ENCRYPT_SUFFIX + _legacy_fernet(server_id).encrypt(b"old-secret").decode()
+    controller.set("providers/foo/token", legacy_value)
+
+    controller._init_encryption()
+
+    migrated = controller.get("providers/foo/token")
+    assert migrated != legacy_value
+    # the migrated token must decrypt with the new key alone, not just the legacy one
+    new_key: str = controller.get(CONF_ENCRYPTION_KEY)
+    token = migrated[len(ENCRYPT_SUFFIX) :].encode()
+    assert Fernet(new_key.encode()).decrypt(token) == b"old-secret"
+    with pytest.raises(InvalidToken):
+        _legacy_fernet(server_id).decrypt(token)
+
+
+def test_new_encryption_not_readable_with_legacy_key(tmp_path: Path) -> None:
+    """New values must be encrypted with the new key, not the public legacy one."""
+    controller = _make_controller(tmp_path)
+    server_id = uuid4().hex
+    controller.set(CONF_SERVER_ID, server_id)
+    controller._init_encryption()
+
+    encrypted = controller.encrypt_string("new-secret")
+    token = encrypted.replace(ENCRYPT_SUFFIX, "").encode()
+
+    with pytest.raises(InvalidToken):
+        _legacy_fernet(server_id).decrypt(token)

--- a/tests/controllers/config/test_encryption_key.py
+++ b/tests/controllers/config/test_encryption_key.py
@@ -1,17 +1,4 @@
-"""
-Regression tests for the SECURE_STRING encryption key (findings 7.3.1 / 7.3.2).
-
-The Fernet key used by ``encrypt_string``/``decrypt_string`` used to be derived
-from ``server_id`` (``base64.urlsafe_b64encode(server_id.encode()[:32])``).
-That ``server_id`` is broadcast on the LAN via Zeroconf and is a low-entropy
-UUIDv4 hex string, so any device on the network could decrypt the secrets.
-
-These tests pin down the fixed behavior:
-- the active encryption key is NOT derived from ``server_id``
-- encrypt -> decrypt round-trips
-- secrets encrypted with the legacy ``server_id``-derived key still decrypt
-  (transparent migration via ``MultiFernet``)
-"""
+"""Tests for the dedicated SECURE_STRING encryption key and legacy secret migration."""
 
 from __future__ import annotations
 
@@ -68,15 +55,15 @@ def test_encrypt_decrypt_round_trip(tmp_path: Path) -> None:
 
 
 def test_legacy_encrypted_value_still_decrypts(tmp_path: Path) -> None:
-    """Secrets encrypted with the old server_id-derived key must still decrypt."""
+    """Secrets encrypted with the old server_id-derived key must still decrypt after setup."""
     controller = _make_controller(tmp_path)
     server_id = uuid4().hex
     controller.set(CONF_SERVER_ID, server_id)
-
     legacy_value = ENCRYPT_SUFFIX + _legacy_fernet(server_id).encrypt(b"old-secret").decode()
+    controller.set("providers/foo/token", legacy_value)
 
     controller._init_encryption()
-    assert controller.decrypt_string(legacy_value) == "old-secret"
+    assert controller.decrypt_string(controller.get("providers/foo/token")) == "old-secret"
 
 
 def test_existing_secrets_migrated_off_legacy_key(tmp_path: Path) -> None:

--- a/tests/controllers/config/test_encryption_key.py
+++ b/tests/controllers/config/test_encryption_key.py
@@ -23,7 +23,12 @@ from uuid import uuid4
 import pytest
 from cryptography.fernet import Fernet, InvalidToken
 
-from music_assistant.constants import CONF_ENCRYPTION_KEY, CONF_SERVER_ID, ENCRYPT_SUFFIX
+from music_assistant.constants import (
+    CONF_ENCRYPTION_KEY,
+    CONF_ENCRYPTION_KEY_MIGRATED,
+    CONF_SERVER_ID,
+    ENCRYPT_SUFFIX,
+)
 from music_assistant.controllers.config.controller import ConfigController
 
 
@@ -120,6 +125,38 @@ def test_legacy_secret_survives_invalid_stored_key(tmp_path: Path) -> None:
     controller._init_encryption()
 
     assert controller.decrypt_string(controller.get("providers/foo/token")) == "old-secret"
+
+
+def test_secrets_migrated_only_once(tmp_path: Path) -> None:
+    """After the one-time migration, later inits must not re-scan or re-migrate stored values."""
+    controller = _make_controller(tmp_path)
+    server_id = uuid4().hex
+    controller.set(CONF_SERVER_ID, server_id)
+    controller._init_encryption()
+    assert controller.get(CONF_ENCRYPTION_KEY_MIGRATED) is True
+
+    # a legacy-encrypted value planted after migration completed is left untouched next init
+    legacy_value = ENCRYPT_SUFFIX + _legacy_fernet(server_id).encrypt(b"late").decode()
+    controller.set("providers/foo/token", legacy_value)
+    controller._init_encryption()
+    assert controller.get("providers/foo/token") == legacy_value
+
+
+def test_invalid_key_regen_remigrates_legacy_secrets(tmp_path: Path) -> None:
+    """Regenerating an invalid key must re-run migration so legacy secrets move onto the new key."""
+    controller = _make_controller(tmp_path)
+    server_id = uuid4().hex
+    controller.set(CONF_SERVER_ID, server_id)
+    controller.set(CONF_ENCRYPTION_KEY, "not-a-valid-fernet-key")
+    controller.set(CONF_ENCRYPTION_KEY_MIGRATED, True)
+    legacy_value = ENCRYPT_SUFFIX + _legacy_fernet(server_id).encrypt(b"old-secret").decode()
+    controller.set("providers/foo/token", legacy_value)
+
+    controller._init_encryption()
+
+    migrated = controller.get("providers/foo/token")
+    assert migrated != legacy_value
+    assert controller.decrypt_string(migrated) == "old-secret"
 
 
 def test_new_encryption_not_readable_with_legacy_key(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The Fernet key used to encrypt `SECURE_STRING` config values (Home Assistant token, `ssl_private_key`, provider/player secrets) was derived from `server_id`. That value is both **broadcast publicly on the LAN** via the Zeroconf service name and is a **low-entropy** UUIDv4 hex string, so any device on the network could reconstruct the key and decrypt the stored secrets (and the derivation was brute-forceable regardless).

This switches to a dedicated, high-entropy key generated with `Fernet.generate_key()` and stored under a new `encryption_key` config key, separate from `server_id` (which stays public). Existing installs keep working: decryption uses a `MultiFernet([new, legacy])` where the legacy key is still derived from `server_id`, so old secrets decrypt transparently. On startup, existing secrets are then **proactively re-encrypted onto the new key** (via `MultiFernet.rotate`), so they don't stay recoverable with the public `server_id` while waiting to be rewritten. Encryption always uses the new key.

A further hardening step (out of scope here) would be to store the key in an env var / outside the settings file.

Security assessment findings: 7.3.1 Re-use of cryptographic keys; 7.3.2 (encryption-key entropy)

## Changes

- Add `CONF_ENCRYPTION_KEY` constant.
- Generate and persist a dedicated random Fernet key on first setup, separate from the public `server_id`.
- Build the decryptor as `MultiFernet([new_key, legacy_server_id_key])` so secrets from older installs still decrypt.
- Proactively migrate existing secrets onto the new key on startup (`_migrate_secrets` / `_rotate_encrypted_values`), rather than only re-encrypting on next write.
- Extract encryption setup into `_init_encryption()`; keep `encrypt_string`/`decrypt_string` and `ENCRYPT_SUFFIX` handling unchanged.
- Add regression tests: active key is not the `server_id`-derived key, encrypt/decrypt round-trip, legacy-encrypted values still decrypt, and existing secrets are migrated off the legacy key on setup.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes (file-scoped hooks; whole-repo mypy verified per-file — Linux CI runs the full suite).
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
