### PR TITLE
Suppress per-item media item events during library sync

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -2260,7 +2260,14 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         async def run_sync() -> None:
             try:
                 async with self._sync_lock:
-                    await provider.sync_library(media_type)
+                    # suppress per-item events during sync; a large library would otherwise
+                    # emit one (serialized per client) for every item. Subscribers refresh
+                    # on MUSIC_SYNC_COMPLETED and track progress via TASKS_UPDATED instead.
+                    token = SUPPRESS_MEDIA_ITEM_UPDATES.set(True)
+                    try:
+                        await provider.sync_library(media_type)
+                    finally:
+                        SUPPRESS_MEDIA_ITEM_UPDATES.reset(token)
             finally:
                 self.mass.call_later(
                     0,

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -71,9 +71,9 @@ JSON_KEYS = (
     "audiobook_artists",
 )
 
-# When set (task-local), per-item MEDIA_ITEM_UPDATED events are suppressed.
-# Used by bulk operations such as provider cleanup, where emitting an event for every
-# touched item would flood subscribers; consumers refresh in bulk afterwards instead.
+# When set (task-local), per-item MEDIA_ITEM_ADDED/UPDATED events and the on_item_updated
+# provider write-back are suppressed, so bulk operations (provider sync, provider cleanup)
+# don't flood subscribers with one event per touched item.
 SUPPRESS_MEDIA_ITEM_UPDATES: ContextVar[bool] = ContextVar(
     "SUPPRESS_MEDIA_ITEM_UPDATES", default=False
 )
@@ -187,11 +187,12 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 new_item = True
         # return final library_item
         library_item = await self.get_library_item(library_id)
-        self.mass.signal_event(
-            EventType.MEDIA_ITEM_ADDED if new_item else EventType.MEDIA_ITEM_UPDATED,
-            library_item.uri,
-            library_item,
-        )
+        if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
+            self.mass.signal_event(
+                EventType.MEDIA_ITEM_ADDED if new_item else EventType.MEDIA_ITEM_UPDATED,
+                library_item.uri,
+                library_item,
+            )
         return library_item
 
     @final
@@ -203,6 +204,10 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         await self._update_library_item(item_id, update, overwrite=overwrite)
         # return the updated object
         library_item = await self.get_library_item(item_id)
+        if SUPPRESS_MEDIA_ITEM_UPDATES.get():
+            # during a sync the update originates from the provider itself,
+            # so skip both the event and the write-back to that provider
+            return library_item
         self.mass.signal_event(
             EventType.MEDIA_ITEM_UPDATED,
             library_item.uri,

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, Mock, patch
+import asyncio
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
-from music_assistant_models.enums import MediaType, ProviderType
+from music_assistant_models.enums import EventType, MediaType, ProviderType
 from music_assistant_models.errors import InsufficientPermissions
 from music_assistant_models.media_items import Album, AudioFormat, ProviderMapping, UniqueList
 
 from music_assistant.constants import CONF_ENTRY_LIBRARY_SYNC_BACK
 from music_assistant.controllers.music import MusicController
-from music_assistant.controllers.music.media.base import MediaControllerBase
+from music_assistant.controllers.music.media.base import (
+    SUPPRESS_MEDIA_ITEM_UPDATES,
+    MediaControllerBase,
+)
 from music_assistant.models.music_provider import (
     CACHE_CATEGORY_PREV_LIBRARY_IDS,
     MusicProvider,
@@ -1077,3 +1081,83 @@ async def test_update_item_in_library_skips_non_music_providers() -> None:
     ctrl._update_library_item.assert_called_once()
     mass.music.match_provider_instances.assert_called_once_with(update)
     mass.get_provider.assert_called_once_with("smart_playlist_1")
+
+
+# --- Group 7: Per-item event suppression during provider sync ---
+
+
+def _create_event_capture_controller(
+    library_item: Mock, events: list[EventType]
+) -> tuple[Mock, Mock]:
+    """Build a controller mock with real add/update methods bound; events records signalled types."""
+    mass = Mock()
+    mass.signal_event = Mock(side_effect=lambda event, *_args, **_kwargs: events.append(event))
+    ctrl = Mock(spec=MediaControllerBase)
+    ctrl.mass = mass
+    ctrl._db_add_lock = asyncio.Lock()
+    ctrl._get_library_item_by_match = AsyncMock(return_value=None)
+    ctrl._add_library_item = AsyncMock(return_value=1)
+    ctrl._update_library_item = AsyncMock()
+    ctrl.get_library_item = AsyncMock(return_value=library_item)
+    ctrl.add_item_to_library = MediaControllerBase.add_item_to_library.__get__(ctrl)
+    ctrl.update_item_in_library = MediaControllerBase.update_item_in_library.__get__(ctrl)
+    return ctrl, mass
+
+
+async def test_add_and_update_item_emit_events_outside_sync() -> None:
+    """Regular add/update calls emit per-item events and run the provider write-back."""
+    mapping = create_provider_mapping()
+    library_item = create_mock_album(provider="library", provider_mappings=[mapping])
+    library_item.uri = "library://album/1"
+    events: list[EventType] = []
+    ctrl, mass = _create_event_capture_controller(library_item, events)
+
+    provider = Mock(type=ProviderType.MUSIC)
+    provider.on_item_updated = AsyncMock()
+    mass.get_provider.return_value = provider
+
+    await ctrl.add_item_to_library(create_mock_album(provider="spotify"))
+    assert events == [EventType.MEDIA_ITEM_ADDED]
+
+    await ctrl.update_item_in_library(1, create_mock_album(provider="spotify"))
+    assert events == [EventType.MEDIA_ITEM_ADDED, EventType.MEDIA_ITEM_UPDATED]
+    provider.on_item_updated.assert_awaited_once_with(library_item)
+
+
+async def test_provider_sync_suppresses_per_item_events() -> None:
+    """A provider sync emits only MUSIC_SYNC_COMPLETED; per-item events resume afterwards."""
+    library_item = create_mock_album(provider="library")
+    library_item.uri = "library://album/1"
+    events: list[EventType] = []
+    ctrl, mass = _create_event_capture_controller(library_item, events)
+    # run the deferred completion check inline instead of on the event loop
+    mass.call_later = Mock(side_effect=lambda _delay, target, **_kwargs: target())
+
+    music_ctrl = MusicController.__new__(MusicController)
+    music_ctrl.mass = mass
+    music_ctrl._sync_lock = asyncio.Lock()
+
+    provider = Mock()
+
+    async def fake_sync_library(_media_type: MediaType) -> None:
+        # stand in for the per-mediatype sync loops adding/updating items
+        await ctrl.add_item_to_library(create_mock_album(provider="spotify"))
+        await ctrl.update_item_in_library(1, create_mock_album(provider="spotify"))
+
+    provider.sync_library = fake_sync_library
+
+    run_sync = music_ctrl._create_provider_sync_handler(provider, MediaType.ALBUM)
+    with (
+        patch.object(MusicController, "active_sync_tasks", new_callable=PropertyMock) as tasks,
+        patch.object(music_ctrl, "_queue_database_cleanup_task"),
+    ):
+        tasks.return_value = []
+        await run_sync()
+
+    assert events == [EventType.MUSIC_SYNC_COMPLETED]
+    # write-back was skipped too (provider lookup never happened)
+    mass.get_provider.assert_not_called()
+    # suppression must not leak past the handler
+    assert SUPPRESS_MEDIA_ITEM_UPDATES.get() is False
+    await ctrl.add_item_to_library(create_mock_album(provider="spotify"))
+    assert events == [EventType.MUSIC_SYNC_COMPLETED, EventType.MEDIA_ITEM_ADDED]


### PR DESCRIPTION
# What does this implement/fix?

During a provider library sync, every synced item emits a `MEDIA_ITEM_ADDED`/`MEDIA_ITEM_UPDATED` event carrying the full library item, and each event is JSON-serialized once per connected websocket client, inline on the event loop. A (first) sync of a large library produces one event per item — easily 100k+ — while clients do next to nothing with them, and the serialization work stalls the loop on Pi-class hardware. Every updated item additionally triggered the per-provider `on_item_updated` write-back callbacks, echoing data back to the providers it just came from.

This reuses the existing `SUPPRESS_MEDIA_ITEM_UPDATES` context (introduced for provider cleanup) and sets it for the duration of a provider sync task:

- `add_item_to_library`/`update_item_in_library` now honor the suppression: no per-item events and no `on_item_updated` write-back while a sync runs.
- Non-sync paths (user adds an item, edits metadata, single item refresh) emit per-item events exactly as before.
- Clients keep tracking sync progress through the (debounced) `TASKS_UPDATED` events and get `MUSIC_SYNC_COMPLETED` once all sync tasks are done.

Frontend follow-up: the library views use the per-item events only as a hint to show the "new items available" banner; they should listen for `MUSIC_SYNC_COMPLETED` for that instead.

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable. (new event-suppression tests in `tests/test_library_sync.py`)
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (current frontend keeps working as-is; small follow-up noted above)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (n/a)
