### PR TITLE
Prevent duplicate versions of the same song in dynamic playlist queues

### DIFF
--- a/music_assistant/controllers/music/constants.py
+++ b/music_assistant/controllers/music/constants.py
@@ -9,7 +9,7 @@ DEFAULT_SYNC_INTERVAL = 12 * 60  # default sync interval in minutes
 CONF_SYNC_INTERVAL = "sync_interval"
 CONF_DELETED_PROVIDERS = "deleted_providers"
 
-DB_SCHEMA_VERSION: Final[int] = 46
+DB_SCHEMA_VERSION: Final[int] = 47
 
 # tracks longer that this will not be included in radio mode
 RADIO_TRACK_MAX_DURATION_SECS: Final[int] = 20 * 60

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -1193,6 +1193,13 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             "media_type": media_item.media_type.value,
             "name": media_item.name,
             "image": serialize_to_json(media_item.image.to_dict()) if media_item.image else None,
+            # store lightweight artist mappings so playlog rows can later be matched or
+            # resolved by artist without an extra provider lookup
+            "artists": serialize_to_json(
+                [ItemMapping.from_item(artist).to_dict() for artist in artists]
+            )
+            if (artists := getattr(media_item, "artists", None))
+            else None,
             "fully_played": fully_played,
             "seconds_played": seconds_played,
             "timestamp": timestamp,

--- a/music_assistant/controllers/music/database.py
+++ b/music_assistant/controllers/music/database.py
@@ -242,6 +242,7 @@ class MusicDatabaseSetupMixin:
                 [media_type] TEXT NOT NULL,
                 [name] TEXT NOT NULL,
                 [image] json,
+                [artists] json,
                 [timestamp] INTEGER DEFAULT 0,
                 [fully_played] BOOLEAN,
                 [seconds_played] INTEGER,

--- a/music_assistant/controllers/music/migrations.py
+++ b/music_assistant/controllers/music/migrations.py
@@ -705,6 +705,15 @@ async def migrate_database(  # noqa: PLR0915
         except Exception as err:
             logger.warning("Could not seed default podcast/audiobook genres: %s", err)
 
+    if prev_version <= 46:
+        # add artists column to playlog (lightweight artist mappings for track rows) so
+        # recency matching can recognize the same song across different releases/providers
+        try:
+            await database.execute(f"ALTER TABLE {DB_TABLE_PLAYLOG} ADD COLUMN artists json")
+        except Exception as err:
+            if "duplicate column" not in str(err):
+                raise
+
     # save changes
     await database.commit()
 

--- a/music_assistant/controllers/music/recency.py
+++ b/music_assistant/controllers/music/recency.py
@@ -3,8 +3,11 @@ Shared recency engine for the Music controller.
 
 Reads the playlog once and exposes fast in-memory "was this heard recently?" tests, used by
 smart shuffle, the smart playlist dedup and (later) radio refills. Song recency is matched on
-provider/item-id pairs resolved across a track's provider mappings; artist recency is matched by
-(lowercased) name, which is provider-agnostic (artist playlog rows are keyed by the library id).
+provider/item-id pairs resolved across a track's provider mappings (the exact escape hatch),
+plus a fuzzy same-song match on (version-stripped title, artist name) keys so the same
+recording is recognized across different releases/providers with differing ids or artist
+credits; artist recency is matched by (lowercased) name, which is provider-agnostic (artist
+playlog rows are keyed by the library id).
 """
 
 from __future__ import annotations
@@ -17,8 +20,13 @@ from music_assistant_models.enums import MediaType
 
 from music_assistant.constants import DB_TABLE_PLAYLOG
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.helpers.compare import create_safe_string
+from music_assistant.helpers.json import json_loads
+from music_assistant.helpers.util import parse_title_and_version
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from music_assistant_models.media_items import MediaItemType
 
     from music_assistant import MusicAssistant
@@ -45,6 +53,7 @@ class RecencySnapshot:
 
     now: int
     song_ts: dict[tuple[str, str], int] = field(default_factory=dict)
+    song_key_ts: dict[tuple[str, str], int] = field(default_factory=dict)
     artist_ts: dict[str, int] = field(default_factory=dict)
 
     def track_recent(self, item: MediaItemType, within_seconds: int | None) -> bool:
@@ -63,7 +72,9 @@ class RecencySnapshot:
         """
         Return the most recent play timestamp for the track, or None if it has no play recorded.
 
-        Matched across the track's own ``(provider, item_id)`` and all of its provider mappings.
+        Matched across the track's own ``(provider, item_id)`` and all of its provider mappings
+        (exact), plus the fuzzy same-song keys so a different release/version of the same
+        recording is recognized too.
 
         :param item: The track (or queue media item) to look up.
         """
@@ -73,6 +84,10 @@ class RecencySnapshot:
             timestamps.append(timestamp)
         for mapping in getattr(item, "provider_mappings", None) or ():
             timestamp = self.song_ts.get((mapping.provider_instance, mapping.item_id))
+            if timestamp is not None:
+                timestamps.append(timestamp)
+        for key in song_keys(item):
+            timestamp = self.song_key_ts.get(key)
             if timestamp is not None:
                 timestamps.append(timestamp)
         return max(timestamps) if timestamps else None
@@ -133,7 +148,7 @@ class RecencyEngine:
         # one row per item is guaranteed when scoped to a user (unique playlog index); the
         # MAX(timestamp) group keeps the most recent play when no user scope is applied.
         query = (
-            f"SELECT item_id, provider, media_type, name, MAX(timestamp) AS ts "
+            f"SELECT item_id, provider, media_type, name, artists, MAX(timestamp) AS ts "
             f"FROM {DB_TABLE_PLAYLOG} WHERE {where} "
             f"GROUP BY item_id, provider, media_type"
         )
@@ -143,6 +158,47 @@ class RecencyEngine:
             timestamp = int(row["ts"])
             if row["media_type"] == MediaType.TRACK.value:
                 snapshot.song_ts[(row["provider"], row["item_id"])] = timestamp
+                for key in _song_keys(row["name"], _row_artist_names(row["artists"])):
+                    if timestamp > snapshot.song_key_ts.get(key, 0):
+                        snapshot.song_key_ts[key] = timestamp
             elif name := row["name"]:
                 snapshot.artist_ts[name.lower()] = timestamp
         return snapshot
+
+
+def song_keys(item: MediaItemType) -> set[tuple[str, str]]:
+    """
+    Return the fuzzy same-song identity keys for a track: (safe title, safe artist) per artist.
+
+    Version/featuring info is stripped from the title so different releases of the same recording
+    (remaster, single vs album edit, differing artist credits across providers) produce
+    overlapping keys. Returns an empty set for items without artists (non-track media).
+
+    :param item: The track (or queue media item) to build keys for.
+    """
+    artist_names = [artist.name for artist in getattr(item, "artists", None) or () if artist.name]
+    return _song_keys(item.name, artist_names)
+
+
+def _song_keys(name: str, artist_names: Iterable[str]) -> set[tuple[str, str]]:
+    """Build (safe title, safe artist) keys from a raw title and artist names."""
+    if not name:
+        return set()
+    title, _ = parse_title_and_version(name, strip_for_search=True)
+    if not (safe_title := create_safe_string(title)):
+        return set()
+    return {
+        (safe_title, safe_artist)
+        for artist_name in artist_names
+        if (safe_artist := create_safe_string(artist_name))
+    }
+
+
+def _row_artist_names(raw_artists: str | None) -> list[str]:
+    """Extract artist names from a playlog row's artists json column (None for legacy rows)."""
+    if not raw_artists:
+        return []
+    try:
+        return [name for artist in json_loads(raw_artists) if (name := artist.get("name"))]
+    except ValueError, TypeError, AttributeError:
+        return []

--- a/music_assistant/controllers/player_queues/managed_pool.py
+++ b/music_assistant/controllers/player_queues/managed_pool.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.media_items import Playlist, Track
 
+from music_assistant.controllers.music.recency import song_keys
 from music_assistant.controllers.player_queues.constants import (
     MANAGED_POOL_SOURCE_CAP,
     MANAGED_POOL_TARGET,
@@ -135,12 +136,17 @@ class ManagedPool:
         if not sources:
             return []
         # dedupe only against the active (current + unplayed) tail; played history is left out so
-        # recency, not permanent exclusion, decides when a track may return
+        # recency, not permanent exclusion, decides when a track may return. Besides exact item
+        # identity we also dedupe on fuzzy same-song keys (title + artist) so a different
+        # release/version of an already-queued song is not pulled in as well.
         items = self.queues.queue_data(queue_id).items
         start = queue.current_index if queue.current_index is not None else 0
-        pool_keys = {
-            item.media_item for item in items[start:] if isinstance(item.media_item, Track)
-        }
+        pool_keys: set[Track] = set()
+        pool_song_keys: set[tuple[str, str]] = set()
+        for item in items[start:]:
+            if isinstance(item.media_item, Track):
+                pool_keys.add(item.media_item)
+                pool_song_keys.update(song_keys(item.media_item))
         slots = (
             MANAGED_POOL_TARGET
             if is_initial
@@ -157,6 +163,7 @@ class ManagedPool:
             sources,
             slots=slots,
             pool_keys=pool_keys,
+            pool_song_keys=pool_song_keys,
             snapshot=snapshot,
             windows=windows,
             preceding_artists=preceding,
@@ -361,6 +368,7 @@ def allocate_refill(
     windows: RecencyWindows,
     weight_model: PoolWeightModel = POOL_WEIGHT_MODEL,
     preceding_artists: set[str] | None = None,
+    pool_song_keys: set[tuple[str, str]] | None = None,
 ) -> list[Track]:
     """
     Pick the next batch of tracks for the managed pool, weighted per source and recency-gated.
@@ -380,10 +388,15 @@ def allocate_refill(
     :param weight_model: How to weight sources against each other.
     :param preceding_artists: Artist names of the track that will sit directly before the batch (the
         seam with the current tail); the first added track is kept clear of it.
+    :param pool_song_keys: Fuzzy same-song keys of the tracks already in the queue, so a different
+        release/version of an already-queued song is skipped as well.
     """
     if slots <= 0 or not sources:
         return []
-    eligible = [_eligible(source, pool_keys, snapshot, windows) for source in sources]
+    pool_song_keys = pool_song_keys or set()
+    eligible = [
+        _eligible(source, pool_keys, pool_song_keys, snapshot, windows) for source in sources
+    ]
     weights = [max(_weight(source, weight_model), 0) for source in sources]
     total_weight = sum(weights) or len(sources)
     shares = [slots * (weight or 0) / total_weight for weight in weights]
@@ -391,13 +404,16 @@ def allocate_refill(
     pointers = [0] * len(sources)
     chosen: list[Track] = []
     chosen_set: set[Track] = set()
+    chosen_song_keys: set[tuple[str, str]] = set()
     for _ in range(slots):
         best_index = -1
         best_deficit = 0.0
         for index in range(len(sources)):
-            # skip candidates already chosen for another source this round
+            # skip candidates already chosen for another source this round (also as a
+            # different release/version of the same song)
             while pointers[index] < len(eligible[index]) and (
                 eligible[index][pointers[index]] in chosen_set
+                or not chosen_song_keys.isdisjoint(song_keys(eligible[index][pointers[index]]))
             ):
                 pointers[index] += 1
             if pointers[index] >= len(eligible[index]):
@@ -410,9 +426,10 @@ def allocate_refill(
         track = eligible[best_index][pointers[best_index]]
         chosen.append(track)
         chosen_set.add(track)
+        chosen_song_keys.update(song_keys(track))
         taken[best_index] += 1
         pointers[best_index] += 1
-    batch = chosen or _ungated_fallback(sources, slots, pool_keys, snapshot)
+    batch = chosen or _ungated_fallback(sources, slots, pool_keys, pool_song_keys, snapshot)
     return _space_tracks(batch, preceding_artists)
 
 
@@ -443,6 +460,7 @@ def gate_tracks(
 def _eligible(
     source: DynamicSource,
     pool_keys: set[Track],
+    pool_song_keys: set[tuple[str, str]],
     snapshot: RecencySnapshot,
     windows: RecencyWindows,
 ) -> list[Track]:
@@ -459,11 +477,13 @@ def _eligible(
         return [
             track
             for track in source.candidates
-            if track not in pool_keys and not snapshot.track_recent(track, window)
+            if track not in pool_keys
+            and pool_song_keys.isdisjoint(song_keys(track))
+            and not snapshot.track_recent(track, window)
         ]
     scored: list[tuple[int, int, int, Track]] = []
     for track in source.candidates:
-        if track in pool_keys:
+        if track in pool_keys or not pool_song_keys.isdisjoint(song_keys(track)):
             continue
         last_played = snapshot.last_played(track)
         if window and last_played is not None and last_played >= snapshot.now - window:
@@ -490,16 +510,26 @@ def _weight(source: DynamicSource, weight_model: PoolWeightModel) -> int:
 
 
 def _ungated_fallback(
-    sources: list[DynamicSource], slots: int, pool_keys: set[Track], snapshot: RecencySnapshot
+    sources: list[DynamicSource],
+    slots: int,
+    pool_keys: set[Track],
+    pool_song_keys: set[tuple[str, str]],
+    snapshot: RecencySnapshot,
 ) -> list[Track]:
     """Return the globally least-recently-played candidates, ignoring the recency gate."""
     seen: set[Track] = set()
+    seen_song_keys = set(pool_song_keys)
     pool: list[Track] = []
     for source in sources:
         for track in source.candidates:
-            if track in pool_keys or track in seen:
+            if (
+                track in pool_keys
+                or track in seen
+                or not seen_song_keys.isdisjoint(track_song_keys := song_keys(track))
+            ):
                 continue
             seen.add(track)
+            seen_song_keys.update(track_song_keys)
             pool.append(track)
     pool.sort(
         key=lambda track: (

--- a/tests/controllers/music/test_recency.py
+++ b/tests/controllers/music/test_recency.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import time
 
 from music_assistant_models.enums import MediaType
-from music_assistant_models.media_items import ProviderMapping, Track
+from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track
+from music_assistant_models.unique_list import UniqueList
 
 from music_assistant.constants import DB_TABLE_PLAYLOG
 from music_assistant.controllers.music.recency import RecencyWindows
+from music_assistant.helpers.json import serialize_to_json
 from music_assistant.mass import MusicAssistant
 
 
@@ -21,6 +23,7 @@ async def _add_playlog_row(
     name: str,
     timestamp: int,
     userid: str = "user-a",
+    artist_names: list[str] | None = None,
 ) -> None:
     """Insert a single row into the playlog."""
     await mass.music.database.insert(
@@ -30,6 +33,9 @@ async def _add_playlog_row(
             "provider": provider,
             "media_type": media_type.value,
             "name": name,
+            "artists": serialize_to_json([{"name": artist_name} for artist_name in artist_names])
+            if artist_names
+            else None,
             "timestamp": timestamp,
             "fully_played": True,
             "seconds_played": 180,
@@ -48,6 +54,28 @@ def _track(item_id: str, provider: str, *, mapping: ProviderMapping | None = Non
         name=f"Track {item_id}",
         uri=f"{provider}://track/{item_id}",
         provider_mappings=mappings,
+    )
+
+
+def _named_track(item_id: str, name: str, artist_names: list[str]) -> Track:
+    """Build a Track with the given title and artist names (no provider mappings)."""
+    return Track(
+        item_id=item_id,
+        provider="library",
+        name=name,
+        uri=f"library://track/{item_id}",
+        provider_mappings=set(),
+        artists=UniqueList(
+            [
+                ItemMapping(
+                    item_id=artist_name.lower(),
+                    provider="library",
+                    name=artist_name,
+                    media_type=MediaType.ARTIST,
+                )
+                for artist_name in artist_names
+            ]
+        ),
     )
 
 
@@ -208,3 +236,45 @@ async def test_song_lookback_uses_duplicate_gap_when_song_window_unset(
 
     assert ("library", "recent") in snapshot.song_ts
     assert ("library", "old") not in snapshot.song_ts
+
+
+async def test_track_recent_fuzzy_matches_other_version(mass: MusicAssistant) -> None:
+    """A different release/version of a played song (same title + shared artist) is recent too."""
+    now = int(time.time())
+    await _add_playlog_row(
+        mass,
+        item_id="amber-1",
+        provider="spotify--x",
+        media_type=MediaType.TRACK,
+        name="Amber",
+        timestamp=now - 60,
+        artist_names=["The Thrillseekers"],
+    )
+    snapshot = await mass.music.recency.snapshot(RecencyWindows(song_seconds=3600), userid="user-a")
+
+    # same song, different catalog item with differing artist credits: matched fuzzily
+    other_version = _named_track("amber-2", "Amber", ["The Thrillseekers", "Hydra"])
+    assert snapshot.track_recent(other_version, 3600) is True
+    # a bracketed version suffix on the candidate title is stripped before matching
+    remaster = _named_track("amber-3", "Amber (Remastered 2019)", ["The Thrillseekers"])
+    assert snapshot.track_recent(remaster, 3600) is True
+    # same title by an unrelated artist is NOT matched
+    unrelated = _named_track("amber-4", "Amber", ["Someone Else"])
+    assert snapshot.track_recent(unrelated, 3600) is False
+
+
+async def test_track_recent_no_fuzzy_match_for_legacy_rows(mass: MusicAssistant) -> None:
+    """Playlog rows without stored artists (legacy) only match on exact ids."""
+    now = int(time.time())
+    await _add_playlog_row(
+        mass,
+        item_id="amber-1",
+        provider="spotify--x",
+        media_type=MediaType.TRACK,
+        name="Amber",
+        timestamp=now - 60,
+    )
+    snapshot = await mass.music.recency.snapshot(RecencyWindows(song_seconds=3600), userid="user-a")
+
+    other_version = _named_track("amber-2", "Amber", ["The Thrillseekers"])
+    assert snapshot.track_recent(other_version, 3600) is False

--- a/tests/controllers/player_queues/test_managed_pool.py
+++ b/tests/controllers/player_queues/test_managed_pool.py
@@ -8,7 +8,7 @@ from music_assistant_models.enums import MediaType
 from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track
 from music_assistant_models.unique_list import UniqueList
 
-from music_assistant.controllers.music.recency import RecencySnapshot, RecencyWindows
+from music_assistant.controllers.music.recency import RecencySnapshot, RecencyWindows, song_keys
 from music_assistant.controllers.player_queues.managed_pool import (
     DynamicFillMode,
     DynamicSource,
@@ -45,6 +45,29 @@ def _artist_track(item_id: str, artist: str) -> Track:
         item_id=item_id,
         provider="test",
         name=f"Track {item_id}",
+        duration=60,
+        artists=UniqueList(
+            [
+                ItemMapping(
+                    item_id=artist.lower(),
+                    provider="test",
+                    name=artist,
+                    media_type=MediaType.ARTIST,
+                )
+            ]
+        ),
+        provider_mappings={
+            ProviderMapping(item_id=item_id, provider_domain="test", provider_instance="test")
+        },
+    )
+
+
+def _version_track(item_id: str, name: str, artist: str) -> Track:
+    """Build a Track with an explicit title and single named artist."""
+    return Track(
+        item_id=item_id,
+        provider="test",
+        name=name,
         duration=60,
         artists=UniqueList(
             [
@@ -230,6 +253,49 @@ def test_pool_keys_excluded() -> None:
     )
     assert "b" not in _ids(result)
     assert set(_ids(result)) == {"a", "c"}
+
+
+def test_pool_song_keys_exclude_other_version() -> None:
+    """A different catalog version of an already-queued song is skipped too."""
+    queued = _version_track("amber-1", "Amber", "The Thrillseekers")
+    other_version = _version_track("amber-2", "Amber", "The Thrillseekers")
+    fresh = _version_track("other", "Two Bodies", "Flight Facilities")
+    source = DynamicSource(
+        media_item=_track("seed"),
+        multiplicity=1,
+        fill_mode=DynamicFillMode.TRACKS,
+        candidates=[other_version, fresh],
+    )
+    result = allocate_refill(
+        [source],
+        slots=10,
+        pool_keys={queued},
+        pool_song_keys=song_keys(queued),
+        snapshot=_snapshot(),
+        windows=RecencyWindows(),
+    )
+    assert _ids(result) == ["other"]
+
+
+def test_batch_never_contains_two_versions_of_same_song() -> None:
+    """Two catalog versions of the same song offered in one refill yield only one pick."""
+    sources = [
+        DynamicSource(
+            media_item=_track("seed"),
+            multiplicity=1,
+            fill_mode=DynamicFillMode.DYNAMIC,
+            candidates=[
+                _version_track("amber-1", "Amber", "The Thrillseekers"),
+                _version_track("amber-2", "Amber (Remastered 2019)", "The Thrillseekers"),
+                _version_track("other", "Two Bodies", "Flight Facilities"),
+            ],
+        )
+    ]
+    result = allocate_refill(
+        sources, slots=10, pool_keys=set(), snapshot=_snapshot(), windows=RecencyWindows()
+    )
+    assert len([tid for tid in _ids(result) if tid.startswith("amber")]) == 1
+    assert "other" in _ids(result)
 
 
 def test_never_exceeds_slots() -> None:


### PR DESCRIPTION
# What does this implement/fix?

A user playing a smart (dynamic) playlist got the same song enqueued multiple times — and again right after it had just played. All dedupe and recency layers matched on exact catalog identity (uri / provider item id / provider mappings), so the same recording under a different release, provider copy or artist credit (e.g. "Amber" by "The Thrillseekers" vs "The Thrillseekers, Hydra") passed every gate.

- Add an `artists` json column to the playlog (schema v47), written in `mark_item_played` as lightweight artist mappings, so a play can later be matched/resolved by artist.
- `RecencySnapshot` now also matches tracks on fuzzy same-song keys (version-stripped title + artist name) besides the exact id match, so a just-played song can't return as a different version.
- The managed pool refill dedupes on the same fuzzy keys against the active queue tail and within the batch being assembled, so two versions of the same song can't be enqueued together.
- Legacy playlog rows have no artists stored and simply keep matching on exact ids only.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.