### PR TITLE
Fix snapcast announcement volume being restored before playback finished

### DIFF
--- a/music_assistant/providers/snapcast/__init__.py
+++ b/music_assistant/providers/snapcast/__init__.py
@@ -78,18 +78,6 @@ async def get_config_entries(
 
     return (
         ConfigEntry(
-            key=CONF_SERVER_BUFFER_SIZE,
-            type=ConfigEntryType.INTEGER,
-            range=(200, 6000),
-            default_value=1000,
-            required=False,
-            category=CONF_CATEGORY_BUILT_IN,
-            hidden=not local_snapserver_present,
-            depends_on=CONF_USE_EXTERNAL_SERVER,
-            depends_on_value_not=True,
-            help_link=CONF_HELP_LINK,
-        ),
-        ConfigEntry(
             key=CONF_SERVER_CHUNK_MS,
             type=ConfigEntryType.INTEGER,
             range=(10, 100),
@@ -163,6 +151,17 @@ async def get_config_entries(
             required=False,
             depends_on=CONF_USE_EXTERNAL_SERVER,
             advanced=local_snapserver_present,
+        ),
+        # the buffer size configures the built-in server and, for an external
+        # server, must mirror its stream.buffer setting (it cannot be read from
+        # the API) so announcement volume changes can be timed correctly
+        ConfigEntry(
+            key=CONF_SERVER_BUFFER_SIZE,
+            type=ConfigEntryType.INTEGER,
+            range=(200, 6000),
+            default_value=1000,
+            required=False,
+            help_link=CONF_HELP_LINK,
         ),
         ConfigEntry(
             key=CONF_STREAM_IDLE_THRESHOLD,

--- a/music_assistant/providers/snapcast/player.py
+++ b/music_assistant/providers/snapcast/player.py
@@ -348,14 +348,19 @@ class SnapCastPlayer(Player):
 
         await player_group.set_stream(ma_stream.stream_id)
 
-        if self.snap_provider._use_builtin_server:
-            await asyncio.sleep(self.snap_provider._snapcast_server_buffer_size / 1000.0)
+        # let the buffered tail of the previous stream play out
+        # before raising the volume
+        await self._wait_for_client_buffer()
 
         if volume_level is not None:
             await self.volume_set(volume_level)
 
         await ma_stream.start_stream()
         await ma_stream.wait_for_stopped()
+
+        # the server received all audio but the clients still have buffer_ms
+        # of it queued; wait for that to play out before restoring anything
+        await self._wait_for_client_buffer()
 
         if self.volume_level == volume_level and orig_volume_level is not None:
             await self.volume_set(orig_volume_level)
@@ -584,3 +589,7 @@ class SnapCastPlayer(Player):
             for ma_id in self._get_player_ids_of_curr_group()
             if (ma_player := self.mass.players.get_player(ma_id))
         ]
+
+    async def _wait_for_client_buffer(self) -> None:
+        """Wait for the snapserver stream buffer to play out on the clients."""
+        await asyncio.sleep(self.snap_provider._snapcast_server_buffer_size / 1000.0)

--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -74,6 +74,7 @@ class SnapCastProvider(PlayerProvider):
     _snapserver_started: asyncio.Event | None
     _snapcast_server_host: str
     _snapcast_server_control_port: int
+    _snapcast_server_buffer_size: int
     _ids_map: bidict[str, str]  # ma_id / snapclient_id
     _use_builtin_server: bool
     _stop_called: bool
@@ -114,9 +115,6 @@ class SnapCastProvider(PlayerProvider):
 
             self._snapcast_server_host = "127.0.0.1"
             self._snapcast_server_control_port = DEFAULT_SNAPSERVER_PORT
-            self._snapcast_server_buffer_size = cast(
-                "int", self.config.get_value(CONF_SERVER_BUFFER_SIZE)
-            )
             self._snapcast_server_chunk_ms = self.config.get_value(CONF_SERVER_CHUNK_MS)
             self._snapcast_server_initial_volume = self.config.get_value(CONF_SERVER_INITIAL_VOLUME)
             self._snapcast_server_send_to_muted = self.config.get_value(
@@ -130,6 +128,11 @@ class SnapCastProvider(PlayerProvider):
             self._snapcast_server_control_port = int(
                 str(self.config.get_value(CONF_SERVER_CONTROL_PORT))
             )
+        # for an external server this must mirror its stream.buffer setting,
+        # which cannot be read from the API (see config entry description)
+        self._snapcast_server_buffer_size = cast(
+            "int", self.config.get_value(CONF_SERVER_BUFFER_SIZE)
+        )
         self._snapcast_stream_idle_threshold = self.config.get_value(CONF_STREAM_IDLE_THRESHOLD)
         self._ids_map = bidict({})
         self._last_status_refresh = 0.0

--- a/music_assistant/providers/snapcast/strings.json
+++ b/music_assistant/providers/snapcast/strings.json
@@ -1,7 +1,8 @@
 {
   "config_entries": {
     "snapcast_server_built_in_buffer_size": {
-      "label": "Snapserver buffer size"
+      "label": "Snapserver buffer size",
+      "description": "The stream buffer size (in milliseconds) of the Snapcast server. This configures the built-in server; when using an external server, set it to match the server's stream.buffer setting. Snapclients play audio this long after the server receives it, so Music Assistant uses this value to time announcement volume changes correctly."
     },
     "snapcast_server_built_in_chunk_ms": {
       "label": "Snapserver chunk size"

--- a/music_assistant/translations/en.json
+++ b/music_assistant/translations/en.json
@@ -1645,6 +1645,7 @@
   "provider.smart_playlist.errors.invalid_name": "{0} is not a valid playlist name.",
   "provider.smart_playlist.manifest.description": "Create dynamic or fixed playlists based on rules: genres, artists, albums, favorites, similar tracks, release year, album type, explicit content, track duration, and rediscover forgotten tracks by filtering out recently played music.",
   "provider.smart_playlist.media.recommendations.smart_playlists.name": "Smart Playlists",
+  "provider.snapcast.config_entries.snapcast_server_built_in_buffer_size.description": "The stream buffer size (in milliseconds) of the Snapcast server. This configures the built-in server; when using an external server, set it to match the server's stream.buffer setting. Snapclients play audio this long after the server receives it, so Music Assistant uses this value to time announcement volume changes correctly.",
   "provider.snapcast.config_entries.snapcast_server_built_in_buffer_size.label": "Snapserver buffer size",
   "provider.snapcast.config_entries.snapcast_server_built_in_chunk_ms.label": "Snapserver chunk size",
   "provider.snapcast.config_entries.snapcast_server_built_in_codec.label": "Snapserver default transport codec",

--- a/tests/providers/snapcast/test_player_announcement.py
+++ b/tests/providers/snapcast/test_player_announcement.py
@@ -1,0 +1,111 @@
+"""Tests for Snapcast announcement timing (issue #4377)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.player import PlayerMedia
+
+from music_assistant.providers.snapcast.player import SnapCastPlayer
+
+if TYPE_CHECKING:
+    from music_assistant.providers.snapcast.snap_cntrl_proto import SnapclientProto
+
+
+def _make_player(
+    events: list[str],
+    *,
+    use_builtin_server: bool,
+    buffer_size: int = 1000,
+    volume_level: int = 25,
+) -> SnapCastPlayer:
+    """Build a SnapCastPlayer with a mocked provider that records call order in events."""
+    player = SnapCastPlayer.__new__(SnapCastPlayer)
+    player._player_id = "player-1"
+    player._attr_volume_level = volume_level
+
+    async def set_volume(level: int) -> None:
+        events.append(f"volume_set:{level}")
+        player._attr_volume_level = level
+
+    # group.name == player_id -> player is its own group leader (not synced)
+    snap_group = SimpleNamespace(name="player-1", stream="default", clients=["client-1"])
+    player.snap_client = cast(
+        "SnapclientProto",
+        SimpleNamespace(group=snap_group, set_volume=set_volume, identifier="client-1"),
+    )
+
+    ma_stream = MagicMock()
+    ma_stream.stream_id = "announce-1"
+    ma_stream.start_stream = AsyncMock(side_effect=lambda: events.append("start_stream"))
+    ma_stream.wait_for_stopped = AsyncMock(side_effect=lambda: events.append("wait_for_stopped"))
+
+    player_group = MagicMock()
+    player_group.set_stream = AsyncMock(
+        side_effect=lambda stream_id: events.append(f"set_stream:{stream_id}")
+    )
+
+    provider = MagicMock()
+    provider._use_builtin_server = use_builtin_server
+    provider._snapcast_server_buffer_size = buffer_size
+    provider.get_snapcast_media_stream = AsyncMock(return_value=ma_stream)
+    provider.ensure_player_owned_group = AsyncMock(return_value=player_group)
+    player._provider = provider
+    return player
+
+
+def _make_announcement() -> PlayerMedia:
+    return PlayerMedia(uri="http://localhost/announce.mp3", media_type=MediaType.ANNOUNCEMENT)
+
+
+async def _run_announcement(player: SnapCastPlayer, events: list[str], **kwargs: int) -> None:
+    async def fake_sleep(delay: float) -> None:
+        events.append(f"sleep:{delay}")
+
+    with patch("music_assistant.providers.snapcast.player.asyncio.sleep", side_effect=fake_sleep):
+        await player.play_announcement(_make_announcement(), **kwargs)
+
+
+@pytest.mark.parametrize("use_builtin_server", [True, False])
+async def test_volume_restore_waits_for_client_buffer(use_builtin_server: bool) -> None:
+    """
+    Volume restore and stream switch-back must wait for the client buffer to play out.
+
+    Snapclients play buffer_ms behind the server; restoring the volume as soon
+    as the server finished receiving the announcement reverts it ~buffer_ms
+    before the audio finishes on the speakers (issue #4377).
+    """
+    events: list[str] = []
+    player = _make_player(events, use_builtin_server=use_builtin_server, buffer_size=1000)
+    await _run_announcement(player, events, volume_level=80)
+
+    assert events == [
+        "set_stream:announce-1",
+        "sleep:1.0",
+        "volume_set:80",
+        "start_stream",
+        "wait_for_stopped",
+        "sleep:1.0",
+        "volume_set:25",
+        "set_stream:default",
+    ]
+
+
+async def test_switch_back_waits_for_client_buffer_without_volume() -> None:
+    """The buffered tail must also play out before switching streams back (clipped endings)."""
+    events: list[str] = []
+    player = _make_player(events, use_builtin_server=False, buffer_size=500)
+    await _run_announcement(player, events)
+
+    assert events == [
+        "set_stream:announce-1",
+        "sleep:0.5",
+        "start_stream",
+        "wait_for_stopped",
+        "sleep:0.5",
+        "set_stream:default",
+    ]


### PR DESCRIPTION
# What does this implement/fix?

Snapcast announcements restore the player volume (and switch the group back to the previous stream) as soon as the *server* has received all announcement audio. Snapclients however play audio `buffer_ms` (default 1000ms) behind the server, so the volume was reverted ~1 second before the announcement actually finished on the speakers, and the tail of the announcement got clipped by the stream switch-back.

- Wait for the client buffer to play out after the announcement stream finished, before restoring volume and switching the group back to the previous stream.
- Apply the same buffer wait before raising the volume on external servers too (previously built-in only).
- The existing "Snapserver buffer size" setting is now also shown when using an external server (the buffer cannot be read via the Snapcast API, so the user must mirror the server's `stream.buffer` setting there). It keeps configuring the buffer of the built-in server as before.
- Add regression tests for the announcement call ordering.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/4377

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
