### PR TITLE
Remove per-track config rebuild overhead

### DIFF
--- a/music_assistant/controllers/config/core.py
+++ b/music_assistant/controllers/config/core.py
@@ -64,9 +64,8 @@ class CoreConfigMixin:
             raw_conf = {}
         if "domain" not in raw_conf:
             raw_conf = {**raw_conf, "domain": domain}
-        # build the schema straight from the controller (no dynamic UI options): CoreConfig.parse
-        # stamps the translation owner itself, and this path must stay cheap because it runs on the
-        # config-value fall-through (get_core_config_value), a hot path on enqueue.
+        # build the schema straight from the controller (no dynamic UI options):
+        # CoreConfig.parse stamps the translation owner itself
         controller: CoreController = getattr(self.mass, domain)
         config_entries = list(await controller.get_config_entries() + DEFAULT_CORE_CONFIG_ENTRIES)
         return cast("CoreConfig", CoreConfig.parse(config_entries, raw_conf))
@@ -238,3 +237,8 @@ class CoreConfigMixin:
             # create base object first if needed
             self.set(f"{CONF_CORE}/{core_module}", CoreConfig({}, core_module).to_raw())
         self.set(f"{CONF_CORE}/{core_module}/values/{key}", value)
+        # also update the controller's in-place config copy (if any) so
+        # object-local value reads stay in sync with raw writes
+        controller = getattr(self.mass, core_module, None)
+        if (config := getattr(controller, "config", None)) and (entry := config.values.get(key)):
+            entry.value = value

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -533,6 +533,12 @@ class PlayerConfigMixin:
             self.set(f"{CONF_PLAYERS}/{player_id}/{key}", value)
         else:
             self.set(f"{CONF_PLAYERS}/{player_id}/values/{key}", value)
+            # also update the player's in-place config copy so object-local
+            # value reads stay in sync with raw writes
+            if (player := self.mass.players.get_player(player_id, False)) and (
+                entry := player.config.values.get(key)
+            ):
+                entry.value = value
 
     async def _get_player_config_entries(
         self,

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -413,6 +413,12 @@ class ProviderConfigMixin:
             self.set(f"{CONF_PROVIDERS}/{provider_instance}/{key}", value)
             return
         self.set(f"{CONF_PROVIDERS}/{provider_instance}/values/{key}", value)
+        # also update the provider's in-place config copy (if loaded) so
+        # object-local value reads stay in sync with raw writes
+        if (provider := self.mass.get_provider(provider_instance)) and (
+            entry := provider.config.values.get(key)
+        ):
+            entry.value = value
 
     @api_command("config/providers/reload", required_role="admin")
     async def _reload_provider(self, instance_id: str) -> None:

--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -613,11 +613,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                         config_key = CONF_DEFAULT_ENQUEUE_OPTION_LIVE_SOURCES
                     else:
                         config_key = f"default_enqueue_option_{media_item.media_type.value}"
-                    config_value = await self.mass.config.get_core_config_value(
-                        self.domain,
-                        config_key,
-                        return_type=str,
-                    )
+                    config_value = cast("str", self.config.get_value(config_key))
                     option = QueueOption(config_value)
                     if option == QueueOption.REPLACE:
                         self.clear(queue_id, skip_stop=True)

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -61,7 +61,9 @@ from music_assistant.constants import (
     CONF_VOLUME_NORMALIZATION,
     CONF_VOLUME_NORMALIZATION_FIXED_GAIN_RADIO,
     CONF_VOLUME_NORMALIZATION_FIXED_GAIN_TRACKS,
+    CONF_VOLUME_NORMALIZATION_RADIO,
     CONF_VOLUME_NORMALIZATION_TARGET,
+    CONF_VOLUME_NORMALIZATION_TRACKS,
     FLOW_MODE_SAMPLE_RATE_48000,
     FLOW_MODE_SAMPLE_RATE_96000,
     FLOW_MODE_SAMPLE_RATE_BIT_PERFECT,
@@ -357,9 +359,8 @@ class StreamsAudio:
         streamdetails.fade_in = fade_in
 
         streamdetails.prefer_album_loudness = prefer_album_loudness
-        core_config = await mass.config.get_core_config("streams")
         conf_volume_normalization_target = float(
-            str(core_config.get_value(CONF_VOLUME_NORMALIZATION_TARGET, -14))
+            str(mass.streams.config.get_value(CONF_VOLUME_NORMALIZATION_TARGET, -14))
         )
         # guard against invalid volume normalization values
         # range and default_value are guaranteed to be set for this constant
@@ -384,7 +385,9 @@ class StreamsAudio:
             != CONF_VALUE_DISABLED
         )
         streamdetails.volume_normalization_mode = get_normalization_mode(
-            core_config, volume_normalization_enabled, streamdetails
+            self._get_volume_normalization_preference(streamdetails),
+            volume_normalization_enabled,
+            streamdetails,
         )
 
         # attach the DSP details of all group members
@@ -1512,7 +1515,6 @@ class StreamsAudio:
             # re-evaluate normalization mode: the background loudness analyzer may have
             # updated streamdetails.loudness since get_stream_details was called
             if streamdetails.queue_id:
-                core_config = await self.mass.config.get_core_config("streams")
                 volume_normalization_enabled = (
                     self.mass.config.get_effective_player_queue_config_value(
                         streamdetails.queue_id, CONF_VOLUME_NORMALIZATION, CONF_VALUE_ENABLED
@@ -1520,7 +1522,9 @@ class StreamsAudio:
                     != CONF_VALUE_DISABLED
                 )
                 streamdetails.volume_normalization_mode = get_normalization_mode(
-                    core_config, volume_normalization_enabled, streamdetails
+                    self._get_volume_normalization_preference(streamdetails),
+                    volume_normalization_enabled,
+                    streamdetails,
                 )
 
         # handle volume normalization
@@ -1537,9 +1541,7 @@ class StreamsAudio:
                 if streamdetails.media_type == MediaType.TRACK
                 else CONF_VOLUME_NORMALIZATION_FIXED_GAIN_RADIO
             )
-            gain_value = await self.mass.config.get_core_config_value(
-                "streams", config_key, default=0.0, return_type=float
-            )
+            gain_value = float(str(self.mass.streams.config.get_value(config_key, 0.0)))
             gain_correct = round(gain_value, 2)
             filter_params.append(f"volume={gain_correct}dB")
         elif streamdetails.volume_normalization_mode == VolumeNormalizationMode.MEASUREMENT_ONLY:
@@ -2601,6 +2603,23 @@ class StreamsAudio:
             await writer.wait_closed()
 
     # --- Private methods ---
+
+    def _get_volume_normalization_preference(
+        self, streamdetails: StreamDetails
+    ) -> VolumeNormalizationMode:
+        """Return the configured normalization preference for the stream's media type."""
+        conf_key = (
+            CONF_VOLUME_NORMALIZATION_RADIO
+            if streamdetails.media_type == MediaType.RADIO
+            else CONF_VOLUME_NORMALIZATION_TRACKS
+        )
+        return VolumeNormalizationMode(
+            str(
+                self.mass.streams.config.get_value(
+                    conf_key, VolumeNormalizationMode.FALLBACK_DYNAMIC.value
+                )
+            )
+        )
 
     def _update_radio_stream_metadata(
         self,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -660,9 +660,7 @@ class StreamsController(CoreController):
 
             resp = web.StreamResponse(status=200, reason="OK", headers=headers)
             resp.content_type = get_mime_type(output_format.output_format_str)
-            http_profile = await self.mass.config.get_player_config_value(
-                player_id, CONF_HTTP_PROFILE, default="default", return_type=str
-            )
+            http_profile = cast("str", player.config.get_value(CONF_HTTP_PROFILE, "default"))
             if http_profile == "forced_content_length" and not queue_item.duration:
                 # just set an insane high content length to make sure the player keeps playing
                 resp.content_length = calculate_content_length(output_format, 12 * 3600)
@@ -907,9 +905,7 @@ class StreamsController(CoreController):
             headers["icy-metaint"] = str(icy_meta_interval)
 
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
-        http_profile = await self.mass.config.get_player_config_value(
-            player_id, CONF_HTTP_PROFILE, default="default", return_type=str
-        )
+        http_profile = cast("str", player.config.get_value(CONF_HTTP_PROFILE, "default"))
         if http_profile == "forced_content_length":
             # just set an insane high content length to make sure the player keeps playing
             resp.content_length = calculate_content_length(output_format, 12 * 3600)
@@ -1009,8 +1005,11 @@ class StreamsController(CoreController):
         fmt = request.match_info["fmt"]
         audio_format = AudioFormat(content_type=ContentType.try_parse(fmt))
 
-        http_profile = await self.mass.config.get_player_config_value(
-            player_id, CONF_HTTP_PROFILE, default="default", return_type=str
+        mass_player = self.mass.players.get_player(player_id)
+        http_profile = (
+            cast("str", mass_player.config.get_value(CONF_HTTP_PROFILE, "default"))
+            if mass_player
+            else "default"
         )
         if http_profile == "forced_content_length":
             # given the fact that an announcement is just a short audio clip,

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -23,8 +23,6 @@ from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.streamdetails import MultiPartPath
 
 from music_assistant.constants import (
-    CONF_VOLUME_NORMALIZATION_RADIO,
-    CONF_VOLUME_NORMALIZATION_TRACKS,
     MASS_LOGGER_NAME,
     VERBOSE_LOG_LEVEL,
 )
@@ -34,7 +32,6 @@ from .ffmpeg import get_ffmpeg_stream
 from .process import AsyncProcess, communicate
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import CoreConfig
     from music_assistant_models.media_items import AudioFormat
     from music_assistant_models.streamdetails import StreamDetails
 
@@ -712,14 +709,15 @@ def parse_loudnorm(raw_stderr: bytes | str) -> float | None:
 
 
 def get_normalization_mode(
-    core_config: CoreConfig,
+    preference: VolumeNormalizationMode,
     volume_normalization_enabled: bool,
     streamdetails: StreamDetails,
 ) -> VolumeNormalizationMode:
     """
     Get the volume normalization mode for a given queue and stream.
 
-    :param core_config: The streams core config (holds the radio/tracks normalization preferences).
+    :param preference: The configured normalization preference for the stream's media type
+        (tracks or radio), from the streams core config.
     :param volume_normalization_enabled: Whether normalization is enabled for the queue, already
         resolved from the per-queue setting and its global (queue controller) fallback.
     :param streamdetails: The stream to evaluate.
@@ -733,16 +731,6 @@ def get_normalization_mode(
     if streamdetails.target_loudness is None:
         # no target loudness set, disable normalization
         return VolumeNormalizationMode.DISABLED
-    # work out preference for track or radio
-    preference = VolumeNormalizationMode(
-        str(
-            core_config.get_value(
-                CONF_VOLUME_NORMALIZATION_RADIO
-                if streamdetails.media_type == MediaType.RADIO
-                else CONF_VOLUME_NORMALIZATION_TRACKS,
-            ),
-        ),
-    )
 
     # handle no measurement available but fallback to dynamic mode is allowed
     if streamdetails.loudness is None and preference == VolumeNormalizationMode.FALLBACK_DYNAMIC:

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -869,67 +869,102 @@ def clean_stream_title(line: str) -> str:
     return line
 
 
-async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
-    """Return all IP-adresses of all network interfaces."""
+# cache for get_ip_addresses: enumerating the network adapters involves a thread hop,
+# socket probes and a full adapter walk, while the result rarely (if ever) changes
+IP_ADDRESSES_CACHE_TTL = 30
+_ip_addresses_cache: dict[bool, tuple[float, tuple[str, ...]]] = {}
+_ip_addresses_pending: dict[bool, asyncio.Task[tuple[str, ...]]] = {}
 
-    def call() -> tuple[str, ...]:
-        result: list[tuple[int, str]] = []
-        # try to get the primary IP address
-        # this is the IP address of the default route
-        primary_ip = ""
-        # try IPv4 first
-        _sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        _sock.settimeout(0)
+
+async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
+    """
+    Return all IP-adresses of all network interfaces.
+
+    Results are cached for a short while, so an IP/interface change may take up to
+    IP_ADDRESSES_CACHE_TTL seconds to be reflected.
+
+    :param include_ipv6: Whether to include IPv6 addresses in the result.
+    """
+    if cached := _ip_addresses_cache.get(include_ipv6):
+        cached_at, addresses = cached
+        if (time.monotonic() - cached_at) < IP_ADDRESSES_CACHE_TTL:
+            return addresses
+
+    async def _probe() -> tuple[str, ...]:
         try:
-            # doesn't even have to be reachable
-            _sock.connect(("10.254.254.254", 1))
-            primary_ip = _sock.getsockname()[0]
+            addresses = await asyncio.to_thread(_enumerate_ip_addresses, include_ipv6)
+            _ip_addresses_cache[include_ipv6] = (time.monotonic(), addresses)
+            return addresses
+        finally:
+            _ip_addresses_pending.pop(include_ipv6, None)
+
+    # single-flight: no await between the pending-check and storing the task,
+    # so concurrent callers always end up awaiting the same probe
+    if not (pending := _ip_addresses_pending.get(include_ipv6)):
+        pending = asyncio.create_task(_probe())
+        _ip_addresses_pending[include_ipv6] = pending
+    # shield the shared probe: a caller awaiting a task holds it as its fut_waiter,
+    # so cancelling that caller would otherwise cancel the probe for all other callers
+    return await asyncio.shield(pending)
+
+
+def _enumerate_ip_addresses(include_ipv6: bool) -> tuple[str, ...]:
+    """Enumerate all IP-adresses of all network interfaces (blocking)."""
+    result: list[tuple[int, str]] = []
+    # try to get the primary IP address
+    # this is the IP address of the default route
+    primary_ip = ""
+    # try IPv4 first
+    _sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    _sock.settimeout(0)
+    try:
+        # doesn't even have to be reachable
+        _sock.connect(("10.254.254.254", 1))
+        primary_ip = _sock.getsockname()[0]
+    except Exception:
+        primary_ip = ""
+    finally:
+        _sock.close()
+    # fall back to IPv6 if no IPv4 primary found (e.g. IPv6-only networks)
+    if not primary_ip:
+        _sock6 = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        _sock6.settimeout(0)
+        try:
+            _sock6.connect(("2001:db8::1", 1))
+            primary_ip = _sock6.getsockname()[0]
         except Exception:
             primary_ip = ""
         finally:
-            _sock.close()
-        # fall back to IPv6 if no IPv4 primary found (e.g. IPv6-only networks)
-        if not primary_ip:
-            _sock6 = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-            _sock6.settimeout(0)
-            try:
-                _sock6.connect(("2001:db8::1", 1))
-                primary_ip = _sock6.getsockname()[0]
-            except Exception:
-                primary_ip = ""
-            finally:
-                _sock6.close()
-        # get all IP addresses of all network interfaces
-        adapters = ifaddr.get_adapters()
-        for adapter in adapters:
-            for ip in adapter.ips:
-                if ip.is_IPv6 and not include_ipv6:
-                    continue
-                # ifaddr returns IPv6 addresses as (address, flowinfo, scope_id) tuples
-                ip_str = ip.ip[0] if isinstance(ip.ip, tuple) else ip.ip
-                if ip_str.startswith(("127", "169.254")):
-                    # filter out IPv4 loopback/APIPA address
-                    continue
-                if ip_str.startswith(("::1", "::ffff:", "fe80")):
-                    # filter out IPv6 loopback/link-local address
-                    continue
-                if ip_str == primary_ip:
-                    score = 10
-                elif ip_str.startswith(("192.168.",)):
-                    # we rank the 192.168 range a bit higher as its most
-                    # often used as the private network subnet
-                    score = 2
-                elif ip_str.startswith(("172.", "10.", "192.")):
-                    # we rank the 172 range a bit lower as its most
-                    # often used as the private docker network
-                    score = 1
-                else:
-                    score = 0
-                result.append((score, ip_str))
-        result.sort(key=lambda x: x[0], reverse=True)
-        return tuple(ip[1] for ip in result)
-
-    return await asyncio.to_thread(call)
+            _sock6.close()
+    # get all IP addresses of all network interfaces
+    adapters = ifaddr.get_adapters()
+    for adapter in adapters:
+        for ip in adapter.ips:
+            if ip.is_IPv6 and not include_ipv6:
+                continue
+            # ifaddr returns IPv6 addresses as (address, flowinfo, scope_id) tuples
+            ip_str = ip.ip[0] if isinstance(ip.ip, tuple) else ip.ip
+            if ip_str.startswith(("127", "169.254")):
+                # filter out IPv4 loopback/APIPA address
+                continue
+            if ip_str.startswith(("::1", "::ffff:", "fe80")):
+                # filter out IPv6 loopback/link-local address
+                continue
+            if ip_str == primary_ip:
+                score = 10
+            elif ip_str.startswith(("192.168.",)):
+                # we rank the 192.168 range a bit higher as its most
+                # often used as the private network subnet
+                score = 2
+            elif ip_str.startswith(("172.", "10.", "192.")):
+                # we rank the 172 range a bit lower as its most
+                # often used as the private docker network
+                score = 1
+            else:
+                score = 0
+            result.append((score, ip_str))
+    result.sort(key=lambda x: x[0], reverse=True)
+    return tuple(ip[1] for ip in result)
 
 
 def interface_name_for_ip(ip: str) -> str | None:

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -208,7 +208,11 @@ class MusicAssistant:
 
         # setup all core controllers in parallel
         async def setup_controller(controller: CoreController) -> None:
-            await controller.setup(await self.config.get_core_config(controller.domain))
+            config = await self.config.get_core_config(controller.domain)
+            # keep the active config on the controller so internal code can read
+            # config values without rebuilding the config entries
+            controller.config = config
+            await controller.setup(config)
             controller.initialized.set()
 
         # set up the translations catalog first so it is ready before any object is serialized
@@ -236,7 +240,9 @@ class MusicAssistant:
 
         # load webserver/api now that the core controllers are setup and ready to be used
         self._register_api_commands()
-        await self.webserver.setup(await self.config.get_core_config("webserver"))
+        webserver_config = await self.config.get_core_config("webserver")
+        self.webserver.config = webserver_config
+        await self.webserver.setup(webserver_config)
         await setup_controller(self.discovery)
         # load builtin providers (always needed, also in safe mode)
         await self._load_builtin_providers()

--- a/music_assistant/models/core_controller.py
+++ b/music_assistant/models/core_controller.py
@@ -22,6 +22,10 @@ class CoreController:
 
     domain: str  # used as identifier (=name of the module)
     manifest: ProviderManifest  # some info for the UI only
+    # config: the controller's active configuration, assigned at startup/reload and kept
+    # up to date by the config controller, so internal code can read config values
+    # (including entry defaults) without rebuilding the config entries
+    config: CoreConfig
 
     def __init__(self, mass: MusicAssistant) -> None:
         """Initialize core controller."""
@@ -69,6 +73,7 @@ class CoreController:
             config = await self.mass.config.get_core_config(self.domain)
         log_level = str(config.get_value(CONF_LOG_LEVEL))
         self._set_logger(log_level)
+        self.config = config
         await self.setup(config)
         await self.post_setup()
 

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -198,9 +198,8 @@ class Provider:
 
     def _update_config_value(self, key: str, value: Any, encrypted: bool = False) -> None:
         """Update a config value."""
+        # the config controller also updates the cached copy within this provider instance
         self.mass.config.set_raw_provider_config_value(self.instance_id, key, value, encrypted)
-        # also update the cached copy within the provider instance
-        self.config.values[key].value = value
 
     def _set_log_level_from_config(self, config: ProviderConfig) -> None:
         """Set log level from config."""

--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -255,9 +255,7 @@ class DLNAPlayer(Player):
         """Send PAUSE command to given player."""
         assert self.device is not None  # for type checking
 
-        replace_pause_with_stop: bool = await self.mass.config.get_player_config_value(
-            self.player_id, "replace_pause_with_stop"
-        )
+        replace_pause_with_stop = bool(self.config.get_value("replace_pause_with_stop"))
 
         if replace_pause_with_stop and self.device.can_stop:
             await self.stop()

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -652,21 +652,13 @@ class MusicCastPlayer(Player):
             return
 
         # skip zone handling if disabled via setting
-        if bool(
-            await self.mass.config.get_player_config_value(
-                player_id, CONF_PLAYER_HANDLE_SOURCE_DISABLED
-            )
-        ):
+        if bool(mass_player.config.get_value(CONF_PLAYER_HANDLE_SOURCE_DISABLED)):
             self.logger.debug("Ignoring zone handling for player %s.", player_id)
             return
 
         self.logger.debug("Handling zone for player %s.", player_id)
 
-        _source = str(
-            await self.mass.config.get_player_config_value(
-                player_id, CONF_PLAYER_SWITCH_SOURCE_NON_NET
-            )
-        )
+        _source = str(mass_player.config.get_value(CONF_PLAYER_SWITCH_SOURCE_NON_NET))
         # verify that this source actually exists and is non net
         _allowed_sources = self._get_allowed_sources_zone_switch(zone_player)
         if _source not in _allowed_sources:
@@ -681,9 +673,7 @@ class MusicCastPlayer(Player):
             _source = _allowed_sources.pop()
 
         await mass_player.select_source(_source)
-        _turn_off = bool(
-            await self.mass.config.get_player_config_value(player_id, CONF_PLAYER_TURN_OFF_ON_LEAVE)
-        )
+        _turn_off = bool(mass_player.config.get_value(CONF_PLAYER_TURN_OFF_ON_LEAVE))
         if _turn_off:
             await asyncio.sleep(2)
             await mass_player.power(powered=False)

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from copy import deepcopy
 from time import time
 from typing import TYPE_CHECKING, cast
@@ -588,12 +587,11 @@ class UniversalGroupPlayer(Player):
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
         http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
         # prefer the child (protocol) player configuration
-        if child_player_id:
-            # player_id may be stale/invalid; fall back to the group profile
-            with contextlib.suppress(KeyError):
-                http_profile = await self.mass.config.get_player_config_value(
-                    child_player_id, CONF_HTTP_PROFILE, default=http_profile, return_type=str
-                )
+        # (child player_id may be stale/invalid; fall back to the group profile)
+        if child_player_id and (child_player := self.mass.players.get_player(child_player_id)):
+            http_profile = cast(
+                "str", child_player.config.get_value(CONF_HTTP_PROFILE, http_profile)
+            )
         if http_profile == "chunked" and request.version < HttpVersion11:
             # chunked encoding is not allowed on HTTP/1.0; fall back to
             # connection-close streaming to avoid raising in resp.prepare()

--- a/tests/controllers/config/test_config_copy_lifecycle.py
+++ b/tests/controllers/config/test_config_copy_lifecycle.py
@@ -1,0 +1,117 @@
+"""Tests for the in-place config copies staying in sync with raw config writes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
+
+from music_assistant_models.config_entries import (
+    ConfigEntry,
+    CoreConfig,
+    PlayerConfig,
+    ProviderConfig,
+)
+from music_assistant_models.enums import ConfigEntryType, PlayerType, ProviderType
+
+from music_assistant.constants import CONF_PROVIDERS, CONF_VOLUME_NORMALIZATION_TARGET
+
+if TYPE_CHECKING:
+    from music_assistant.mass import MusicAssistant
+
+CORE_DOMAIN = "faketestcore"
+PLAYER_ID = "test_copy_player"
+PROVIDER_INSTANCE = "test_copy_provider"
+
+
+def _entry(key: str, entry_type: ConfigEntryType, default: object) -> ConfigEntry:
+    return ConfigEntry(key=key, type=entry_type, default_value=default, required=False)  # type: ignore[arg-type]
+
+
+async def test_core_controllers_hold_active_config(mass: MusicAssistant) -> None:
+    """At startup every core controller holds its active (parsed) config."""
+    assert mass.streams.config.get_value(CONF_VOLUME_NORMALIZATION_TARGET) == -14
+    assert mass.webserver.config.domain == "webserver"
+    assert mass.player_queues.config.domain == "player_queues"
+
+
+async def test_set_raw_core_config_value_updates_controller_copy(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A raw core config write is reflected in the controller's in-place config copy."""
+    controller = SimpleNamespace(
+        config=cast(
+            "CoreConfig",
+            CoreConfig.parse(
+                [_entry("magic_number", ConfigEntryType.INTEGER, 42)], {"domain": CORE_DOMAIN}
+            ),
+        )
+    )
+    setattr(mass_minimal, CORE_DOMAIN, controller)
+    mass_minimal.config.set_raw_core_config_value(CORE_DOMAIN, "magic_number", 5)
+    assert controller.config.get_value("magic_number") == 5
+    assert mass_minimal.config.get_raw_core_config_value(CORE_DOMAIN, "magic_number") == 5
+
+
+async def test_set_raw_core_config_value_without_controller_copy(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """Raw core config writes for a module without an (initialized) controller still work."""
+    mass_minimal.config.set_raw_core_config_value("nonexistent_module", "some_key", 1)
+    setattr(mass_minimal, CORE_DOMAIN, SimpleNamespace())  # controller without config (pre-setup)
+    mass_minimal.config.set_raw_core_config_value(CORE_DOMAIN, "some_key", 2)
+    assert mass_minimal.config.get_raw_core_config_value(CORE_DOMAIN, "some_key") == 2
+
+
+async def test_set_raw_player_config_value_updates_player_copy(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A raw player config write is reflected in the player's in-place config copy."""
+    mass_minimal.config.create_default_player_config(PLAYER_ID, "test_instance", PlayerType.PLAYER)
+    player = MagicMock()
+    player.config = cast(
+        "PlayerConfig",
+        PlayerConfig.parse(
+            [_entry("fancy_option", ConfigEntryType.STRING, "foo")],
+            {"player_id": PLAYER_ID, "provider": "test_instance"},
+        ),
+    )
+    mass_minimal.players = MagicMock()
+    mass_minimal.players.get_player.return_value = player
+    mass_minimal.config.set_raw_player_config_value(PLAYER_ID, "fancy_option", "bar")
+    assert player.config.get_value("fancy_option") == "bar"
+    # a write for a key without config entry only lands in storage
+    mass_minimal.config.set_raw_player_config_value(PLAYER_ID, "unknown_key", "baz")
+    assert mass_minimal.config.get_raw_player_config_value(PLAYER_ID, "unknown_key") == "baz"
+
+
+async def test_set_raw_provider_config_value_updates_provider_copy(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """A raw provider config write is reflected in the provider's in-place config copy."""
+    provider = MagicMock()
+    provider.config = cast(
+        "ProviderConfig",
+        ProviderConfig.parse(
+            [
+                _entry("api_token", ConfigEntryType.STRING, None),
+                _entry("api_secret", ConfigEntryType.SECURE_STRING, None),
+            ],
+            {
+                "type": ProviderType.MUSIC,
+                "domain": "test",
+                "instance_id": PROVIDER_INSTANCE,
+            },
+        ),
+    )
+    mass_minimal.get_provider = MagicMock(return_value=provider)  # type: ignore[method-assign]
+    mass_minimal.config.set(
+        f"{CONF_PROVIDERS}/{PROVIDER_INSTANCE}", {"instance_id": PROVIDER_INSTANCE}
+    )
+    mass_minimal.config.set_raw_provider_config_value(PROVIDER_INSTANCE, "api_token", "abc")
+    assert provider.config.get_value("api_token") == "abc"
+    # encrypted writes store the encrypted value; get_value transparently decrypts
+    mass_minimal.config.set_raw_provider_config_value(
+        PROVIDER_INSTANCE, "api_secret", "s3cret", encrypted=True
+    )
+    assert provider.config.get_value("api_secret") == "s3cret"

--- a/tests/controllers/streams/test_normalization_override.py
+++ b/tests/controllers/streams/test_normalization_override.py
@@ -82,7 +82,7 @@ def audio(monkeypatch: pytest.MonkeyPatch) -> tuple[StreamsAudio, dict[str, list
     mass.streams.audio_analysis.get_audio_analysis = AsyncMock(
         return_value=SimpleNamespace(loudness_integrated=MEASURED_LOUDNESS, loudness_album=None)
     )
-    mass.config.get_core_config = AsyncMock(return_value=MagicMock())
+    mass.streams.config.get_value.return_value = VolumeNormalizationMode.FALLBACK_DYNAMIC.value
     mass.config.get_player_config = AsyncMock(return_value=MagicMock())
     return controller, captured
 
@@ -131,7 +131,7 @@ async def test_dynamic_override_forces_loudnorm_and_ignores_measurement(
     # the just-in-time hydration / re-evaluation is skipped entirely
     mass = cast("MagicMock", controller.mass)
     mass.streams.audio_analysis.get_audio_analysis.assert_not_called()
-    mass.config.get_core_config.assert_not_called()
+    mass.streams.config.get_value.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -1,8 +1,9 @@
 """Tests for music_assistant.helpers.util helpers."""
 
 import asyncio
+import time
 from collections.abc import Iterator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -152,3 +153,84 @@ class TestLoadProviderModule:
             install_mock.side_effect = None
             await load_provider_module("sendspin", ["aiosendspin[server]==6.1.1"])
         assert install_mock.await_count == 2
+
+
+class TestGetIpAddresses:
+    """get_ip_addresses caches the (expensive) adapter enumeration for a short while."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_cache(self) -> Iterator[None]:
+        """Run every test against an empty module-level cache."""
+        util._ip_addresses_cache.clear()
+        util._ip_addresses_pending.clear()
+        yield
+        util._ip_addresses_cache.clear()
+        util._ip_addresses_pending.clear()
+
+    @pytest.fixture
+    def enumerate_mock(self) -> Iterator[MagicMock]:
+        """Replace the blocking adapter enumeration with a counting fake."""
+        with patch(
+            "music_assistant.helpers.util._enumerate_ip_addresses",
+            return_value=("192.168.1.10",),
+        ) as mock:
+            yield mock
+
+    @pytest.mark.asyncio
+    async def test_concurrent_callers_share_a_single_probe(self, enumerate_mock: MagicMock) -> None:
+        """Concurrent callers within the TTL all get the result of one enumeration."""
+        results = await asyncio.gather(*(util.get_ip_addresses() for _ in range(10)))
+        assert all(result == ("192.168.1.10",) for result in results)
+        assert enumerate_mock.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_sequential_calls_within_ttl_reuse_the_cache(
+        self, enumerate_mock: MagicMock
+    ) -> None:
+        """A repeated call shortly after the first is served from the cache."""
+        assert await util.get_ip_addresses() == ("192.168.1.10",)
+        assert await util.get_ip_addresses() == ("192.168.1.10",)
+        assert enumerate_mock.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_is_kept_per_ipv6_flag(self, enumerate_mock: MagicMock) -> None:
+        """include_ipv6 True/False are distinct probes (each cached separately)."""
+        await util.get_ip_addresses(include_ipv6=False)
+        await util.get_ip_addresses(include_ipv6=True)
+        await util.get_ip_addresses(include_ipv6=True)
+        assert enumerate_mock.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_expired_cache_triggers_a_new_probe(self, enumerate_mock: MagicMock) -> None:
+        """Once the TTL passed, the next call enumerates the adapters again."""
+        await util.get_ip_addresses()
+        # age the cached entry beyond the TTL
+        cached_at, addresses = util._ip_addresses_cache[False]
+        util._ip_addresses_cache[False] = (
+            cached_at - util.IP_ADDRESSES_CACHE_TTL - 1,
+            addresses,
+        )
+        await util.get_ip_addresses()
+        assert enumerate_mock.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cancelled_caller_does_not_break_concurrent_callers(self) -> None:
+        """Cancelling one caller must not cancel the shared probe for the others."""
+
+        def slow_enumerate(_include_ipv6: bool) -> tuple[str, ...]:
+            time.sleep(0.1)
+            return ("192.168.1.10",)
+
+        with patch(
+            "music_assistant.helpers.util._enumerate_ip_addresses",
+            side_effect=slow_enumerate,
+        ) as enumerate_mock:
+            task_a = asyncio.create_task(util.get_ip_addresses())
+            task_b = asyncio.create_task(util.get_ip_addresses())
+            # let both callers await the (same) in-flight probe, then cancel one
+            await asyncio.sleep(0.02)
+            task_a.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task_a
+            assert await task_b == ("192.168.1.10",)
+        assert enumerate_mock.call_count == 1

--- a/tests/providers/mpd/test_provider.py
+++ b/tests/providers/mpd/test_provider.py
@@ -25,12 +25,6 @@ async def test_remove_player_prunes_manual_host_config() -> None:
     provider.config.get_value.side_effect = lambda key, default=None: (
         config_entries.get(key, SimpleNamespace(value=default)).value
     )
-    original_entries = [
-        "kitchen.local:6600",
-        "office.local:6601",
-        "office.local:6601",
-        "bedroom.local",
-    ]
     provider.mass = Mock()
     provider.mass.config = Mock()
     provider.mass.players = Mock()
@@ -39,15 +33,11 @@ async def test_remove_player_prunes_manual_host_config() -> None:
 
     await provider.remove_player("mpd_office.local_6601")
 
+    # the config controller stores the pruned list (and updates the in-place config copy)
     provider.mass.config.set_raw_provider_config_value.assert_called_once_with(
         "mpd_test",
         "manual_discovery_ip_addresses",
         ["kitchen.local:6600", "bedroom.local"],
         False,
     )
-    assert config_entries["manual_discovery_ip_addresses"].value == [
-        "kitchen.local:6600",
-        "bedroom.local",
-    ]
-    assert original_entries != config_entries["manual_discovery_ip_addresses"].value
     provider.mass.players.unregister.assert_awaited_once_with("mpd_office.local_6601", True)


### PR DESCRIPTION
# What does this implement/fix?

Every track start did 2-3 full config rebuilds: `get_core_config("streams")` rebuilds all config entries on each call — including a full network interface enumeration (thread hop + socket probes + adapter walk) — and `get_core_config_value`/`get_player_config_value` fell through to the same full rebuild whenever a setting was left at its default. That's several ms of pure overhead per played track on small hardware (Pi et al), for what is essentially reading 2-3 scalar values.

Instead of making the config controller lookups faster, internal code now doesn't call them at all: every config-owning object keeps a parsed copy of its own config (players and providers already did), so a value read is a plain dict lookup that also resolves the entry default.

- core controllers now hold their active config (`self.config`), assigned at startup/reload (`update_config` already maintained it) — mirroring what players and providers already do
- `set_raw_*_config_value` now updates the owning object's in-place config copy for core controllers, players and providers, so raw writes are immediately visible to object-local reads (this centralizes what `Provider._update_config_value` did locally, and closes that gap for the raw writers that never patched the copy)
- hot paths read the object-local copies: the streams volume-normalization values, the queue-loader enqueue defaults and the per-stream-request `http_profile` reads (plus the same pattern in the universal group, dlna and musiccast players)
- `get_ip_addresses` results are cached for 30 seconds (single-flight), which keeps the remaining UI/startup entry builds cheap

Playing a track now does zero NIC enumerations and zero config entry rebuilds (verified end-to-end with the demo player: previously 3 enumerations per track, now 0).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
