### PR TITLE
Improve error presentation for folder playback resolution

### DIFF
--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -1621,7 +1621,9 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             return self.podcasts
         if media_type == MediaType.GENRE:
             return self.genres
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"No media controller available for media type: {media_type.value}"
+        )
 
     def get_provider_instances(
         self, domain: str, return_unavailable: bool = False

--- a/music_assistant/controllers/player_queues/media_resolver.py
+++ b/music_assistant/controllers/player_queues/media_resolver.py
@@ -15,7 +15,7 @@ from types import NoneType
 from typing import TYPE_CHECKING, Any, cast
 
 from music_assistant_models.enums import MediaType
-from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError
 from music_assistant_models.media_items import (
     Album,
     Artist,
@@ -507,12 +507,22 @@ class MediaResolver:
             "Fetching tracks to play for folder %s",
             folder.name,
         )
+        try:
+            folder_items = await self.mass.music.browse(folder.path)
+        except OSError as err:
+            # e.g. the (top-level) folder URI points at a path that no longer exists
+            raise MediaNotFoundError(f"Folder '{folder.path}' could not be found") from err
         tracks: list[Track] = []
-        for item in await self.mass.music.browse(folder.path):
+        for item in folder_items:
             if not item.is_playable:
                 continue
-            # recursively fetch tracks from all media types
-            resolved = await self._resolve_media_items(item)
+            try:
+                # recursively fetch tracks from all media types
+                resolved = await self._resolve_media_items(item)
+            except MediaNotFoundError:
+                # best-effort: skip child items/subfolders that are empty or unreachable
+                # so a single bad entry does not abort playback of the whole folder
+                continue
             tracks += [x for x in resolved if isinstance(x, Track)]
 
         return tracks


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

A user was reporting they kept getting a not implemented error when trying to play a folder https://github.com/orgs/music-assistant/discussions/4509  The problem was an incorrect URI however the error message was misleasding. 

A bare `raise NotImplementedError` in `MusicController.get_controller` and an unhandled `FileNotFoundError` from scanning a stale/incorrect folder URI both surfaced to callers (e.g. the Home Assistant play_media action) as opaque, unactionable errors.

- get_controller now includes the offending media type in the message.
- _get_folder_tracks converts an unresolvable folder path into a clear MediaNotFoundError, and skips empty/unreachable child items so a single bad entry no longer aborts playback of the whole folder.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
