### PR TITLE
Prevent Qobuz credentials leaking into logs on HTTP error responses

### DIFF
--- a/music_assistant/providers/qobuz/__init__.py
+++ b/music_assistant/providers/qobuz/__init__.py
@@ -911,14 +911,18 @@ class QobuzProvider(MusicProvider):
             # handle 404 not found, convert to MediaNotFoundError
             if response.status == 404:
                 raise MediaNotFoundError(f"{endpoint} not found")
-            # raise_for_status on 401 embeds the request URL in the exception message;
-            # on /user/login that URL carries the username/password query params.
+            # deliberately no raise_for_status here: its exception message embeds
+            # the full request URL, which on /user/login carries the username and
+            # password as query params (and the user_auth_token on signed requests),
+            # so those would end up in the logs.
             if response.status == 401:
                 if endpoint == "user/login":
                     raise LoginFailed("Invalid Qobuz credentials")
                 self._user_auth_info = None
                 raise LoginFailed("Qobuz session expired")
-            response.raise_for_status()
+            if response.status >= 400:
+                msg = f"Error {response.status} ({response.reason}) while handling {endpoint}"
+                raise InvalidDataError(msg)
             try:
                 return cast("dict[str, Any]", await response.json(loads=json_loads))
             except client_exceptions.ContentTypeError as err:
@@ -963,12 +967,15 @@ class QobuzProvider(MusicProvider):
             # handle 404 not found, convert to MediaNotFoundError
             if response.status == 404:
                 raise MediaNotFoundError(f"{endpoint} not found")
-            # raise_for_status on 401 embeds the request URL in the exception message,
-            # which carries the user_auth_token as a query param.
+            # deliberately no raise_for_status here: its exception message embeds
+            # the full request URL, which carries the user_auth_token as a query
+            # param, so it would end up in the logs.
             if response.status == 401:
                 self._user_auth_info = None
                 raise LoginFailed("Qobuz session expired")
-            response.raise_for_status()
+            if response.status >= 400:
+                msg = f"Error {response.status} ({response.reason}) while handling {endpoint}"
+                raise InvalidDataError(msg)
             return cast("dict[str, Any]", await response.json(loads=json_loads))
 
     def __get_image(self, obj: dict[str, Any]) -> str | None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Noticed the Qobuiz password in the log after a code 500 failure. 

aiohttp's `raise_for_status()` embeds the full request URL in the exception message. For the Qobuz user/login endpoint that URL carries the username and password as query params (and the `user_auth_token` on other requests), so any non-401 error status  logged the plain password. 

This PR replaces `raise_for_status()` with a sanitized error that only includes the status code, reason and endpoint.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
