### PR TITLE
Sanitize all control characters in icy-name stream header

### DIFF
--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -84,7 +84,11 @@ from music_assistant.helpers.audio import (
 from music_assistant.helpers.buffered_generator import buffered
 from music_assistant.helpers.ffmpeg import LOGGER as FFMPEG_LOGGER
 from music_assistant.helpers.ffmpeg import check_ffmpeg_version, get_ffmpeg_stream
-from music_assistant.helpers.util import format_ip_for_url, get_ip_addresses
+from music_assistant.helpers.util import (
+    format_ip_for_url,
+    get_ip_addresses,
+    sanitize_http_header_value,
+)
 from music_assistant.helpers.webserver import Webserver
 from music_assistant.models.core_controller import CoreController
 from music_assistant.models.music_provider import MusicProvider
@@ -551,9 +555,7 @@ class StreamsController(CoreController):
                 head_fmt = ContentType.WAV.value
             headers = {
                 **DEFAULT_STREAM_HEADERS,
-                "icy-name": queue_item.name.replace("\n", " ")
-                .replace("\r", " ")
-                .replace("\t", " "),
+                "icy-name": sanitize_http_header_value(queue_item.name),
                 "contentFeatures.dlna.org": DLNA_CONTENT_FEATURES_REALTIME,
                 "Content-Type": get_mime_type(head_fmt),
             }
@@ -641,8 +643,10 @@ class StreamsController(CoreController):
             )
 
             # prepare request, add some DLNA/UPNP compatible headers
-            # icy-name is sanitized to avoid a "Potential header injection attack" by aiohttp
+            # icy-name is sanitized (all control chars, not just newlines) to avoid a
+            # "Potential header injection attack" ValueError by aiohttp
             # see https://github.com/music-assistant/support/issues/4913
+            # and https://github.com/music-assistant/support/issues/5791
             # use realtime DLNA flags for radio (sender-paced) since the source delivers slowly
             dlna_features = (
                 DLNA_CONTENT_FEATURES_REALTIME
@@ -651,9 +655,7 @@ class StreamsController(CoreController):
             )
             headers = {
                 **DEFAULT_STREAM_HEADERS,
-                "icy-name": queue_item.name.replace("\n", " ")
-                .replace("\r", " ")
-                .replace("\t", " "),
+                "icy-name": sanitize_http_header_value(queue_item.name),
                 "contentFeatures.dlna.org": dlna_features,
                 "Content-Type": get_mime_type(output_format.output_format_str),
             }

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -574,6 +574,16 @@ def filename_from_string(string: str) -> str:
     return "".join(c for c in string if c.isalnum() or c in keepcharacters).rstrip()
 
 
+# aiohttp rejects the full C0 control character range plus DEL in response headers
+# to prevent header injection attacks (see aiohttp http_writer._FORBIDDEN_HEADER_CHARS_RE)
+_FORBIDDEN_HEADER_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def sanitize_http_header_value(value: str) -> str:
+    """Replace control characters that are not allowed in HTTP header values."""
+    return _FORBIDDEN_HEADER_CHARS_RE.sub(" ", value).strip()
+
+
 def try_parse_int(possible_int: Any, default: int | None = 0) -> int | None:
     """Try to parse an int."""
     try:

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -11,6 +11,7 @@ from music_assistant.helpers import util
 from music_assistant.helpers.util import (
     get_source_ip_for_target,
     load_provider_module,
+    sanitize_http_header_value,
     select_free_port,
 )
 
@@ -234,3 +235,36 @@ class TestGetIpAddresses:
                 await task_a
             assert await task_b == ("192.168.1.10",)
         assert enumerate_mock.call_count == 1
+
+
+class TestSanitizeHttpHeaderValue:
+    """sanitize_http_header_value strips characters aiohttp forbids in response headers."""
+
+    def test_clean_value_unchanged(self) -> None:
+        """A regular track name passes through untouched."""
+        assert sanitize_http_header_value("AC/DC - Thunderstruck") == "AC/DC - Thunderstruck"
+
+    def test_newline_and_carriage_return_replaced(self) -> None:
+        """CR/LF (the classic header injection vector) are replaced with spaces."""
+        assert sanitize_http_header_value("Artist -\r\nEvil: header") == "Artist -  Evil: header"
+
+    def test_all_c0_control_chars_and_del_replaced(self) -> None:
+        r"""
+        Every char aiohttp's _FORBIDDEN_HEADER_CHARS_RE rejects is replaced.
+
+        Regression test for https://github.com/music-assistant/support/issues/5791
+        where a control char (other than \n, \r, \t) in a FLAC tag crashed
+        serve_queue_item_stream with a 500.
+        """
+        for codepoint in [*range(0x20), 0x7F]:
+            value = f"Artist - Some{chr(codepoint)}Track"
+            sanitized = sanitize_http_header_value(value)
+            assert sanitized == "Artist - Some Track", f"codepoint {codepoint:#04x} not replaced"
+
+    def test_non_ascii_preserved(self) -> None:
+        """Non-ASCII text is allowed in headers and must be preserved."""
+        assert sanitize_http_header_value("Björk - Jóga") == "Björk - Jóga"
+
+    def test_leading_trailing_whitespace_stripped(self) -> None:
+        """Control chars at the edges don't leave dangling whitespace."""
+        assert sanitize_http_header_value("\x00Artist - Track\x1f") == "Artist - Track"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

aiohttp rejects the full C0 control range plus DEL in response headers (not just CR/LF), so a track with e.g. a vertical-tab in its tags crashed `serve_queue_item_stream` with a 500. Replace the newline/tab-only sanitization with a helper that strips everything aiohttp forbids.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5791

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
