### PR TITLE
Local Audio: promote attribution stubs to regular visible players

### DIFF
--- a/music_assistant/controllers/config/migrations.py
+++ b/music_assistant/controllers/config/migrations.py
@@ -12,6 +12,7 @@ from music_assistant.constants import (
     CONF_CROSSFADE_DURATION,
     CONF_CROSSFADE_MODE,
     CONF_LINKED_PROTOCOL_IDS,
+    CONF_PLAYER_DSP,
     CONF_PLAYER_QUEUES,
     CONF_PLAYERS,
     CONF_PROTOCOL_PARENT_ID,
@@ -32,7 +33,7 @@ from music_assistant.controllers.player_queues.constants import (
 LOGGER = logging.getLogger(__name__)
 
 
-async def migrate(data: dict[str, Any]) -> bool:
+async def migrate(data: dict[str, Any]) -> bool:  # noqa: PLR0915
     """Migrate the persistent settings data in-place; return True if anything changed."""
     changed = False
 
@@ -144,6 +145,12 @@ async def migrate(data: dict[str, Any]) -> bool:
     # above so any values it just landed are picked up here.
     # TODO: remove after 2.10 release
     if _migrate_global_queue_settings(data):
+        changed = True
+
+    # Promote local_audio attribution stubs to regular players and fold the settings of
+    # their (now obsolete) universal player wrappers back onto them.
+    # TODO: remove after 2.11 release
+    if _migrate_local_audio_attribution_stubs(data):
         changed = True
 
     return changed
@@ -321,6 +328,126 @@ def _migrate_volume_normalization_target(data: dict[str, Any]) -> bool:
                 player_id,
             )
     return True
+
+
+def _migrate_local_audio_attribution_stubs(data: dict[str, Any]) -> bool:
+    """
+    Promote local_audio attribution-stub players to regular players.
+
+    The local_audio provider used to register a hidden PROTOCOL "attribution stub"
+    per audio device, which got wrapped (together with the Sendspin bridge player)
+    in an auto-created universal player. The stub is now a regular, visible player
+    that parents the Sendspin bridge directly, making the universal player wrapper
+    obsolete: its user settings move onto the stub's config (same bare device-uuid
+    player_id) and the wrapper is removed.
+    """
+    all_player_configs = data.get(CONF_PLAYERS, {})
+    if not isinstance(all_player_configs, dict):
+        return False
+    changed = False
+    for player_id, player_cfg in list(all_player_configs.items()):
+        if not isinstance(player_cfg, dict):
+            continue
+        if player_cfg.get("provider") != "local_audio":
+            continue
+        if player_cfg.get("player_type") != "protocol":
+            continue
+        player_cfg["player_type"] = "player"
+        values = player_cfg.setdefault("values", {})
+        values.pop(CONF_PROTOCOL_PARENT_ID, None)
+        changed = True
+
+        # the universal player wrapper was keyed on the stub's player_id
+        # (the stub had no device identifiers to derive a device key from)
+        universal_id = f"up{player_id.replace('-', '').lower()}"
+        universal_cfg = all_player_configs.get(universal_id)
+        if isinstance(universal_cfg, dict) and universal_cfg.get("provider") == "universal_player":
+            del all_player_configs[universal_id]
+            _absorb_universal_player_config(
+                data, player_id, player_cfg, universal_id, universal_cfg
+            )
+            LOGGER.info(
+                "Migrated universal player %s settings to local_audio player %s",
+                universal_id,
+                player_id,
+            )
+        LOGGER.info("Promoted local_audio player %s to a regular player", player_id)
+    return changed
+
+
+def _absorb_universal_player_config(
+    data: dict[str, Any],
+    player_id: str,
+    player_cfg: dict[str, Any],
+    universal_id: str,
+    universal_cfg: dict[str, Any],
+) -> None:
+    """
+    Fold the user settings of an obsolete universal player onto its replacement.
+
+    The universal player was the visible device the user configured, so its
+    settings win over anything stored on the (hidden) stub. Everything keyed on
+    the old universal player_id (protocol parent links, queue settings, DSP
+    config, group memberships) is re-pointed to the new player_id.
+    """
+    player_cfg["enabled"] = universal_cfg.get("enabled", True)
+    # only carry an actual user rename, not the auto-generated default name
+    if universal_cfg.get("name") and universal_cfg.get("name") != universal_cfg.get("default_name"):
+        player_cfg["name"] = universal_cfg["name"]
+
+    values = player_cfg.setdefault("values", {})
+    universal_values = universal_cfg.get("values")
+    universal_values = universal_values if isinstance(universal_values, dict) else {}
+    # bookkeeping only relevant to the universal player wrapper itself
+    internal_keys = (
+        CONF_LINKED_PROTOCOL_IDS,
+        CONF_PROTOCOL_PARENT_ID,
+        "device_identifiers",
+        "device_info",
+    )
+    for key, value in universal_values.items():
+        if key in internal_keys:
+            continue
+        values[key] = value
+
+    # carry the linked protocols (minus the stub itself, it is the parent now)
+    # and re-point their cached parent so they restore fast on the next start
+    linked_ids = [
+        pid for pid in (universal_values.get(CONF_LINKED_PROTOCOL_IDS) or []) if pid != player_id
+    ]
+    if linked_ids:
+        existing_ids = list(values.get(CONF_LINKED_PROTOCOL_IDS) or [])
+        values[CONF_LINKED_PROTOCOL_IDS] = existing_ids + [
+            pid for pid in linked_ids if pid not in existing_ids
+        ]
+    all_player_configs = data.get(CONF_PLAYERS, {})
+    for protocol_id in linked_ids:
+        protocol_cfg = all_player_configs.get(protocol_id)
+        if not isinstance(protocol_cfg, dict):
+            continue
+        protocol_values = protocol_cfg.setdefault("values", {})
+        if protocol_values.get(CONF_PROTOCOL_PARENT_ID) == universal_id:
+            protocol_values[CONF_PROTOCOL_PARENT_ID] = player_id
+
+    # move per-queue settings and DSP configuration to the new player_id
+    for tree_key in (CONF_PLAYER_QUEUES, CONF_PLAYER_DSP):
+        tree = data.get(tree_key)
+        if isinstance(tree, dict) and universal_id in tree and player_id not in tree:
+            tree[player_id] = tree.pop(universal_id)
+            if tree_key == CONF_PLAYER_QUEUES and isinstance(tree[player_id], dict):
+                tree[player_id]["queue_id"] = player_id
+
+    # re-point group memberships that referenced the universal player
+    for other_cfg in all_player_configs.values():
+        if not isinstance(other_cfg, dict):
+            continue
+        other_values = other_cfg.get("values")
+        if not isinstance(other_values, dict):
+            continue
+        for key in ("group_members", "dynamic_group_members", "allowed_members"):
+            members = other_values.get(key)
+            if isinstance(members, list) and universal_id in members:
+                other_values[key] = [player_id if pid == universal_id else pid for pid in members]
 
 
 def _migrate_self_referential_protocol_links(data: dict[str, Any]) -> bool:

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -432,6 +432,11 @@ class ProtocolLinkingMixin:
             protocol_player = self.get_player(player_id)
             if not protocol_player or protocol_player.protocol_parent_id:
                 return
+            if protocol_player.state.type != PlayerType.PROTOCOL:
+                # The player changed type while the evaluation was pending
+                # (e.g. re-registered as a regular player); it must never be
+                # linked as a protocol or wrapped in a universal player.
+                return
 
             # Derived protocol players resolve strictly via their underlying
             # player and never match by identifiers or wrap into universal
@@ -980,9 +985,15 @@ class ProtocolLinkingMixin:
             cached_only_ids = known_protocol_ids - active_protocol_ids
             preserved_protocol_ids = moved_protocol_ids | cached_only_ids
             # A device that kept its id across a type change lists itself here.
+            # It must never become its own protocol, and it must also be dropped
+            # from the obsolete universal player so the permanent cleanup below
+            # doesn't treat it as an orphaned protocol (which would re-wrap the
+            # native player in a fresh universal player).
             preserved_protocol_ids.discard(native_player.player_id)
             self._migrate_protocol_ids_to_parent(native_player, preserved_protocol_ids)
-            self._remove_protocol_ids_from_parent(player, preserved_protocol_ids)
+            self._remove_protocol_ids_from_parent(
+                player, preserved_protocol_ids | {native_player.player_id}
+            )
             native_player.refresh_state()
 
             # Remove the now-obsolete universal player

--- a/music_assistant/providers/local_audio/README.md
+++ b/music_assistant/providers/local_audio/README.md
@@ -9,7 +9,7 @@ The Local Audio Out provider exposes locally attached soundcards as players in M
 - **Automatic Device Discovery**: On Linux with PulseAudio/PipeWire, enumerates all output sinks via `pactl --format=json` — returns native sample rate and format regardless of active stream state. On Linux with ALSA direct, enumerates hardware `hw:` devices via PortAudio. On macOS, enumerates via PortAudio/sounddevice
 - **Backend Selector** *(Linux)*: Choose between Auto (PulseAudio/PipeWire if available, else ALSA direct), PulseAudio/PipeWire, or ALSA direct. Auto mode detects PulseAudio/PipeWire first and falls back to ALSA if unavailable
 - **Native Format Negotiation** *(Linux PulseAudio)*: Each PA sink advertises its native sample rate and bit depth (16, 24, or 32-bit) so Music Assistant transcodes to the correct format — no unnecessary resampling
-- **Sendspin Integration**: Each device is registered as a Sendspin bridge client, enabling synchronized multi-room playback
+- **Sendspin Integration**: Each device is registered as a regular, visible MA player whose (single) output protocol is provided by a Sendspin bridge client, enabling synchronized multi-room playback. Disabling the player tears the bridge down; enabling it re-registers the player and rebuilds the bridge
 - **Self-Managed Remap-Sink Topology** *(Linux PulseAudio)*: For multi-channel sound cards (5.1, 7.1), the provider creates and owns its own `module-remap-sink` topology on startup — one stereo "zone" sink per channel pair (front, rear, side, center/LFE) plus a full-channel "multichannel stereo" passthrough sink. No external addon or pre-configuration is required; the topology is created idempotently on every startup and torn down on provider stop
 - **Hardware Volume Control** *(Linux PulseAudio)*: Per-player volume and mute are applied as native PulseAudio sink volume via `libpulse`, using an exponential "audio taper" curve mapped from the MA 0-100 slider so slider position corresponds to a constant dB change per step (see Volume Control below). Each remap sink has an independent hardware volume that doesn't affect its master sink or sibling sinks. Falls back to software volume (PCM scaling) if hardware volume control is unavailable
 - **Stable Player IDs**: Uses UUIDv5 derived from device name + host API index so players persist across restarts
@@ -29,7 +29,10 @@ The Local Audio Out provider exposes locally attached soundcards as players in M
                               │
                 ┌─────────────▼──────────────┐
                 │  LocalAudioBridgeManager   │
+                │  (SendspinBridgeManagerBase│
+                │   desired-state reconciler)│
                 │  - Enumerates devices      │
+                │  - Registers device players│
                 │  - Creates/stops bridges   │
                 └─────────────┬──────────────┘
                               │

--- a/music_assistant/providers/local_audio/provider.py
+++ b/music_assistant/providers/local_audio/provider.py
@@ -44,19 +44,11 @@ class LocalAudioProvider(PlayerProvider):
 
         self._bridge_manager = LocalAudioBridgeManager(self)
 
-    async def loaded_in_mass(self) -> None:
-        """Handle provider fully loaded in Music Assistant."""
+    async def discover_players(self) -> None:
+        """Discover local audio output devices and register their players."""
         await self._bridge_manager.discover_and_register()
 
     async def unload(self, is_removed: bool = False) -> None:
         """Handle unload/removal of the provider."""
         if bridge_manager := getattr(self, "_bridge_manager", None):
-            await bridge_manager.stop_all()
-
-    def on_player_enabled(self, player_id: str) -> None:
-        """
-        Override to suppress re-discovery on player enable.
-
-        ALSA devices are statically enumerated once at startup —
-        there is no need to re-run discovery when a player is enabled.
-        """
+            await bridge_manager.close()

--- a/music_assistant/providers/local_audio/sendspin_bridge.py
+++ b/music_assistant/providers/local_audio/sendspin_bridge.py
@@ -14,11 +14,11 @@ from aiosendspin.models.core import ClientHelloPayload
 from aiosendspin.models.core import DeviceInfo as SendspinDeviceInfo
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
 from aiosendspin.models.types import AudioCodec, PlayerCommand
-from music_assistant_models.enums import IdentifierType, PlayerType
+from music_assistant_models.enums import IdentifierType
 from music_assistant_models.player import DeviceInfo
 
-from music_assistant.constants import CONF_PLAYERS
 from music_assistant.models.player import Player
+from music_assistant.providers.sendspin.bridge_manager import SendspinBridgeManagerBase
 from music_assistant.providers.sendspin.bridge_role import (
     BRIDGE_BIT_DEPTH,
     BRIDGE_CHANNELS,
@@ -210,8 +210,8 @@ class SendspinLocalAudioBridge:
                 self._bridge_client_id,
                 {IdentifierType.UUID: self._device_uuid},
             )
-            # The attribution-stub protocol player (registered under the bare
-            # device uuid) is the player this bridge runs on top of.
+            # The local audio device player (registered under the bare device
+            # uuid) is the player this bridge runs on top of.
             sendspin_prov.register_bridge_underlying_player(
                 self._bridge_client_id, self._device_uuid
             )
@@ -771,77 +771,62 @@ class SendspinLocalAudioBridge:
             self._write_queue.get_nowait()
 
 
-class LocalAudioBridgeManager:
+class LocalAudioBridgeManager(SendspinBridgeManagerBase[SendspinLocalAudioBridge]):
     """Manages Sendspin bridges for all local audio output devices."""
 
     def __init__(self, provider: LocalAudioProvider) -> None:
         """Initialize the bridge manager."""
-        self.provider = provider
-        self.mass = provider.mass
-        self.logger = provider.logger.getChild("bridge_manager")
-        self._bridges: dict[str, SendspinLocalAudioBridge] = {}
-        self._lock = asyncio.Lock()
+        super().__init__(provider)
+        self._discover_lock = asyncio.Lock()
         self._volume_controller: PAVolumeController | None = None
+        # player_id (device uuid) -> device info dict from the last enumeration
+        self._devices: dict[str, dict[str, Any]] = {}
+        self._backend: str = AUDIO_BACKEND_AUTO
+        # master sink names with at least one remap-sink child (see _remap_master_sinks)
+        self._remap_masters: set[str] = set()
         # sink_name -> PA module index, for sinks local_audio created via
         # _ensure_remap_topology(). Unloaded on stop_all().
         self._loaded_remap_modules: dict[str, int] = {}
 
-    @property
-    def sendspin_server(self) -> SendspinServer | None:
-        """Get the Sendspin server if available."""
-        if provider := cast("SendspinProvider | None", self.mass.get_provider("sendspin")):
-            return provider.server_api
-        return None
-
     async def discover_and_register(self) -> None:
-        """Enumerate output devices and register Sendspin bridges."""
-        sendspin_server = self.sendspin_server
-        if not sendspin_server:
+        """Enumerate output devices, register their players and set up the bridges."""
+        if not self.sendspin_server:
             self.logger.debug("Sendspin provider not available, skipping device enumeration")
             return
 
-        # Read audio backend config (Linux only; ignored on Darwin)
-        configured_backend: str = str(
-            self.provider.config.get_value(CONF_AUDIO_BACKEND) or AUDIO_BACKEND_AUTO
-        )
-
-        try:
-            resolved_backend, devices = await self.mass.loop.run_in_executor(
-                None, self._enumerate_output_devices, configured_backend
+        async with self._discover_lock:
+            # Read audio backend config (Linux only; ignored on Darwin)
+            configured_backend: str = str(
+                self.provider.config.get_value(CONF_AUDIO_BACKEND) or AUDIO_BACKEND_AUTO
             )
-        except Exception as err:
-            self.logger.warning("Failed to enumerate audio devices: %s", err)
-            return
+            try:
+                resolved_backend, devices = await self.mass.loop.run_in_executor(
+                    None, self._enumerate_output_devices, configured_backend
+                )
+            except Exception as err:
+                self.logger.warning("Failed to enumerate audio devices: %s", err)
+                return
 
-        self.logger.info(
-            "Found %d local audio output device(s) via %s backend",
-            len(devices),
-            resolved_backend,
-        )
+            self.logger.info(
+                "Found %d local audio output device(s) via %s backend",
+                len(devices),
+                resolved_backend,
+            )
+            if not devices:
+                self.logger.info("No local audio output devices found")
+                return
 
-        if not devices:
-            self.logger.info("No local audio output devices found")
-            return
+            await self._ensure_volume_controller(resolved_backend)
+            if resolved_backend == "pulse":
+                devices = await self._refresh_after_remap_topology(devices)
 
-        await self._ensure_volume_controller(resolved_backend)
-        if resolved_backend == "pulse":
-            devices = await self._refresh_after_remap_topology(devices)
+            self._backend = resolved_backend
+            self._remap_masters = self._remap_master_sinks(devices)
+            passthrough_masters = self._remap_masters_with_passthrough(devices)
 
-        remap_masters = self._remap_master_sinks(devices)
-        passthrough_masters = self._remap_masters_with_passthrough(devices)
-
-        async with self._lock:
+            device_map: dict[str, dict[str, Any]] = {}
             for device in devices:
                 device_name: str = device["name"]
-                display_name: str = device.get("description", device_name)
-                hostapi_index: int = device.get("hostapi", 0)
-                device_uuid = get_device_uuid(device_name, hostapi_index)
-                client_id = bridge_client_id_from_uuid(device_uuid)
-
-                if client_id in self._bridges:
-                    self.logger.debug("Bridge already exists for %s", display_name)
-                    continue
-
                 # A master sink fully covered by its own remap-sink topology
                 # (per-zone sinks plus a full-passthrough
                 # "_multichannel_stereo" sink) isn't registered as its own
@@ -849,50 +834,48 @@ class LocalAudioBridgeManager:
                 # all outputs" with independent hardware volume control.
                 if not device.get("is_remap", False) and device_name in passthrough_masters:
                     self.logger.debug(
-                        "Skipping %s — covered by its remap-sink topology", display_name
+                        "Skipping %s — covered by its remap-sink topology",
+                        device.get("description", device_name),
                     )
                     continue
+                device_map[get_device_uuid(device_name, device.get("hostapi", 0))] = device
+            self._devices = device_map
 
-                protocol_player = await self._register_protocol_player(device_uuid, display_name)
-
-                bridge = SendspinLocalAudioBridge(
-                    self.provider,
-                    device,
-                    sendspin_server,
-                    backend=resolved_backend,
-                    volume_controller=self._volume_controller,
-                    has_remap_children=device_name in remap_masters,
-                )
-                try:
-                    await bridge.start()
-                except Exception:
-                    self.logger.warning("Failed to start bridge for %s", device_name)
-                    with suppress(OSError):
-                        await bridge.stop()
-                    protocol_player._attr_available = False
-                    protocol_player.update_state()
+            for device_uuid, device in self._devices.items():
+                player = self.mass.players.get_player(device_uuid)
+                if player is None or player.provider is not self.provider:
+                    # not registered yet, or a stale player object left behind by a
+                    # previous provider instance (players survive a provider reload):
+                    # (re)register so the player is bound to this provider instance
+                    player = await self._register_player(
+                        device_uuid, device.get("description", device["name"])
+                    )
+                if player is None:
+                    # registration skipped - the player is disabled
                     continue
+                await self.evaluate_bridge(player)
 
-                if not bridge.is_registered:
-                    protocol_player._attr_available = False
-                    protocol_player.update_state()
-                    continue
+    async def evaluate_bridge(self, player: Player) -> None:
+        """
+        Reconcile the Sendspin bridge for a player and update the player's availability.
 
-                self._bridges[client_id] = bridge
-                self.logger.info(
-                    "Bridge created for %s (backend=%s, pa_sink=%s)",
-                    device_name,
-                    resolved_backend,
-                    device.get("pa_sink_name") or "n/a",
-                )
+        A local audio player has no playback path other than its bridge, so a
+        bridge that should exist but failed to start marks the player
+        unavailable (and a successful rebuild restores it).
+
+        :param player: The player to evaluate.
+        """
+        await super().evaluate_bridge(player)
+        if not (self._should_have_bridge(player) and self._lifecycle_allows_bridge(player)):
+            return
+        available = self._has_bridge(player.player_id)
+        if player.available != available:
+            player._attr_available = available
+            player.update_state()
 
     async def stop_all(self) -> None:
         """Stop all Sendspin bridges and unload any remap sinks we created."""
-        async with self._lock:
-            for bridge in list(self._bridges.values()):
-                with suppress(OSError):
-                    await bridge.stop()
-            self._bridges.clear()
+        await super().stop_all()
         if self._loaded_remap_modules:
             # Give PA a moment to release active streams on the remap sinks
             # before unloading their modules — unload-module fails if a stream
@@ -911,7 +894,6 @@ class LocalAudioBridgeManager:
             with suppress(OSError):
                 await self.mass.loop.run_in_executor(None, self._volume_controller.close)
             self._volume_controller = None
-        self.logger.debug("All local audio bridges stopped")
 
     async def _ensure_volume_controller(self, resolved_backend: str) -> None:
         """
@@ -1066,38 +1048,49 @@ class LocalAudioBridgeManager:
 
         return loaded_any
 
-    async def _register_protocol_player(self, device_uuid: str, display_name: str) -> Player:
-        """
-        Register the local_audio-owned PROTOCOL attribution-stub player.
+    def _bridge_client_id(self, player: Player) -> str | None:
+        """Return the Sendspin client_id used to bridge a local audio player."""
+        return bridge_client_id_from_uuid(player.player_id)
 
-        Gives Universal Player a local_audio domain link so the wrapped
-        up_... player is attributed to the Local Audio Out provider filter
-        in the MA UI. Mirrors the pattern used by AirPlay — the bare UUID
-        player_id is what provides this link.
-        """
-        # Force-enable the attribution stub *before* constructing/registering
-        # the player. PlayerController.register() reads the persisted
-        # "enabled" config value and silently skips registration entirely if
-        # it's False — so re-enabling after register_or_update() has already
-        # been awaited is too late, the player has already been dropped.
-        # config.set() (not a mutation of the dict from config.get()) is
-        # required for the change to actually persist across restarts.
-        enabled_key = f"{CONF_PLAYERS}/{device_uuid}/enabled"
-        if self.mass.config.get(enabled_key, True) is False:
-            self.logger.debug("Re-enabling disabled attribution stub for %s", display_name)
-            self.mass.config.set(enabled_key, True)
-
-        protocol_player = Player(self.provider, device_uuid)
-        protocol_player._attr_type = PlayerType.PROTOCOL
-        protocol_player._attr_name = display_name
-        protocol_player._attr_available = True
-        protocol_player._attr_hidden_by_default = True  # attribution stub — hide from UI
-        protocol_player._attr_supported_features = set()  # no direct playback capability
-        protocol_player._attr_device_info = DeviceInfo(
-            model=display_name, manufacturer="Local Audio"
+    def _create_bridge(self, player: Player) -> SendspinLocalAudioBridge:
+        """Create a bridge instance for a local audio player."""
+        sendspin_server = self.sendspin_server
+        assert sendspin_server is not None  # guaranteed by _lifecycle_allows_bridge
+        device = self._devices[player.player_id]
+        return SendspinLocalAudioBridge(
+            cast("LocalAudioProvider", self.provider),
+            device,
+            sendspin_server,
+            backend=self._backend,
+            volume_controller=self._volume_controller,
+            has_remap_children=device["name"] in self._remap_masters,
         )
-        await self.mass.players.register_or_update(protocol_player)
-        return protocol_player
+
+    def _should_have_bridge(self, player: Player) -> bool:
+        """Return whether a local audio player should have a Sendspin bridge."""
+        return player.player_id in self._devices
+
+    async def _register_player(self, device_uuid: str, display_name: str) -> Player | None:
+        """
+        Register a local audio output device as a regular, visible player.
+
+        The player has no native playback features of its own — the Sendspin
+        bridge provides its (single) output protocol — and its enabled flag
+        is the on/off toggle for the device.
+
+        :param device_uuid: The stable device UUID, used as player_id.
+        :param display_name: The human friendly device name.
+        :return: The registered player, or None when the player is disabled
+            (registration of disabled players is skipped).
+        """
+        player = Player(self.provider, device_uuid)
+        player._attr_name = display_name
+        player._attr_available = True
+        player._attr_supported_features = set()  # no direct playback capability
+        player._attr_device_info = DeviceInfo(model=display_name, manufacturer="Local Audio")
+        player._attr_device_info.add_identifier(IdentifierType.UUID, device_uuid)
+        await self.mass.players.register_or_update(player)
+        return self.mass.players.get_player(device_uuid)
 
     async def _refresh_after_remap_topology(
         self, devices: list[dict[str, Any]]

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -11,6 +11,8 @@ from music_assistant_models.player import OutputProtocol, PlayerMedia
 
 from music_assistant.constants import (
     ATTR_ENABLED,
+    CONF_PLAYER_DSP,
+    CONF_PLAYER_QUEUES,
     CONF_PLAYERS,
     CONF_PREFERRED_OUTPUT_PROTOCOL,
 )
@@ -7633,6 +7635,9 @@ class TestSelfReferentialProtocolLinks:
         assert display_player.protocol_parent_id is None
         assert store.get("players/esp_client/values/protocol_parent_id") != "esp_client"
         assert "esp_client" not in store.get("players/esp_client/values/linked_protocol_ids", [])
+        # the obsolete universal player must not keep listing the native player,
+        # or its permanent cleanup would re-evaluate it as an orphaned protocol
+        assert "esp_client" not in universal._protocol_player_ids
 
     async def test_migrate_clears_persisted_self_referential_link(self) -> None:
         """Config migration scrubs a self-referential link left by an older version."""
@@ -7874,3 +7879,206 @@ class TestDerivedProtocolLinking:
         del stored["players/spb_1"]
         controller._save_underlying_player_id(derived)
         mock_mass.config.set.assert_not_called()
+
+
+class TestLocalAudioPlayerPromotion:
+    """
+    Tests for the local_audio reshape: attribution stub -> regular native player.
+
+    The local_audio device player (bare device-uuid player_id) is a regular,
+    visible PLAYER that parents its Sendspin bridge directly. On upgrade, the
+    previously auto-created universal player wrapper (up<uuid-hex>) must be
+    absorbed by the native player without re-wrapping it.
+    """
+
+    DEVICE_UUID = "aabbccdd-1122-3344-5566-77889900aabb"
+    UNIVERSAL_ID = "upaabbccdd11223344556677889900aabb"
+
+    def test_native_local_player_absorbs_universal_wrapper(self, mock_mass: MagicMock) -> None:
+        """The native player takes over the bridge protocol and the wrapper is emptied."""
+        universal = _create_universal_player(
+            mock_mass,
+            self.UNIVERSAL_ID,
+            "Dummy Output",
+            protocol_player_ids=[self.DEVICE_UUID, "spb_1"],
+        )
+        native = MockPlayer(
+            MockProvider("local_audio", mass=mock_mass),
+            self.DEVICE_UUID,
+            "Dummy Output",
+            player_type=PlayerType.PLAYER,
+            identifiers={IdentifierType.UUID: self.DEVICE_UUID},
+        )
+        native.set_initialized()
+        spb = MockPlayer(
+            MockProvider("sendspin", mass=mock_mass),
+            "spb_1",
+            "Dummy Output Sendspin",
+            player_type=PlayerType.PROTOCOL,
+        )
+        spb._attr_underlying_player_id = self.DEVICE_UUID
+        spb.set_initialized()
+
+        store: dict[str, Any] = {
+            f"players/{self.DEVICE_UUID}": {"enabled": True},
+            "players/spb_1": {"enabled": True},
+        }
+        mock_mass.config.get = MagicMock(
+            side_effect=lambda key, default=None: store.get(key, default)
+        )
+        mock_mass.config.set = MagicMock(side_effect=store.__setitem__)
+
+        def _close_coro(coro: Any, *_args: Any, **_kwargs: Any) -> None:
+            if hasattr(coro, "close"):
+                coro.close()
+
+        mock_mass.create_task = MagicMock(side_effect=_close_coro)
+        mock_mass.players = controller = PlayerController(mock_mass)
+        controller._players = {
+            self.UNIVERSAL_ID: universal,
+            self.DEVICE_UUID: native,
+            "spb_1": spb,
+        }
+        controller._add_protocol_link(universal, spb, "sendspin")
+
+        controller._try_link_protocols_to_native(native)
+
+        assert spb.protocol_parent_id == self.DEVICE_UUID
+        assert [link.output_protocol_id for link in native.linked_output_protocols] == ["spb_1"]
+        # the obsolete wrapper keeps neither the bridge nor the native player itself,
+        # so its permanent cleanup has no orphaned protocols to re-evaluate
+        assert universal._protocol_player_ids == []
+        assert store.get("players/spb_1/values/protocol_parent_id") == self.DEVICE_UUID
+
+    async def test_delayed_eval_skips_type_changed_player(self, mock_mass: MagicMock) -> None:
+        """A pending evaluation for a player that is not (or no longer) a protocol is a no-op."""
+        controller, _ = TestEndToEndDuplicateProtocol._setup_e2e_controller(mock_mass)
+        mock_mass.config.get = MagicMock(return_value=[])
+
+        native = MockPlayer(
+            MockProvider("local_audio", mass=mock_mass),
+            self.DEVICE_UUID,
+            "Dummy Output",
+            player_type=PlayerType.PLAYER,
+        )
+        native.set_initialized()
+        controller._players = {self.DEVICE_UUID: native}
+
+        await controller._delayed_protocol_evaluation(self.DEVICE_UUID)
+
+        assert native.protocol_parent_id is None
+        assert not any(pid.startswith("up") for pid in controller._players)
+
+
+class TestLocalAudioStubMigration:
+    """Tests for the config migration that promotes local_audio stubs to regular players."""
+
+    DEVICE_UUID = "aabbccdd-1122-3344-5566-77889900aabb"
+    UNIVERSAL_ID = "upaabbccdd11223344556677889900aabb"
+
+    def _make_data(self) -> dict[str, Any]:
+        """Build a settings dict as persisted by the previous local_audio setup."""
+        return {
+            CONF_PLAYERS: {
+                self.DEVICE_UUID: {
+                    "player_id": self.DEVICE_UUID,
+                    "provider": "local_audio",
+                    "player_type": "protocol",
+                    "enabled": True,
+                    "values": {"protocol_parent_id": self.UNIVERSAL_ID},
+                },
+                self.UNIVERSAL_ID: {
+                    "player_id": self.UNIVERSAL_ID,
+                    "provider": "universal_player",
+                    "player_type": "group",
+                    "enabled": False,
+                    "name": "Kitchen Output",
+                    "values": {
+                        "linked_protocol_ids": [self.DEVICE_UUID, "spb_1"],
+                        "device_identifiers": {"uuid": self.DEVICE_UUID},
+                        "device_info": {"model": "Dummy Output", "manufacturer": "Local Audio"},
+                        "expose_to_ha": False,
+                        "hide_in_ui": True,
+                    },
+                },
+                "spb_1": {
+                    "player_id": "spb_1",
+                    "provider": "sendspin",
+                    "player_type": "protocol",
+                    "enabled": True,
+                    "values": {"protocol_parent_id": self.UNIVERSAL_ID},
+                },
+                "syncgroup_1": {
+                    "player_id": "syncgroup_1",
+                    "provider": "sync_group",
+                    "player_type": "group",
+                    "enabled": True,
+                    "values": {
+                        "group_members": [self.UNIVERSAL_ID, "other_player"],
+                        "allowed_members": [self.UNIVERSAL_ID],
+                    },
+                },
+            },
+            CONF_PLAYER_QUEUES: {
+                self.UNIVERSAL_ID: {
+                    "queue_id": self.UNIVERSAL_ID,
+                    "values": {"autoplay_mode": "smart"},
+                },
+            },
+            CONF_PLAYER_DSP: {
+                self.UNIVERSAL_ID: {"enabled": True},
+            },
+        }
+
+    async def test_stub_promoted_and_universal_absorbed(self) -> None:
+        """The stub becomes a regular player carrying the universal player's settings."""
+        data = self._make_data()
+
+        assert await migrate(data) is True
+
+        stub_cfg = data[CONF_PLAYERS][self.DEVICE_UUID]
+        assert stub_cfg["player_type"] == "player"
+        # the universal player was the device toggle the user operated
+        assert stub_cfg["enabled"] is False
+        assert stub_cfg["name"] == "Kitchen Output"
+        values = stub_cfg["values"]
+        assert "protocol_parent_id" not in values
+        assert values["expose_to_ha"] is False
+        assert values["hide_in_ui"] is True
+        assert values["linked_protocol_ids"] == ["spb_1"]
+        assert "device_identifiers" not in values
+        assert "device_info" not in values
+
+        # the wrapper is gone and the bridge protocol re-parented
+        assert self.UNIVERSAL_ID not in data[CONF_PLAYERS]
+        assert data[CONF_PLAYERS]["spb_1"]["values"]["protocol_parent_id"] == self.DEVICE_UUID
+        assert data[CONF_PLAYERS]["spb_1"]["player_type"] == "protocol"
+
+        # queue settings, DSP config and group memberships follow the new player_id
+        queue_cfg = data[CONF_PLAYER_QUEUES][self.DEVICE_UUID]
+        assert queue_cfg["queue_id"] == self.DEVICE_UUID
+        assert queue_cfg["values"]["autoplay_mode"] == "smart"
+        assert self.UNIVERSAL_ID not in data[CONF_PLAYER_QUEUES]
+        assert data[CONF_PLAYER_DSP] == {self.DEVICE_UUID: {"enabled": True}}
+        group_values = data[CONF_PLAYERS]["syncgroup_1"]["values"]
+        assert group_values["group_members"] == [self.DEVICE_UUID, "other_player"]
+        assert group_values["allowed_members"] == [self.DEVICE_UUID]
+
+    async def test_stub_without_universal_wrapper(self) -> None:
+        """A stub without a universal player wrapper is still promoted."""
+        data = self._make_data()
+        del data[CONF_PLAYERS][self.UNIVERSAL_ID]
+
+        assert await migrate(data) is True
+
+        stub_cfg = data[CONF_PLAYERS][self.DEVICE_UUID]
+        assert stub_cfg["player_type"] == "player"
+        assert stub_cfg["enabled"] is True
+        assert "protocol_parent_id" not in stub_cfg["values"]
+
+    async def test_migration_is_idempotent(self) -> None:
+        """A second run finds nothing left to migrate."""
+        data = self._make_data()
+
+        assert await migrate(data) is True
+        assert await migrate(data) is False

--- a/tests/providers/sendspin/test_bridge_manager.py
+++ b/tests/providers/sendspin/test_bridge_manager.py
@@ -2,12 +2,16 @@
 
 import logging
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from music_assistant.providers.chromecast.sendspin_bridge import (
     SendspinBridgeManager as CastSendspinBridgeManager,
+)
+from music_assistant.providers.local_audio.sendspin_bridge import (
+    LocalAudioBridgeManager,
+    get_device_uuid,
 )
 from music_assistant.providers.sendspin.bridge_manager import SendspinBridgeManagerBase
 
@@ -257,3 +261,154 @@ class TestCastBridgePolicy:
         mass.players.get_player = MagicMock(return_value=parent)
 
         assert manager._should_have_bridge(cast_player) is True
+
+
+class TestLocalAudioBridgeManager:
+    """Tests for the local audio specific bridge manager behavior."""
+
+    DEVICE_UUID = "aabbccdd-1122-3344-5566-77889900aabb"
+
+    @staticmethod
+    def _make_local_environment() -> tuple[LocalAudioBridgeManager, MagicMock, MagicMock]:
+        """
+        Build a local audio bridge manager with a mocked environment.
+
+        :return: Tuple of (manager, mass, player).
+        """
+        registered_players: dict[str, Any] = {}
+        mass = MagicMock()
+        mass.subscribe = MagicMock(return_value=MagicMock())
+        sendspin_provider = MagicMock()
+        sendspin_provider.server_api = MagicMock()
+        mass.get_provider = MagicMock(
+            side_effect=lambda domain: sendspin_provider if domain == "sendspin" else None
+        )
+        mass.players.get_player = MagicMock(side_effect=registered_players.get)
+        mass.config.get = MagicMock(side_effect=lambda _key, default=None: default)
+
+        provider = MagicMock()
+        provider.mass = mass
+        provider.logger = logging.getLogger("test.local_audio_bridge_manager")
+
+        player = MagicMock()
+        player.player_id = TestLocalAudioBridgeManager.DEVICE_UUID
+        player.display_name = "Dummy Output"
+        player.provider = provider
+        player.available = True
+        registered_players[player.player_id] = player
+        provider.players = [player]
+
+        manager = LocalAudioBridgeManager(provider)
+        device = {"name": "sink1", "description": "Dummy Output"}
+        manager._devices = {TestLocalAudioBridgeManager.DEVICE_UUID: device}
+        return manager, mass, player
+
+    def test_policy_requires_enumerated_device(self) -> None:
+        """Test a bridge is only wanted for devices present in the last enumeration."""
+        manager, _, player = self._make_local_environment()
+
+        assert manager._should_have_bridge(player) is True
+        manager._devices = {}
+        assert manager._should_have_bridge(player) is False
+
+    def test_bridge_client_id_derived_from_device_uuid(self) -> None:
+        """Test the bridge client_id is the spb-prefixed device uuid."""
+        manager, _, player = self._make_local_environment()
+
+        assert manager._bridge_client_id(player) == f"spb_{self.DEVICE_UUID.replace('-', '')}"
+
+    @pytest.mark.asyncio
+    async def test_failed_bridge_marks_player_unavailable(self) -> None:
+        """Test a bridge that fails to start marks the player unavailable."""
+        manager, _, player = self._make_local_environment()
+        failing_bridge = FakeBridge(manager.sendspin_server)
+
+        async def _fail_start() -> None:
+            raise RuntimeError("no audio device")
+
+        failing_bridge.start = _fail_start  # type: ignore[method-assign]
+        manager._create_bridge = MagicMock(return_value=failing_bridge)  # type: ignore[method-assign]
+
+        await manager.evaluate_bridge(player)
+
+        assert manager.get_bridge(player.player_id) is None
+        assert player._attr_available is False
+        player.update_state.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_recovered_bridge_restores_player_availability(self) -> None:
+        """Test a successful bridge rebuild restores the player's availability."""
+        manager, _, player = self._make_local_environment()
+        player.available = False
+        manager._create_bridge = MagicMock(  # type: ignore[method-assign]
+            return_value=FakeBridge(manager.sendspin_server)
+        )
+
+        await manager.evaluate_bridge(player)
+
+        assert manager.get_bridge(player.player_id) is not None
+        assert player._attr_available is True
+
+    @pytest.mark.asyncio
+    async def test_disabled_player_does_not_touch_availability(self) -> None:
+        """Test a lifecycle-blocked bridge leaves the player's availability alone."""
+        manager, mass, player = self._make_local_environment()
+        player_configs = {f"players/{player.player_id}": {"enabled": False}}
+        mass.config.get = MagicMock(
+            side_effect=lambda key, default=None: player_configs.get(key, default)
+        )
+
+        await manager.evaluate_bridge(player)
+
+        assert manager.get_bridge(player.player_id) is None
+        player.update_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_discover_rebinds_player_after_provider_reload(self) -> None:
+        """Test discovery re-registers a player left behind by a previous provider instance."""
+        registered: dict[str, Any] = {}
+        mass = MagicMock()
+        mass.subscribe = MagicMock(return_value=MagicMock())
+        sendspin_provider = MagicMock()
+        sendspin_provider.server_api = MagicMock()
+        mass.get_provider = MagicMock(
+            side_effect=lambda domain: sendspin_provider if domain == "sendspin" else None
+        )
+        mass.players.get_player = MagicMock(side_effect=registered.get)
+        mass.config.get = MagicMock(side_effect=lambda _key, default=None: default)
+        base_config = MagicMock()
+        base_config.name = None
+        base_config.default_name = "Dummy Output"
+        mass.config.get_base_player_config = MagicMock(return_value=base_config)
+
+        async def fake_register_or_update(player: Any) -> None:
+            registered[player.player_id] = player
+
+        mass.players.register_or_update = AsyncMock(side_effect=fake_register_or_update)
+
+        provider = MagicMock()
+        provider.mass = mass
+        provider.logger = logging.getLogger("test.local_audio_bridge_manager")
+        provider.config.get_value = MagicMock(return_value="auto")
+
+        device = {"name": "sink1", "description": "Dummy Output", "hostapi": 0}
+        device_uuid = get_device_uuid("sink1", 0)
+        mass.loop.run_in_executor = AsyncMock(return_value=("sounddevice", [device]))
+
+        # a player object from before the provider reload is still registered
+        stale_player = MagicMock()
+        stale_player.player_id = device_uuid
+        stale_player.provider = MagicMock()
+        registered[device_uuid] = stale_player
+
+        manager = LocalAudioBridgeManager(provider)
+        manager._create_bridge = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda _player: FakeBridge(manager.sendspin_server)
+        )
+
+        await manager.discover_and_register()
+
+        fresh_player = registered[device_uuid]
+        assert fresh_player is not stale_player
+        assert fresh_player.provider is provider
+        assert manager.get_bridge(device_uuid) is not None


### PR DESCRIPTION
The Local Audio provider registered a hidden PROTOCOL "attribution stub" per soundcard, which then got wrapped (together with its Sendspin bridge player) in an auto-created universal player. That sandwich showed a dead "Local Audio Out" protocol section in the player settings and the stub's enabled flag was force-re-enabled on every boot, directly fighting the toggle the UI writes.

- Each soundcard now registers as a regular, visible player (same stable device-uuid player_id) whose single output protocol is its Sendspin bridge — no universal player wrapper anymore.
- The enabled flag is now the legitimate device on/off toggle: `LocalAudioBridgeManager` moved onto `SendspinBridgeManagerBase`, so disabling the player (or its Sendspin toggle) tears the bridge down and enabling re-registers the player and rebuilds it. A bridge that should exist but failed to start marks the player unavailable.
- A config migration folds the obsolete `up...` universal player's settings back onto the device player: enabled state, rename, player settings, queue settings, DSP config and group memberships all follow the new player_id. Home Assistant entities are the one thing that resets — they are keyed on the old universal player_id, which cannot be migrated server-side.
- Fixed a latent protocol-linking bug affecting any protocol→player type change: after a native player absorbed its universal wrapper, the wrapper's cleanup still saw the native player's own id as an orphaned protocol and scheduled an evaluation that could re-wrap it in a fresh universal player.
