### PR TITLE
Match NetEase image CDN hostname exactly when upgrading to https

### DIFF
--- a/music_assistant/providers/neteasecloudmusic/__init__.py
+++ b/music_assistant/providers/neteasecloudmusic/__init__.py
@@ -730,8 +730,10 @@ class NeteaseCloudMusicProvider(MusicProvider):
         # NCM often returns http://p*.music.126.net links.
         # In secure/ingress contexts these can be blocked as mixed content,
         # which makes the frontend fall back to a generic provider icon.
-        if url.startswith("http://") and "music.126.net" in url:
-            return "https://" + url[len("http://") :]
+        if url.startswith("http://"):
+            host = urlparse(url).hostname or ""
+            if host == "music.126.net" or host.endswith(".music.126.net"):
+                return "https://" + url[len("http://") :]
         return url
 
     def _make_image_list(

--- a/tests/providers/neteasecloudmusic/__init__.py
+++ b/tests/providers/neteasecloudmusic/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the NetEase Cloud Music provider."""

--- a/tests/providers/neteasecloudmusic/test_image_urls.py
+++ b/tests/providers/neteasecloudmusic/test_image_urls.py
@@ -1,0 +1,36 @@
+"""Tests for image URL normalization."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from music_assistant.providers.neteasecloudmusic import NeteaseCloudMusicProvider
+
+
+def _normalize(url: str) -> str:
+    # _normalize_image_url does not touch instance state
+    return NeteaseCloudMusicProvider._normalize_image_url(
+        cast("NeteaseCloudMusicProvider", None), url
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        # http links on the NCM image CDN are upgraded to https
+        ("http://p1.music.126.net/abc.jpg", "https://p1.music.126.net/abc.jpg"),
+        ("http://music.126.net/abc.jpg", "https://music.126.net/abc.jpg"),
+        # the CDN hostname must be the actual host, not just a substring anywhere
+        ("http://evil.com/music.126.net/abc.jpg", "http://evil.com/music.126.net/abc.jpg"),
+        ("http://evil-music.126.net/abc.jpg", "http://evil-music.126.net/abc.jpg"),
+        ("http://music.126.net.evil.com/abc.jpg", "http://music.126.net.evil.com/abc.jpg"),
+        # https and non-NCM urls stay untouched
+        ("https://p1.music.126.net/abc.jpg", "https://p1.music.126.net/abc.jpg"),
+        ("http://example.com/abc.jpg", "http://example.com/abc.jpg"),
+    ],
+)
+def test_normalize_image_url(url: str, expected: str) -> None:
+    """Only real *.music.126.net hosts are upgraded to https."""
+    assert _normalize(url) == expected


### PR DESCRIPTION
# What does this implement/fix?

Fixes code scanning alert #102: the http→https upgrade for NetEase image links checked `"music.126.net" in url`, which matches the string anywhere in the URL (e.g. in the path of an unrelated host). The check now parses the URL and compares the actual hostname (`music.126.net` or a subdomain).

**Related issue (if applicable):**

- related issue: code scanning alert 102

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
