### PR TITLE
Fix playlog unique constraint errors on long-lived databases

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 48
+DB_SCHEMA_VERSION: Final[int] = 49
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -725,6 +725,63 @@ async def migrate_database(  # noqa: PLR0915
         except Exception as err:
             logger.warning("Could not refresh default genre icons: %s", err)
 
+    if prev_version <= 48:
+        # databases from before the userid column still carry the original inline
+        # UNIQUE(item_id, provider, media_type) constraint, which ALTER TABLE could not
+        # remove. It collides with the per-user upsert (ON CONFLICT on 4 columns) and
+        # raises IntegrityError on every replay of an item. SQLite can only drop an
+        # inline constraint by rebuilding the table.
+        stale_unique = False
+        for index in await database.get_rows_from_query(
+            f"PRAGMA index_list({DB_TABLE_PLAYLOG})", limit=0
+        ):
+            if not index["unique"]:
+                continue
+            index_columns = {
+                column["name"]
+                for column in await database.get_rows_from_query(
+                    f"PRAGMA index_info({index['name']})", limit=0
+                )
+            }
+            if "userid" not in index_columns:
+                stale_unique = True
+                break
+        if stale_unique:
+            logger.info("Rebuilding playlog table to update its unique constraint")
+            await database.execute(
+                f"ALTER TABLE {DB_TABLE_PLAYLOG} RENAME TO {DB_TABLE_PLAYLOG}_old"
+            )
+            await database.execute(
+                f"""CREATE TABLE {DB_TABLE_PLAYLOG}(
+                    [id] INTEGER PRIMARY KEY AUTOINCREMENT,
+                    [item_id] TEXT NOT NULL,
+                    [provider] TEXT NOT NULL,
+                    [media_type] TEXT NOT NULL,
+                    [name] TEXT NOT NULL,
+                    [image] json,
+                    [artists] json,
+                    [timestamp] INTEGER DEFAULT 0,
+                    [fully_played] BOOLEAN,
+                    [seconds_played] INTEGER,
+                    [userid] TEXT NOT NULL,
+                    [queue_id] TEXT,
+                    [user_initiated] BOOLEAN NOT NULL DEFAULT 1,
+                    [playback_speed] REAL NOT NULL DEFAULT 1.0,
+                    UNIQUE(item_id, provider, media_type, userid));"""
+            )
+            # rows from before the userid column existed have no owner and cannot be
+            # kept under the NOT NULL schema
+            await database.execute(
+                f"INSERT INTO {DB_TABLE_PLAYLOG} "
+                "(id, item_id, provider, media_type, name, image, artists, timestamp, "
+                "fully_played, seconds_played, userid, queue_id, user_initiated, "
+                "playback_speed) "
+                "SELECT id, item_id, provider, media_type, name, image, artists, timestamp, "
+                "fully_played, seconds_played, userid, queue_id, user_initiated, "
+                f"playback_speed FROM {DB_TABLE_PLAYLOG}_old WHERE userid IS NOT NULL"
+            )
+            await database.execute(f"DROP TABLE {DB_TABLE_PLAYLOG}_old")
+
     # save changes
     await database.commit()
 

--- a/tests/controllers/music/test_music_migrations.py
+++ b/tests/controllers/music/test_music_migrations.py
@@ -2,12 +2,171 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from music_assistant_models.errors import MusicAssistantError
 
+from music_assistant.constants import DB_TABLE_PLAYLOG
 from music_assistant.controllers.music.migrations import migrate_database
+from music_assistant.helpers.database import DatabaseConnection
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from pathlib import Path
+
+
+@pytest.fixture
+async def database(tmp_path: Path) -> AsyncGenerator[DatabaseConnection]:
+    """Return an initialized DatabaseConnection backed by a temp file."""
+    db = DatabaseConnection(str(tmp_path / "library.db"))
+    await db.setup()
+    yield db
+    await db.close()
+
+
+# the exact upsert used by MusicController._credit_artist_plays - it targets the
+# 4-column unique constraint, so it raises IntegrityError on databases that still
+# carry the legacy 3-column constraint (issue #5754)
+PLAYLOG_UPSERT = (
+    f"INSERT INTO {DB_TABLE_PLAYLOG} "
+    "(item_id, provider, media_type, name, image, fully_played, "
+    "seconds_played, timestamp, queue_id, user_initiated, userid) "
+    "VALUES (:item_id, :provider, :media_type, :name, :image, :fully_played, "
+    ":seconds_played, :timestamp, :queue_id, :user_initiated, :userid) "
+    "ON CONFLICT(item_id, provider, media_type, userid) DO UPDATE SET "
+    "timestamp = excluded.timestamp"
+)
+
+
+def _playlog_entry(userid: str, timestamp: int = 100) -> dict[str, object]:
+    return {
+        "item_id": "1",
+        "provider": "library",
+        "media_type": "track",
+        "name": "Test Track",
+        "image": None,
+        "fully_played": 1,
+        "seconds_played": 195,
+        "timestamp": timestamp,
+        "queue_id": "queue1",
+        "user_initiated": 1,
+        "userid": userid,
+    }
+
+
+async def _create_legacy_playlog_table(database: DatabaseConnection) -> None:
+    """Create the playlog table as it exists on pre-userid installs."""
+    # original table layout (schema version <= 22) with the 3-column UNIQUE constraint
+    await database.execute(
+        f"""CREATE TABLE {DB_TABLE_PLAYLOG}(
+            [id] INTEGER PRIMARY KEY AUTOINCREMENT,
+            [item_id] TEXT NOT NULL,
+            [provider] TEXT NOT NULL,
+            [media_type] TEXT NOT NULL,
+            [name] TEXT NOT NULL,
+            [image] json,
+            [timestamp] INTEGER DEFAULT 0,
+            [fully_played] BOOLEAN,
+            [seconds_played] INTEGER,
+            UNIQUE(item_id, provider, media_type));"""
+    )
+    # columns + index added in-place by the later ALTER TABLE migrations
+    await database.execute(f"ALTER TABLE {DB_TABLE_PLAYLOG} ADD COLUMN userid TEXT")
+    await database.execute(f"ALTER TABLE {DB_TABLE_PLAYLOG} ADD COLUMN queue_id TEXT")
+    await database.execute(
+        f"ALTER TABLE {DB_TABLE_PLAYLOG} ADD COLUMN user_initiated BOOLEAN NOT NULL DEFAULT 1"
+    )
+    await database.execute(
+        f"ALTER TABLE {DB_TABLE_PLAYLOG} ADD COLUMN playback_speed REAL NOT NULL DEFAULT 1.0"
+    )
+    await database.execute(f"ALTER TABLE {DB_TABLE_PLAYLOG} ADD COLUMN artists json")
+    await database.execute(
+        f"CREATE UNIQUE INDEX {DB_TABLE_PLAYLOG}_unique_idx "
+        f"ON {DB_TABLE_PLAYLOG}(item_id,provider,media_type,userid)"
+    )
+    await database.commit()
+
+
+async def test_migration_rebuilds_playlog_with_stale_unique_constraint(
+    database: DatabaseConnection,
+) -> None:
+    """The legacy 3-column UNIQUE constraint on playlog is dropped by a table rebuild."""
+    await _create_legacy_playlog_table(database)
+    await database.execute(PLAYLOG_UPSERT, _playlog_entry("user1"))
+    # a legacy row from before the userid column existed
+    await database.execute(
+        f"INSERT INTO {DB_TABLE_PLAYLOG} (item_id, provider, media_type, name) "
+        "VALUES ('2', 'library', 'track', 'Legacy Track')"
+    )
+    await database.commit()
+
+    mass = MagicMock()
+    mass.cache.clear = AsyncMock()
+    await migrate_database(
+        mass,
+        database,
+        MagicMock(),
+        prev_version=48,
+        create_tables=AsyncMock(),
+    )
+
+    # replaying the same item for the same user updates the existing row in place
+    await database.execute(PLAYLOG_UPSERT, _playlog_entry("user1", timestamp=200))
+    # another user playing the same item gets their own row
+    await database.execute(PLAYLOG_UPSERT, _playlog_entry("user2"))
+    rows = await database.get_rows(DB_TABLE_PLAYLOG, {"item_id": "1"})
+    assert len(rows) == 2
+    user1_row = next(row for row in rows if row["userid"] == "user1")
+    assert user1_row["timestamp"] == 200
+    assert user1_row["name"] == "Test Track"
+    # legacy rows without a userid cannot be kept under the NOT NULL schema
+    assert not await database.get_rows(DB_TABLE_PLAYLOG, {"item_id": "2"})
+
+
+async def test_migration_leaves_correct_playlog_untouched(
+    database: DatabaseConnection,
+) -> None:
+    """A playlog table that already has the 4-column constraint is not rebuilt."""
+    await database.execute(
+        f"""CREATE TABLE {DB_TABLE_PLAYLOG}(
+            [id] INTEGER PRIMARY KEY AUTOINCREMENT,
+            [item_id] TEXT NOT NULL,
+            [provider] TEXT NOT NULL,
+            [media_type] TEXT NOT NULL,
+            [name] TEXT NOT NULL,
+            [image] json,
+            [artists] json,
+            [timestamp] INTEGER DEFAULT 0,
+            [fully_played] BOOLEAN,
+            [seconds_played] INTEGER,
+            [userid] TEXT NOT NULL,
+            [queue_id] TEXT,
+            [user_initiated] BOOLEAN NOT NULL DEFAULT 1,
+            [playback_speed] REAL NOT NULL DEFAULT 1.0,
+            UNIQUE(item_id, provider, media_type, userid));"""
+    )
+    await database.execute(PLAYLOG_UPSERT, _playlog_entry("user1"))
+    await database.commit()
+    table_sql_query = (
+        f"SELECT sql FROM sqlite_master WHERE type = 'table' AND name = '{DB_TABLE_PLAYLOG}'"
+    )
+    table_sql_before = (await database.get_rows_from_query(table_sql_query))[0]["sql"]
+
+    mass = MagicMock()
+    mass.cache.clear = AsyncMock()
+    await migrate_database(
+        mass,
+        database,
+        MagicMock(),
+        prev_version=48,
+        create_tables=AsyncMock(),
+    )
+
+    assert (await database.get_rows_from_query(table_sql_query))[0]["sql"] == table_sql_before
+    rows = await database.get_rows(DB_TABLE_PLAYLOG)
+    assert len(rows) == 1
 
 
 async def test_migrate_database_rejects_too_old_schema() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Databases created before the `userid` column was added to the playlog table (schema version <= 22) still carry the original inline `UNIQUE(item_id, provider, media_type)` constraint. The migration back then could only add a new 4-column unique index — SQLite cannot drop an inline constraint via `ALTER TABLE`. The per-user playlog upsert targets `ON CONFLICT(item_id, provider, media_type, userid)`, so on these databases every replay of an item violates the leftover 3-column constraint and raises `sqlite3.IntegrityError`, losing artist play credits and spamming the log with unhandled task errors.

Changes:

- Add a migration that detects the stale constraint and rebuilds the playlog table with the current schema (rename -> create -> copy -> drop). Play history is preserved; only pre-userid rows without an owner are dropped.
- Databases that already have the correct 4-column constraint are left untouched.
- Bump DB schema version to 47.
- Add regression tests covering both the rebuild and the no-op path.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5754

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
