### PR TITLE
Fix XSS and cross-host request issues in MSX Bridge web player

### DIFF
--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -255,7 +255,8 @@ class MSXHTTPServer:
     async def _handle_root(self, request: web.Request) -> web.Response:
         """Serve status dashboard."""
         players = self.provider.players
-        base = self._get_prefix(request)
+        # base is derived from the Host header, so escape it before embedding in HTML
+        base = html_escape(self._get_prefix(request))
         player_rows = []
         for p in players:
             row = (
@@ -263,7 +264,7 @@ class MSXHTTPServer:
                 f"{html_escape(p.display_name)} — {html_escape(p.playback_state.value)}"
                 f"</span>"
             )
-            row += f'<form method="post" action="{base}/api/quick-stop/{p.player_id}" '
+            row += f'<form method="post" action="{base}/api/quick-stop/{html_escape(p.player_id)}" '
             row += 'style="display:inline">'
             row += '<button type="submit" class="btn">Quick stop</button></form></li>'
             player_rows.append(row)

--- a/music_assistant/providers/msx_bridge/static/web/web.js
+++ b/music_assistant/providers/msx_bridge/static/web/web.js
@@ -286,7 +286,12 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
             }
         }
         if (artCenter) {
-            artCenter.src = imgUrl;
+            if (imgUrl) {
+                artCenter.src = imgUrl;
+                artCenter.style.display = '';
+            } else {
+                artCenter.style.display = 'none';
+            }
         }
         if (titleEl) titleEl.textContent = track.title || '';
         if (artistEl) artistEl.textContent = track.artist || '';
@@ -444,10 +449,11 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
 
             // Build img container via DOM to safely assign src without innerHTML injection
             var imgContainer = document.createElement('div');
-            if (item.image) {
+            var cardImgUrl = safeImageUrl(item.image);
+            if (cardImgUrl) {
                 imgContainer.className = 'card-img';
                 var img = document.createElement('img');
-                img.src = safeImageUrl(item.image);
+                img.src = cardImgUrl;
                 img.alt = '';
                 img.loading = 'lazy';
                 imgContainer.appendChild(img);
@@ -481,9 +487,10 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
             var sub = esc(item.titleFooter || item.label || '');
 
             // Build art element via DOM to safely assign src without innerHTML injection
-            if (item.image) {
+            var trackArtUrl = safeImageUrl(item.image);
+            if (trackArtUrl) {
                 var img = document.createElement('img');
-                img.src = safeImageUrl(item.image);
+                img.src = trackArtUrl;
                 img.alt = '';
                 img.className = 'track-art';
                 img.loading = 'lazy';
@@ -1046,9 +1053,10 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
                 '</div>' +
                 '<div class="kiosk-queue-dur">' + durStr + '</div>';
 
-            if (item.image) {
+            var kioskArtUrl = safeImageUrl(item.image);
+            if (kioskArtUrl) {
                 var img = document.createElement('img');
-                img.src = safeImageUrl(item.image);
+                img.src = kioskArtUrl;
                 img.alt = '';
                 img.className = 'kiosk-queue-art';
                 img.loading = 'lazy';
@@ -1126,9 +1134,10 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
 
             // Build img element via DOM to safely assign src without innerHTML injection
             var artEl;
-            if (item.image) {
+            var artUrl = safeImageUrl(item.image);
+            if (artUrl) {
                 artEl = document.createElement('img');
-                artEl.src = safeImageUrl(item.image);
+                artEl.src = artUrl;
                 artEl.alt = '';
                 artEl.className = 'queue-item-art';
                 artEl.loading = 'lazy';

--- a/music_assistant/providers/msx_bridge/static/web/web.js
+++ b/music_assistant/providers/msx_bridge/static/web/web.js
@@ -119,11 +119,30 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
         return url + (url.indexOf('?') >= 0 ? '&' : '?') + param;
     }
 
+    function isHttpUrl(url) {
+        return url.indexOf('http://') === 0 || url.indexOf('https://') === 0;
+    }
+
+    // Resolve a content/audio URL. The bridge only ever hands out URLs pointing
+    // at itself, so anything targeting another host is rejected here.
     function resolveUrl(url) {
         if (!url) return '';
-        if (url.indexOf('http://') === 0 || url.indexOf('https://') === 0) return url;
+        if (isHttpUrl(url)) {
+            var a = document.createElement('a');
+            a.href = url;
+            return a.host === location.host ? url : '';
+        }
         if (url.charAt(0) === '/') return BASE + url;
-        return url;
+        return '';
+    }
+
+    // Image URLs may legitimately point at remote CDNs (album art), so any
+    // http(s) URL is allowed here — but never other schemes like javascript:.
+    function safeImageUrl(url) {
+        if (!url) return '';
+        if (isHttpUrl(url)) return url;
+        if (url.charAt(0) === '/') return BASE + url;
+        return '';
     }
 
     function parseMsx(text) {
@@ -255,16 +274,17 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
         var artistEl = document.getElementById('kiosk-artist');
         var durEl = document.getElementById('kiosk-dur');
 
+        var imgUrl = safeImageUrl(track.image);
         if (bgImg) {
-            if (track.image) {
-                bgImg.src = track.image;
+            if (imgUrl) {
+                bgImg.src = imgUrl;
                 bgImg.style.opacity = '1';
             } else {
                 bgImg.style.opacity = '0';
             }
         }
         if (artCenter) {
-            artCenter.src = track.image || '';
+            artCenter.src = imgUrl;
         }
         if (titleEl) titleEl.textContent = track.title || '';
         if (artistEl) artistEl.textContent = track.artist || '';
@@ -425,7 +445,7 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
             if (item.image) {
                 imgContainer.className = 'card-img';
                 var img = document.createElement('img');
-                img.src = item.image;
+                img.src = safeImageUrl(item.image);
                 img.alt = '';
                 img.loading = 'lazy';
                 imgContainer.appendChild(img);
@@ -461,7 +481,7 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
             // Build art element via DOM to safely assign src without innerHTML injection
             if (item.image) {
                 var img = document.createElement('img');
-                img.src = item.image;
+                img.src = safeImageUrl(item.image);
                 img.alt = '';
                 img.className = 'track-art';
                 img.loading = 'lazy';
@@ -576,7 +596,8 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
         document.getElementById('bar-title').textContent = track.title;
         document.getElementById('bar-artist').textContent = track.artist;
         var art = document.getElementById('player-art');
-        if (track.image) { art.src = track.image; art.style.display = ''; }
+        var imgUrl = safeImageUrl(track.image);
+        if (imgUrl) { art.src = imgUrl; art.style.display = ''; }
         else { art.style.display = 'none'; }
         document.getElementById('bar-dur').textContent = track.duration ? fmtDur(track.duration) : '';
         syncPlayBtn();
@@ -584,8 +605,9 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
 
     function updateFullPlayer(track) {
         var art = document.getElementById('full-art');
+        var imgUrl = safeImageUrl(track.image);
         if (art) {
-            if (track.image) { art.src = track.image; art.style.display = ''; }
+            if (imgUrl) { art.src = imgUrl; art.style.display = ''; }
             else { art.style.display = 'none'; }
         }
         var titleEl = document.getElementById('full-title');
@@ -1024,7 +1046,7 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
 
             if (item.image) {
                 var img = document.createElement('img');
-                img.src = item.image;
+                img.src = safeImageUrl(item.image);
                 img.alt = '';
                 img.className = 'kiosk-queue-art';
                 img.loading = 'lazy';
@@ -1104,7 +1126,7 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
             var artEl;
             if (item.image) {
                 artEl = document.createElement('img');
-                artEl.src = item.image;
+                artEl.src = safeImageUrl(item.image);
                 artEl.alt = '';
                 artEl.className = 'queue-item-art';
                 artEl.loading = 'lazy';

--- a/music_assistant/providers/msx_bridge/static/web/web.js
+++ b/music_assistant/providers/msx_bridge/static/web/web.js
@@ -128,9 +128,11 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
     function resolveUrl(url) {
         if (!url) return '';
         if (isHttpUrl(url)) {
-            var a = document.createElement('a');
-            a.href = url;
-            return a.host === location.host ? url : '';
+            try {
+                return new URL(url).host === location.host ? url : '';
+            } catch (e) {
+                return '';
+            }
         }
         if (url.charAt(0) === '/') return BASE + url;
         return '';

--- a/tests/providers/msx_bridge/test_http_server.py
+++ b/tests/providers/msx_bridge/test_http_server.py
@@ -41,6 +41,14 @@ async def test_root_html(http_client: TestClient[Any, Any]) -> None:
     assert "MSX" in body
 
 
+async def test_root_html_escapes_host_header(http_client: TestClient[Any, Any]) -> None:
+    """A crafted Host header must not be reflected unescaped (XSS)."""
+    resp = await http_client.get("/", headers={"Host": 'evil"><script>alert(1)</script>'})
+    assert resp.status == 200
+    body = await resp.text()
+    assert "<script>alert(1)</script>" not in body
+
+
 async def test_start_json(http_client: TestClient[Any, Any]) -> None:
     """GET /msx/start.json should return launcher menu config."""
     resp = await http_client.get("/msx/start.json")


### PR DESCRIPTION
# What does this implement/fix?

Fixes the MSX Bridge findings from GitHub code scanning (alerts #88–#97):

- The status page reflected the `Host` header unescaped into HTML (reflected XSS). The URL prefix and player id are now HTML-escaped.
- `resolveUrl()` in the web player accepted any absolute URL from JSON content for `fetch()` and audio playback. It now rejects URLs pointing at other hosts — the bridge only ever hands out URLs to itself.
- Artwork `img.src` sinks now go through `safeImageUrl()`, which allows http(s) only (remote CDN album art keeps working, `javascript:` etc. do not).

**Related issue (if applicable):**

- related issue: code scanning alerts 88-97

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
