### PR TITLE
Fix builtin Snapserver failing to load on busy MA startup

### DIFF
--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -209,7 +209,17 @@ class SnapCastProvider(PlayerProvider):
         if self._use_builtin_server:
             self._snapserver_started = asyncio.Event()
             self._snapserver_runner = self.mass.create_task(self._builtin_server_runner())
-            await asyncio.wait_for(self._snapserver_started.wait(), 10)
+            try:
+                # during startup the executor and event loop can be contended
+                # by other providers loading, which delays the start signal
+                # by several seconds
+                await asyncio.wait_for(self._snapserver_started.wait(), 30)
+            except TimeoutError as err:
+                # cancel the runner so the spawned snapserver process
+                # does not linger and occupy the ports on the next attempt
+                await self._stop_builtin_server()
+                msg = "Builtin Snapserver did not start within 30 seconds"
+                raise SetupFailedError(msg) from err
 
     async def _stop_builtin_server(self) -> None:
         """Stop the built-in Snapserver."""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

I couldn’t recreate this but the debug log showed the problem sequence.

Currently, the builtin snapserver is only given 10 seconds to signal startup, and that time also covered the control script copy plus a 2 second post-start grace delay. During startup the executor and event loop can be contended by other providers loading (the incident log showed the torch based audio analysis starting immediately before), which can consume the entire budget even though the snapserver process itself starts fine. The resulting raw `TimeoutError` is not a `MusicAssistantError`, so the provider load was never retried and stayed dead until a manual reload. The already spawned snapserver process was also left running as an orphan.

The fix is to extend the startup timeout to 30 seconds (same as what core allows for the provider to setup) and, on timeout, cancel the runner task (terminating the orphaned snapserver process) and raise `SetupFailedError` so the load is automatically retried.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5789

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
