### PR TITLE
Add explicit parameter to TracksController.library_items

### DIFF
--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -184,6 +184,7 @@ class TracksController(MediaControllerBase[Track]):
         provider: str | list[str] | None = None,
         genre: int | list[int] | None = None,
         played_only: bool = False,
+        explicit: bool | None = None,
         **kwargs: Any,
     ) -> list[Track]:
         """
@@ -196,10 +197,24 @@ class TracksController(MediaControllerBase[Track]):
         :param order_by: Order by field (e.g. 'sort_name', 'timestamp_added').
         :param provider: Filter by provider instance ID (single string or list).
         :param genre: Filter by genre id(s).
+        :param played_only: Filter to only played tracks.
+        :param explicit: Filter by explicit content (True=only explicit, False=no explicit, None=all).
         """
         extra_query_params: dict[str, Any] = {}
         extra_query_parts: list[str] = []
         extra_join_parts: list[str] = []
+
+        # Apply explicit content filter
+        if explicit is not None:
+            if explicit:
+                # Only explicit tracks
+                extra_query_parts.append("json_extract(tracks.metadata, '$.explicit') = 1")
+            else:
+                # No explicit tracks (null or false)
+                extra_query_parts.append(
+                    "(json_extract(tracks.metadata, '$.explicit') IS NULL "
+                    "OR json_extract(tracks.metadata, '$.explicit') = 0)"
+                )
         if search and " - " in search:
             # handle combined artist + title search
             artist_str, title_str = search.split(" - ", 1)

--- a/tests/controllers/music/test_tracks.py
+++ b/tests/controllers/music/test_tracks.py
@@ -1,0 +1,78 @@
+"""Tests for the tracks controller explicit filter."""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from music_assistant.controllers.music import MusicController
+from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture
+async def music(mass_minimal: MusicAssistant) -> AsyncGenerator[MusicController]:
+    """Return a music controller attached to the minimal mass instance."""
+    controller = MusicController(mass_minimal)
+    mass_minimal.music = controller
+    yield controller
+    if controller._database:
+        await controller._database.close()
+
+
+@pytest.mark.asyncio
+async def test_explicit_filter_true_generates_sql(music: MusicController) -> None:
+    """Test that explicit=True generates correct SQL filter."""
+    captured_parts: list[str] = []
+
+    async def mock_query(*_args: Any, **kwargs: Any) -> list[Any]:
+        captured_parts.extend(kwargs.get("extra_query_parts", []))
+        return []
+
+    with patch.object(music.tracks, "get_library_items_by_query", mock_query):
+        await music.tracks.library_items(explicit=True, limit=10)
+        assert any(
+            "json_extract(tracks.metadata, '$.explicit') = 1" in part for part in captured_parts
+        )
+
+
+@pytest.mark.asyncio
+async def test_explicit_filter_false_generates_sql(music: MusicController) -> None:
+    """Test that explicit=False generates correct SQL filter."""
+    captured_parts: list[str] = []
+
+    async def mock_query(*_args: Any, **kwargs: Any) -> list[Any]:
+        captured_parts.extend(kwargs.get("extra_query_parts", []))
+        return []
+
+    with patch.object(music.tracks, "get_library_items_by_query", mock_query):
+        await music.tracks.library_items(explicit=False, limit=10)
+        assert any("IS NULL" in part and "= 0" in part for part in captured_parts)
+
+
+@pytest.mark.asyncio
+async def test_explicit_filter_none_generates_no_sql(music: MusicController) -> None:
+    """Test that explicit=None generates no explicit filter."""
+    captured_parts: list[str] = []
+
+    async def mock_query(*_args: Any, **kwargs: Any) -> list[Any]:
+        captured_parts.extend(kwargs.get("extra_query_parts", []))
+        return []
+
+    with patch.object(music.tracks, "get_library_items_by_query", mock_query):
+        await music.tracks.library_items(explicit=None, limit=10)
+        assert not any("explicit" in part.lower() for part in captured_parts)
+
+
+@pytest.mark.asyncio
+async def test_explicit_filter_default_is_none(music: MusicController) -> None:
+    """Test that omitting explicit parameter behaves like explicit=None."""
+    captured_parts: list[str] = []
+
+    async def mock_query(*_args: Any, **kwargs: Any) -> list[Any]:
+        captured_parts.extend(kwargs.get("extra_query_parts", []))
+        return []
+
+    with patch.object(music.tracks, "get_library_items_by_query", mock_query):
+        await music.tracks.library_items(limit=10)
+        assert not any("explicit" in part.lower() for part in captured_parts)


### PR DESCRIPTION
# What does this implement/fix?

Adds a dedicated `explicit` parameter to `TracksController.library_items()` for SQL-based filtering of explicit content at the database level.

**Background:** This is the core component needed for fixing the smart playlist explicit filter issue (PR #4594). Based on maintainer feedback, this implements option (a): add an explicit filter parameter to the public API method rather than using kwargs for extensibility.

**Implementation:**
- Added `explicit: bool | None = None` parameter to `library_items()` signature
- Builds SQL filter using `json_extract(tracks.metadata, '$.explicit')`
- Filter executed at database query level before sampling
- Fully backward compatible - default `None` means no filtering

**Filter logic:**
- **None** (default): No filter, returns all tracks
- **True**: Only explicit tracks (`json_extract(...) = 1`)
- **False**: No explicit tracks (`IS NULL OR = 0`)

**Related issue (if applicable):**

- Supersedes PR #4594 (kwargs-based approach)
- Required for smart playlist explicit filter fix

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.