### PR TITLE
Scope based authorization for API commands and centralized user impersonation

### DIFF
--- a/music_assistant/controllers/config/core.py
+++ b/music_assistant/controllers/config/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, cast, overload
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueType,
@@ -40,7 +41,7 @@ class CoreConfigMixin:
 
         def save(self, immediate: bool = False) -> None: ...  # noqa: D102
 
-    @api_command("config/core")
+    @api_command("config/core", required_scope=Scope.CONFIG_CORE_READ)
     async def get_core_configs(self, include_values: bool = False) -> list[CoreConfig]:
         """Return all core controllers config options."""
         return [
@@ -56,7 +57,7 @@ class CoreConfigMixin:
             for core_controller in CONFIGURABLE_CORE_CONTROLLERS
         ]
 
-    @api_command("config/core/get")
+    @api_command("config/core/get", required_scope=Scope.CONFIG_CORE_READ)
     async def get_core_config(self, domain: str) -> CoreConfig:
         """Return configuration for a single core controller."""
         raw_conf = self.get(f"{CONF_CORE}/{domain}", {})
@@ -100,7 +101,7 @@ class CoreConfigMixin:
         return_type: None = ...,
     ) -> ConfigValueType: ...
 
-    @api_command("config/core/get_value")
+    @api_command("config/core/get_value", required_scope=Scope.CONFIG_CORE_READ)
     async def get_core_config_value(
         self,
         domain: str,
@@ -135,7 +136,7 @@ class CoreConfigMixin:
             else conf.values[key].default_value
         )
 
-    @api_command("config/core/get_entries")
+    @api_command("config/core/get_entries", required_scope=Scope.CONFIG_CORE_READ)
     async def get_core_config_entries(
         self,
         domain: str,
@@ -163,7 +164,7 @@ class CoreConfigMixin:
                     entry.options = playlist_options
         return _with_translation_owner(all_entries, f"core.{domain}", action, values)
 
-    @api_command("config/core/save", required_role="admin")
+    @api_command("config/core/save", required_scope=Scope.CONFIG_CORE_WRITE)
     async def save_core_config(
         self,
         domain: str,

--- a/music_assistant/controllers/config/dsp.py
+++ b/music_assistant/controllers/config/dsp.py
@@ -65,13 +65,13 @@ class DSPConfigMixin:
         )
         return config
 
-    @api_command("config/dsp_presets/get", required_scope=Scope.CONFIG_CORE_READ)
+    @api_command("config/dsp_presets/get", required_scope=Scope.CONFIG_PLAYERS_READ)
     async def get_dsp_presets(self) -> list[DSPConfigPreset]:
         """Return all user-defined DSP presets."""
         raw_presets = self.get(CONF_PLAYER_DSP_PRESETS, {})
         return [DSPConfigPreset.from_dict(preset) for preset in raw_presets.values()]
 
-    @api_command("config/dsp_presets/save", required_scope=Scope.CONFIG_CORE_WRITE)
+    @api_command("config/dsp_presets/save", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def save_dsp_presets(self, preset: DSPConfigPreset) -> DSPConfigPreset:
         """
         Save/update a user-defined DSP presets.
@@ -96,7 +96,7 @@ class DSPConfigMixin:
 
         return preset
 
-    @api_command("config/dsp_presets/remove", required_scope=Scope.CONFIG_CORE_WRITE)
+    @api_command("config/dsp_presets/remove", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def remove_dsp_preset(self, preset_id: str) -> None:
         """Remove a user-defined DSP preset."""
         self.mass.config.remove(f"{CONF_PLAYER_DSP_PRESETS}/preset_{preset_id}")

--- a/music_assistant/controllers/config/dsp.py
+++ b/music_assistant/controllers/config/dsp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import shortuuid
+from music_assistant_models.auth import Scope
 from music_assistant_models.dsp import DSPConfig, DSPConfigPreset
 from music_assistant_models.enums import EventType
 
@@ -26,7 +27,7 @@ class DSPConfigMixin:
 
         def set(self, key: str, value: Any) -> None: ...  # noqa: D102
 
-    @api_command("config/players/dsp/get")
+    @api_command("config/players/dsp/get", required_scope=Scope.CONFIG_PLAYERS_READ)
     def get_player_dsp_config(self, player_id: str) -> DSPConfig:
         """
         Return the DSP Configuration for a player.
@@ -41,7 +42,7 @@ class DSPConfigMixin:
         dsp_config.enabled = False
         return dsp_config
 
-    @api_command("config/players/dsp/save", required_role="admin")
+    @api_command("config/players/dsp/save", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def save_dsp_config(self, player_id: str, config: DSPConfig) -> DSPConfig:
         """
         Save/update DSPConfig for a player.
@@ -64,13 +65,13 @@ class DSPConfigMixin:
         )
         return config
 
-    @api_command("config/dsp_presets/get")
+    @api_command("config/dsp_presets/get", required_scope=Scope.CONFIG_CORE_READ)
     async def get_dsp_presets(self) -> list[DSPConfigPreset]:
         """Return all user-defined DSP presets."""
         raw_presets = self.get(CONF_PLAYER_DSP_PRESETS, {})
         return [DSPConfigPreset.from_dict(preset) for preset in raw_presets.values()]
 
-    @api_command("config/dsp_presets/save", required_role="admin")
+    @api_command("config/dsp_presets/save", required_scope=Scope.CONFIG_CORE_WRITE)
     async def save_dsp_presets(self, preset: DSPConfigPreset) -> DSPConfigPreset:
         """
         Save/update a user-defined DSP presets.
@@ -95,7 +96,7 @@ class DSPConfigMixin:
 
         return preset
 
-    @api_command("config/dsp_presets/remove", required_role="admin")
+    @api_command("config/dsp_presets/remove", required_scope=Scope.CONFIG_CORE_WRITE)
     async def remove_dsp_preset(self, preset_id: str) -> None:
         """Remove a user-defined DSP preset."""
         self.mass.config.remove(f"{CONF_PLAYER_DSP_PRESETS}/preset_{preset_id}")

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -7,6 +7,7 @@ import logging
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueOption,
@@ -112,7 +113,7 @@ class PlayerConfigMixin:
 
         def remove(self, key: str) -> None: ...  # noqa: D102
 
-    @api_command("config/players")
+    @api_command("config/players", required_scope=Scope.CONFIG_PLAYERS_READ)
     async def get_player_configs(
         self,
         provider: str | None = None,
@@ -161,7 +162,7 @@ class PlayerConfigMixin:
                 result.append(cast("PlayerConfig", PlayerConfig.parse([], raw_conf)))
         return result
 
-    @api_command("config/players/get")
+    @api_command("config/players/get", required_scope=Scope.CONFIG_PLAYERS_READ)
     async def get_player_config(
         self,
         player_id: str,
@@ -210,7 +211,7 @@ class PlayerConfigMixin:
         msg = f"No config found for player id {player_id}"
         raise KeyError(msg)
 
-    @api_command("config/players/get_entries")
+    @api_command("config/players/get_entries", required_scope=Scope.CONFIG_PLAYERS_READ)
     async def get_player_config_entries(
         self,
         player_id: str,
@@ -306,7 +307,7 @@ class PlayerConfigMixin:
         return_type: None = ...,
     ) -> ConfigValueType: ...
 
-    @api_command("config/players/get_value")
+    @api_command("config/players/get_value", required_scope=Scope.CONFIG_PLAYERS_READ)
     async def get_player_config_value(
         self,
         player_id: str,
@@ -389,7 +390,7 @@ class PlayerConfigMixin:
             }
         return cast("PlayerConfig", PlayerConfig.parse([], raw_conf))
 
-    @api_command("config/players/save", required_role="admin")
+    @api_command("config/players/save", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def save_player_config(
         self, player_id: str, values: dict[str, ConfigValueType]
     ) -> PlayerConfig:
@@ -437,7 +438,7 @@ class PlayerConfigMixin:
         # return full player config (just in case)
         return await self.get_player_config(player_id)
 
-    @api_command("config/players/remove", required_role="admin")
+    @api_command("config/players/remove", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def remove_player_config(self, player_id: str) -> None:
         """Remove PlayerConfig."""
         conf_key = f"{CONF_PLAYERS}/{player_id}"

--- a/music_assistant/controllers/config/providers.py
+++ b/music_assistant/controllers/config/providers.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any, cast, overload
 
 import shortuuid
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueType,
@@ -74,7 +75,7 @@ class ProviderConfigMixin:
 
         async def set_onboard_complete(self) -> None: ...  # noqa: D102
 
-    @api_command("config/providers")
+    @api_command("config/providers", required_scope=Scope.CONFIG_PROVIDERS_READ)
     async def get_provider_configs(
         self,
         provider_type: ProviderType | None = None,
@@ -105,7 +106,7 @@ class ProviderConfigMixin:
             configs.append(conf)
         return configs
 
-    @api_command("config/providers/get")
+    @api_command("config/providers/get", required_scope=Scope.CONFIG_PROVIDERS_READ)
     async def get_provider_config(self, instance_id: str) -> ProviderConfig:
         """Return configuration for a single provider."""
         if raw_conf := self.get(f"{CONF_PROVIDERS}/{instance_id}", {}):
@@ -157,7 +158,7 @@ class ProviderConfigMixin:
         return_type: None = ...,
     ) -> ConfigValueType: ...
 
-    @api_command("config/providers/get_value")
+    @api_command("config/providers/get_value", required_scope=Scope.CONFIG_PROVIDERS_READ)
     async def get_provider_config_value(
         self,
         instance_id: str,
@@ -192,7 +193,7 @@ class ProviderConfigMixin:
             else conf.values[key].default_value
         )
 
-    @api_command("config/providers/get_entries")
+    @api_command("config/providers/get_entries", required_scope=Scope.CONFIG_PROVIDERS_READ)
     async def get_provider_config_entries(
         self,
         provider_domain: str,
@@ -241,7 +242,7 @@ class ProviderConfigMixin:
         ]
         return _with_translation_owner(all_entries, f"provider.{provider_domain}", action, values)
 
-    @api_command("config/providers/save", required_role="admin")
+    @api_command("config/providers/save", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
     async def save_provider_config(
         self,
         provider_domain: str,
@@ -262,7 +263,7 @@ class ProviderConfigMixin:
         # return full config, just in case
         return await self.get_provider_config(config.instance_id)
 
-    @api_command("config/providers/remove", required_role="admin")
+    @api_command("config/providers/remove", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
     async def remove_provider_config(self, instance_id: str) -> None:
         """Remove ProviderConfig."""
         conf_key = f"{CONF_PROVIDERS}/{instance_id}"
@@ -420,7 +421,7 @@ class ProviderConfigMixin:
         ):
             entry.value = value
 
-    @api_command("config/providers/reload", required_role="admin")
+    @api_command("config/providers/reload", required_scope=Scope.CONFIG_PROVIDERS_WRITE)
     async def _reload_provider(self, instance_id: str) -> None:
         """Reload provider."""
         try:

--- a/music_assistant/controllers/config/queues.py
+++ b/music_assistant/controllers/config/queues.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast, overload
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueOption,
@@ -36,7 +37,7 @@ class PlayerQueueConfigMixin:
 
         def set(self, key: str, value: Any) -> None: ...  # noqa: D102
 
-    @api_command("config/player_queues")
+    @api_command("config/player_queues", required_scope=Scope.CONFIG_PLAYERS_READ)
     def get_player_queue_configs(self) -> list[PlayerQueueConfig]:
         """Return all (stored) queue configurations."""
         return [
@@ -44,7 +45,7 @@ class PlayerQueueConfigMixin:
             for queue_id, raw_conf in list(self.get(CONF_PLAYER_QUEUES, {}).items())
         ]
 
-    @api_command("config/player_queues/get")
+    @api_command("config/player_queues/get", required_scope=Scope.CONFIG_PLAYERS_READ)
     async def get_player_queue_config_for_api(self, queue_id: str) -> PlayerQueueConfig:
         """Return (full) configuration for a single queue, with dynamic options populated."""
         # The frontend renders the queue settings form straight from this config, so the
@@ -60,7 +61,7 @@ class PlayerQueueConfigMixin:
         raw_conf = self.get(f"{CONF_PLAYER_QUEUES}/{queue_id}") or {"queue_id": queue_id}
         return self._parse_player_queue_config(queue_id, raw_conf)
 
-    @api_command("config/player_queues/get_entries")
+    @api_command("config/player_queues/get_entries", required_scope=Scope.CONFIG_PLAYERS_READ)
     async def get_player_queue_config_entries(
         self,
         queue_id: str,
@@ -73,7 +74,7 @@ class PlayerQueueConfigMixin:
         )
         return _with_translation_owner(entries, PLAYER_QUEUE_CONFIG_OWNER, action, values)
 
-    @api_command("config/player_queues/get_value")
+    @api_command("config/player_queues/get_value", required_scope=Scope.CONFIG_PLAYERS_READ)
     def get_player_queue_config_value(self, queue_id: str, key: str) -> ConfigValueType:
         """Return single config(entry) value for a queue."""
         return self.get_player_queue_config(queue_id).get_value(key)
@@ -124,7 +125,7 @@ class PlayerQueueConfigMixin:
             return self.mass.config.get_raw_core_config_value(CONF_PLAYER_QUEUES, key, default)
         return value
 
-    @api_command("config/player_queues/save", required_role="admin")
+    @api_command("config/player_queues/save", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def save_player_queue_config(
         self, queue_id: str, values: dict[str, ConfigValueType]
     ) -> PlayerQueueConfig:

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -12,6 +12,7 @@ from time import time
 from typing import TYPE_CHECKING, cast
 from uuid import NAMESPACE_URL, uuid5
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, MediaType, ProviderFeature, ProviderType
@@ -184,7 +185,7 @@ class MetaDataController(
         )
         return str(value)
 
-    @api_command("metadata/set_default_preferred_language")
+    @api_command("metadata/set_default_preferred_language", required_scope=Scope.CONFIG_CORE_WRITE)
     def set_default_preferred_language(self, lang: str) -> None:
         """
         Set the default preferred language.
@@ -198,7 +199,7 @@ class MetaDataController(
             return  # already set
         self.set_preferred_language(lang)
 
-    @api_command("metadata/set_preferred_language")
+    @api_command("metadata/set_preferred_language", required_scope=Scope.LIBRARY_MANAGE)
     def set_preferred_language(self, lang: str) -> None:
         """
         Set the preferred language.
@@ -228,7 +229,7 @@ class MetaDataController(
         # if we reach this point, we couldn't match the language
         self.logger.warning("%s is not a valid language", lang)
 
-    @api_command("metadata/update_metadata")
+    @api_command("metadata/update_metadata", required_scope=Scope.LIBRARY_MANAGE)
     async def update_metadata(
         self, item: str | MediaItemType, force_refresh: bool = False
     ) -> MediaItemType:
@@ -293,7 +294,7 @@ class MetaDataController(
             },
         )
 
-    @api_command("metadata/get_track_lyrics")
+    @api_command("metadata/get_track_lyrics", required_scope=Scope.LIBRARY_READ)
     async def get_track_lyrics(
         self,
         track: Track,

--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, cast
 
 import aiofiles
 from aiohttp import web
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import ImageType
 from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailableError
 from music_assistant_models.media_items import (
@@ -232,7 +233,7 @@ class ImageProxyMixin:
             return f"{base_url}/imageproxy/{image_id}?size={size}&fmt={image_format}"
         return image.path
 
-    @api_command("metadata/get_image_palette")
+    @api_command("metadata/get_image_palette", required_scope=Scope.LIBRARY_READ)
     async def get_image_palette(self, image_id: str) -> MediaItemPalette | None:
         """
         Get the color palette extracted from a (proxied) image.

--- a/music_assistant/controllers/music/controller.py
+++ b/music_assistant/controllers/music/controller.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, cast
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import BackgroundTask, TaskMetadata, TaskSchedule
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueType
 from music_assistant_models.enums import (
@@ -74,10 +75,7 @@ from music_assistant.controllers.music.media.podcasts import PodcastsController
 from music_assistant.controllers.music.media.radio import RadioController
 from music_assistant.controllers.music.media.tracks import TracksController
 from music_assistant.controllers.music.recency import RecencyEngine
-from music_assistant.controllers.webserver.helpers.auth_middleware import (
-    ImpersonatedUser,
-    get_current_user,
-)
+from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.compare import compare_strings, compare_version
 from music_assistant.helpers.database import UNSET, DatabaseConnection
@@ -218,7 +216,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             ],
         )
 
-    @api_command("music/sync")
+    @api_command("music/sync", required_scope=Scope.LIBRARY_MANAGE)
     async def start_sync(
         self,
         media_types: list[MediaType] | None = None,
@@ -279,7 +277,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             if task.status in (TaskStatus.PENDING, TaskStatus.RUNNING)
         ]
 
-    @api_command("music/search")
+    @api_command("music/search", required_scope=Scope.LIBRARY_READ, allow_impersonation=True)
     async def search(
         self,
         search_query: str,
@@ -484,7 +482,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                     result.podcasts = cast("list[Podcast]", search_results)
         return result
 
-    @api_command("music/browse")
+    @api_command("music/browse", required_scope=Scope.LIBRARY_READ)
     async def browse(
         self, path: str | None = None
     ) -> Sequence[MediaItemType | ItemMapping | BrowseFolder]:
@@ -567,7 +565,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         prov_items = await cast("MusicProvider", browse_prov).browse(path=path)
         return [*prepend_items, *prov_items]
 
-    @api_command("music/recently_played_items")
+    @api_command("music/recently_played_items", required_scope=Scope.LIBRARY_READ)
     async def recently_played(
         self,
         limit: int = 10,
@@ -647,12 +645,12 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             )
         return result
 
-    @api_command("music/recently_added_tracks")
+    @api_command("music/recently_added_tracks", required_scope=Scope.LIBRARY_READ)
     async def recently_added_tracks(self, limit: int = 10) -> list[Track]:
         """Return a list of the last added tracks."""
         return await self.tracks.library_items(limit=limit, order_by="timestamp_added_desc")
 
-    @api_command("music/in_progress_items")
+    @api_command("music/in_progress_items", required_scope=Scope.LIBRARY_READ)
     async def in_progress_items(
         self, limit: int = 10, all_users: bool = False
     ) -> list[ItemMapping]:
@@ -767,7 +765,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
 
         return result
 
-    @api_command("music/item_by_uri")
+    @api_command("music/item_by_uri", required_scope=Scope.LIBRARY_READ)
     async def get_item_by_uri(
         self, uri: str, allow_update_metadata: bool = False
     ) -> MediaItemType | BrowseFolder:
@@ -780,7 +778,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             allow_update_metadata=allow_update_metadata,
         )
 
-    @api_command("music/recommendations")
+    @api_command("music/recommendations", required_scope=Scope.LIBRARY_READ)
     async def recommendations(self) -> list[RecommendationFolder]:
         """Get all recommendations."""
         providers_with_recommendations = self.mass.get_providers_supporting_feature(
@@ -800,7 +798,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         # so the result is sorted as each provider delivered
         return [item for sublist in zip_longest(*results_per_provider) for item in sublist if item]
 
-    @api_command("music/item")
+    @api_command("music/item", required_scope=Scope.LIBRARY_READ)
     async def get_item(
         self,
         media_type: MediaType,
@@ -845,7 +843,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             allow_update_metadata=allow_update_metadata,
         )
 
-    @api_command("music/get_library_item")
+    @api_command("music/get_library_item", required_scope=Scope.LIBRARY_READ)
     async def get_library_item_by_prov_id(
         self,
         media_type: MediaType,
@@ -859,7 +857,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             provider_instance_id_or_domain=provider_instance_id_or_domain,
         )
 
-    @api_command("music/favorites/add_item")
+    @api_command("music/favorites/add_item", required_scope=Scope.LIBRARY_WRITE)
     async def add_item_to_favorites(
         self,
         item: str | MediaItemType | ItemMapping,
@@ -911,7 +909,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 continue
             await provider.set_favorite(prov_mapping.item_id, full_item.media_type, True)
 
-    @api_command("music/favorites/remove_item")
+    @api_command("music/favorites/remove_item", required_scope=Scope.LIBRARY_WRITE)
     async def remove_item_from_favorites(
         self,
         media_type: MediaType,
@@ -935,7 +933,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 continue
             self.mass.create_task(provider.set_favorite(prov_mapping.item_id, media_type, False))
 
-    @api_command("music/library/remove_item")
+    @api_command("music/library/remove_item", required_scope=Scope.LIBRARY_WRITE)
     async def remove_item_from_library(
         self, media_type: MediaType, library_item_id: str | int, recursive: bool = True
     ) -> None:
@@ -962,7 +960,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         # remove from library
         await ctrl.remove_item_from_library(library_item_id, recursive)
 
-    @api_command("music/library/add_item")
+    @api_command("music/library/add_item", required_scope=Scope.LIBRARY_WRITE)
     async def add_item_to_library(
         self, item: str | MediaItemType | ItemMapping, overwrite_existing: bool = False
     ) -> MediaItemType:
@@ -1042,7 +1040,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             for media_item in items:
                 tg.create_task(self.refresh_item(media_item))
 
-    @api_command("music/refresh_item")
+    @api_command("music/refresh_item", required_scope=Scope.LIBRARY_MANAGE)
     async def refresh_item(  # noqa: PLR0915
         self,
         media_item: str | MediaItemType,
@@ -1151,7 +1149,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         await self.mass.metadata.update_metadata(library_item, force_refresh=True)
         return library_item
 
-    @api_command("music/mark_played")
+    @api_command("music/mark_played", required_scope=Scope.LIBRARY_WRITE)
     async def mark_item_played(
         self,
         media_item: MediaItemType,
@@ -1330,7 +1328,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 ids.add(db_artist.item_id)
         return ids
 
-    @api_command("music/mark_unplayed")
+    @api_command("music/mark_unplayed", required_scope=Scope.LIBRARY_WRITE)
     async def mark_item_unplayed(
         self,
         media_item: MediaItemType,
@@ -1400,7 +1398,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
             )
             await self.database.commit()
 
-    @api_command("music/track_by_name")
+    @api_command("music/track_by_name", required_scope=Scope.LIBRARY_READ)
     async def get_track_by_name(
         self,
         track_name: str,
@@ -1853,7 +1851,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
                 mappings_added = True
         return mappings_added
 
-    @api_command("music/add_provider_mapping")
+    @api_command("music/add_provider_mapping", required_scope=Scope.LIBRARY_MANAGE)
     async def add_provider_mapping(
         self, media_type: MediaType, db_id: str, mapping: ProviderMapping
     ) -> None:
@@ -1861,7 +1859,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         ctrl = self.get_controller(media_type)
         await ctrl.add_provider_mappings(db_id, [mapping])
 
-    @api_command("music/remove_provider_mapping")
+    @api_command("music/remove_provider_mapping", required_scope=Scope.LIBRARY_MANAGE)
     async def remove_provider_mapping(
         self, media_type: MediaType, db_id: str, mapping: ProviderMapping
     ) -> None:
@@ -1869,7 +1867,7 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         ctrl = self.get_controller(media_type)
         await ctrl.remove_provider_mapping(db_id, mapping.provider_instance, mapping.item_id)
 
-    @api_command("music/match_providers")
+    @api_command("music/match_providers", required_scope=Scope.LIBRARY_MANAGE)
     async def match_providers(self, media_type: MediaType, db_id: str) -> None:
         """Search for mappings on all providers for the given library item."""
         ctrl = self.get_controller(media_type)
@@ -2008,30 +2006,27 @@ class MusicController(MusicDatabaseSetupMixin, CoreController):
         )
         return bool(conf_value)
 
-    @api_command("music/item_by_name")
+    @api_command("music/item_by_name", required_scope=Scope.LIBRARY_READ, allow_impersonation=True)
     async def get_item_by_name(
         self,
         name: str,
         artist: str | None = None,
         album: str | None = None,
         media_type: MediaType | None = None,
-        username: str | None = None,
     ) -> MediaItemType | ItemMapping | None:
         """Try to find a media item (such as a playlist) by name."""
-        async with ImpersonatedUser(self.mass, username):
-            return await self._get_item_by_name(name, artist, album, media_type)
+        return await self._get_item_by_name(name, artist, album, media_type)
 
-    @api_command("music/verify_item_uri")
-    async def verify_item_uri(self, uri: str, username: str | None = None) -> bool:
+    @api_command(
+        "music/verify_item_uri", required_scope=Scope.LIBRARY_READ, allow_impersonation=True
+    )
+    async def verify_item_uri(self, uri: str) -> bool:
         """
         Verify whether a uri points to a valid, accessible item.
 
         :param uri: The uri to verify.
-        :param username: Optional user to additionally verify access for. Requires
-            the authenticated caller to also have access to the item.
         """
-        async with ImpersonatedUser(self.mass, username):
-            return await self._handle_verify_item_uri(uri)
+        return await self._handle_verify_item_uri(uri)
 
     def _apply_user_provider_filter(
         self,

--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -6,6 +6,7 @@ import contextlib
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import AlbumType, ExternalID, MediaType, ProviderFeature
 from music_assistant_models.errors import InvalidDataError, MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
@@ -49,8 +50,12 @@ class AlbumsController(MediaControllerBase[Album]):
         super().__init__(mass)
         # register (extra) api handlers
         api_base = self.api_base
-        self.mass.register_api_command(f"music/{api_base}/album_tracks", self.tracks)
-        self.mass.register_api_command(f"music/{api_base}/album_versions", self.versions)
+        self.mass.register_api_command(
+            f"music/{api_base}/album_tracks", self.tracks, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/album_versions", self.versions, required_scope=Scope.LIBRARY_READ
+        )
 
     @property
     def base_query(self) -> tuple[str, dict[str, Any]]:

--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -7,6 +7,7 @@ import contextlib
 from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, cast
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import (
     AlbumType,
     ArtistType,
@@ -67,12 +68,28 @@ class ArtistsController(MediaControllerBase[Artist]):
         self._db_add_lock = asyncio.Lock()
         # register (extra) api handlers
         api_base = self.api_base
-        self.mass.register_api_command(f"music/{api_base}/artist_albums", self.albums)
-        self.mass.register_api_command(f"music/{api_base}/artist_tracks", self.tracks)
-        self.mass.register_api_command(f"music/{api_base}/top_tracks", self.top_tracks)
-        self.mass.register_api_command(f"music/{api_base}/top_albums", self.top_albums)
-        self.mass.register_api_command(f"music/{api_base}/artist_audiobooks", self.audiobooks)
-        self.mass.register_api_command(f"music/{api_base}/similar_artists", self.similar_artists)
+        self.mass.register_api_command(
+            f"music/{api_base}/artist_albums", self.albums, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/artist_tracks", self.tracks, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/top_tracks", self.top_tracks, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/top_albums", self.top_albums, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/artist_audiobooks",
+            self.audiobooks,
+            required_scope=Scope.LIBRARY_READ,
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/similar_artists",
+            self.similar_artists,
+            required_scope=Scope.LIBRARY_READ,
+        )
 
     async def library_count(
         self,

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from json import loads as json_loads
 from typing import TYPE_CHECKING, Any
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import ArtistType, MediaType, ProviderFeature
 from music_assistant_models.media_items import (
     Artist,
@@ -54,8 +55,12 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         super().__init__(mass)
         # register (extra) api handlers
         api_base = self.api_base
-        self.mass.register_api_command(f"music/{api_base}/audiobook_versions", self.versions)
-        self.mass.register_api_command(f"music/{api_base}/collections", self.collections)
+        self.mass.register_api_command(
+            f"music/{api_base}/audiobook_versions", self.versions, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/collections", self.collections, required_scope=Scope.LIBRARY_READ
+        )
 
     @property
     def base_query(self) -> tuple[str, dict[str, Any]]:

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -11,6 +11,7 @@ from contextvars import ContextVar
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypeVar, cast, final
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import (
     EventType,
     ExternalID,
@@ -120,18 +121,34 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         self.logger = logging.getLogger(f"{MASS_LOGGER_NAME}.music.{self.media_type.value}")
         # register (base) api handlers
         self.api_base = api_base = f"{self.media_type}s"
-        self.mass.register_api_command(f"music/{api_base}/count", self.library_count)
-        self.mass.register_api_command(f"music/{api_base}/library_items", self.library_items)
-        self.mass.register_api_command(f"music/{api_base}/get", self.get)
+        self.mass.register_api_command(
+            f"music/{api_base}/count", self.library_count, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/library_items",
+            self.library_items,
+            required_scope=Scope.LIBRARY_READ,
+            allow_impersonation=True,
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/get", self.get, required_scope=Scope.LIBRARY_READ
+        )
         # Backward compatibility alias - prefer the generic "get" endpoint
         self.mass.register_api_command(
-            f"music/{api_base}/get_{self.media_type}", self.get, alias=True
+            f"music/{api_base}/get_{self.media_type}",
+            self.get,
+            required_scope=Scope.LIBRARY_READ,
+            alias=True,
         )
         self.mass.register_api_command(
-            f"music/{api_base}/update", self.update_item_in_library, required_role="admin"
+            f"music/{api_base}/update",
+            self.update_item_in_library,
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
-            f"music/{api_base}/remove", self.remove_item_from_library, required_role="admin"
+            f"music/{api_base}/remove",
+            self.remove_item_from_library,
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self._db_add_lock = asyncio.Lock()
 

--- a/music_assistant/controllers/music/media/genres.py
+++ b/music_assistant/controllers/music/media/genres.py
@@ -8,6 +8,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import BackgroundTask, TaskSchedule
 from music_assistant_models.enums import EventType, ImageType, MediaType, TaskStatus
 from music_assistant_models.errors import InvalidDataError
@@ -119,90 +120,100 @@ class GenreController(MediaControllerBase[Genre]):
 
         # register extra api handlers
         self.mass.register_api_command(
-            "music/genres/add_alias", self.add_alias, required_role="admin"
+            "music/genres/add_alias", self.add_alias, required_scope=Scope.LIBRARY_MANAGE
         )
         self.mass.register_api_command(
-            "music/genres/remove_alias", self.remove_alias, required_role="admin"
+            "music/genres/remove_alias", self.remove_alias, required_scope=Scope.LIBRARY_MANAGE
         )
         self.mass.register_api_command(
-            "music/genres/add_media_mapping", self.add_media_mapping, required_role="admin"
+            "music/genres/add_media_mapping",
+            self.add_media_mapping,
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
             "music/genres/remove_media_mapping",
             self.remove_media_mapping,
-            required_role="admin",
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
             "music/genres/promote_alias",
             self.promote_alias_to_genre,
-            required_role="admin",
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
             "music/genres/restore_defaults",
             self.restore_default_genres,
-            required_role="admin",
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
             "music/genres/add",
             self.add_item_to_library,
-            required_role="admin",
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
             "music/genres/overview",
             self.get_overview,
+            required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
             "music/genres/tracks",
             self.tracks,
+            required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
             "music/genres/albums",
             self.albums,
+            required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
             "music/genres/scan_mappings",
             self.scan_mappings,
-            required_role="admin",
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
             "music/genres/scanner_status",
             self.get_scanner_status,
+            required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
             "music/genres/genres_for_media_item",
             self.get_genres_for_media_item,
+            required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
             "music/genres/genre_exclusions_for_media_item",
             self.get_genre_exclusions_for_media_item,
+            required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
             "music/genres/exclude_genre_from_media_item",
             self.exclude_genre_from_media_item,
-            required_role="admin",
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
             "music/genres/remove_genre_exclusion",
             self.remove_genre_exclusion,
-            required_role="admin",
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
             "music/genres/merge",
             self.merge_genres,
-            required_role="admin",
+            required_scope=Scope.LIBRARY_MANAGE,
         )
         self.mass.register_api_command(
             "music/genres/media_counts",
             self.get_genre_media_counts,
+            required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
             "music/genres/global_exclusions",
             self.get_global_genre_exclusions,
+            required_scope=Scope.LIBRARY_READ,
         )
         self.mass.register_api_command(
             "music/genres/remove_global_exclusion",
             self.remove_global_genre_exclusion,
-            required_role="admin",
+            required_scope=Scope.LIBRARY_MANAGE,
         )
 
         # Run genre mapping scanner after library sync completes

--- a/music_assistant/controllers/music/media/playlists.py
+++ b/music_assistant/controllers/music/media/playlists.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator, Sequence
 from contextlib import suppress
 from typing import TYPE_CHECKING, cast
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import (
     InvalidDataError,
@@ -73,16 +74,34 @@ class PlaylistController(MediaControllerBase[Playlist]):
         super().__init__(mass)
         # register (extra) api handlers
         api_base = self.api_base
-        self.mass.register_api_command(f"music/{api_base}/create_playlist", self.create_playlist)
-        self.mass.register_api_command("music/playlists/playlist_tracks", self.tracks)
         self.mass.register_api_command(
-            "music/playlists/add_playlist_tracks", self.add_playlist_tracks
+            f"music/{api_base}/create_playlist",
+            self.create_playlist,
+            required_scope=Scope.LIBRARY_WRITE,
         )
         self.mass.register_api_command(
-            "music/playlists/remove_playlist_tracks", self.remove_playlist_tracks
+            "music/playlists/playlist_tracks", self.tracks, required_scope=Scope.LIBRARY_READ
         )
-        self.mass.register_api_command("music/playlists/export_playlist", self.export_playlist)
-        self.mass.register_api_command("music/playlists/import_playlist", self.import_playlist)
+        self.mass.register_api_command(
+            "music/playlists/add_playlist_tracks",
+            self.add_playlist_tracks,
+            required_scope=Scope.LIBRARY_WRITE,
+        )
+        self.mass.register_api_command(
+            "music/playlists/remove_playlist_tracks",
+            self.remove_playlist_tracks,
+            required_scope=Scope.LIBRARY_WRITE,
+        )
+        self.mass.register_api_command(
+            "music/playlists/export_playlist",
+            self.export_playlist,
+            required_scope=Scope.LIBRARY_READ,
+        )
+        self.mass.register_api_command(
+            "music/playlists/import_playlist",
+            self.import_playlist,
+            required_scope=Scope.LIBRARY_WRITE,
+        )
 
     async def tracks(
         self,

--- a/music_assistant/controllers/music/media/podcasts.py
+++ b/music_assistant/controllers/music/media/podcasts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import MediaNotFoundError, ProviderUnavailableError
 from music_assistant_models.media_items import Podcast, PodcastEpisode, ProviderMapping, UniqueList
@@ -41,9 +42,15 @@ class PodcastsController(MediaControllerBase[Podcast]):
         super().__init__(mass)
         # register (extra) api handlers
         api_base = self.api_base
-        self.mass.register_api_command(f"music/{api_base}/podcast_episodes", self.episodes)
-        self.mass.register_api_command(f"music/{api_base}/podcast_episode", self.episode)
-        self.mass.register_api_command(f"music/{api_base}/podcast_versions", self.versions)
+        self.mass.register_api_command(
+            f"music/{api_base}/podcast_episodes", self.episodes, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/podcast_episode", self.episode, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/podcast_versions", self.versions, required_scope=Scope.LIBRARY_READ
+        )
 
     async def library_items(
         self,

--- a/music_assistant/controllers/music/media/radio.py
+++ b/music_assistant/controllers/music/media/radio.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, cast
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import ProviderUnavailableError
 from music_assistant_models.media_items import ProviderMapping, Radio
@@ -40,9 +41,17 @@ class RadioController(MediaControllerBase[Radio]):
         super().__init__(mass)
         # register (extra) api handlers
         api_base = self.api_base
-        self.mass.register_api_command(f"music/{api_base}/radio_versions", self.versions)
-        self.mass.register_api_command(f"music/{api_base}/export_radios", self.export_radios)
-        self.mass.register_api_command(f"music/{api_base}/import_radios", self.import_radios)
+        self.mass.register_api_command(
+            f"music/{api_base}/radio_versions", self.versions, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/export_radios", self.export_radios, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/import_radios",
+            self.import_radios,
+            required_scope=Scope.LIBRARY_WRITE,
+        )
 
     async def export_radios(self) -> str:
         """Export all library radio stations to M3U8 format."""

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -6,6 +6,7 @@ import urllib.parse
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import ExternalID, MediaType, ProviderFeature, ProviderType
 from music_assistant_models.errors import (
     InvalidDataError,
@@ -58,10 +59,20 @@ class TracksController(MediaControllerBase[Track]):
         super().__init__(mass)
         # register (extra) api handlers
         api_base = self.api_base
-        self.mass.register_api_command(f"music/{api_base}/track_versions", self.versions)
-        self.mass.register_api_command(f"music/{api_base}/track_albums", self.albums)
-        self.mass.register_api_command(f"music/{api_base}/preview", self.get_preview_url)
-        self.mass.register_api_command(f"music/{api_base}/similar_tracks", self.similar_tracks)
+        self.mass.register_api_command(
+            f"music/{api_base}/track_versions", self.versions, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/track_albums", self.albums, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/preview", self.get_preview_url, required_scope=Scope.LIBRARY_READ
+        )
+        self.mass.register_api_command(
+            f"music/{api_base}/similar_tracks",
+            self.similar_tracks,
+            required_scope=Scope.LIBRARY_READ,
+        )
 
     @property
     def base_query(self) -> tuple[str, dict[str, Any]]:

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -19,6 +19,7 @@ import time
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import shortuuid
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import (
     EventType,
     MediaType,
@@ -52,9 +53,7 @@ from music_assistant.constants import (
     MASS_LOGO_ONLINE,
     PLAYLIST_MEDIA_TYPES,
 )
-from music_assistant.controllers.player_queues.autoplay import (
-    Autoplay,
-)
+from music_assistant.controllers.player_queues.autoplay import Autoplay
 from music_assistant.controllers.player_queues.config import (
     core_config_entries,
     queue_config_entries,
@@ -75,10 +74,7 @@ from music_assistant.controllers.player_queues.queue_loader import QueueLoaderMi
 from music_assistant.controllers.player_queues.smart_shuffle import SmartShuffle
 from music_assistant.controllers.player_queues.state import PlayerQueueData
 from music_assistant.controllers.player_queues.stream_feeder import StreamFeederMixin
-from music_assistant.controllers.webserver.helpers.auth_middleware import (
-    ImpersonatedUser,
-    get_current_user,
-)
+from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.api import api_command
 from music_assistant.models.player import Player, PlayerMedia
 
@@ -192,12 +188,12 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         """Iterate over (available) players."""
         return iter(queue_data.queue for queue_data in self._queue_data.values())
 
-    @api_command("player_queues/all")
+    @api_command("player_queues/all", required_scope=Scope.QUEUES_READ)
     def all(self) -> tuple[PlayerQueue, ...]:
         """Return all registered PlayerQueues."""
         return tuple(queue_data.queue for queue_data in self._queue_data.values())
 
-    @api_command("player_queues/get")
+    @api_command("player_queues/get", required_scope=Scope.QUEUES_READ)
     def get(self, queue_id: str) -> PlayerQueue | None:
         """Return PlayerQueue by queue_id or None if not found."""
         queue_data = self._queue_data.get(queue_id)
@@ -216,14 +212,14 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         """Return the server-side record for a queue, or None if it is not registered."""
         return self._queue_data.get(queue_id)
 
-    @api_command("player_queues/items")
+    @api_command("player_queues/items", required_scope=Scope.QUEUES_READ)
     def items(self, queue_id: str, limit: int = 500, offset: int = 0) -> list[QueueItem]:
         """Return all QueueItems for given PlayerQueue."""
         if (queue_data := self._queue_data.get(queue_id)) is None:
             return []
         return queue_data.items[offset : offset + limit]
 
-    @api_command("player_queues/get_active_queue")
+    @api_command("player_queues/get_active_queue", required_scope=Scope.QUEUES_READ)
     def get_active_queue(self, player_id: str) -> PlayerQueue | None:
         """Return the current active/synced queue for a player."""
         if player := self.mass.players.get_player(player_id):
@@ -232,7 +228,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
 
     # Queue commands
 
-    @api_command("player_queues/shuffle")
+    @api_command("player_queues/shuffle", required_scope=Scope.QUEUES_CONTROL)
     async def set_shuffle(self, queue_id: str, shuffle_enabled: bool) -> None:
         """Configure shuffle setting on the the queue."""
         queue = self._queue_data[queue_id].queue
@@ -279,7 +275,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             return True
         return queue.shuffle_enabled and self._smart_shuffle.is_enabled(queue.queue_id)
 
-    @api_command("player_queues/autoplay")
+    @api_command("player_queues/autoplay", required_scope=Scope.QUEUES_CONTROL)
     def set_autoplay(self, queue_id: str, autoplay_enabled: bool) -> None:
         """Configure Autoplay setting on the queue."""
         queue_data = self._queue_data[queue_id]
@@ -298,12 +294,14 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             self.mass.call_later(5, self._fill_autoplay_tracks, queue_id, task_id=task_id)
         self.signal_update(queue_id=queue_id)
 
-    @api_command("player_queues/dont_stop_the_music", alias=True)
+    @api_command(
+        "player_queues/dont_stop_the_music", required_scope=Scope.QUEUES_CONTROL, alias=True
+    )
     def set_dont_stop_the_music(self, queue_id: str, dont_stop_the_music_enabled: bool) -> None:
         """Backwards-compatible alias for the autoplay command, used by older clients."""
         self.set_autoplay(queue_id, dont_stop_the_music_enabled)
 
-    @api_command("player_queues/repeat")
+    @api_command("player_queues/repeat", required_scope=Scope.QUEUES_CONTROL)
     def set_repeat(self, queue_id: str, repeat_mode: RepeatMode) -> None:
         """Configure repeat setting on the the queue."""
         queue = self._queue_data[queue_id].queue
@@ -326,7 +324,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             if next_item := self.get_next_item(queue_id, queue.index_in_buffer):
                 self._enqueue_next_item(queue_id, next_item)
 
-    @api_command("player_queues/crossfade")
+    @api_command("player_queues/crossfade", required_scope=Scope.QUEUES_CONTROL)
     def set_crossfade(self, queue_id: str, crossfade_enabled: bool) -> None:
         """Enable or disable crossfade on the queue."""
         queue = self._queue_data[queue_id].queue
@@ -353,7 +351,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
     #                    What the user expects to see on the progress bar and what
     #                    we use for resume positions.
     # Conversion: media-time = stream-time x playback_speed.
-    @api_command("player_queues/set_playback_speed")
+    @api_command("player_queues/set_playback_speed", required_scope=Scope.QUEUES_CONTROL)
     async def set_playback_speed(
         self, queue_id: str, speed: float, queue_item_id: str | None = None
     ) -> None:
@@ -401,7 +399,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         if queue.state == PlaybackState.PLAYING:
             await self.resume(queue_id)
 
-    @api_command("player_queues/play_media")
+    @api_command(
+        "player_queues/play_media", required_scope=Scope.QUEUES_CONTROL, allow_impersonation=True
+    )
     async def play_media(
         self,
         queue_id: str,
@@ -409,7 +409,6 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         option: QueueOption | None = None,
         radio_mode: bool = False,
         start_item: PlayableMediaItemType | str | None = None,
-        username: str | None = None,
         sort_by: str | None = None,
     ) -> None:
         """
@@ -421,20 +420,15 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         :param radio_mode: Deprecated — translated to a radio_playlist:// dynamic playlist;
             prefer enqueuing that URI directly.
         :param start_item: Optional item to start the playlist or album from.
-        :param username: The username of the user requesting the playback.
-            Setting the username allows for overriding the logged-in user
-            to account for playback history per user when the play_media is
-            called from a shared context (like a web hook or automation).
         :param sort_by: Optional sort key to order tracks before applying start_item.
         """
         self._check_player_permission(queue_id)
         if not self.get(queue_id):
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
         # Lock is acquired by the @handle_play_action decorator on the internal handler
-        async with ImpersonatedUser(self.mass, username):
-            await self._handle_play_media(queue_id, media, option, radio_mode, start_item, sort_by)
+        await self._handle_play_media(queue_id, media, option, radio_mode, start_item, sort_by)
 
-    @api_command("player_queues/move_item")
+    @api_command("player_queues/move_item", required_scope=Scope.QUEUES_CONTROL)
     def move_item(self, queue_id: str, queue_item_id: str, pos_shift: int = 1) -> None:
         """
         Move queue item x up/down the queue.
@@ -468,7 +462,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         queue_items.insert(new_index, queue_items.pop(item_index))
         self.update_items(queue_id, queue_items)
 
-    @api_command("player_queues/move_item_end")
+    @api_command("player_queues/move_item_end", required_scope=Scope.QUEUES_CONTROL)
     def move_item_end(self, queue_id: str, queue_item_id: str) -> None:
         """
         Move queue item to the end the queue.
@@ -495,7 +489,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         queue_items.insert(new_index, queue_items.pop(item_index))
         self.update_items(queue_id, queue_items)
 
-    @api_command("player_queues/delete_item")
+    @api_command("player_queues/delete_item", required_scope=Scope.QUEUES_CONTROL)
     def delete_item(self, queue_id: str, item_id_or_index: int | str) -> None:
         """Delete item (by id or index) from the queue."""
         if isinstance(item_id_or_index, str):
@@ -514,7 +508,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         queue_items.pop(item_index)
         self.update_items(queue_id, queue_items)
 
-    @api_command("player_queues/clear")
+    @api_command("player_queues/clear", required_scope=Scope.QUEUES_CONTROL)
     def clear(self, queue_id: str, skip_stop: bool = False) -> None:
         """Clear all items in the queue."""
         queue = self._queue_data[queue_id].queue
@@ -530,7 +524,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
         self.update_items(queue_id, [])
 
-    @api_command("player_queues/save_as_playlist")
+    @api_command("player_queues/save_as_playlist", required_scope=Scope.LIBRARY_WRITE)
     async def save_as_playlist(self, queue_id: str, name: str) -> BackgroundTask:
         """
         Save the current queue items as a new playlist.
@@ -553,7 +547,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         playlist = await self.mass.music.playlists.create_playlist(name)
         return await self.mass.music.playlists.add_playlist_tracks(playlist.item_id, uris)
 
-    @api_command("player_queues/stop")
+    @api_command("player_queues/stop", required_scope=Scope.QUEUES_CONTROL)
     @handle_play_action
     async def stop(self, queue_id: str) -> None:
         """
@@ -581,7 +575,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         await self.mass.players._handle_cmd_stop(queue_id)
         self.mass.create_task(self._cleanup_queue_audio_data(queue_id))
 
-    @api_command("player_queues/play")
+    @api_command("player_queues/play", required_scope=Scope.QUEUES_CONTROL)
     async def play(self, queue_id: str) -> None:
         """
         Handle PLAY command for given queue.
@@ -593,7 +587,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             raise PlayerUnavailableError(f"Queue {queue_id} is not available")
         await self._handle_play(queue_id)
 
-    @api_command("player_queues/pause")
+    @api_command("player_queues/pause", required_scope=Scope.QUEUES_CONTROL)
     async def pause(self, queue_id: str) -> None:
         """
         Handle PAUSE command for given queue.
@@ -638,7 +632,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         ):
             self.mass.create_task(_watch_pause(queue_player))
 
-    @api_command("player_queues/play_pause")
+    @api_command("player_queues/play_pause", required_scope=Scope.QUEUES_CONTROL)
     async def play_pause(self, queue_id: str) -> None:
         """
         Toggle play/pause on given playerqueue.
@@ -650,7 +644,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             return
         await self.play(queue_id)
 
-    @api_command("player_queues/next")
+    @api_command("player_queues/next", required_scope=Scope.QUEUES_CONTROL)
     @handle_play_action
     async def next(self, queue_id: str) -> None:
         """
@@ -690,7 +684,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             task_id=f"queue_play_index_{queue_id}",
         )
 
-    @api_command("player_queues/previous")
+    @api_command("player_queues/previous", required_scope=Scope.QUEUES_CONTROL)
     @handle_play_action
     async def previous(self, queue_id: str) -> None:
         """
@@ -729,7 +723,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             task_id=f"queue_play_index_{queue_id}",
         )
 
-    @api_command("player_queues/skip")
+    @api_command("player_queues/skip", required_scope=Scope.QUEUES_CONTROL)
     async def skip(self, queue_id: str, seconds: int = 10) -> None:
         """
         Handle SKIP command for given queue.
@@ -741,7 +735,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             raise InvalidCommand(f"Queue {queue_id} is not active")
         await self.seek(queue_id, int(self._queue_data[queue_id].queue.elapsed_time + seconds))
 
-    @api_command("player_queues/seek")
+    @api_command("player_queues/seek", required_scope=Scope.QUEUES_CONTROL)
     async def seek(self, queue_id: str, position: int = 10) -> None:
         """
         Handle SEEK command for given queue.
@@ -765,7 +759,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             raise InvalidCommand(f"Queue {queue_player.state.name} has no current index.")
         await self.play_index(queue_id, queue.current_index, seek_position=position)
 
-    @api_command("player_queues/resume")
+    @api_command("player_queues/resume", required_scope=Scope.QUEUES_CONTROL)
     @handle_play_action
     async def resume(self, queue_id: str, fade_in: bool | None = None) -> None:
         """
@@ -817,7 +811,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             msg = f"Resume queue requested but queue {queue.display_name} is empty"
             raise QueueEmpty(msg)
 
-    @api_command("player_queues/play_index")
+    @api_command("player_queues/play_index", required_scope=Scope.QUEUES_CONTROL)
     @handle_play_action
     async def play_index(  # noqa: PLR0915
         self,
@@ -931,7 +925,7 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         finally:
             self._set_transitioning(queue_id, False)
 
-    @api_command("player_queues/transfer")
+    @api_command("player_queues/transfer", required_scope=Scope.QUEUES_CONTROL)
     async def transfer_queue(
         self,
         source_queue_id: str,

--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -24,7 +24,7 @@ from collections.abc import AsyncIterator
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
-from music_assistant_models.auth import UserRole
+from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.constants import (
     PLAYER_CONTROL_FAKE,
@@ -98,6 +98,7 @@ from music_assistant.constants import (
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     get_current_user,
     get_sendspin_player_id,
+    has_scope,
 )
 from music_assistant.helpers.api import api_command
 from music_assistant.helpers.colors import get_palette_for_url
@@ -309,7 +310,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         current_user = get_current_user()
         user_filter = (
             current_user.player_filter
-            if current_user and current_user.role != UserRole.ADMIN
+            if current_user and not has_scope(current_user, Scope.ALL)
             else None
         )
         current_sendspin_player = get_sendspin_player_id()
@@ -328,7 +329,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             and (return_protocol_players or player.state.type != PlayerType.PROTOCOL)
         ]
 
-    @api_command("players/all")
+    @api_command("players/all", required_scope=Scope.PLAYERS_READ)
     def all_player_states(
         self,
         return_unavailable: bool = True,
@@ -380,7 +381,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             raise PlayerUnavailableError(msg)
         return None
 
-    @api_command("players/get")
+    @api_command("players/get", required_scope=Scope.PLAYERS_READ)
     def get_player_state(
         self,
         player_id: str,
@@ -398,7 +399,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         current_user = get_current_user()
         user_filter = (
             current_user.player_filter
-            if current_user and current_user.role != UserRole.ADMIN
+            if current_user and not has_scope(current_user, Scope.ALL)
             else None
         )
         current_sendspin_player = get_sendspin_player_id()
@@ -449,7 +450,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
         return matches[0]
 
-    @api_command("players/get_by_name")
+    @api_command("players/get_by_name", required_scope=Scope.PLAYERS_READ)
     def get_player_state_by_name(self, name: str) -> PlayerState | None:
         """
         Return PlayerState by name.
@@ -460,7 +461,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         current_user = get_current_user()
         user_filter = (
             current_user.player_filter
-            if current_user and current_user.role != UserRole.ADMIN
+            if current_user and not has_scope(current_user, Scope.ALL)
             else None
         )
         current_sendspin_player = get_sendspin_player_id()
@@ -476,14 +477,14 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             return player.state
         return None
 
-    @api_command("players/player_controls")
+    @api_command("players/player_controls", required_scope=Scope.PLAYERS_READ)
     def player_controls(
         self,
     ) -> list[PlayerControl]:
         """Return all registered playercontrols."""
         return list(self._controls.values())
 
-    @api_command("players/player_control")
+    @api_command("players/player_control", required_scope=Scope.PLAYERS_READ)
     def get_player_control(
         self,
         control_id: str,
@@ -498,7 +499,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             return control
         return None
 
-    @api_command("players/sleep_timer/get")
+    @api_command("players/sleep_timer/get", required_scope=Scope.PLAYERS_READ)
     def get_sleep_timer(self, player_id: str) -> float | None:
         """
         Return the active sleep timer expiry timestamp for the player.
@@ -508,7 +509,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         player = self._get_player_with_redirect(player_id)
         return player.sleep_timer_expires_at
 
-    @api_command("players/sleep_timer/set")
+    @api_command("players/sleep_timer/set", required_scope=Scope.PLAYERS_CONTROL)
     def set_sleep_timer(self, player_id: str, seconds: int) -> float:
         """
         Set a sleep timer for the player.
@@ -537,7 +538,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         )
         return expires_at
 
-    @api_command("players/sleep_timer/clear")
+    @api_command("players/sleep_timer/clear", required_scope=Scope.PLAYERS_CONTROL)
     def clear_sleep_timer(self, player_id: str) -> None:
         """
         Clear the active sleep timer for the player.
@@ -549,7 +550,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     # Player commands
 
-    @api_command("players/cmd/stop")
+    @api_command("players/cmd/stop", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def cmd_stop(self, player_id: str) -> None:
         """
@@ -565,7 +566,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # Delegate to internal handler for actual implementation
         await self._handle_cmd_stop(player.player_id)
 
-    @api_command("players/cmd/play")
+    @api_command("players/cmd/play", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_play(self, player_id: str) -> None:
         """
@@ -589,7 +590,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # Delegate to internal handler for actual implementation
         await self._handle_cmd_play(player.player_id)
 
-    @api_command("players/cmd/pause")
+    @api_command("players/cmd/pause", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_pause(self, player_id: str) -> None:
         """
@@ -605,7 +606,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # Delegate to internal handler for actual implementation
         await self._handle_cmd_pause(player.player_id)
 
-    @api_command("players/cmd/play_pause")
+    @api_command("players/cmd/play_pause", required_scope=Scope.PLAYERS_CONTROL)
     async def cmd_play_pause(self, player_id: str) -> None:
         """
         Toggle play/pause on given player.
@@ -618,7 +619,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         else:
             await self.cmd_play(player.player_id)
 
-    @api_command("players/cmd/resume")
+    @api_command("players/cmd/resume", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def cmd_resume(
         self, player_id: str, source: str | None = None, media: PlayerMedia | None = None
@@ -634,7 +635,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         await self._handle_cmd_resume(player_id, source, media)
 
-    @api_command("players/cmd/seek")
+    @api_command("players/cmd/seek", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_seek(self, player_id: str, position: int) -> None:
         """
@@ -670,7 +671,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # handle command on player directly
         await player.seek(position)
 
-    @api_command("players/cmd/next")
+    @api_command("players/cmd/next", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_next_track(self, player_id: str) -> None:
         """Handle NEXT TRACK command for given player."""
@@ -700,7 +701,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         msg = f"Player {player.state.name} does not support skipping to the next track."
         raise UnsupportedFeaturedException(msg)
 
-    @api_command("players/cmd/previous")
+    @api_command("players/cmd/previous", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_previous_track(self, player_id: str) -> None:
         """Handle PREVIOUS TRACK command for given player."""
@@ -730,7 +731,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         msg = f"Player {player.state.name} does not support skipping to the previous track."
         raise UnsupportedFeaturedException(msg)
 
-    @api_command("players/cmd/power")
+    @api_command("players/cmd/power", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def cmd_power(self, player_id: str, powered: bool) -> None:
         """
@@ -744,7 +745,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # play_media / cmd_resume / cmd_set_members on the same player.
         await self._handle_cmd_power(player_id, powered)
 
-    @api_command("players/cmd/volume_set")
+    @api_command("players/cmd/volume_set", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command(lock=PlayerLockPurpose.VOLUME)
     async def cmd_volume_set(self, player_id: str, volume_level: int) -> None:
         """
@@ -760,7 +761,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if (player := self.get_player(player_id)) and player.type != PlayerType.GROUP:
             self._invalidate_group_volume_snapshot(player_id)
 
-    @api_command("players/cmd/volume_up")
+    @api_command("players/cmd/volume_up", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_volume_up(self, player_id: str) -> None:
         """
@@ -783,7 +784,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         new_volume = min(100, current_volume + step_size)
         await self.cmd_volume_set(player_id, new_volume)
 
-    @api_command("players/cmd/volume_down")
+    @api_command("players/cmd/volume_down", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_volume_down(self, player_id: str) -> None:
         """
@@ -806,7 +807,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         new_volume = max(0, current_volume - step_size)
         await self.cmd_volume_set(player_id, new_volume)
 
-    @api_command("players/cmd/group_volume")
+    @api_command("players/cmd/group_volume", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_group_volume(
         self,
@@ -834,7 +835,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # treat as normal player volume change
         await self.cmd_volume_set(player_id, volume_level)
 
-    @api_command("players/cmd/group_volume_up")
+    @api_command("players/cmd/group_volume_up", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_group_volume_up(self, player_id: str) -> None:
         """
@@ -856,7 +857,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         new_volume = min(100, cur_volume + step_size)
         await self.cmd_group_volume(player_id, new_volume)
 
-    @api_command("players/cmd/group_volume_down")
+    @api_command("players/cmd/group_volume_down", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_group_volume_down(self, player_id: str) -> None:
         """
@@ -878,7 +879,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         new_volume = max(0, cur_volume - step_size)
         await self.cmd_group_volume(player_id, new_volume)
 
-    @api_command("players/cmd/group_volume_mute")
+    @api_command("players/cmd/group_volume_mute", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_group_volume_mute(self, player_id: str, muted: bool) -> None:
         """
@@ -898,7 +899,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 coros.append(self.cmd_volume_mute(child_player.player_id, muted))
             await asyncio.gather(*coros)
 
-    @api_command("players/cmd/volume_mute")
+    @api_command("players/cmd/volume_mute", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command(lock=PlayerLockPurpose.VOLUME)
     async def cmd_volume_mute(self, player_id: str, muted: bool) -> None:
         """
@@ -965,7 +966,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             await protocol_player.volume_mute(muted)
             return
 
-    @api_command("players/cmd/play_announcement")
+    @api_command("players/cmd/play_announcement", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command(lock=PlayerLockPurpose.PLAYBACK)
     async def play_announcement(
         self,
@@ -1114,7 +1115,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         async with self.get_player_lock(player.player_id, PlayerLockPurpose.PLAYBACK):
             await self._handle_play_media(player.player_id, media)
 
-    @api_command("players/cmd/select_sound_mode")
+    @api_command("players/cmd/select_sound_mode", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def select_sound_mode(self, player_id: str, sound_mode: str) -> None:
         """
@@ -1144,7 +1145,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # forward to player
         await player.select_sound_mode(sound_mode)
 
-    @api_command("players/cmd/set_option")
+    @api_command("players/cmd/set_option", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def set_option(
         self, player_id: str, option_key: str, option_value: PlayerOptionValueType
@@ -1178,7 +1179,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # forward to player
         await player.set_option(option_key=option_key, option_value=option_value)
 
-    @api_command("players/cmd/select_source")
+    @api_command("players/cmd/select_source", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def select_source(self, player_id: str, source: str | None) -> None:
         """
@@ -1238,7 +1239,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # Delegate to internal handler for actual implementation
         await self._handle_enqueue_next_media(player_id, media)
 
-    @api_command("players/cmd/set_members")
+    @api_command("players/cmd/set_members", required_scope=Scope.PLAYERS_CONTROL)
     async def cmd_set_members(
         self,
         target_player: str,
@@ -1292,7 +1293,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         async with self.get_player_lock(parent_player.player_id, PlayerLockPurpose.PLAYBACK):
             await self._handle_set_members(parent_player, player_ids_to_add, player_ids_to_remove)
 
-    @api_command("players/cmd/group")
+    @api_command("players/cmd/group", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_group(self, player_id: str, target_player: str) -> None:
         """
@@ -1314,7 +1315,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         await self.cmd_set_members(target_player, player_ids_to_add=[player_id])
 
-    @api_command("players/cmd/group_many")
+    @api_command("players/cmd/group_many", required_scope=Scope.PLAYERS_CONTROL)
     async def cmd_group_many(self, target_player: str, child_player_ids: list[str]) -> None:
         """
         Join given player(s) to target player.
@@ -1324,7 +1325,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         """
         await self.cmd_set_members(target_player, player_ids_to_add=child_player_ids)
 
-    @api_command("players/cmd/ungroup")
+    @api_command("players/cmd/ungroup", required_scope=Scope.PLAYERS_CONTROL)
     @handle_player_command
     async def cmd_ungroup(self, player_id: str) -> None:
         """
@@ -1388,13 +1389,13 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 await self.cmd_set_members(player.player_id, player_ids_to_remove=[player_id])
                 return
 
-    @api_command("players/cmd/ungroup_many")
+    @api_command("players/cmd/ungroup_many", required_scope=Scope.PLAYERS_CONTROL)
     async def cmd_ungroup_many(self, player_ids: list[str]) -> None:
         """Handle UNGROUP command for all the given players."""
         for player_id in list(player_ids):
             await self.cmd_ungroup(player_id)
 
-    @api_command("players/create_group_player", required_role="admin")
+    @api_command("players/create_group_player", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def create_group_player(
         self, provider: str, name: str, members: list[str], dynamic: bool = True
     ) -> Player:
@@ -1415,7 +1416,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             )
         return await provider_instance.create_group_player(name, members, dynamic)
 
-    @api_command("players/remove_group_player", required_role="admin")
+    @api_command("players/remove_group_player", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def remove_group_player(self, player_id: str) -> None:
         """Remove a group player."""
         if not (player := self.get_player(player_id)):
@@ -1427,7 +1428,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         player.provider.check_feature(ProviderFeature.REMOVE_GROUP_PLAYER)
         await player.provider.remove_group_player(player_id)
 
-    @api_command("players/add_currently_playing_to_favorites")
+    @api_command("players/add_currently_playing_to_favorites", required_scope=Scope.LIBRARY_WRITE)
     async def add_currently_playing_to_favorites(self, player_id: str) -> None:
         """
         Add the currently playing item/track on given player to the favorites.
@@ -1712,7 +1713,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         # Schedule debounced update of all players since can_group_with values may change
         self._schedule_update_all_players()
 
-    @api_command("players/remove", required_role="admin")
+    @api_command("players/remove", required_scope=Scope.CONFIG_PLAYERS_WRITE)
     async def remove(self, player_id: str) -> None:
         """
         Remove a player from a provider.

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -15,6 +15,7 @@ from math import inf
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.audio_analysis import AudioAnalysisCoverage
+from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import ContentType, MediaType, ProviderType, StreamType
 from music_assistant_models.errors import ProviderUnavailableError
@@ -752,7 +753,7 @@ class AudioAnalysisController:
             if merged is not None:
                 yield (*current_key, merged)
 
-    @api_command("audio_analysis/coverage")
+    @api_command("audio_analysis/coverage", required_scope=Scope.SYSTEM_MANAGE)
     async def get_coverage(self, aa_domain: str) -> AudioAnalysisCoverage:
         """
         Return analysis-coverage health counts for an AA provider.
@@ -796,7 +797,7 @@ class AudioAnalysisController:
             analysis_version=provider.analysis_version,
         )
 
-    @api_command("audio_analysis/failures")
+    @api_command("audio_analysis/failures", required_scope=Scope.SYSTEM_MANAGE)
     async def get_failures(self, aa_domain: str | None = None) -> list[dict[str, Any]]:
         """
         Return recorded analysis failures, optionally filtered by AA provider domain.
@@ -819,7 +820,7 @@ class AudioAnalysisController:
             for r in rows
         ]
 
-    @api_command("audio_analysis/failures/clear")
+    @api_command("audio_analysis/failures/clear", required_scope=Scope.SYSTEM_MANAGE)
     async def clear_failures(
         self,
         item_id: str | None = None,

--- a/music_assistant/controllers/tasks/controller.py
+++ b/music_assistant/controllers/tasks/controller.py
@@ -13,7 +13,7 @@ from threading import get_ident
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from music_assistant_models.auth import User, UserRole
+from music_assistant_models.auth import Scope, User
 from music_assistant_models.background_task import (
     BackgroundTask,
     TaskMetadata,
@@ -23,7 +23,10 @@ from music_assistant_models.background_task import (
 from music_assistant_models.enums import EventType, TaskStatus
 from music_assistant_models.errors import InvalidDataError
 
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    get_current_user,
+    has_scope,
+)
 from music_assistant.helpers.api import api_command
 from music_assistant.models.core_controller import CoreController
 
@@ -94,7 +97,7 @@ class TasksController(CoreController):
             logging.getLogger().removeHandler(self._log_handler)
             self._log_handler = None
 
-    @api_command("tasks/list")
+    @api_command("tasks/list", required_scope=Scope.SYSTEM_READ)
     def list_tasks(self) -> list[BackgroundTask]:
         """Return all visible managed tasks."""
         return self.list_tasks_for_user(get_current_user())
@@ -103,17 +106,17 @@ class TasksController(CoreController):
         """Return tasks visible to the given user."""
         return [managed.task_info for managed in get_visible_tasks(self._tasks.values(), user)]
 
-    @api_command("tasks/get")
+    @api_command("tasks/get", required_scope=Scope.SYSTEM_READ)
     def get_task(self, task_id: str) -> BackgroundTask:
         """Return a single task by id."""
         return self._get_visible_managed_task(task_id, get_current_user()).task_info
 
-    @api_command("tasks/log")
+    @api_command("tasks/log", required_scope=Scope.SYSTEM_READ)
     def get_task_log(self, task_id: str) -> str:
         """Return the log buffer for a single task."""
         return "\n".join(self._get_visible_managed_task(task_id, get_current_user()).task_info.logs)
 
-    @api_command("tasks/run", required_role=UserRole.ADMIN)
+    @api_command("tasks/run", required_scope=Scope.SYSTEM_MANAGE)
     def run_task(self, task_id: str) -> BackgroundTask:
         """Queue a task for immediate execution."""
         managed = self._get_managed_task(task_id)
@@ -127,7 +130,7 @@ class TasksController(CoreController):
         )
         return managed.task_info
 
-    @api_command("tasks/retry", required_role=UserRole.ADMIN)
+    @api_command("tasks/retry", required_scope=Scope.SYSTEM_MANAGE)
     def retry_task(self, task_id: str) -> BackgroundTask:
         """Retry a failed or cancelled task."""
         managed = self._get_managed_task(task_id)
@@ -147,14 +150,14 @@ class TasksController(CoreController):
         )
         return managed.task_info
 
-    @api_command("tasks/cancel", required_role=UserRole.ADMIN)
+    @api_command("tasks/cancel", required_scope=Scope.SYSTEM_MANAGE)
     def cancel_task(self, task_id: str) -> BackgroundTask:
         """Cancel a pending or running task."""
         managed = self._get_managed_task(task_id)
         self._cancel_managed_task(managed)
         return managed.task_info
 
-    @api_command("tasks/set_enabled", required_role=UserRole.ADMIN)
+    @api_command("tasks/set_enabled", required_scope=Scope.SYSTEM_MANAGE)
     def set_task_enabled(self, task_id: str, enabled: bool) -> BackgroundTask:
         """Enable or disable automatic scheduling for a recurring task."""
         managed = self._get_managed_task(task_id)
@@ -177,7 +180,7 @@ class TasksController(CoreController):
             self._schedule_task_update(force=True)
         return managed.task_info
 
-    @api_command("tasks/update_schedule", required_role=UserRole.ADMIN)
+    @api_command("tasks/update_schedule", required_scope=Scope.SYSTEM_MANAGE)
     def update_task_schedule(
         self,
         task_id: str,
@@ -202,7 +205,7 @@ class TasksController(CoreController):
             self._schedule_task_update(force=True)
         return managed.task_info
 
-    @api_command("tasks/remove", required_role=UserRole.ADMIN)
+    @api_command("tasks/remove", required_scope=Scope.SYSTEM_MANAGE)
     def remove_task(self, task_id: str) -> None:
         """Remove a finished task from history."""
         managed = self._get_managed_task(task_id)
@@ -211,7 +214,7 @@ class TasksController(CoreController):
         self._tasks.pop(task_id, None)
         self._schedule_task_update(force=True)
 
-    @api_command("tasks/clear_finished", required_role=UserRole.ADMIN)
+    @api_command("tasks/clear_finished", required_scope=Scope.SYSTEM_MANAGE)
     def clear_finished_tasks(self) -> None:
         """Remove finished non-scheduled tasks from history."""
         for task_id in [task_id for task_id, task in self._tasks.items() if task.can_remove]:
@@ -482,7 +485,7 @@ class TasksController(CoreController):
         managed = self._get_managed_task(task_id)
         if (
             user is not None
-            and user.role != UserRole.ADMIN
+            and not has_scope(user, Scope.SYSTEM_MANAGE)
             and managed.task_info.user_id != user.user_id
         ):
             raise InvalidDataError(f"Task {task_id} not found")

--- a/music_assistant/controllers/tasks/helpers.py
+++ b/music_assistant/controllers/tasks/helpers.py
@@ -7,10 +7,11 @@ from collections.abc import Callable, Iterable, Mapping
 from datetime import UTC, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
 
-from music_assistant_models.auth import User, UserRole
+from music_assistant_models.auth import Scope, User
 from music_assistant_models.background_task import BackgroundTask, TaskSchedule
 from music_assistant_models.enums import TaskScheduleType, TaskStatus
 
+from music_assistant.controllers.webserver.helpers.auth_middleware import has_scope
 from music_assistant.helpers.datetime import utc
 
 from .constants import ACTIVE_TASK_ID
@@ -50,7 +51,7 @@ def task_sort_key(managed: ManagedTask) -> tuple[int, float]:
 
 def is_task_visible_to_user(task: ManagedTask, user: User | None) -> bool:
     """Return if a task should be visible to the given user."""
-    if user is None or user.role == UserRole.ADMIN:
+    if user is None or has_scope(user, Scope.SYSTEM_MANAGE):
         return True
     return task.task_info.user_id == user.user_id
 
@@ -58,7 +59,7 @@ def is_task_visible_to_user(task: ManagedTask, user: User | None) -> bool:
 def get_visible_tasks(tasks: Iterable[ManagedTask], user: User | None) -> list[ManagedTask]:
     """Return tasks visible to the given user."""
     visible_tasks = list(tasks)
-    if user is not None and user.role != UserRole.ADMIN:
+    if user is not None and not has_scope(user, Scope.SYSTEM_MANAGE):
         visible_tasks = [task for task in visible_tasks if is_task_visible_to_user(task, user)]
     visible_tasks.sort(key=task_sort_key)
     return visible_tasks

--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -437,8 +437,8 @@ async def admin_command():
     pass
 ```
 
-Scopes are granted to users through their role, see `ROLE_SCOPES` in the
-`music_assistant_models.auth` module for the builtin role definitions.
+Scopes are granted to users through their role, see `ROLE_SCOPES` in
+[helpers/auth_middleware.py](helpers/auth_middleware.py) for the builtin role definitions.
 
 ### Database Migrations
 

--- a/music_assistant/controllers/webserver/README.md
+++ b/music_assistant/controllers/webserver/README.md
@@ -391,7 +391,10 @@ Remote Client → WebRTC Data Channel → Gateway → Local WebSocket API
 
 1. Define route handler in [controller.py](controller.py) (for HTTP endpoints)
 2. Use `@api_command()` decorator for WebSocket commands (in respective controllers)
-3. Specify authentication requirements: `authenticated=True` or `required_role="admin"`
+3. Specify authentication requirements: `authenticated=True` and/or `required_scope=Scope.<SCOPE>`
+4. Optionally set `allow_impersonation=True` to let callers execute the command on behalf of
+   another user via the injected `user` argument (requires the `users.impersonate` scope
+   when targeting another user)
 
 ### Testing Authentication
 
@@ -424,13 +427,18 @@ async def my_command():
     # ... use token ...
 ```
 
-**Requiring admin role:**
+**Requiring a scope:**
 ```python
-@api_command("admin_only_command", required_role="admin")
+from music_assistant_models.auth import Scope
+
+@api_command("admin_only_command", required_scope=Scope.CONFIG_CORE_WRITE)
 async def admin_command():
-    # Only admins can call this
+    # Only users whose role grants the config.core.write scope can call this
     pass
 ```
+
+Scopes are granted to users through their role, see `ROLE_SCOPES` in the
+`music_assistant_models.auth` module for the builtin role definitions.
 
 ### Database Migrations
 

--- a/music_assistant/controllers/webserver/api_docs.py
+++ b/music_assistant/controllers/webserver/api_docs.py
@@ -1114,7 +1114,7 @@ def generate_commands_json(command_handlers: dict[str, APICommandHandler]) -> li
         ],
         "return_type": str,  # Return type
         "authenticated": bool,  # Whether authentication is required
-        "required_role": str | None,  # Required user role (if any)
+        "required_scope": str | None,  # Required scope (if any)
     }
     """
     commands_data = []
@@ -1159,6 +1159,21 @@ def generate_commands_json(command_handlers: dict[str, APICommandHandler]) -> li
                 }
             )
 
+        if handler.allow_impersonation:
+            # the 'user' argument is injected by the command dispatch
+            parameters.append(
+                {
+                    "name": "user",
+                    "type": "string",
+                    "required": False,
+                    "description": (
+                        "Optional user_id or username of the user to execute this "
+                        "command on behalf of. Requires the users.impersonate scope "
+                        "when targeting another user."
+                    ),
+                }
+            )
+
         commands_data.append(
             {
                 "command": command,
@@ -1168,7 +1183,7 @@ def generate_commands_json(command_handlers: dict[str, APICommandHandler]) -> li
                 "parameters": parameters,
                 "return_type": return_type_str,
                 "authenticated": handler.authenticated,
-                "required_role": handler.required_role,
+                "required_scope": handler.required_scope,
             }
         )
 

--- a/music_assistant/controllers/webserver/api_docs.py
+++ b/music_assistant/controllers/webserver/api_docs.py
@@ -1183,7 +1183,7 @@ def generate_commands_json(command_handlers: dict[str, APICommandHandler]) -> li
                 "parameters": parameters,
                 "return_type": return_type_str,
                 "authenticated": handler.authenticated,
-                "required_scope": handler.required_scope,
+                "required_scope": str(handler.required_scope) if handler.required_scope else None,
             }
         )
 

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -16,6 +16,7 @@ import jwt as pyjwt
 from music_assistant_models.auth import (
     AuthProviderType,
     AuthToken,
+    Scope,
     User,
     UserAuthProvider,
     UserRole,
@@ -28,8 +29,10 @@ from music_assistant_models.errors import (
 
 from music_assistant.constants import DB_TABLE_PLAYLOG, HOMEASSISTANT_SYSTEM_USER, MASS_LOGGER_NAME
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    ROLE_SCOPES,
     get_current_token,
     get_current_user,
+    has_scope,
 )
 from music_assistant.controllers.webserver.helpers.auth_providers import (
     AuthResult,
@@ -107,6 +110,9 @@ class AuthenticationManager:
         await self._setup_login_providers()
 
         self._has_users = await self._has_non_system_users()
+
+        # migrate the Home Assistant system user of pre-existing installs to the service role
+        await self._migrate_system_user_role()
 
         self._schedule_join_code_cleanup()
 
@@ -247,7 +253,7 @@ class AuthenticationManager:
             return None
         return str(token_row["token_id"])
 
-    @api_command("auth/user", required_role="admin")
+    @api_command("auth/user", required_scope=Scope.USERS_MANAGE)
     async def get_user(self, user_id: str) -> User | None:
         """
         Get user by ID (admin only).
@@ -262,7 +268,7 @@ class AuthenticationManager:
         return User(
             user_id=user_row["user_id"],
             username=user_row["username"],
-            role=UserRole(user_row["role"]),
+            role=user_row["role"],
             enabled=bool(user_row["enabled"]),
             created_at=datetime.fromisoformat(user_row["created_at"]),
             display_name=user_row["display_name"],
@@ -389,7 +395,7 @@ class AuthenticationManager:
         """
         username = HOMEASSISTANT_SYSTEM_USER
         display_name = "Home Assistant Integration"
-        role = UserRole.USER
+        role = UserRole.SERVICE
 
         normalized_username = normalize_username(username)
 
@@ -659,8 +665,9 @@ class AuthenticationManager:
         if not token_row:
             raise InvalidDataError("Token not found")
 
-        # Check permissions - users can only revoke their own tokens unless admin
-        if token_row["user_id"] != user.user_id and user.role != UserRole.ADMIN:
+        # Check permissions - users can only revoke their own tokens
+        # unless they hold the users.manage scope
+        if token_row["user_id"] != user.user_id and not has_scope(user, Scope.USERS_MANAGE):
             raise InsufficientPermissions("You can only revoke your own tokens")
 
         await self.database.delete("auth_tokens", {"token_id": token_id})
@@ -714,9 +721,10 @@ class AuthenticationManager:
         if not current_user:
             return []
 
-        # If user_id is provided and different from current user, require admin
+        # If user_id is provided and different from current user,
+        # require the users.manage scope
         if user_id and user_id != current_user.user_id:
-            if current_user.role != UserRole.ADMIN:
+            if not has_scope(current_user, Scope.USERS_MANAGE):
                 return []
             target_user = await self.get_user(user_id)
             if not target_user:
@@ -729,7 +737,7 @@ class AuthenticationManager:
         )
         return [AuthToken.from_dict(dict(row)) for row in token_rows]
 
-    @api_command("auth/users", required_role="admin")
+    @api_command("auth/users", required_scope=Scope.USERS_MANAGE)
     async def list_users(self) -> list[User]:
         """
         Get all users (admin only).
@@ -748,7 +756,7 @@ class AuthenticationManager:
                 User(
                     user_id=row["user_id"],
                     username=row["username"],
-                    role=UserRole(row["role"]),
+                    role=row["role"],
                     enabled=bool(row["enabled"]),
                     created_at=datetime.fromisoformat(row["created_at"]),
                     display_name=row["display_name"],
@@ -762,13 +770,13 @@ class AuthenticationManager:
 
     async def update_user_role(self, user_id: str, new_role: UserRole, admin_user: User) -> bool:
         """
-        Update a user's role (admin only).
+        Update a user's role (requires the users.manage scope).
 
         :param user_id: The user ID to update.
         :param new_role: The new role to assign.
-        :param admin_user: The admin user performing the action.
+        :param admin_user: The user performing the action.
         """
-        if admin_user.role != UserRole.ADMIN:
+        if not has_scope(admin_user, Scope.USERS_MANAGE):
             return False
 
         user_row = await self.database.get_row("users", {"user_id": user_id})
@@ -790,7 +798,7 @@ class AuthenticationManager:
         )
         return True
 
-    @api_command("auth/user/enable", required_role="admin")
+    @api_command("auth/user/enable", required_scope=Scope.USERS_MANAGE)
     async def enable_user(self, user_id: str) -> None:
         """
         Enable user account (admin only).
@@ -804,7 +812,7 @@ class AuthenticationManager:
         )
         self.logger.info("User account enabled (user_id=%s)", user_id)
 
-    @api_command("auth/user/disable", required_role="admin")
+    @api_command("auth/user/disable", required_scope=Scope.USERS_MANAGE)
     async def disable_user(self, user_id: str) -> None:
         """
         Disable user account (admin only).
@@ -916,7 +924,7 @@ class AuthenticationManager:
                 "user_id": auth_result.user.user_id,
                 "username": auth_result.user.username,
                 "display_name": auth_result.user.display_name,
-                "role": auth_result.user.role.value,
+                "role": auth_result.user.role,
             },
         }
 
@@ -1010,11 +1018,12 @@ class AuthenticationManager:
         if not current_user:
             raise AuthenticationRequired("Not authenticated")
 
-        # If user_id is provided and different from current user, require admin
+        # If user_id is provided and different from current user,
+        # require the users.manage scope
         if user_id and user_id != current_user.user_id:
-            if current_user.role != UserRole.ADMIN:
+            if not has_scope(current_user, Scope.USERS_MANAGE):
                 raise InsufficientPermissions(
-                    "Admin access required to create tokens for other users"
+                    "The users.manage scope is required to create tokens for other users"
                 )
             target_user = await self.get_user(user_id)
             if not target_user:
@@ -1027,7 +1036,7 @@ class AuthenticationManager:
         self.logger.info("Created long-lived token '%s' for user '%s'", name, target_user.username)
         return token
 
-    @api_command("auth/user/create", required_role="admin")
+    @api_command("auth/user/create", required_scope=Scope.USERS_MANAGE)
     async def create_user_with_api(
         self,
         username: str,
@@ -1088,7 +1097,7 @@ class AuthenticationManager:
         self.logger.info("User created by admin: %s (role: %s)", username, role)
         return user
 
-    @api_command("auth/user/delete", required_role="admin")
+    @api_command("auth/user/delete", required_scope=Scope.USERS_MANAGE)
     async def delete_user(self, user_id: str) -> None:
         """
         Delete user account (admin only).
@@ -1128,6 +1137,11 @@ class AuthenticationManager:
         if not current_user_obj:
             raise AuthenticationRequired("Not authenticated")
         return current_user_obj
+
+    @api_command("auth/scopes")
+    async def get_role_scopes(self) -> dict[str, list[str]]:
+        """Get the scopes granted to each of the builtin user roles."""
+        return {role: sorted(scopes) for role, scopes in ROLE_SCOPES.items()}
 
     async def update_user_filters(
         self,
@@ -1185,11 +1199,13 @@ class AuthenticationManager:
             raise AuthenticationRequired("Not authenticated")
 
         # Determine target user
-        is_admin = current_user_obj.role == UserRole.ADMIN
+        may_manage_users = has_scope(current_user_obj, Scope.USERS_MANAGE)
         if user_id and user_id != current_user_obj.user_id:
-            # Updating another user - requires admin
-            if not is_admin:
-                raise InsufficientPermissions("Admin access required")
+            # Updating another user - requires the users.manage scope
+            if not may_manage_users:
+                raise InsufficientPermissions(
+                    "The users.manage scope is required to update other users"
+                )
             target_user = await self.get_user(user_id)
             if not target_user:
                 raise InvalidDataError("User not found")
@@ -1197,10 +1213,12 @@ class AuthenticationManager:
             # Updating own profile
             target_user = current_user_obj
 
-        # Update role (admin only)
+        # Update role (requires the users.manage scope)
         if role:
-            if not is_admin:
-                raise InsufficientPermissions("Only admins can update user roles")
+            if not may_manage_users:
+                raise InsufficientPermissions(
+                    "The users.manage scope is required to update user roles"
+                )
 
             try:
                 new_role = UserRole(role)
@@ -1233,17 +1251,21 @@ class AuthenticationManager:
         if preferences is not None:
             target_user = await self.update_user_preferences(target_user, preferences)
 
-        # Update player_filter and provider_filter (admin only)
+        # Update player_filter and provider_filter (requires the users.manage scope)
         if player_filter is not None or provider_filter is not None:
-            if not is_admin:
-                raise InsufficientPermissions("Only admins can update player/provider filters")
+            if not may_manage_users:
+                raise InsufficientPermissions(
+                    "The users.manage scope is required to update player/provider filters"
+                )
             target_user = await self.update_user_filters(
                 target_user, player_filter, provider_filter
             )
 
         # Update password if provided
         if password:
-            await self._update_profile_password(target_user, password, is_admin, current_user_obj)
+            await self._update_profile_password(
+                target_user, password, may_manage_users, current_user_obj
+            )
 
         return target_user
 
@@ -1286,7 +1308,7 @@ class AuthenticationManager:
         providers = [UserAuthProvider.from_dict(dict(row)) for row in rows]
         return [p.to_dict() for p in providers]
 
-    @api_command("auth/user/unlink_provider", required_role="admin")
+    @api_command("auth/user/unlink_provider", required_scope=Scope.USERS_MANAGE)
     async def unlink_provider(self, user_id: str, provider_type: str) -> bool:
         """
         Unlink authentication provider from user (admin only).
@@ -1462,7 +1484,7 @@ class AuthenticationManager:
                 "error": "Failed to create access token",
             }
 
-    @api_command("auth/join_codes", required_role="admin")
+    @api_command("auth/join_codes", required_scope=Scope.USERS_MANAGE)
     async def list_join_codes(self, user_id: str | None = None) -> list[dict[str, Any]]:
         """
         List join codes, optionally filtered by user (admin only).
@@ -1474,7 +1496,7 @@ class AuthenticationManager:
         rows = await self.database.get_rows("join_codes", filter_args, limit=100)
         return [dict(row) for row in rows]
 
-    @api_command("auth/join_code/revoke", required_role="admin")
+    @api_command("auth/join_code/revoke", required_scope=Scope.USERS_MANAGE)
     async def revoke_join_code(self, code_id: str) -> None:
         """
         Revoke a specific join code (admin only).
@@ -1763,6 +1785,19 @@ class AuthenticationManager:
         """Check if any non-system users exist."""
         user_rows = await self.database.get_rows("users", limit=10)
         return any(row["username"] != HOMEASSISTANT_SYSTEM_USER for row in user_rows)
+
+    async def _migrate_system_user_role(self) -> None:
+        """Migrate the Home Assistant system user of pre-existing installs to the service role."""
+        user_row = await self.database.get_row(
+            "users", {"username": normalize_username(HOMEASSISTANT_SYSTEM_USER)}
+        )
+        if user_row and user_row["role"] != UserRole.SERVICE.value:
+            await self.database.update(
+                "users", {"user_id": user_row["user_id"]}, {"role": UserRole.SERVICE.value}
+            )
+            self.logger.info(
+                "Updated Home Assistant system user role to %s", UserRole.SERVICE.value
+            )
 
     async def _migrate_playlog_to_first_user(self, user_id: str) -> None:
         """

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1141,7 +1141,10 @@ class AuthenticationManager:
     @api_command("auth/scopes")
     async def get_role_scopes(self) -> dict[str, list[str]]:
         """Get the scopes granted to each of the builtin user roles."""
-        return {role: sorted(scopes) for role, scopes in ROLE_SCOPES.items()}
+        return {
+            str(role): sorted(str(scope) for scope in scopes)
+            for role, scopes in ROLE_SCOPES.items()
+        }
 
     async def update_user_filters(
         self,

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -27,6 +27,7 @@ from music_assistant_models.api import CommandMessage
 from music_assistant_models.auth import UserRole
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType
+from music_assistant_models.errors import InsufficientPermissions, InvalidDataError
 from music_assistant_models.media_items.metadata import IMAGE_PROXY_ID_RESOLVER
 from music_assistant_models.translations import TRANSLATION_RESOLVER
 
@@ -55,8 +56,11 @@ from .api_docs import generate_commands_json, generate_openapi_spec, generate_sc
 from .auth import AuthenticationManager
 from .helpers.auth_middleware import (
     get_authenticated_user,
+    has_scope,
     is_request_from_ingress,
+    resolve_command_impersonation,
     set_current_user,
+    set_impersonated_user,
 )
 from .helpers.auth_providers import BuiltinLoginProvider, get_ha_user_role
 from .remote_access import RemoteAccessManager
@@ -67,6 +71,7 @@ if TYPE_CHECKING:
     from music_assistant_models.config_entries import ConfigValueType, CoreConfig
 
     from music_assistant import MusicAssistant
+    from music_assistant.helpers.api import APICommandHandler
 
 DEFAULT_SERVER_PORT = 8095
 CONF_BASE_URL = "base_url"
@@ -531,33 +536,16 @@ class WebserverController(CoreController):
             return web.Response(status=400, text=error)
 
         # Check authentication if required
-        if handler.authenticated or handler.required_role:
-            try:
-                user = await get_authenticated_user(request)
-            except Exception as e:
-                self.logger.exception("Authentication error: %s", e)
-                return web.Response(
-                    status=401,
-                    text="Authentication failed",
-                    headers={"WWW-Authenticate": 'Bearer realm="Music Assistant"'},
-                )
-
-            if not user:
-                return web.Response(
-                    status=401,
-                    text="Authentication required",
-                    headers={"WWW-Authenticate": 'Bearer realm="Music Assistant"'},
-                )
-
-            # Set user in context and check role
-            set_current_user(user)
-            if handler.required_role == "admin" and user.role != UserRole.ADMIN:
-                return web.Response(
-                    status=403,
-                    text="Admin access required",
-                )
+        if error_response := await self._authenticate_api_command(request, handler):
+            return error_response
 
         try:
+            # handle the optional impersonation argument for impersonation-enabled commands
+            if handler.allow_impersonation and command_msg.args:
+                if impersonation_user := await resolve_command_impersonation(
+                    self.mass, command_msg.args
+                ):
+                    set_impersonated_user(impersonation_user)
             args = parse_arguments(handler.signature, handler.type_hints, command_msg.args)
             result: Any = handler.target(**args)
             if hasattr(result, "__anext__"):
@@ -570,6 +558,10 @@ class WebserverController(CoreController):
             locale = _locale_from_request(request)
             await self.mass.translations.ensure_locale_loaded(locale)
             return self._localized_json_response(result, locale)
+        except InsufficientPermissions as e:
+            return web.Response(status=403, text=str(e))
+        except InvalidDataError as e:
+            return web.Response(status=400, text=str(e))
         except Exception as e:
             # Return clean error message without stacktrace
             error_type = type(e).__name__
@@ -577,6 +569,43 @@ class WebserverController(CoreController):
             error = f"{error_type}: {error_msg}"
             self.logger.exception("Error executing command %s: %s", command_msg.command, error)
             return web.Response(status=500, text="Internal server error")
+
+    async def _authenticate_api_command(
+        self, request: web.Request, handler: APICommandHandler
+    ) -> web.Response | None:
+        """
+        Authenticate the request and check the handler's required scope.
+
+        Sets the authenticated user in context and returns an error response
+        if authentication or the scope check failed, None otherwise.
+        """
+        if not (handler.authenticated or handler.required_scope):
+            return None
+        try:
+            user = await get_authenticated_user(request)
+        except Exception as e:
+            self.logger.exception("Authentication error: %s", e)
+            return web.Response(
+                status=401,
+                text="Authentication failed",
+                headers={"WWW-Authenticate": 'Bearer realm="Music Assistant"'},
+            )
+
+        if not user:
+            return web.Response(
+                status=401,
+                text="Authentication required",
+                headers={"WWW-Authenticate": 'Bearer realm="Music Assistant"'},
+            )
+
+        # Set user in context and check the required scope
+        set_current_user(user)
+        if handler.required_scope and not has_scope(user, handler.required_scope):
+            return web.Response(
+                status=403,
+                text=f"This command requires the {handler.required_scope} scope",
+            )
+        return None
 
     def _localized_json_response(self, result: Any, locale: str | None) -> web.Response:
         """

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -59,6 +59,7 @@ from .helpers.auth_middleware import (
     has_scope,
     is_request_from_ingress,
     resolve_command_impersonation,
+    set_current_token,
     set_current_user,
     set_impersonated_user,
 )
@@ -598,8 +599,11 @@ class WebserverController(CoreController):
                 headers={"WWW-Authenticate": 'Bearer realm="Music Assistant"'},
             )
 
-        # Set user in context and check the required scope
+        # Set user and token in context and check the required scope
         set_current_user(user)
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            set_current_token(auth_header[7:])
         if handler.required_scope and not has_scope(user, handler.required_scope):
             return web.Response(
                 status=403,

--- a/music_assistant/controllers/webserver/helpers/auth_middleware.py
+++ b/music_assistant/controllers/webserver/helpers/auth_middleware.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from contextvars import ContextVar
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, Final, Self, cast
 
 from aiohttp import web
-from music_assistant_models.auth import AuthProviderType, User, UserRole
+from music_assistant_models.auth import AuthProviderType, Scope, User, UserRole
 from music_assistant_models.errors import InsufficientPermissions, InvalidDataError
 
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER, MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
@@ -22,6 +23,37 @@ if TYPE_CHECKING:
 
 # Context key for storing authenticated user in request
 USER_CONTEXT_KEY = "authenticated_user"
+
+_GUEST_SCOPES: Final[frozenset[Scope]] = frozenset(
+    {
+        Scope.LIBRARY_READ,
+        Scope.PLAYERS_READ,
+        Scope.PLAYERS_CONTROL,
+        Scope.QUEUES_READ,
+        Scope.QUEUES_CONTROL,
+        Scope.PROVIDERS_READ,
+        Scope.CONFIG_PLAYERS_READ,
+    }
+)
+_USER_SCOPES: Final[frozenset[Scope]] = _GUEST_SCOPES | {
+    Scope.LIBRARY_WRITE,
+    Scope.CONFIG_PROVIDERS_READ,
+    Scope.CONFIG_CORE_READ,
+    Scope.USERS_INVITE,
+    Scope.SYSTEM_READ,
+}
+
+# Scopes granted to each of the builtin user roles.
+# Roles are identified by their (string) role id to allow for custom roles in the future:
+# a role id not present in this mapping simply grants no scopes at all.
+ROLE_SCOPES: Final[Mapping[str, frozenset[Scope]]] = {
+    UserRole.ADMIN: frozenset({Scope.ALL}),
+    UserRole.USER: _USER_SCOPES,
+    UserRole.GUEST: _GUEST_SCOPES,
+    # service accounts (such as the Home Assistant integration) get
+    # slightly elevated rights over a regular user
+    UserRole.SERVICE: _USER_SCOPES | {Scope.CONFIG_PLAYERS_WRITE, Scope.USERS_IMPERSONATE},
+}
 
 # ContextVar for tracking current user and token across async calls
 current_user: ContextVar[User | None] = ContextVar("current_user", default=None)
@@ -151,16 +183,60 @@ async def require_authentication(request: web.Request) -> User:
     return user
 
 
-async def require_admin(request: web.Request) -> User:
+def has_scope(user: User, scope: Scope) -> bool:
     """
-    Require admin role for a request, raise 403 if not admin.
+    Check if the given user is granted the given scope (through its role).
 
-    :param request: The aiohttp request.
+    :param user: The user to check.
+    :param scope: The scope required.
     """
-    user = await require_authentication(request)
-    if user.role != UserRole.ADMIN:
-        raise web.HTTPForbidden(text="Admin access required")
-    return user
+    role_scopes = ROLE_SCOPES.get(user.role, frozenset())
+    return Scope.ALL in role_scopes or scope in role_scopes
+
+
+async def resolve_impersonated_user(mass: MusicAssistant, user: str) -> User:
+    """
+    Resolve and validate the user to impersonate for the current call.
+
+    The authenticated caller may always impersonate itself, impersonating
+    another user requires the users.impersonate scope.
+
+    :param mass: The MusicAssistant instance.
+    :param user: The user_id or username of the user to impersonate.
+    """
+    authenticated_user = current_user.get()
+    if authenticated_user is None:
+        raise InsufficientPermissions("Authentication is necessary to impersonate another user.")
+    target_user = await mass.webserver.auth.get_user(user)
+    if target_user is None:
+        target_user = await mass.webserver.auth.get_user_by_username(user)
+    if target_user is None:
+        raise InvalidDataError(f"A user with user id or name {user} is not available.")
+    if target_user.user_id != authenticated_user.user_id and not has_scope(
+        authenticated_user, Scope.USERS_IMPERSONATE
+    ):
+        raise InsufficientPermissions(
+            "The users.impersonate scope is required to impersonate another user."
+        )
+    return target_user
+
+
+async def resolve_command_impersonation(mass: MusicAssistant, args: dict[str, Any]) -> User | None:
+    """
+    Pop and resolve the optional impersonation argument for an API command invocation.
+
+    Returns the user to impersonate for the command, or None if no
+    impersonation was requested.
+
+    :param mass: The MusicAssistant instance.
+    :param args: The (mutable) arguments dict of the incoming command.
+    """
+    user_arg = args.pop("user", None)
+    # username is accepted as (deprecated) alias for user
+    username_arg = args.pop("username", None)
+    if target := user_arg or username_arg:
+        return await resolve_impersonated_user(mass, str(target))
+    return None
 
 
 def get_current_user() -> User | None:
@@ -313,56 +389,34 @@ async def auth_middleware(request: web.Request, handler: Any) -> web.StreamRespo
 
 class ImpersonatedUser:
     """
-    Optional impersonated user context manager.
+    Optional impersonated user context manager, for use by internal (server) code.
 
-    Nested use possible.
-    Case A:
-        calling user's role: Admin or User
-        username: username of calling user or None
-        -> impersonated user set to calling user (i.e. no change, nested use)
-    Case B:
-        calling user's role: User
-        username: username of another user
-        -> raises InsufficientPermissions
-    Case C:
-        calling user's role: Admin
-        username: username of another user
-        -> impersonated user set to requested user
+    API commands should instead be registered with the allow_impersonation flag,
+    which handles impersonation centrally in the command dispatch.
+
+    Nested use possible: passing None for the user is a no-op which preserves
+    any impersonation already active in the current context.
     """
 
-    def __init__(self, mass: MusicAssistant, username: str | None) -> None:
-        """Initialize ImpersonatedUser."""
+    def __init__(self, mass: MusicAssistant, user: str | None) -> None:
+        """
+        Initialize ImpersonatedUser.
+
+        :param mass: The MusicAssistant instance.
+        :param user: The user_id or username of the user to impersonate, or None for a no-op.
+        """
         self.mass = mass
-        self.username = username
+        self.user = user
         self.previous_impersonated_user = impersonated_user.get()
-        authenticated_user = current_user.get()
-        if authenticated_user is None:
-            # No authenticated user in context (e.g. playback from a hardware button
-            # or an external protocol). Impersonating another user is not allowed, but a
-            # call without a username is a no-op so anonymous playback keeps working.
-            if username is not None:
-                raise InsufficientPermissions(
-                    "Authentication is necessary to impersonate another user."
-                )
-            return
-        if username is not None:
-            if (
-                authenticated_user.role != UserRole.ADMIN
-                and authenticated_user.username != self.username
-            ):
-                raise InsufficientPermissions("Can only impersonate another user as Admin.")
-        else:
-            self.username = authenticated_user.username
 
     async def __aenter__(self) -> Self:
         """Set the impersonated user if applicable."""
-        if self.username is None:
-            # no-op: nothing to impersonate (no authenticated user, no username)
+        if self.user is None:
+            # no-op: nothing to impersonate (e.g. playback from a hardware button
+            # or an external protocol without a user context)
             return self
-        if user := await self.mass.webserver.auth.get_user_by_username(self.username):
-            set_impersonated_user(user)
-            return self
-        raise InvalidDataError(f"A user with user id or name {self.username} is not available.")
+        set_impersonated_user(await resolve_impersonated_user(self.mass, self.user))
+        return self
 
     async def __aexit__(
         self,

--- a/music_assistant/controllers/webserver/helpers/auth_middleware.py
+++ b/music_assistant/controllers/webserver/helpers/auth_middleware.py
@@ -234,6 +234,8 @@ async def resolve_command_impersonation(mass: MusicAssistant, args: dict[str, An
     user_arg = args.pop("user", None)
     # username is accepted as (deprecated) alias for user
     username_arg = args.pop("username", None)
+    # deliberately treat None and empty string as "no impersonation requested":
+    # optional fields in automations/scripts commonly template to an empty string
     if target := user_arg or username_arg:
         return await resolve_impersonated_user(mass, str(target))
     return None

--- a/music_assistant/controllers/webserver/helpers/auth_providers.py
+++ b/music_assistant/controllers/webserver/helpers/auth_providers.py
@@ -794,7 +794,7 @@ class HomeAssistantOAuthProvider(LoginProvider):
             existing_user = User(
                 user_id=user_dict["user_id"],
                 username=user_dict["username"],
-                role=UserRole(user_dict["role"]),
+                role=user_dict["role"],
                 enabled=bool(user_dict["enabled"]),
                 created_at=datetime.fromisoformat(user_dict["created_at"]),
                 display_name=user_dict["display_name"],

--- a/music_assistant/controllers/webserver/remote_access/__init__.py
+++ b/music_assistant/controllers/webserver/remote_access/__init__.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, cast
 
 from awesomeversion import AwesomeVersion
 from mashumaro import DataClassDictMixin
+from music_assistant_models.auth import Scope
 from music_assistant_models.enums import EventType
 
 from music_assistant.constants import CONF_CORE
@@ -288,11 +289,13 @@ class RemoteAccessManager:
 
         self._on_unload_callbacks.append(
             self.mass.register_api_command(
-                "remote_access/info", get_remote_access_info, required_role="admin"
+                "remote_access/info", get_remote_access_info, required_scope=Scope.SYSTEM_MANAGE
             )
         )
         self._on_unload_callbacks.append(
             self.mass.register_api_command(
-                "remote_access/configure", configure_remote_access, required_role="admin"
+                "remote_access/configure",
+                configure_remote_access,
+                required_scope=Scope.SYSTEM_MANAGE,
             )
         )

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -18,7 +18,7 @@ from music_assistant_models.api import (
     MessageType,
     SuccessResultMessage,
 )
-from music_assistant_models.auth import AuthProviderType, User, UserRole
+from music_assistant_models.auth import AuthProviderType, User
 from music_assistant_models.enums import EventType
 from music_assistant_models.errors import (
     AuthenticationRequired,
@@ -35,9 +35,12 @@ from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER, VERBOSE_LOG_LEV
 from music_assistant.helpers.api import APICommandHandler, parse_arguments
 
 from .helpers.auth_middleware import (
+    has_scope,
     is_request_from_ingress,
+    resolve_command_impersonation,
     set_current_token,
     set_current_user,
+    set_impersonated_user,
     set_sendspin_player_id,
 )
 from .helpers.auth_providers import get_ha_user_details, get_ha_user_role
@@ -205,7 +208,7 @@ class WebsocketClientHandler:
             return
 
         # Check authentication if required
-        if handler.authenticated or handler.required_role:
+        if handler.authenticated or handler.required_scope:
             # For Ingress, user should already be set from _handle_ingress_auth
             # For regular connections, user must be set via auth command
             if self._authenticated_user is None:
@@ -224,18 +227,19 @@ class WebsocketClientHandler:
             set_current_token(self._current_token)
             set_sendspin_player_id(self._sendspin_player_id)
 
-            # Check role if required
-            if handler.required_role == "admin":
-                if self._authenticated_user.role != UserRole.ADMIN:
-                    await self._send_message(
-                        ErrorResultMessage(
-                            msg.message_id,
-                            InsufficientPermissions.error_code,
-                            "Admin access required",
-                            translation_key="insufficient_permissions",
-                        )
+            # Check scope if required
+            if handler.required_scope and not has_scope(
+                self._authenticated_user, handler.required_scope
+            ):
+                await self._send_message(
+                    ErrorResultMessage(
+                        msg.message_id,
+                        InsufficientPermissions.error_code,
+                        f"This command requires the {handler.required_scope} scope",
+                        translation_key="insufficient_permissions",
                     )
-                    return
+                )
+                return
 
         # schedule task to handle the command
         self.mass.create_task(self._run_handler(handler, msg))
@@ -243,6 +247,10 @@ class WebsocketClientHandler:
     async def _run_handler(self, handler: APICommandHandler, msg: CommandMessage) -> None:
         """Run command handler and send response."""
         try:
+            # handle the optional impersonation argument for impersonation-enabled commands
+            if handler.allow_impersonation and msg.args:
+                if impersonation_user := await resolve_command_impersonation(self.mass, msg.args):
+                    set_impersonated_user(impersonation_user)
             args = parse_arguments(handler.signature, handler.type_hints, msg.args)
             result: Any = handler.target(**args)
             if hasattr(result, "__anext__"):

--- a/music_assistant/helpers/api.py
+++ b/music_assistant/helpers/api.py
@@ -12,12 +12,15 @@ from datetime import datetime
 from enum import Enum
 from functools import cache
 from types import NoneType, UnionType
-from typing import Any, TypeVar, Union, get_args, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, TypeVar, Union, get_args, get_origin, get_type_hints
 
 from mashumaro.exceptions import MissingField
 from music_assistant_models.media_items.media_item import MediaItem
 
 from music_assistant.helpers.util import try_parse_bool
+
+if TYPE_CHECKING:
+    from music_assistant_models.auth import Scope
 
 LOGGER = logging.getLogger(__name__)
 
@@ -279,7 +282,8 @@ class APICommandHandler:
     type_hints: dict[str, Any]
     target: Callable[..., Coroutine[Any, Any, Any] | AsyncGenerator[Any, Any]]
     authenticated: bool = True
-    required_role: str | None = None  # "admin" or "user" or None
+    required_scope: Scope | None = None  # None means any authenticated user
+    allow_impersonation: bool = False  # If True, the command accepts a 'user' argument
     alias: bool = False  # If True, this is an alias for backward compatibility
 
     @classmethod
@@ -288,7 +292,8 @@ class APICommandHandler:
         command: str,
         func: Callable[..., Coroutine[Any, Any, Any] | AsyncGenerator[Any, Any]],
         authenticated: bool = True,
-        required_role: str | None = None,
+        required_scope: Scope | None = None,
+        allow_impersonation: bool = False,
         alias: bool = False,
     ) -> APICommandHandler:
         """
@@ -297,8 +302,10 @@ class APICommandHandler:
         :param command: The command name/path.
         :param func: The function to handle the command.
         :param authenticated: Whether authentication is required (default: True).
-        :param required_role: Required user role ("admin" or "user")
+        :param required_scope: Scope required to execute the command,
             None for any authenticated user.
+        :param allow_impersonation: Whether the command accepts a 'user' argument
+            to execute the command on behalf of another user (default: False).
         :param alias: Whether this is an alias for backward compatibility (default: False).
         """
         type_hints = _get_type_hints_for_api_command(func)
@@ -354,13 +361,20 @@ class APICommandHandler:
             elif isinstance(value, TypeVar):
                 if value.__bound__ is not None:
                     type_hints[key] = value.__bound__
+        signature = inspect.signature(func)
+        # the 'user' argument of impersonation-enabled commands is injected by the
+        # command dispatch, so it may not clash with the handler's own arguments
+        if allow_impersonation and not signature.parameters.keys().isdisjoint(("user", "username")):
+            msg = f"Command {command} allows impersonation but accepts a user(name) argument"
+            raise RuntimeError(msg)
         return APICommandHandler(
             command=command,
-            signature=inspect.signature(func),
+            signature=signature,
             type_hints=type_hints,
             target=func,
             authenticated=authenticated,
-            required_role=required_role,
+            required_scope=required_scope,
+            allow_impersonation=allow_impersonation,
             alias=alias,
         )
 
@@ -368,7 +382,8 @@ class APICommandHandler:
 def api_command(
     command: str,
     authenticated: bool = True,
-    required_role: str | None = None,
+    required_scope: Scope | None = None,
+    allow_impersonation: bool = False,
     alias: bool = False,
 ) -> Callable[[_F], _F]:
     """
@@ -376,7 +391,10 @@ def api_command(
 
     :param command: The command name/path.
     :param authenticated: Whether authentication is required (default: True).
-    :param required_role: Required user role ("admin" or "user"), None means any authenticated user.
+    :param required_scope: Scope required to execute the command,
+        None means any authenticated user.
+    :param allow_impersonation: Whether the command accepts a 'user' argument
+        to execute the command on behalf of another user (default: False).
     :param alias: Whether this is a backward-compatible alias (default: False).
         Aliases remain functional but are hidden from the API documentation.
     """
@@ -384,7 +402,8 @@ def api_command(
     def decorate(func: _F) -> _F:
         func.api_cmd = command  # type: ignore[attr-defined]
         func.api_authenticated = authenticated  # type: ignore[attr-defined]
-        func.api_required_role = required_role  # type: ignore[attr-defined]
+        func.api_required_scope = required_scope  # type: ignore[attr-defined]
+        func.api_allow_impersonation = allow_impersonation  # type: ignore[attr-defined]
         func.api_alias = alias  # type: ignore[attr-defined]
         return func
 

--- a/music_assistant/helpers/jwt_auth.py
+++ b/music_assistant/helpers/jwt_auth.py
@@ -63,7 +63,7 @@ class JWTHelper:
             "iat": int(now.timestamp()),
             "exp": int(expires_at.timestamp()),
             "username": user.username,
-            "role": user.role.value,
+            "role": user.role,
             "token_name": token_name,
             "is_long_lived": is_long_lived,
         }

--- a/music_assistant/mass.py
+++ b/music_assistant/mass.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 import aiofiles
 from aiofiles.os import wrap
 from music_assistant_models.api import ServerInfoMessage
-from music_assistant_models.auth import UserRole
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import ProviderError
 from music_assistant_models.enums import CoreState, EventType, ProviderFeature, ProviderType
 from music_assistant_models.errors import (
@@ -49,7 +49,10 @@ from music_assistant.controllers.streams import StreamsController
 from music_assistant.controllers.tasks import TasksController
 from music_assistant.controllers.translations import TranslationController
 from music_assistant.controllers.webserver import WebserverController
-from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
+from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    get_current_user,
+    has_scope,
+)
 from music_assistant.helpers.aiohttp_client import create_clientsession
 from music_assistant.helpers.api import APICommandHandler, api_command
 from music_assistant.helpers.images import get_icon_string
@@ -341,12 +344,12 @@ class MusicAssistant:
             status=self._state,
         )
 
-    @api_command("providers/manifests")
+    @api_command("providers/manifests", required_scope=Scope.PROVIDERS_READ)
     def get_provider_manifests(self) -> list[ProviderManifest]:
         """Return all Provider manifests."""
         return list(self._provider_manifests.values())
 
-    @api_command("providers/manifests/get")
+    @api_command("providers/manifests/get", required_scope=Scope.PROVIDERS_READ)
     def get_provider_manifest(self, instance_id_or_domain: str) -> ProviderManifest:
         """Return Provider manifests of single provider(domain)."""
         if instance_id_or_domain in self._provider_manifests:
@@ -355,7 +358,7 @@ class MusicAssistant:
             return provider.manifest
         raise KeyError(f"Provider manifest not found for {instance_id_or_domain}")
 
-    @api_command("providers")
+    @api_command("providers", required_scope=Scope.PROVIDERS_READ)
     def get_providers(
         self, provider_type: ProviderType | None = None
     ) -> list[ProviderInstanceType]:
@@ -367,7 +370,7 @@ class MusicAssistant:
         """
         user = get_current_user()
         user_provider_filter = (
-            user.provider_filter if user and user.role != UserRole.ADMIN else None
+            user.provider_filter if user and not has_scope(user, Scope.ALL) else None
         )
         return [
             x
@@ -381,7 +384,7 @@ class MusicAssistant:
             )
         ]
 
-    @api_command("logging/get", required_role=UserRole.ADMIN)
+    @api_command("logging/get", required_scope=Scope.SYSTEM_MANAGE)
     async def get_application_log(self) -> str:
         """Return the application log from file."""
         logfile = os.path.join(self.storage_path, "musicassistant.log")
@@ -697,7 +700,8 @@ class MusicAssistant:
         command: str,
         handler: Callable[..., Coroutine[Any, Any, Any] | AsyncGenerator[Any, Any]],
         authenticated: bool = True,
-        required_role: str | None = None,
+        required_scope: Scope | None = None,
+        allow_impersonation: bool = False,
         alias: bool = False,
     ) -> Callable[[], None]:
         """
@@ -706,8 +710,10 @@ class MusicAssistant:
         :param command: The command name/path.
         :param handler: The function to handle the command.
         :param authenticated: Whether authentication is required (default: True).
-        :param required_role: Required user role ("admin" or "user")
+        :param required_scope: Scope required to execute the command,
             None means any authenticated user.
+        :param allow_impersonation: Whether the command accepts a 'user' argument
+            to execute the command on behalf of another user (default: False).
         :param alias: Whether this is an alias for backward compatibility (default: False).
             Aliases are not shown in API documentation but remain functional.
 
@@ -717,7 +723,7 @@ class MusicAssistant:
             msg = f"Command {command} is already registered"
             raise RuntimeError(msg)
         self.command_handlers[command] = APICommandHandler.parse(
-            command, handler, authenticated, required_role, alias
+            command, handler, authenticated, required_scope, allow_impersonation, alias
         )
 
         def unregister() -> None:
@@ -931,9 +937,12 @@ class MusicAssistant:
                 if hasattr(obj, "api_cmd"):
                     # method is decorated with our api decorator
                     authenticated = getattr(obj, "api_authenticated", True)
-                    required_role = getattr(obj, "api_required_role", None)
+                    required_scope = getattr(obj, "api_required_scope", None)
+                    allow_impersonation = getattr(obj, "api_allow_impersonation", False)
                     alias = getattr(obj, "api_alias", False)
-                    self.register_api_command(obj.api_cmd, obj, authenticated, required_role, alias)
+                    self.register_api_command(
+                        obj.api_cmd, obj, authenticated, required_scope, allow_impersonation, alias
+                    )
 
     async def _load_builtin_providers(self) -> None:
         """

--- a/music_assistant/providers/builtin/__init__.py
+++ b/music_assistant/providers/builtin/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Final, cast
 from urllib.parse import urlparse
 
 import aiofiles
+from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import (
     ContentType,
@@ -182,8 +183,12 @@ class BuiltinProvider(MusicProvider):
             initial_delay=60,
         )
         # register API commands for manual item management
-        self.mass.register_api_command("builtin/add_radio", self.add_radio)
-        self.mass.register_api_command("builtin/add_track", self.add_track)
+        self.mass.register_api_command(
+            "builtin/add_radio", self.add_radio, required_scope=Scope.LIBRARY_WRITE
+        )
+        self.mass.register_api_command(
+            "builtin/add_track", self.add_track, required_scope=Scope.LIBRARY_WRITE
+        )
 
     @property
     def is_streaming_provider(self) -> bool:

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -16,6 +16,7 @@ from aiohttp import WSMsgType, web
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat, Track
 
+from music_assistant.controllers.webserver.helpers.auth_middleware import ImpersonatedUser
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
 
 from .constants import (
@@ -1035,9 +1036,10 @@ small {{ color: #666; display: block; margin-top: 4px; }}
                 player._skip_ws_notify = True
 
             try:
-                await self.provider.mass.player_queues.play_media(
-                    player_id, uri, username=await self.provider.get_owner_username()
-                )
+                async with ImpersonatedUser(
+                    self.provider.mass, await self.provider.get_owner_username()
+                ):
+                    await self.provider.mass.player_queues.play_media(player_id, uri)
             finally:
                 if from_playlist:
                     player._skip_ws_notify = False
@@ -2046,9 +2048,8 @@ small {{ color: #666; display: block; margin-top: 4px; }}
         if self._get_msx_player(player_id) is None:
             return web.json_response({"error": "Unknown MSX player"}, status=404)
 
-        await self.provider.mass.player_queues.play_media(
-            player_id, track_uri, username=await self.provider.get_owner_username()
-        )
+        async with ImpersonatedUser(self.provider.mass, await self.provider.get_owner_username()):
+            await self.provider.mass.player_queues.play_media(player_id, track_uri)
         return web.json_response({"status": "ok"})
 
     async def _handle_pause(self, request: web.Request) -> web.Response:

--- a/music_assistant/providers/party/__init__.py
+++ b/music_assistant/providers/party/__init__.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from mashumaro import DataClassDictMixin
-from music_assistant_models.auth import User, UserRole
+from music_assistant_models.auth import Scope, User, UserRole
 from music_assistant_models.config_entries import (
     ConfigEntry,
     ConfigValueOption,
@@ -399,23 +399,33 @@ class PartyPlugin(PluginProvider):
         """Call after the provider has been loaded."""
         # Register API commands and store unregister handles
         self._unregister_handles.append(
-            self.mass.register_api_command("party/url", self.get_party_url, required_role="user")
+            self.mass.register_api_command(
+                "party/url", self.get_party_url, required_scope=Scope.USERS_INVITE
+            )
         )
         self._unregister_handles.append(
-            self.mass.register_api_command("party/player", self.get_party_player)
+            self.mass.register_api_command(
+                "party/player", self.get_party_player, required_scope=Scope.PLAYERS_READ
+            )
         )
         self._unregister_handles.append(
             self.mass.register_api_command("party/config", self.get_party_config)
         )
         # Guest action commands - these are called by the guest frontend
         self._unregister_handles.append(
-            self.mass.register_api_command("party/add_to_queue", self.add_to_queue)
+            self.mass.register_api_command(
+                "party/add_to_queue", self.add_to_queue, required_scope=Scope.QUEUES_CONTROL
+            )
         )
         self._unregister_handles.append(
-            self.mass.register_api_command("party/boost_queue_item", self.boost_queue_item)
+            self.mass.register_api_command(
+                "party/boost_queue_item", self.boost_queue_item, required_scope=Scope.QUEUES_CONTROL
+            )
         )
         self._unregister_handles.append(
-            self.mass.register_api_command("party/skip", self.skip_current)
+            self.mass.register_api_command(
+                "party/skip", self.skip_current, required_scope=Scope.QUEUES_CONTROL
+            )
         )
 
     async def unload(self, is_removed: bool = False) -> None:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -22,6 +22,7 @@ from dataclasses import replace as dc_replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from music_assistant_models.auth import Scope
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import (
     AlbumType,
@@ -30,11 +31,7 @@ from music_assistant_models.enums import (
     MediaType,
     ProviderFeature,
 )
-from music_assistant_models.errors import (
-    InvalidDataError,
-    MediaNotFoundError,
-    MusicAssistantError,
-)
+from music_assistant_models.errors import InvalidDataError, MediaNotFoundError, MusicAssistantError
 from music_assistant_models.media_items import (
     BrowseFolder,
     ItemMapping,
@@ -47,9 +44,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.media_items.metadata import MediaItemImage, MediaItemMetadata
 
-from music_assistant.constants import (
-    DYNAMIC_PLAYLIST_SAMPLE_SIZE,
-)
+from music_assistant.constants import DYNAMIC_PLAYLIST_SAMPLE_SIZE
 from music_assistant.controllers.cache import use_cache
 from music_assistant.controllers.webserver.helpers.auth_middleware import get_current_user
 from music_assistant.helpers.security import is_safe_name
@@ -193,29 +188,49 @@ class SmartPlaylistProvider(PluginProvider):
     async def loaded_in_mass(self) -> None:
         """Register API commands after the provider is loaded."""
         self._unregister_handles.append(
-            self.mass.register_api_command("smart_playlists/create", self.create_smart_playlist)
-        )
-        self._unregister_handles.append(
-            self.mass.register_api_command("smart_playlists/generate", self.generate_playlist)
-        )
-        self._unregister_handles.append(
             self.mass.register_api_command(
-                "smart_playlists/get_rules", self.get_smart_playlist_rules
+                "smart_playlists/create",
+                self.create_smart_playlist,
+                required_scope=Scope.LIBRARY_WRITE,
             )
         )
         self._unregister_handles.append(
             self.mass.register_api_command(
-                "smart_playlists/update_rules", self.update_smart_playlist_rules
+                "smart_playlists/generate",
+                self.generate_playlist,
+                required_scope=Scope.LIBRARY_WRITE,
             )
         )
         self._unregister_handles.append(
-            self.mass.register_api_command("smart_playlists/list", self.list_smart_playlists)
+            self.mass.register_api_command(
+                "smart_playlists/get_rules",
+                self.get_smart_playlist_rules,
+                required_scope=Scope.LIBRARY_READ,
+            )
         )
         self._unregister_handles.append(
-            self.mass.register_api_command("smart_playlists/preview_tracks", self.preview_tracks)
+            self.mass.register_api_command(
+                "smart_playlists/update_rules",
+                self.update_smart_playlist_rules,
+                required_scope=Scope.LIBRARY_WRITE,
+            )
         )
         self._unregister_handles.append(
-            self.mass.register_api_command("smart_playlists/count_tracks", self.count_tracks)
+            self.mass.register_api_command(
+                "smart_playlists/list", self.list_smart_playlists, required_scope=Scope.LIBRARY_READ
+            )
+        )
+        self._unregister_handles.append(
+            self.mass.register_api_command(
+                "smart_playlists/preview_tracks",
+                self.preview_tracks,
+                required_scope=Scope.LIBRARY_READ,
+            )
+        )
+        self._unregister_handles.append(
+            self.mass.register_api_command(
+                "smart_playlists/count_tracks", self.count_tracks, required_scope=Scope.LIBRARY_READ
+            )
         )
         # Subscribe to library events to handle playlist deletion and renaming.
         self._unregister_handles.append(

--- a/music_assistant/providers/sonic_similarity/provider.py
+++ b/music_assistant/providers/sonic_similarity/provider.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
+from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import MediaType, ProviderFeature
 from music_assistant_models.errors import MusicAssistantError, SetupFailedError
@@ -142,14 +143,20 @@ class SonicSimilarityPlugin(PluginProvider):
     async def loaded_in_mass(self) -> None:
         """Register similarity API commands and set up the optional CLAP engine."""
         self._unregister_handles.append(
-            self.mass.register_api_command("sonic_similarity/similar", self._handle_similar)
-        )
-        self._unregister_handles.append(
-            self.mass.register_api_command("sonic_similarity/status", self._handle_status)
+            self.mass.register_api_command(
+                "sonic_similarity/similar", self._handle_similar, required_scope=Scope.LIBRARY_READ
+            )
         )
         self._unregister_handles.append(
             self.mass.register_api_command(
-                "sonic_similarity/rebuild_index", self._handle_rebuild_index
+                "sonic_similarity/status", self._handle_status, required_scope=Scope.LIBRARY_READ
+            )
+        )
+        self._unregister_handles.append(
+            self.mass.register_api_command(
+                "sonic_similarity/rebuild_index",
+                self._handle_rebuild_index,
+                required_scope=Scope.LIBRARY_MANAGE,
             )
         )
 
@@ -164,7 +171,9 @@ class SonicSimilarityPlugin(PluginProvider):
                 await self._clap_index.load()
                 self._unregister_handles.append(
                     self.mass.register_api_command(
-                        "sonic_similarity/similar_clap", self._handle_similar_clap
+                        "sonic_similarity/similar_clap",
+                        self._handle_similar_clap,
+                        required_scope=Scope.LIBRARY_READ,
                     )
                 )
                 await self._rebuild_clap_index_from_database()
@@ -179,7 +188,9 @@ class SonicSimilarityPlugin(PluginProvider):
         if text_search_enabled:
             self._unregister_handles.append(
                 self.mass.register_api_command(
-                    "sonic_similarity/text_search", self._handle_text_search
+                    "sonic_similarity/text_search",
+                    self._handle_text_search,
+                    required_scope=Scope.LIBRARY_READ,
                 )
             )
             # The ~500MB GPT2 text encoder loads lazily on the first query (see search()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "ifaddr==0.2.0",
   "getmac==0.9.5",
   "mashumaro==3.20",
-  "music-assistant-models==1.1.152",
+  "music-assistant-models==1.1.153",
   "music-assistant-frontend==2.17.210",
   "mutagen==1.47.0",
   "orjson==3.11.6",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -50,7 +50,7 @@ markdownify==1.2.3
 mashumaro==3.20
 modern_colorthief==0.2.1
 music-assistant-frontend==2.17.210
-music-assistant-models==1.1.152
+music-assistant-models==1.1.153
 mutagen==1.47.0
 niconico.py-ma==2.1.0.post2
 nnAudio==0.3.3

--- a/tests/providers/msx_bridge/test_http_server.py
+++ b/tests/providers/msx_bridge/test_http_server.py
@@ -283,9 +283,7 @@ async def test_play_track(provider: MSXBridgeProvider, mass_mock: Mock) -> None:
         assert resp.status == 200
         data = await resp.json()
         assert data["status"] == "ok"
-        mass_mock.player_queues.play_media.assert_awaited_once_with(
-            "msx_test", "library://track/1", username=None
-        )
+        mass_mock.player_queues.play_media.assert_awaited_once_with("msx_test", "library://track/1")
     finally:
         await client.close()
 

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from sqlite3 import IntegrityError
 
 import pytest
-from music_assistant_models.auth import AuthProviderType, UserRole
+from music_assistant_models.auth import AuthProviderType, Scope, User, UserRole
 from music_assistant_models.errors import InsufficientPermissions, InvalidDataError
 
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
@@ -27,6 +27,8 @@ from music_assistant.controllers.webserver.controller import WebserverController
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
     ImpersonatedUser,
     get_current_user,
+    has_scope,
+    resolve_command_impersonation,
     set_current_token,
     set_current_user,
     set_impersonated_user,
@@ -499,7 +501,7 @@ async def test_homeassistant_system_user(auth_manager: AuthenticationManager) ->
     assert system_user is not None
     assert system_user.username == HOMEASSISTANT_SYSTEM_USER
     assert system_user.display_name == "Home Assistant Integration"
-    assert system_user.role == UserRole.USER
+    assert system_user.role == UserRole.SERVICE
 
     # Getting it again should return the same user
     system_user2 = await auth_manager.get_homeassistant_system_user()
@@ -1427,13 +1429,14 @@ async def test_impersonated_user_context_manager(auth_manager: AuthenticationMan
     admin_user = await auth_manager.create_user(username="admin", role=UserRole.ADMIN)
     standard_user_a = await auth_manager.create_user(username="user_a", role=UserRole.USER)
     standard_user_b = await auth_manager.create_user(username="user_b", role=UserRole.USER)
+    service_user = await auth_manager.create_user(username="service", role=UserRole.SERVICE)
 
     # non-authenticated user must raise
     set_current_user(None)
     with pytest.raises(InsufficientPermissions):
         async with ImpersonatedUser(auth_manager.mass, "user_a"):
             ...
-    # non-admin impersonation attempt must raise
+    # impersonation attempt without the users.impersonate scope must raise
     set_current_user(standard_user_a)
     with pytest.raises(InsufficientPermissions):
         async with ImpersonatedUser(auth_manager.mass, "admin"):
@@ -1444,20 +1447,20 @@ async def test_impersonated_user_context_manager(auth_manager: AuthenticationMan
         async with ImpersonatedUser(auth_manager.mass, "wrong_username"):
             ...
 
-    # verify, that a standard user not attempting personation changes the current user
-    # to the caller temporarily and restores the impersonated user afterwards
+    # verify that a standard user may impersonate itself (by username or user_id)
     set_current_user(standard_user_a)
-    set_impersonated_user(standard_user_b)  # simulate nested use
-
-    assert get_current_user() == standard_user_b
+    set_impersonated_user(None)
     async with ImpersonatedUser(auth_manager.mass, "user_a"):
         assert get_current_user() == standard_user_a
-    assert get_current_user() == standard_user_b
-    async with ImpersonatedUser(auth_manager.mass, None):
+    async with ImpersonatedUser(auth_manager.mass, standard_user_a.user_id):
         assert get_current_user() == standard_user_a
+    # passing None is a no-op which preserves any active impersonation
+    set_impersonated_user(standard_user_b)
+    async with ImpersonatedUser(auth_manager.mass, None):
+        assert get_current_user() == standard_user_b
     assert get_current_user() == standard_user_b
 
-    # verify, that an admin user may impersonate another user
+    # verify that an admin user may impersonate another user
     set_current_user(admin_user)
 
     set_impersonated_user(None)  # non-nested use
@@ -1471,16 +1474,13 @@ async def test_impersonated_user_context_manager(auth_manager: AuthenticationMan
         assert get_current_user() == standard_user_a
     assert get_current_user() == standard_user_b
 
-    # verify, that an admin user not attempting impersonation is treated normally
-    set_current_user(admin_user)
+    # verify that a service user may impersonate another user (users.impersonate scope)
+    set_current_user(service_user)
     set_impersonated_user(None)
-    assert get_current_user() == admin_user
-    async with ImpersonatedUser(auth_manager.mass, "admin"):
-        assert get_current_user() == admin_user
-    assert get_current_user() == admin_user
-    async with ImpersonatedUser(auth_manager.mass, None):
-        assert get_current_user() == admin_user
-    assert get_current_user() == admin_user
+    assert has_scope(service_user, Scope.USERS_IMPERSONATE)
+    async with ImpersonatedUser(auth_manager.mass, "user_a"):
+        assert get_current_user() == standard_user_a
+    assert get_current_user() == service_user
 
 
 async def test_impersonated_user_anonymous_playback_is_noop(
@@ -1576,3 +1576,81 @@ async def test_exchange_join_code_success_does_not_reset_rate_limit(
     result = await auth_manager.exchange_join_code(code)
     assert result["success"] is False
     assert "too many" in result["error"].lower()
+
+
+async def test_resolve_command_impersonation(auth_manager: AuthenticationManager) -> None:
+    """Test resolving the impersonation argument of an incoming API command."""
+    admin_user = await auth_manager.create_user(username="admin", role=UserRole.ADMIN)
+    standard_user = await auth_manager.create_user(username="user_a", role=UserRole.USER)
+    set_current_user(admin_user)
+    set_impersonated_user(None)
+
+    # no user argument present is a no-op and leaves other args untouched
+    args: dict[str, object] = {"queue_id": "abc"}
+    assert await resolve_command_impersonation(auth_manager.mass, args) is None
+    assert args == {"queue_id": "abc"}
+
+    # the user argument is popped and resolved (by username)
+    args = {"queue_id": "abc", "user": "user_a"}
+    resolved = await resolve_command_impersonation(auth_manager.mass, args)
+    assert resolved == standard_user
+    assert args == {"queue_id": "abc"}
+
+    # the user argument is also resolved by user_id
+    args = {"user": standard_user.user_id}
+    resolved = await resolve_command_impersonation(auth_manager.mass, args)
+    assert resolved == standard_user
+
+    # username is accepted as (deprecated) alias for user
+    args = {"username": "user_a"}
+    resolved = await resolve_command_impersonation(auth_manager.mass, args)
+    assert resolved == standard_user
+    assert args == {}
+
+    # a caller without the users.impersonate scope may not impersonate another user
+    set_current_user(standard_user)
+    with pytest.raises(InsufficientPermissions):
+        await resolve_command_impersonation(auth_manager.mass, {"user": "admin"})
+
+
+def test_has_scope() -> None:
+    """Test the scope check for each of the builtin user roles."""
+
+    def _user(role: str) -> User:
+        return User(user_id="abc123", username="testuser", role=role)
+
+    # admin has all scopes through the wildcard
+    assert has_scope(_user(UserRole.ADMIN), Scope.CONFIG_CORE_WRITE)
+    assert has_scope(_user(UserRole.ADMIN), Scope.LIBRARY_MANAGE)
+    # regular user
+    assert has_scope(_user(UserRole.USER), Scope.LIBRARY_WRITE)
+    assert has_scope(_user(UserRole.USER), Scope.CONFIG_CORE_READ)
+    assert not has_scope(_user(UserRole.USER), Scope.CONFIG_CORE_WRITE)
+    assert not has_scope(_user(UserRole.USER), Scope.USERS_IMPERSONATE)
+    # guest
+    assert has_scope(_user(UserRole.GUEST), Scope.LIBRARY_READ)
+    assert not has_scope(_user(UserRole.GUEST), Scope.LIBRARY_WRITE)
+    assert not has_scope(_user(UserRole.GUEST), Scope.CONFIG_CORE_READ)
+    # service
+    assert has_scope(_user(UserRole.SERVICE), Scope.USERS_IMPERSONATE)
+    assert has_scope(_user(UserRole.SERVICE), Scope.CONFIG_PLAYERS_WRITE)
+    assert not has_scope(_user(UserRole.SERVICE), Scope.CONFIG_CORE_WRITE)
+    # an unknown (custom) role id is fail-closed and grants no scopes at all
+    assert not has_scope(_user("some_future_role"), Scope.LIBRARY_READ)
+
+
+async def test_homeassistant_system_user_has_service_role(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """Test that the Home Assistant system user is created with the service role."""
+    system_user = await auth_manager.get_homeassistant_system_user()
+    assert system_user.role == UserRole.SERVICE
+
+    # a pre-existing system user with the old user role is migrated to service
+    await auth_manager.database.update(
+        "users", {"user_id": system_user.user_id}, {"role": UserRole.USER.value}
+    )
+    await auth_manager._migrate_system_user_role()
+    migrated_user = await auth_manager.get_user(system_user.user_id)
+    assert migrated_user is not None
+    assert migrated_user.role == UserRole.SERVICE

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -1590,6 +1590,12 @@ async def test_resolve_command_impersonation(auth_manager: AuthenticationManager
     assert await resolve_command_impersonation(auth_manager.mass, args) is None
     assert args == {"queue_id": "abc"}
 
+    # an empty string is deliberately treated as "no impersonation requested"
+    # (optional fields in automations/scripts commonly template to an empty string)
+    args = {"queue_id": "abc", "user": ""}
+    assert await resolve_command_impersonation(auth_manager.mass, args) is None
+    assert args == {"queue_id": "abc"}
+
     # the user argument is popped and resolved (by username)
     args = {"queue_id": "abc", "user": "user_a"}
     resolved = await resolve_command_impersonation(auth_manager.mass, args)


### PR DESCRIPTION
# What does this implement/fix?

API command authorization was limited to a static admin/user role check, which caused several problems: the auto-generated Home Assistant system user (role `user`) could not impersonate users for playback/library attribution nor remove players, `required_role="user"` was never actually enforced (a guest was treated identical to a user, security finding 3.1) and adding per-user impersonation required repetitive `username` arguments and `ImpersonatedUser` wrappers on every method.

This replaces the static role checks with fine grained, scope based authorization and centralizes impersonation in the command dispatch. A role is nothing more than a predefined bundle of scopes assigned to a user.

- every API command now declares a `required_scope` (e.g. `library.write`, `config.players.write`) instead of `required_role`; enforcement happens centrally in both the WebSocket and HTTP dispatch
- the role -> scope bundles for the builtin roles live in the server (`ROLE_SCOPES`), an unknown role id is fail-closed and grants no scopes at all (prepares for custom roles later)
- new `allow_impersonation` flag on `api_command`: the dispatch accepts an optional `user` argument (user_id or username, `username` kept as deprecated alias), validates it against the `users.impersonate` scope and sets the impersonation context around the handler — the per-method `username` arguments and `ImpersonatedUser` wrappers are removed (play_media, item_by_name, verify_item_uri, search, library_items)
- the Home Assistant system user now gets the new builtin `service` role (regular user + `users.impersonate` + `config.players.write`), fixing impersonation from the HA integration and the "insufficient rights" error when removing players from HA; existing installs are migrated on startup
- guests are now restricted to their intended access level: no library edits, no core/provider config reads (they keep everything the party/guest frontend uses)
- metadata edits, provider mappings, refresh and sync now require `library.manage` (admin)
- new `auth/scopes` command exposes the role -> scope mapping to clients; API docs list `required_scope` and the injected `user` argument

Supersedes #4555 and folds in #4592 (both covered by the central mechanism).

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked: music-assistant/models#289
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.

---

Draft until music-assistant/models#289 is merged and released; the models dependency bump follows on this branch afterwards.
