### PR TITLE
Add username parameter to the search, search_library and library_items methods of music controller

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -286,6 +286,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         media_types: list[MediaType] = MediaType.ALL,
         limit: int = 25,
         library_only: bool = False,
+        username: str | None = None,
     ) -> SearchResults:
         """
         Perform global search for media items on all providers.
@@ -293,6 +294,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param search_query: Search query.
         :param media_types: A list of media_types to include.
         :param limit: number of items to return in the search (per type).
+        :param username: search providers/ library of this user
         """
         # use cache to avoid repeated searches
         plugin_search_providers = [
@@ -302,7 +304,8 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 priority=(ProviderType.PLUGIN,),
             )
         ]
-        search_providers = sorted(self.get_unique_providers() + plugin_search_providers)
+        async with ImpersonatedUser(self.mass, username):
+            search_providers = sorted(self.get_unique_providers() + plugin_search_providers)
         cache_provider_key = "library" if library_only else ",".join(search_providers)
         cache_key = f"{search_query}{'-'.join(sorted([mt.value for mt in media_types]))}-{limit}-{library_only}-{cache_provider_key}"
         if cache := await self.mass.cache.get(
@@ -353,7 +356,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         # handle normal global search by querying all providers
         results_per_provider: list[SearchResults] = []
         # always first search the library
-        library_results = await self.search_library(search_query, media_types, limit=limit)
+        library_results = await self.search_library(
+            search_query, media_types, limit=limit, username=username
+        )
         results_per_provider.append(library_results)
         if not library_only:
             # create a set of all provider item ids already in library
@@ -455,6 +460,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         search_query: str,
         media_types: list[MediaType],
         limit: int = 10,
+        username: str | None = None,
     ) -> SearchResults:
         """
         Perform search on the library.
@@ -462,26 +468,28 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         :param search_query: Search query
         :param media_types: A list of media_types to include.
         :param limit: number of items to return in the search (per type).
+        :param username: search providers/ library of this user
         """
         result = SearchResults()
-        for media_type in media_types:
-            ctrl = self.get_controller(media_type)
-            search_results = await ctrl.search(search_query, "library", limit=limit)
-            if search_results:
-                if media_type == MediaType.ARTIST:
-                    result.artists = cast("list[Artist]", search_results)
-                elif media_type == MediaType.ALBUM:
-                    result.albums = cast("list[Album]", search_results)
-                elif media_type == MediaType.TRACK:
-                    result.tracks = cast("list[Track]", search_results)
-                elif media_type == MediaType.PLAYLIST:
-                    result.playlists = cast("list[Playlist]", search_results)
-                elif media_type == MediaType.RADIO:
-                    result.radio = cast("list[Radio]", search_results)
-                elif media_type == MediaType.AUDIOBOOK:
-                    result.audiobooks = cast("list[Audiobook]", search_results)
-                elif media_type == MediaType.PODCAST:
-                    result.podcasts = cast("list[Podcast]", search_results)
+        async with ImpersonatedUser(self.mass, username):
+            for media_type in media_types:
+                ctrl = self.get_controller(media_type)
+                search_results = await ctrl.search(search_query, "library", limit=limit)
+                if search_results:
+                    if media_type == MediaType.ARTIST:
+                        result.artists = cast("list[Artist]", search_results)
+                    elif media_type == MediaType.ALBUM:
+                        result.albums = cast("list[Album]", search_results)
+                    elif media_type == MediaType.TRACK:
+                        result.tracks = cast("list[Track]", search_results)
+                    elif media_type == MediaType.PLAYLIST:
+                        result.playlists = cast("list[Playlist]", search_results)
+                    elif media_type == MediaType.RADIO:
+                        result.radio = cast("list[Radio]", search_results)
+                    elif media_type == MediaType.AUDIOBOOK:
+                        result.audiobooks = cast("list[Audiobook]", search_results)
+                    elif media_type == MediaType.PODCAST:
+                        result.podcasts = cast("list[Podcast]", search_results)
         return result
 
     @api_command("music/browse")

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -19,7 +19,10 @@ from music_assistant_models.media_items import (
 )
 
 from music_assistant.constants import DB_TABLE_ALBUM_ARTISTS, DB_TABLE_ALBUM_TRACKS, DB_TABLE_ALBUMS
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    ImpersonatedUser,
+    get_current_user,
+)
 from music_assistant.helpers.compare import (
     compare_album,
     compare_artists,
@@ -122,6 +125,7 @@ class AlbumsController(MediaControllerBase[Album]):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        username: str | None = None,
         album_types: list[AlbumType] | None = None,
         **kwargs: Any,
     ) -> list[Album]:
@@ -134,9 +138,13 @@ class AlbumsController(MediaControllerBase[Album]):
         :param offset: Number of items to skip.
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID (single string or list).
+        :param username: Get library items of this user.
         :param album_types: Filter by album types.
         :param genre: Filter by genre id(s).
         """
+        async with ImpersonatedUser(self.mass, username):
+            provider_filter = self._ensure_provider_filter(provider)
+
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
         extra_join_parts: list[str] = []
@@ -177,7 +185,7 @@ class AlbumsController(MediaControllerBase[Album]):
             limit=limit,
             offset=offset,
             order_by=order_by,
-            provider_filter=self._ensure_provider_filter(provider),
+            provider_filter=provider_filter,
             extra_query_parts=extra_query_parts,
             extra_query_params=extra_query_params,
             extra_join_parts=extra_join_parts,
@@ -206,7 +214,7 @@ class AlbumsController(MediaControllerBase[Album]):
                 search=None,
                 limit=remaining_limit,
                 order_by=order_by,
-                provider_filter=self._ensure_provider_filter(provider),
+                provider_filter=provider_filter,
                 extra_query_parts=extra_query_parts,
                 extra_query_params=extra_query_params,
                 extra_join_parts=extra_join_parts,

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -36,6 +36,7 @@ from music_assistant.constants import (
     VARIOUS_ARTISTS_MBID,
     VARIOUS_ARTISTS_NAME,
 )
+from music_assistant.controllers.webserver.helpers.auth_middleware import ImpersonatedUser
 from music_assistant.helpers.compare import (
     compare_album,
     compare_artist,
@@ -106,10 +107,12 @@ class ArtistsController(MediaControllerBase[Artist]):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        username: str | None = None,
         album_artists_only: bool = False,
         artist_type: ArtistType | None = None,
         **kwargs: Any,
     ) -> list[Artist]:
+        # ruff: noqa: PLR0913
         """
         Get in-database (album) artists.
 
@@ -122,7 +125,11 @@ class ArtistsController(MediaControllerBase[Artist]):
         :param album_artists_only: Only return artists that have albums.
         :param genre: Filter by genre id(s).
         :param artist_type: The artist's type
+        :param username: Get library items of this user.
         """
+        async with ImpersonatedUser(self.mass, username):
+            provider_filter = self._ensure_provider_filter(provider)
+
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
         if artist_type:
@@ -139,7 +146,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             limit=limit,
             offset=offset,
             order_by=order_by,
-            provider_filter=self._ensure_provider_filter(provider),
+            provider_filter=provider_filter,
             extra_query_parts=extra_query_parts,
             extra_query_params=extra_query_params,
             played_only=played_only,

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -21,7 +21,10 @@ from music_assistant.constants import (
     DB_TABLE_AUDIOBOOKS,
     DB_TABLE_PLAYLOG,
 )
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    ImpersonatedUser,
+    get_current_user,
+)
 from music_assistant.helpers.compare import (
     compare_audiobook,
     compare_media_item,
@@ -113,6 +116,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        username: str | None = None,
         without_collections: bool | None = None,
         **kwargs: Any,
     ) -> list[Audiobook]:
@@ -126,8 +130,12 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
+        :param username: Get library items of this user.
         :param without_collections: Do not return audiobooks which are part of a collection
         """
+        async with ImpersonatedUser(self.mass, username):
+            provider_filter = self._ensure_provider_filter(provider)
+
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
         if without_collections:
@@ -142,7 +150,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             limit=limit,
             offset=offset,
             order_by=order_by,
-            provider_filter=self._ensure_provider_filter(provider),
+            provider_filter=provider_filter,
             extra_query_parts=extra_query_parts,
             extra_query_params=extra_query_params,
             played_only=played_only,
@@ -160,7 +168,7 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
                 genre_ids=genre,
                 limit=limit,
                 order_by=order_by,
-                provider_filter=self._ensure_provider_filter(provider),
+                provider_filter=provider_filter,
                 extra_query_parts=extra_query_parts,
                 extra_query_params=extra_query_params,
                 in_library_only=True,

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -40,7 +40,10 @@ from music_assistant.constants import (
     DB_TABLE_PROVIDER_MAPPINGS,
     MASS_LOGGER_NAME,
 )
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    ImpersonatedUser,
+    get_current_user,
+)
 from music_assistant.helpers.compare import compare_media_item, create_safe_string
 from music_assistant.helpers.database import UNSET
 from music_assistant.helpers.json import json_loads, serialize_to_json
@@ -296,6 +299,7 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        username: str | None = None,
         **kwargs: Any,
     ) -> list[ItemCls]:
         """
@@ -309,34 +313,36 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
         :param played_only: Only include items that have been played (last_played > 0).
+        :param username: Get library items of this user.
         """
-        items = await self.get_library_items_by_query(
-            favorite=favorite,
-            search=search,
-            limit=limit,
-            offset=offset,
-            order_by=order_by,
-            provider_filter=self._ensure_provider_filter(provider),
-            genre_ids=genre,
-            played_only=played_only,
-            in_library_only=True,
-        )
-        if (
-            kwargs.get("_localized_fallback", True)
-            and search
-            and not items
-            and self.media_type in (MediaType.GENRE, MediaType.PLAYLIST)
-        ):
-            return await self._localized_search_fallback(
-                search,
+        async with ImpersonatedUser(self.mass, username):
+            items = await self.get_library_items_by_query(
+                favorite=favorite,
+                search=search,
                 limit=limit,
                 offset=offset,
-                favorite=favorite,
                 order_by=order_by,
-                provider=provider,
-                genre=genre,
+                provider_filter=self._ensure_provider_filter(provider),
+                genre_ids=genre,
+                played_only=played_only,
+                in_library_only=True,
             )
-        return items
+            if (
+                kwargs.get("_localized_fallback", True)
+                and search
+                and not items
+                and self.media_type in (MediaType.GENRE, MediaType.PLAYLIST)
+            ):
+                return await self._localized_search_fallback(
+                    search,
+                    limit=limit,
+                    offset=offset,
+                    favorite=favorite,
+                    order_by=order_by,
+                    provider=provider,
+                    genre=genre,
+                )
+            return items
 
     async def iter_library_items(
         self,

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -244,6 +244,7 @@ class GenreController(MediaControllerBase[Genre]):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        username: str | None = None,
         hide_empty: bool | None = None,
         media_type: MediaType | None = None,
         content_type: str | None = None,

--- a/music_assistant/controllers/music/media/podcasts.py
+++ b/music_assistant/controllers/music/media/podcasts.py
@@ -10,7 +10,10 @@ from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailabl
 from music_assistant_models.media_items import Podcast, PodcastEpisode, ProviderMapping, UniqueList
 
 from music_assistant.constants import DB_TABLE_PLAYLOG, DB_TABLE_PODCASTS
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    ImpersonatedUser,
+    get_current_user,
+)
 from music_assistant.helpers.compare import (
     compare_media_item,
     compare_podcast,
@@ -55,6 +58,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        username: str | None = None,
         **kwargs: Any,
     ) -> list[Podcast]:
         """
@@ -67,7 +71,11 @@ class PodcastsController(MediaControllerBase[Podcast]):
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
+        :param username: Get library items of this user.
         """
+        async with ImpersonatedUser(self.mass, username):
+            provider_filter = self._ensure_provider_filter(provider)
+
         result = await self.get_library_items_by_query(
             favorite=favorite,
             search=search,
@@ -75,7 +83,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
             limit=limit,
             offset=offset,
             order_by=order_by,
-            provider_filter=self._ensure_provider_filter(provider),
+            provider_filter=provider_filter,
             played_only=played_only,
             in_library_only=True,
         )
@@ -93,7 +101,7 @@ class PodcastsController(MediaControllerBase[Podcast]):
                 genre_ids=genre,
                 limit=limit,
                 order_by=order_by,
-                provider_filter=self._ensure_provider_filter(provider),
+                provider_filter=provider_filter,
                 extra_query_parts=extra_query_parts,
                 extra_query_params=extra_query_params,
                 in_library_only=True,

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -27,6 +27,7 @@ from music_assistant.constants import (
     DB_TABLE_TRACK_ARTISTS,
     DB_TABLE_TRACKS,
 )
+from music_assistant.controllers.webserver.helpers.auth_middleware import ImpersonatedUser
 from music_assistant.helpers.compare import (
     compare_artists,
     compare_media_item,
@@ -184,6 +185,7 @@ class TracksController(MediaControllerBase[Track]):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        username: str | None = None,
         **kwargs: Any,
     ) -> list[Track]:
         """
@@ -196,7 +198,11 @@ class TracksController(MediaControllerBase[Track]):
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
+        :param username: Get library items of this user.
         """
+        async with ImpersonatedUser(self.mass, username):
+            provider_filter = self._ensure_provider_filter(provider)
+
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
         extra_join_parts: list[str] = []
@@ -222,7 +228,7 @@ class TracksController(MediaControllerBase[Track]):
             limit=limit,
             offset=offset,
             order_by=order_by,
-            provider_filter=self._ensure_provider_filter(provider),
+            provider_filter=provider_filter,
             extra_query_parts=extra_query_parts,
             extra_query_params=extra_query_params,
             extra_join_parts=extra_join_parts,
@@ -245,7 +251,7 @@ class TracksController(MediaControllerBase[Track]):
                 genre_ids=genre,
                 limit=limit,
                 order_by=order_by,
-                provider_filter=self._ensure_provider_filter(provider),
+                provider_filter=provider_filter,
                 extra_query_parts=extra_query_parts,
                 extra_query_params=extra_query_params,
                 extra_join_parts=extra_join_parts,

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -869,6 +869,7 @@ async def test_set_provider_mappings_upsert_writes_explicit_in_library(
 async def test_library_items_default_filters_in_library_only() -> None:
     """Test that library_items passes in_library_only=True by default."""
     ctrl = Mock(spec=MediaControllerBase)
+    ctrl.mass = Mock()
     ctrl._ensure_provider_filter = Mock(return_value=None)
     ctrl.get_library_items_by_query = AsyncMock(return_value=[])
     ctrl.library_items = MediaControllerBase.library_items.__get__(ctrl)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->
Add username to global search and library_items method of media controllers. Will allow me to add username support to the HA integration for music_assistant.get_library & music_assistant.search.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
