### PR TITLE
Fix open redirect on login page and requirements regex char range

### DIFF
--- a/music_assistant/helpers/resources/login.html
+++ b/music_assistant/helpers/resources/login.html
@@ -273,9 +273,17 @@
                 if (data.success && data.access_token) {
                     // Redirect with the token
                     let redirectUrl = '/';
-                    // Only allow same-origin relative paths (e.g. "/path"), not external URLs
-                    if (typeof returnUrl === 'string' && returnUrl.startsWith('/') && !returnUrl.startsWith('//')) {
-                        redirectUrl = returnUrl;
+                    // Only allow same-origin relative paths (e.g. "/path"), not external URLs.
+                    // Parse with the URL API: prefix tricks like "//evil.com" or "/\evil.com"
+                    // resolve to a different origin and are rejected.
+                    if (typeof returnUrl === 'string') {
+                        try {
+                            const parsed = new URL(returnUrl, window.location.origin);
+                            if (parsed.origin === window.location.origin) {
+                                // Drop any #fragment so the code param below stays in the query
+                                redirectUrl = parsed.pathname + parsed.search;
+                            }
+                        } catch (e) { /* keep default */ }
                     }
                     const separator = redirectUrl.includes('?') ? '&' : '?';
                     window.location.href = `${redirectUrl}${separator}code=${encodeURIComponent(data.access_token)}`;

--- a/music_assistant/helpers/resources/login.html
+++ b/music_assistant/helpers/resources/login.html
@@ -273,9 +273,7 @@
                 if (data.success && data.access_token) {
                     // Redirect with the token
                     let redirectUrl = '/';
-                    // Only allow same-origin relative paths (e.g. "/path"), not external URLs.
-                    // Parse with the URL API: prefix tricks like "//evil.com" or "/\evil.com"
-                    // resolve to a different origin and are rejected.
+                    // Accept only same-origin paths; the URL API rejects prefix tricks like "//evil.com" or "/\evil.com".
                     if (typeof returnUrl === 'string') {
                         try {
                             const parsed = new URL(returnUrl, window.location.origin);

--- a/scripts/gen_requirements_all.py
+++ b/scripts/gen_requirements_all.py
@@ -10,7 +10,7 @@ import tomllib
 from pathlib import Path
 
 PACKAGE_REGEX = re.compile(r"^(?:--.+\s)?([-_\.\w\d]+).*==.+$")
-GIT_REPO_REGEX = re.compile(r"^(git\+https:\/\/[-_\.\w\d\/]+[@-_\.\w\d\/]*)$")
+GIT_REPO_REGEX = re.compile(r"^(git\+https:\/\/[-_\.\w\d\/]+[-@_\.\w\d\/]*)$")
 
 # ruff: noqa: T201
 

--- a/tests/scripts/test_gen_requirements_all.py
+++ b/tests/scripts/test_gen_requirements_all.py
@@ -1,0 +1,34 @@
+"""Tests for the requirements file generator."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.gen_requirements_all import GIT_REPO_REGEX
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "git+https://github.com/owner/repo",
+        "git+https://github.com/owner/repo@v1.0.0",
+        "git+https://github.com/owner/some-repo@feature_branch",
+    ],
+)
+def test_git_repo_regex_matches(line: str) -> None:
+    """Valid git requirement lines are recognized."""
+    assert GIT_REPO_REGEX.match(line)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # chars like ^ [ ] were accidentally accepted by the former @-_ char range
+        "git+https://github.com/owner/repo@v1^0",
+        "git+https://github.com/owner/repo@[tag]",
+        "git+https://example.com/repo; rm -rf /",
+    ],
+)
+def test_git_repo_regex_rejects(line: str) -> None:
+    """Lines with unexpected characters are not recognized as git requirements."""
+    assert not GIT_REPO_REGEX.match(line)


### PR DESCRIPTION
# What does this implement/fix?

Fixes two core code scanning findings:

- **Login page open redirect (alerts #86/#87):** the `return_url` guard (`startsWith('/') && !startsWith('//')`) could be bypassed with `/\evil.com`, since browsers treat `\` as `/`. The value is now parsed with the URL API and only same-origin paths are accepted.
- **Requirements generator regex (alert #98):** `GIT_REPO_REGEX` contained an accidental `@-_` character range (matching `[`, `^`, etc.) where literal `@`, `-`, `_` were intended.

**Related issue (if applicable):**

- related issue: code scanning alerts 86, 87, 98

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
