### PR TITLE
Prevent path traversal outside the filesystem provider base directory

### DIFF
--- a/music_assistant/helpers/security.py
+++ b/music_assistant/helpers/security.py
@@ -3,12 +3,31 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 
-def is_safe_path(path: str) -> bool:
-    """Check if path is free from path traversal components."""
+def is_safe_path(path: str, base_path: str | None = None) -> bool:
+    """
+    Check if path is free from path traversal components.
+
+    :param path: The path to validate.
+    :param base_path: If given, additionally require that path (resolved against
+        base_path when relative) stays inside this base directory.
+    """
     norm_path = os.path.normpath(path)
-    return not (norm_path.startswith("..") or "/../" in norm_path or "\\..\\" in norm_path)
+    if norm_path.startswith("..") or "/../" in norm_path or "\\..\\" in norm_path:
+        return False
+    if base_path is None:
+        return True
+    # Purely lexical containment check: no filesystem IO, so safe to call on the event loop.
+    norm_base = os.path.normpath(base_path)
+    if not Path(norm_path).is_absolute():
+        norm_path = os.path.normpath(os.path.join(norm_base, norm_path))
+    try:
+        return os.path.commonpath((norm_base, norm_path)) == norm_base
+    except ValueError:
+        # commonpath raises for paths on different (Windows) drives
+        return False
 
 
 def is_safe_name(name: str) -> bool:

--- a/music_assistant/providers/filesystem_local/__init__.py
+++ b/music_assistant/providers/filesystem_local/__init__.py
@@ -930,7 +930,11 @@ class LocalFileSystemProvider(MusicProvider):
         """Return bool is this FileSystem musicprovider has given file/dir."""
         if not file_path:
             return False
-        abs_path = self.get_absolute_path(file_path)
+        try:
+            abs_path = self.get_absolute_path(file_path)
+        except MediaNotFoundError:
+            # a path that escapes the base directory simply does not exist here
+            return False
         return bool(await exists(abs_path))
 
     def get_absolute_path(self, file_path: str) -> str:

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -238,8 +238,6 @@ def get_absolute_path(base_path: str, path: str) -> str:
         (e.g. via ``../`` traversal or an absolute path outside the base).
     """
     absolute_path = path if path.startswith(base_path) else os.path.join(base_path, path)
-    # The check is lexical (no symlink resolving): attackers can only supply path strings,
-    # not symlinks, and resolving would reject legitimate symlinks inside the base directory.
     if not is_safe_path(absolute_path, base_path):
         msg = f"Path is outside the configured base directory: {path}"
         raise MediaNotFoundError(msg)

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -237,10 +237,17 @@ def get_absolute_path(base_path: str, path: str) -> str:
         (e.g. via ``../`` traversal or an absolute path outside the base).
     """
     absolute_path = path if path.startswith(base_path) else os.path.join(base_path, path)
-    # Resolve symlinks/.. and confirm the result stays within base_path (traversal guard).
-    real_base = os.path.realpath(base_path)
-    real_path = os.path.realpath(absolute_path)
-    if os.path.commonpath((real_base, real_path)) != real_base:
+    # Purely lexical containment check: no filesystem IO, as this runs on the event loop.
+    # Attackers can only supply path strings, not symlinks, so resolving links is not needed
+    # (and would reject legitimate admin-created symlinks inside the base directory).
+    norm_base = os.path.normpath(base_path)
+    norm_path = os.path.normpath(absolute_path)
+    try:
+        escapes_base = os.path.commonpath((norm_base, norm_path)) != norm_base
+    except ValueError:
+        # commonpath raises for paths on different (Windows) drives
+        escapes_base = True
+    if escapes_base:
         msg = f"Path is outside the configured base directory: {path}"
         raise MediaNotFoundError(msg)
     return absolute_path

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -10,6 +10,8 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
+from music_assistant_models.errors import MediaNotFoundError
+
 from music_assistant.helpers.compare import compare_strings
 
 logger = logging.getLogger(__name__)
@@ -228,10 +230,20 @@ def get_relative_path(base_path: str, path: str) -> str:
 
 
 def get_absolute_path(base_path: str, path: str) -> str:
-    """Return the absolute path string for a path."""
-    if path.startswith(base_path):
-        return path
-    return os.path.join(base_path, path)
+    """
+    Return the absolute path for a path, constrained to base_path.
+
+    :raises MediaNotFoundError: If the resolved path escapes base_path
+        (e.g. via ``../`` traversal or an absolute path outside the base).
+    """
+    absolute_path = path if path.startswith(base_path) else os.path.join(base_path, path)
+    # Resolve symlinks/.. and confirm the result stays within base_path (traversal guard).
+    real_base = os.path.realpath(base_path)
+    real_path = os.path.realpath(absolute_path)
+    if os.path.commonpath((real_base, real_path)) != real_base:
+        msg = f"Path is outside the configured base directory: {path}"
+        raise MediaNotFoundError(msg)
+    return absolute_path
 
 
 def recursive_iter(

--- a/music_assistant/providers/filesystem_local/helpers.py
+++ b/music_assistant/providers/filesystem_local/helpers.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from music_assistant_models.errors import MediaNotFoundError
 
 from music_assistant.helpers.compare import compare_strings
+from music_assistant.helpers.security import is_safe_path
 
 logger = logging.getLogger(__name__)
 
@@ -237,17 +238,9 @@ def get_absolute_path(base_path: str, path: str) -> str:
         (e.g. via ``../`` traversal or an absolute path outside the base).
     """
     absolute_path = path if path.startswith(base_path) else os.path.join(base_path, path)
-    # Purely lexical containment check: no filesystem IO, as this runs on the event loop.
-    # Attackers can only supply path strings, not symlinks, so resolving links is not needed
-    # (and would reject legitimate admin-created symlinks inside the base directory).
-    norm_base = os.path.normpath(base_path)
-    norm_path = os.path.normpath(absolute_path)
-    try:
-        escapes_base = os.path.commonpath((norm_base, norm_path)) != norm_base
-    except ValueError:
-        # commonpath raises for paths on different (Windows) drives
-        escapes_base = True
-    if escapes_base:
+    # The check is lexical (no symlink resolving): attackers can only supply path strings,
+    # not symlinks, and resolving would reject legitimate symlinks inside the base directory.
+    if not is_safe_path(absolute_path, base_path):
         msg = f"Path is outside the configured base directory: {path}"
         raise MediaNotFoundError(msg)
     return absolute_path

--- a/tests/providers/filesystem/test_path_traversal.py
+++ b/tests/providers/filesystem/test_path_traversal.py
@@ -1,0 +1,87 @@
+"""Tests that the filesystem provider rejects path-traversal outside its base path."""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.errors import MediaNotFoundError
+
+from music_assistant.providers.filesystem_local import LocalFileSystemProvider, helpers
+
+INSTANCE_ID = "filesystem_local--test"
+
+
+def _make_provider(base_path: str) -> LocalFileSystemProvider:
+    provider = LocalFileSystemProvider.__new__(LocalFileSystemProvider)
+    provider.base_path = base_path
+    provider.logger = MagicMock()
+    provider.write_access = False
+    provider.media_content_type = "music"
+    provider.config = MagicMock()
+    provider.config.instance_id = INSTANCE_ID
+    provider.manifest = MagicMock()
+    provider.manifest.domain = "filesystem_local"
+    return provider
+
+
+@pytest.fixture
+def music_tree(tmp_path: Path) -> Path:
+    """Create a base dir with one in-base track and a secret file outside it."""
+    base = tmp_path / "music"
+    base.mkdir()
+    (base / "track.mp3").write_bytes(b"\x00" * 128)
+    (tmp_path / "secret.mp3").write_bytes(b"\x00" * 128)
+    return base
+
+
+def test_get_absolute_path_rejects_traversal(music_tree: Path) -> None:
+    """A `../`-escaping relative path is rejected by the helper."""
+    with pytest.raises(MediaNotFoundError):
+        helpers.get_absolute_path(str(music_tree), "../secret.mp3")
+
+
+def test_get_absolute_path_rejects_absolute_outside_base(music_tree: Path) -> None:
+    """An absolute path outside the base is rejected by the helper."""
+    outside = str(music_tree.parent / "secret.mp3")
+    with pytest.raises(MediaNotFoundError):
+        helpers.get_absolute_path(str(music_tree), outside)
+
+
+def test_get_absolute_path_allows_in_base(music_tree: Path) -> None:
+    """A legitimate in-base path still resolves."""
+    result = helpers.get_absolute_path(str(music_tree), "track.mp3")
+    assert result == str(music_tree / "track.mp3")
+
+
+def test_get_absolute_path_allows_absolute_in_base(music_tree: Path) -> None:
+    """An already-absolute in-base path still resolves (used by internal scans)."""
+    abs_in_base = str(music_tree / "track.mp3")
+    assert helpers.get_absolute_path(str(music_tree), abs_in_base) == abs_in_base
+
+
+async def test_resolve_rejects_traversal(music_tree: Path) -> None:
+    """provider.resolve() (used by get_track/preview) rejects `../` escapes."""
+    provider = _make_provider(str(music_tree))
+    with pytest.raises(MediaNotFoundError):
+        await provider.resolve("../secret.mp3")
+
+
+async def test_exists_rejects_traversal(music_tree: Path) -> None:
+    """provider.exists() returns False for a `../`-escaping path instead of leaking it."""
+    provider = _make_provider(str(music_tree))
+    assert await provider.exists("../secret.mp3") is False
+
+
+async def test_scandir_rejects_traversal(music_tree: Path) -> None:
+    """provider._scandir() (used by browse) rejects listing a dir outside the base."""
+    provider = _make_provider(str(music_tree))
+    with pytest.raises(MediaNotFoundError):
+        await provider._scandir("..")
+
+
+async def test_resolve_allows_in_base(music_tree: Path) -> None:
+    """A legitimate in-base file still resolves through provider.resolve()."""
+    provider = _make_provider(str(music_tree))
+    file_item = await provider.resolve("track.mp3")
+    assert file_item.absolute_path == os.path.join(str(music_tree), "track.mp3")

--- a/tests/providers/filesystem/test_path_traversal.py
+++ b/tests/providers/filesystem/test_path_traversal.py
@@ -85,3 +85,10 @@ async def test_resolve_allows_in_base(music_tree: Path) -> None:
     provider = _make_provider(str(music_tree))
     file_item = await provider.resolve("track.mp3")
     assert file_item.absolute_path == os.path.join(str(music_tree), "track.mp3")
+
+
+def test_get_absolute_path_allows_symlink_inside_base(music_tree: Path) -> None:
+    """A symlink inside the base still resolves (check is lexical, symlinks are admin-created)."""
+    link = music_tree / "linked.mp3"
+    link.symlink_to(music_tree.parent / "secret.mp3")
+    assert helpers.get_absolute_path(str(music_tree), "linked.mp3") == str(link)


### PR DESCRIPTION
# What does this implement/fix?

The local filesystem provider (and the SMB/NFS subclasses that inherit it) resolved an `item_id` / browse path relative to its configured base directory but never checked that the result stayed inside that base. A `../`-containing (or absolute) path escaped the base, allowing arbitrary file reads via the `/preview` endpoint and arbitrary directory listing via `music/browse`.

This constrains every resolved filesystem path to the provider's configured base directory. After building the absolute path we `realpath` both it and the base and reject the request (`MediaNotFoundError`) when the resolved path falls outside the base. Fixing it in the shared `get_absolute_path` helper covers all file access (preview / get_item / stream details / playlist read+write) and directory browse for local, SMB and NFS providers, using each provider's own base path.

The imageproxy path-traversal case from the same finding is out of scope here (the imageproxy was rewritten separately).

**Related issue (if applicable):**

- N/A (security assessment finding)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Changes

- Add a base-directory containment check to `get_absolute_path` in `filesystem_local/helpers.py` (realpath + `os.path.commonpath`), raising `MediaNotFoundError` on escape.
- `LocalFileSystemProvider.exists()` returns `False` for out-of-base paths instead of propagating.
- Add regression tests under `tests/providers/filesystem/test_path_traversal.py` covering helper, `resolve`, `exists` and `_scandir`, asserting `../`/absolute escapes are rejected while in-base paths still resolve.

Security assessment finding: 5.1.1 File-injection with downloads (Path traversal)

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
