### PR TITLE
Implement SQL-based explicit filter for smart playlists

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -727,8 +727,7 @@ class SmartPlaylistProvider(PluginProvider):
                     and t.metadata.popularity >= rules.min_popularity
                 ]
 
-            # Apply explicit filter in library mode
-            tracks = _filter_by_explicit(tracks, rules.explicit)
+            # Explicit filter is now handled at SQL level via _get_library_tracks()
 
             if rules.year_from is not None or rules.year_to is not None:
                 tracks = [
@@ -1101,6 +1100,7 @@ class SmartPlaylistProvider(PluginProvider):
             return await self._get_library_tracks(
                 favorite=None,
                 genre_ids=None,
+                explicit=rules.explicit,
                 limit=min(rules.limit * 3, 2000),
                 user_provider_filter=user_provider_filter,
             )
@@ -1110,6 +1110,7 @@ class SmartPlaylistProvider(PluginProvider):
         base_tracks = await self._get_library_tracks(
             favorite=favorite,
             genre_ids=genre_ids,
+            explicit=rules.explicit,
             limit=min(rules.limit * 5, 2000),
             user_provider_filter=user_provider_filter,
         )
@@ -1152,7 +1153,10 @@ class SmartPlaylistProvider(PluginProvider):
 
         if rules.favorites_only:
             for track in await self._get_library_tracks(
-                favorite=True, limit=fetch_limit, user_provider_filter=user_provider_filter
+                favorite=True,
+                explicit=rules.explicit,
+                limit=fetch_limit,
+                user_provider_filter=user_provider_filter,
             ):
                 if track.uri:
                     track_sets[track.uri] = track
@@ -1160,6 +1164,7 @@ class SmartPlaylistProvider(PluginProvider):
         if rules.genre_ids:
             for track in await self._get_library_tracks(
                 genre_ids=rules.genre_ids,
+                explicit=rules.explicit,
                 limit=fetch_limit,
                 user_provider_filter=user_provider_filter,
             ):
@@ -1168,7 +1173,9 @@ class SmartPlaylistProvider(PluginProvider):
 
         if rules.artist_ids or rules.album_ids:
             all_tracks = await self._get_library_tracks(
-                limit=min(fetch_limit * 2, FETCH_LIMIT), user_provider_filter=user_provider_filter
+                explicit=rules.explicit,
+                limit=min(fetch_limit * 2, FETCH_LIMIT),
+                user_provider_filter=user_provider_filter,
             )
             if rules.artist_ids:
                 artist_id_set = set(rules.artist_ids)
@@ -1199,7 +1206,9 @@ class SmartPlaylistProvider(PluginProvider):
         )
         if no_filters:
             for track in await self._get_library_tracks(
-                limit=fetch_limit, user_provider_filter=user_provider_filter
+                explicit=rules.explicit,
+                limit=fetch_limit,
+                user_provider_filter=user_provider_filter,
             ):
                 if track.uri:
                     track_sets[track.uri] = track
@@ -1210,6 +1219,7 @@ class SmartPlaylistProvider(PluginProvider):
         self,
         favorite: bool | None = None,
         genre_ids: list[int] | None = None,
+        explicit: bool | None = None,
         limit: int = 500,
         user_provider_filter: list[str] | None = None,
     ) -> list[Track]:
@@ -1217,6 +1227,7 @@ class SmartPlaylistProvider(PluginProvider):
         return await self.mass.music.tracks.library_items(
             favorite=favorite,
             genre=genre_ids,
+            explicit=explicit,
             limit=limit,
             order_by="random",
             provider=user_provider_filter,

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -370,6 +370,7 @@ def _make_mock_track(
     provider_instance: str = "library",
     duration: int | None = None,
     last_played: int = 0,
+    explicit: bool | None = None,
 ) -> MagicMock:
     """Build a minimal mock Track object."""
     track = MagicMock()
@@ -396,6 +397,7 @@ def _make_mock_track(
 
     track.metadata = MagicMock()
     track.metadata.popularity = popularity
+    track.metadata.explicit = explicit
 
     return track
 
@@ -518,6 +520,135 @@ async def test_favorites_only_filter() -> None:
     uris = [t.uri for t in result]
     assert "library://track/1" in uris
     assert "library://track/2" not in uris
+
+
+@pytest.mark.asyncio
+async def test_explicit_only_filter() -> None:
+    """explicit=True passes explicit=True to _get_library_tracks for SQL filtering."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    explicit_track = _make_mock_track("1", uri="library://track/1", explicit=True)
+    clean_track = _make_mock_track("2", uri="library://track/2", explicit=False)
+    unknown_track = _make_mock_track("3", uri="library://track/3", explicit=None)
+
+    async def mock_get_library(**kwargs: Any) -> list[MagicMock]:
+        explicit_filter = kwargs.get("explicit")
+        all_tracks = [explicit_track, clean_track, unknown_track]
+        if explicit_filter is True:
+            # Simulate SQL filter: json_extract(...) = 1
+            return [t for t in all_tracks if t.metadata.explicit is True]
+        if explicit_filter is False:
+            # Simulate SQL filter: IS NULL OR = 0
+            return [t for t in all_tracks if t.metadata.explicit is not True]
+        return all_tracks
+
+    cast("Any", plugin)._get_library_tracks = mock_get_library
+
+    # Test explicit only
+    rules = SmartPlaylistRules(explicit=True, logic=LOGIC_AND, limit=10)
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris
+    assert "library://track/2" not in uris
+    assert "library://track/3" not in uris
+
+
+@pytest.mark.asyncio
+async def test_no_explicit_filter() -> None:
+    """explicit=False excludes explicit tracks via SQL filtering."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    explicit_track = _make_mock_track("1", uri="library://track/1", explicit=True)
+    clean_track = _make_mock_track("2", uri="library://track/2", explicit=False)
+    unknown_track = _make_mock_track("3", uri="library://track/3", explicit=None)
+
+    async def mock_get_library(**kwargs: Any) -> list[MagicMock]:
+        explicit_filter = kwargs.get("explicit")
+        all_tracks = [explicit_track, clean_track, unknown_track]
+        if explicit_filter is True:
+            return [t for t in all_tracks if t.metadata.explicit is True]
+        if explicit_filter is False:
+            # Simulate SQL filter: IS NULL OR = 0
+            return [t for t in all_tracks if t.metadata.explicit is not True]
+        return all_tracks
+
+    cast("Any", plugin)._get_library_tracks = mock_get_library
+
+    # Test no explicit
+    rules = SmartPlaylistRules(explicit=False, logic=LOGIC_AND, limit=10)
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" not in uris
+    assert "library://track/2" in uris
+    assert "library://track/3" in uris
+
+
+@pytest.mark.asyncio
+async def test_allow_explicit_filter() -> None:
+    """explicit=None returns all tracks regardless of explicit flag."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    explicit_track = _make_mock_track("1", uri="library://track/1", explicit=True)
+    clean_track = _make_mock_track("2", uri="library://track/2", explicit=False)
+    unknown_track = _make_mock_track("3", uri="library://track/3", explicit=None)
+
+    all_tracks = [explicit_track, clean_track, unknown_track]
+    cast("Any", plugin)._get_library_tracks = AsyncMock(return_value=all_tracks)
+
+    # Test allow explicit (no filter)
+    rules = SmartPlaylistRules(explicit=None, logic=LOGIC_AND, limit=10)
+    result = await plugin._evaluate_rules(rules)
+    uris = [t.uri for t in result]
+    assert "library://track/1" in uris
+    assert "library://track/2" in uris
+    assert "library://track/3" in uris
+
+
+@pytest.mark.asyncio
+async def test_explicit_filter_generates_sql_query_parts() -> None:
+    """_get_library_tracks passes explicit parameter correctly to library_items."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    # Mock tracks.library_items to capture kwargs
+    library_items_mock = AsyncMock(return_value=[])
+    mass.music.tracks.library_items = library_items_mock
+
+    # Test explicit=True passes correctly
+    await plugin._get_library_tracks(explicit=True, limit=10)
+    call_kwargs = library_items_mock.call_args.kwargs
+    assert call_kwargs["explicit"] is True
+
+    # Test explicit=False passes correctly
+    library_items_mock.reset_mock()
+    await plugin._get_library_tracks(explicit=False, limit=10)
+    call_kwargs = library_items_mock.call_args.kwargs
+    assert call_kwargs["explicit"] is False
+
+    # Test explicit=None passes correctly
+    library_items_mock.reset_mock()
+    await plugin._get_library_tracks(explicit=None, limit=10)
+    call_kwargs = library_items_mock.call_args.kwargs
+    assert call_kwargs["explicit"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Implements SQL-based filtering for the explicit content filter in smart playlists, replacing the inefficient POST-filter that operated on small samples.

**⚠️ This PR depends on #4597** - must be merged after #4597.

**Problem:** Smart playlists with "explicit only" filter showed only 1-3 tracks instead of expected 83 because the POST-filter was applied to a small 75-track random sample (6.3% explicit rate = ~5 explicit tracks, further reduced by recency).

**Solution:** 
- Uses the new `explicit` parameter from `TracksController.library_items()` (added in PR #4597)
- Smart playlist provider passes `explicit=rules.explicit` through all code paths
- Ensures accurate filtering before random sampling
- POST-filter removed in library mode, kept in seed mode

**Filter logic:**
- **Allow explicit** (`None`): No filter, shows all tracks
- **Explicit only** (`True`): SQL filter for explicit=1
- **No explicit** (`False`): SQL filter for explicit IS NULL OR = 0

**Related issue (if applicable):**

- Depends on: PR #4597

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.