### PR TITLE
Smart crossfade: content-aware 3-band EQ from frequency band analysis

### DIFF
--- a/music_assistant/controllers/streams/smart_fades/bands.py
+++ b/music_assistant/controllers/streams/smart_fades/bands.py
@@ -9,30 +9,18 @@ cross-track-comparable quantity the stored data supports.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
-from music_assistant.controllers.streams.smart_fades.models import BAND_RMS_BANDS
+from music_assistant.controllers.streams.smart_fades.models import BAND_RMS_BANDS, BandProfile
 
 if TYPE_CHECKING:
     from music_assistant.models.audio_analysis import AudioAnalysisData
 
 # bars quieter than 1/16th of the track's p95 power carry no usable signal
 _ACTIVE_FLOOR_FRACTION = 0.0625
-
-
-@dataclass(slots=True)
-class BandProfile:
-    """Bar-level band-power view of one track, on its own downbeat grid."""
-
-    bar_starts: npt.NDArray[np.float64]
-    bar_power: dict[str, npt.NDArray[np.float64]]
-    total_power: npt.NDArray[np.float64]
-    active: npt.NDArray[np.bool_]
-    reference: dict[str, float]
 
 
 def build_band_profile(analysis: AudioAnalysisData) -> BandProfile | None:

--- a/music_assistant/controllers/streams/smart_fades/bands.py
+++ b/music_assistant/controllers/streams/smart_fades/bands.py
@@ -1,0 +1,166 @@
+"""
+Smart Fades - band-power signal module.
+
+Turns the analyzer-v2 ``band_rms`` envelopes into bar-level power statistics on
+a track's own downbeat grid.  All planner gates read these fractions — power
+fractions cancel the per-track peak normalization, so they are the only
+cross-track-comparable quantity the stored data supports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from music_assistant.controllers.streams.smart_fades.models import BAND_RMS_BANDS
+
+if TYPE_CHECKING:
+    from music_assistant.models.audio_analysis import AudioAnalysisData
+
+# bars quieter than 1/16th of the track's p95 power carry no usable signal
+_ACTIVE_FLOOR_FRACTION = 0.0625
+
+
+@dataclass(slots=True)
+class BandProfile:
+    """Bar-level band-power view of one track, on its own downbeat grid."""
+
+    bar_starts: npt.NDArray[np.float64]
+    bar_power: dict[str, npt.NDArray[np.float64]]
+    total_power: npt.NDArray[np.float64]
+    active: npt.NDArray[np.bool_]
+    reference: dict[str, float]
+
+
+def build_band_profile(analysis: AudioAnalysisData) -> BandProfile | None:
+    """
+    Build the bar-level band-power profile for one track.
+
+    Returns ``None`` when the stored analysis lacks usable v2 band envelopes or
+    a usable downbeat grid, or the track has no active bars (all-silent
+    envelopes) — callers must treat that as "bypass this policy".
+
+    :param analysis: Stored analysis row (any version).
+    """
+    band_rms = (analysis.extra_data or {}).get("band_rms")
+    if (
+        not band_rms
+        or set(band_rms) != set(BAND_RMS_BANDS)
+        or any(len(v) != 1800 for v in band_rms.values())
+        or analysis.downbeats is None
+        or len(analysis.downbeats) < 8
+        or not analysis.duration
+    ):
+        return None
+    downbeats = np.asarray(analysis.downbeats, dtype=np.float64)
+    median_bar = float(np.median(np.diff(downbeats)))
+    edges = np.concatenate([downbeats, [downbeats[-1] + median_bar]])
+    bin_duration = analysis.duration / 1800
+    idx = np.clip((edges / bin_duration).astype(int), 0, 1800)
+    n_bars = len(downbeats)
+    bar_power: dict[str, npt.NDArray[np.float64]] = {}
+    for name, env in band_rms.items():
+        power = np.asarray(env, dtype=np.float64) ** 2
+        cum = np.concatenate([[0.0], np.cumsum(power)])
+        widths = np.maximum(idx[1:] - idx[:-1], 1)
+        bar_power[name] = (cum[idx[1:]] - cum[idx[:-1]]) / widths
+    total: npt.NDArray[np.float64] = np.sum(list(bar_power.values()), axis=0)
+    # the > 0 term keeps all-silent tracks bar-less (0 >= 0 would mark every bar active)
+    active: npt.NDArray[np.bool_] = (
+        total >= _ACTIVE_FLOOR_FRACTION * float(np.percentile(total, 95))
+    ) & (total > 0.0)
+    if not active.any():
+        return None
+    reference = {name: float(np.median(p[active])) for name, p in bar_power.items()}
+    return BandProfile(
+        bar_starts=downbeats[:n_bars],
+        bar_power=bar_power,
+        total_power=total,
+        active=active,
+        reference=reference,
+    )
+
+
+def window_fraction(profile: BandProfile, band: str, start_s: float, end_s: float) -> float:
+    """
+    Power fraction of one band over a media-time window (0.0 on an empty window).
+
+    :param profile: The track's band profile.
+    :param band: One of the ``BAND_RMS_BANDS`` names.
+    :param start_s: Window start in media seconds (inclusive).
+    :param end_s: Window end in media seconds (exclusive).
+    """
+    mask = (profile.bar_starts >= start_s) & (profile.bar_starts < end_s)
+    if not mask.any():
+        return 0.0
+    total = float(profile.total_power[mask].sum())
+    return float(profile.bar_power[band][mask].sum()) / total if total > 0 else 0.0
+
+
+def window_level(profile: BandProfile, band: str, start_s: float, end_s: float) -> float:
+    """
+    Mean bar power of one band over a media-time window (0.0 on an empty window).
+
+    :param profile: The track's band profile.
+    :param band: One of the ``BAND_RMS_BANDS`` names.
+    :param start_s: Window start in media seconds (inclusive).
+    :param end_s: Window end in media seconds (exclusive).
+    """
+    mask = (profile.bar_starts >= start_s) & (profile.bar_starts < end_s)
+    return float(profile.bar_power[band][mask].mean()) if mask.any() else 0.0
+
+
+def window_duty(
+    profile: BandProfile, band: str, start_s: float, end_s: float, k: float = 0.5
+) -> float:
+    """
+    Fraction of window bars whose band power reaches ``k`` x the track's reference.
+
+    :param profile: The track's band profile.
+    :param band: One of the ``BAND_RMS_BANDS`` names.
+    :param start_s: Window start in media seconds (inclusive).
+    :param end_s: Window end in media seconds (exclusive).
+    :param k: Reference multiplier a bar must reach to count.
+    """
+    mask = (profile.bar_starts >= start_s) & (profile.bar_starts < end_s)
+    if not mask.any():
+        return 0.0
+    threshold = k * profile.reference[band]
+    return float((profile.bar_power[band][mask] >= threshold).mean())
+
+
+def smoothstep(x: float, lo: float, hi: float) -> float:
+    """
+    Hermite ramp: 0 at/below ``lo``, 1 at/above ``hi``, smooth in between.
+
+    :param x: Input value.
+    :param lo: Threshold below which the result is exactly 0.
+    :param hi: Value at/above which the result is exactly 1.
+    """
+    if x <= lo:
+        return 0.0
+    if x >= hi:
+        return 1.0
+    t = (x - lo) / (hi - lo)
+    return t * t * (3.0 - 2.0 * t)
+
+
+def loudness_referenced_level(
+    profile: BandProfile, band: str, start_s: float, end_s: float
+) -> float:
+    """
+    Window level scaled by the track's own active-bar total power.
+
+    Cancels per-track peak normalization; cross-deck comparable only when
+    playback loudness normalization is active for both tracks.
+
+    :param profile: The track's band profile.
+    :param band: One of the ``BAND_RMS_BANDS`` names.
+    :param start_s: Window start in media seconds (inclusive).
+    :param end_s: Window end in media seconds (exclusive).
+    """
+    reference = float(profile.total_power[profile.active].mean())
+    return window_level(profile, band, start_s, end_s) / reference if reference > 0 else 0.0

--- a/music_assistant/controllers/streams/smart_fades/filters.py
+++ b/music_assistant/controllers/streams/smart_fades/filters.py
@@ -126,10 +126,11 @@ class FadeOutTrimFilter(Filter):
 
 
 class ShelfType(StrEnum):
-    """Shelving EQ band; values are the ffmpeg filter names."""
+    """EQ band for a scheduled-gain filter; values are the ffmpeg filter names."""
 
     LOW = "lowshelf"
     HIGH = "highshelf"
+    PEAK = "equalizer"
 
 
 class ShelfFilter(Filter):
@@ -188,6 +189,62 @@ class ShelfFilter(Filter):
         """Return string representation of ShelfFilter."""
         gains = f"{self.gain_steps[0][1]:.0f}->{self.gain_steps[-1][1]:.0f}dB"
         return f"Shelf({self.shelf_type}@{self.frequency}Hz {self.stream_type} {gains})"
+
+
+class PeakFilter(Filter):
+    """Parametric peak EQ (mid swap) whose gain follows a scheduled ramp (asendcmd-driven)."""
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        frequency: int,
+        width_oct: float,
+        gain_steps: list[tuple[float, float]],
+        stream_type: str,
+    ):
+        """
+        Initialize peak filter.
+
+        :param frequency: Peak center frequency in Hz.
+        :param width_oct: Peak bandwidth in octaves.
+        :param gain_steps: Schedule of (time_seconds, gain_db); the first step at
+            t=0 sets the initial gain.
+        :param stream_type: 'fadeout' or 'fadein' - which stream to process.
+        """
+        self.frequency = frequency
+        self.width_oct = width_oct
+        self.gain_steps = gain_steps
+        self.stream_type = stream_type
+        if stream_type == "fadeout":
+            self.output_fadeout_label = "fadeout_midswap"
+            self.output_fadein_label = "fadein_pt_midswap"
+        else:
+            self.output_fadeout_label = "fadeout_pt_midswap"
+            self.output_fadein_label = "fadein_midswap"
+        super().__init__(logger)
+
+    def apply(self, input_fadein_label: str, input_fadeout_label: str) -> list[str]:
+        """Generate the peak EQ chain on this filter's stream and passthrough on the other."""
+        if self.stream_type == "fadeout":
+            input_label, output_label = input_fadeout_label, self.output_fadeout_label
+            pass_in, pass_out = input_fadein_label, self.output_fadein_label
+        else:
+            input_label, output_label = input_fadein_label, self.output_fadein_label
+            pass_in, pass_out = input_fadeout_label, self.output_fadeout_label
+        instance = f"{ShelfType.PEAK}@{self.stream_type}_mid"
+        cmd = "; ".join(f"{t:.3f} {instance} g {g:.2f}" for t, g in self.gain_steps)
+        initial = self.gain_steps[0][1]
+        return [
+            f"{pass_in}anull[{pass_out}]",  # codespell:ignore anull
+            f"{input_label}asendcmd=c='{cmd}',"
+            f"{instance}=g={initial:.2f}:f={self.frequency}:width_type=o:width={self.width_oct}"
+            f"[{output_label}]",
+        ]
+
+    def __repr__(self) -> str:
+        """Return string representation of PeakFilter."""
+        gains = f"{self.gain_steps[0][1]:.0f}->{self.gain_steps[-1][1]:.0f}dB"
+        return f"Peak({self.frequency}Hz {self.stream_type} {gains})"
 
 
 class CrossfadeFilter(Filter):

--- a/music_assistant/controllers/streams/smart_fades/models.py
+++ b/music_assistant/controllers/streams/smart_fades/models.py
@@ -12,10 +12,12 @@ is buffered.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import itertools
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
 from music_assistant.controllers.streams.smart_fades.filters import ShelfType
+from music_assistant.controllers.streams.smart_fades.helpers import db_ramp
 
 if TYPE_CHECKING:
     import numpy as np
@@ -51,6 +53,17 @@ class Deck:
     bpm: float
     beats: npt.NDArray[np.float32]
     downbeats: npt.NDArray[np.float32]
+
+
+@dataclass(slots=True)
+class BandProfile:
+    """Bar-level band-power view of one track, on its own downbeat grid."""
+
+    bar_starts: npt.NDArray[np.float64]
+    bar_power: dict[str, npt.NDArray[np.float64]]
+    total_power: npt.NDArray[np.float64]
+    active: npt.NDArray[np.bool_]
+    reference: dict[str, float]
 
 
 @dataclass(slots=True)
@@ -114,6 +127,19 @@ class ShelfSchedule:
     # PEAK bandwidth in octaves; unused for LOW/HIGH shelves
     width_oct: float = 0.707
 
+    def gain_at(self, schedule_time: float) -> float:
+        """Interpolate the scheduled gain (dB) at a schedule-time position (clamped at the ends)."""
+        steps = self.steps
+        if schedule_time <= steps[0][0]:
+            return steps[0][1]
+        if schedule_time >= steps[-1][0]:
+            return steps[-1][1]
+        for (t0, g0), (t1, g1) in itertools.pairwise(steps):
+            if t0 <= schedule_time <= t1:
+                frac = (schedule_time - t0) / (t1 - t0) if t1 > t0 else 0.0
+                return g0 + frac * (g1 - g0)
+        return steps[-1][1]
+
 
 @dataclass(slots=True)
 class EqPlan:
@@ -130,6 +156,56 @@ class EqPlan:
     # measured mid-band (vocal) handover; None on either side means it is bypassed
     mid_out: ShelfSchedule | None = None
     mid_in: ShelfSchedule | None = None
+
+    def with_mid_depth_scaled(self, shrink: float, *, bypass_below_db: float) -> EqPlan:
+        """
+        Return a copy with both mid schedules' depth scaled by ``shrink`` (fraction to KEEP).
+
+        Bypasses the mid swap entirely when scaling drops its depth below ``bypass_below_db``.
+        """
+        if self.mid_out is None and self.mid_in is None:
+            return self
+        source = self.mid_out or self.mid_in
+        assert source is not None  # narrowed by the check above
+        depth = source.steps[-1 if self.mid_out else 0][1]
+        if shrink <= 0.0 or abs(depth * shrink) < abs(bypass_below_db):
+            return replace(self, mid_out=None, mid_in=None)
+        mid_out = self.mid_out
+        mid_in = self.mid_in
+        if mid_out is not None:
+            mid_out = replace(mid_out, steps=[(t, g * shrink) for t, g in mid_out.steps])
+        if mid_in is not None:
+            mid_in = replace(mid_in, steps=[(t, g * shrink) for t, g in mid_in.steps])
+        return replace(self, mid_out=mid_out, mid_in=mid_in)
+
+    def with_low_ramps_steepened(
+        self, swap_at: float, new_len: float, ratio: float, cf_start_input: float
+    ) -> EqPlan:
+        """
+        Return a copy whose low ramps span ``new_len`` centered on ``swap_at``.
+
+        Only the ramp span is tightened; the endpoint gains stay put.
+        """
+        if self.low_out is None and self.low_in is None:
+            return self
+        start_in = max(0.0, swap_at - new_len / 2)
+        new_len_input = new_len * ratio
+        swap_at_input = cf_start_input + swap_at * ratio
+        start_out = max(cf_start_input, swap_at_input - new_len_input / 2)
+
+        low_out = self.low_out
+        if low_out is not None:
+            depth_a = low_out.steps[-1][1]
+            low_out = replace(
+                low_out, steps=[(0.0, 0.0), *db_ramp(start_out, new_len_input, 0.0, depth_a)]
+            )
+        low_in = self.low_in
+        if low_in is not None:
+            depth_b = low_in.steps[0][1]
+            low_in = replace(
+                low_in, steps=[(0.0, depth_b), *db_ramp(start_in, new_len, depth_b, 0.0)]
+            )
+        return replace(self, low_out=low_out, low_in=low_in)
 
 
 @dataclass(slots=True)

--- a/music_assistant/controllers/streams/smart_fades/models.py
+++ b/music_assistant/controllers/streams/smart_fades/models.py
@@ -105,12 +105,14 @@ class TempoPlan:
 
 @dataclass(slots=True)
 class ShelfSchedule:
-    """One shelving-EQ gain schedule for a ShelfFilter."""
+    """One EQ gain schedule for a ShelfFilter (LOW/HIGH) or PeakFilter (PEAK)."""
 
     shelf_type: ShelfType
     frequency: int
     # (time_seconds, gain_db); the step at t=0 sets the initial gain
     steps: list[tuple[float, float]]
+    # PEAK bandwidth in octaves; unused for LOW/HIGH shelves
+    width_oct: float = 0.707
 
 
 @dataclass(slots=True)
@@ -119,11 +121,15 @@ class EqPlan:
 
     # seconds into the rendered crossfade
     swap_at: float
-    # A-side schedules are in input time (pre-stretch), B-side in post-trim time
-    low_out: ShelfSchedule
-    low_in: ShelfSchedule
-    high_out: ShelfSchedule
-    high_in: ShelfSchedule
+    # A-side schedules are in input time (pre-stretch), B-side in post-trim time;
+    # None means the schedule is bypassed (a shelf shallower than the bypass floor)
+    low_out: ShelfSchedule | None
+    low_in: ShelfSchedule | None
+    high_out: ShelfSchedule | None
+    high_in: ShelfSchedule | None
+    # measured mid-band (vocal) handover; None on either side means it is bypassed
+    mid_out: ShelfSchedule | None = None
+    mid_in: ShelfSchedule | None = None
 
 
 @dataclass(slots=True)

--- a/music_assistant/controllers/streams/smart_fades/planner.py
+++ b/music_assistant/controllers/streams/smart_fades/planner.py
@@ -104,15 +104,20 @@ class SmartCrossFadePlanner(TransitionPlanner):
 
     # reciprocal bass-swap depth gate: each side's low-band power fraction over
     # the other deck's window is smoothstepped across this corridor to scale
-    # its own kill depth; below eq_bypass_below_db the schedule is dropped
+    # its own kill depth; below eq_bypass_below_db the schedule is dropped.
+    # Corridor from published LTAS integrations over these band edges: dance
+    # masters carry ~0.34-0.45 of their power below 120Hz, mean pop ~0.14,
+    # acoustic genres less (Elowsson & Friberg 2017; Pestana et al. 2013)
     low_gate_lo: float = 0.10
     low_gate_hi: float = 0.25
     eq_bypass_below_db: float = -6.0
 
     # reciprocal high-ease depth gate: same reciprocal-window shape as the bass
-    # swap, but on the high band (4kHz+ power fractions are intrinsically
-    # small, hence the low corridor); a deck whose OWN window high level falls
-    # below high_own_side_floor of its own reference gets no shelf at all
+    # swap, but on the high band. Mean-music LTAS integrates to ~0.02 in
+    # 4-11kHz (Elowsson & Friberg 2017), so lo = an average track earns no
+    # duck and hi = unmistakably brighter than average earns the full ease.
+    # A deck whose OWN window high level falls below high_own_side_floor of
+    # its own reference gets no shelf at all
     high_gate_lo: float = 0.02
     high_gate_hi: float = 0.06
     high_own_side_floor: float = 0.25
@@ -130,9 +135,11 @@ class SmartCrossFadePlanner(TransitionPlanner):
     # unlock a swap over an otherwise instrumental track
     mid_freq: int = 1200
     mid_width_oct: float = 2.5
-    # corpus-tabled placement in the measured gap between instrumental (<=0.15)
-    # and vocal (>=0.26) mid fractions; the panel prior overshot because vocal
-    # fundamentals sit below 400 Hz
+    # Vocal fundamentals sit below 400Hz (~90% of voice power is under 1kHz,
+    # Sundberg-line voice research), so vocal-forward mixes integrate to only
+    # ~0.25-0.45 mid fraction vs ~0.10-0.15 for instrumental dance material
+    # (LTAS: Elowsson & Friberg 2017; Pestana et al. 2013). The corridor sits
+    # in that gap; absolute placement verified on our unweighted pipeline
     mid_gate_lo: float = 0.18
     mid_gate_hi: float = 0.30
     mid_duty_lo: float = 0.60

--- a/music_assistant/controllers/streams/smart_fades/planner.py
+++ b/music_assistant/controllers/streams/smart_fades/planner.py
@@ -12,14 +12,25 @@ Alternative transition strategies slot in as sibling subclasses of
 
 from __future__ import annotations
 
+import itertools
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
+from music_assistant.controllers.streams.smart_fades.bands import (
+    BandProfile,
+    build_band_profile,
+    loudness_referenced_level,
+    smoothstep,
+    window_duty,
+    window_fraction,
+    window_level,
+)
 from music_assistant.controllers.streams.smart_fades.filters import ShelfType
 from music_assistant.controllers.streams.smart_fades.helpers import (
     MIN_EFFECTIVE_FADE_BUFFER,
@@ -32,6 +43,7 @@ from music_assistant.controllers.streams.smart_fades.helpers import (
     generate_synthetic_timestamps,
 )
 from music_assistant.controllers.streams.smart_fades.models import (
+    BAND_RMS_BANDS,
     Deck,
     EqPlan,
     FadeOutTrim,
@@ -87,13 +99,68 @@ class SmartCrossFadePlanner(TransitionPlanner):
     bass_swap_fraction: float = 0.5
     bass_swap_min_bars: int = 2
     bass_swap_max_bars: int = 8
+    # decision window for the reciprocal swap depth gates, in A/B-bars
+    bass_swap_window_bars: int = 8
+
+    # reciprocal bass-swap depth gate: each side's low-band power fraction over
+    # the other deck's window is smoothstepped across this corridor to scale
+    # its own kill depth; below eq_bypass_below_db the schedule is dropped
+    low_gate_lo: float = 0.10
+    low_gate_hi: float = 0.25
+    eq_bypass_below_db: float = -6.0
+
+    # reciprocal high-ease depth gate: same reciprocal-window shape as the bass
+    # swap, but on the high band (4kHz+ power fractions are intrinsically
+    # small, hence the low corridor); a deck whose OWN window high level falls
+    # below high_own_side_floor of its own reference gets no shelf at all
+    high_gate_lo: float = 0.02
+    high_gate_hi: float = 0.06
+    high_own_side_floor: float = 0.25
+    # cymbal-wash mode: both decks' own windows read bright and comparably
+    # loud (loudness-normalized playback assumed), so a plain reciprocal ease
+    # would let their highs stack; duck A complementary with B's restore instead
+    wash_duty: float = 0.8
+    wash_depth_db: float = -26.0
+    wash_level_tolerance_db: float = 6.0
+    wash_min_blend_bars: int = 8
+
+    # measured mid-band (vocal) swap: same reciprocal-gate shape as the bass
+    # swap, but on the mid band and gated additionally on how consistently
+    # that band is present (duty), since a single loud mid bar shouldn't
+    # unlock a swap over an otherwise instrumental track
+    mid_freq: int = 1200
+    mid_width_oct: float = 2.5
+    # corpus-tabled placement in the measured gap between instrumental (<=0.15)
+    # and vocal (>=0.26) mid fractions; the panel prior overshot because vocal
+    # fundamentals sit below 400 Hz
+    mid_gate_lo: float = 0.18
+    mid_gate_hi: float = 0.30
+    mid_duty_lo: float = 0.60
+    mid_duty_hi: float = 0.85
+    mid_cap_db: float = -8.0
+    mid_bypass_below_db: float = -1.0
+
+    # plan-time predicted-loudness-dip guard: the combined qsin-weighted power
+    # of both decks' scheduled bands may never sag more than this many dB
+    # below its plateau across the overlap
+    max_predicted_dip_db: float = 3.0
 
     # Working state for one plan() run, (re)set by _prepare_decks
     outgoing: Deck
     incoming: Deck
     effective_end: float
+    # outgoing media time minus buffer-local time, i.e. media_time = buffer_local + offset
+    _buffer_offset: float
     fadeout_trim: FadeOutTrim | None
     extrapolated_downbeats: npt.NDArray[np.float32]
+    outgoing_profile: BandProfile | None
+    incoming_profile: BandProfile | None
+    # incoming groove entry (media time), computed once so the swap point and
+    # the reciprocal decision windows agree
+    _incoming_entry: float
+    # set by _choose_eq: the low crossover's rendered ramp window, exempt from
+    # the dip guard (its notch is the intentional bass-handover gesture)
+    _swap_notch: tuple[float, float]
 
     def plan(
         self,
@@ -147,17 +214,7 @@ class SmartCrossFadePlanner(TransitionPlanner):
         fade_in_analysis: AudioAnalysisData,
         buffer_duration: float,
     ) -> None:
-        """
-        Load both tracks onto the decks and cue the outgoing tail.
-
-        Validates the analysis, derives the usable beat grids and locates the
-        audible end of the outgoing tail.  Raises ``SmartFadeNotApplicable``
-        when the tail is too short to be useful.
-
-        :param fade_out_analysis: Analysis data for the outgoing track.
-        :param fade_in_analysis: Analysis data for the incoming track.
-        :param buffer_duration: Length in seconds of the fade-out holdback buffer.
-        """
+        """Load both tracks onto the decks, cue the outgoing tail and detect B's entry."""
         if (
             fade_out_analysis.bpm is None
             or fade_in_analysis.bpm is None
@@ -189,11 +246,19 @@ class SmartCrossFadePlanner(TransitionPlanner):
                 else np.array([], dtype=np.float32)
             ),
         )
+        self.outgoing_profile = build_band_profile(fade_out_analysis)
+        self.incoming_profile = build_band_profile(fade_in_analysis)
         self._cue_outgoing_tail(buffer_duration)
         self.extrapolated_downbeats = extrapolate_downbeats(
             self.outgoing.downbeats,
             buffer_size=self.effective_end,
             bpm=self.outgoing.bpm,
+        )
+        # Computed once so the swap point and the reciprocal decision windows agree
+        self._incoming_entry = detect_groove_entry(
+            self.incoming.analysis.rms_energy,
+            self.incoming.analysis.duration,
+            self.incoming.downbeats,
         )
         # Additional verbose logging to debug rare failures
         self.logger.log(
@@ -204,17 +269,7 @@ class SmartCrossFadePlanner(TransitionPlanner):
         )
 
     def _cue_outgoing_tail(self, buffer_duration: float) -> None:
-        """
-        Locate the audible end of the outgoing tail and align its grids to it.
-
-        Sets ``self.effective_end``, ``self.fadeout_trim`` (when trailing silence
-        is worth dropping), converts the outgoing deck's grids from full-track to
-        buffer-local coordinates using the actual buffer length, and masks them
-        to the audible window.  Raises ``SmartFadeNotApplicable`` when the tail
-        is too short to be useful.
-
-        :param buffer_duration: Length in seconds of the fade-out holdback buffer.
-        """
+        """Locate the audible end of the outgoing tail and shift its grids to buffer-local time."""
         self.fadeout_trim = None
         self.effective_end = detect_effective_audio_end(
             self.outgoing.analysis.rms_energy,
@@ -241,9 +296,9 @@ class SmartCrossFadePlanner(TransitionPlanner):
         # ACTUAL buffer length: the holdback yield loop leaves up to ~1s less than the
         # constant 45s depending on chunk boundaries, and effective_end above is in real
         # buffer coordinates — a constant-45 shift would misalign every beat by the difference
-        buffer_offset = max(0.0, (self.outgoing.analysis.duration or 0.0) - buffer_duration)
-        beats = self.outgoing.beats - buffer_offset
-        downbeats = self.outgoing.downbeats - buffer_offset
+        self._buffer_offset = max(0.0, (self.outgoing.analysis.duration or 0.0) - buffer_duration)
+        beats = self.outgoing.beats - self._buffer_offset
+        downbeats = self.outgoing.downbeats - self._buffer_offset
 
         # Mask fade-out beats to the audible buffer window; negative timestamps are
         # beats before the buffer, beats past effective_end sit in the silent tail
@@ -531,21 +586,9 @@ class SmartCrossFadePlanner(TransitionPlanner):
         tempo_plan: TempoPlan,
         fadein_trim_start: float | None,
     ) -> EqPlan:
-        """
-        Plan the bass swap between the two tracks.
-
-        B enters bass-killed; both low shelves trade over a proportional window
-        (half the overlap, clamped to 2-8 bars) CENTERED on the swap point, so
-        the handover reads as a morph around the musical moment rather than an
-        event.  Highs ease in before the exchange and out after it.  A-side
-        schedules are in the outgoing track's input time (the renderer places
-        them before the tempo stretch); B-side schedules are in the incoming
-        track's post-trim time, where t=0 equals the crossfade start.
-
-        :param crossfade_duration: Rendered overlap length in seconds.
-        :param tempo_plan: Tempo ramp (maps rendered offsets to A-input offsets).
-        :param fadein_trim_start: Incoming head trim, if beat alignment applied one.
-        """
+        """Plan the low/mid/high EQ handover, centered on the swap point."""
+        # A-side schedules are in A-input time (rendered before the tempo stretch);
+        # B-side schedules are in B's post-trim time, where t=0 is the crossfade start
         bar_in = 4 * 60.0 / self.incoming.bpm
         swap_at = self._choose_swap_point(crossfade_duration, fadein_trim_start)
         swap_len = min(
@@ -565,56 +608,86 @@ class SmartCrossFadePlanner(TransitionPlanner):
         start_in = max(0.0, swap_at - swap_len / 2)
         start_out = max(cf_start_input, swap_at_input - swap_len_input / 2)
 
-        low_out = ShelfSchedule(
-            ShelfType.LOW,
-            self.low_shelf_freq,
-            [(0.0, 0.0), *db_ramp(start_out, swap_len_input, 0.0, self.eq_kill_db)],
+        depth_a, depth_b = self._choose_swap_depths()
+
+        low_out = (
+            ShelfSchedule(
+                ShelfType.LOW,
+                self.low_shelf_freq,
+                [(0.0, 0.0), *db_ramp(start_out, swap_len_input, 0.0, depth_a)],
+            )
+            if abs(depth_a) >= abs(self.eq_bypass_below_db)
+            else None
         )
-        low_in = ShelfSchedule(
-            ShelfType.LOW,
-            self.low_shelf_freq,
-            [(0.0, self.eq_kill_db), *db_ramp(start_in, swap_len, self.eq_kill_db, 0.0)],
+        low_in = (
+            ShelfSchedule(
+                ShelfType.LOW,
+                self.low_shelf_freq,
+                [(0.0, depth_b), *db_ramp(start_in, swap_len, depth_b, 0.0)],
+            )
+            if abs(depth_b) >= abs(self.eq_bypass_below_db)
+            else None
         )
-        high_out = ShelfSchedule(
-            ShelfType.HIGH,
-            self.high_shelf_freq,
-            [
-                (0.0, 0.0),
-                *db_ramp(start_out + swap_len_input, ease * ratio, 0.0, self.high_ease_db),
-            ],
+        high_out, high_in = self._choose_high_swap(
+            start_out, start_in, cf_start_input, swap_len_input, ease, ratio, crossfade_duration
         )
-        high_in = ShelfSchedule(
-            ShelfType.HIGH,
-            self.high_shelf_freq,
-            [
-                (0.0, self.high_ease_db),
-                *db_ramp(max(0.0, start_in - ease), ease, self.high_ease_db, 0.0),
-            ],
+
+        depth_mid_a, depth_mid_b = self._choose_mid_swap_depths()
+        mid_out = (
+            ShelfSchedule(
+                ShelfType.PEAK,
+                self.mid_freq,
+                [(0.0, 0.0), *db_ramp(start_out, swap_len_input, 0.0, depth_mid_a)],
+                width_oct=self.mid_width_oct,
+            )
+            if depth_mid_a is not None
+            else None
         )
-        return EqPlan(
-            swap_at=swap_at, low_out=low_out, low_in=low_in, high_out=high_out, high_in=high_in
+        mid_in = (
+            ShelfSchedule(
+                ShelfType.PEAK,
+                self.mid_freq,
+                [(0.0, depth_mid_b), *db_ramp(start_in, swap_len, depth_mid_b, 0.0)],
+                width_oct=self.mid_width_oct,
+            )
+            if depth_mid_b is not None
+            else None
+        )
+
+        eq_plan = EqPlan(
+            swap_at=swap_at,
+            low_out=low_out,
+            low_in=low_in,
+            high_out=high_out,
+            high_in=high_in,
+            mid_out=mid_out,
+            mid_in=mid_in,
+        )
+        # the low crossover's rendered ramp window; the dip guard exempts it as
+        # the intentional bass-handover gesture, but ONLY when a low swap is
+        # actually engaged — a bass-light pair has no handover to exempt, so
+        # the notch collapses to an interval that never matches a sample time
+        self._swap_notch = (
+            (start_in, start_in + swap_len)
+            if (low_out is not None or low_in is not None)
+            else (-1.0, -1.0)
+        )
+        return self._apply_dip_guard(
+            eq_plan,
+            crossfade_duration=crossfade_duration,
+            cf_start_input=cf_start_input,
+            ratio=ratio,
+            swap_at=swap_at,
+            bar_in=bar_in,
+            notch=self._swap_notch,
         )
 
     def _choose_swap_point(
         self, crossfade_duration: float, fadein_trim_start: float | None
     ) -> float:
-        """
-        Pick the bass-swap moment, in rendered seconds into the crossfade.
-
-        Prefers the incoming track's groove entry (drums coming in) when it lands
-        anywhere inside the overlap; otherwise the incoming downbeat nearest to
-        60% through the overlap.
-
-        :param crossfade_duration: Rendered overlap length in seconds.
-        :param fadein_trim_start: Incoming head trim, if beat alignment applied one.
-        """
+        """Pick the bass-swap moment: B's groove entry when inside the overlap, else 60% through."""
         trim = fadein_trim_start or 0.0
-        entry = detect_groove_entry(
-            self.incoming.analysis.rms_energy,
-            self.incoming.analysis.duration,
-            self.incoming.downbeats,
-        )
-        candidate = entry - trim
+        candidate = self._incoming_entry - trim
         if not 0.0 < candidate <= crossfade_duration:
             candidate = 0.6 * crossfade_duration
         # snap to the incoming grid so the new bassline lands on its own 1
@@ -623,3 +696,336 @@ class SmartCrossFadePlanner(TransitionPlanner):
         if len(post_trim):
             candidate = float(post_trim[np.argmin(np.abs(post_trim - candidate))])
         return candidate
+
+    def _swap_windows(self, window_bars: int) -> tuple[tuple[float, float], tuple[float, float]]:
+        """Reciprocal decision windows for the swap gates: A's outgoing tail, B's incoming head."""
+        bar_out = 4 * 60.0 / self.outgoing.bpm
+        bar_in = 4 * 60.0 / self.incoming.bpm
+        anchor_media = self._buffer_offset + self.effective_end
+        w_a_out = (anchor_media - window_bars * bar_out, anchor_media)
+        entry = self._incoming_entry
+        w_b_in = (entry, entry + window_bars * bar_in)
+        return w_a_out, w_b_in
+
+    def _choose_swap_depths(self) -> tuple[float, float]:
+        """Reciprocally scale each side's bass-kill depth to the other deck's measured bass."""
+        # missing band data on either side keeps the shipped full-depth kill (bit-identical)
+        if self.outgoing_profile is None or self.incoming_profile is None:
+            return self.eq_kill_db, self.eq_kill_db
+        w_a_out, w_b_in = self._swap_windows(self.bass_swap_window_bars)
+        f_low_b_in = window_fraction(self.incoming_profile, "low", *w_b_in)
+        f_low_a_out = window_fraction(self.outgoing_profile, "low", *w_a_out)
+        depth_a = self.eq_kill_db * smoothstep(f_low_b_in, self.low_gate_lo, self.low_gate_hi)
+        depth_b = self.eq_kill_db * smoothstep(f_low_a_out, self.low_gate_lo, self.low_gate_hi)
+        return depth_a, depth_b
+
+    def _choose_high_swap(
+        self,
+        start_out: float,
+        start_in: float,
+        cf_start_input: float,
+        swap_len_input: float,
+        ease: float,
+        ratio: float,
+        crossfade_duration: float,
+    ) -> tuple[ShelfSchedule | None, ShelfSchedule | None]:
+        """Build the high-ease shelves: reciprocal depths, own-side no-op skip, cymbal-wash mode."""
+        wash = False
+        if self.outgoing_profile is None or self.incoming_profile is None:
+            depth_a = depth_b = self.high_ease_db
+        else:
+            w_a_out, w_b_in = self._swap_windows(self.bass_swap_window_bars)
+            f_high_b_in = window_fraction(self.incoming_profile, "high", *w_b_in)
+            f_high_a_out = window_fraction(self.outgoing_profile, "high", *w_a_out)
+            depth_a = self.high_ease_db * smoothstep(
+                f_high_b_in, self.high_gate_lo, self.high_gate_hi
+            )
+            depth_b = self.high_ease_db * smoothstep(
+                f_high_a_out, self.high_gate_lo, self.high_gate_hi
+            )
+
+            own_dark_a = window_level(self.outgoing_profile, "high", *w_a_out) < (
+                self.high_own_side_floor * self.outgoing_profile.reference["high"]
+            )
+            own_dark_b = window_level(self.incoming_profile, "high", *w_b_in) < (
+                self.high_own_side_floor * self.incoming_profile.reference["high"]
+            )
+            if own_dark_a:
+                depth_a = 0.0
+            if own_dark_b:
+                depth_b = 0.0
+
+            wash = self._wash_mode_engages(w_a_out, w_b_in, crossfade_duration)
+            if wash:
+                depth_a = self.wash_depth_db
+
+        high_out = (
+            ShelfSchedule(
+                ShelfType.HIGH,
+                self.high_shelf_freq,
+                self._high_out_steps(
+                    depth_a,
+                    start_out,
+                    start_in,
+                    cf_start_input,
+                    swap_len_input,
+                    ease,
+                    ratio,
+                    wash=wash,
+                ),
+            )
+            if abs(depth_a) >= abs(self.eq_bypass_below_db)
+            else None
+        )
+        high_in = (
+            ShelfSchedule(
+                ShelfType.HIGH,
+                self.high_shelf_freq,
+                [
+                    (0.0, depth_b),
+                    *db_ramp(max(0.0, start_in - ease), ease, depth_b, 0.0),
+                ],
+            )
+            if abs(depth_b) >= abs(self.eq_bypass_below_db)
+            else None
+        )
+        return high_out, high_in
+
+    def _high_out_steps(
+        self,
+        depth_a: float,
+        start_out: float,
+        start_in: float,
+        cf_start_input: float,
+        swap_len_input: float,
+        ease: float,
+        ratio: float,
+        *,
+        wash: bool,
+    ) -> list[tuple[float, float]]:
+        """Build A's high-duck ramp: shipped post-swap placement, or wash mode's mirrored duck."""
+        if wash:
+            # mirror B's restore window; it ends at start_in inside the overlap,
+            # so the duck can never overrun the crossfade end
+            start = cf_start_input + max(0.0, start_in - ease) * ratio
+        else:
+            start = start_out + swap_len_input
+        return [(0.0, 0.0), *db_ramp(start, ease * ratio, 0.0, depth_a)]
+
+    def _wash_mode_engages(
+        self,
+        w_a_out: tuple[float, float],
+        w_b_in: tuple[float, float],
+        crossfade_duration: float,
+    ) -> bool:
+        """Return True when both decks read bright, comparably loud, over a long enough blend."""
+        assert self.outgoing_profile is not None  # narrowed by the caller
+        assert self.incoming_profile is not None
+        bar_out = 4 * 60.0 / self.outgoing.bpm
+        if crossfade_duration < self.wash_min_blend_bars * bar_out:
+            return False
+        # absolute brightness floor: duty vs a track's OWN reference measures
+        # consistency, not brightness — a dark steady track has duty 1.0
+        f_high_a = window_fraction(self.outgoing_profile, "high", *w_a_out)
+        f_high_b = window_fraction(self.incoming_profile, "high", *w_b_in)
+        if f_high_a < self.high_gate_hi or f_high_b < self.high_gate_hi:
+            return False
+        duty_a = window_duty(self.outgoing_profile, "high", *w_a_out, k=0.5)
+        duty_b = window_duty(self.incoming_profile, "high", *w_b_in, k=0.5)
+        if duty_a < self.wash_duty or duty_b < self.wash_duty:
+            return False
+        level_a = loudness_referenced_level(self.outgoing_profile, "high", *w_a_out)
+        level_b = loudness_referenced_level(self.incoming_profile, "high", *w_b_in)
+        if level_a <= 0.0 or level_b <= 0.0:
+            return False
+        # the planner has no access to playback state, so this presumes loudness-
+        # normalized playback; that assumption is strictly more conservative than
+        # a duty-only fallback, which would engage wash mode more often
+        level_gap_db = abs(10.0 * float(np.log10(level_a / level_b)))
+        return level_gap_db <= self.wash_level_tolerance_db
+
+    def _choose_mid_swap_depths(self) -> tuple[float | None, float | None]:
+        """Gate and scale the measured mid-band (vocal) swap depth; ``None`` means bypass."""
+        if self.outgoing_profile is None or self.incoming_profile is None:
+            return None, None
+        w_a_out, w_b_in = self._swap_windows(self.bass_swap_window_bars)
+
+        def _score(profile: BandProfile, window: tuple[float, float]) -> float:
+            f_mid = window_fraction(profile, "mid", *window)
+            duty_mid = window_duty(profile, "mid", *window, k=0.5)
+            return smoothstep(f_mid, self.mid_gate_lo, self.mid_gate_hi) * smoothstep(
+                duty_mid, self.mid_duty_lo, self.mid_duty_hi
+            )
+
+        score_a = _score(self.outgoing_profile, w_a_out)
+        score_b = _score(self.incoming_profile, w_b_in)
+        # the weaker side rules: a swap only reads as a handover when both decks carry a mid element
+        depth = self.mid_cap_db * min(score_a, score_b)
+        if abs(depth) < abs(self.mid_bypass_below_db):
+            return None, None
+        return depth, depth
+
+    def _apply_dip_guard(
+        self,
+        eq_plan: EqPlan,
+        *,
+        crossfade_duration: float,
+        cf_start_input: float,
+        ratio: float,
+        swap_at: float,
+        bar_in: float,
+        notch: tuple[float, float],
+    ) -> EqPlan:
+        """Remediate a predicted outside-notch dip: shrink mid depth, then steepen low ramps."""
+        if self.outgoing_profile is None or self.incoming_profile is None:
+            return eq_plan
+        w_a_out, w_b_in = self._swap_windows(self.bass_swap_window_bars)
+        f_a = {
+            band: window_fraction(self.outgoing_profile, band, *w_a_out) for band in BAND_RMS_BANDS
+        }
+        f_b = {
+            band: window_fraction(self.incoming_profile, band, *w_b_in) for band in BAND_RMS_BANDS
+        }
+
+        def dip_db(plan: EqPlan) -> float:
+            return self._predicted_dip_db(
+                plan, crossfade_duration, cf_start_input, ratio, f_a, f_b, notch
+            )
+
+        if dip_db(eq_plan) <= self.max_predicted_dip_db:
+            return eq_plan
+
+        # (1) reduce mid depth toward bypass, in steps, until the dip clears
+        # or mid is fully bypassed
+        shrink_steps = (0.75, 0.5, 0.25, 0.0)
+        for shrink in shrink_steps:
+            candidate = self._scale_mid_depth(eq_plan, shrink)
+            if dip_db(candidate) <= self.max_predicted_dip_db or shrink == 0.0:
+                eq_plan = candidate
+                break
+        if dip_db(eq_plan) <= self.max_predicted_dip_db:
+            return eq_plan
+
+        # (2) steepen the low ramps to the 2-bar floor; endpoints untouched.
+        # This is the last remediation step (never shallow the low depth —
+        # there is no further knob beyond the floor), so its result is
+        # returned whether or not it fully clears the budget.
+        floor_len = self.bass_swap_min_bars * bar_in
+        eq_plan = self._steepen_low_ramps(eq_plan, swap_at, floor_len, ratio, cf_start_input)
+        # the notch narrowed along with the ramp span; keep it in sync so it
+        # still reflects the plan's actual bass-handover window
+        start_in = max(0.0, swap_at - floor_len / 2)
+        self._swap_notch = (start_in, start_in + floor_len)
+        return eq_plan
+
+    def _predicted_dip_db(
+        self,
+        eq_plan: EqPlan,
+        crossfade_duration: float,
+        cf_start_input: float,
+        ratio: float,
+        f_a: dict[str, float],
+        f_b: dict[str, float],
+        notch: tuple[float, float],
+        n_samples: int = 64,
+    ) -> float:
+        """Max plateau-to-valley drop, in dB, of the predicted combined qsin-weighted power."""
+        # qsin weights match the renderer's acrossfade=...:c1=qsin:c2=qsin curve
+        schedules_a = {"low": eq_plan.low_out, "mid": eq_plan.mid_out, "high": eq_plan.high_out}
+        schedules_b = {"low": eq_plan.low_in, "mid": eq_plan.mid_in, "high": eq_plan.high_in}
+        running_max = 0.0
+        max_drop_db = 0.0
+        for i in range(n_samples + 1):
+            t = crossfade_duration * i / n_samples
+            if notch[0] <= t <= notch[1]:
+                continue
+            w_a = np.cos(np.pi / 2 * t / crossfade_duration) ** 2 if crossfade_duration else 1.0
+            w_b = np.sin(np.pi / 2 * t / crossfade_duration) ** 2 if crossfade_duration else 0.0
+            p_a = sum(
+                f_a[band]
+                * 10.0
+                ** (self._gain_at(schedules_a.get(band), t, cf_start_input, ratio, side="A") / 10.0)
+                for band in BAND_RMS_BANDS
+            )
+            p_b = sum(
+                f_b[band]
+                * 10.0
+                ** (self._gain_at(schedules_b.get(band), t, cf_start_input, ratio, side="B") / 10.0)
+                for band in BAND_RMS_BANDS
+            )
+            power = float(w_a * p_a + w_b * p_b)
+            running_max = max(running_max, power)
+            if running_max > 0.0 and power > 0.0:
+                max_drop_db = max(max_drop_db, 10.0 * float(np.log10(running_max / power)))
+        return max_drop_db
+
+    @staticmethod
+    def _gain_at(
+        schedule: ShelfSchedule | None,
+        t: float,
+        cf_start_input: float,
+        ratio: float,
+        *,
+        side: str,
+    ) -> float:
+        """Interpolate a schedule's gain (dB) at rendered overlap time ``t``; ``None`` is 0dB."""
+        if schedule is None:
+            return 0.0
+        tt = cf_start_input + t * ratio if side == "A" else t
+        steps = schedule.steps
+        if tt <= steps[0][0]:
+            return steps[0][1]
+        if tt >= steps[-1][0]:
+            return steps[-1][1]
+        for (t0, g0), (t1, g1) in itertools.pairwise(steps):
+            if t0 <= tt <= t1:
+                frac = (tt - t0) / (t1 - t0) if t1 > t0 else 0.0
+                return g0 + frac * (g1 - g0)
+        return steps[-1][1]
+
+    def _scale_mid_depth(self, eq_plan: EqPlan, shrink: float) -> EqPlan:
+        """Scale the mid schedules' depth by ``shrink`` (fraction to KEEP); bypass below the floor."""
+        if eq_plan.mid_out is None and eq_plan.mid_in is None:
+            return eq_plan
+        source = eq_plan.mid_out or eq_plan.mid_in
+        assert source is not None  # narrowed by the check above
+        depth = source.steps[-1 if eq_plan.mid_out else 0][1]
+        if shrink <= 0.0 or abs(depth * shrink) < abs(self.mid_bypass_below_db):
+            return replace(eq_plan, mid_out=None, mid_in=None)
+        mid_out = eq_plan.mid_out
+        mid_in = eq_plan.mid_in
+        if mid_out is not None:
+            mid_out = replace(mid_out, steps=[(t, g * shrink) for t, g in mid_out.steps])
+        if mid_in is not None:
+            mid_in = replace(mid_in, steps=[(t, g * shrink) for t, g in mid_in.steps])
+        return replace(eq_plan, mid_out=mid_out, mid_in=mid_in)
+
+    @staticmethod
+    def _steepen_low_ramps(
+        eq_plan: EqPlan,
+        swap_at: float,
+        new_len: float,
+        ratio: float,
+        cf_start_input: float,
+    ) -> EqPlan:
+        """Rebuild the low ramps to span ``new_len`` centered on ``swap_at``; endpoint gains unchanged."""
+        if eq_plan.low_out is None and eq_plan.low_in is None:
+            return eq_plan
+        start_in = max(0.0, swap_at - new_len / 2)
+        new_len_input = new_len * ratio
+        swap_at_input = cf_start_input + swap_at * ratio
+        start_out = max(cf_start_input, swap_at_input - new_len_input / 2)
+
+        low_out = eq_plan.low_out
+        if low_out is not None:
+            depth_a = low_out.steps[-1][1]
+            low_out = replace(
+                low_out, steps=[(0.0, 0.0), *db_ramp(start_out, new_len_input, 0.0, depth_a)]
+            )
+        low_in = eq_plan.low_in
+        if low_in is not None:
+            depth_b = low_in.steps[0][1]
+            low_in = replace(
+                low_in, steps=[(0.0, depth_b), *db_ramp(start_in, new_len, depth_b, 0.0)]
+            )
+        return replace(eq_plan, low_out=low_out, low_in=low_in)

--- a/music_assistant/controllers/streams/smart_fades/planner.py
+++ b/music_assistant/controllers/streams/smart_fades/planner.py
@@ -12,10 +12,8 @@ Alternative transition strategies slot in as sibling subclasses of
 
 from __future__ import annotations
 
-import itertools
 import logging
 from abc import ABC, abstractmethod
-from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -23,7 +21,6 @@ import numpy.typing as npt
 
 from music_assistant.constants import VERBOSE_LOG_LEVEL
 from music_assistant.controllers.streams.smart_fades.bands import (
-    BandProfile,
     build_band_profile,
     loudness_referenced_level,
     smoothstep,
@@ -44,6 +41,7 @@ from music_assistant.controllers.streams.smart_fades.helpers import (
 )
 from music_assistant.controllers.streams.smart_fades.models import (
     BAND_RMS_BANDS,
+    BandProfile,
     Deck,
     EqPlan,
     FadeOutTrim,
@@ -55,6 +53,22 @@ from music_assistant.controllers.streams.smart_fades.models import (
 
 if TYPE_CHECKING:
     from music_assistant.models.audio_analysis import AudioAnalysisData
+
+
+def _band_gain(
+    schedule: ShelfSchedule | None,
+    rendered_t: float,
+    cf_start_input: float,
+    ratio: float,
+    *,
+    side: str,
+) -> float:
+    """Gain (dB) of a band schedule at rendered overlap time; ``None`` is 0dB."""
+    if schedule is None:
+        return 0.0
+    # A-side schedules live in pre-stretch input time; B-side already in rendered time
+    schedule_time = cf_start_input + rendered_t * ratio if side == "A" else rendered_t
+    return schedule.gain_at(schedule_time)
 
 
 class TransitionPlanner(ABC):
@@ -102,44 +116,37 @@ class SmartCrossFadePlanner(TransitionPlanner):
     # decision window for the reciprocal swap depth gates, in A/B-bars
     bass_swap_window_bars: int = 8
 
-    # reciprocal bass-swap depth gate: each side's low-band power fraction over
-    # the other deck's window is smoothstepped across this corridor to scale
-    # its own kill depth; below eq_bypass_below_db the schedule is dropped.
-    # Corridor from published LTAS integrations over these band edges: dance
-    # masters carry ~0.34-0.45 of their power below 120Hz, mean pop ~0.14,
-    # acoustic genres less (Elowsson & Friberg 2017; Pestana et al. 2013)
+    # Reciprocal bass-swap gate: smoothstep each side's low-band fraction (over the
+    # OTHER deck's window) to scale its own kill depth; dropped below eq_bypass_below_db.
+    # Corridor sits deliberately below the published dance-master figures (~0.34-0.45
+    # of power under 120Hz; pop ~0.14 — Elowsson & Friberg 2017, Pestana et al. 2013):
+    # it reads an 8-bar transition window, not a whole-track LTAS, and putting lo under
+    # the pop mean lets ordinary pop still earn a partial swap. Final values corpus-tuned.
     low_gate_lo: float = 0.10
     low_gate_hi: float = 0.25
     eq_bypass_below_db: float = -6.0
 
-    # reciprocal high-ease depth gate: same reciprocal-window shape as the bass
-    # swap, but on the high band. Mean-music LTAS integrates to ~0.02 in
-    # 4-11kHz (Elowsson & Friberg 2017), so lo = an average track earns no
-    # duck and hi = unmistakably brighter than average earns the full ease.
-    # A deck whose OWN window high level falls below high_own_side_floor of
-    # its own reference gets no shelf at all
+    # Reciprocal high-ease gate, same shape on the high band. Mean-music LTAS is ~0.02 in
+    # 4-11kHz (Elowsson & Friberg 2017): lo = an average track earns no duck, hi = clearly
+    # brighter than average earns the full ease. A deck whose own-window high level is below
+    # high_own_side_floor of its own reference gets no shelf at all.
     high_gate_lo: float = 0.02
     high_gate_hi: float = 0.06
     high_own_side_floor: float = 0.25
-    # cymbal-wash mode: both decks' own windows read bright and comparably
-    # loud (loudness-normalized playback assumed), so a plain reciprocal ease
-    # would let their highs stack; duck A complementary with B's restore instead
+    # Cymbal-wash mode: when both own-windows read bright and comparably loud a plain
+    # reciprocal ease would stack their highs, so duck A complementary with B's restore.
     wash_duty: float = 0.8
     wash_depth_db: float = -26.0
     wash_level_tolerance_db: float = 6.0
     wash_min_blend_bars: int = 8
 
-    # measured mid-band (vocal) swap: same reciprocal-gate shape as the bass
-    # swap, but on the mid band and gated additionally on how consistently
-    # that band is present (duty), since a single loud mid bar shouldn't
-    # unlock a swap over an otherwise instrumental track
+    # Measured mid-band (vocal) swap: bass-swap gate shape on the mid band, gated also on
+    # duty so one loud mid bar can't unlock a swap over otherwise instrumental material.
     mid_freq: int = 1200
     mid_width_oct: float = 2.5
-    # Vocal fundamentals sit below 400Hz (~90% of voice power is under 1kHz,
-    # Sundberg-line voice research), so vocal-forward mixes integrate to only
-    # ~0.25-0.45 mid fraction vs ~0.10-0.15 for instrumental dance material
-    # (LTAS: Elowsson & Friberg 2017; Pestana et al. 2013). The corridor sits
-    # in that gap; absolute placement verified on our unweighted pipeline
+    # Corridor sits in the gap between vocal-forward mixes (~0.25-0.45 mid fraction) and
+    # instrumental dance (~0.10-0.15); absolute placement verified on our unweighted
+    # pipeline (LTAS: Elowsson & Friberg 2017, Pestana et al. 2013).
     mid_gate_lo: float = 0.18
     mid_gate_hi: float = 0.30
     mid_duty_lo: float = 0.60
@@ -147,9 +154,8 @@ class SmartCrossFadePlanner(TransitionPlanner):
     mid_cap_db: float = -8.0
     mid_bypass_below_db: float = -1.0
 
-    # plan-time predicted-loudness-dip guard: the combined qsin-weighted power
-    # of both decks' scheduled bands may never sag more than this many dB
-    # below its plateau across the overlap
+    # Dip guard: combined qsin-weighted power of both decks may never sag more than this
+    # below its plateau across the overlap (outside the intentional bass-handover notch).
     max_predicted_dip_db: float = 3.0
 
     # Working state for one plan() run, (re)set by _prepare_decks
@@ -906,7 +912,9 @@ class SmartCrossFadePlanner(TransitionPlanner):
         # or mid is fully bypassed
         shrink_steps = (0.75, 0.5, 0.25, 0.0)
         for shrink in shrink_steps:
-            candidate = self._scale_mid_depth(eq_plan, shrink)
+            candidate = eq_plan.with_mid_depth_scaled(
+                shrink, bypass_below_db=self.mid_bypass_below_db
+            )
             if dip_db(candidate) <= self.max_predicted_dip_db or shrink == 0.0:
                 eq_plan = candidate
                 break
@@ -918,7 +926,7 @@ class SmartCrossFadePlanner(TransitionPlanner):
         # there is no further knob beyond the floor), so its result is
         # returned whether or not it fully clears the budget.
         floor_len = self.bass_swap_min_bars * bar_in
-        eq_plan = self._steepen_low_ramps(eq_plan, swap_at, floor_len, ratio, cf_start_input)
+        eq_plan = eq_plan.with_low_ramps_steepened(swap_at, floor_len, ratio, cf_start_input)
         # the notch narrowed along with the ramp span; keep it in sync so it
         # still reflects the plan's actual bass-handover window
         start_in = max(0.0, swap_at - floor_len / 2)
@@ -951,13 +959,13 @@ class SmartCrossFadePlanner(TransitionPlanner):
             p_a = sum(
                 f_a[band]
                 * 10.0
-                ** (self._gain_at(schedules_a.get(band), t, cf_start_input, ratio, side="A") / 10.0)
+                ** (_band_gain(schedules_a.get(band), t, cf_start_input, ratio, side="A") / 10.0)
                 for band in BAND_RMS_BANDS
             )
             p_b = sum(
                 f_b[band]
                 * 10.0
-                ** (self._gain_at(schedules_b.get(band), t, cf_start_input, ratio, side="B") / 10.0)
+                ** (_band_gain(schedules_b.get(band), t, cf_start_input, ratio, side="B") / 10.0)
                 for band in BAND_RMS_BANDS
             )
             power = float(w_a * p_a + w_b * p_b)
@@ -965,74 +973,3 @@ class SmartCrossFadePlanner(TransitionPlanner):
             if running_max > 0.0 and power > 0.0:
                 max_drop_db = max(max_drop_db, 10.0 * float(np.log10(running_max / power)))
         return max_drop_db
-
-    @staticmethod
-    def _gain_at(
-        schedule: ShelfSchedule | None,
-        t: float,
-        cf_start_input: float,
-        ratio: float,
-        *,
-        side: str,
-    ) -> float:
-        """Interpolate a schedule's gain (dB) at rendered overlap time ``t``; ``None`` is 0dB."""
-        if schedule is None:
-            return 0.0
-        tt = cf_start_input + t * ratio if side == "A" else t
-        steps = schedule.steps
-        if tt <= steps[0][0]:
-            return steps[0][1]
-        if tt >= steps[-1][0]:
-            return steps[-1][1]
-        for (t0, g0), (t1, g1) in itertools.pairwise(steps):
-            if t0 <= tt <= t1:
-                frac = (tt - t0) / (t1 - t0) if t1 > t0 else 0.0
-                return g0 + frac * (g1 - g0)
-        return steps[-1][1]
-
-    def _scale_mid_depth(self, eq_plan: EqPlan, shrink: float) -> EqPlan:
-        """Scale the mid schedules' depth by ``shrink`` (fraction to KEEP); bypass below the floor."""
-        if eq_plan.mid_out is None and eq_plan.mid_in is None:
-            return eq_plan
-        source = eq_plan.mid_out or eq_plan.mid_in
-        assert source is not None  # narrowed by the check above
-        depth = source.steps[-1 if eq_plan.mid_out else 0][1]
-        if shrink <= 0.0 or abs(depth * shrink) < abs(self.mid_bypass_below_db):
-            return replace(eq_plan, mid_out=None, mid_in=None)
-        mid_out = eq_plan.mid_out
-        mid_in = eq_plan.mid_in
-        if mid_out is not None:
-            mid_out = replace(mid_out, steps=[(t, g * shrink) for t, g in mid_out.steps])
-        if mid_in is not None:
-            mid_in = replace(mid_in, steps=[(t, g * shrink) for t, g in mid_in.steps])
-        return replace(eq_plan, mid_out=mid_out, mid_in=mid_in)
-
-    @staticmethod
-    def _steepen_low_ramps(
-        eq_plan: EqPlan,
-        swap_at: float,
-        new_len: float,
-        ratio: float,
-        cf_start_input: float,
-    ) -> EqPlan:
-        """Rebuild the low ramps to span ``new_len`` centered on ``swap_at``; endpoint gains unchanged."""
-        if eq_plan.low_out is None and eq_plan.low_in is None:
-            return eq_plan
-        start_in = max(0.0, swap_at - new_len / 2)
-        new_len_input = new_len * ratio
-        swap_at_input = cf_start_input + swap_at * ratio
-        start_out = max(cf_start_input, swap_at_input - new_len_input / 2)
-
-        low_out = eq_plan.low_out
-        if low_out is not None:
-            depth_a = low_out.steps[-1][1]
-            low_out = replace(
-                low_out, steps=[(0.0, 0.0), *db_ramp(start_out, new_len_input, 0.0, depth_a)]
-            )
-        low_in = eq_plan.low_in
-        if low_in is not None:
-            depth_b = low_in.steps[0][1]
-            low_in = replace(
-                low_in, steps=[(0.0, depth_b), *db_ramp(start_in, new_len, depth_b, 0.0)]
-            )
-        return replace(eq_plan, low_out=low_out, low_in=low_in)

--- a/music_assistant/controllers/streams/smart_fades/planner.py
+++ b/music_assistant/controllers/streams/smart_fades/planner.py
@@ -925,6 +925,10 @@ class SmartCrossFadePlanner(TransitionPlanner):
         # This is the last remediation step (never shallow the low depth —
         # there is no further knob beyond the floor), so its result is
         # returned whether or not it fully clears the budget.
+        if eq_plan.low_out is None and eq_plan.low_in is None:
+            # a bass-light pair has no low handover to tighten and no notch to
+            # narrow; mid-scaling was the only lever, so leave the sentinel notch
+            return eq_plan
         floor_len = self.bass_swap_min_bars * bar_in
         eq_plan = eq_plan.with_low_ramps_steepened(swap_at, floor_len, ratio, cf_start_input)
         # the notch narrowed along with the ramp span; keep it in sync so it

--- a/music_assistant/controllers/streams/smart_fades/renderer.py
+++ b/music_assistant/controllers/streams/smart_fades/renderer.py
@@ -20,7 +20,9 @@ from music_assistant.controllers.streams.smart_fades.filters import (
     FadeOutTrimFilter,
     Filter,
     GradualTimeStretchFilter,
+    PeakFilter,
     ShelfFilter,
+    ShelfType,
 )
 from music_assistant.controllers.streams.smart_fades.models import (
     CrossfadeTimingInfo,
@@ -89,25 +91,44 @@ class TransitionRenderer:
                 )
             )
         # outgoing shelves before the stretch keep their schedules in musical input time
-        filters.append(self._shelf_filter(plan.eq_plan.low_out, "fadeout"))
-        filters.append(self._shelf_filter(plan.eq_plan.high_out, "fadeout"))
+        self._append_shelf(filters, plan.eq_plan.low_out, "fadeout")
+        self._append_shelf(filters, plan.eq_plan.high_out, "fadeout")
+        self._append_shelf(filters, plan.eq_plan.mid_out, "fadeout")
         if plan.tempo_plan:
             filters.append(GradualTimeStretchFilter(self.logger, plan.tempo_plan.steps))
         if plan.fadein_trim_start is not None:
             filters.append(
                 FadeInTrimFilter(logger=self.logger, fadein_start_pos=plan.fadein_trim_start)
             )
-        filters.append(self._shelf_filter(plan.eq_plan.low_in, "fadein"))
-        filters.append(self._shelf_filter(plan.eq_plan.high_in, "fadein"))
+        self._append_shelf(filters, plan.eq_plan.low_in, "fadein")
+        self._append_shelf(filters, plan.eq_plan.high_in, "fadein")
+        self._append_shelf(filters, plan.eq_plan.mid_in, "fadein")
         filters.append(CrossfadeFilter(logger=self.logger, crossfade_samples=crossfade_samples))
         return filters
 
-    def _shelf_filter(self, schedule: ShelfSchedule, stream_type: str) -> ShelfFilter:
-        """Instantiate a ShelfFilter from a shelf schedule."""
-        return ShelfFilter(
-            logger=self.logger,
-            shelf_type=schedule.shelf_type,
-            frequency=schedule.frequency,
-            gain_steps=schedule.steps,
-            stream_type=stream_type,
+    def _append_shelf(
+        self, filters: list[Filter], schedule: ShelfSchedule | None, stream_type: str
+    ) -> None:
+        """Append the matching filter for ``schedule``, or nothing when bypassed (None)."""
+        if schedule is None:
+            return
+        if schedule.shelf_type is ShelfType.PEAK:
+            filters.append(
+                PeakFilter(
+                    logger=self.logger,
+                    frequency=schedule.frequency,
+                    width_oct=schedule.width_oct,
+                    gain_steps=schedule.steps,
+                    stream_type=stream_type,
+                )
+            )
+            return
+        filters.append(
+            ShelfFilter(
+                logger=self.logger,
+                shelf_type=schedule.shelf_type,
+                frequency=schedule.frequency,
+                gain_steps=schedule.steps,
+                stream_type=stream_type,
+            )
         )

--- a/tests/controllers/streams/smart_fades/conftest.py
+++ b/tests/controllers/streams/smart_fades/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 
 from music_assistant.models.audio_analysis import AudioAnalysisData
@@ -13,7 +15,7 @@ def _envelope(value: float | list[float] | np.ndarray) -> list[float]:
         arr = np.asarray(value, dtype=np.float32)
         if len(arr) != 1800:
             raise ValueError(f"band envelope arrays must have 1800 bins, got {len(arr)}")
-        return arr.tolist()
+        return cast("list[float]", arr.tolist())
     return np.full(1800, value, dtype=np.float32).tolist()
 
 

--- a/tests/controllers/streams/smart_fades/conftest.py
+++ b/tests/controllers/streams/smart_fades/conftest.py
@@ -1,0 +1,54 @@
+"""Shared test helpers for the smart_fades test suite."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from music_assistant.models.audio_analysis import AudioAnalysisData
+
+
+def _envelope(value: float | list[float] | np.ndarray) -> list[float]:
+    """Broadcast a scalar to a flat 1800-bin envelope, or pass an array through."""
+    if isinstance(value, (list, np.ndarray)):
+        arr = np.asarray(value, dtype=np.float32)
+        if len(arr) != 1800:
+            raise ValueError(f"band envelope arrays must have 1800 bins, got {len(arr)}")
+        return arr.tolist()
+    return np.full(1800, value, dtype=np.float32).tolist()
+
+
+def _analysis_with_bands(
+    low: float | list[float] | np.ndarray,
+    low_mid: float | list[float] | np.ndarray,
+    mid: float | list[float] | np.ndarray,
+    high: float | list[float] | np.ndarray,
+    duration: float = 240.0,
+) -> AudioAnalysisData:
+    """
+    Build an analysis row with v2 ``band_rms`` envelopes for band-profile tests.
+
+    Each band accepts either a constant level or a 1800-bin array, so callers
+    can vary a band's envelope over time (e.g. a kick that drops out midway).
+
+    :param low: Low-band envelope, constant level or 1800-bin array.
+    :param low_mid: Low-mid-band envelope, constant level or 1800-bin array.
+    :param mid: Mid-band envelope, constant level or 1800-bin array.
+    :param high: High-band envelope, constant level or 1800-bin array.
+    :param duration: Track duration in seconds.
+    """
+    beats = np.arange(0.0, duration, 0.5, dtype=np.float32)
+    return AudioAnalysisData(
+        duration=duration,
+        bpm=120.0,
+        beats=beats,
+        downbeats=beats[::4],
+        rms_energy=np.full(1800, 0.5, dtype=np.float32),
+        extra_data={
+            "band_rms": {
+                "low": _envelope(low),
+                "low_mid": _envelope(low_mid),
+                "mid": _envelope(mid),
+                "high": _envelope(high),
+            }
+        },
+    )

--- a/tests/controllers/streams/smart_fades/test_bands.py
+++ b/tests/controllers/streams/smart_fades/test_bands.py
@@ -1,0 +1,102 @@
+"""Tests for the band-power signal module (bar fractions on the deck's own grid)."""
+
+from __future__ import annotations
+
+import pytest
+
+from music_assistant.controllers.streams.smart_fades.bands import (
+    build_band_profile,
+    loudness_referenced_level,
+    smoothstep,
+    window_duty,
+    window_fraction,
+)
+from tests.controllers.streams.smart_fades.conftest import _analysis_with_bands
+
+
+class TestBandProfile:
+    """Power fractions on the bar grid, invariant to the peak normalization."""
+
+    def test_fractions_are_power_not_amplitude(self) -> None:
+        """Equal amplitudes in two bands give 0.5 power fraction each."""
+        a = _analysis_with_bands(0.3, 0.3, 0.0, 0.0)
+        p = build_band_profile(a)
+        assert p is not None
+        assert window_fraction(p, "low", 0.0, 60.0) == pytest.approx(0.5, abs=1e-6)
+
+    def test_normalization_cancels(self) -> None:
+        """Scaling all envelopes by a constant leaves fractions unchanged."""
+        a1 = _analysis_with_bands(0.4, 0.1, 0.2, 0.05)
+        a2 = _analysis_with_bands(0.2, 0.05, 0.1, 0.025)
+        f1 = window_fraction(build_band_profile(a1), "mid", 0.0, 60.0)
+        f2 = window_fraction(build_band_profile(a2), "mid", 0.0, 60.0)
+        assert f1 == pytest.approx(f2, abs=1e-6)
+
+    def test_missing_band_rms_returns_none(self) -> None:
+        """v1 rows (no extra_data) yield None so policies bypass."""
+        a = _analysis_with_bands(0.3, 0.1, 0.1, 0.05)
+        a.extra_data = None
+        assert build_band_profile(a) is None
+
+    def test_all_silent_track_returns_none(self) -> None:
+        """All-zero envelopes have no active bars, so the profile is None."""
+        assert build_band_profile(_analysis_with_bands(0.0, 0.0, 0.0, 0.0)) is None
+
+    def test_too_few_downbeats_returns_none(self) -> None:
+        """Fewer than 8 downbeats leaves no usable bar grid, so the profile is None."""
+        a = _analysis_with_bands(0.3, 0.1, 0.1, 0.05)
+        a.downbeats = a.downbeats[:7]
+        assert build_band_profile(a) is None
+
+    def test_falsy_duration_returns_none(self) -> None:
+        """A zero/missing duration leaves no bin-to-second mapping, so the profile is None."""
+        a = _analysis_with_bands(0.3, 0.1, 0.1, 0.05)
+        a.duration = 0.0
+        assert build_band_profile(a) is None
+
+    def test_empty_window_is_zero(self) -> None:
+        """A window past the track end returns 0.0, never NaN."""
+        p = build_band_profile(_analysis_with_bands(0.3, 0.1, 0.1, 0.05))
+        assert window_fraction(p, "low", 500.0, 600.0) == 0.0
+        assert window_duty(p, "low", 500.0, 600.0) == 0.0
+
+    def test_duty_counts_bars_above_reference_fraction(self) -> None:
+        """Duty = share of window bars at >= k x the track's sustained band power."""
+        a = _analysis_with_bands(0.3, 0.1, 0.1, 0.05)
+        bands = a.extra_data["band_rms"]
+        bands["mid"] = ([0.0] * 900) + ([0.4] * 900)  # mid silent first half
+        p = build_band_profile(a)
+        assert window_duty(p, "mid", 0.0, 120.0) == pytest.approx(0.0, abs=0.05)
+        assert window_duty(p, "mid", 120.0, 240.0) == pytest.approx(1.0, abs=0.05)
+
+
+class TestSmoothstep:
+    """The only depth-shaping primitive: zero at threshold, saturating, continuous."""
+
+    def test_endpoints_and_midpoint(self) -> None:
+        """Exactly 0 below lo, 1 above hi, 0.5 at the midpoint."""
+        assert smoothstep(0.09, 0.10, 0.25) == 0.0
+        assert smoothstep(0.30, 0.10, 0.25) == 1.0
+        assert smoothstep(0.175, 0.10, 0.25) == pytest.approx(0.5)
+
+
+class TestLoudnessReferencedLevel:
+    """Level normalized by the track's own active-bar total power."""
+
+    def test_normalization_cancels(self) -> None:
+        """Scaling all envelopes by a constant leaves the referenced level unchanged."""
+        a1 = _analysis_with_bands(0.4, 0.1, 0.2, 0.05)
+        a2 = _analysis_with_bands(0.2, 0.05, 0.1, 0.025)
+        r1 = loudness_referenced_level(build_band_profile(a1), "mid", 0.0, 60.0)
+        r2 = loudness_referenced_level(build_band_profile(a2), "mid", 0.0, 60.0)
+        assert r1 == pytest.approx(r2, abs=1e-6)
+
+    def test_louder_window_scores_higher(self) -> None:
+        """A window with more low-band power than the track average scores > 1."""
+        a = _analysis_with_bands(0.1, 0.1, 0.1, 0.1)
+        bands = a.extra_data["band_rms"]
+        bands["low"] = ([0.1] * 900) + ([0.5] * 900)  # louder low band, second half
+        p = build_band_profile(a)
+        quiet = loudness_referenced_level(p, "low", 0.0, 120.0)
+        loud = loudness_referenced_level(p, "low", 120.0, 240.0)
+        assert loud > quiet

--- a/tests/controllers/streams/smart_fades/test_bands.py
+++ b/tests/controllers/streams/smart_fades/test_bands.py
@@ -28,8 +28,11 @@ class TestBandProfile:
         """Scaling all envelopes by a constant leaves fractions unchanged."""
         a1 = _analysis_with_bands(0.4, 0.1, 0.2, 0.05)
         a2 = _analysis_with_bands(0.2, 0.05, 0.1, 0.025)
-        f1 = window_fraction(build_band_profile(a1), "mid", 0.0, 60.0)
-        f2 = window_fraction(build_band_profile(a2), "mid", 0.0, 60.0)
+        p1, p2 = build_band_profile(a1), build_band_profile(a2)
+        assert p1 is not None
+        assert p2 is not None
+        f1 = window_fraction(p1, "mid", 0.0, 60.0)
+        f2 = window_fraction(p2, "mid", 0.0, 60.0)
         assert f1 == pytest.approx(f2, abs=1e-6)
 
     def test_missing_band_rms_returns_none(self) -> None:
@@ -45,6 +48,7 @@ class TestBandProfile:
     def test_too_few_downbeats_returns_none(self) -> None:
         """Fewer than 8 downbeats leaves no usable bar grid, so the profile is None."""
         a = _analysis_with_bands(0.3, 0.1, 0.1, 0.05)
+        assert a.downbeats is not None
         a.downbeats = a.downbeats[:7]
         assert build_band_profile(a) is None
 
@@ -57,15 +61,18 @@ class TestBandProfile:
     def test_empty_window_is_zero(self) -> None:
         """A window past the track end returns 0.0, never NaN."""
         p = build_band_profile(_analysis_with_bands(0.3, 0.1, 0.1, 0.05))
+        assert p is not None
         assert window_fraction(p, "low", 500.0, 600.0) == 0.0
         assert window_duty(p, "low", 500.0, 600.0) == 0.0
 
     def test_duty_counts_bars_above_reference_fraction(self) -> None:
         """Duty = share of window bars at >= k x the track's sustained band power."""
         a = _analysis_with_bands(0.3, 0.1, 0.1, 0.05)
+        assert a.extra_data is not None
         bands = a.extra_data["band_rms"]
         bands["mid"] = ([0.0] * 900) + ([0.4] * 900)  # mid silent first half
         p = build_band_profile(a)
+        assert p is not None
         assert window_duty(p, "mid", 0.0, 120.0) == pytest.approx(0.0, abs=0.05)
         assert window_duty(p, "mid", 120.0, 240.0) == pytest.approx(1.0, abs=0.05)
 
@@ -87,16 +94,21 @@ class TestLoudnessReferencedLevel:
         """Scaling all envelopes by a constant leaves the referenced level unchanged."""
         a1 = _analysis_with_bands(0.4, 0.1, 0.2, 0.05)
         a2 = _analysis_with_bands(0.2, 0.05, 0.1, 0.025)
-        r1 = loudness_referenced_level(build_band_profile(a1), "mid", 0.0, 60.0)
-        r2 = loudness_referenced_level(build_band_profile(a2), "mid", 0.0, 60.0)
+        p1, p2 = build_band_profile(a1), build_band_profile(a2)
+        assert p1 is not None
+        assert p2 is not None
+        r1 = loudness_referenced_level(p1, "mid", 0.0, 60.0)
+        r2 = loudness_referenced_level(p2, "mid", 0.0, 60.0)
         assert r1 == pytest.approx(r2, abs=1e-6)
 
     def test_louder_window_scores_higher(self) -> None:
         """A window with more low-band power than the track average scores > 1."""
         a = _analysis_with_bands(0.1, 0.1, 0.1, 0.1)
+        assert a.extra_data is not None
         bands = a.extra_data["band_rms"]
         bands["low"] = ([0.1] * 900) + ([0.5] * 900)  # louder low band, second half
         p = build_band_profile(a)
+        assert p is not None
         quiet = loudness_referenced_level(p, "low", 0.0, 120.0)
         loud = loudness_referenced_level(p, "low", 120.0, 240.0)
         assert loud > quiet

--- a/tests/controllers/streams/smart_fades/test_filters.py
+++ b/tests/controllers/streams/smart_fades/test_filters.py
@@ -9,6 +9,7 @@ import pytest
 from music_assistant.controllers.streams.smart_fades.filters import (
     CrossfadeFilter,
     FadeOutTrimFilter,
+    PeakFilter,
     ShelfFilter,
     ShelfType,
 )
@@ -103,3 +104,46 @@ class TestShelfFilter:
         assert a.output_fadeout_label != b.output_fadeout_label
         c = ShelfFilter(LOGGER, ShelfType.LOW, 100, [(0.0, -26.0)], "fadeout")
         assert a.output_fadein_label != c.output_fadein_label
+
+
+class TestPeakFilter:
+    """asendcmd-driven parametric peak EQ (mid swap) on one stream, passthrough on the other."""
+
+    def test_fadeout_peak_strings(self) -> None:
+        """A fadeout peak emits an asendcmd gain schedule and a fadein passthrough."""
+        f = PeakFilter(
+            LOGGER,
+            1200,
+            2.5,
+            [(0.0, 0.0), (30.0, -4.0), (31.0, -8.0)],
+            "fadeout",
+        )
+        strings = f.apply("[1]", "[0]")
+        assert len(strings) == 2
+        assert any("anull" in s and "[1]" in s for s in strings)  # codespell:ignore anull
+        chain = next(s for s in strings if "[0]" in s)
+        assert "asendcmd=" in chain
+        assert "equalizer@fadeout_mid" in chain
+        assert "g=0.00" in chain
+        assert "f=1200:width_type=o:width=2.5" in chain
+        assert "30.000 equalizer@fadeout_mid g -4.00" in chain
+
+    def test_fadein_peak_processes_other_stream(self) -> None:
+        """A fadein peak processes the incoming stream and passes the outgoing through."""
+        f = PeakFilter(LOGGER, 1200, 2.5, [(0.0, -8.0), (5.0, 0.0)], "fadein")
+        strings = f.apply("[1]", "[0]")
+        chain = next(s for s in strings if "[1]" in s)
+        assert "equalizer@fadein_mid" in chain
+        assert "g=-8.00" in chain
+        passthrough = next(s for s in strings if "[0]" in s)
+        assert "anull" in passthrough  # codespell:ignore anull
+
+    def test_labels_unique_and_no_collision_with_shelf(self) -> None:
+        """Peak labels differ per stream and don't collide with ShelfFilter's labels."""
+        a = PeakFilter(LOGGER, 1200, 2.5, [(0.0, -8.0)], "fadein")
+        b = PeakFilter(LOGGER, 1200, 2.5, [(0.0, -8.0)], "fadeout")
+        assert a.output_fadein_label != b.output_fadein_label
+        low = ShelfFilter(LOGGER, ShelfType.LOW, 100, [(0.0, -26.0)], "fadein")
+        high = ShelfFilter(LOGGER, ShelfType.HIGH, 13000, [(0.0, -20.0)], "fadein")
+        assert a.output_fadein_label not in {low.output_fadein_label, high.output_fadein_label}
+        assert a.output_fadeout_label not in {low.output_fadeout_label, high.output_fadeout_label}

--- a/tests/controllers/streams/smart_fades/test_planner.py
+++ b/tests/controllers/streams/smart_fades/test_planner.py
@@ -623,6 +623,22 @@ def _wash_low_stack_pair() -> tuple[AudioAnalysisData, AudioAnalysisData]:
     return out, inc
 
 
+def _wash_no_low_stack_pair() -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """
+    Like ``_wash_low_stack_pair`` but bass-light, so the low swap stays bypassed.
+
+    The deep wash overruns the budget even after mid bypass, so remediation
+    reaches step 2 with no low schedules to steepen — the fixture for the
+    "step 2 must not fabricate an in-overlap notch exemption" regression.
+    """
+    amps = (0.05**0.5, 0.05**0.5, 0.25**0.5, 0.55**0.5)
+    out = _analysis_with_bands(*amps, duration=240.0)
+    inc = _analysis_with_bands(*amps, duration=240.0)
+    t = np.linspace(0, 240.0, 1800)
+    inc.rms_energy = np.where(t < 14.0, 0.05, 0.5).astype(np.float32)
+    return out, inc
+
+
 def _unguarded_plan(
     out: AudioAnalysisData, inc: AudioAnalysisData
 ) -> tuple[SmartCrossFadePlanner, TransitionPlan]:
@@ -781,6 +797,22 @@ class TestPredictedDipGuard:
         assert plan.eq_plan.low_out is None
         assert plan.eq_plan.low_in is None
         # the notch must not swallow any real sample in [0, crossfade_duration]
+        assert not (0.0 <= planner._swap_notch[0] <= plan.crossfade_duration) or not (
+            0.0 <= planner._swap_notch[1] <= plan.crossfade_duration
+        )
+
+    def test_step2_on_bass_light_pair_keeps_the_sentinel_notch(self) -> None:
+        """Reaching step 2 with no low swap must not fabricate an in-overlap notch exemption."""
+        out, inc = _wash_no_low_stack_pair()
+        _, unguarded = _unguarded_plan(out, inc)
+        # the mid swap engaged and remediation had to fire (deep wash dip)...
+        assert unguarded.eq_plan.mid_out is not None
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        # ...on a bass-light pair, so there are no low schedules to steepen
+        assert plan.eq_plan.low_out is None
+        assert plan.eq_plan.low_in is None
+        # the notch must stay the sentinel: no real sample in [0, crossfade_duration]
         assert not (0.0 <= planner._swap_notch[0] <= plan.crossfade_duration) or not (
             0.0 <= planner._swap_notch[1] <= plan.crossfade_duration
         )

--- a/tests/controllers/streams/smart_fades/test_planner.py
+++ b/tests/controllers/streams/smart_fades/test_planner.py
@@ -2,19 +2,25 @@
 
 from __future__ import annotations
 
+import itertools
 import logging
+import math
 
 import numpy as np
 import pytest
 
+from music_assistant.controllers.streams.smart_fades.bands import window_fraction
 from music_assistant.controllers.streams.smart_fades.filters import ShelfType
 from music_assistant.controllers.streams.smart_fades.helpers import SMART_CROSSFADE_DURATION
 from music_assistant.controllers.streams.smart_fades.models import (
+    EqPlan,
+    ShelfSchedule,
     SmartFadeNotApplicable,
     TransitionPlan,
 )
 from music_assistant.controllers.streams.smart_fades.planner import SmartCrossFadePlanner
 from music_assistant.models.audio_analysis import AudioAnalysisData
+from tests.controllers.streams.smart_fades.conftest import _analysis_with_bands
 
 LOGGER = logging.getLogger(__name__)
 
@@ -156,3 +162,698 @@ class TestSmartCrossFadePlanner:
         assert span == pytest.approx(expected, rel=0.05)
         midpoint = (ramp[0][0] + ramp[-1][0]) / 2
         assert midpoint == pytest.approx(plan.eq_plan.swap_at, abs=0.2)
+
+
+def _bands_pair(f_low_out: float, f_low_in: float) -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """
+    Build an outgoing/incoming pair whose low band carries the given power fractions.
+
+    ``band_rms`` envelopes store amplitude, but ``window_fraction`` compares
+    squared (power) sums, so the fixture solves for the amplitude that yields
+    the requested power fraction rather than passing it through directly.
+    """
+
+    def _levels(f_low: float) -> tuple[float, float, float, float]:
+        low = 1.0
+        rest = ((1.0 - f_low) / (3.0 * f_low)) ** 0.5 * low
+        return low, rest, rest, rest
+
+    out = _analysis_with_bands(*_levels(f_low_out), duration=240.0)
+    inc = _analysis_with_bands(*_levels(f_low_in), duration=240.0)
+    return out, inc
+
+
+def _mid_pair(f_mid_out: float, f_mid_in: float) -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """
+    Build an outgoing/incoming pair whose mid band carries the given power fractions.
+
+    Low band is fixed bass-light on both sides so the low swap never engages,
+    isolating the mid gate. Mid bands are constant over time, so ``duty_mid``
+    is trivially 1.0 (every window bar sits at the track's own reference).
+    """
+
+    def _levels(f_mid: float) -> tuple[float, float, float, float]:
+        mid = 1.0
+        low = 0.05**0.5 * mid  # low power fraction ~0.05: well under the bass-swap gate
+        rest = (((1.0 - 0.05 - f_mid) / 2.0) / f_mid) ** 0.5 * mid
+        return low, rest, mid, rest
+
+    out = _analysis_with_bands(*_levels(f_mid_out), duration=240.0)
+    inc = _analysis_with_bands(*_levels(f_mid_in), duration=240.0)
+    return out, inc
+
+
+def _rich_pair() -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """
+    Bass-rich AND mid-heavy pair: both the low and mid swap engage.
+
+    Its combined dip sits inside the low-swap notch, which the dip guard
+    exempts (the intentional handover gesture), so its schedules are never
+    remediated.
+    """
+    out = _analysis_with_bands(1.0, 0.3, 1.0, 0.3, duration=240.0)
+    inc = _analysis_with_bands(1.0, 0.3, 1.0, 0.3, duration=240.0)
+    return out, inc
+
+
+class TestMeasuredMidSwap:
+    """The mid-band (vocal) handover is gated by measured mid-band content."""
+
+    def test_vocal_vs_vocal_engages_at_full_depth(self) -> None:
+        """Both sides mid-heavy: mid swap engages at the -8dB cap."""
+        out, inc = _mid_pair(0.5, 0.5)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.mid_out is not None
+        assert plan.eq_plan.mid_in is not None
+        assert plan.eq_plan.mid_out.steps[-1][1] == pytest.approx(-8.0, abs=0.2)
+        assert plan.eq_plan.mid_in.steps[0][1] == pytest.approx(-8.0, abs=0.2)
+        assert plan.eq_plan.mid_out.steps[0][1] == pytest.approx(0.0)
+        assert plan.eq_plan.mid_in.steps[-1][1] == pytest.approx(0.0)
+        assert plan.eq_plan.mid_out.shelf_type == ShelfType.PEAK
+        assert plan.eq_plan.mid_out.frequency == 1200
+
+    def test_mid_corridor_fraction_scales_the_depth(self) -> None:
+        """F_mid at the corridor midpoint (0.24, smoothstep 0.5) scales the depth to -4dB."""
+        # the fixture's fixed bass-light term makes F_mid = f/(0.05f+0.95),
+        # so 0.231 lands the measured fraction on the 0.18-0.30 midpoint
+        out, inc = _mid_pair(0.231, 0.231)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.mid_out is not None
+        assert plan.eq_plan.mid_out.steps[-1][1] == pytest.approx(-4.0, abs=0.3)
+
+    def test_mid_schedule_mirrors_low_schedule_geometry(self) -> None:
+        """Mid ramps share start/end timing with the low swap (scaled gain only)."""
+        out, inc = _rich_pair()
+        plan = _plan(out, inc)
+        eq = plan.eq_plan
+        assert eq.low_out is not None
+        assert eq.mid_out is not None
+        assert [t for t, _ in eq.low_out.steps] == pytest.approx([t for t, _ in eq.mid_out.steps])
+        assert eq.low_in is not None
+        assert eq.mid_in is not None
+        assert [t for t, _ in eq.low_in.steps] == pytest.approx([t for t, _ in eq.mid_in.steps])
+
+    def test_instrumental_pair_bypasses_mid_swap(self) -> None:
+        """Both sides mid-light (F_mid under the 0.18 gate floor): mid swap stays bypassed."""
+        out, inc = _mid_pair(0.12, 0.12)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.mid_out is None
+        assert plan.eq_plan.mid_in is None
+
+    def test_one_sided_mid_bypasses_via_min_gate(self) -> None:
+        """One side mid-light: the min(score_A, score_B) gate bypasses both."""
+        out, inc = _mid_pair(0.5, 0.12)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.mid_out is None
+        assert plan.eq_plan.mid_in is None
+
+    def test_missing_profile_on_either_side_bypasses_mid_swap(self) -> None:
+        """No band data on either side: mid swap stays bypassed (no shipped mid filter)."""
+        plan = _plan(_analysis(120.0, duration=240.0), _analysis(120.0, duration=240.0))
+        assert plan.eq_plan.mid_out is None
+        assert plan.eq_plan.mid_in is None
+
+    def test_a_mid_never_starts_earlier_than_a_low_when_both_exist(self) -> None:
+        """Constraint: A's mid ramp never starts before A's low ramp when both engage."""
+        out, inc = _rich_pair()
+        plan = _plan(out, inc)
+        # engagement asserted first so this test can never silently vacuate
+        assert plan.eq_plan.low_out is not None
+        assert plan.eq_plan.mid_out is not None
+        low_start = next(t for t, g in plan.eq_plan.low_out.steps if g != 0.0)
+        mid_start = next(t for t, g in plan.eq_plan.mid_out.steps if g != 0.0)
+        assert mid_start >= low_start - 1e-6
+
+
+class TestReciprocalBassSwapDepth:
+    """Each deck's low-shelf kill scales with the OTHER deck's measured bass."""
+
+    def test_both_bass_rich_matches_full_depth_plan(self) -> None:
+        """Both decks bass-rich: the EQ schedules' gain endpoints stay at full depth."""
+        out, inc = _bands_pair(0.4, 0.4)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.low_out is not None
+        assert plan.eq_plan.low_in is not None
+        assert plan.eq_plan.low_out.steps[-1][1] == pytest.approx(-26.0)
+        assert plan.eq_plan.low_in.steps[0][1] == pytest.approx(-26.0)
+        assert plan.eq_plan.low_in.steps[-1][1] == pytest.approx(0.0)
+        assert plan.eq_plan.low_out.steps[0][1] == pytest.approx(0.0)
+
+    def test_bass_light_incoming_bypasses_outgoing_low_shelf(self) -> None:
+        """B bass-light: A's low-shelf kill is bypassed (no low filter on A)."""
+        out, inc = _bands_pair(0.4, 0.05)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.low_out is None
+        assert plan.eq_plan.low_in is not None
+
+    def test_both_bass_light_bypasses_both_low_shelves(self) -> None:
+        """Both decks bass-light: no low filters at all (pure equal-power crossfade)."""
+        out, inc = _bands_pair(0.05, 0.05)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.low_out is None
+        assert plan.eq_plan.low_in is None
+
+    def test_mid_corridor_bass_scales_the_depth(self) -> None:
+        """A's kill depth follows B's mid-corridor f_low (~0.175, smoothstep 0.5) to -13 dB."""
+        out, inc = _bands_pair(0.4, 0.175)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.low_out is not None
+        assert plan.eq_plan.low_out.steps[-1][1] == pytest.approx(-13.0, abs=0.5)
+
+    def test_missing_profile_on_either_side_keeps_full_depth(self) -> None:
+        """No band data on either side falls back to the shipped full-depth kill."""
+        plan = _plan(_analysis(120.0, duration=240.0), _analysis(120.0, duration=240.0))
+        assert plan.eq_plan.low_out is not None
+        assert plan.eq_plan.low_in is not None
+        assert plan.eq_plan.low_out.steps[-1][1] == pytest.approx(-26.0)
+        assert plan.eq_plan.low_in.steps[0][1] == pytest.approx(-26.0)
+
+    def test_swap_at_always_set_even_when_both_bypassed(self) -> None:
+        """swap_at stays populated regardless of whether the low shelves bypass."""
+        out, inc = _bands_pair(0.05, 0.05)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.swap_at > 0.0
+
+
+def _high_pair(f_high_out: float, f_high_in: float) -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """
+    Build a pair whose high band carries the given power fractions.
+
+    Same amplitude-solving approach as ``_bands_pair``/``_mid_pair``, targeting
+    the high band. Flat envelopes, so each side's own window level always
+    equals its own reference (the "dark own side" case needs a time-varying
+    fixture instead, see ``_dark_own_side_pair``).
+    """
+
+    def _levels(f_high: float) -> tuple[float, float, float, float]:
+        high = 1.0
+        rest = ((1.0 - f_high) / (3.0 * f_high)) ** 0.5 * high
+        return rest, rest, rest, high
+
+    out = _analysis_with_bands(*_levels(f_high_out), duration=240.0)
+    inc = _analysis_with_bands(*_levels(f_high_in), duration=240.0)
+    return out, inc
+
+
+def _dark_own_side_pair() -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """Build A: bright overall but its own outgoing window (last bars) gone dark; B: bright."""
+    duration = 240.0
+    t = np.linspace(0, duration, 1800)
+    high_out_env = np.where(t < 220.0, 1.0, 0.05).astype(np.float32)
+    out = _analysis_with_bands(0.577, 0.577, 0.577, high_out_env, duration=duration)
+    _, inc = _high_pair(0.5, 0.5)
+    return out, inc
+
+
+def _wash_pair(*, level_gap: bool = False) -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """
+    Both sides bright (high duty 1.0) on a long enough blend, sized for wash mode.
+
+    With ``level_gap=True``, B's non-high bands are boosted well outside its
+    own incoming window (media >= 150s) so its loudness-referenced high level
+    drops >6dB below A's while B's window-local high duty/fraction (0-16s) are
+    untouched — B looks bright locally but the mix as a whole is far quieter,
+    the "loudness normalization gone wrong" case the wash gate must reject.
+    """
+    out, _ = _high_pair(0.8, 0.8)
+    if not level_gap:
+        _, inc = _high_pair(0.8, 0.8)
+        return out, inc
+    duration = 240.0
+    t = np.linspace(0, duration, 1800)
+    low_mid = np.where(t >= 150.0, 3.0, 0.577).astype(np.float32)
+    mid = np.where(t >= 150.0, 3.0, 0.577).astype(np.float32)
+    inc = _analysis_with_bands(0.577, low_mid, mid, 1.0, duration=duration)
+    return out, inc
+
+
+class TestHighShelfReciprocalAndWash:
+    """The high-ease shelf makes room only for highs the other deck actually brings."""
+
+    def test_dark_incoming_keeps_outgoing_air(self) -> None:
+        """B has almost no highs: A's post-swap duck is bypassed (A keeps its air)."""
+        out, inc = _high_pair(0.5, 0.005)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.high_out is None
+        # B's own restore still follows A's (bright) gate
+        assert plan.eq_plan.high_in is not None
+        assert plan.eq_plan.high_in.steps[0][1] == pytest.approx(-20.0, abs=0.5)
+
+    def test_dark_own_side_emits_no_shelf_regardless_of_other_side(self) -> None:
+        """A's own outgoing window has gone dark: no high shelf on A, whatever B brings."""
+        out, inc = _dark_own_side_pair()
+        plan = _plan(out, inc)
+        assert plan.eq_plan.high_out is None
+
+    def test_wash_mode_deepens_and_mirrors_b_restore(self) -> None:
+        """Wash mode: A's duck deepens to -26 over the SAME rendered window as B's restore."""
+        out, inc = _wash_pair()
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        bar_out = 4 * 60.0 / 120.0
+        assert plan.crossfade_duration >= 8 * bar_out
+        eq = plan.eq_plan
+        assert eq.high_out is not None
+        assert eq.high_in is not None
+        assert eq.high_out.steps[-1][1] == pytest.approx(-26.0, abs=0.2)
+        # complementarity: A's highs fall in lockstep while B's rise, so the
+        # summed high energy stays ~flat; steps[0] is the t=0 pin, the ramp
+        # itself starts at steps[1] — high_out is A INPUT time, high_in is
+        # rendered (B post-trim) time, so map A's ramp back before comparing
+        ratio = 1.0  # equal BPMs on both sides -> no tempo stretch
+        cf_start_input = planner.effective_end - plan.crossfade_duration * ratio
+        duck_start_rendered = (eq.high_out.steps[1][0] - cf_start_input) / ratio
+        duck_end_rendered = (eq.high_out.steps[-1][0] - cf_start_input) / ratio
+        assert duck_start_rendered == pytest.approx(eq.high_in.steps[1][0], abs=0.2)
+        assert duck_end_rendered == pytest.approx(eq.high_in.steps[-1][0], abs=0.2)
+
+    def test_wash_duck_never_overruns_the_crossfade_end(self) -> None:
+        """With a late-clamped swap point, the wash duck stays inside the overlap."""
+        out, inc = _wash_pair()
+        # B's full-band energy steps in late (14s) so the swap point clamps
+        # against the overlap end — the reviewer's overrun reproduction
+        t = np.linspace(0, 240.0, 1800)
+        inc.rms_energy = np.where(t < 14.0, 0.05, 0.5).astype(np.float32)
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        eq = plan.eq_plan
+        assert eq.high_out is not None
+        assert eq.high_out.steps[-1][1] == pytest.approx(-26.0, abs=0.2)  # wash engaged
+        # A INPUT time: the duck must complete at or before the crossfade end
+        assert eq.high_out.steps[-1][0] <= planner.effective_end + 1e-6
+
+    def test_wash_mode_skipped_when_levels_differ_more_than_6db(self) -> None:
+        """Both sides bright but loudness-referenced levels differ >6dB: normal reciprocal ease."""
+        out, inc = _wash_pair(level_gap=True)
+        plan = _plan(out, inc)
+        eq = plan.eq_plan
+        assert eq.high_out is not None
+        # not the wash depth
+        assert eq.high_out.steps[-1][1] != pytest.approx(-26.0, abs=0.2)
+
+    def test_missing_profile_matches_shipped_high_schedule(self) -> None:
+        """No band data on either side: high schedules are byte-identical to the shipped ease."""
+        plan = _plan(_analysis(120.0, duration=240.0), _analysis(120.0, duration=240.0))
+        eq = plan.eq_plan
+        assert eq.high_out is not None
+        assert eq.high_in is not None
+        assert eq.high_out.steps[-1][1] == pytest.approx(-20.0)
+        assert eq.high_in.steps[0][1] == pytest.approx(-20.0)
+        assert eq.high_out.steps[-1][0] == pytest.approx(47.0, abs=0.1)
+        assert eq.high_in.steps[-1][0] == pytest.approx(7.0, abs=0.1)
+
+    def test_mid_corridor_incoming_scales_duck_to_half_depth(self) -> None:
+        """B's F_high in the gate's mid-corridor (~0.04) scales A's duck to ~-10dB."""
+        out, inc = _high_pair(0.5, 0.04)
+        plan = _plan(out, inc)
+        assert plan.eq_plan.high_out is not None
+        assert plan.eq_plan.high_out.steps[-1][1] == pytest.approx(-10.0, abs=0.5)
+
+    def test_dark_steady_pair_never_washes(self) -> None:
+        """Duty 1.0 on both sides but F_high 0.03 (dark): the brightness floor blocks wash."""
+        # duty measures consistency vs a track's OWN reference — a dark steady
+        # track scores 1.0, which is exactly what the absolute floor exists for
+        out, inc = _high_pair(0.03, 0.03)
+        plan = _plan(out, inc)
+        # wash would force A's duck to -26; instead the reciprocal ease applies
+        # and at F_high 0.03 it gates shallow enough to bypass entirely
+        assert plan.eq_plan.high_out is None
+
+
+def _gain_at(
+    schedule: object, t: float, *, cf_start_input: float, ratio: float, side: str
+) -> float:
+    """Interpolate a ShelfSchedule's gain (dB) at rendered time ``t``; 0.0 when bypassed."""
+    if schedule is None:
+        return 0.0
+    tt = cf_start_input + t * ratio if side == "A" else t
+    steps = schedule.steps  # type: ignore[attr-defined]
+    if tt <= steps[0][0]:
+        return float(steps[0][1])
+    if tt >= steps[-1][0]:
+        return float(steps[-1][1])
+    for (t0, g0), (t1, g1) in itertools.pairwise(steps):
+        if t0 <= tt <= t1:
+            frac = (tt - t0) / (t1 - t0) if t1 > t0 else 0.0
+            return float(g0 + frac * (g1 - g0))
+    return float(steps[-1][1])
+
+
+def _predicted_power_curve(
+    planner: SmartCrossFadePlanner, plan: TransitionPlan, n_samples: int = 200
+) -> list[tuple[float, float]]:
+    """
+    Sample the predicted combined power curve P(t) across the overlap.
+
+    Mirrors the plan-time dip guard's own math: reuses the reciprocal-gate
+    windows' band fractions and combines each deck's scheduled gain with the
+    qsin equal-power crossfade weights. Independent re-derivation from the
+    plan's public schedules, not a call into the guard itself, so the test
+    doesn't just check the implementation against itself.
+    """
+    eq = plan.eq_plan
+    duration = plan.crossfade_duration
+    ratio = plan.tempo_plan.steps[-1][1] if plan.tempo_plan else 1.0
+    cf_start_input = planner.effective_end - duration * ratio
+    w_a_out, w_b_in = planner._swap_windows(planner.bass_swap_window_bars)
+    assert planner.outgoing_profile is not None
+    assert planner.incoming_profile is not None
+    f_a = {
+        band: window_fraction(planner.outgoing_profile, band, *w_a_out)
+        for band in ("low", "low_mid", "mid", "high")
+    }
+    f_b = {
+        band: window_fraction(planner.incoming_profile, band, *w_b_in)
+        for band in ("low", "low_mid", "mid", "high")
+    }
+    schedules_a = {"low": eq.low_out, "mid": eq.mid_out, "high": eq.high_out}
+    schedules_b = {"low": eq.low_in, "mid": eq.mid_in, "high": eq.high_in}
+
+    curve = []
+    for i in range(n_samples + 1):
+        t = duration * i / n_samples
+        w_a = math.cos(math.pi / 2 * t / duration) ** 2
+        w_b = math.sin(math.pi / 2 * t / duration) ** 2
+        p_a = sum(
+            f_a[band]
+            * 10
+            ** (
+                _gain_at(
+                    schedules_a.get(band), t, cf_start_input=cf_start_input, ratio=ratio, side="A"
+                )
+                / 10
+            )
+            for band in ("low", "low_mid", "mid", "high")
+        )
+        p_b = sum(
+            f_b[band]
+            * 10
+            ** (
+                _gain_at(
+                    schedules_b.get(band), t, cf_start_input=cf_start_input, ratio=ratio, side="B"
+                )
+                / 10
+            )
+            for band in ("low", "low_mid", "mid", "high")
+        )
+        curve.append((t, w_a * p_a + w_b * p_b))
+    return curve
+
+
+def _max_plateau_to_valley_drop_db(
+    curve: list[tuple[float, float]], exclude: tuple[float, float] | None = None
+) -> float:
+    """
+    Max running-max-to-current drop in dB across a sampled power curve (max-drawdown).
+
+    :param curve: Sampled ``(t, power)`` points across the overlap.
+    :param exclude: Rendered interval to skip (the exempt low-swap notch), if any.
+    """
+    max_drop_db = 0.0
+    running_max = 0.0
+    for t, p in curve:
+        if exclude is not None and exclude[0] <= t <= exclude[1]:
+            continue
+        running_max = max(running_max, p)
+        if running_max > 0.0 and p > 0.0:
+            max_drop_db = max(max_drop_db, 10.0 * math.log10(running_max / p))
+    return max_drop_db
+
+
+def _wash_mid_stack_pair() -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """
+    Bright + vocal pair whose dip lands OUTSIDE the low-swap notch.
+
+    Both sides bright enough for wash mode (F_high 0.45) and mid-heavy enough
+    for the vocal swap (F_mid 0.42), bass-light (low swap bypassed, so the
+    exempt notch contains no low crossing). B's groove enters late (14s) so
+    the swap window sits at the end of the overlap; the wash duck mirrors B's
+    high restore BEFORE it, where it stacks with B's pinned mid kill — a
+    >3dB combined dip outside the notch, recoverable by shrinking the mid.
+    """
+    amps = (0.065**0.5, 0.065**0.5, 0.42**0.5, 0.45**0.5)
+    out = _analysis_with_bands(*amps, duration=240.0)
+    inc = _analysis_with_bands(*amps, duration=240.0)
+    t = np.linspace(0, 240.0, 1800)
+    inc.rms_energy = np.where(t < 14.0, 0.05, 0.5).astype(np.float32)
+    return out, inc
+
+
+def _wash_low_stack_pair() -> tuple[AudioAnalysisData, AudioAnalysisData]:
+    """
+    Like ``_wash_mid_stack_pair`` but with the low swap engaged and a residual dip.
+
+    F_high 0.55 makes the wash stack deep enough that mid bypass alone cannot
+    clear the budget, so remediation reaches step 2 (low-ramp steepening) —
+    the fixture for the never-shallow-the-low-depth and 2-bar-floor tests.
+    F_low 0.15 sits in the reciprocal gate's corridor (partial-depth kill).
+    """
+    amps = (0.15**0.5, 0.05**0.5, 0.25**0.5, 0.55**0.5)
+    out = _analysis_with_bands(*amps, duration=240.0)
+    inc = _analysis_with_bands(*amps, duration=240.0)
+    t = np.linspace(0, 240.0, 1800)
+    inc.rms_energy = np.where(t < 14.0, 0.05, 0.5).astype(np.float32)
+    return out, inc
+
+
+def _unguarded_plan(
+    out: AudioAnalysisData, inc: AudioAnalysisData
+) -> tuple[SmartCrossFadePlanner, TransitionPlan]:
+    """Plan with the dip guard effectively disabled (budget set beyond any real dip)."""
+    planner = SmartCrossFadePlanner(LOGGER)
+    planner.max_predicted_dip_db = 1000.0
+    return planner, planner.plan(out, inc, 45.0)
+
+
+class TestScaleMidDepth:
+    """Scaling the mid depth toward bypass never ships a schedule under the bypass floor."""
+
+    def _plan_with_mid(self, depth: float) -> EqPlan:
+        mid_out = ShelfSchedule(ShelfType.PEAK, 1200, [(0.0, 0.0), (5.0, depth), (10.0, depth)])
+        mid_in = ShelfSchedule(ShelfType.PEAK, 1200, [(0.0, depth), (5.0, depth), (10.0, 0.0)])
+        return EqPlan(
+            swap_at=5.0,
+            low_out=None,
+            low_in=None,
+            high_out=None,
+            high_in=None,
+            mid_out=mid_out,
+            mid_in=mid_in,
+        )
+
+    def test_shrink_below_bypass_floor_yields_none_not_a_shallow_schedule(self) -> None:
+        """Shrinking -2dB by 0.25 (-0.5dB, under the -1dB floor) bypasses instead of shipping it."""
+        planner = SmartCrossFadePlanner(LOGGER)
+        eq = self._plan_with_mid(-2.0)
+        candidate = planner._scale_mid_depth(eq, 0.25)
+        assert candidate.mid_out is None
+        assert candidate.mid_in is None
+
+    def test_shrink_at_the_bypass_floor_is_kept(self) -> None:
+        """Shrinking -2dB by 0.5 (exactly -1dB, at the floor) is kept, not bypassed."""
+        planner = SmartCrossFadePlanner(LOGGER)
+        eq = self._plan_with_mid(-2.0)
+        candidate = planner._scale_mid_depth(eq, 0.5)
+        assert candidate.mid_out is not None
+        assert candidate.mid_out.steps[-1][1] == pytest.approx(-1.0)
+
+
+class TestPredictedDipGuard:
+    """
+    The dip check polices the overlap OUTSIDE the low-swap notch.
+
+    The notch (the low crossover's ramp window) is the intentional,
+    ear-approved bass-handover gesture and is exempt — like the
+    band-conservation check's notch. Only dips leaking outside it are
+    remediated (mid depth first, then low-ramp steepening; the low depth is
+    never shallowed).
+    """
+
+    def test_outside_notch_dip_reduces_mid_depth(self) -> None:
+        """A >3dB dip outside the notch (wash + pinned mid stack) shrinks the mid depth."""
+        out, inc = _wash_mid_stack_pair()
+        _, unguarded = _unguarded_plan(out, inc)
+        assert unguarded.eq_plan.mid_out is not None
+        gate_depth = unguarded.eq_plan.mid_out.steps[-1][1]
+        assert gate_depth == pytest.approx(-8.0, abs=0.2)
+
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        eq = plan.eq_plan
+        curve = _predicted_power_curve(planner, plan)
+        dip = _max_plateau_to_valley_drop_db(curve, exclude=planner._swap_notch)
+        assert dip <= planner.max_predicted_dip_db + 0.2
+        # remediation shrank the mid depth (or bypassed it) vs the gate's value
+        if eq.mid_out is not None:
+            assert abs(eq.mid_out.steps[-1][1]) < abs(gate_depth)
+        else:
+            assert eq.mid_in is None
+
+    def test_full_depth_house_notch_is_not_remediated(self) -> None:
+        """A full-depth bass swap's >3dB in-notch dip is the intentional gesture: untouched."""
+        out, inc = _bands_pair(0.7, 0.7)
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        eq = plan.eq_plan
+        curve = _predicted_power_curve(planner, plan)
+        # the notch itself dips well past the budget...
+        assert _max_plateau_to_valley_drop_db(curve) > planner.max_predicted_dip_db
+        # ...but outside it the plan is within budget, so nothing is remediated:
+        assert _max_plateau_to_valley_drop_db(curve, exclude=planner._swap_notch) <= (
+            planner.max_predicted_dip_db
+        )
+        assert eq.low_out is not None
+        assert eq.low_out.steps[-1][1] == pytest.approx(-26.0)
+        assert eq.low_in is not None
+        assert eq.low_in.steps[0][1] == pytest.approx(-26.0)
+        # ramp span keeps the shipped proportional length (half the overlap,
+        # here unclamped) — no steepening happened
+        ramp = eq.low_in.steps[1:]
+        assert ramp[-1][0] - ramp[0][0] == pytest.approx(plan.crossfade_duration / 2, rel=0.05)
+
+    def test_normal_house_pair_is_untouched(self) -> None:
+        """A normal (mid-bypassed) house pair keeps its shipped schedules unchanged."""
+        out, inc = _bands_pair(0.4, 0.4)
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        eq = plan.eq_plan
+        curve = _predicted_power_curve(planner, plan)
+        assert _max_plateau_to_valley_drop_db(curve, exclude=planner._swap_notch) <= (
+            planner.max_predicted_dip_db
+        )
+        assert eq.mid_out is None
+        assert eq.mid_in is None
+        assert eq.low_out is not None
+        assert eq.low_out.steps[-1][1] == pytest.approx(-26.0)
+        assert eq.low_in is not None
+        assert eq.low_in.steps[0][1] == pytest.approx(-26.0)
+
+    def test_remediation_never_shallows_the_low_endpoint(self) -> None:
+        """Even when remediation reaches the low ramps, their endpoint gains are untouched."""
+        out, inc = _wash_low_stack_pair()
+        _, unguarded = _unguarded_plan(out, inc)
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        eq, ueq = plan.eq_plan, unguarded.eq_plan
+        # remediation fired (mid differs from the unguarded plan)...
+        assert (eq.mid_out is None) or (
+            ueq.mid_out is not None and abs(eq.mid_out.steps[-1][1]) < abs(ueq.mid_out.steps[-1][1])
+        )
+        # ...but the low endpoints are bit-identical to the unguarded plan's
+        assert eq.low_out is not None
+        assert ueq.low_out is not None
+        assert eq.low_out.steps[-1][1] == ueq.low_out.steps[-1][1]
+        assert eq.low_in is not None
+        assert ueq.low_in is not None
+        assert eq.low_in.steps[0][1] == ueq.low_in.steps[0][1]
+
+    def test_remediated_low_ramp_steepens_to_the_two_bar_floor(self) -> None:
+        """When steepening engages, the ramp lands exactly at the 2-bar floor, never below."""
+        out, inc = _wash_low_stack_pair()
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        eq = plan.eq_plan
+        assert eq.low_in is not None
+        bar_in = 4 * 60.0 / 120.0
+        ramp = eq.low_in.steps[1:]
+        span = ramp[-1][0] - ramp[0][0]
+        assert span == pytest.approx(planner.bass_swap_min_bars * bar_in, rel=0.01)
+
+    def test_notch_narrows_after_low_ramp_steepening(self) -> None:
+        """After step-2 remediation, the notch reflects the steepened (2-bar) ramp."""
+        out, inc = _wash_low_stack_pair()
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        assert plan.eq_plan.low_in is not None
+        ramp = plan.eq_plan.low_in.steps[1:]
+        assert planner._swap_notch == pytest.approx((ramp[0][0], ramp[-1][0]), abs=0.01)
+
+    def test_bass_light_pair_gets_no_notch_exemption(self) -> None:
+        """No low swap engaged: the notch never exempts a sample (no handover to exempt)."""
+        out, inc = _bands_pair(0.05, 0.05)
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        assert plan.eq_plan.low_out is None
+        assert plan.eq_plan.low_in is None
+        # the notch must not swallow any real sample in [0, crossfade_duration]
+        assert not (0.0 <= planner._swap_notch[0] <= plan.crossfade_duration) or not (
+            0.0 <= planner._swap_notch[1] <= plan.crossfade_duration
+        )
+
+    def test_dip_guard_is_a_no_op_when_already_within_budget(self) -> None:
+        """A plan whose dip is already within budget produces bit-identical schedules."""
+        out, inc = _bands_pair(0.4, 0.4)
+        plan_a = _plan(out, inc)
+        plan_b = _plan(out, inc)
+        assert plan_a == plan_b
+
+
+class TestBandConservation:
+    """TEST-ONLY: where both sides pass their gate floor, one deck stays within 6dB of unity."""
+
+    def _conserves(
+        self, planner: SmartCrossFadePlanner, plan: TransitionPlan, band: str, gate_floor: float
+    ) -> bool:
+        """
+        Check conservation for one band: True when the invariant holds.
+
+        The exception zone is the swap ramp's own span (derived from the
+        engaging schedule's steps), not a fixed 1-bar constant: a reciprocal
+        swap symmetric around ``swap_at`` necessarily drives BOTH sides away
+        from unity across its whole ramp (that is the handover), so a fixed
+        ≤1-bar notch as literally read in the plan would be violated by any
+        shipped ramp longer than ~1 bar (this pair's ramps are 2-8 bars by
+        design, see ``bass_swap_min_bars``/``bass_swap_max_bars``). Outside
+        the ramp, one side always sits at its 0dB/unengaged endpoint, so the
+        invariant holds trivially there.
+        """
+        eq = plan.eq_plan
+        ratio = plan.tempo_plan.steps[-1][1] if plan.tempo_plan else 1.0
+        duration = plan.crossfade_duration
+        cf_start_input = planner.effective_end - duration * ratio
+        w_a_out, w_b_in = planner._swap_windows(planner.bass_swap_window_bars)
+        assert planner.outgoing_profile is not None
+        assert planner.incoming_profile is not None
+        f_a = window_fraction(planner.outgoing_profile, band, *w_a_out)
+        f_b = window_fraction(planner.incoming_profile, band, *w_b_in)
+        if f_a < gate_floor or f_b < gate_floor:
+            return True  # gate floor not cleared on both sides: invariant N/A
+        schedule_a = {"low": eq.low_out, "mid": eq.mid_out, "high": eq.high_out}[band]
+        schedule_b = {"low": eq.low_in, "mid": eq.mid_in, "high": eq.high_in}[band]
+        if schedule_a is None or schedule_b is None:
+            return True  # one side bypassed: no double-engagement possible
+        # B's schedule is already in rendered time; its ramp span IS the swap window
+        ramp_start, ramp_end = schedule_b.steps[0][0], schedule_b.steps[-1][0]
+        n_samples = 200
+        for i in range(n_samples + 1):
+            t = duration * i / n_samples
+            g_a = _gain_at(schedule_a, t, cf_start_input=cf_start_input, ratio=ratio, side="A")
+            g_b = _gain_at(schedule_b, t, cf_start_input=cf_start_input, ratio=ratio, side="B")
+            in_ramp = ramp_start <= t <= ramp_end
+            if in_ramp:
+                continue
+            if abs(g_a) > 6.0 and abs(g_b) > 6.0:
+                return False
+        return True
+
+    def test_holds_for_bass_rich_plan(self) -> None:
+        """Representative engaged plan: both bass-rich, full low swap engaged."""
+        out, inc = _bands_pair(0.4, 0.4)
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        assert self._conserves(planner, plan, "low", planner.low_gate_lo)
+
+    def test_holds_for_mid_and_low_engaged_plan(self) -> None:
+        """Representative engaged plan: both low and mid swaps engaged (_rich_pair)."""
+        out, inc = _rich_pair()
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        assert self._conserves(planner, plan, "low", planner.low_gate_lo)
+        assert self._conserves(planner, plan, "mid", planner.mid_gate_lo)
+
+    def test_holds_for_wash_mode_plan(self) -> None:
+        """Representative engaged plan: cymbal-wash mode on the high band."""
+        out, inc = _wash_pair()
+        planner = SmartCrossFadePlanner(LOGGER)
+        plan = planner.plan(out, inc, 45.0)
+        assert self._conserves(planner, plan, "high", planner.high_gate_lo)

--- a/tests/controllers/streams/smart_fades/test_planner.py
+++ b/tests/controllers/streams/smart_fades/test_planner.py
@@ -643,17 +643,15 @@ class TestScaleMidDepth:
 
     def test_shrink_below_bypass_floor_yields_none_not_a_shallow_schedule(self) -> None:
         """Shrinking -2dB by 0.25 (-0.5dB, under the -1dB floor) bypasses instead of shipping it."""
-        planner = SmartCrossFadePlanner(LOGGER)
         eq = self._plan_with_mid(-2.0)
-        candidate = planner._scale_mid_depth(eq, 0.25)
+        candidate = eq.with_mid_depth_scaled(0.25, bypass_below_db=-1.0)
         assert candidate.mid_out is None
         assert candidate.mid_in is None
 
     def test_shrink_at_the_bypass_floor_is_kept(self) -> None:
         """Shrinking -2dB by 0.5 (exactly -1dB, at the floor) is kept, not bypassed."""
-        planner = SmartCrossFadePlanner(LOGGER)
         eq = self._plan_with_mid(-2.0)
-        candidate = planner._scale_mid_depth(eq, 0.5)
+        candidate = eq.with_mid_depth_scaled(0.5, bypass_below_db=-1.0)
         assert candidate.mid_out is not None
         assert candidate.mid_out.steps[-1][1] == pytest.approx(-1.0)
 

--- a/tests/controllers/streams/smart_fades/test_planner.py
+++ b/tests/controllers/streams/smart_fades/test_planner.py
@@ -69,6 +69,10 @@ class TestSmartCrossFadePlanner:
         assert isinstance(plan, TransitionPlan)
         assert plan.crossfade_duration > 0
         eq = plan.eq_plan
+        assert eq.low_out is not None
+        assert eq.low_in is not None
+        assert eq.high_out is not None
+        assert eq.high_in is not None
         assert eq.low_out.shelf_type is ShelfType.LOW
         assert eq.low_in.shelf_type is ShelfType.LOW
         assert eq.high_out.shelf_type is ShelfType.HIGH
@@ -147,6 +151,8 @@ class TestSmartCrossFadePlanner:
         bins[t < 20.0] = 0.05
         inc.rms_energy = bins
         plan = _plan(_analysis(120.0, duration=240.0), inc)
+        assert plan.eq_plan.low_in is not None
+        assert plan.eq_plan.low_out is not None
         # B's bass must be fully restored before the rendered mix ends
         assert plan.eq_plan.low_in.steps[-1][0] <= plan.crossfade_duration + 1e-6
         # A's bass kill must complete before A's audible end
@@ -157,6 +163,7 @@ class TestSmartCrossFadePlanner:
         plan = _plan(_analysis(120.0, duration=240.0), _analysis(120.0, duration=240.0))
         bar = 4 * 60.0 / 120.0
         expected = min(max(plan.crossfade_duration / 2, 2 * bar), 8 * bar)
+        assert plan.eq_plan.low_in is not None
         ramp = plan.eq_plan.low_in.steps[1:]  # steps[0] is the (0.0, kill) pin
         span = ramp[-1][0] - ramp[0][0]
         assert span == pytest.approx(expected, rel=0.05)

--- a/tests/controllers/streams/smart_fades/test_render_integration.py
+++ b/tests/controllers/streams/smart_fades/test_render_integration.py
@@ -38,6 +38,35 @@ def _analysis(bpm: float, duration: float) -> AudioAnalysisData:
     )
 
 
+def _with_bands(
+    analysis: AudioAnalysisData, low: float, low_mid: float, mid: float, high: float
+) -> AudioAnalysisData:
+    """Attach flat ``band_rms`` envelopes at the given amplitudes."""
+    analysis.extra_data = {
+        "band_rms": {
+            "low": np.full(1800, low, dtype=np.float32).tolist(),
+            "low_mid": np.full(1800, low_mid, dtype=np.float32).tolist(),
+            "mid": np.full(1800, mid, dtype=np.float32).tolist(),
+            "high": np.full(1800, high, dtype=np.float32).tolist(),
+        }
+    }
+    return analysis
+
+
+def _analysis_with_mid_bands(bpm: float, duration: float) -> AudioAnalysisData:
+    """Analysis with a mid-heavy, bass-light ``band_rms`` profile that clears the mid gate."""
+    # bass-light so the low swap stays out of the way; mid-heavy and constant
+    # so duty_mid saturates to 1.0 and F_mid clears the 0.18-0.30 gate corridor
+    return _with_bands(_analysis(bpm, duration), 0.05, 0.3, 0.7, 0.3)
+
+
+def _analysis_with_instrumental_bands(bpm: float, duration: float) -> AudioAnalysisData:
+    """Analysis with a bass-light, mid-light profile: every measured EQ gate bypasses."""
+    # f_low ~0.014 and f_mid ~0.13 sit below their gate corridors, so both the
+    # low and mid swap bypass while anchors/entry stay on the full-band paths
+    return _with_bands(_analysis(bpm, duration), 0.1, 0.55, 0.3, 0.55)
+
+
 def _band_rms(x: np.ndarray, lo: float, hi: float) -> float:
     """RMS of one frequency band of the (interleaved stereo) signal's left channel."""
     mono = x[0::2]
@@ -47,17 +76,90 @@ def _band_rms(x: np.ndarray, lo: float, hi: float) -> float:
     return float(np.sqrt(np.mean(spec[mask] ** 2)))
 
 
-@pytest.mark.asyncio
-async def test_bass_swaps_between_tracks() -> None:
-    """Early mix output carries A's bass (60Hz); late output carries B's (90Hz)."""
-    fade = SmartCrossFade(logging.getLogger(), _analysis(120.0, 240.0), _analysis(120.0, 240.0))
-    fade_out = (_tone(60.0, 45.0) + _tone(3000.0, 45.0)).tobytes()  # A: 60Hz bass
-    fade_in = (_tone(90.0, 45.0) + _tone(5000.0, 45.0)).tobytes()  # B: 90Hz bass
+async def _render(
+    out_analysis: AudioAnalysisData,
+    in_analysis: AudioAnalysisData,
+    fade_out: bytes,
+    fade_in: bytes,
+) -> tuple[np.ndarray, SmartCrossFade]:
+    """Build and apply a SmartCrossFade, returning the rendered mix and the fade."""
+    fade = SmartCrossFade(logging.getLogger(), out_analysis, in_analysis)
     fade.build(len(fade_out), len(fade_in), PCM)
     chunks = [chunk async for chunk in fade.apply(fade_out, fade_in, PCM)]
-    mix = np.frombuffer(b"".join(chunks), dtype=np.float32)
+    return np.frombuffer(b"".join(chunks), dtype=np.float32), fade
+
+
+def _thirds(mix: np.ndarray) -> list[np.ndarray]:
+    """Split an interleaved mix into three frame-aligned thirds."""
     third = len(mix) // 3 // 2 * 2
-    head, tail = mix[:third], mix[-third:]
-    # A's bass dominates early; B's bass dominates late (the swap happened)
-    assert _band_rms(head, 55, 65) > 3 * _band_rms(head, 85, 95)
-    assert _band_rms(tail, 85, 95) > 3 * _band_rms(tail, 55, 65)
+    return [mix[i * third : (i + 1) * third] for i in range(3)]
+
+
+@pytest.mark.asyncio
+async def test_bass_swaps_between_tracks() -> None:
+    """The low shelves attenuate A's bass and duck B's entrance vs an EQ-bypassed render."""
+    fade_out = (_tone(60.0, 45.0) + _tone(3000.0, 45.0)).tobytes()  # A: 60Hz bass
+    fade_in = (_tone(90.0, 45.0) + _tone(5000.0, 45.0)).tobytes()  # B: 90Hz bass
+    # differential render: identical PCM, one plan with the shipped full-depth
+    # kill (no band data) and one whose measured gates bypass all low shelves --
+    # any energy difference is then attributable to the low EQ, not acrossfade
+    killed_mix, killed = await _render(
+        _analysis(120.0, 240.0), _analysis(120.0, 240.0), fade_out, fade_in
+    )
+    open_mix, open_ = await _render(
+        _analysis_with_instrumental_bands(120.0, 240.0),
+        _analysis_with_instrumental_bands(120.0, 240.0),
+        fade_out,
+        fade_in,
+    )
+    assert killed.plan is not None
+    assert killed.plan.eq_plan.low_out is not None
+    assert open_.plan is not None
+    assert open_.plan.eq_plan.low_out is None
+    assert open_.plan.eq_plan.low_in is None
+    # identical geometry: the band data must only change EQ, never the timing
+    assert len(killed_mix) == len(open_mix)
+    killed_thirds, open_thirds = _thirds(killed_mix), _thirds(open_mix)
+    # A's bass is killed where the swap completes (late); B enters bass-ducked
+    # (early); -26dB kill leaves well under 30% of the bypassed render's energy
+    assert _band_rms(killed_thirds[2], 55, 65) < 0.3 * _band_rms(open_thirds[2], 55, 65)
+    assert _band_rms(killed_thirds[0], 85, 95) < 0.3 * _band_rms(open_thirds[0], 85, 95)
+    # sanity on the killed render alone: A's bass dominates early, B's late
+    assert _band_rms(killed_thirds[0], 55, 65) > 3 * _band_rms(killed_thirds[0], 85, 95)
+    assert _band_rms(killed_thirds[2], 85, 95) > 3 * _band_rms(killed_thirds[2], 55, 65)
+
+
+@pytest.mark.asyncio
+async def test_mid_swaps_between_tracks() -> None:
+    """The mid peaks trade A's 1kHz for B's 2kHz vs an EQ-bypassed render of the same PCM."""
+    fade_out = _tone(1000.0, 45.0).tobytes()  # A: 1kHz "vocal"
+    fade_in = _tone(2000.0, 45.0).tobytes()  # B: 2kHz "vocal"
+    # differential render: identical PCM, one plan whose band data engages the
+    # mid gate and one whose band data bypasses every measured EQ gate -- the
+    # 1k/2k energy difference is then attributable to the mid EQ alone
+    gated_mix, gated = await _render(
+        _analysis_with_mid_bands(120.0, 240.0),
+        _analysis_with_mid_bands(120.0, 240.0),
+        fade_out,
+        fade_in,
+    )
+    open_mix, open_ = await _render(
+        _analysis_with_instrumental_bands(120.0, 240.0),
+        _analysis_with_instrumental_bands(120.0, 240.0),
+        fade_out,
+        fade_in,
+    )
+    assert gated.plan is not None
+    assert gated.plan.eq_plan.mid_out is not None
+    assert gated.plan.eq_plan.mid_in is not None
+    assert open_.plan is not None
+    assert open_.plan.eq_plan.mid_out is None
+    assert open_.plan.eq_plan.mid_in is None
+    # identical geometry: the band data must only change EQ, never the timing
+    assert len(gated_mix) == len(open_mix)
+    gated_thirds, open_thirds = _thirds(gated_mix), _thirds(open_mix)
+    # the -8dB depth is modest, so assert a measurable drop (not dominance):
+    # A's 1kHz is attenuated where the swap completes (late); B's 2kHz enters
+    # ducked (early); both measured against the EQ-bypassed render
+    assert _band_rms(gated_thirds[2], 950, 1050) < 0.7 * _band_rms(open_thirds[2], 950, 1050)
+    assert _band_rms(gated_thirds[0], 1950, 2050) < 0.7 * _band_rms(open_thirds[0], 1950, 2050)

--- a/tests/controllers/streams/smart_fades/test_render_integration.py
+++ b/tests/controllers/streams/smart_fades/test_render_integration.py
@@ -89,10 +89,12 @@ async def _render(
     return np.frombuffer(b"".join(chunks), dtype=np.float32), fade
 
 
-def _thirds(mix: np.ndarray) -> list[np.ndarray]:
-    """Split an interleaved mix into three frame-aligned thirds."""
-    third = len(mix) // 3 // 2 * 2
-    return [mix[i * third : (i + 1) * third] for i in range(3)]
+def _cf_slice(mix: np.ndarray, fade: SmartCrossFade, frac0: float, frac1: float) -> np.ndarray:
+    """Slice the rendered crossfade window between two fractions of its span."""
+    timing = fade.timing_info
+    start_s = timing.pre_crossfade_duration + frac0 * timing.crossfade_duration
+    end_s = timing.pre_crossfade_duration + frac1 * timing.crossfade_duration
+    return mix[int(start_s * SR) * 2 : int(end_s * SR) * 2]
 
 
 @pytest.mark.asyncio
@@ -119,14 +121,18 @@ async def test_bass_swaps_between_tracks() -> None:
     assert open_.plan.eq_plan.low_in is None
     # identical geometry: the band data must only change EQ, never the timing
     assert len(killed_mix) == len(open_mix)
-    killed_thirds, open_thirds = _thirds(killed_mix), _thirds(open_mix)
-    # A's bass is killed where the swap completes (late); B enters bass-ducked
-    # (early); -26dB kill leaves well under 30% of the bypassed render's energy
-    assert _band_rms(killed_thirds[2], 55, 65) < 0.3 * _band_rms(open_thirds[2], 55, 65)
-    assert _band_rms(killed_thirds[0], 85, 95) < 0.3 * _band_rms(open_thirds[0], 85, 95)
+    # measure inside the crossfade window itself: A's bass is killed where the
+    # swap completes (late); B enters bass-ducked (early); -26dB kill leaves
+    # well under 30% of the bypassed render's energy
+    killed_late = _cf_slice(killed_mix, killed, 0.7, 0.95)
+    open_late = _cf_slice(open_mix, open_, 0.7, 0.95)
+    killed_early = _cf_slice(killed_mix, killed, 0.05, 0.3)
+    open_early = _cf_slice(open_mix, open_, 0.05, 0.3)
+    assert _band_rms(killed_late, 55, 65) < 0.3 * _band_rms(open_late, 55, 65)
+    assert _band_rms(killed_early, 85, 95) < 0.3 * _band_rms(open_early, 85, 95)
     # sanity on the killed render alone: A's bass dominates early, B's late
-    assert _band_rms(killed_thirds[0], 55, 65) > 3 * _band_rms(killed_thirds[0], 85, 95)
-    assert _band_rms(killed_thirds[2], 85, 95) > 3 * _band_rms(killed_thirds[2], 55, 65)
+    assert _band_rms(killed_early, 55, 65) > 3 * _band_rms(killed_early, 85, 95)
+    assert _band_rms(killed_late, 85, 95) > 3 * _band_rms(killed_late, 55, 65)
 
 
 @pytest.mark.asyncio
@@ -157,9 +163,13 @@ async def test_mid_swaps_between_tracks() -> None:
     assert open_.plan.eq_plan.mid_in is None
     # identical geometry: the band data must only change EQ, never the timing
     assert len(gated_mix) == len(open_mix)
-    gated_thirds, open_thirds = _thirds(gated_mix), _thirds(open_mix)
     # the -8dB depth is modest, so assert a measurable drop (not dominance):
     # A's 1kHz is attenuated where the swap completes (late); B's 2kHz enters
-    # ducked (early); both measured against the EQ-bypassed render
-    assert _band_rms(gated_thirds[2], 950, 1050) < 0.7 * _band_rms(open_thirds[2], 950, 1050)
-    assert _band_rms(gated_thirds[0], 1950, 2050) < 0.7 * _band_rms(open_thirds[0], 1950, 2050)
+    # ducked (early); both measured against the EQ-bypassed render, inside
+    # the crossfade window itself
+    gated_late = _cf_slice(gated_mix, gated, 0.7, 0.95)
+    open_late = _cf_slice(open_mix, open_, 0.7, 0.95)
+    gated_early = _cf_slice(gated_mix, gated, 0.05, 0.3)
+    open_early = _cf_slice(open_mix, open_, 0.05, 0.3)
+    assert _band_rms(gated_late, 950, 1050) < 0.7 * _band_rms(open_late, 950, 1050)
+    assert _band_rms(gated_early, 1950, 2050) < 0.7 * _band_rms(open_early, 1950, 2050)

--- a/tests/controllers/streams/smart_fades/test_renderer.py
+++ b/tests/controllers/streams/smart_fades/test_renderer.py
@@ -13,6 +13,7 @@ from music_assistant.controllers.streams.smart_fades.filters import (
     FadeInTrimFilter,
     FadeOutTrimFilter,
     GradualTimeStretchFilter,
+    PeakFilter,
     ShelfFilter,
     ShelfType,
 )
@@ -86,6 +87,28 @@ class TestTransitionRenderer:
             CrossfadeFilter,
         ]
 
+    def test_bypassed_low_shelves_are_skipped(self) -> None:
+        """A bypassed (None) low shelf on either side emits no ShelfFilter for it."""
+        eq_plan = _eq_plan()
+        eq_plan.low_out = None
+        eq_plan.low_in = None
+        filters, _ = TransitionRenderer(LOGGER).render(_plan(eq_plan=eq_plan), PCM, _seconds(45))
+        assert [type(f) for f in filters] == [
+            ShelfFilter,  # A high
+            ShelfFilter,  # B high
+            CrossfadeFilter,
+        ]
+
+    def test_all_shelves_bypassed_leaves_only_crossfade(self) -> None:
+        """When every shelf is bypassed the chain is a pure crossfade."""
+        eq_plan = _eq_plan()
+        eq_plan.low_out = None
+        eq_plan.low_in = None
+        eq_plan.high_out = None
+        eq_plan.high_in = None
+        filters, _ = TransitionRenderer(LOGGER).render(_plan(eq_plan=eq_plan), PCM, _seconds(45))
+        assert [type(f) for f in filters] == [CrossfadeFilter]
+
     def test_timing_accounts_for_both_tracks(self) -> None:
         """PRE+CF spans the fade-out, TRIM+CF+POST spans the fade-in."""
         plan = _plan(fadein_trim_start=1.0)
@@ -139,3 +162,28 @@ class TestTransitionRenderer:
         assert timing.pre_crossfade_duration + timing.crossfade_duration == pytest.approx(
             expected_fade_out
         )
+
+
+class TestMidSwapRendering:
+    """A PEAK ShelfSchedule (mid swap) renders as a PeakFilter; None is skipped."""
+
+    def test_peak_schedule_renders_as_peak_filter(self) -> None:
+        """Populated mid_out/mid_in schedules render as PeakFilter instances."""
+        eq_plan = _eq_plan()
+        eq_plan.mid_out = ShelfSchedule(ShelfType.PEAK, 1200, [(0.0, 0.0), (36.0, -8.0)])
+        eq_plan.mid_in = ShelfSchedule(ShelfType.PEAK, 1200, [(0.0, -8.0), (7.0, 0.0)])
+        filters, _ = TransitionRenderer(LOGGER).render(_plan(eq_plan=eq_plan), PCM, _seconds(45))
+        assert [type(f) for f in filters] == [
+            ShelfFilter,  # A low
+            ShelfFilter,  # A high
+            PeakFilter,  # A mid
+            ShelfFilter,  # B low
+            ShelfFilter,  # B high
+            PeakFilter,  # B mid
+            CrossfadeFilter,
+        ]
+
+    def test_mid_none_is_skipped(self) -> None:
+        """A bypassed (None) mid schedule emits no PeakFilter."""
+        filters, _ = TransitionRenderer(LOGGER).render(_plan(), PCM, _seconds(45))
+        assert not any(isinstance(f, PeakFilter) for f in filters)

--- a/tests/controllers/streams/test_smartfade_transition_timings.py
+++ b/tests/controllers/streams/test_smartfade_transition_timings.py
@@ -938,6 +938,7 @@ class TestStretchSavings:
         fade = self._stretched_fade()
         assert fade.plan is not None
         low_out = fade.plan.eq_plan.low_out
+        assert low_out is not None
         assert low_out.steps[-1][1] == pytest.approx(-26.0)
         assert low_out.steps[-1][0] <= fade.effective_end + 0.05
 


### PR DESCRIPTION
# What does this implement/fix?

The smart crossfade EQ now turns each knob only when the music justifies it, scaled by what the *other* deck measurably carries (analyzer-v2 frequency band data). Every gate degrades to today's shipped behavior bit-identically when the evidence is absent (v1 analysis rows) or weak.

- **Shared signal module** (`bands.py`): bar-level band-power fractions on each deck's own downbeat grid — the only cross-track-comparable quantity the stored data supports.
- **Reciprocal bass swap**: A's low kill scales with the bass B actually brings (and vice versa) — no more one-sided bass holes on pop/bass-light pairs; house pairs keep the full −26 dB swap unchanged.
- **Measured mid swap** (new `PeakFilter`, 1.2 kHz): engages only when both sides carry sustained mid content (vocal-vs-vocal), capped at −8 dB, mirroring the bass swap's geometry.
- **Reciprocal high ease + cymbal-wash mode**: never ducks A's air against a dark incoming track; removes no-op shelves; a rare wash mode mirrors B's restore for genuinely bright-on-bright handovers.
- **Plan-time loudness dip guard**: predicted overlap loudness outside the intentional bass-handover notch stays within 3 dB, with mid-first remediation (the low depth is never shallowed).

All gate thresholds are expert-panel priors validated (and where the priors overshot, corrected) against a 22-direction calibration corpus. Timing is intentionally untouched — the EQ decision windows are placed by today's full-band detectors; kick-anchored window placement (which unlocks the mid swap on the known vocal-clash pair) follows in the upcoming alignment PR.

**Stacked PR:** based on #4580 (analyzer v2) so it retargets to `dev` automatically when that merges.

**Related issue (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes. *(hooks could not spawn in the dev worktree; ruff check/format + mypy verified clean per commit — CI will confirm)*
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.