### PR TITLE
Pace background audio analysis to stop it saturating the CPU

### DIFF
--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -53,11 +53,8 @@ BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
 # player streams, so a chunk may wait behind other work before it computes.
 CHUNK_HANG_GUARD_SECONDS = 120.0
 # Floor on wall-seconds between consecutive background chunk dispatches (one chunk = one
-# audio-second), capping each scanned track at ~4x realtime. The offload governor (niced
-# pool, half-the-cores semaphore, solo lock) only bounds Python offloads; providers that do
-# their work in ffmpeg subprocesses (loudness ebur128) are otherwise unthrottled, and an
-# unpaced scan runs source-decode plus analysis ffmpeg flat-out per track, pegging small
-# hosts for the whole run. Pacing the dispatch backpressures both processes via their pipes.
+# audio-second), capping each scanned track at ~4x realtime so a background analyse doesn't
+# consume all resources. Nice and slow is preferred for nightly background scans.
 BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR = 0.250
 # OS nice value for analysis worker threads (Linux): keeps analysis below playback so the
 # scheduler favors the event loop and ffmpeg under contention.

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -52,6 +52,13 @@ BACKGROUND_SCAN_RUN_BUDGET_SECONDS = 4 * 3600
 # treated as stuck and evicted. Generous because analysis runs one offload at a time while a
 # player streams, so a chunk may wait behind other work before it computes.
 CHUNK_HANG_GUARD_SECONDS = 120.0
+# Floor on wall-seconds between consecutive background chunk dispatches (one chunk = one
+# audio-second), capping each scanned track at ~4x realtime. The offload governor (niced
+# pool, half-the-cores semaphore, solo lock) only bounds Python offloads; providers that do
+# their work in ffmpeg subprocesses (loudness ebur128) are otherwise unthrottled, and an
+# unpaced scan runs source-decode plus analysis ffmpeg flat-out per track, pegging small
+# hosts for the whole run. Pacing the dispatch backpressures both processes via their pipes.
+BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR = 0.250
 # OS nice value for analysis worker threads (Linux): keeps analysis below playback so the
 # scheduler favors the event loop and ffmpeg under contention.
 ANALYSIS_THREAD_NICE = 10
@@ -1024,11 +1031,16 @@ class AudioAnalysisController:
         self._active_sessions[session_key] = accepted
 
         audio_source = self.mass.streams.audio.get_media_stream(streamdetails, pcm_format)
+        next_allowed = time.monotonic()
         async for chunk in audio_source:
             if session_key not in self._active_sessions:
                 # all providers evicted — bail early
                 break
+            now = time.monotonic()
+            if now < next_allowed:
+                await asyncio.sleep(next_allowed - now)
             await self._distribute_chunk(session_key, chunk, max_interval=CHUNK_HANG_GUARD_SECONDS)
+            next_allowed = time.monotonic() + BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR
         if session_key in self._active_sessions:
             self._finalize_providers(session_key)
 

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -244,7 +244,7 @@ def _make_stream_mock(chunks: list[bytes]) -> object:
 
 
 @pytest.mark.asyncio
-async def test_background_streaming_happy_path() -> None:
+async def test_background_streaming_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     """PCM chunks reach providers; session is cleaned up on clean EOF."""
     controller = _make_controller()
     streamdetails = _make_streamdetails(path="/music/test.flac")
@@ -255,6 +255,7 @@ async def test_background_streaming_happy_path() -> None:
 
     fake_chunks = [b"\x00\x01" * 512 for _ in range(5)]
     controller.mass.streams.audio.get_media_stream = _make_stream_mock(fake_chunks)  # type: ignore[method-assign,assignment]
+    monkeypatch.setattr(audio_analysis_mod, "BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR", 0.0)
 
     await controller._run_background_streaming_for_track(streamdetails, [p])
 
@@ -262,6 +263,31 @@ async def test_background_streaming_happy_path() -> None:
     assert p.process_pcm_chunk.await_count == len(fake_chunks)
     # _finalize_providers pops the session key before dispatching — key must be gone
     assert streamdetails.uri not in controller._active_sessions
+
+
+@pytest.mark.asyncio
+async def test_background_streaming_paces_chunk_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Background dispatch enforces the pacing floor between consecutive chunks."""
+    controller = _make_controller()
+    streamdetails = _make_streamdetails(path="/music/test.flac")
+    p = _make_aa_provider("p1", available=True)
+    p.start_analysis = AsyncMock(return_value=True)
+    p.finalize = AsyncMock(return_value=None)
+    controller.mass.get_provider = MagicMock(return_value=p)  # type: ignore[method-assign]
+
+    fake_chunks = [b"\x00\x01" * 512 for _ in range(4)]
+    controller.mass.streams.audio.get_media_stream = _make_stream_mock(fake_chunks)  # type: ignore[method-assign,assignment]
+    monkeypatch.setattr(audio_analysis_mod, "BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR", 0.05)
+
+    started = asyncio.get_running_loop().time()
+    await controller._run_background_streaming_for_track(streamdetails, [p])
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert p.process_pcm_chunk.await_count == len(fake_chunks)
+    # First chunk dispatches immediately; each of the remaining 3 waits out the floor.
+    assert elapsed >= 3 * 0.05
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

The background loudness scan runs its ffmpeg processes without throttling, pegging every core on small hosts. On the reporter's Pi CM5 that is ~95% CPU and 85C for the whole nightly run with ~18k tracks pending (music-assistant/support#5781).

The loudness provider does its analysis inside an ffmpeg subprocess, so it does not pass through the offload governor (`_run_offloaded`) that bounds the Python analysis providers. Its only backpressure is the dispatch loop in `_run_background_streaming_inner`, which used to sleep a floor between chunks. That floor was removed in #4449 when the realtime path was reworked. This restores it (`BACKGROUND_PACE_INTERVAL_SECONDS_FLOOR = 0.250`), capping each scanned track at ~4x realtime. The sleep backpressures both the source-decode and ebur128 ffmpeg processes through their pipes, so total CPU work is unchanged, just spread over wall time.

Measured on 8 FLACs (3 min each, 2 tracks concurrent, one core per ffmpeg): mean ffmpeg CPU while active drops from ~190% to 2.5% of a core, peak aggregate from 577% to 7.5%, and the ebur128 result is byte-identical. A large first-time library will not finish in one 4h run and resumes across nights, which the scan already handles with its run budget and deferred counter.

**Related issue:**

- related issue https://github.com/music-assistant/support/issues/5781

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. (`tests/controllers/streams/test_audio_analysis.py`, incl. a new pacing test; ruff, ruff-format and mypy are clean on the changed files.)
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's AI Policy for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository. (n/a — no user-facing docs change)
