### PR TITLE
Cache negative results in @use_cache and avoid the SWR double read

### DIFF
--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -123,31 +123,68 @@ class CacheController(CoreController):
         :param allow_bypass: Whether to respect the BYPASS_CACHE context variable.
         :param base_class: If provided, reconstruct data using base_class.from_dict().
         :param allow_expired_cache: If True, also return entries past their expiration
-            time instead of treating them as cache misses. Used by the
-            stale-while-revalidate path of `@use_cache`.
+            time instead of treating them as cache misses.
+        """
+        data, _, found = await self.get_with_freshness(
+            key,
+            provider=provider,
+            category=category,
+            checksum=checksum,
+            allow_bypass=allow_bypass,
+            base_class=base_class,
+            include_expired=allow_expired_cache,
+        )
+        return data if found else default
+
+    async def get_with_freshness(
+        self,
+        key: str,
+        provider: str = "default",
+        category: int = 0,
+        checksum: str | int | None = None,
+        allow_bypass: bool | None = None,
+        base_class: Any = None,
+        include_expired: bool = False,
+    ) -> tuple[Any, bool, bool]:
+        """
+        Get data from cache together with the freshness and presence of the entry.
+
+        Returns a (data, is_fresh, found) tuple. found is False when there is no usable
+        entry, in which case data is None; is_fresh is False when the entry is expired.
+        Because a stored None value is returned as-is, use the found flag to tell a cache
+        miss from a cached None.
+
+        :param key: The (unique) lookup key of the cache object.
+        :param provider: Provider id to group cache objects.
+        :param category: Category to group cache objects.
+        :param checksum: If provided, only return data if the stored checksum matches.
+        :param allow_bypass: Whether to respect the BYPASS_CACHE context variable.
+        :param base_class: If provided, reconstruct data using base_class.from_dict().
+        :param include_expired: If False (default), an expired entry is reported as not found
+            and is not deserialized; set True to also return expired entries as stale data.
         """
         assert self.database is not None
         assert key, "No key provided"
         if allow_bypass and BYPASS_CACHE.get():
-            return default
+            return None, False, False
         cur_time = int(time.time())
         if checksum is not None and not isinstance(checksum, str):
             checksum = str(checksum)
         if (
-            (
-                db_row := await self.database.get_row(
-                    DB_TABLE_CACHE, {"category": category, "provider": provider, "key": key}
-                )
+            db_row := await self.database.get_row(
+                DB_TABLE_CACHE, {"category": category, "provider": provider, "key": key}
             )
-            and (db_row["expires"] >= cur_time or allow_expired_cache)
-            and (not checksum or db_row["checksum"] == checksum)
-        ):
+        ) and (not checksum or db_row["checksum"] == checksum):
             # if allow_bypass is not explicitly set,
             # determine it based on the 'persistent' flag of the cache entry
             if allow_bypass is None:
                 allow_bypass = not bool(db_row["persistent"])
             if allow_bypass and BYPASS_CACHE.get():
-                return default
+                return None, False, False
+            is_fresh = bool(db_row["expires"] >= cur_time)
+            # skip deserialization for an expired entry the caller will not use
+            if not is_fresh and not include_expired:
+                return None, False, False
             try:
                 data = await async_json_loads(db_row["data"])
             except Exception as exc:
@@ -162,10 +199,10 @@ class CacheController(CoreController):
             else:
                 if base_class is not None and data is not None:
                     if isinstance(data, list):
-                        return [base_class.from_dict(item) for item in data]
-                    return base_class.from_dict(data)
-                return data
-        return default
+                        return [base_class.from_dict(item) for item in data], is_fresh, True
+                    return base_class.from_dict(data), is_fresh, True
+                return data, is_fresh, True
+        return None, False, False
 
     async def set(
         self,

--- a/music_assistant/controllers/cache/helpers.py
+++ b/music_assistant/controllers/cache/helpers.py
@@ -49,6 +49,7 @@ def use_cache(
     allow_bypass: bool | None = None,
     base_class: Any = None,
     allow_expired_cache: bool = False,
+    cache_none: bool = True,
 ) -> Callable[
     [Callable[Concatenate[ProviderT, P], Awaitable[R]]],
     Callable[Concatenate[ProviderT, P], Coroutine[Any, Any, R]],
@@ -68,6 +69,10 @@ def use_cache(
         entry has expired, return it immediately and trigger a background refresh that
         re-runs the wrapped function and updates the cache. Expired entries also
         survive the cache auto-cleanup task so they remain available as fallback data.
+    :param cache_none: Whether a None result is cached and served like any other value
+        (a negative hit, e.g. "no lyrics exist for this track"). Set to False for
+        methods where None signals a (transient) failure, so the call is retried on
+        the next invocation instead of serving a cached None.
     """
     if allow_bypass is None:
         allow_bypass = not persistent
@@ -104,52 +109,51 @@ def use_cache(
                     allow_expired_cache=allow_expired_cache,
                 )
 
-            # try the fresh-only lookup first
-            cachedata = await cache.get(
+            # single lookup that returns the entry, its freshness and whether it was found;
+            # found distinguishes a stored None (a negative hit) from a cache miss. expired
+            # entries are only read (and deserialized) when this call serves stale data
+            cachedata, is_fresh, found = await cache.get_with_freshness(
                 cache_key,
                 provider=provider_id,
                 checksum=cache_checksum,
                 category=category,
                 allow_bypass=allow_bypass,
                 base_class=base_class,
+                include_expired=allow_expired_cache,
             )
-            if cachedata is not None:
+            # a found value counts as a hit, except a None that this call opted out of
+            # caching (cache_none=False) which is treated as a miss and re-fetched
+            cache_hit = found and (cache_none or cachedata is not None)
+
+            if cache_hit and is_fresh:
                 return _reconstruct(cachedata)
 
-            if allow_expired_cache:
-                # nothing fresh; try again accepting expired entries
-                cachedata = await cache.get(
-                    cache_key,
-                    provider=provider_id,
-                    checksum=cache_checksum,
-                    category=category,
-                    allow_bypass=allow_bypass,
-                    base_class=base_class,
-                    allow_expired_cache=True,
-                )
-                if cachedata is not None:
-                    # serve stale data and refresh in the background;
-                    # task_id deduplicates concurrent refreshes for the same entry
-                    async def _background_refresh() -> None:
-                        try:
-                            result = await func(self, *args, **kwargs)
+            if cache_hit and allow_expired_cache:
+                # serve stale data and refresh in the background;
+                # task_id deduplicates concurrent refreshes for the same entry
+                async def _background_refresh() -> None:
+                    try:
+                        result = await func(self, *args, **kwargs)
+                        if cache_none or result is not None:
                             await _store_task(result)
-                        except Exception:
-                            LOGGER.exception(
-                                "Background cache refresh failed for %s/%s",
-                                provider_id,
-                                cache_key,
-                            )
+                    except Exception:
+                        LOGGER.exception(
+                            "Background cache refresh failed for %s/%s",
+                            provider_id,
+                            cache_key,
+                        )
 
-                    self.mass.create_task(
-                        _background_refresh(),
-                        task_id=f"cache_refresh.{provider_id}.{cache_key}",
-                    )
-                    return _reconstruct(cachedata)
+                self.mass.create_task(
+                    _background_refresh(),
+                    task_id=f"cache_refresh.{provider_id}.{cache_key}",
+                )
+                return _reconstruct(cachedata)
 
-            # cache miss: fetch synchronously, store in background
+            # cache miss (or expired entry without stale-while-revalidate):
+            # fetch synchronously, store in background
             result = await func(self, *args, **kwargs)
-            self.mass.create_task(_store_task(result))
+            if cache_none or result is not None:
+                self.mass.create_task(_store_task(result))
             return result
 
         return wrapper

--- a/music_assistant/providers/acoustid_lookup/provider.py
+++ b/music_assistant/providers/acoustid_lookup/provider.py
@@ -515,7 +515,8 @@ class AcoustidLookupProvider(AudioAnalysisProvider):
             media_type=streamdetails.media_type,
         )
 
-    @use_cache(ACOUSTID_LOOKUP_CACHE_TTL)
+    # None can signal an auth/bad-request failure as well as "no match", so don't cache it
+    @use_cache(ACOUSTID_LOOKUP_CACHE_TTL, cache_none=False)
     @throttle_with_retries
     async def _lookup(self, api_key: str, fingerprint: str, duration: int) -> dict[str, Any] | None:
         """

--- a/music_assistant/providers/coverartarchive/__init__.py
+++ b/music_assistant/providers/coverartarchive/__init__.py
@@ -88,7 +88,8 @@ class CoverArtArchiveMetadataProvider(MetadataProvider):
             )
         )
 
-    @use_cache(86400 * 30)
+    # None can signal a network failure as well as "no cover art", so don't cache it
+    @use_cache(86400 * 30, cache_none=False)
     async def _get_cover_art_url(self, release_group_id: str) -> str | None:
         """
         Retrieve cover art URL for a release group.

--- a/music_assistant/providers/fanarttv/__init__.py
+++ b/music_assistant/providers/fanarttv/__init__.py
@@ -181,7 +181,8 @@ class FanartTvMetadataProvider(MetadataProvider):
                     return metadata
         return None
 
-    @use_cache(86400 * 60)  # Cache for 60 days
+    # None here only signals a failed or rate-limited request, so don't cache it
+    @use_cache(86400 * 60, cache_none=False)  # Cache for 60 days
     async def _get_data(self, endpoint: str, **kwargs: str) -> dict[str, Any] | None:
         """Get data from api."""
         url = f"http://webservice.fanart.tv/v3/{endpoint}"

--- a/music_assistant/providers/itunes_artwork/__init__.py
+++ b/music_assistant/providers/itunes_artwork/__init__.py
@@ -92,7 +92,8 @@ class ITunesArtworkMetadataProvider(MetadataProvider):
             )
         )
 
-    @use_cache(86400 * 30)
+    # None can signal a network failure as well as "no artwork", so don't cache it
+    @use_cache(86400 * 30, cache_none=False)
     async def _get_artwork_url(self, barcode: str) -> str | None:
         """
         Look up album artwork URL from iTunes by UPC barcode.

--- a/music_assistant/providers/lrclib/__init__.py
+++ b/music_assistant/providers/lrclib/__init__.py
@@ -152,7 +152,8 @@ class LrclibProvider(MetadataProvider):
             )
         return None
 
-    @use_cache(3600 * 24 * 14)  # Cache for 14 days
+    # None can signal a fetch/parse failure as well as "no lyrics", so don't cache it
+    @use_cache(3600 * 24 * 14, cache_none=False)  # Cache for 14 days
     @throttle_with_retries
     async def _get_data(self, **params: Any) -> dict[str, Any] | None:
         """Get data from LRCLib API with throttling and retries."""

--- a/music_assistant/providers/theaudiodb/__init__.py
+++ b/music_assistant/providers/theaudiodb/__init__.py
@@ -428,7 +428,8 @@ class AudioDbMetadataProvider(MetadataProvider):
             return value, "en"
         return None, None
 
-    @use_cache(86400 * 90, persistent=True)  # Cache for 90 days
+    # None here only signals a failed request (a miss still returns a body), so don't cache it
+    @use_cache(86400 * 90, persistent=True, cache_none=False)  # Cache for 90 days
     async def _get_data(self, endpoint: str, **kwargs: Any) -> dict[str, Any] | None:
         """Get data from api."""
         url = f"https://theaudiodb.com/api/v1/json/{app_var('theaudiodb_api_key')}/{endpoint}"

--- a/music_assistant/providers/wikipedia/__init__.py
+++ b/music_assistant/providers/wikipedia/__init__.py
@@ -143,7 +143,8 @@ class WikipediaMetadataProvider(MetadataProvider):
                 result[lang] = title
         return result
 
-    @use_cache(86400 * 90, persistent=True)
+    # None can signal a fetch failure as well as a missing bio, so don't cache it
+    @use_cache(86400 * 90, persistent=True, cache_none=False)
     async def _fetch_bio(self, lang: str, title: str) -> str | None:
         """
         Return the plain-text lead section of a Wikipedia article.

--- a/tests/controllers/cache/test_helpers.py
+++ b/tests/controllers/cache/test_helpers.py
@@ -1,0 +1,207 @@
+"""Tests for the @use_cache decorator."""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from music_assistant.constants import DB_TABLE_CACHE
+from music_assistant.controllers.cache import CacheController
+from music_assistant.controllers.cache.helpers import use_cache
+from music_assistant.mass import MusicAssistant
+
+_PROVIDER = "test_cache_helpers"
+
+
+class _FakeProvider:
+    """Minimal object that satisfies the @use_cache protocol."""
+
+    domain = _PROVIDER
+
+    def __init__(self, mass: MusicAssistant) -> None:
+        self.mass = mass
+        self.calls = 0
+        self.result: str | None = None
+
+    @use_cache(3600)
+    async def fetch(self, item_id: str) -> str | None:
+        """Return the preset result, counting invocations."""
+        self.calls += 1
+        return self.result
+
+    @use_cache(3600, cache_none=False)
+    async def fetch_no_none(self, item_id: str) -> str | None:
+        """Return the preset result, counting invocations."""
+        self.calls += 1
+        return self.result
+
+    @use_cache(3600, allow_expired_cache=True)
+    async def fetch_swr(self, item_id: str) -> str | None:
+        """Return the preset result, counting invocations."""
+        self.calls += 1
+        return self.result
+
+
+@pytest.fixture
+async def cache(mass_minimal: MusicAssistant) -> CacheController:
+    """Return an initialized cache controller."""
+    await mass_minimal.cache._setup_database()
+    return mass_minimal.cache
+
+
+@pytest.fixture
+def provider(cache: CacheController) -> _FakeProvider:
+    """Return a fake provider with @use_cache decorated methods."""
+    return _FakeProvider(cache.mass)
+
+
+async def _get_row(cache: CacheController, key: str) -> Any:
+    """Return the raw cache db row for the given key."""
+    assert cache.database is not None
+    return await cache.database.get_row(
+        DB_TABLE_CACHE, {"category": 0, "provider": _PROVIDER, "key": key}
+    )
+
+
+async def _wait_for_stored(cache: CacheController, key: str) -> None:
+    """Wait until the background store task has written the cache row."""
+    for _ in range(200):
+        if await _get_row(cache, key):
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail(f"cache row for {key} was never written")
+
+
+async def _wait_for(condition: Callable[[], Awaitable[bool]]) -> None:
+    """Wait until the given (async) condition callable returns True."""
+    for _ in range(200):
+        if await condition():
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail("condition was never met")
+
+
+# --- result caching (including None results) ---
+
+
+async def test_result_served_from_cache(cache: CacheController, provider: _FakeProvider) -> None:
+    """Test that a second call is served from cache without re-invoking the function."""
+    provider.result = "value"
+    assert await provider.fetch("a") == "value"
+    assert provider.calls == 1
+    await _wait_for_stored(cache, "fetch.a")
+    provider.result = "changed"
+    assert await provider.fetch("a") == "value"
+    assert provider.calls == 1
+
+
+async def test_none_result_cached_and_served(
+    cache: CacheController, provider: _FakeProvider
+) -> None:
+    """Test that a None result is cached and served without re-invoking the function."""
+    provider.result = None
+    assert await provider.fetch("a") is None
+    assert provider.calls == 1
+    await _wait_for_stored(cache, "fetch.a")
+    assert await provider.fetch("a") is None
+    assert provider.calls == 1
+
+
+async def test_cache_none_false_retries_and_skips_store(
+    cache: CacheController, provider: _FakeProvider
+) -> None:
+    """Test that cache_none=False re-invokes on None and does not store the None result."""
+    provider.result = None
+    assert await provider.fetch_no_none("a") is None
+    assert provider.calls == 1
+    # give a (wrongly created) store task time to run, then verify nothing was written
+    await asyncio.sleep(0.05)
+    assert await _get_row(cache, "fetch_no_none.a") is None
+    assert await provider.fetch_no_none("a") is None
+    assert provider.calls == 2
+    # once the function returns a real value, it is cached again
+    provider.result = "found"
+    assert await provider.fetch_no_none("a") == "found"
+    assert provider.calls == 3
+    await _wait_for_stored(cache, "fetch_no_none.a")
+    assert await provider.fetch_no_none("a") == "found"
+    assert provider.calls == 3
+
+
+async def test_cache_none_false_ignores_stored_none(
+    cache: CacheController, provider: _FakeProvider
+) -> None:
+    """Test that cache_none=False treats a previously stored None row as a cache miss."""
+    await cache.set("fetch_no_none.a", None, provider=_PROVIDER)
+    provider.result = "fresh"
+    assert await provider.fetch_no_none("a") == "fresh"
+    assert provider.calls == 1
+
+
+# --- stale-while-revalidate ---
+
+
+async def test_swr_serves_stale_and_refreshes(
+    cache: CacheController, provider: _FakeProvider
+) -> None:
+    """Test that an expired entry is served immediately and refreshed in the background."""
+    await cache.set(
+        "fetch_swr.a", "stale", provider=_PROVIDER, expiration=-1, allow_expired_cache=True
+    )
+    provider.result = "fresh"
+    assert await provider.fetch_swr("a") == "stale"
+
+    async def _refreshed() -> bool:
+        return bool(await cache.get("fetch_swr.a", provider=_PROVIDER) == "fresh")
+
+    await _wait_for(_refreshed)
+    assert provider.calls == 1
+    assert await provider.fetch_swr("a") == "fresh"
+    assert provider.calls == 1
+
+
+async def test_wrapper_performs_single_row_fetch(
+    cache: CacheController, provider: _FakeProvider
+) -> None:
+    """Test that one wrapper call does exactly one db row fetch (miss, fresh and stale)."""
+    assert cache.database is not None
+    # cache miss
+    provider.result = "value"
+    with patch.object(cache.database, "get_row", wraps=cache.database.get_row) as spy:
+        assert await provider.fetch_swr("a") == "value"
+    assert spy.await_count == 1
+    # fresh hit
+    await _wait_for_stored(cache, "fetch_swr.a")
+    with patch.object(cache.database, "get_row", wraps=cache.database.get_row) as spy:
+        assert await provider.fetch_swr("a") == "value"
+    assert spy.await_count == 1
+    # stale hit (previously fetched the same row twice)
+    await cache.set(
+        "fetch_swr.b", "stale", provider=_PROVIDER, expiration=-1, allow_expired_cache=True
+    )
+    with patch.object(cache.database, "get_row", wraps=cache.database.get_row) as spy:
+        assert await provider.fetch_swr("b") == "stale"
+    assert spy.await_count == 1
+
+
+# --- get_with_freshness ---
+
+
+async def test_get_with_freshness(cache: CacheController) -> None:
+    """Test that get_with_freshness reports the freshness and presence of entries."""
+    await cache.set("fresh", "data", provider=_PROVIDER, expiration=3600)
+    assert await cache.get_with_freshness("fresh", provider=_PROVIDER) == ("data", True, True)
+    await cache.set("expired", "old", provider=_PROVIDER, expiration=-1)
+    # an expired entry is reported as not found unless include_expired is set
+    assert await cache.get_with_freshness("expired", provider=_PROVIDER) == (None, False, False)
+    assert await cache.get_with_freshness("expired", provider=_PROVIDER, include_expired=True) == (
+        "old",
+        False,
+        True,
+    )
+    data, is_fresh, found = await cache.get_with_freshness("missing", provider=_PROVIDER)
+    assert found is False
+    assert is_fresh is False
+    assert data is None

--- a/tests/providers/apple_music/test_parsers.py
+++ b/tests/providers/apple_music/test_parsers.py
@@ -29,6 +29,7 @@ def _create_provider_mock() -> MagicMock:
     provider.logger = MagicMock()
     provider._storefront = "us"
     provider.mass.cache.get = AsyncMock(return_value=None)
+    provider.mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     provider.mass.cache.set = AsyncMock()
     return provider
 

--- a/tests/providers/apple_music/test_similar_artists.py
+++ b/tests/providers/apple_music/test_similar_artists.py
@@ -58,6 +58,7 @@ def manager(mock_api: MagicMock) -> AppleMusicRecommendationManager:
     provider._storefront = "us"
     provider.logger = MagicMock()
     provider.mass.cache.get = AsyncMock(return_value=None)
+    provider.mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     provider.mass.cache.set = AsyncMock()
     provider.api_client = mock_api
 

--- a/tests/providers/bandcamp/test_provider.py
+++ b/tests/providers/bandcamp/test_provider.py
@@ -63,6 +63,7 @@ def mass_mock() -> Mock:
     mass.http_session = AsyncMock()
     mass.metadata.locale = "en_US"
     mass.cache.get = AsyncMock(return_value=None)
+    mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     mass.cache.set = AsyncMock()
     mass.cache.delete = AsyncMock()
     return mass

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -1030,7 +1030,7 @@ async def test_get_playlist_tracks_dynamic_cold_evaluates_and_caches(tmp_path: A
     """On a fully-cold cache the sample is evaluated and a store task is scheduled."""
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
-    mass.cache.get = AsyncMock(return_value=None)
+    mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     mass.cache.set = AsyncMock()
     mass.create_task = MagicMock(side_effect=_swallow_task)
     manifest = MagicMock()
@@ -1061,7 +1061,7 @@ async def test_get_playlist_tracks_dynamic_returns_fresh_cache(tmp_path: Any) ->
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
     cached = [_make_mock_track(str(i), f"library://track/cached-{i}") for i in range(3)]
-    mass.cache.get = AsyncMock(return_value=cached)
+    mass.cache.get_with_freshness = AsyncMock(return_value=(cached, True, True))
     mass.cache.set = AsyncMock()
     mass.create_task = MagicMock()
     manifest = MagicMock()
@@ -1078,8 +1078,8 @@ async def test_get_playlist_tracks_dynamic_returns_fresh_cache(tmp_path: Any) ->
     result = await plugin.get_playlist_tracks("abc")
     assert result == cached
     evaluate_mock.assert_not_awaited()
-    # Only the fresh lookup runs; no stale lookup, no scheduled refresh.
-    mass.cache.get.assert_awaited_once()
+    # A single freshness lookup runs; no scheduled refresh.
+    mass.cache.get_with_freshness.assert_awaited_once()
     mass.create_task.assert_not_called()
 
 
@@ -1089,8 +1089,8 @@ async def test_get_playlist_tracks_dynamic_serves_stale_and_refreshes(tmp_path: 
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
     stale = [_make_mock_track(str(i), f"library://track/stale-{i}") for i in range(3)]
-    # First (fresh) lookup misses, second (stale-allowed) lookup returns the expired entry.
-    mass.cache.get = AsyncMock(side_effect=[None, stale])
+    # The single freshness lookup returns the expired entry (a stale hit).
+    mass.cache.get_with_freshness = AsyncMock(return_value=(stale, False, True))
     mass.cache.set = AsyncMock()
     mass.create_task = MagicMock(side_effect=_swallow_task)
     manifest = MagicMock()

--- a/tests/providers/sonic_similarity/conftest.py
+++ b/tests/providers/sonic_similarity/conftest.py
@@ -53,9 +53,10 @@ def mock_mass(tmp_path: Path) -> MagicMock:
     mass = MagicMock()
     mass.storage_path = str(tmp_path)
     mass.cache = MagicMock()
-    # @use_cache on recommendations() awaits cache.get; return a miss so the
+    # @use_cache on recommendations() awaits cache.get_with_freshness; return a miss so the
     # wrapped method runs. cache.set is fire-and-forget via create_task (mocked).
     mass.cache.get = AsyncMock(return_value=None)
+    mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     mass.create_task = MagicMock()  # fire-and-forget; we assert it was called
     mass.get_provider = MagicMock(return_value=None)
 

--- a/tests/providers/spotify/test_browse.py
+++ b/tests/providers/spotify/test_browse.py
@@ -65,6 +65,7 @@ def provider(get_data: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> SpotifyPro
     mass.metadata.locale = "de_DE"
     # bypass the use_cache decorator: always miss, swallow the background store task
     mass.cache.get = AsyncMock(return_value=None)
+    mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     mass.cache.set = AsyncMock()
     mass.create_task = MagicMock(side_effect=lambda coro, **_: coro.close())
     prov.mass = mass

--- a/tests/providers/tidal/test_provider.py
+++ b/tests/providers/tidal/test_provider.py
@@ -19,6 +19,7 @@ def mass_mock() -> Mock:
     mass.http_session = AsyncMock()
     mass.metadata.locale = "en_US"
     mass.cache.get = AsyncMock(return_value=None)
+    mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     mass.cache.set = AsyncMock()
     mass.cache.delete = AsyncMock()
     return mass

--- a/tests/providers/yandex_music/test_recommendations.py
+++ b/tests/providers/yandex_music/test_recommendations.py
@@ -52,6 +52,7 @@ def provider_mock() -> Mock:
     provider.mass.metadata.locale = "en_US"
     provider.mass.cache = AsyncMock()
     provider.mass.cache.get = AsyncMock(return_value=None)  # Cache always misses
+    provider.mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     provider.mass.cache.set = AsyncMock()
 
     # Mix recommendation folders look up a tag's English label via _media_label; stub it to

--- a/tests/providers/yandex_music/test_search_audiobooks.py
+++ b/tests/providers/yandex_music/test_search_audiobooks.py
@@ -57,6 +57,7 @@ def provider_mock() -> Mock:
     provider.mass = Mock()
     provider.mass.cache = AsyncMock()
     provider.mass.cache.get = AsyncMock(return_value=None)
+    provider.mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
     provider.mass.cache.set = AsyncMock()
     return provider
 


### PR DESCRIPTION
## Problem

The `@use_cache` wrapper treated a stored `None` as a cache miss, so decorated methods that legitimately return "nothing found" (lyrics, artwork, bios, recommendations) re-fetched every negative result from the network on every access — behind 1 req/s throttlers — and rewrote the `null` row each time. On large libraries the negative results are the majority, so the cache was defeated exactly where it matters most. The stale-while-revalidate path also read the same database row twice per lookup.

## Changes

- A cached `None` is now a real (negative) cache hit. The wrapper does a single `cache.get_with_freshness()` lookup that returns `(data, is_fresh, found)`, so a stored `None` is distinguished from a miss and the stale-while-revalidate path no longer does a second identical read.
- New `cache_none` flag on `@use_cache` (default `True`) to opt out where `None` signals a fetch failure rather than a genuine miss — applied to theaudiodb, fanart.tv, wikipedia, lrclib, coverartarchive, itunes_artwork and acoustid after auditing every method with a top-level `X | None` return. All other negative-returning methods (errors propagate there instead of collapsing to `None`) now cache their negatives.
- `cache.get()` keeps its existing behaviour and delegates to `get_with_freshness()`.
