### PR TITLE
Stop exposing internal error details in Plex Connect responses

### DIFF
--- a/music_assistant/providers/plex_connect/playback.py
+++ b/music_assistant/providers/plex_connect/playback.py
@@ -207,7 +207,7 @@ class PlaybackMixin:
 
         except Exception as e:
             LOGGER.exception(f"Error handling skipTo: {e}")
-            return web.Response(status=500, text=str(e))
+            return web.Response(status=500, text="Internal error")
         finally:
             self._updating_from_plex = False
 

--- a/music_assistant/providers/plex_connect/queue_commands.py
+++ b/music_assistant/providers/plex_connect/queue_commands.py
@@ -429,7 +429,7 @@ class QueueCommandsMixin:
 
         except Exception as e:
             LOGGER.exception(f"Error handling playMedia: {e}")
-            return web.Response(status=500, text=str(e))
+            return web.Response(status=500, text="Internal error")
         finally:
             self._updating_from_plex = False
 
@@ -513,14 +513,14 @@ class QueueCommandsMixin:
 
                 except Exception as e:
                     LOGGER.exception(f"Error starting playback with first track: {e}")
-                    return web.Response(status=500, text=f"Failed to start playback: {e}")
+                    return web.Response(status=500, text="Failed to start playback")
             else:
                 LOGGER.error("Failed to create play queue or queue is empty")
                 return web.Response(status=500, text="Failed to create play queue")
 
         except Exception as e:
             LOGGER.exception(f"Error handling createPlayQueue: {e}")
-            return web.Response(status=500, text=str(e))
+            return web.Response(status=500, text="Internal error")
         finally:
             self._updating_from_plex = False
 
@@ -608,6 +608,6 @@ class QueueCommandsMixin:
 
         except Exception as e:
             LOGGER.exception(f"Error handling refreshPlayQueue: {e}")
-            return web.Response(status=500, text=str(e))
+            return web.Response(status=500, text="Internal error")
         finally:
             self._updating_from_plex = False

--- a/tests/providers/plex_connect/__init__.py
+++ b/tests/providers/plex_connect/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Plex Connect provider."""

--- a/tests/providers/plex_connect/test_error_responses.py
+++ b/tests/providers/plex_connect/test_error_responses.py
@@ -1,0 +1,74 @@
+"""Tests that HTTP error responses do not leak exception details to the client."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from music_assistant.providers.plex_connect.playback import PlaybackMixin
+from music_assistant.providers.plex_connect.queue_commands import QueueCommandsMixin
+
+
+class _PlaybackHandler(PlaybackMixin):
+    """PlaybackMixin with the host-class attributes mocked."""
+
+    def __init__(self) -> None:
+        self.provider = Mock()
+        self._ma_player_id = "player1"
+        self._updating_from_plex = False
+        self.play_queue_id = None
+        self.play_queue_item_ids: dict[int, int] = {}
+        self._broadcast_timeline = AsyncMock()  # type: ignore[method-assign]
+
+
+class _QueueHandler(QueueCommandsMixin):
+    """QueueCommandsMixin with the host-class attributes mocked."""
+
+    def __init__(self) -> None:
+        self.provider = Mock()
+        self._ma_player_id = "player1"
+        self._updating_from_plex = False
+        self.play_queue_id = None
+        self.play_queue_version = 1
+        self.play_queue_item_ids: dict[int, int] = {}
+        self._broadcast_timeline = AsyncMock()  # type: ignore[method-assign]
+
+
+def _request_with_query(query: dict[str, str]) -> Any:
+    request = Mock()
+    request.query = query
+    return request
+
+
+@pytest.mark.asyncio
+async def test_skip_to_error_does_not_leak_exception() -> None:
+    """An internal error in skipTo must return a generic 500 body."""
+    handler = _PlaybackHandler()
+    provider_mock = Mock()
+    provider_mock.mass.player_queues.items = Mock(
+        side_effect=RuntimeError("secret internal details")
+    )
+    handler.provider = provider_mock
+
+    response = await handler.handle_skip_to(_request_with_query({"key": "/library/item/1"}))
+
+    assert response.status == 500
+    assert "secret internal details" not in (response.text or "")
+
+
+@pytest.mark.asyncio
+async def test_create_play_queue_error_does_not_leak_exception() -> None:
+    """An internal error in createPlayQueue must return a generic 500 body."""
+    handler = _QueueHandler()
+    provider_mock = Mock()
+    provider_mock._plex_server.fetchItem = Mock(side_effect=RuntimeError("secret internal details"))
+    handler.provider = provider_mock
+
+    response = await handler.handle_create_play_queue(
+        _request_with_query({"uri": "server://xyz/library/item/1"})
+    )
+
+    assert response.status == 500
+    assert "secret internal details" not in (response.text or "")


### PR DESCRIPTION
# What does this implement/fix?

Fixes code scanning alerts #115–#119: the Plex Connect HTTP handlers returned raw exception text (`str(e)`) in 500 responses, exposing internal details to the network. Responses now carry a generic message; full details still go to the log via `LOGGER.exception`.

Includes regression tests asserting exception details never reach the response body.

**Related issue (if applicable):**

- related issue: code scanning alerts 115-119

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
