### PR TITLE
Smart fades analyzer v2: frequency band envelopes, time signature and anti-aliased energy binning

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/models.py
+++ b/music_assistant/controllers/streams/smart_fades/models.py
@@ -24,6 +24,16 @@ if TYPE_CHECKING:
     from music_assistant.models.audio_analysis import AudioAnalysisData
 
 
+# Band edges (Hz) of the smart_fades ``extra_data["band_rms"]`` envelopes; None = up to Nyquist.
+# Stored rows keep whatever bands their analysis_version wrote — read historical rows by shape.
+BAND_RMS_BANDS: dict[str, tuple[float, float | None]] = {
+    "low": (20.0, 120.0),
+    "low_mid": (120.0, 400.0),
+    "mid": (400.0, 4000.0),
+    "high": (4000.0, None),
+}
+
+
 class SmartFadeNotApplicable(Exception):
     """Raised when the tracks cannot yield a smart crossfade and the caller should fall back."""
 

--- a/music_assistant/models/audio_analysis.py
+++ b/music_assistant/models/audio_analysis.py
@@ -18,15 +18,6 @@ import numpy.typing as npt
 from mashumaro import DataClassDictMixin
 from mashumaro.config import BaseConfig
 
-# Band edges (Hz) of the smart_fades ``extra_data["band_rms"]`` envelopes; None = up to Nyquist.
-# Stored rows keep whatever bands their analysis_version wrote — read historical rows by shape.
-BAND_RMS_BANDS: dict[str, tuple[float, float | None]] = {
-    "low": (20.0, 120.0),
-    "low_mid": (120.0, 400.0),
-    "mid": (400.0, 4000.0),
-    "high": (4000.0, None),
-}
-
 
 class AudioAnalysisError(Exception):
     """Raised by an Audio Analysis provider to fail the current analysis."""

--- a/music_assistant/models/audio_analysis.py
+++ b/music_assistant/models/audio_analysis.py
@@ -18,6 +18,20 @@ import numpy.typing as npt
 from mashumaro import DataClassDictMixin
 from mashumaro.config import BaseConfig
 
+# Band edges (Hz) of the ``extra_data["band_rms"]`` envelopes written by the
+# smart_fades analyzer (v2); None = up to Nyquist. Edges mirror the club-mixer
+# actuator regions (100 Hz lowshelf, ~1.2 kHz mid bell, 13 kHz highshelf) plus a
+# knobless 120-400 Hz decision band (rotary isolator low/mid crossover).
+# This is the CURRENT contract: stored rows keep whatever bands their
+# analysis_version wrote, so consumers read historical rows by shape, not by
+# this constant.
+BAND_RMS_BANDS: dict[str, tuple[float, float | None]] = {
+    "low": (20.0, 120.0),
+    "low_mid": (120.0, 400.0),
+    "mid": (400.0, 4000.0),
+    "high": (4000.0, None),
+}
+
 
 class AudioAnalysisError(Exception):
     """Raised by an Audio Analysis provider to fail the current analysis."""

--- a/music_assistant/models/audio_analysis.py
+++ b/music_assistant/models/audio_analysis.py
@@ -18,13 +18,8 @@ import numpy.typing as npt
 from mashumaro import DataClassDictMixin
 from mashumaro.config import BaseConfig
 
-# Band edges (Hz) of the ``extra_data["band_rms"]`` envelopes written by the
-# smart_fades analyzer (v2); None = up to Nyquist. Edges mirror the club-mixer
-# actuator regions (100 Hz lowshelf, ~1.2 kHz mid bell, 13 kHz highshelf) plus a
-# knobless 120-400 Hz decision band (rotary isolator low/mid crossover).
-# This is the CURRENT contract: stored rows keep whatever bands their
-# analysis_version wrote, so consumers read historical rows by shape, not by
-# this constant.
+# Band edges (Hz) of the smart_fades ``extra_data["band_rms"]`` envelopes; None = up to Nyquist.
+# Stored rows keep whatever bands their analysis_version wrote — read historical rows by shape.
 BAND_RMS_BANDS: dict[str, tuple[float, float | None]] = {
     "low": (20.0, 120.0),
     "low_mid": (120.0, 400.0),

--- a/music_assistant/providers/smart_fades/dbn_postprocessor.py
+++ b/music_assistant/providers/smart_fades/dbn_postprocessor.py
@@ -68,14 +68,16 @@ class DBNDownBeatTracker:
                 }
             )
 
-    def __call__(self, activations: NDArray[np.float64]) -> NDArray[np.float64]:
+    def __call__(self, activations: NDArray[np.float64]) -> tuple[NDArray[np.float64], int]:
         """
         Run DBN decoding on beat/downbeat activations.
 
         :param activations: Shape (T, 2), columns [beat_act, downbeat_act].
             Values should be probabilities in (0, 1).
-        :return: Shape (M, 2) array of [time_seconds, beat_position].
-            beat_position is 1 for downbeats, 2..num_beats for other beats.
+        :return: Tuple of (beats, num_beats).
+            beats: Shape (M, 2) array of [time_seconds, beat_position].
+                beat_position is 1 for downbeats, 2..num_beats for other beats.
+            num_beats: Beats per bar of the winning meter hypothesis (0 if no beats found).
         """
         # Threshold: trim leading/trailing silence
         first = 0
@@ -116,12 +118,12 @@ class DBNDownBeatTracker:
             beats = np.nonzero(np.diff(beat_numbers))[0] + 1
 
         if len(beats) == 0:
-            return np.empty((0, 2), dtype=np.float64)
+            return np.empty((0, 2), dtype=np.float64), 0
 
         beat_times = (beats + first) / self.fps
         beat_positions = beat_numbers[beats]
 
-        return np.column_stack([beat_times, beat_positions])
+        return np.column_stack([beat_times, beat_positions]), int(best_hmm["num_beats"])
 
     @staticmethod
     def _build_bar_state_space(

--- a/music_assistant/providers/smart_fades/helpers.py
+++ b/music_assistant/providers/smart_fades/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+import numpy.typing as npt
 import torch
 from music_assistant_models.enums import ContentType
 
@@ -45,6 +46,39 @@ def calculate_overall_bpm(beats: np.ndarray, n_segments: int = 5) -> float:
         return float(np.mean(seg_arr))
 
     return float(np.mean(consistent))
+
+
+def aggregate_series_to_bins(
+    values: npt.NDArray[np.float32],
+    n_bins: int,
+    *,
+    power: bool = False,
+) -> npt.NDArray[np.float32]:
+    """
+    Resample a frame series to a fixed bin count by averaging over each bin's span.
+
+    Every bin is the exact fractional-overlap mean of the frames it covers
+    (mean of squares then square root when ``power`` is True, appropriate for
+    RMS/energy series).  Unlike point sampling this acts as a boxcar low-pass,
+    so periodic frame-rate detail (e.g. beat-level energy ripple) cannot alias
+    into the bin grid.
+
+    :param values: Input frame series (uniform frame spacing).
+    :param n_bins: Number of output bins.
+    :param power: Average squared values and return the root (RMS-correct).
+    """
+    x = values.astype(np.float64)
+    if power:
+        x = x * x
+    # integral image: interpolating the cumulative sum at fractional bin edges
+    # gives exact partial-frame overlap weighting in O(n)
+    cum = np.concatenate(([0.0], np.cumsum(x)))
+    edges = np.linspace(0.0, len(values), n_bins + 1)
+    cum_at_edges = np.interp(edges, np.arange(len(values) + 1, dtype=np.float64), cum)
+    binned = np.diff(cum_at_edges) / np.diff(edges)
+    if power:
+        binned = np.sqrt(binned)
+    return binned.astype(np.float32)
 
 
 def decode_pcm_chunk_to_mono(audio_format: AudioFormat, pcm_chunk: bytes) -> np.ndarray:

--- a/music_assistant/providers/smart_fades/helpers.py
+++ b/music_assistant/providers/smart_fades/helpers.py
@@ -9,6 +9,8 @@ import numpy.typing as npt
 import torch
 from music_assistant_models.enums import ContentType
 
+from music_assistant.models.audio_analysis import BAND_RMS_BANDS
+
 if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat
 
@@ -79,6 +81,40 @@ def aggregate_series_to_bins(
     if power:
         binned = np.sqrt(binned)
     return binned.astype(np.float32)
+
+
+def compute_band_rms_frames(
+    pcm: npt.NDArray[np.float32],
+    sample_rate: int,
+    window_samples: int,
+) -> dict[str, npt.NDArray[np.float32]]:
+    """
+    Compute per-band RMS frames over fixed windows of a mono PCM block.
+
+    Returns one RMS value per window (including a trailing partial window) per
+    band in ``BAND_RMS_BANDS``, at the same frame cadence as the full-band RMS
+    frames, so both series can be aggregated to the same bin grid.
+
+    :param pcm: Mono float32 PCM samples.
+    :param sample_rate: Sample rate of ``pcm`` in Hz.
+    :param window_samples: Frame length in samples (e.g. 100 ms worth).
+    """
+    out: dict[str, list[float]] = {name: [] for name in BAND_RMS_BANDS}
+    n_full = len(pcm) // window_samples
+    windows: list[npt.NDArray[np.float32]] = []
+    if n_full > 0:
+        windows.extend(pcm[: n_full * window_samples].reshape(n_full, window_samples))
+    if len(pcm) - n_full * window_samples > 0:
+        windows.append(pcm[n_full * window_samples :])
+    for window in windows:
+        spectrum = np.fft.rfft(window.astype(np.float64))
+        freqs = np.fft.rfftfreq(len(window), 1.0 / sample_rate)
+        # Parseval: mean-square of the window = 2 * sum(|X|^2) / N^2 (single-sided)
+        power = 2.0 * np.abs(spectrum) ** 2 / len(window) ** 2
+        for name, (lo, hi) in BAND_RMS_BANDS.items():
+            mask = (freqs >= lo) & (freqs < hi if hi is not None else np.ones_like(freqs, bool))
+            out[name].append(float(np.sqrt(power[mask].sum())))
+    return {name: np.array(vals, dtype=np.float32) for name, vals in out.items()}
 
 
 def decode_pcm_chunk_to_mono(audio_format: AudioFormat, pcm_chunk: bytes) -> np.ndarray:

--- a/music_assistant/providers/smart_fades/helpers.py
+++ b/music_assistant/providers/smart_fades/helpers.py
@@ -9,7 +9,7 @@ import numpy.typing as npt
 import torch
 from music_assistant_models.enums import ContentType
 
-from music_assistant.models.audio_analysis import BAND_RMS_BANDS
+from music_assistant.controllers.streams.smart_fades.models import BAND_RMS_BANDS
 
 if TYPE_CHECKING:
     from music_assistant_models.media_items import AudioFormat

--- a/music_assistant/providers/smart_fades/helpers.py
+++ b/music_assistant/providers/smart_fades/helpers.py
@@ -72,8 +72,7 @@ def aggregate_series_to_bins(
     x = values.astype(np.float64)
     if power:
         x = x * x
-    # integral image: interpolating the cumulative sum at fractional bin edges
-    # gives exact partial-frame overlap weighting in O(n)
+    # interpolating the cumulative sum at fractional bin edges = exact boxcar average in O(n)
     cum = np.concatenate(([0.0], np.cumsum(x)))
     edges = np.linspace(0.0, len(values), n_bins + 1)
     cum_at_edges = np.interp(edges, np.arange(len(values) + 1, dtype=np.float64), cum)

--- a/music_assistant/providers/smart_fades/helpers.py
+++ b/music_assistant/providers/smart_fades/helpers.py
@@ -108,8 +108,12 @@ def compute_band_rms_frames(
     for window in windows:
         spectrum = np.fft.rfft(window.astype(np.float64))
         freqs = np.fft.rfftfreq(len(window), 1.0 / sample_rate)
-        # Parseval: mean-square of the window = 2 * sum(|X|^2) / N^2 (single-sided)
-        power = 2.0 * np.abs(spectrum) ** 2 / len(window) ** 2
+        # Parseval, single-sided: double every bin except DC (and Nyquist for even N),
+        # which are not mirrored in the negative-frequency half.
+        power = np.abs(spectrum) ** 2 / len(window) ** 2
+        power[1:] *= 2.0
+        if len(window) % 2 == 0:
+            power[-1] /= 2.0
         for name, (lo, hi) in BAND_RMS_BANDS.items():
             mask = (freqs >= lo) & (freqs < hi if hi is not None else np.ones_like(freqs, bool))
             out[name].append(float(np.sqrt(power[mask].sum())))

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -242,7 +242,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
             data.musical_key_feature_blocks.clear()
 
         # Run beat and key inference sequentially to keep peak CPU bounded.
-        beats, downbeats = await self._run_offloaded(self._infer_beat_timings, feats)
+        beats, downbeats, beats_per_bar = await self._run_offloaded(self._infer_beat_timings, feats)
         if len(beats) < 2:
             raise AudioAnalysisError("no rhythmic beat detected")
         key, mode = await self._run_offloaded(self._infer_musical_key, all_vqt)
@@ -292,6 +292,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
             key=key,
             mode=mode,
             extra_data=extra_data,
+            beats_per_bar=beats_per_bar or None,
         )
 
         self.logger.debug(
@@ -395,7 +396,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
         )
         return parts[0], parts[1].lower()
 
-    def _infer_beat_timings(self, feats: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    def _infer_beat_timings(self, feats: np.ndarray) -> tuple[np.ndarray, np.ndarray, int]:
         """Run Beat This model inference to detect beat and downbeat timings."""
         assert self._beat_this_model is not None
         assert self._beat_this_post_processor is not None
@@ -421,7 +422,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
             ]
         )
 
-        dbn_out = self._beat_this_post_processor(combined_act)
+        dbn_out, beats_per_bar = self._beat_this_post_processor(combined_act)
         post_elapsed = (time.perf_counter() - post_start) * 1000
 
         beats = dbn_out[:, 0]
@@ -436,4 +437,4 @@ class SmartFadesProvider(AudioAnalysisProvider):
             len(downbeats),
         )
 
-        return beats, downbeats
+        return beats, downbeats, beats_per_bar

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -24,7 +24,12 @@ from music_assistant.models.audio_analysis_provider import (
 
 from .dbn_postprocessor import DBNDownBeatTracker
 from .feature_extractor import AdvancedBeatFeatureExtractor
-from .helpers import aggregate_series_to_bins, calculate_overall_bpm, decode_pcm_chunk_to_mono
+from .helpers import (
+    aggregate_series_to_bins,
+    calculate_overall_bpm,
+    compute_band_rms_frames,
+    decode_pcm_chunk_to_mono,
+)
 from .resources.skey_model import KEY_MAP as SKEY_KEY_MAP
 from .resources.skey_model import load_skey_components
 
@@ -56,6 +61,7 @@ class SmartFadesData:
     beats_feature_blocks: list[np.ndarray] = field(default_factory=list)
     energy_chunks: list[np.ndarray] = field(default_factory=list)
     centroid_chunks: list[np.ndarray] = field(default_factory=list)
+    band_chunks: dict[str, list[np.ndarray]] = field(default_factory=dict)
     musical_key_feature_blocks: list[torch.Tensor] = field(default_factory=list)
 
 
@@ -264,6 +270,18 @@ class SmartFadesProvider(AudioAnalysisProvider):
                 if rms_energy is not None:
                     spectral_centroid[rms_energy < 0.01] = 0.0
 
+        extra_data = None
+        if energy_peak > 0 and data.band_chunks:
+            extra_data = {
+                "band_rms": {
+                    name: (
+                        aggregate_series_to_bins(np.concatenate(chunks), 1800, power=True)
+                        / energy_peak
+                    ).tolist()
+                    for name, chunks in data.band_chunks.items()
+                }
+            }
+
         analysis = AudioAnalysisData(
             bpm=bpm,
             beats=beats,
@@ -273,6 +291,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
             spectral_centroid=spectral_centroid,
             key=key,
             mode=mode,
+            extra_data=extra_data,
         )
 
         self.logger.debug(
@@ -329,6 +348,10 @@ class SmartFadesProvider(AudioAnalysisProvider):
                 rms_list.append(np.array([np.sqrt(np.mean(tail**2))]))
             if rms_list:
                 data.energy_chunks.append(np.concatenate(rms_list).astype(np.float32))
+
+            band_frames = compute_band_rms_frames(pcm_22k, sr, window_samples)
+            for name, frames in band_frames.items():
+                data.band_chunks.setdefault(name, []).append(frames)
 
         # Spectral centroid: keep per-frame (hop_length=512, ~43 frames/s)
         # Skip short tail buffers: STFT reflect-pad requires len > n_fft // 2.

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -69,6 +69,8 @@ class SmartFadesProvider(AudioAnalysisProvider):
     """Smart fades audio analysis provider using Beat This for beat tracking."""
 
     max_analysis_duration = ACCUMULATING_ANALYSIS_MAX_DURATION_SECONDS
+    # v2: anti-aliased 1800-bin envelopes, band_rms extra_data, beats_per_bar
+    analysis_version = 2
     has_unloadable_models = True
 
     def __init__(

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -399,7 +399,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
         return parts[0], parts[1].lower()
 
     def _infer_beat_timings(self, feats: np.ndarray) -> tuple[np.ndarray, np.ndarray, int]:
-        """Run Beat This model inference to detect beat and downbeat timings."""
+        """Run Beat This model inference to detect beat/downbeat timings and the meter."""
         assert self._beat_this_model is not None
         assert self._beat_this_post_processor is not None
 

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -61,7 +61,7 @@ class SmartFadesData:
     beats_feature_blocks: list[np.ndarray] = field(default_factory=list)
     energy_chunks: list[np.ndarray] = field(default_factory=list)
     centroid_chunks: list[np.ndarray] = field(default_factory=list)
-    band_chunks: dict[str, list[np.ndarray]] = field(default_factory=dict)
+    frequency_band_chunks: dict[str, list[np.ndarray]] = field(default_factory=dict)
     musical_key_feature_blocks: list[torch.Tensor] = field(default_factory=list)
 
 
@@ -251,8 +251,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         bpm = calculate_overall_bpm(beats)
 
-        # Aggregate energy and centroid to 1800 fixed bins (mean power per bin:
-        # point sampling would alias beat-rate ripple on longer tracks)
+        # mean power per bin: point sampling aliases beat-rate ripple into the bins
         rms_energy = None
         energy_peak = 0.0
         if data.energy_chunks:
@@ -273,14 +272,14 @@ class SmartFadesProvider(AudioAnalysisProvider):
                     spectral_centroid[rms_energy < 0.01] = 0.0
 
         extra_data = None
-        if energy_peak > 0 and data.band_chunks:
+        if energy_peak > 0 and data.frequency_band_chunks:
             extra_data = {
                 "band_rms": {
                     name: (
                         aggregate_series_to_bins(np.concatenate(chunks), 1800, power=True)
                         / energy_peak
                     ).tolist()
-                    for name, chunks in data.band_chunks.items()
+                    for name, chunks in data.frequency_band_chunks.items()
                 }
             }
 
@@ -354,7 +353,7 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
             band_frames = compute_band_rms_frames(pcm_22k, sr, window_samples)
             for name, frames in band_frames.items():
-                data.band_chunks.setdefault(name, []).append(frames)
+                data.frequency_band_chunks.setdefault(name, []).append(frames)
 
         # Spectral centroid: keep per-frame (hop_length=512, ~43 frames/s)
         # Skip short tail buffers: STFT reflect-pad requires len > n_fft // 2.

--- a/music_assistant/providers/smart_fades/provider.py
+++ b/music_assistant/providers/smart_fades/provider.py
@@ -24,7 +24,7 @@ from music_assistant.models.audio_analysis_provider import (
 
 from .dbn_postprocessor import DBNDownBeatTracker
 from .feature_extractor import AdvancedBeatFeatureExtractor
-from .helpers import calculate_overall_bpm, decode_pcm_chunk_to_mono
+from .helpers import aggregate_series_to_bins, calculate_overall_bpm, decode_pcm_chunk_to_mono
 from .resources.skey_model import KEY_MAP as SKEY_KEY_MAP
 from .resources.skey_model import load_skey_components
 
@@ -243,25 +243,23 @@ class SmartFadesProvider(AudioAnalysisProvider):
 
         bpm = calculate_overall_bpm(beats)
 
-        # Interpolate energy and centroid to 1800 fixed bins
+        # Aggregate energy and centroid to 1800 fixed bins (mean power per bin:
+        # point sampling would alias beat-rate ripple on longer tracks)
         rms_energy = None
+        energy_peak = 0.0
         if data.energy_chunks:
             energy_all = np.concatenate(data.energy_chunks)
             if len(energy_all) >= 2:
-                src_x = np.linspace(0, 1, len(energy_all))
-                dst_x = np.linspace(0, 1, 1800)
-                rms_energy = np.interp(dst_x, src_x, energy_all).astype(np.float32)
-                peak = rms_energy.max()
-                if peak > 0:
-                    rms_energy = rms_energy / peak
+                rms_energy = aggregate_series_to_bins(energy_all, 1800, power=True)
+                energy_peak = float(rms_energy.max())
+                if energy_peak > 0:
+                    rms_energy = rms_energy / energy_peak
 
         spectral_centroid = None
         if data.centroid_chunks:
             centroid_all = np.concatenate(data.centroid_chunks)
             if len(centroid_all) >= 2:
-                src_x = np.linspace(0, 1, len(centroid_all))
-                dst_x = np.linspace(0, 1, 1800)
-                spectral_centroid = np.interp(dst_x, src_x, centroid_all).astype(np.float32)
+                spectral_centroid = aggregate_series_to_bins(centroid_all, 1800)
                 # Zero out centroid where energy is negligible (noise dominates)
                 if rms_energy is not None:
                     spectral_centroid[rms_energy < 0.01] = 0.0

--- a/tests/providers/smart_fades/test_dbn_postprocessor.py
+++ b/tests/providers/smart_fades/test_dbn_postprocessor.py
@@ -79,7 +79,7 @@ def test_dbn_tracker_constant_tempo() -> None:
     )
 
     tracker = DBNDownBeatTracker(beats_per_bar=[4], min_bpm=55, max_bpm=215, fps=fps)
-    result = tracker(combined)
+    result, _num_beats = tracker(combined)
 
     # Should detect ~20 beats in 10s at 120 BPM
     beat_times = result[:, 0]
@@ -121,12 +121,43 @@ def test_dbn_tracker_fills_intro_gaps() -> None:
     )
 
     tracker = DBNDownBeatTracker(beats_per_bar=[4], min_bpm=55, max_bpm=215, fps=fps, threshold=0.0)
-    result = tracker(combined)
+    result, _num_beats = tracker(combined)
 
     beat_times = result[:, 0]
     # DBN should still find beats in the first 5s via tempo continuity
     early_beats = beat_times[beat_times < 5.0]
     assert len(early_beats) >= 5, f"Expected beats in intro region, got {len(early_beats)}"
+
+
+def test_winning_meter_is_returned() -> None:
+    """A 4/4 activation pattern reports beats_per_bar=4 alongside the beats."""
+    fps = 50
+    bpm = 120.0
+    duration = 20.0
+    num_frames = int(duration * fps)
+
+    interval = 60.0 / bpm * fps
+    beat_act = np.full(num_frames, 0.05)
+    downbeat_act = np.full(num_frames, 0.02)
+    for i in range(int(duration * bpm / 60)):
+        frame = int(i * interval)
+        if frame < num_frames:
+            beat_act[frame] = 0.95
+            if i % 4 == 0:
+                downbeat_act[frame] = 0.95
+
+    combined = np.column_stack(
+        [
+            np.maximum(beat_act - downbeat_act, 1e-5),
+            downbeat_act,
+        ]
+    )
+
+    tracker = DBNDownBeatTracker(beats_per_bar=[3, 4], min_bpm=55, max_bpm=215, fps=fps)
+    result, num_beats = tracker(combined)
+
+    assert num_beats == 4
+    assert len(result) > 0
 
 
 def test_dbn_tracker_output_format() -> None:
@@ -142,7 +173,7 @@ def test_dbn_tracker_output_format() -> None:
             combined[i, 1] = 0.9
 
     tracker = DBNDownBeatTracker(beats_per_bar=[4], min_bpm=55, max_bpm=215, fps=fps)
-    result = tracker(combined)
+    result, _num_beats = tracker(combined)
 
     assert result.ndim == 2
     assert result.shape[1] == 2

--- a/tests/providers/smart_fades/test_helpers.py
+++ b/tests/providers/smart_fades/test_helpers.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from music_assistant.providers.smart_fades.helpers import aggregate_series_to_bins
+from music_assistant.models.audio_analysis import AudioAnalysisData
+from music_assistant.providers.smart_fades.helpers import (
+    BAND_RMS_BANDS,
+    aggregate_series_to_bins,
+    compute_band_rms_frames,
+)
 
 
 class TestAggregateSeriesToBins:
@@ -40,3 +45,45 @@ class TestAggregateSeriesToBins:
         assert len(bins) == 10
         assert bins[0] == pytest.approx(1.0)
         assert bins[-1] == pytest.approx(0.0)
+
+
+class TestBandRmsFrames:
+    """Band-limited RMS frames: a pure tone lands in exactly one band."""
+
+    def _tone(self, freq: float, seconds: float = 2.0, sr: int = 22050) -> np.ndarray:
+        t = np.arange(int(sr * seconds)) / sr
+        return (0.5 * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+    @pytest.mark.parametrize(
+        ("freq", "band"),
+        [(60.0, "low"), (250.0, "low_mid"), (1000.0, "mid"), (8000.0, "high")],
+    )
+    def test_tone_lands_in_its_band(self, freq: float, band: str) -> None:
+        """Each band's tone dominates its own envelope by an order of magnitude."""
+        frames = compute_band_rms_frames(self._tone(freq), 22050, 2205)
+        assert set(frames) == set(BAND_RMS_BANDS)
+        target = float(np.mean(frames[band]))
+        others = max(float(np.mean(v)) for k, v in frames.items() if k != band)
+        assert target > 10 * others
+
+    def test_band_sum_tracks_full_rms(self) -> None:
+        """Total band power approximates the plain time-domain RMS (Parseval)."""
+        pcm = self._tone(60.0) + self._tone(1000.0)
+        frames = compute_band_rms_frames(pcm, 22050, 2205)
+        total = np.sqrt(sum(np.mean(v.astype(np.float64) ** 2) for v in frames.values()))
+        expected = np.sqrt(np.mean(pcm.astype(np.float64) ** 2))
+        assert total == pytest.approx(expected, rel=0.05)
+
+    def test_partial_tail_window_included(self) -> None:
+        """A trailing partial window still yields a frame (parity with full-band RMS)."""
+        frames = compute_band_rms_frames(self._tone(1000.0, seconds=1.05), 22050, 2205)
+        assert len(frames["mid"]) == 11  # 10 full + 1 partial
+
+
+def test_extra_data_roundtrips_through_dict() -> None:
+    """Band envelopes survive to_dict/from_dict (plain lists, no ndarrays)."""
+    analysis = AudioAnalysisData(
+        duration=10.0, extra_data={"band_rms": {"low": [0.1, 0.2], "mid": [0.3, 0.4]}}
+    )
+    restored = AudioAnalysisData.from_dict(analysis.to_dict())
+    assert restored.extra_data == analysis.extra_data

--- a/tests/providers/smart_fades/test_helpers.py
+++ b/tests/providers/smart_fades/test_helpers.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from music_assistant.controllers.streams.smart_fades.models import BAND_RMS_BANDS
 from music_assistant.models.audio_analysis import AudioAnalysisData
 from music_assistant.providers.smart_fades.helpers import (
-    BAND_RMS_BANDS,
     aggregate_series_to_bins,
     compute_band_rms_frames,
 )

--- a/tests/providers/smart_fades/test_helpers.py
+++ b/tests/providers/smart_fades/test_helpers.py
@@ -1,0 +1,42 @@
+"""Tests for the pure numpy frame aggregation helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from music_assistant.providers.smart_fades.helpers import aggregate_series_to_bins
+
+
+class TestAggregateSeriesToBins:
+    """Anti-aliased frame-to-bin resampling (mean power per bin, not point samples)."""
+
+    def test_beat_ripple_does_not_alias(self) -> None:
+        """A beat-rate amplitude ripple averages out instead of aliasing into bins."""
+        # 40k frames of RMS oscillating 0.3..0.7: the ripple period (~7 frames) is
+        # much shorter than a bin (~22 frames), so the boxcar must average it out;
+        # point sampling would land bins anywhere in 0.3..0.7 (up to 0.2 off the mean)
+        frames = (0.5 + 0.2 * np.sin(np.arange(40_000) * 0.9)).astype(np.float32)
+        bins = aggregate_series_to_bins(frames, 1800, power=True)
+        assert len(bins) == 1800
+        rms_of_ripple = np.sqrt(np.mean(frames.astype(np.float64) ** 2))
+        assert np.all(np.abs(bins - rms_of_ripple) < 0.02)
+
+    def test_constant_series_is_preserved(self) -> None:
+        """A flat series stays flat at the same level."""
+        bins = aggregate_series_to_bins(np.full(999, 0.4, dtype=np.float32), 1800)
+        assert bins == pytest.approx(np.full(1800, 0.4), abs=1e-6)
+
+    def test_step_stays_sharp(self) -> None:
+        """A cliff moves by at most one bin (no smearing beyond the boxcar)."""
+        frames = np.concatenate([np.ones(1000, np.float32), np.zeros(1000, np.float32)])
+        bins = aggregate_series_to_bins(frames, 200, power=True)
+        # exactly one transition bin may hold an intermediate value
+        assert np.sum((bins > 0.01) & (bins < 0.99)) <= 1
+
+    def test_upsampling_short_series(self) -> None:
+        """Fewer frames than bins (very short track) still yields n_bins values."""
+        bins = aggregate_series_to_bins(np.array([1.0, 0.0], dtype=np.float32), 10)
+        assert len(bins) == 10
+        assert bins[0] == pytest.approx(1.0)
+        assert bins[-1] == pytest.approx(0.0)

--- a/tests/providers/smart_fades/test_helpers.py
+++ b/tests/providers/smart_fades/test_helpers.py
@@ -18,9 +18,7 @@ class TestAggregateSeriesToBins:
 
     def test_beat_ripple_does_not_alias(self) -> None:
         """A beat-rate amplitude ripple averages out instead of aliasing into bins."""
-        # 40k frames of RMS oscillating 0.3..0.7: the ripple period (~7 frames) is
-        # much shorter than a bin (~22 frames), so the boxcar must average it out;
-        # point sampling would land bins anywhere in 0.3..0.7 (up to 0.2 off the mean)
+        # ripple period (~7 frames) << bin (~22 frames): the boxcar must flatten it
         frames = (0.5 + 0.2 * np.sin(np.arange(40_000) * 0.9)).astype(np.float32)
         bins = aggregate_series_to_bins(frames, 1800, power=True)
         assert len(bins) == 1800

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -246,6 +246,17 @@ async def test_extended_analysis_fields(provider: SmartFadesProvider, mass_mock:
     assert analysis.bpm is not None
     assert 115 < analysis.bpm < 125
 
+    # v2: per-band RMS envelopes in extra_data, normalized by the full-band peak
+    assert analysis.extra_data is not None
+    band_rms = analysis.extra_data["band_rms"]
+    assert set(band_rms) == {"low", "low_mid", "mid", "high"}
+    for band in band_rms.values():
+        assert len(band) == 1800
+        assert all(v >= 0.0 for v in band)
+    # music with drums has real low-band content; bands are lists (JSON-safe)
+    assert isinstance(band_rms["low"], list)
+    assert max(band_rms["low"]) > 0.05
+
 
 async def test_finalize_returns_audio_analysis_data(provider: SmartFadesProvider) -> None:
     """Test that _finalize returns an AudioAnalysisData on success."""

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -178,6 +178,9 @@ async def test_beat_detection(provider: SmartFadesProvider, mass_mock: Mock) -> 
     assert analysis.bpm is not None
     assert 115 < analysis.bpm < 125, f"Expected BPM ~120, got {analysis.bpm:.1f}"
 
+    # the 120 BPM fixture is common time
+    assert analysis.beats_per_bar == 4
+
 
 async def test_extended_analysis_fields(provider: SmartFadesProvider, mass_mock: Mock) -> None:
     """Test that extended analysis fields (energy, centroid, key) are populated."""
@@ -324,7 +327,7 @@ async def test_finalize_raises_when_not_enough_beats(provider: SmartFadesProvide
         patch.object(
             provider,
             "_infer_beat_timings",
-            return_value=(np.array([0.5]), np.array([])),
+            return_value=(np.array([0.5]), np.array([]), 4),
         ),
         pytest.raises(AudioAnalysisError, match="beat"),
     ):

--- a/tests/providers/smart_fades/test_provider.py
+++ b/tests/providers/smart_fades/test_provider.py
@@ -348,3 +348,8 @@ async def test_setup_raises_when_requirements_not_met(
         pytest.raises(SetupFailedError),
     ):
         await smart_fades.setup(mass_mock, manifest_mock, config_mock)
+
+
+async def test_analysis_version_is_2(provider: SmartFadesProvider) -> None:
+    """v2 = anti-aliased bins + band_rms extra_data + beats_per_bar."""
+    assert provider.analysis_version == 2


### PR DESCRIPTION
# What does this implement/fix?

Bumps the smart_fades audio analysis to version 2, capturing the data the upcoming DJ-style EQ improvements need — and fixing a real aliasing bug in the existing energy envelope on the way.

- **Anti-aliased 1800-bin envelopes**: the energy/centroid series were built with `np.interp` point-sampling, which aliases beat-rate energy ripple into the bins on longer tracks (measured on real 5-6 min club tracks: per-bar energy statistics off by up to 14% of peak, and one mix-out anchor shifted by ~6 seconds). Bins are now exact mean-power averages over their span.
- **Per-band RMS envelopes** in `extra_data["band_rms"]`: low 20–120 Hz, low_mid 120–400 Hz, mid 400–4000 Hz, high 4000+ Hz (edges match club-mixer EQ action regions), all normalized by the same full-band peak so inter-band ratios stay meaningful. Band contract constant (`BAND_RMS_BANDS`) lives in `controllers/streams/smart_fades/models.py`, next to the smart-fades consumer that reads it.
- **`beats_per_bar`** (3 or 4) captured from the DBN post-processor's winning meter hypothesis — previously decoded and thrown away.
- **`analysis_version = 2`**: previously analyzed tracks re-analyze lazily on next play; v1 rows stay valid for all existing consumers.

Verified beyond unit tests: stored band envelopes reconstruct the full-band envelope (median ratio 0.999 across a 56-track corpus) and match an independent PCM recomputation at r ≥ 0.989 at decision granularity.

**Related issue (if applicable):**

- n/a (groundwork for smart fades EQ/timing improvements)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes. *(hooks could not spawn in the dev worktree; ruff check/format + mypy verified clean per commit — CI will confirm)*
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.