### PR TITLE
Reduce database commit overhead during library sync

### DIFF
--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -175,16 +175,18 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
     ) -> ItemCls:
         """Add item to library and return the new (or updated) database item."""
         new_item = False
-        # check for existing item first
-        if library_id := await self._get_library_item_by_match(item):
-            # update existing item
-            await self._update_library_item(library_id, item, overwrite=overwrite_existing)
-        else:
-            # actually add a new item in the library db
-            self.mass.music.match_provider_instances(item)
-            async with self._db_add_lock:
-                library_id = await self._add_library_item(item)
-                new_item = True
+        # batch the many writes of an item add/update into a single commit
+        async with self.mass.music.database.deferred_commit():
+            # check for existing item first
+            if library_id := await self._get_library_item_by_match(item):
+                # update existing item
+                await self._update_library_item(library_id, item, overwrite=overwrite_existing)
+            else:
+                # actually add a new item in the library db
+                self.mass.music.match_provider_instances(item)
+                async with self._db_add_lock:
+                    library_id = await self._add_library_item(item)
+                    new_item = True
         # return final library_item
         library_item = await self.get_library_item(library_id)
         if not SUPPRESS_MEDIA_ITEM_UPDATES.get():
@@ -201,7 +203,9 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
     ) -> ItemCls:
         """Update existing library record in the library database."""
         self.mass.music.match_provider_instances(update)
-        await self._update_library_item(item_id, update, overwrite=overwrite)
+        # batch the many writes of an item update into a single commit
+        async with self.mass.music.database.deferred_commit():
+            await self._update_library_item(item_id, update, overwrite=overwrite)
         # return the updated object
         library_item = await self.get_library_item(item_id)
         if SUPPRESS_MEDIA_ITEM_UPDATES.get():
@@ -907,6 +911,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 DB_TABLE_PROVIDER_MAPPINGS,
                 {"media_type": self.media_type.value, "item_id": db_id},
             )
+        prov_map_objs: list[dict[str, Any]] = []
         for provider_mapping in provider_mappings:
             prov_map_obj = {
                 "media_type": self.media_type.value,
@@ -920,10 +925,11 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             for key in ("url", "details", "in_library", "is_unique"):
                 if (value := getattr(provider_mapping, key, None)) is not None:
                     prov_map_obj[key] = value
-            await self.mass.music.database.upsert(
-                DB_TABLE_PROVIDER_MAPPINGS,
-                prov_map_obj,
-            )
+            prov_map_objs.append(prov_map_obj)
+        await self.mass.music.database.upsert_many(
+            DB_TABLE_PROVIDER_MAPPINGS,
+            prov_map_objs,
+        )
 
     @abstractmethod
     async def match_providers(self, db_item: ItemCls) -> None:

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -1037,52 +1037,55 @@ class GenreController(MediaControllerBase[Genre]):
         media_id_int = int(media_id)
         gm = DB_TABLE_GENRE_MEDIA_ITEM_MAPPING
 
-        # Build target set: (genre_id, alias_name) from incoming names.
-        # One alias can map to multiple genres (n:n). Genres resolve within the taxonomy
-        # the item belongs to, so a podcast tag never lands on a music genre.
-        content_type = genre_content_type_for(media_type)
-        target_mappings: dict[int, str] = {}
-        for name in genre_names:
-            normalized = self._normalize_genre_name(name)
-            if not normalized:
-                continue
-            genre_ids = await self._find_genres_for_alias(normalized[0], content_type)
-            for gid in genre_ids:
-                if gid not in target_mappings:
-                    target_mappings[gid] = normalized[0]
+        # batch the (possible) genre creations and mapping changes into a single commit
+        async with self.mass.music.database.deferred_commit():
+            # Build target set: (genre_id, alias_name) from incoming names.
+            # One alias can map to multiple genres (n:n). Genres resolve within the taxonomy
+            # the item belongs to, so a podcast tag never lands on a music genre.
+            content_type = genre_content_type_for(media_type)
+            target_mappings: dict[int, str] = {}
+            for name in genre_names:
+                normalized = self._normalize_genre_name(name)
+                if not normalized:
+                    continue
+                genre_ids = await self._find_genres_for_alias(normalized[0], content_type)
+                for gid in genre_ids:
+                    if gid not in target_mappings:
+                        target_mappings[gid] = normalized[0]
 
-        # Get current genre_ids from database
-        rows = await self.mass.music.database.get_rows_from_query(
-            f"SELECT genre_id FROM {gm} WHERE media_type = :media_type AND media_id = :media_id",
-            {"media_type": media_type.value, "media_id": media_id_int},
-            limit=0,
-        )
-        existing_genre_ids = {int(row["genre_id"]) for row in rows}
-
-        to_add = set(target_mappings.keys()) - existing_genre_ids
-        to_remove = existing_genre_ids - set(target_mappings.keys())
-
-        for genre_id in to_remove:
-            await self.mass.music.database.delete(
-                gm,
-                {
-                    "genre_id": genre_id,
-                    "media_id": media_id_int,
-                    "media_type": media_type.value,
-                },
+            # Get current genre_ids from database
+            rows = await self.mass.music.database.get_rows_from_query(
+                f"SELECT genre_id FROM {gm} "
+                "WHERE media_type = :media_type AND media_id = :media_id",
+                {"media_type": media_type.value, "media_id": media_id_int},
+                limit=0,
             )
+            existing_genre_ids = {int(row["genre_id"]) for row in rows}
 
-        for genre_id in to_add:
-            await self.mass.music.database.insert(
-                gm,
-                {
-                    "genre_id": genre_id,
-                    "media_id": media_id_int,
-                    "media_type": media_type.value,
-                    "alias": target_mappings[genre_id],
-                },
-                allow_replace=True,
-            )
+            to_add = set(target_mappings.keys()) - existing_genre_ids
+            to_remove = existing_genre_ids - set(target_mappings.keys())
+
+            for genre_id in to_remove:
+                await self.mass.music.database.delete(
+                    gm,
+                    {
+                        "genre_id": genre_id,
+                        "media_id": media_id_int,
+                        "media_type": media_type.value,
+                    },
+                )
+
+            for genre_id in to_add:
+                await self.mass.music.database.insert(
+                    gm,
+                    {
+                        "genre_id": genre_id,
+                        "media_id": media_id_int,
+                        "media_type": media_type.value,
+                        "alias": target_mappings[genre_id],
+                    },
+                    allow_replace=True,
+                )
 
     def register_scheduled_scan_task(self) -> BackgroundTask:
         """Register the recurring genre mapping scan task."""

--- a/music_assistant/helpers/database.py
+++ b/music_assistant/helpers/database.py
@@ -8,6 +8,7 @@ import os
 import time
 from collections.abc import Mapping
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from sqlite3 import OperationalError
 from typing import TYPE_CHECKING, Any, cast
 
@@ -16,7 +17,7 @@ import aiosqlite
 from music_assistant.constants import MASS_LOGGER_NAME
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import AsyncGenerator, Sequence
 
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.database")
 
@@ -139,6 +140,12 @@ class DatabaseConnection:
     def __init__(self, db_path: str) -> None:
         """Initialize class."""
         self.db_path = db_path
+        # per-instance ContextVar (instead of module level) so multiple database
+        # connections (library/cache/auth) track their deferred_commit scopes
+        # independently; only a handful of long-lived instances exist per process
+        self._deferred_commit_depth: ContextVar[int] = ContextVar(
+            "deferred_commit_depth", default=0
+        )
 
     async def setup(
         self,
@@ -288,7 +295,7 @@ class DatabaseConnection:
             sql_query = f"INSERT INTO {table}({','.join(keys)})"
         sql_query += f" VALUES ({','.join(f':{x}' for x in keys)})"
         row_id = await self._db.execute_insert(sql_query, values)
-        await self._db.commit()
+        await self._maybe_commit()
         assert row_id is not None  # for type checking
         assert isinstance(row_id[0], int)  # for type checking
         return row_id[0]
@@ -307,14 +314,40 @@ class DatabaseConnection:
         )
         sql_query += f" ON CONFLICT DO UPDATE SET {','.join(f'{x}=:{x}' for x in keys)}"
         await self._db.execute(sql_query, values)
-        await self._db.commit()
+        await self._maybe_commit()
+
+    async def upsert_many(self, table: str, values: Sequence[dict[str, Any]]) -> None:
+        """
+        Upsert multiple rows in the given table with a single commit.
+
+        :param table: The table to upsert the rows into.
+        :param values: The rows to upsert, each given as a column->value dict.
+            Rows do not need to share the same set of columns.
+        """
+        if not values:
+            return
+        # rows are grouped by their column set so each group can be executed as a
+        # single (prepared) statement, while omitted columns keep their existing
+        # value on conflict - identical to calling upsert() per row
+        rows_per_column_set: dict[tuple[str, ...], list[dict[str, Any]]] = {}
+        for row in values:
+            # Filter out UNSET values so database defaults are used
+            filtered_row = {k: v for k, v in row.items() if v is not UNSET}
+            rows_per_column_set.setdefault(tuple(sorted(filtered_row)), []).append(filtered_row)
+        for keys, rows in rows_per_column_set.items():
+            sql_query = (
+                f"INSERT INTO {table}({','.join(keys)}) VALUES ({','.join(f':{x}' for x in keys)})"
+            )
+            sql_query += f" ON CONFLICT DO UPDATE SET {','.join(f'{x}=:{x}' for x in keys)}"
+            await self._db.executemany(sql_query, rows)
+        await self._maybe_commit()
 
     async def update(
         self,
         table: str,
         match: dict[str, Any],
         values: dict[str, Any],
-    ) -> Mapping[str, Any]:
+    ) -> None:
         """Update record."""
         # Filter out UNSET values so those fields are not updated
         values = {k: v for k, v in values.items() if v is not UNSET}
@@ -322,11 +355,7 @@ class DatabaseConnection:
         sql_query = f"UPDATE {table} SET {','.join(f'{x}=:{x}' for x in keys)} WHERE "
         sql_query += " AND ".join(f"{x} = :{x}" for x in match)
         await self.execute(sql_query, {**match, **values})
-        await self._db.commit()
-        # return updated item
-        updated_item = await self.get_row(table, match)
-        assert updated_item is not None  # for type checking
-        return updated_item
+        await self._maybe_commit()
 
     async def delete(
         self, table: str, match: dict[str, Any] | None = None, query: str | None = None
@@ -341,13 +370,13 @@ class DatabaseConnection:
         elif query:
             sql_query += query
         await self.execute(sql_query, match)
-        await self._db.commit()
+        await self._maybe_commit()
 
     async def delete_where_query(self, table: str, query: str | None = None) -> None:
         """Delete data in given table using given where clausule."""
         sql_query = f"DELETE FROM {table} WHERE {query}"
         await self.execute(sql_query)
-        await self._db.commit()
+        await self._maybe_commit()
 
     async def execute(self, query: str, values: dict[str, Any] | None = None) -> Any:
         """Execute command on the database."""
@@ -356,6 +385,34 @@ class DatabaseConnection:
     async def commit(self) -> None:
         """Commit the current transaction."""
         return await self._db.commit()
+
+    @asynccontextmanager
+    async def deferred_commit(self) -> AsyncGenerator[None]:
+        """
+        Batch all writes of the current task into a single commit when the scope exits.
+
+        Within the scope, the per-statement commit of the insert/upsert/update/delete
+        helpers is skipped for the current task and a single commit is issued when the
+        outermost scope exits (scopes may be nested). This greatly reduces the commit
+        overhead of multi-statement operations such as adding a media item with all
+        its relations to the library.
+
+        Note: this is not an atomic transaction. The scope always commits on exit -
+        also on error or cancellation - and never rolls back. Writes from other tasks
+        are unaffected and still commit immediately.
+        """
+        depth = self._deferred_commit_depth.get()
+        token = self._deferred_commit_depth.set(depth + 1)
+        try:
+            yield
+        finally:
+            self._deferred_commit_depth.reset(token)
+            # always commit on exit, never rollback: the connection is shared by all
+            # tasks, so statements from concurrent writers may interleave with this
+            # scope's statements in the same underlying SQLite transaction and a
+            # rollback would revert their (already acknowledged) writes as well
+            if depth == 0:
+                await self._db.commit()
 
     async def iter_items(
         self,
@@ -409,3 +466,8 @@ class DatabaseConnection:
         async with self._db.execute(f"PRAGMA {pragma}") as cursor:
             row = await cursor.fetchone()
             return int(row[0]) if row else 0
+
+    async def _maybe_commit(self) -> None:
+        """Commit now, unless the current task is inside a deferred_commit scope."""
+        if self._deferred_commit_depth.get() == 0:
+            await self._db.commit()

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -835,13 +835,7 @@ class MusicProvider(Provider):
                         for prov_map in prov_item.provider_mappings:
                             prov_map.in_library = True
                         library_item = await self.mass.music.artists.add_item_to_library(prov_item)
-                    elif not self._check_provider_mappings(library_item, prov_item, True):
-                        # existing library item but provider mapping doesn't match
-                        library_item = await self.mass.music.artists.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                        # update date_added if it changed
+                    elif self._library_item_needs_update(library_item, prov_item):
                         library_item = await self.mass.music.artists.update_item_in_library(
                             library_item.item_id, prov_item
                         )
@@ -899,13 +893,7 @@ class MusicProvider(Provider):
                         for prov_map in prov_item.provider_mappings:
                             prov_map.in_library = True
                         library_item = await self.mass.music.albums.add_item_to_library(prov_item)
-                    elif not self._check_provider_mappings(library_item, prov_item, True):
-                        # existing library item but provider mapping doesn't match
-                        library_item = await self.mass.music.albums.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                        # update date_added if it changed
+                    elif self._library_item_needs_update(library_item, prov_item):
                         library_item = await self.mass.music.albums.update_item_in_library(
                             library_item.item_id, prov_item
                         )
@@ -1041,13 +1029,7 @@ class MusicProvider(Provider):
                         library_item = await self.mass.music.audiobooks.add_item_to_library(
                             prov_item
                         )
-                    elif not self._check_provider_mappings(library_item, prov_item, True):
-                        # existing library item but provider mapping doesn't match
-                        library_item = await self.mass.music.audiobooks.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                        # update date_added if it changed
+                    elif self._library_item_needs_update(library_item, prov_item):
                         library_item = await self.mass.music.audiobooks.update_item_in_library(
                             library_item.item_id, prov_item
                         )
@@ -1145,18 +1127,11 @@ class MusicProvider(Provider):
                         library_item = await self.mass.music.playlists.add_item_to_library(
                             prov_item
                         )
-                    elif not self._check_provider_mappings(library_item, prov_item, True):
-                        # existing library item but provider mapping doesn't match
-                        library_item = await self.mass.music.playlists.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                        # update date_added if it changed
-                        library_item = await self.mass.music.playlists.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.supported_mediatypes != library_item.supported_mediatypes:
-                        # update if supported mediatypes changed
+                    elif (
+                        self._library_item_needs_update(library_item, prov_item)
+                        # or the supported mediatypes changed
+                        or prov_item.supported_mediatypes != library_item.supported_mediatypes
+                    ):
                         library_item = await self.mass.music.playlists.update_item_in_library(
                             library_item.item_id, prov_item
                         )
@@ -1276,18 +1251,10 @@ class MusicProvider(Provider):
                         for prov_map in prov_item.provider_mappings:
                             prov_map.in_library = True
                         library_item = await self.mass.music.tracks.add_item_to_library(prov_item)
-                    elif not self._check_provider_mappings(library_item, prov_item, True):
-                        # existing library item but provider mapping doesn't match
-                        library_item = await self.mass.music.tracks.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                        # update date_added if it changed
-                        library_item = await self.mass.music.tracks.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.album and not library_item.album:
-                        # Backfill missing album_tracks link for existing tracks.
+                    elif self._library_item_needs_update(library_item, prov_item) or (
+                        # or backfill a missing album(_tracks) link for existing tracks
+                        prov_item.album and not library_item.album
+                    ):
                         library_item = await self.mass.music.tracks.update_item_in_library(
                             library_item.item_id, prov_item
                         )
@@ -1335,13 +1302,7 @@ class MusicProvider(Provider):
                         for prov_map in prov_item.provider_mappings:
                             prov_map.in_library = True
                         library_item = await self.mass.music.podcasts.add_item_to_library(prov_item)
-                    elif not self._check_provider_mappings(library_item, prov_item, True):
-                        # existing library item but provider mapping doesn't match
-                        library_item = await self.mass.music.podcasts.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                        # update date_added if it changed
+                    elif self._library_item_needs_update(library_item, prov_item):
                         library_item = await self.mass.music.podcasts.update_item_in_library(
                             library_item.item_id, prov_item
                         )
@@ -1395,13 +1356,7 @@ class MusicProvider(Provider):
                         for prov_map in prov_item.provider_mappings:
                             prov_map.in_library = True
                         library_item = await self.mass.music.radio.add_item_to_library(prov_item)
-                    elif not self._check_provider_mappings(library_item, prov_item, True):
-                        # existing library item but provider mapping doesn't match
-                        library_item = await self.mass.music.radio.update_item_in_library(
-                            library_item.item_id, prov_item
-                        )
-                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                        # update date_added if it changed
+                    elif self._library_item_needs_update(library_item, prov_item):
                         library_item = await self.mass.music.radio.update_item_in_library(
                             library_item.item_id, prov_item
                         )
@@ -1471,6 +1426,16 @@ class MusicProvider(Provider):
         if media_type == MediaType.PODCAST:
             return self.get_library_podcasts()
         raise NotImplementedError
+
+    def _library_item_needs_update(
+        self, library_item: MediaItemType, prov_item: MediaItemType
+    ) -> bool:
+        """Return True if the library item needs an update from the given provider item."""
+        if not self._check_provider_mappings(library_item, prov_item, True):
+            # provider mapping doesn't match the library item
+            return True
+        # the item's date_added changed on the provider
+        return bool(prov_item.date_added and library_item.date_added != prov_item.date_added)
 
     def _check_provider_mappings(
         self, library_item: MediaItemType, provider_item: MediaItemType, in_library: bool

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -828,35 +828,37 @@ class MusicProvider(Provider):
                 prov_item.provider_mappings,
             )
             try:
-                if not library_item:
-                    # add item to the library
-                    for prov_map in prov_item.provider_mappings:
-                        prov_map.in_library = True
-                    library_item = await self.mass.music.artists.add_item_to_library(prov_item)
-                elif not self._check_provider_mappings(library_item, prov_item, True):
-                    # existing library item but provider mapping doesn't match
-                    library_item = await self.mass.music.artists.update_item_in_library(
-                        library_item.item_id, prov_item
+                # batch all writes for this item into a single commit
+                async with self.mass.music.database.deferred_commit():
+                    if not library_item:
+                        # add item to the library
+                        for prov_map in prov_item.provider_mappings:
+                            prov_map.in_library = True
+                        library_item = await self.mass.music.artists.add_item_to_library(prov_item)
+                    elif not self._check_provider_mappings(library_item, prov_item, True):
+                        # existing library item but provider mapping doesn't match
+                        library_item = await self.mass.music.artists.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
+                        # update date_added if it changed
+                        library_item = await self.mass.music.artists.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    if not library_item.favorite and prov_item.favorite:
+                        # existing library item not favorite but should be
+                        await self.mass.music.artists.set_favorite(library_item.item_id, True)
+                    fallback_genres = (
+                        set(prov_item.metadata.genres)
+                        if prov_item.metadata and prov_item.metadata.genres
+                        else None
                     )
-                elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                    # update date_added if it changed
-                    library_item = await self.mass.music.artists.update_item_in_library(
-                        library_item.item_id, prov_item
+                    await self._sync_item_genres(
+                        MediaType.ARTIST,
+                        prov_item.item_id,
+                        int(library_item.item_id),
+                        fallback_genres,
                     )
-                if not library_item.favorite and prov_item.favorite:
-                    # existing library item not favorite but should be
-                    await self.mass.music.artists.set_favorite(library_item.item_id, True)
-                fallback_genres = (
-                    set(prov_item.metadata.genres)
-                    if prov_item.metadata and prov_item.metadata.genres
-                    else None
-                )
-                await self._sync_item_genres(
-                    MediaType.ARTIST,
-                    prov_item.item_id,
-                    int(library_item.item_id),
-                    fallback_genres,
-                )
                 cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
             except MusicAssistantError as err:
@@ -890,35 +892,37 @@ class MusicProvider(Provider):
                 prov_item.provider_mappings,
             )
             try:
-                if not library_item:
-                    # add item to the library
-                    for prov_map in prov_item.provider_mappings:
-                        prov_map.in_library = True
-                    library_item = await self.mass.music.albums.add_item_to_library(prov_item)
-                elif not self._check_provider_mappings(library_item, prov_item, True):
-                    # existing library item but provider mapping doesn't match
-                    library_item = await self.mass.music.albums.update_item_in_library(
-                        library_item.item_id, prov_item
+                # batch all writes for this item into a single commit
+                async with self.mass.music.database.deferred_commit():
+                    if not library_item:
+                        # add item to the library
+                        for prov_map in prov_item.provider_mappings:
+                            prov_map.in_library = True
+                        library_item = await self.mass.music.albums.add_item_to_library(prov_item)
+                    elif not self._check_provider_mappings(library_item, prov_item, True):
+                        # existing library item but provider mapping doesn't match
+                        library_item = await self.mass.music.albums.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
+                        # update date_added if it changed
+                        library_item = await self.mass.music.albums.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    if not library_item.favorite and prov_item.favorite:
+                        # existing library item not favorite but should be
+                        await self.mass.music.albums.set_favorite(library_item.item_id, True)
+                    fallback_genres = (
+                        set(prov_item.metadata.genres)
+                        if prov_item.metadata and prov_item.metadata.genres
+                        else None
                     )
-                elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                    # update date_added if it changed
-                    library_item = await self.mass.music.albums.update_item_in_library(
-                        library_item.item_id, prov_item
+                    await self._sync_item_genres(
+                        MediaType.ALBUM,
+                        prov_item.item_id,
+                        int(library_item.item_id),
+                        fallback_genres,
                     )
-                if not library_item.favorite and prov_item.favorite:
-                    # existing library item not favorite but should be
-                    await self.mass.music.albums.set_favorite(library_item.item_id, True)
-                fallback_genres = (
-                    set(prov_item.metadata.genres)
-                    if prov_item.metadata and prov_item.metadata.genres
-                    else None
-                )
-                await self._sync_item_genres(
-                    MediaType.ALBUM,
-                    prov_item.item_id,
-                    int(library_item.item_id),
-                    fallback_genres,
-                )
                 cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
                 # optionally add album tracks to library
@@ -952,27 +956,29 @@ class MusicProvider(Provider):
                 prov_track.provider_mappings,
             )
             try:
-                if not library_track:
-                    # add item to the library
-                    for prov_map in prov_track.provider_mappings:
-                        prov_map.in_library = True
-                    library_track = await self.mass.music.tracks.add_item_to_library(prov_track)
-                elif not self._check_provider_mappings(library_track, prov_track, True):
-                    # existing library track but provider mapping doesn't match
-                    library_track = await self.mass.music.tracks.update_item_in_library(
-                        library_track.item_id, prov_track
+                # batch all writes for this item into a single commit
+                async with self.mass.music.database.deferred_commit():
+                    if not library_track:
+                        # add item to the library
+                        for prov_map in prov_track.provider_mappings:
+                            prov_map.in_library = True
+                        library_track = await self.mass.music.tracks.add_item_to_library(prov_track)
+                    elif not self._check_provider_mappings(library_track, prov_track, True):
+                        # existing library track but provider mapping doesn't match
+                        library_track = await self.mass.music.tracks.update_item_in_library(
+                            library_track.item_id, prov_track
+                        )
+                    fallback_genres = (
+                        set(prov_track.metadata.genres)
+                        if prov_track.metadata and prov_track.metadata.genres
+                        else None
                     )
-                fallback_genres = (
-                    set(prov_track.metadata.genres)
-                    if prov_track.metadata and prov_track.metadata.genres
-                    else None
-                )
-                await self._sync_item_genres(
-                    MediaType.TRACK,
-                    prov_track.item_id,
-                    int(library_track.item_id),
-                    fallback_genres,
-                )
+                    await self._sync_item_genres(
+                        MediaType.TRACK,
+                        prov_track.item_id,
+                        int(library_track.item_id),
+                        fallback_genres,
+                    )
                 await asyncio.sleep(0)  # yield to eventloop
             except MusicAssistantError as err:
                 self.logger.warning(
@@ -981,6 +987,37 @@ class MusicProvider(Provider):
                     str(err),
                 )
                 self._report_sync_task_failure(MediaType.TRACK, prov_track.uri, err)
+
+    def _validate_audiobook_author_narrator_types(self, prov_item: Audiobook) -> None:
+        """Validate that authors/narrators types match the provider's supported features."""
+        if ProviderFeature.AUTHOR_AUDIOBOOKS in self.supported_features and not all(
+            isinstance(author, Artist) for author in prov_item.authors
+        ):
+            raise MusicAssistantError(
+                f"Provider {self.name} supports ProviderFeature.AUTHOR_AUDIOBOOKS, but"
+                f" item {prov_item.name} does not exclusively provide Artist instances."
+            )
+        if ProviderFeature.NARRATOR_AUDIOBOOKS in self.supported_features and not all(
+            isinstance(narrator, Artist) for narrator in prov_item.narrators
+        ):
+            raise MusicAssistantError(
+                f"Provider {self.name} supports ProviderFeature.NARRATOR_AUDIOBOOKS, but"
+                f" item {prov_item.name} does not exclusively provide Artist instances."
+            )
+        if ProviderFeature.AUTHOR_AUDIOBOOKS not in self.supported_features and not all(
+            isinstance(author, str) for author in prov_item.authors
+        ):
+            raise MusicAssistantError(
+                f"Provider {self.name} does not support ProviderFeature.AUTHOR_AUDIOBOOKS, but"
+                f" item {prov_item.name} does not exclusively provide strings."
+            )
+        if ProviderFeature.NARRATOR_AUDIOBOOKS not in self.supported_features and not all(
+            isinstance(narrator, str) for narrator in prov_item.narrators
+        ):
+            raise MusicAssistantError(
+                f"Provider {self.name} does not support ProviderFeature.NARRATOR_AUDIOBOOKS, but"
+                f" item {prov_item.name} does not exclusively provide strings."
+            )
 
     async def _sync_library_audiobooks(self) -> set[int]:
         """Sync Library Audiobooks to Music Assistant library."""
@@ -994,103 +1031,82 @@ class MusicProvider(Provider):
                 prov_item.provider_mappings,
             )
             try:
-                if ProviderFeature.AUTHOR_AUDIOBOOKS in self.supported_features and not all(
-                    isinstance(author, Artist) for author in prov_item.authors
-                ):
-                    raise MusicAssistantError(
-                        f"Provider {self.name} supports ProviderFeature.AUTHOR_AUDIOBOOKS, but"
-                        f" item {prov_item.name} does not exclusively provide Artist instances."
-                    )
-                if ProviderFeature.NARRATOR_AUDIOBOOKS in self.supported_features and not all(
-                    isinstance(narrator, Artist) for narrator in prov_item.narrators
-                ):
-                    raise MusicAssistantError(
-                        f"Provider {self.name} supports ProviderFeature.NARRATOR_AUDIOBOOKS, but"
-                        f" item {prov_item.name} does not exclusively provide Artist instances."
-                    )
-                if ProviderFeature.AUTHOR_AUDIOBOOKS not in self.supported_features and not all(
-                    isinstance(author, str) for author in prov_item.authors
-                ):
-                    raise MusicAssistantError(
-                        f"Provider {self.name} does not support ProviderFeature.AUTHOR_AUDIOBOOKS, but"
-                        f" item {prov_item.name} does not exclusively provide strings."
-                    )
-                if ProviderFeature.NARRATOR_AUDIOBOOKS not in self.supported_features and not all(
-                    isinstance(narrator, str) for narrator in prov_item.narrators
-                ):
-                    raise MusicAssistantError(
-                        f"Provider {self.name} does not support ProviderFeature.NARRATOR_AUDIOBOOKS, but"
-                        f" item {prov_item.name} does not exclusively provide strings."
-                    )
-                if not library_item:
-                    # add item to the library
-                    for prov_map in prov_item.provider_mappings:
-                        prov_map.in_library = True
-                    library_item = await self.mass.music.audiobooks.add_item_to_library(prov_item)
-                elif not self._check_provider_mappings(library_item, prov_item, True):
-                    # existing library item but provider mapping doesn't match
-                    library_item = await self.mass.music.audiobooks.update_item_in_library(
-                        library_item.item_id, prov_item
-                    )
-                elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                    # update date_added if it changed
-                    library_item = await self.mass.music.audiobooks.update_item_in_library(
-                        library_item.item_id, prov_item
-                    )
-                else:
-                    # detect a change in ProviderFeature
-                    lib_author: str | Artist | ItemMapping | None = None
-                    prov_author: str | Artist | ItemMapping | None = None
-                    lib_narrator: str | Artist | ItemMapping | None = None
-                    prov_narrator: str | Artist | ItemMapping | None = None
-                    if len(library_item.authors) > 0:
-                        lib_author = library_item.authors[0]
-                    if len(prov_item.authors) > 0:
-                        prov_author = prov_item.authors[0]
-                    if len(library_item.narrators) > 0:
-                        lib_narrator = library_item.narrators[0]
-                    if len(prov_item.narrators) > 0:
-                        prov_narrator = prov_item.narrators[0]
-                    for possible_type in [Artist, str]:
-                        if (
-                            isinstance(lib_author, possible_type)
-                            and not isinstance(prov_author, possible_type)
-                        ) or (
-                            isinstance(lib_narrator, possible_type)
-                            and not isinstance(prov_narrator, possible_type)
-                        ):
-                            library_item = await self.mass.music.audiobooks.update_item_in_library(
-                                library_item.item_id, prov_item
-                            )
-                            break
+                self._validate_audiobook_author_narrator_types(prov_item)
+                # batch all writes for this item into a single commit
+                async with self.mass.music.database.deferred_commit():
+                    if not library_item:
+                        # add item to the library
+                        for prov_map in prov_item.provider_mappings:
+                            prov_map.in_library = True
+                        library_item = await self.mass.music.audiobooks.add_item_to_library(
+                            prov_item
+                        )
+                    elif not self._check_provider_mappings(library_item, prov_item, True):
+                        # existing library item but provider mapping doesn't match
+                        library_item = await self.mass.music.audiobooks.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
+                        # update date_added if it changed
+                        library_item = await self.mass.music.audiobooks.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    else:
+                        # detect a change in ProviderFeature
+                        lib_author: str | Artist | ItemMapping | None = None
+                        prov_author: str | Artist | ItemMapping | None = None
+                        lib_narrator: str | Artist | ItemMapping | None = None
+                        prov_narrator: str | Artist | ItemMapping | None = None
+                        if len(library_item.authors) > 0:
+                            lib_author = library_item.authors[0]
+                        if len(prov_item.authors) > 0:
+                            prov_author = prov_item.authors[0]
+                        if len(library_item.narrators) > 0:
+                            lib_narrator = library_item.narrators[0]
+                        if len(prov_item.narrators) > 0:
+                            prov_narrator = prov_item.narrators[0]
+                        for possible_type in [Artist, str]:
+                            if (
+                                isinstance(lib_author, possible_type)
+                                and not isinstance(prov_author, possible_type)
+                            ) or (
+                                isinstance(lib_narrator, possible_type)
+                                and not isinstance(prov_narrator, possible_type)
+                            ):
+                                library_item = (
+                                    await self.mass.music.audiobooks.update_item_in_library(
+                                        library_item.item_id, prov_item
+                                    )
+                                )
+                                break
 
-                if not library_item.favorite and prov_item.favorite:
-                    # existing library item not favorite but should be
-                    await self.mass.music.audiobooks.set_favorite(library_item.item_id, True)
-                # check if resume_position_ms or fully_played changed
-                if (
-                    prov_item.resume_position_ms is not None
-                    and prov_item.fully_played is not None
-                    and (
-                        library_item.resume_position_ms != prov_item.resume_position_ms
-                        or library_item.fully_played != prov_item.fully_played
-                    )
-                ):
-                    library_item = await self.mass.music.audiobooks.update_item_in_library(
-                        library_item.item_id, prov_item
-                    )
+                    if not library_item.favorite and prov_item.favorite:
+                        # existing library item not favorite but should be
+                        await self.mass.music.audiobooks.set_favorite(library_item.item_id, True)
+                    # check if resume_position_ms or fully_played changed
+                    if (
+                        prov_item.resume_position_ms is not None
+                        and prov_item.fully_played is not None
+                        and (
+                            library_item.resume_position_ms != prov_item.resume_position_ms
+                            or library_item.fully_played != prov_item.fully_played
+                        )
+                    ):
+                        library_item = await self.mass.music.audiobooks.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
 
-                fallback_genres = (
-                    set(prov_item.metadata.genres)
-                    if prov_item.metadata and prov_item.metadata.genres
-                    else None
-                )
-                await self._sync_item_genres(
-                    MediaType.AUDIOBOOK,
-                    prov_item.item_id,
-                    int(library_item.item_id),
-                    fallback_genres,
-                )
+                    fallback_genres = (
+                        set(prov_item.metadata.genres)
+                        if prov_item.metadata and prov_item.metadata.genres
+                        else None
+                    )
+                    await self._sync_item_genres(
+                        MediaType.AUDIOBOOK,
+                        prov_item.item_id,
+                        int(library_item.item_id),
+                        fallback_genres,
+                    )
 
                 cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
@@ -1120,46 +1136,50 @@ class MusicProvider(Provider):
                 prov_item.provider_mappings,
             )
             try:
-                if not library_item:
-                    # add item to the library
-                    for prov_map in prov_item.provider_mappings:
-                        prov_map.in_library = True
-                    library_item = await self.mass.music.playlists.add_item_to_library(prov_item)
-                elif not self._check_provider_mappings(library_item, prov_item, True):
-                    # existing library item but provider mapping doesn't match
-                    library_item = await self.mass.music.playlists.update_item_in_library(
-                        library_item.item_id, prov_item
-                    )
-                elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                    # update date_added if it changed
-                    library_item = await self.mass.music.playlists.update_item_in_library(
-                        library_item.item_id, prov_item
-                    )
-                elif prov_item.supported_mediatypes != library_item.supported_mediatypes:
-                    # update if supported mediatypes changed
-                    library_item = await self.mass.music.playlists.update_item_in_library(
-                        library_item.item_id, prov_item
-                    )
-                elif (
-                    prov_item.is_dynamic
-                    and not library_item.is_editable
-                    and (
-                        prov_item.name != library_item.name
-                        or prov_item.metadata.images != library_item.metadata.images
-                    )
-                ):
-                    # the provider is the sole source of truth for non-editable dynamic
-                    # playlists (e.g. Pandora/personalized-radio stations): overwrite=True
-                    # replaces the full stored record (not just name/images), which is fine
-                    # here since there's no local customization on these to lose. Restricted
-                    # to is_dynamic so static non-editable playlists (e.g. provider
-                    # "favorites") keep their locally-enriched metadata/images.
-                    library_item = await self.mass.music.playlists.update_item_in_library(
-                        library_item.item_id, prov_item, overwrite=True
-                    )
-                if not library_item.favorite and prov_item.favorite:
-                    # existing library item not favorite but should be
-                    await self.mass.music.playlists.set_favorite(library_item.item_id, True)
+                # batch all writes for this item into a single commit
+                async with self.mass.music.database.deferred_commit():
+                    if not library_item:
+                        # add item to the library
+                        for prov_map in prov_item.provider_mappings:
+                            prov_map.in_library = True
+                        library_item = await self.mass.music.playlists.add_item_to_library(
+                            prov_item
+                        )
+                    elif not self._check_provider_mappings(library_item, prov_item, True):
+                        # existing library item but provider mapping doesn't match
+                        library_item = await self.mass.music.playlists.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
+                        # update date_added if it changed
+                        library_item = await self.mass.music.playlists.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif prov_item.supported_mediatypes != library_item.supported_mediatypes:
+                        # update if supported mediatypes changed
+                        library_item = await self.mass.music.playlists.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif (
+                        prov_item.is_dynamic
+                        and not library_item.is_editable
+                        and (
+                            prov_item.name != library_item.name
+                            or prov_item.metadata.images != library_item.metadata.images
+                        )
+                    ):
+                        # the provider is the sole source of truth for non-editable dynamic
+                        # playlists (e.g. Pandora/personalized-radio stations): overwrite=True
+                        # replaces the full stored record (not just name/images), which is fine
+                        # here since there's no local customization on these to lose. Restricted
+                        # to is_dynamic so static non-editable playlists (e.g. provider
+                        # "favorites") keep their locally-enriched metadata/images.
+                        library_item = await self.mass.music.playlists.update_item_in_library(
+                            library_item.item_id, prov_item, overwrite=True
+                        )
+                    if not library_item.favorite and prov_item.favorite:
+                        # existing library item not favorite but should be
+                        await self.mass.music.playlists.set_favorite(library_item.item_id, True)
                 cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
                 # optionally sync playlist tracks
@@ -1196,28 +1216,30 @@ class MusicProvider(Provider):
                 prov_track.provider_mappings,
             )
             try:
-                if not library_track:
-                    # add item to the library
-                    for prov_map in prov_track.provider_mappings:
-                        prov_map.in_library = True
-                    library_track = await controller.add_item_to_library(prov_track)  # type: ignore[arg-type]
-                elif not self._check_provider_mappings(library_track, prov_track, True):
-                    # existing library track but provider mapping doesn't match
-                    library_track = await controller.update_item_in_library(
-                        library_track.item_id,
-                        prov_track,  # type: ignore[arg-type]
+                # batch all writes for this item into a single commit
+                async with self.mass.music.database.deferred_commit():
+                    if not library_track:
+                        # add item to the library
+                        for prov_map in prov_track.provider_mappings:
+                            prov_map.in_library = True
+                        library_track = await controller.add_item_to_library(prov_track)  # type: ignore[arg-type]
+                    elif not self._check_provider_mappings(library_track, prov_track, True):
+                        # existing library track but provider mapping doesn't match
+                        library_track = await controller.update_item_in_library(
+                            library_track.item_id,
+                            prov_track,  # type: ignore[arg-type]
+                        )
+                    fallback_genres = (
+                        set(prov_track.metadata.genres)
+                        if prov_track.metadata and prov_track.metadata.genres
+                        else None
                     )
-                fallback_genres = (
-                    set(prov_track.metadata.genres)
-                    if prov_track.metadata and prov_track.metadata.genres
-                    else None
-                )
-                await self._sync_item_genres(
-                    MediaType.TRACK,
-                    prov_track.item_id,
-                    int(library_track.item_id),
-                    fallback_genres,
-                )
+                    await self._sync_item_genres(
+                        MediaType.TRACK,
+                        prov_track.item_id,
+                        int(library_track.item_id),
+                        fallback_genres,
+                    )
                 await asyncio.sleep(0)  # yield to eventloop
             except MusicAssistantError as err:
                 self.logger.warning(
@@ -1247,40 +1269,42 @@ class MusicProvider(Provider):
                         prov_item.uri,
                     )
                     continue
-                if not library_item:
-                    # add item to the library
-                    for prov_map in prov_item.provider_mappings:
-                        prov_map.in_library = True
-                    library_item = await self.mass.music.tracks.add_item_to_library(prov_item)
-                elif not self._check_provider_mappings(library_item, prov_item, True):
-                    # existing library item but provider mapping doesn't match
-                    library_item = await self.mass.music.tracks.update_item_in_library(
-                        library_item.item_id, prov_item
+                # batch all writes for this item into a single commit
+                async with self.mass.music.database.deferred_commit():
+                    if not library_item:
+                        # add item to the library
+                        for prov_map in prov_item.provider_mappings:
+                            prov_map.in_library = True
+                        library_item = await self.mass.music.tracks.add_item_to_library(prov_item)
+                    elif not self._check_provider_mappings(library_item, prov_item, True):
+                        # existing library item but provider mapping doesn't match
+                        library_item = await self.mass.music.tracks.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
+                        # update date_added if it changed
+                        library_item = await self.mass.music.tracks.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif prov_item.album and not library_item.album:
+                        # Backfill missing album_tracks link for existing tracks.
+                        library_item = await self.mass.music.tracks.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    if not library_item.favorite and prov_item.favorite:
+                        # existing library item not favorite but should be
+                        await self.mass.music.tracks.set_favorite(library_item.item_id, True)
+                    fallback_genres = (
+                        set(prov_item.metadata.genres)
+                        if prov_item.metadata and prov_item.metadata.genres
+                        else None
                     )
-                elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                    # update date_added if it changed
-                    library_item = await self.mass.music.tracks.update_item_in_library(
-                        library_item.item_id, prov_item
+                    await self._sync_item_genres(
+                        MediaType.TRACK,
+                        prov_item.item_id,
+                        int(library_item.item_id),
+                        fallback_genres,
                     )
-                elif prov_item.album and not library_item.album:
-                    # Backfill missing album_tracks link for existing tracks.
-                    library_item = await self.mass.music.tracks.update_item_in_library(
-                        library_item.item_id, prov_item
-                    )
-                if not library_item.favorite and prov_item.favorite:
-                    # existing library item not favorite but should be
-                    await self.mass.music.tracks.set_favorite(library_item.item_id, True)
-                fallback_genres = (
-                    set(prov_item.metadata.genres)
-                    if prov_item.metadata and prov_item.metadata.genres
-                    else None
-                )
-                await self._sync_item_genres(
-                    MediaType.TRACK,
-                    prov_item.item_id,
-                    int(library_item.item_id),
-                    fallback_genres,
-                )
                 cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
             except MusicAssistantError as err:
@@ -1304,35 +1328,37 @@ class MusicProvider(Provider):
                 prov_item.provider_mappings,
             )
             try:
-                if not library_item:
-                    # add item to the library
-                    for prov_map in prov_item.provider_mappings:
-                        prov_map.in_library = True
-                    library_item = await self.mass.music.podcasts.add_item_to_library(prov_item)
-                elif not self._check_provider_mappings(library_item, prov_item, True):
-                    # existing library item but provider mapping doesn't match
-                    library_item = await self.mass.music.podcasts.update_item_in_library(
-                        library_item.item_id, prov_item
+                # batch all writes for this item into a single commit
+                async with self.mass.music.database.deferred_commit():
+                    if not library_item:
+                        # add item to the library
+                        for prov_map in prov_item.provider_mappings:
+                            prov_map.in_library = True
+                        library_item = await self.mass.music.podcasts.add_item_to_library(prov_item)
+                    elif not self._check_provider_mappings(library_item, prov_item, True):
+                        # existing library item but provider mapping doesn't match
+                        library_item = await self.mass.music.podcasts.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
+                        # update date_added if it changed
+                        library_item = await self.mass.music.podcasts.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    if not library_item.favorite and prov_item.favorite:
+                        # existing library item not favorite but should be
+                        await self.mass.music.podcasts.set_favorite(library_item.item_id, True)
+                    fallback_genres = (
+                        set(prov_item.metadata.genres)
+                        if prov_item.metadata and prov_item.metadata.genres
+                        else None
                     )
-                elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                    # update date_added if it changed
-                    library_item = await self.mass.music.podcasts.update_item_in_library(
-                        library_item.item_id, prov_item
+                    await self._sync_item_genres(
+                        MediaType.PODCAST,
+                        prov_item.item_id,
+                        int(library_item.item_id),
+                        fallback_genres,
                     )
-                if not library_item.favorite and prov_item.favorite:
-                    # existing library item not favorite but should be
-                    await self.mass.music.podcasts.set_favorite(library_item.item_id, True)
-                fallback_genres = (
-                    set(prov_item.metadata.genres)
-                    if prov_item.metadata and prov_item.metadata.genres
-                    else None
-                )
-                await self._sync_item_genres(
-                    MediaType.PODCAST,
-                    prov_item.item_id,
-                    int(library_item.item_id),
-                    fallback_genres,
-                )
                 cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
 
@@ -1362,24 +1388,26 @@ class MusicProvider(Provider):
                 prov_item.provider_mappings,
             )
             try:
-                if not library_item:
-                    # add item to the library
-                    for prov_map in prov_item.provider_mappings:
-                        prov_map.in_library = True
-                    library_item = await self.mass.music.radio.add_item_to_library(prov_item)
-                elif not self._check_provider_mappings(library_item, prov_item, True):
-                    # existing library item but provider mapping doesn't match
-                    library_item = await self.mass.music.radio.update_item_in_library(
-                        library_item.item_id, prov_item
-                    )
-                elif prov_item.date_added and library_item.date_added != prov_item.date_added:
-                    # update date_added if it changed
-                    library_item = await self.mass.music.radio.update_item_in_library(
-                        library_item.item_id, prov_item
-                    )
-                if not library_item.favorite and prov_item.favorite:
-                    # existing library item not favorite but should be
-                    await self.mass.music.radio.set_favorite(library_item.item_id, True)
+                # batch all writes for this item into a single commit
+                async with self.mass.music.database.deferred_commit():
+                    if not library_item:
+                        # add item to the library
+                        for prov_map in prov_item.provider_mappings:
+                            prov_map.in_library = True
+                        library_item = await self.mass.music.radio.add_item_to_library(prov_item)
+                    elif not self._check_provider_mappings(library_item, prov_item, True):
+                        # existing library item but provider mapping doesn't match
+                        library_item = await self.mass.music.radio.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    elif prov_item.date_added and library_item.date_added != prov_item.date_added:
+                        # update date_added if it changed
+                        library_item = await self.mass.music.radio.update_item_in_library(
+                            library_item.item_id, prov_item
+                        )
+                    if not library_item.favorite and prov_item.favorite:
+                        # existing library item not favorite but should be
+                        await self.mass.music.radio.set_favorite(library_item.item_id, True)
                 cur_db_ids.add(int(library_item.item_id))
                 await asyncio.sleep(0)  # yield to eventloop
 

--- a/tests/controllers/music/test_sync_commit_batching.py
+++ b/tests/controllers/music/test_sync_commit_batching.py
@@ -1,0 +1,89 @@
+"""Tests that library sync batches database writes into few commits."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import ProviderType
+
+from music_assistant.constants import CONF_LOG_LEVEL, DB_TABLE_ARTISTS, DB_TABLE_TRACKS
+from music_assistant.controllers.music import MusicController
+from music_assistant.providers.test import (
+    CONF_KEY_NUM_ALBUMS,
+    CONF_KEY_NUM_ARTISTS,
+    CONF_KEY_NUM_TRACKS,
+)
+from music_assistant.providers.test import TestProvider as FakeMusicProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from music_assistant.mass import MusicAssistant
+
+NUM_ARTISTS = 2
+NUM_ALBUMS = 2
+NUM_TRACKS = 3  # per album
+TOTAL_TRACKS = NUM_ARTISTS * NUM_ALBUMS * NUM_TRACKS
+
+
+@pytest.fixture
+async def music(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicController]:
+    """Return a music controller with initialized database on the minimal mass instance."""
+    controller = MusicController(mass_minimal)
+    mass_minimal.music = controller
+    await controller._setup_database()
+    yield controller
+    if controller._database:
+        await controller._database.close()
+
+
+@pytest.fixture
+def provider(mass_minimal: MusicAssistant) -> FakeMusicProvider:
+    """Return a fake music provider with a small deterministic library."""
+    manifest = MagicMock()
+    manifest.type = ProviderType.MUSIC
+    manifest.domain = "test"
+    config = MagicMock()
+    config.instance_id = "test--1"
+    config.domain = "test"
+    values = {
+        CONF_KEY_NUM_ARTISTS: NUM_ARTISTS,
+        CONF_KEY_NUM_ALBUMS: NUM_ALBUMS,
+        CONF_KEY_NUM_TRACKS: NUM_TRACKS,
+        CONF_LOG_LEVEL: "GLOBAL",
+    }
+    config.get_value.side_effect = lambda key, default=None: values.get(key, default)
+    return FakeMusicProvider(mass_minimal, manifest, config)
+
+
+async def test_track_sync_commits_once_per_item(
+    music: MusicController, provider: FakeMusicProvider
+) -> None:
+    """
+    Test that an initial track sync performs roughly one commit per synced item.
+
+    Adding a single track involves many statements (track row, provider mappings,
+    artists, album, album/track relations, genre mappings) which previously each
+    committed individually (6-10 commits per track).
+    """
+    commits = 0
+    original_commit = music.database._db.commit
+
+    async def counting_commit() -> None:
+        nonlocal commits
+        commits += 1
+        await original_commit()
+
+    music.database._db.commit = counting_commit  # type: ignore[method-assign]
+
+    cur_db_ids = await provider._sync_library_tracks()
+
+    # all tracks (and their artists/albums) actually landed in the library
+    assert len(cur_db_ids) == TOTAL_TRACKS
+    assert await music.database.get_count(DB_TABLE_TRACKS) == TOTAL_TRACKS
+    assert await music.database.get_count(DB_TABLE_ARTISTS) == NUM_ARTISTS
+    # every synced item is batched into a single commit
+    # (per-statement commits produce ~7x more here: 88 commits for these 12 tracks)
+    assert 0 < commits <= TOTAL_TRACKS + 2

--- a/tests/helpers/test_database_connection.py
+++ b/tests/helpers/test_database_connection.py
@@ -1,5 +1,6 @@
 """Tests for the DatabaseConnection helper."""
 
+import asyncio
 import os
 import pathlib
 from collections.abc import AsyncGenerator
@@ -25,6 +26,30 @@ async def db_connection(tmp_path: pathlib.Path) -> AsyncGenerator[DatabaseConnec
     await db.setup()
     yield db
     await db.close()
+
+
+@pytest.fixture
+async def db_with_table(db_connection: DatabaseConnection) -> DatabaseConnection:
+    """Return an initialized DatabaseConnection with a simple test table."""
+    await db_connection.execute(
+        "CREATE TABLE items(id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "name TEXT NOT NULL UNIQUE, url TEXT, plays INTEGER)"
+    )
+    await db_connection.commit()
+    return db_connection
+
+
+def _count_commits(db: DatabaseConnection) -> list[None]:
+    """Wrap the raw connection commit so every commit appends to the returned list."""
+    calls: list[None] = []
+    original_commit = db._db.commit
+
+    async def counting_commit() -> None:
+        calls.append(None)
+        await original_commit()
+
+    db._db.commit = counting_commit  # type: ignore[method-assign]
+    return calls
 
 
 async def _get_temp_store(db: DatabaseConnection) -> int:
@@ -151,3 +176,138 @@ async def test_setup_clamps_pragma_values(tmp_path: pathlib.Path) -> None:
         assert await _read_pragma_int(db, "mmap_size") == 0
     finally:
         await db.close()
+
+
+async def test_deferred_commit_batches_writes_into_single_commit(
+    db_with_table: DatabaseConnection,
+) -> None:
+    """Test that writes within a deferred_commit scope result in one commit at scope exit."""
+    commits = _count_commits(db_with_table)
+    async with db_with_table.deferred_commit():
+        for i in range(10):
+            await db_with_table.insert("items", {"name": f"item{i}"})
+        await db_with_table.update("items", {"name": "item0"}, {"url": "http://test"})
+        await db_with_table.delete("items", {"name": "item9"})
+        assert len(commits) == 0
+    assert len(commits) == 1
+    assert len(await db_with_table.get_rows("items")) == 9
+
+
+async def test_deferred_commit_nested_scopes_commit_once(
+    db_with_table: DatabaseConnection,
+) -> None:
+    """Test that nested deferred_commit scopes only commit when the outermost scope exits."""
+    commits = _count_commits(db_with_table)
+    async with db_with_table.deferred_commit():
+        await db_with_table.insert("items", {"name": "outer"})
+        async with db_with_table.deferred_commit():
+            await db_with_table.insert("items", {"name": "inner"})
+        assert len(commits) == 0
+    assert len(commits) == 1
+    assert len(await db_with_table.get_rows("items")) == 2
+
+
+async def test_deferred_commit_commits_pending_writes_on_error(
+    db_with_table: DatabaseConnection,
+) -> None:
+    """Test that a deferred_commit scope commits (not rolls back) already executed writes."""
+
+    async def write_and_fail() -> None:
+        async with db_with_table.deferred_commit():
+            await db_with_table.insert("items", {"name": "kept"})
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        await write_and_fail()
+    assert await db_with_table.get_row("items", {"name": "kept"}) is not None
+
+
+async def test_deferred_commit_commits_on_cancellation(
+    db_with_table: DatabaseConnection,
+) -> None:
+    """Test that cancelling a task inside a scope commits its writes and keeps the db usable."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def writer() -> None:
+        async with db_with_table.deferred_commit():
+            await db_with_table.insert("items", {"name": "written-before-cancel"})
+            started.set()
+            await release.wait()
+
+    task = asyncio.get_running_loop().create_task(writer())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not db_with_table._db.in_transaction
+    assert await db_with_table.get_row("items", {"name": "written-before-cancel"}) is not None
+    # the connection remains fully usable for subsequent writes
+    await db_with_table.insert("items", {"name": "after-cancel"})
+    assert await db_with_table.get_row("items", {"name": "after-cancel"}) is not None
+
+
+async def test_deferred_commit_scope_only_defers_own_task(
+    db_with_table: DatabaseConnection,
+) -> None:
+    """Test that writes from tasks outside a scope still commit immediately."""
+    commits = _count_commits(db_with_table)
+    in_scope = asyncio.Event()
+    release = asyncio.Event()
+
+    async def scoped_writer() -> None:
+        async with db_with_table.deferred_commit():
+            await db_with_table.insert("items", {"name": "scoped"})
+            in_scope.set()
+            await release.wait()
+
+    task = asyncio.get_running_loop().create_task(scoped_writer())
+    await in_scope.wait()
+    # this write happens on the test task (no scope) while the writer's scope is open
+    commits_before = len(commits)
+    await db_with_table.insert("items", {"name": "plain"})
+    assert len(commits) == commits_before + 1
+    release.set()
+    await task
+    assert len(await db_with_table.get_rows("items")) == 2
+
+
+async def test_update_returns_none(db_with_table: DatabaseConnection) -> None:
+    """Test that update() no longer fetches and returns the updated row."""
+    row_id = await db_with_table.insert("items", {"name": "old"})
+    result = await db_with_table.update("items", {"id": row_id}, {"name": "new"})  # type: ignore[func-returns-value]
+    assert result is None
+    row = await db_with_table.get_row("items", {"id": row_id})
+    assert row is not None
+    assert row["name"] == "new"
+
+
+async def test_upsert_many(db_with_table: DatabaseConnection) -> None:
+    """Test that upsert_many inserts/updates multiple rows with a single commit."""
+    commits = _count_commits(db_with_table)
+    # rows with different column sets are handled in a single call
+    await db_with_table.upsert_many(
+        "items",
+        [
+            {"name": "a", "url": "http://a", "plays": 1},
+            {"name": "b", "plays": 2},
+            {"name": "c", "plays": 3},
+        ],
+    )
+    assert len(commits) == 1
+    rows = {row["name"]: row for row in await db_with_table.get_rows("items")}
+    assert len(rows) == 3
+    assert rows["a"]["url"] == "http://a"
+    # upserting again updates on conflict; omitted columns keep their existing value
+    await db_with_table.upsert_many("items", [{"name": "a", "plays": 10}])
+    row = await db_with_table.get_row("items", {"name": "a"})
+    assert row is not None
+    assert row["plays"] == 10
+    assert row["url"] == "http://a"
+
+
+async def test_upsert_many_empty_is_noop(db_with_table: DatabaseConnection) -> None:
+    """Test that upsert_many with no rows does nothing."""
+    commits = _count_commits(db_with_table)
+    await db_with_table.upsert_many("items", [])
+    assert len(commits) == 0

--- a/tests/helpers/test_database_connection.py
+++ b/tests/helpers/test_database_connection.py
@@ -272,6 +272,29 @@ async def test_deferred_commit_scope_only_defers_own_task(
     assert len(await db_with_table.get_rows("items")) == 2
 
 
+async def test_deferred_commit_concurrent_scopes_do_not_interfere(
+    db_with_table: DatabaseConnection,
+) -> None:
+    """Test that concurrent tasks (e.g. parallel syncs) each batch their own writes."""
+    commits = _count_commits(db_with_table)
+    barrier = asyncio.Barrier(2)
+
+    async def sync_task(name: str) -> None:
+        async with db_with_table.deferred_commit():
+            await db_with_table.insert("items", {"name": f"{name}-1"})
+            # force both scopes to be open at the same time
+            await barrier.wait()
+            await db_with_table.insert("items", {"name": f"{name}-2"})
+
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(sync_task("a"))
+        tg.create_task(sync_task("b"))
+
+    # all writes from both tasks landed, with one commit per scope exit
+    assert len(await db_with_table.get_rows("items")) == 4
+    assert len(commits) == 2
+
+
 async def test_update_returns_none(db_with_table: DatabaseConnection) -> None:
     """Test that update() no longer fetches and returns the updated row."""
     row_id = await db_with_table.insert("items", {"name": "old"})

--- a/tests/test_dynamic_playlist_framework.py
+++ b/tests/test_dynamic_playlist_framework.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, Mock, patch
 
 from music_assistant_models.enums import MediaType
@@ -22,6 +23,12 @@ def _controller() -> MetaDataController:
 def _provider() -> MusicProvider:
     """Create a bare MusicProvider without running __init__."""
     return MusicProvider.__new__(MusicProvider)
+
+
+@asynccontextmanager
+async def _noop_deferred_commit() -> AsyncGenerator[None]:
+    """Stand-in for DatabaseConnection.deferred_commit on mocked databases."""
+    yield
 
 
 def _provider_mapping(item_id: str = "station_1") -> ProviderMapping:
@@ -136,6 +143,7 @@ def _build_sync_fixture(
 
     mass = Mock()
     mass.music.playlists = playlists_ctrl
+    mass.music.database.deferred_commit = _noop_deferred_commit
 
     provider = _provider()
     provider.mass = mass

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
@@ -74,6 +76,12 @@ def create_mock_album(
     album.favorite = favorite
     album.provider_mappings = UniqueList(provider_mappings or [])
     return album
+
+
+@asynccontextmanager
+async def _noop_deferred_commit() -> AsyncGenerator[None]:
+    """Stand-in for DatabaseConnection.deferred_commit on mocked databases."""
+    yield
 
 
 # --- Group 1: Optimistic in_library on add ---
@@ -793,7 +801,7 @@ def mock_controller() -> Mock:
     ctrl.media_type = MediaType.ALBUM
     ctrl.mass = Mock()
     ctrl.mass.music.database.delete = AsyncMock()
-    ctrl.mass.music.database.upsert = AsyncMock()
+    ctrl.mass.music.database.upsert_many = AsyncMock()
     ctrl.set_provider_mappings = MediaControllerBase.set_provider_mappings.__get__(ctrl)
     return ctrl
 
@@ -811,7 +819,7 @@ async def test_set_provider_mappings_overwrite_deletes_and_reinserts(
     await mock_controller.set_provider_mappings(1, [mapping], overwrite=True)
 
     mock_controller.mass.music.database.delete.assert_called_once()
-    mock_controller.mass.music.database.upsert.assert_called_once()
+    mock_controller.mass.music.database.upsert_many.assert_called_once()
 
 
 async def test_set_provider_mappings_upsert_preserves_null_in_library(
@@ -829,9 +837,10 @@ async def test_set_provider_mappings_upsert_preserves_null_in_library(
 
     await mock_controller.set_provider_mappings(1, [mapping], overwrite=False)
 
-    upsert_call = mock_controller.mass.music.database.upsert.call_args
-    upsert_dict = upsert_call[0][1]
-    assert "in_library" not in upsert_dict
+    upsert_call = mock_controller.mass.music.database.upsert_many.call_args
+    upsert_rows = upsert_call[0][1]
+    assert len(upsert_rows) == 1
+    assert "in_library" not in upsert_rows[0]
 
 
 async def test_set_provider_mappings_upsert_writes_explicit_in_library(
@@ -848,9 +857,10 @@ async def test_set_provider_mappings_upsert_writes_explicit_in_library(
 
     await mock_controller.set_provider_mappings(1, [mapping], overwrite=False)
 
-    upsert_call = mock_controller.mass.music.database.upsert.call_args
-    upsert_dict = upsert_call[0][1]
-    assert upsert_dict["in_library"] is True
+    upsert_call = mock_controller.mass.music.database.upsert_many.call_args
+    upsert_rows = upsert_call[0][1]
+    assert len(upsert_rows) == 1
+    assert upsert_rows[0]["in_library"] is True
 
 
 # --- Group 6: library_items filtering ---
@@ -1067,6 +1077,7 @@ async def test_update_item_in_library_skips_non_music_providers() -> None:
     mass = Mock()
     mass.music = Mock()
     mass.music.match_provider_instances = Mock()
+    mass.music.database.deferred_commit = _noop_deferred_commit
     mass.signal_event = Mock()
     mass.get_provider = Mock(return_value=Mock(type=ProviderType.PLUGIN))
     ctrl.mass = mass
@@ -1092,6 +1103,7 @@ def _create_event_capture_controller(
     """Build a controller mock with real add/update methods bound; events records signalled types."""
     mass = Mock()
     mass.signal_event = Mock(side_effect=lambda event, *_args, **_kwargs: events.append(event))
+    mass.music.database.deferred_commit = _noop_deferred_commit
     ctrl = Mock(spec=MediaControllerBase)
     ctrl.mass = mass
     ctrl._db_add_lock = asyncio.Lock()


### PR DESCRIPTION
# What does this implement/fix?

Reduce SQLite commit overhead during library sync. Every database write helper commits per statement, so adding a single track during a sync spans 6-10 individual WAL commits (track row, each provider mapping, artist/album records and relation tables, genre mappings), plus `update()` re-selected the full row after every update while no caller uses that result. On an initial sync of a large library this adds up to significant overhead, and write amplification on SD-card based installs.

Changes:

- New `DatabaseConnection.deferred_commit()` scope that batches all writes of the current task into a single commit at scope exit. Deliberately **not** a rollback transaction: the connection is shared by all tasks, so a rollback could revert interleaved statements from concurrent writers - the scope always commits on exit (also on error/cancellation), matching the previous per-statement commit semantics. Writes from tasks outside a scope are unaffected and still commit immediately.
- The library sync loops wrap each item's writes in such a scope (one commit per synced item). `add_item_to_library`, `update_item_in_library` and the genre sync carry their own scope as well (nested scopes are no-ops), so non-sync callers like favorites also benefit.
- `set_provider_mappings` now writes all mappings with a single `upsert_many` (executemany) instead of one upsert+commit per mapping.
- `DatabaseConnection.update()` no longer re-selects and returns the updated row.

Measured on the new regression test: an initial sync of a small test library (tracks incl. artists/albums/genres) went from 88 commits to 12 (one per synced item).

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
