### PR TITLE
Expose album artist on player current media

### DIFF
--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1878,6 +1878,7 @@ class Player(ABC):
                     title=f"{media_item.name} ({version})" if version else media_item.name,
                     artist=getattr(media_item, "artist_str", None),
                     album=album.name if album else podcast.name if podcast else description,
+                    album_artist=getattr(album, "artist_str", None),
                     image_url=image_url,
                     palette=self._resolved_palette(image_url),
                     duration=media_item.duration,


### PR DESCRIPTION
# What does this implement/fix?

`player.current_media` (built by `Player.__final_current_media`) did not include the album artist, so consumers — notably the Home Assistant integration — had to re-derive it from the queue. This populates `album_artist` there from the current track's album.

Note: the track *version* is already folded into `current_media.title` (`"Name (Version)"`) by the same method, so no separate field is needed for it (the `version` field added to the models has been removed again in music-assistant/models#287, released in 1.1.151, which `dev` already pins).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.