### PR TITLE
Populate derived_from on output protocols

### DIFF
--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -1045,6 +1045,13 @@ class ProtocolLinkingMixin:
         # Get priority for this protocol
         priority = PROTOCOL_PRIORITY.get(protocol_domain, 100)
 
+        # Derived transports (e.g. a Sendspin bridge riding on an AirPlay player)
+        # reference the base output they run on top of; "native" when they ride
+        # on the parent player itself
+        derived_from = protocol_player.underlying_player_id
+        if derived_from == native_player.player_id:
+            derived_from = "native"
+
         # Add the new link
         updated_protocols.append(
             OutputProtocol(
@@ -1052,6 +1059,7 @@ class ProtocolLinkingMixin:
                 name=protocol_player.provider.name,
                 protocol_domain=protocol_domain,
                 priority=priority,
+                derived_from=derived_from,
             )
         )
         native_player.set_linked_output_protocols(updated_protocols)
@@ -1255,6 +1263,16 @@ class ProtocolLinkingMixin:
             protocol_player = self.get_player(protocol_id)
             is_available = protocol_player is not None and protocol_player.available
 
+            # Resolve the derived-transport edge from the live player when
+            # registered, else from the persisted edge in config
+            derived_from = (
+                protocol_player.underlying_player_id
+                if protocol_player
+                else protocol_config.get("values", {}).get(CONF_UNDERLYING_PLAYER_ID)
+            )
+            if derived_from == native_player.player_id:
+                derived_from = "native"
+
             # Add the OutputProtocol entry
             native_player.linked_output_protocols.append(
                 OutputProtocol(
@@ -1264,6 +1282,7 @@ class ProtocolLinkingMixin:
                     priority=priority,
                     is_native=False,
                     available=is_available,
+                    derived_from=derived_from,
                 )
             )
             self.logger.debug(

--- a/music_assistant/models/player.py
+++ b/music_assistant/models/player.py
@@ -56,6 +56,7 @@ from music_assistant.constants import (
     CONF_POWER_CONTROL,
     CONF_PREFERRED_OUTPUT_PROTOCOL,
     CONF_SAMPLE_RATES,
+    CONF_UNDERLYING_PLAYER_ID,
     CONF_VOLUME_CONTROL,
     EXTERNAL_SOURCES,
     PLAYER_CONTROL_PROTOCOL,
@@ -261,7 +262,15 @@ def _state_fingerprint(state: PlayerState) -> dict[str, Any]:
             for s in state.source_list
         ),
         "output_protocols": tuple(
-            (o.output_protocol_id, o.name, o.protocol_domain, o.is_native, o.priority, o.available)
+            (
+                o.output_protocol_id,
+                o.name,
+                o.protocol_domain,
+                o.is_native,
+                o.priority,
+                o.available,
+                o.derived_from,
+            )
             for o in state.output_protocols
         ),
         "device_info.model": state.device_info.model,
@@ -1424,6 +1433,7 @@ class Player(ABC):
                     protocol_domain=linked.protocol_domain,
                     priority=linked.priority,
                     available=is_available,
+                    derived_from=linked.derived_from,
                 )
             )
 
@@ -1440,6 +1450,11 @@ class Player(ABC):
                 provider_id = raw_conf.get("provider", "")
                 protocol_domain = provider_id.split("--")[0] if provider_id else "unknown"
                 priority = PROTOCOL_PRIORITY.get(protocol_domain, 100)
+                # resolve the persisted derived-transport edge (if any) so derived
+                # outputs keep their base reference even while not registered
+                derived_from = raw_conf.get("values", {}).get(CONF_UNDERLYING_PLAYER_ID)
+                if derived_from == self.player_id:
+                    derived_from = "native"
                 result.append(
                     OutputProtocol(
                         output_protocol_id=protocol_id,
@@ -1447,6 +1462,7 @@ class Player(ABC):
                         protocol_domain=protocol_domain,
                         priority=priority,
                         available=False,  # Disabled protocols are not available
+                        derived_from=derived_from,
                     )
                 )
 
@@ -1554,6 +1570,7 @@ class Player(ABC):
                     priority=linked.priority,
                     available=current_available,
                     is_native=False,
+                    derived_from=linked.derived_from,
                 )
         return None
 
@@ -1937,7 +1954,7 @@ class Player(ABC):
                 self._extra_data.get(ATTR_FAKE_MUTE),
             ),
             "linked_protocols": tuple(
-                (p.output_protocol_id, p.protocol_domain, p.priority)
+                (p.output_protocol_id, p.protocol_domain, p.priority, p.derived_from)
                 for p in self.__attr_linked_protocols
             ),
             "protocol_parent_id": self.__attr_protocol_parent_id,

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7706,6 +7706,10 @@ class TestDerivedProtocolLinking:
         controller._try_link_protocol_to_native(derived)
 
         assert derived.protocol_parent_id == "native_1"
+        # the derived link carries its base output, the non-derived link does not
+        links = {link.output_protocol_id: link for link in native.linked_output_protocols}
+        assert links["spb_1"].derived_from == "ap_1"
+        assert links["ap_1"].derived_from is None
 
     def test_waiting_derived_follows_when_underlying_links(self, mock_mass: MagicMock) -> None:
         """Test a derived player that registered early follows once its underlying links."""
@@ -7753,6 +7757,9 @@ class TestDerivedProtocolLinking:
         controller._try_link_protocols_to_native(local_player)
 
         assert derived.protocol_parent_id == "local_1"
+        # riding on the parent player itself normalizes the base output to "native"
+        links = {link.output_protocol_id: link for link in local_player.linked_output_protocols}
+        assert links["spb_1"].derived_from == "native"
 
     @pytest.mark.asyncio
     async def test_derived_delayed_eval_never_creates_universal_player(


### PR DESCRIPTION
# What does this implement/fix?

models 1.1.152 added `derived_from` to `OutputProtocol` (music-assistant/models#288) so API consumers can see which base output a derived transport (e.g. a Sendspin bridge riding on an AirPlay player) runs on top of. The server never stamped it, so it was always `null` on the wire. This wires it up:

- the protocol-linking layer stamps `derived_from` from the protocol player's declared `underlying_player_id` when creating a link, normalized to `"native"` when the bridge rides on the parent player itself; cached/unregistered links resolve it from the live player or the persisted edge in config
- `Player.output_protocols` / `get_linked_protocol` carry the field through into the serialized state, including disabled protocols recovered from config
- the state fingerprint (and the linked-protocols input snapshot) include the new field, so a change to it actually fires a player-updated event

**Related issue (if applicable):**

- companion models change: music-assistant/models#288 (released as 1.1.152, already pinned)
- companion frontend change (consumes the field): music-assistant/frontend#2017

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [x] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
