### PR TITLE
Fix test-ordering flake caused by a leaked models global cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,16 +4,33 @@ import asyncio
 import logging
 import pathlib
 import threading
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 
 import pytest
+from music_assistant_models import helpers as models_helpers
 from zeroconf.asyncio import AsyncZeroconf
 
 from music_assistant.controllers.cache import CacheController
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.discovery import DiscoveryController
 from music_assistant.mass import MusicAssistant
+
+
+@pytest.fixture(autouse=True)
+def isolate_models_global_cache() -> Generator[None]:
+    """
+    Reset the models package's process-global cache between tests.
+
+    A full server boot populates module-level globals in music_assistant_models
+    (e.g. ``available_providers``, which drives ``MediaItem.available``). Left in
+    place, they leak into later tests in the same pytest process and change item
+    availability depending on test ordering. Note that an empty cache falls back
+    to permissive defaults, so tests sharing a broader-scoped server instance are
+    unaffected by the per-test clear.
+    """
+    yield
+    models_helpers._global_cache.clear()
 
 
 @pytest.fixture(name="caplog")

--- a/tests/controllers/config/test_config_protocol_defaults.py
+++ b/tests/controllers/config/test_config_protocol_defaults.py
@@ -18,7 +18,7 @@ import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-from music_assistant_models.enums import PlayerFeature, PlayerType
+from music_assistant_models.enums import PlayerFeature, PlayerType, ProviderType
 from music_assistant_models.player import OutputProtocol
 
 from music_assistant.constants import (
@@ -50,6 +50,14 @@ class _TestProvider:
         self.manifest = MagicMock()
         self.manifest.domain = domain
         self.manifest.name = self.name
+        self.manifest.type = ProviderType.PLAYER
+        # registered in mass._providers, so the stand-in must survive the provider
+        # bookkeeping that mass.stop()/unload_provider applies to every provider
+        self.type = ProviderType.PLAYER
+        self.players: list[Player] = []
+
+    async def unload(self, is_removed: bool = False) -> None:
+        """Unload the provider (nothing to clean up)."""
 
 
 class _TestPlayer(Player):


### PR DESCRIPTION
# What does this implement/fix?

`test_track_sync_commits_once_per_item` failed (0 tracks synced instead of 12) whenever it ran after `tests/controllers/config/test_config_protocol_defaults.py`, while passing in isolation.

The cause is the process-global cache in `music_assistant_models` (`available_providers`, which backs `MediaItem.available`): it is populated on server boot and must be cleared on shutdown. The config test registered minimal player stand-ins that lacked the attributes `mass.stop()` touches during teardown, so unloading them raised swallowed `AttributeError`s and left a stale provider set in the cache. Later tests then saw their own provider as unavailable, so library sync skipped every track.

Changes:
- Add an autouse fixture in `tests/conftest.py` that clears the models global cache after each test.
- Give the config-test provider stand-ins the `type`, `players` and `unload()` members `mass.stop()` needs, so teardown runs cleanly.

**Related issue (if applicable):**

- Surfaced after #4584

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
