### PR TITLE
Rate-limit join code exchange and lengthen join codes

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -35,6 +35,7 @@ from music_assistant.controllers.webserver.helpers.auth_providers import (
     HomeAssistantOAuthProvider,
     HomeAssistantProviderConfig,
     LoginProvider,
+    LoginRateLimiter,
     normalize_username,
 )
 from music_assistant.helpers.api import api_command
@@ -56,9 +57,11 @@ TOKEN_SHORT_LIVED_EXPIRATION = 30  # Short-lived tokens (auto-renewing on use)
 TOKEN_LONG_LIVED_EXPIRATION = 3650  # Long-lived tokens (10 years, no auto-renewal)
 
 # Join code constants (short codes for QR/link-based login)
-JOIN_CODE_LENGTH = 6
+JOIN_CODE_LENGTH = 12
 JOIN_CODE_CHARSET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"  # No I/O/0/1 for readability
 JOIN_CODE_DEFAULT_EXPIRY_HOURS = 8
+# No source IP available here, so throttle failed exchanges globally under one key.
+JOIN_CODE_RATE_LIMIT_KEY = "join_code_exchange"
 
 
 class AuthenticationManager:
@@ -77,6 +80,7 @@ class AuthenticationManager:
         self.logger = LOGGER
         self._has_users: bool = False
         self.jwt_helper: JWTHelper = None  # type: ignore[assignment]
+        self._join_code_rate_limiter = LoginRateLimiter()
 
     async def setup(self) -> None:
         """Initialize the authentication manager."""
@@ -1398,13 +1402,28 @@ class AuthenticationManager:
         :param code: The short join code.
         :return: Authentication result with access token if successful.
         """
+        allowed, remaining_delay = await self._join_code_rate_limiter.check_rate_limit(
+            JOIN_CODE_RATE_LIMIT_KEY
+        )
+        if not allowed:
+            self.logger.warning(
+                "Join code exchange rate limit exceeded. %d seconds remaining.", remaining_delay
+            )
+            return {
+                "success": False,
+                "error": f"Too many failed attempts. Please try again in {remaining_delay} seconds.",
+            }
+
         token = await self._exchange_join_code(code)
 
         if not token:
+            await self._join_code_rate_limiter.record_failed_attempt(JOIN_CODE_RATE_LIMIT_KEY)
             return {
                 "success": False,
                 "error": "Invalid or expired join code",
             }
+
+        await self._join_code_rate_limiter.clear_attempts(JOIN_CODE_RATE_LIMIT_KEY)
 
         # Decode token to get user info
         try:

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -82,8 +82,7 @@ class AuthenticationManager:
         self._has_users: bool = False
         self.jwt_helper: JWTHelper = None  # type: ignore[assignment]
         self._join_code_rate_limiter = LoginRateLimiter()
-        # Serializes exchange attempts so concurrent requests cannot all pass the
-        # rate limit check before any of them records a failure.
+        # Stops concurrent exchanges from passing the rate limit check before failures land
         self._join_code_exchange_lock = asyncio.Lock()
 
     async def setup(self) -> None:
@@ -1430,9 +1429,7 @@ class AuthenticationManager:
                     "error": "Invalid or expired join code",
                 }
 
-        # Deliberately no clear_attempts on success: the key is global, so clearing
-        # would let anyone holding a valid code reset the counter and bypass throttling.
-        # Failures expire via the limiter's tracking window instead.
+        # No clear_attempts on success: any valid-code holder could reset the global counter
 
         # Decode token to get user info
         try:

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import hashlib
 import logging
@@ -81,6 +82,9 @@ class AuthenticationManager:
         self._has_users: bool = False
         self.jwt_helper: JWTHelper = None  # type: ignore[assignment]
         self._join_code_rate_limiter = LoginRateLimiter()
+        # Serializes exchange attempts so concurrent requests cannot all pass the
+        # rate limit check before any of them records a failure.
+        self._join_code_exchange_lock = asyncio.Lock()
 
     async def setup(self) -> None:
         """Initialize the authentication manager."""
@@ -1402,26 +1406,29 @@ class AuthenticationManager:
         :param code: The short join code.
         :return: Authentication result with access token if successful.
         """
-        allowed, remaining_delay = await self._join_code_rate_limiter.check_rate_limit(
-            JOIN_CODE_RATE_LIMIT_KEY
-        )
-        if not allowed:
-            self.logger.warning(
-                "Join code exchange rate limit exceeded. %d seconds remaining.", remaining_delay
+        async with self._join_code_exchange_lock:
+            allowed, remaining_delay = await self._join_code_rate_limiter.check_rate_limit(
+                JOIN_CODE_RATE_LIMIT_KEY
             )
-            return {
-                "success": False,
-                "error": f"Too many failed attempts. Please try again in {remaining_delay} seconds.",
-            }
+            if not allowed:
+                self.logger.warning(
+                    "Join code exchange rate limit exceeded. %d seconds remaining.", remaining_delay
+                )
+                return {
+                    "success": False,
+                    "error": (
+                        f"Too many failed attempts. Please try again in {remaining_delay} seconds."
+                    ),
+                }
 
-        token = await self._exchange_join_code(code)
+            token = await self._exchange_join_code(code)
 
-        if not token:
-            await self._join_code_rate_limiter.record_failed_attempt(JOIN_CODE_RATE_LIMIT_KEY)
-            return {
-                "success": False,
-                "error": "Invalid or expired join code",
-            }
+            if not token:
+                await self._join_code_rate_limiter.record_failed_attempt(JOIN_CODE_RATE_LIMIT_KEY)
+                return {
+                    "success": False,
+                    "error": "Invalid or expired join code",
+                }
 
         # Deliberately no clear_attempts on success: the key is global, so clearing
         # would let anyone holding a valid code reset the counter and bypass throttling.

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1423,7 +1423,9 @@ class AuthenticationManager:
                 "error": "Invalid or expired join code",
             }
 
-        await self._join_code_rate_limiter.clear_attempts(JOIN_CODE_RATE_LIMIT_KEY)
+        # Deliberately no clear_attempts on success: the key is global, so clearing
+        # would let anyone holding a valid code reset the counter and bypass throttling.
+        # Failures expire via the limiter's tracking window instead.
 
         # Decode token to get user info
         try:

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -1366,6 +1366,29 @@ async def test_exchange_join_code_rate_limited(auth_manager: AuthenticationManag
     assert "too many" in result["error"].lower()
 
 
+async def test_exchange_join_code_rate_limit_concurrent_burst(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Verify concurrent failed exchanges cannot race past the rate limiter.
+
+    Without serialization, parallel requests all pass the rate limit check
+    before any of them records a failure, allowing brute-force bursts.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    results = await asyncio.gather(
+        *(auth_manager.exchange_join_code("WRONGCODE123") for _ in range(10))
+    )
+
+    assert all(result["success"] is False for result in results)
+    # Only the first 3 attempts may reach the actual code check; the rest must be throttled.
+    invalid_count = sum(1 for result in results if "invalid" in result["error"].lower())
+    throttled_count = sum(1 for result in results if "too many" in result["error"].lower())
+    assert invalid_count == 3
+    assert throttled_count == 7
+
+
 async def test_exchange_join_code_success_does_not_reset_rate_limit(
     auth_manager: AuthenticationManager,
 ) -> None:

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -15,7 +15,7 @@ from music_assistant_models.errors import InsufficientPermissions, InvalidDataEr
 
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
 from music_assistant.controllers.config import ConfigController
-from music_assistant.controllers.webserver.auth import AuthenticationManager
+from music_assistant.controllers.webserver.auth import JOIN_CODE_LENGTH, AuthenticationManager
 from music_assistant.controllers.webserver.controller import WebserverController
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     ImpersonatedUser,
@@ -966,7 +966,7 @@ async def test_generate_join_code(auth_manager: AuthenticationManager) -> None:
     )
 
     assert code is not None
-    assert len(code) == 6  # JOIN_CODE_LENGTH
+    assert len(code) == JOIN_CODE_LENGTH
     assert code.isalnum()
     assert expires_at is not None
     assert expires_at > utc()
@@ -1342,3 +1342,49 @@ async def test_impersonated_user_anonymous_playback_is_noop(
     with pytest.raises(InsufficientPermissions):
         async with ImpersonatedUser(auth_manager.mass, "user_a"):
             ...
+
+
+async def test_join_code_length_at_least_12() -> None:
+    """Verify join codes are long enough to resist brute force (security finding 7.3.2)."""
+    assert JOIN_CODE_LENGTH >= 12
+
+
+async def test_exchange_join_code_rate_limited(auth_manager: AuthenticationManager) -> None:
+    """
+    Verify repeated failed join code exchanges get throttled (security finding 7.3.2).
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    # Fire enough wrong codes to trip the progressive delay.
+    for _ in range(5):
+        result = await auth_manager.exchange_join_code("WRONGCODE123")
+        assert result["success"] is False
+
+    # The next attempt must be rejected for rate limiting, not just "invalid".
+    result = await auth_manager.exchange_join_code("WRONGCODE123")
+    assert result["success"] is False
+    assert "too many" in result["error"].lower()
+
+
+async def test_exchange_join_code_success_resets_rate_limit(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Verify a successful join code exchange clears the failed-attempt counter.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="resetrluser", role=UserRole.GUEST)
+    code, _ = await auth_manager.generate_join_code(user=user, expires_in_hours=24, max_uses=0)
+
+    # A couple of failures, still below the throttle threshold.
+    for _ in range(2):
+        assert (await auth_manager.exchange_join_code("NOPE12345678"))["success"] is False
+
+    # A successful exchange resets the counter.
+    assert (await auth_manager.exchange_join_code(code))["success"] is True
+
+    # Further failures start counting from zero, so we are not immediately throttled.
+    result = await auth_manager.exchange_join_code("NOPE12345678")
+    assert result["success"] is False
+    assert "too many" not in result["error"].lower()

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -1355,8 +1355,8 @@ async def test_exchange_join_code_rate_limited(auth_manager: AuthenticationManag
 
     :param auth_manager: AuthenticationManager instance.
     """
-    # Fire enough wrong codes to trip the progressive delay.
-    for _ in range(5):
+    # Three failures trip the progressive delay threshold.
+    for _ in range(3):
         result = await auth_manager.exchange_join_code("WRONGCODE123")
         assert result["success"] is False
 
@@ -1366,25 +1366,29 @@ async def test_exchange_join_code_rate_limited(auth_manager: AuthenticationManag
     assert "too many" in result["error"].lower()
 
 
-async def test_exchange_join_code_success_resets_rate_limit(
+async def test_exchange_join_code_success_does_not_reset_rate_limit(
     auth_manager: AuthenticationManager,
 ) -> None:
     """
-    Verify a successful join code exchange clears the failed-attempt counter.
+    Verify a successful exchange does not clear the failed-attempt counter.
+
+    The rate limit key is global, so clearing on success would let an attacker
+    holding any valid code reset the counter at will and bypass throttling.
 
     :param auth_manager: AuthenticationManager instance.
     """
-    user = await auth_manager.create_user(username="resetrluser", role=UserRole.GUEST)
+    user = await auth_manager.create_user(username="norstuser", role=UserRole.GUEST)
     code, _ = await auth_manager.generate_join_code(user=user, expires_in_hours=24, max_uses=0)
 
     # A couple of failures, still below the throttle threshold.
     for _ in range(2):
         assert (await auth_manager.exchange_join_code("NOPE12345678"))["success"] is False
 
-    # A successful exchange resets the counter.
+    # A valid exchange still succeeds but must not wipe the counter.
     assert (await auth_manager.exchange_join_code(code))["success"] is True
 
-    # Further failures start counting from zero, so we are not immediately throttled.
-    result = await auth_manager.exchange_join_code("NOPE12345678")
+    # The third failure trips the threshold, throttling further attempts.
+    assert (await auth_manager.exchange_join_code("NOPE12345678"))["success"] is False
+    result = await auth_manager.exchange_join_code(code)
     assert result["success"] is False
-    assert "too many" not in result["error"].lower()
+    assert "too many" in result["error"].lower()


### PR DESCRIPTION
# What does this implement/fix?

Guest "join codes" (`auth/join_code/exchange`) were 6 characters from a 32-symbol
charset (~2^30 combinations) and valid for 8 hours, with no rate limiting on the
exchange command. That makes them brute-forceable within the validity window.

This hardens join codes on two fronts:

- Reuses the existing `LoginRateLimiter` (progressive delays, same as login) to
  throttle failed `exchange_join_code` attempts. There is no per-request source IP
  in this API context, so failed attempts are throttled globally under a single key.
  A successful exchange deliberately does not reset the counter — with a global key
  that would let anyone holding a valid code bypass throttling. Failures expire via
  the limiter's 30-minute tracking window instead.
- Lengthens the join code from 6 to 12 characters, raising the search space from
  ~2^30 to ~2^60. UX impact is minor since codes are primarily shared via link/QR.

The encryption-key-entropy half of finding 7.3.2 is handled separately in the
finding 7.3.1 PR (config.py / Fernet) and is not touched here.

Security assessment finding: 7.3.2 Random number generator (join-code brute force)

## Changes

- Add a `LoginRateLimiter` to `AuthenticationManager` and apply it in the public
  `exchange_join_code` command (check before exchange, record on failure).
- `JOIN_CODE_LENGTH` raised from 6 to 12.
- Add regression tests: throttling after repeated failed exchanges, success does not
  reset the global counter, and `JOIN_CODE_LENGTH >= 12`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

