### PR TITLE
Isolate the unit-test `mass` fixture from host audio and default providers

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -4,14 +4,15 @@ import asyncio
 import contextlib
 import logging
 import pathlib
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterator
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import aiofiles.os
 from music_assistant_models.enums import EventType, IdentifierType, PlayerFeature, PlayerType
 from music_assistant_models.player import DeviceInfo
 
+from music_assistant.controllers.config.providers import ProviderConfigMixin
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import Player
 
@@ -54,6 +55,44 @@ async def wait_for_sync_completion(mass: MusicAssistant) -> AsyncGenerator[None]
                 await flag.wait()
         finally:
             release_cb()
+
+
+# builtin providers that must not be auto-set-up during a fixture boot: local_audio
+# bridges the host machine's sound devices (built-in speakers, bluetooth, ...) as
+# sendspin players, which would leak real hardware into the player registry
+SUPPRESSED_BUILTIN_PROVIDERS = {"local_audio"}
+
+_orig_create_builtin_provider_config = ProviderConfigMixin.create_builtin_provider_config
+
+
+@contextlib.contextmanager
+def suppress_auto_loaded_providers() -> Iterator[None]:
+    """
+    Stop a fixture boot from auto-setting-up providers that reach into the host.
+
+    Keeps a booted test instance isolated from the developer's machine: the default
+    device providers (airplay/chromecast/dlna/...) are not auto-configured, and neither
+    is the builtin local_audio provider, which would otherwise bridge the host's sound
+    devices (built-in speakers, bluetooth, ...) into the player registry.
+    """
+    with (
+        patch("music_assistant.mass.DEFAULT_PROVIDERS", ()),
+        patch.object(
+            ProviderConfigMixin,
+            "create_builtin_provider_config",
+            _create_builtin_provider_config_hermetic,
+        ),
+    ):
+        yield
+
+
+async def _create_builtin_provider_config_hermetic(
+    self: ProviderConfigMixin, provider_domain: str
+) -> None:
+    """Create builtin provider configs, skipping providers that discover host hardware."""
+    if provider_domain in SUPPRESSED_BUILTIN_PROVIDERS:
+        return
+    await _orig_create_builtin_provider_config(self, provider_domain)
 
 
 # Mock classes for testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from music_assistant.controllers.cache import CacheController
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.discovery import DiscoveryController
 from music_assistant.mass import MusicAssistant
+from tests.common import suppress_auto_loaded_providers
 
 
 @pytest.fixture(autouse=True)
@@ -101,6 +102,9 @@ async def mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
             "music_assistant.controllers.streams.controller.check_ffmpeg_version",
             new=AsyncMock(),
         ),
+        # keep the fixture isolated from the developer's machine: no auto-loaded device
+        # providers and no local_audio bridging the host's sound devices as players
+        suppress_auto_loaded_providers(),
     ):
         await mass_instance.start()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,19 +19,12 @@ from unittest.mock import AsyncMock, MagicMock, NonCallableMagicMock, patch
 import pytest
 from zeroconf.asyncio import AsyncZeroconf
 
-from music_assistant.controllers.config.providers import ProviderConfigMixin
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.music_provider import MusicProvider
 from music_assistant.models.player import Player
+from tests.common import suppress_auto_loaded_providers
 
 NUM_DEMO_PLAYERS = 3
-
-# builtin providers that must not be auto-setup in the hermetic boot: local_audio
-# bridges the host machine's sound devices (built-in speakers, bluetooth, ...) as
-# sendspin players, which would leak real hardware into the player registry
-SUPPRESSED_BUILTIN_PROVIDERS = {"local_audio"}
-
-_orig_create_builtin_provider_config = ProviderConfigMixin.create_builtin_provider_config
 
 
 async def wait_for(predicate: Callable[[], bool], timeout: float = 25.0) -> bool:
@@ -78,15 +71,6 @@ async def play_test_track(mass: MusicAssistant, queue_id: str, track_id: str = "
     assert test_prov is not None
     track = await test_prov.get_track(track_id)
     await mass.player_queues.play_media(queue_id, track)
-
-
-async def _create_builtin_provider_config_hermetic(
-    self: ProviderConfigMixin, provider_domain: str
-) -> None:
-    """Create builtin provider configs, skipping providers that discover host hardware."""
-    if provider_domain in SUPPRESSED_BUILTIN_PROVIDERS:
-        return
-    await _orig_create_builtin_provider_config(self, provider_domain)
 
 
 def _create_mock_zeroconf() -> MagicMock:
@@ -136,19 +120,13 @@ async def e2e_mass(tmp_path: pathlib.Path) -> AsyncGenerator[MusicAssistant]:
             "music_assistant.controllers.streams.controller.check_ffmpeg_version",
             new=AsyncMock(),
         ),
-        # hermetic: no real SSDP search and no auto-loaded device providers
+        # hermetic: no real SSDP search
         patch(
             "music_assistant.controllers.discovery.controller.async_upnp_search",
             new=AsyncMock(),
         ),
-        patch("music_assistant.mass.DEFAULT_PROVIDERS", ()),
-        # hermetic: local_audio is a builtin provider that would bridge the host
-        # machine's sound devices (e.g. bluetooth headsets) as extra players
-        patch.object(
-            ProviderConfigMixin,
-            "create_builtin_provider_config",
-            _create_builtin_provider_config_hermetic,
-        ),
+        # hermetic: no auto-loaded device providers and no host-audio bridging
+        suppress_auto_loaded_providers(),
     ):
         await mass_instance.start()
         # configure the fake music + player providers


### PR DESCRIPTION
# What does this implement/fix?

The hermetic `e2e_mass` fixture mocks discovery, empties `DEFAULT_PROVIDERS` and (since #4583) suppresses the builtin `local_audio` provider. The unit-test `mass` fixture in `tests/conftest.py` did none of that: it auto-configured the full default provider set (airplay/chromecast/dlna/party/smart_fades/…) and loaded `local_audio`, which on a dev machine with audio outputs (e.g. a connected Bluetooth headset) bridges the host's sound devices into `mass.players`. That makes unit tests slower and can make any test that iterates `mass.players` flaky in a way that depends on the developer's environment.

The `mass` fixture now applies the same suppression as `e2e_mass`, and both share a single helper instead of duplicating it.

## Changes

- New `suppress_auto_loaded_providers()` context manager in `tests/common.py`: patches `DEFAULT_PROVIDERS` to empty and wraps `create_builtin_provider_config` to skip `SUPPRESSED_BUILTIN_PROVIDERS = {"local_audio"}`, so neither the default device providers nor host-audio bridging load during a fixture boot.
- `mass` fixture (`tests/conftest.py`) now enters this context manager.
- `e2e_mass` fixture (`tests/integration/conftest.py`) reuses the shared helper; the `local_audio` suppression added in #4583 moves into `tests/common.py` (no behaviour change for the e2e boot).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally. (the change is to the test fixtures themselves)
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (n/a)
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (n/a)
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (n/a)
