### PR TITLE
Add typed get_config_value helper to the config-owning base models

### DIFF
--- a/music_assistant/controllers/player_queues/queue_loader.py
+++ b/music_assistant/controllers/player_queues/queue_loader.py
@@ -613,7 +613,7 @@ class QueueLoaderMixin(_PlayerQueuesBase):
                         config_key = CONF_DEFAULT_ENQUEUE_OPTION_LIVE_SOURCES
                     else:
                         config_key = f"default_enqueue_option_{media_item.media_type.value}"
-                    config_value = cast("str", self.config.get_value(config_key))
+                    config_value = self.get_config_value(config_key, return_type=str)
                     option = QueueOption(config_value)
                     if option == QueueOption.REPLACE:
                         self.clear(queue_id, skip_stop=True)

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -360,7 +360,7 @@ class StreamsAudio:
 
         streamdetails.prefer_album_loudness = prefer_album_loudness
         conf_volume_normalization_target = float(
-            str(mass.streams.config.get_value(CONF_VOLUME_NORMALIZATION_TARGET, -14))
+            mass.streams.get_config_value(CONF_VOLUME_NORMALIZATION_TARGET, return_type=int)
         )
         # guard against invalid volume normalization values
         # range and default_value are guaranteed to be set for this constant
@@ -1541,7 +1541,7 @@ class StreamsAudio:
                 if streamdetails.media_type == MediaType.TRACK
                 else CONF_VOLUME_NORMALIZATION_FIXED_GAIN_RADIO
             )
-            gain_value = float(str(self.mass.streams.config.get_value(config_key, 0.0)))
+            gain_value = self.mass.streams.get_config_value(config_key, return_type=float)
             gain_correct = round(gain_value, 2)
             filter_params.append(f"volume={gain_correct}dB")
         elif streamdetails.volume_normalization_mode == VolumeNormalizationMode.MEASUREMENT_ONLY:
@@ -2614,11 +2614,7 @@ class StreamsAudio:
             else CONF_VOLUME_NORMALIZATION_TRACKS
         )
         return VolumeNormalizationMode(
-            str(
-                self.mass.streams.config.get_value(
-                    conf_key, VolumeNormalizationMode.FALLBACK_DYNAMIC.value
-                )
-            )
+            self.mass.streams.get_config_value(conf_key, return_type=str)
         )
 
     def _update_radio_stream_metadata(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -667,7 +667,7 @@ class StreamsController(CoreController):
 
             resp = web.StreamResponse(status=200, reason="OK", headers=headers)
             resp.content_type = get_mime_type(output_format.output_format_str)
-            http_profile = cast("str", player.config.get_value(CONF_HTTP_PROFILE, "default"))
+            http_profile = player.get_config_value(CONF_HTTP_PROFILE, "default")
             if http_profile == "forced_content_length" and not queue_item.duration:
                 # just set an insane high content length to make sure the player keeps playing
                 resp.content_length = calculate_content_length(output_format, 12 * 3600)
@@ -912,7 +912,7 @@ class StreamsController(CoreController):
             headers["icy-metaint"] = str(icy_meta_interval)
 
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
-        http_profile = cast("str", player.config.get_value(CONF_HTTP_PROFILE, "default"))
+        http_profile = player.get_config_value(CONF_HTTP_PROFILE, "default")
         if http_profile == "forced_content_length":
             # just set an insane high content length to make sure the player keeps playing
             resp.content_length = calculate_content_length(output_format, 12 * 3600)
@@ -1014,9 +1014,7 @@ class StreamsController(CoreController):
 
         mass_player = self.mass.players.get_player(player_id)
         http_profile = (
-            cast("str", mass_player.config.get_value(CONF_HTTP_PROFILE, "default"))
-            if mass_player
-            else "default"
+            mass_player.get_config_value(CONF_HTTP_PROFILE, "default") if mass_player else "default"
         )
         if http_profile == "forced_content_length":
             # given the fact that an announcement is just a short audio clip,

--- a/music_assistant/models/core_controller.py
+++ b/music_assistant/models/core_controller.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, overload
 
+from music_assistant_models.config_entries import ConfigValueType
 from music_assistant_models.enums import ProviderStage, ProviderType
 from music_assistant_models.provider import ProviderManifest
 
 from music_assistant.constants import CONF_LOG_LEVEL, MASS_LOGGER_NAME
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, CoreConfig
+    from music_assistant_models.config_entries import ConfigEntry, CoreConfig
 
     from music_assistant.mass import MusicAssistant
+
+# TypeVar for config value type inference
+_ConfigValueT = TypeVar("_ConfigValueT", bound=ConfigValueType)
 
 
 class CoreController:
@@ -56,6 +60,43 @@ class CoreController:
     ) -> tuple[ConfigEntry, ...]:
         """Return all Config Entries for this core module (if any)."""
         return ()
+
+    @overload
+    def get_config_value(
+        self, key: str, default: _ConfigValueT, *, return_type: type[_ConfigValueT] = ...
+    ) -> _ConfigValueT: ...
+
+    @overload
+    def get_config_value(
+        self, key: str, default: ConfigValueType = ..., *, return_type: type[_ConfigValueT]
+    ) -> _ConfigValueT: ...
+
+    @overload
+    def get_config_value(
+        self, key: str, default: ConfigValueType = ..., *, return_type: None = ...
+    ) -> ConfigValueType: ...
+
+    def get_config_value(
+        self,
+        key: str,
+        default: ConfigValueType = None,
+        *,
+        return_type: type[_ConfigValueT | ConfigValueType] | None = None,
+    ) -> _ConfigValueT | ConfigValueType:
+        """
+        Return a single config value from this core controller's active configuration.
+
+        Entry defaults are already applied to the active configuration, so the
+        default is only returned when the key itself is not present.
+
+        :param key: The config key to retrieve.
+        :param default: Value to return when the key is not present in the config.
+        :param return_type: Optional type hint for type inference (e.g., str, int, bool).
+            Note: This parameter is used purely for static type checking and does not
+            perform runtime type validation. Callers are responsible for ensuring the
+            specified type matches the actual config value type.
+        """
+        return self.config.get_value(key, default)
 
     async def setup(self, config: CoreConfig) -> None:
         """Async initialize of module."""

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -13,12 +13,13 @@ The final active source can be retrieved by using the 'state' property.
 from __future__ import annotations
 
 import asyncio
+import builtins
 import time
 from abc import ABC
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, cast, final
+from typing import TYPE_CHECKING, Any, TypeVar, cast, final, overload
 
-from music_assistant_models.config_entries import MULTI_VALUE_SPLITTER
+from music_assistant_models.config_entries import MULTI_VALUE_SPLITTER, ConfigValueType
 from music_assistant_models.constants import (
     EXTRA_ATTRIBUTES_TYPES,
     PLAYER_CONTROL_FAKE,
@@ -64,11 +65,14 @@ from music_assistant.constants import (
 from music_assistant.helpers.util import html_to_markdown
 
 if TYPE_CHECKING:
-    from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, PlayerConfig
+    from music_assistant_models.config_entries import ConfigEntry, PlayerConfig
     from music_assistant_models.media_items import MediaItemPalette
     from music_assistant_models.player_queue import PlayerQueue
 
     from .player_provider import PlayerProvider
+
+# TypeVar for config value type inference
+_ConfigValueT = TypeVar("_ConfigValueT", bound=ConfigValueType)
 
 
 def _clamp_elapsed_time(elapsed_time: float | None) -> float | None:
@@ -859,6 +863,43 @@ class Player(ABC):
         # To override the default config entries, simply define an entry with the same key
         # and it will be used instead of the default one.
         return []
+
+    @overload
+    def get_config_value(
+        self, key: str, default: _ConfigValueT, *, return_type: builtins.type[_ConfigValueT] = ...
+    ) -> _ConfigValueT: ...
+
+    @overload
+    def get_config_value(
+        self, key: str, default: ConfigValueType = ..., *, return_type: builtins.type[_ConfigValueT]
+    ) -> _ConfigValueT: ...
+
+    @overload
+    def get_config_value(
+        self, key: str, default: ConfigValueType = ..., *, return_type: None = ...
+    ) -> ConfigValueType: ...
+
+    def get_config_value(
+        self,
+        key: str,
+        default: ConfigValueType = None,
+        *,
+        return_type: builtins.type[_ConfigValueT | ConfigValueType] | None = None,
+    ) -> _ConfigValueT | ConfigValueType:
+        """
+        Return a single config value from this player's active configuration.
+
+        Entry defaults are already applied to the active configuration, so the
+        default is only returned when the key itself is not present.
+
+        :param key: The config key to retrieve.
+        :param default: Value to return when the key is not present in the config.
+        :param return_type: Optional type hint for type inference (e.g., str, int, bool).
+            Note: This parameter is used purely for static type checking and does not
+            perform runtime type validation. Callers are responsible for ensuring the
+            specified type matches the actual config value type.
+        """
+        return self.config.get_value(key, default)
 
     async def on_config_updated(self) -> None:
         """

--- a/music_assistant/models/provider.py
+++ b/music_assistant/models/provider.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import logging
-from typing import TYPE_CHECKING, Any, final
+from typing import TYPE_CHECKING, Any, TypeVar, final, overload
 
+from music_assistant_models.config_entries import ConfigValueType
 from music_assistant_models.errors import UnsupportedFeaturedException
 
 from music_assistant.constants import CONF_LOG_LEVEL, MASS_LOGGER_NAME
@@ -19,6 +21,9 @@ if TYPE_CHECKING:
     from zeroconf.asyncio import AsyncServiceInfo
 
     from music_assistant.mass import MusicAssistant
+
+# TypeVar for config value type inference
+_ConfigValueT = TypeVar("_ConfigValueT", bound=ConfigValueType)
 
 
 class Provider:
@@ -195,6 +200,43 @@ class Provider:
             raise UnsupportedFeaturedException(
                 f"Provider {self.name} does not support feature {feature.name}"
             )
+
+    @overload
+    def get_config_value(
+        self, key: str, default: _ConfigValueT, *, return_type: builtins.type[_ConfigValueT] = ...
+    ) -> _ConfigValueT: ...
+
+    @overload
+    def get_config_value(
+        self, key: str, default: ConfigValueType = ..., *, return_type: builtins.type[_ConfigValueT]
+    ) -> _ConfigValueT: ...
+
+    @overload
+    def get_config_value(
+        self, key: str, default: ConfigValueType = ..., *, return_type: None = ...
+    ) -> ConfigValueType: ...
+
+    def get_config_value(
+        self,
+        key: str,
+        default: ConfigValueType = None,
+        *,
+        return_type: builtins.type[_ConfigValueT | ConfigValueType] | None = None,
+    ) -> _ConfigValueT | ConfigValueType:
+        """
+        Return a single config value from this provider's active configuration.
+
+        Entry defaults are already applied to the active configuration, so the
+        default is only returned when the key itself is not present.
+
+        :param key: The config key to retrieve.
+        :param default: Value to return when the key is not present in the config.
+        :param return_type: Optional type hint for type inference (e.g., str, int, bool).
+            Note: This parameter is used purely for static type checking and does not
+            perform runtime type validation. Callers are responsible for ensuring the
+            specified type matches the actual config value type.
+        """
+        return self.config.get_value(key, default)
 
     def _update_config_value(self, key: str, value: Any, encrypted: bool = False) -> None:
         """Update a config value."""

--- a/music_assistant/providers/dlna/player.py
+++ b/music_assistant/providers/dlna/player.py
@@ -255,7 +255,7 @@ class DLNAPlayer(Player):
         """Send PAUSE command to given player."""
         assert self.device is not None  # for type checking
 
-        replace_pause_with_stop = bool(self.config.get_value("replace_pause_with_stop"))
+        replace_pause_with_stop = self.get_config_value("replace_pause_with_stop", return_type=bool)
 
         if replace_pause_with_stop and self.device.can_stop:
             await self.stop()

--- a/music_assistant/providers/musiccast/player.py
+++ b/music_assistant/providers/musiccast/player.py
@@ -652,13 +652,13 @@ class MusicCastPlayer(Player):
             return
 
         # skip zone handling if disabled via setting
-        if bool(mass_player.config.get_value(CONF_PLAYER_HANDLE_SOURCE_DISABLED)):
+        if mass_player.get_config_value(CONF_PLAYER_HANDLE_SOURCE_DISABLED):
             self.logger.debug("Ignoring zone handling for player %s.", player_id)
             return
 
         self.logger.debug("Handling zone for player %s.", player_id)
 
-        _source = str(mass_player.config.get_value(CONF_PLAYER_SWITCH_SOURCE_NON_NET))
+        _source = mass_player.get_config_value(CONF_PLAYER_SWITCH_SOURCE_NON_NET, return_type=str)
         # verify that this source actually exists and is non net
         _allowed_sources = self._get_allowed_sources_zone_switch(zone_player)
         if _source not in _allowed_sources:
@@ -673,7 +673,7 @@ class MusicCastPlayer(Player):
             _source = _allowed_sources.pop()
 
         await mass_player.select_source(_source)
-        _turn_off = bool(mass_player.config.get_value(CONF_PLAYER_TURN_OFF_ON_LEAVE))
+        _turn_off = mass_player.get_config_value(CONF_PLAYER_TURN_OFF_ON_LEAVE, return_type=bool)
         if _turn_off:
             await asyncio.sleep(2)
             await mass_player.power(powered=False)

--- a/music_assistant/providers/universal_group/player.py
+++ b/music_assistant/providers/universal_group/player.py
@@ -585,13 +585,11 @@ class UniversalGroupPlayer(Player):
             "Content-Type": get_mime_type(output_format_str),
         }
         resp = web.StreamResponse(status=200, reason="OK", headers=headers)
-        http_profile = cast("str", self.config.get_value(CONF_HTTP_PROFILE, "chunked"))
+        http_profile = self.get_config_value(CONF_HTTP_PROFILE, "chunked")
         # prefer the child (protocol) player configuration
         # (child player_id may be stale/invalid; fall back to the group profile)
         if child_player_id and (child_player := self.mass.players.get_player(child_player_id)):
-            http_profile = cast(
-                "str", child_player.config.get_value(CONF_HTTP_PROFILE, http_profile)
-            )
+            http_profile = child_player.get_config_value(CONF_HTTP_PROFILE, http_profile)
         if http_profile == "chunked" and request.version < HttpVersion11:
             # chunked encoding is not allowed on HTTP/1.0; fall back to
             # connection-close streaming to avoid raising in resp.prepare()


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4585, which left the object-local config reads with two ergonomic warts: `Config.get_value` returns the raw `ConfigValueType` union, so call sites needed `cast("str", ...)` / `bool(...)` / `float(str(...))` wrappers, and several call sites passed a `default=` that can never apply (parse bakes the entry default into the value; the passed default only matters when the key itself is absent from the config).

- the three config-owning base models (`Player`, `Provider`, `CoreController`) get a `get_config_value(key, default=None, *, return_type=...)` convenience method that delegates to the in-place parsed config copy, mirroring the typed-overload pattern of `ConfigController.get_core_config_value` — so `player.get_config_value(CONF_HTTP_PROFILE, "default")` and `mass.streams.get_config_value(CONF_VOLUME_NORMALIZATION_TARGET, return_type=int)` type correctly without casts (`Player`/`Provider` define a `type` property, hence the `builtins.type` spelling in the annotations)
- the object-local read sites from #4585 are converted to the helper and the now-unneeded casts/wrappers dropped
- redundant `default=` arguments are dropped where the entry is guaranteed to exist (core controllers reading their own entries — e.g. the fixed-gain sites passed `0.0` while the entry default is `-6`, a default that could never apply); explicit fallbacks are kept where the key may legitimately be absent (`http_profile` on players)

Other provider-internal `self.config.get_value` usages are left as-is; providers can adopt the helper organically.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
