### PR TITLE
Isolate the hermetic e2e fixture from host audio devices

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,11 +19,19 @@ from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 import pytest
 from zeroconf.asyncio import AsyncZeroconf
 
+from music_assistant.controllers.config.providers import ProviderConfigMixin
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.player import Player
 
 NUM_DEMO_PLAYERS = 3
+
+# builtin providers that must not be auto-setup in the hermetic boot: local_audio
+# bridges the host machine's sound devices (built-in speakers, bluetooth, ...) as
+# sendspin players, which would leak real hardware into the player registry
+SUPPRESSED_BUILTIN_PROVIDERS = {"local_audio"}
+
+_orig_create_builtin_provider_config = ProviderConfigMixin.create_builtin_provider_config
 
 
 async def wait_for(predicate: Callable[[], bool], timeout: float = 25.0) -> bool:
@@ -72,6 +80,15 @@ async def play_test_track(mass: MusicAssistant, queue_id: str, track_id: str = "
     await mass.player_queues.play_media(queue_id, track)
 
 
+async def _create_builtin_provider_config_hermetic(
+    self: ProviderConfigMixin, provider_domain: str
+) -> None:
+    """Create builtin provider configs, skipping providers that discover host hardware."""
+    if provider_domain in SUPPRESSED_BUILTIN_PROVIDERS:
+        return
+    await _orig_create_builtin_provider_config(self, provider_domain)
+
+
 def _create_mock_zeroconf() -> MagicMock:
     """Create a mock AsyncZeroconf that prevents real mDNS network I/O."""
     mock_zc = MagicMock(spec=AsyncZeroconf)
@@ -91,9 +108,10 @@ async def e2e_mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
     """
     Boot a hermetic MusicAssistant with only the fake `test` + demo player providers.
 
-    No real network discovery happens: mDNS (zeroconf) and SSDP are mocked and the
-    default device providers (dlna/sonos/...) are suppressed. The `test` music provider
-    and three grouped-capable demo players are configured and ready.
+    No real network discovery happens: mDNS (zeroconf) and SSDP are mocked, the
+    default device providers (dlna/sonos/...) are suppressed and so is local_audio,
+    which would otherwise register the host's sound devices as players. The `test`
+    music provider and three grouped-capable demo players are configured and ready.
     """
     storage_path = tmp_path / "data"
     cache_path = tmp_path / "cache"
@@ -124,6 +142,13 @@ async def e2e_mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
             new=AsyncMock(),
         ),
         patch("music_assistant.mass.DEFAULT_PROVIDERS", ()),
+        # hermetic: local_audio is a builtin provider that would bridge the host
+        # machine's sound devices (e.g. bluetooth headsets) as extra players
+        patch.object(
+            ProviderConfigMixin,
+            "create_builtin_provider_config",
+            _create_builtin_provider_config_hermetic,
+        ),
     ):
         await mass_instance.start()
         # configure the fake music + player providers


### PR DESCRIPTION
# What does this implement/fix?

`tests/integration/test_demo_group_e2e.py` asserts a hermetic boot registers exactly `demo_0/demo_1/demo_2`. The `e2e_mass` fixture mocks zeroconf/SSDP and empties `DEFAULT_PROVIDERS`, but `local_audio` is a `builtin` provider, so it's auto-configured and loaded regardless of that patch. On a dev machine with audio outputs (e.g. a connected Bluetooth headset) it bridges the host's sound devices as Sendspin players, so extra players show up and the assertion fails. It's environment-dependent (appears when a Bluetooth device is connected) and unrelated to any code change.

The fixture now also suppresses `local_audio`, so the boot stays hermetic on both CI and dev machines that have local audio devices.

## Changes

- `e2e_mass` wraps `ProviderConfigMixin.create_builtin_provider_config` to skip domains in a new `SUPPRESSED_BUILTIN_PROVIDERS = {"local_audio"}` set — no config is created, so the provider (and its Sendspin bridge players) never loads.
- Sendspin itself stays loaded; it only registers players for connected clients, of which a hermetic boot has none.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally. (the change is to the test fixture itself)
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (n/a)
