### PR TITLE
Don't reinstall provider requirements with extras on every startup

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -21,7 +21,6 @@ import urllib.request
 import weakref
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Coroutine
 from contextlib import suppress
-from functools import lru_cache
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from ipaddress import IPv4Address, IPv6Address, ip_address
@@ -1239,10 +1238,13 @@ async def is_hass_supervisor() -> bool:
     return await asyncio.to_thread(_check)
 
 
+# requirements verified this session, so repeated (config) loads skip the version check
+_checked_requirements: set[str] = set()
+
+
 async def load_provider_module(domain: str, requirements: list[str]) -> ProviderModuleType:
     """Return module for given provider domain and make sure the requirements are met."""
 
-    @lru_cache
     def _get_provider_module(domain: str) -> ProviderModuleType:
         return cast(
             "ProviderModuleType", importlib.import_module(f".{domain}", "music_assistant.providers")
@@ -1250,16 +1252,22 @@ async def load_provider_module(domain: str, requirements: list[str]) -> Provider
 
     # ensure module requirements are met
     for requirement in requirements:
+        if requirement in _checked_requirements:
+            continue
         if "==" not in requirement:
             # we should really get rid of unpinned requirements
             continue
         package_name, version = requirement.split("==", 1)
+        # importlib.metadata can't resolve extras (e.g. aiosendspin[server]), so strip them
+        package_name = package_name.split("[", 1)[0]
         installed_version = await get_package_version(package_name)
         if installed_version == "0.0.0":
             # ignore editable installs
+            _checked_requirements.add(requirement)
             continue
         if installed_version != version:
             await install_package(requirement)
+        _checked_requirements.add(requirement)
 
     # try to load the module
     try:

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -1,4 +1,4 @@
-"""Tests for music_assistant.helpers.util networking helpers."""
+"""Tests for music_assistant.helpers.util helpers."""
 
 import asyncio
 from collections.abc import Iterator
@@ -7,7 +7,11 @@ from unittest.mock import patch
 import pytest
 
 from music_assistant.helpers import util
-from music_assistant.helpers.util import get_source_ip_for_target, select_free_port
+from music_assistant.helpers.util import (
+    get_source_ip_for_target,
+    load_provider_module,
+    select_free_port,
+)
 
 
 class TestGetSourceIpForTarget:
@@ -80,3 +84,71 @@ class TestSelectFreePort:
             util._reserved_ports[first] = 0.0
             second = await select_free_port(38800, 38900)
         assert first == second
+
+
+class TestLoadProviderModule:
+    """load_provider_module verifies pinned requirements before importing the provider."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_checked_requirements(self) -> Iterator[None]:
+        """Ensure no requirement-check state leaks between tests."""
+        util._checked_requirements.clear()
+        yield
+        util._checked_requirements.clear()
+
+    @pytest.mark.asyncio
+    async def test_requirement_with_extras_not_reinstalled(self) -> None:
+        """A requirement with extras is version-checked on the bare package name."""
+        with (
+            patch(
+                "music_assistant.helpers.util.get_package_version", return_value="6.1.1"
+            ) as version_mock,
+            patch("music_assistant.helpers.util.install_package") as install_mock,
+            patch("music_assistant.helpers.util.importlib.import_module"),
+        ):
+            await load_provider_module("sendspin", ["aiosendspin[server]==6.1.1"])
+        version_mock.assert_awaited_once_with("aiosendspin")
+        install_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_outdated_requirement_installed_with_extras_preserved(self) -> None:
+        """An outdated requirement is (re)installed with the full requirement string."""
+        with (
+            patch("music_assistant.helpers.util.get_package_version", return_value="6.0.0"),
+            patch("music_assistant.helpers.util.install_package") as install_mock,
+            patch("music_assistant.helpers.util.importlib.import_module"),
+        ):
+            await load_provider_module("sendspin", ["aiosendspin[server]==6.1.1"])
+        install_mock.assert_awaited_once_with("aiosendspin[server]==6.1.1")
+
+    @pytest.mark.asyncio
+    async def test_requirement_checked_only_once(self) -> None:
+        """Repeated loads of the same provider don't re-run the version check."""
+        with (
+            patch(
+                "music_assistant.helpers.util.get_package_version", return_value="6.1.1"
+            ) as version_mock,
+            patch("music_assistant.helpers.util.install_package") as install_mock,
+            patch("music_assistant.helpers.util.importlib.import_module"),
+        ):
+            await load_provider_module("sendspin", ["aiosendspin[server]==6.1.1"])
+            await load_provider_module("sendspin", ["aiosendspin[server]==6.1.1"])
+        version_mock.assert_awaited_once()
+        install_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_install_is_retried_on_next_load(self) -> None:
+        """A failed install is not marked as checked, so the next load retries it."""
+        with (
+            patch("music_assistant.helpers.util.get_package_version", return_value=None),
+            patch(
+                "music_assistant.helpers.util.install_package",
+                side_effect=RuntimeError("install failed"),
+            ) as install_mock,
+            patch("music_assistant.helpers.util.importlib.import_module"),
+        ):
+            with pytest.raises(RuntimeError):
+                await load_provider_module("sendspin", ["aiosendspin[server]==6.1.1"])
+            install_mock.side_effect = None
+            await load_provider_module("sendspin", ["aiosendspin[server]==6.1.1"])
+        assert install_mock.await_count == 2


### PR DESCRIPTION
# What does this implement/fix?

Provider requirements with extras (e.g. `aiosendspin[server]==6.1.1`) were reinstalled on every startup and again on every provider config access, because the installed-version lookup passed the package name *including* the extras to `importlib.metadata`, which can't resolve it → `PackageNotFoundError` → `None != "6.1.1"` → reinstall. sendspin is a builtin provider, so this ran on every boot (also `zvuk_music` / `ard_audiothek` when configured).

Our container image and HA addon ship with all requirements preinstalled, so this check should short-circuit — but for extras-packages it never did:
- **Online:** several needless `uv pip install --no-cache` PyPI roundtrips on every boot (and every config access) for packages that are already present.
- **Offline / air-gapped:** the `--no-cache` reinstall of an already-present but unreachable package *fails*, so the builtin sendspin provider fails to load even though the package is right there.

Fix:
- Strip extras from the package name for the installed-version lookup (the full requirement string is still used for the actual install).
- Remember already-checked requirements for the lifetime of the process, so repeated provider (config) loads don't repeat the version lookups.
- Removed a pointless `lru_cache` on the nested import helper (fresh cache per call, so it never cached anything).

Stable pins the same extras requirements and has the identical function, so it's affected too. The auto-backport won't apply cleanly (the touched test file doesn't exist on stable yet) — I'll do a manual backport if you want it on stable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.