### PR TITLE
Emit player update when the current media position jumps

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1786,10 +1786,16 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # a lightweight event.
         clean_changed_keys = set(changed_values.keys()) - {
             "current_media.elapsed_time",
+            "current_media.elapsed_time_last_updated",
             "elapsed_time_last_updated",
         }
-        if len(clean_changed_keys) == 0 and not force_update:
-            # nothing changed
+        if (
+            len(clean_changed_keys) == 0
+            and not force_update
+            # suppress regular playback ticks, pass through significant
+            # jumps of the corrected position (seek/buffer correction)
+            and not self._current_media_time_jumped(changed_values)
+        ):
             return
 
         if clean_changed_keys == {ATTR_ELAPSED_TIME} and not force_update:
@@ -1804,6 +1810,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 # stays in sync. Skipping the forward on small ticks avoids a per-second
                 # cascade through group → children → group.
                 self.mass.player_queues.on_player_elapsed_time_corrected(player)
+                # re-anchor current_media onto the corrected queue time
+                self.trigger_player_update(player.player_id)
                 if not skip_forward or force_update:
                     self._forward_state_update(player, changed_values)
             return
@@ -3540,6 +3548,27 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         :param player_id: Player ID to build the task ID for.
         """
         return f"player_sleep_timer_{player_id}"
+
+    @staticmethod
+    def _current_media_time_jumped(changed_values: dict[str, tuple[Any, Any]]) -> bool:
+        """
+        Return whether the current media's corrected position jumped significantly.
+
+        :param changed_values: The changed state values from a player state update.
+        """
+        if "current_media.elapsed_time" not in changed_values:
+            # anchor-only change
+            return False
+        prev_cm_time, new_cm_time = changed_values["current_media.elapsed_time"]
+        if prev_cm_time is None or new_cm_time is None:
+            return False
+        now = time.time()
+        prev_cm_updated, new_cm_updated = changed_values.get(
+            "current_media.elapsed_time_last_updated", (now, now)
+        )
+        prev_corrected = float(prev_cm_time) + (now - float(prev_cm_updated or now))
+        new_corrected = float(new_cm_time) + (now - float(new_cm_updated or now))
+        return abs(prev_corrected - new_corrected) > 1.0
 
     # Private command handlers (no permission checks)
 

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -1346,7 +1346,6 @@ class Player(ABC):
         # ignore some values that are not relevant for the state
         changed_values.pop("extra_attributes.seq_no", None)
         changed_values.pop("extra_attributes.last_poll", None)
-        changed_values.pop("current_media.elapsed_time_last_updated", None)
         # persist the default name if it changed
         if self.name and self.config.default_name != self.name:
             self.mass.config.set_player_default_name(self.player_id, self.name)

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1055,6 +1056,73 @@ class TestVolumeScalingOnRedirect:
             await controller._handle_cmd_volume_set("user_player", 100)
 
         control.volume_set.assert_awaited_once_with(50)
+
+
+class TestCurrentMediaTimeUpdates:
+    """Test suppression/passthrough of current_media timing-only state updates."""
+
+    def _make_player(self, mock_mass: MagicMock) -> tuple[PlayerController, MockPlayer]:
+        """Build a controller with a single registered player."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        controller._players = {"player_1": player}
+        mock_mass.players = controller
+        player.set_initialized()
+        player.update_state(signal_event=False)
+        # isolate from the unrelated state-forwarding machinery
+        controller._forward_state_update = MagicMock()  # type: ignore[method-assign]
+        mock_mass.signal_event.reset_mock()
+        return controller, player
+
+    def _player_updated_signalled(self, mock_mass: MagicMock) -> bool:
+        """Return whether a PLAYER_UPDATED event was signalled."""
+        return any(
+            call.args and call.args[0] == EventType.PLAYER_UPDATED
+            for call in mock_mass.signal_event.call_args_list
+        )
+
+    def test_regular_tick_is_suppressed(self, mock_mass: MagicMock) -> None:
+        """A regular playback tick (position and anchor advance together) emits nothing."""
+        controller, player = self._make_player(mock_mass)
+        now = time.time()
+
+        controller.signal_player_state_update(
+            player,
+            {
+                "current_media.elapsed_time": (10, 11),
+                "current_media.elapsed_time_last_updated": (now - 1, now),
+            },
+        )
+
+        assert not self._player_updated_signalled(mock_mass)
+
+    def test_anchor_only_change_is_suppressed(self, mock_mass: MagicMock) -> None:
+        """An anchor-only change (no position change) emits nothing."""
+        controller, player = self._make_player(mock_mass)
+        now = time.time()
+
+        controller.signal_player_state_update(
+            player,
+            {"current_media.elapsed_time_last_updated": (now - 1, now)},
+        )
+
+        assert not self._player_updated_signalled(mock_mass)
+
+    def test_corrected_position_jump_emits_player_updated(self, mock_mass: MagicMock) -> None:
+        """A significant corrected-position jump (e.g. seek) emits a player update."""
+        controller, player = self._make_player(mock_mass)
+        now = time.time()
+
+        controller.signal_player_state_update(
+            player,
+            {
+                "current_media.elapsed_time": (17, 61),
+                "current_media.elapsed_time_last_updated": (now - 2, now),
+            },
+        )
+
+        assert self._player_updated_signalled(mock_mass)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this implement/fix?

After a seek — or when a player adjusts its elapsed time (e.g. once its buffer is filled) — the corrected playback position never reached consumers that read the position from `player.current_media`:

- The queue's `playback_tracker` detects the >2s jump and calls `trigger_player_update()`, but the resulting state diff contains only `current_media.elapsed_time` (the anchor is dropped in `update_state`) — and `signal_player_state_update` ignores that key entirely, so the update was silently discarded.
- The player-drift branch (>1s corrected drift, the buffer-fill case) corrected the queue and emitted `QUEUE_TIME_UPDATED`, but never triggered a player update at all.

Captured live: `QUEUE_TIME_UPDATED data=61.1` after a seek with **no** `PLAYER_UPDATED` following; `current_media` stayed at the pre-seek position indefinitely.

Fix: keep the `current_media.elapsed_time_last_updated` anchor in the diff, apply the same corrected-position drift check (>1s) that already gates the player-level `elapsed_time` handling, and trigger a player update from the drift branch. Regular playback ticks stay suppressed (no eventbus spam), while seeks and buffer corrections emit the full player update with the fresh position and anchor — the thresholds now match the situations in which `QUEUE_TIME_UPDATED` is emitted.

Verified live: every `QUEUE_TIME_UPDATED` (seek to 75, settle refinement, initial buffering adjustment) is now followed within 0.25s by a `PLAYER_UPDATED` carrying the corrected `current_media` position; steady playback emits nothing.

This makes `current_media` a reliable position source for consumers (e.g. the Home Assistant integration), making `QUEUE_TIME_UPDATED` redundant for them.

**Related issue (if applicable):**

- related to home-assistant/core#175465

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.