### PR TITLE
Fix mypy no-any-return error in Plex lyrics fetch

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -1739,7 +1739,8 @@ class PlexProvider(MusicProvider):
                 url, headers={"Accept": "application/json"}, timeout=30
             )
             response.raise_for_status()
-            return response.text
+            # plexapi's untyped session makes the response Any for mypy; force str
+            return str(response.text)
 
         try:
             content = await self._run_async(_fetch)


### PR DESCRIPTION
# What does this implement/fix?

`pre-commit run mypy` fails on a `no-any-return` error in the Plex lyrics fetch (`plex/__init__.py`): plexapi's untyped `_session` makes the response effectively `Any` in some environments, which blocks local commits even for unrelated changes.

- Wrap the returned response body in `str()` so the return type is always `str | None` regardless of installed type stubs.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.