### PR TITLE
Slim cache indexes, upsert in place, and clean up stale SWR rows

### DIFF
--- a/music_assistant/controllers/cache/constants.py
+++ b/music_assistant/controllers/cache/constants.py
@@ -11,9 +11,13 @@ from music_assistant.constants import MASS_LOGGER_NAME
 LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.cache")
 CONF_CLEAR_CACHE = "clear_cache"
 DEFAULT_CACHE_EXPIRATION = 86400 * 30  # 30 days
-DB_SCHEMA_VERSION = 8
+DB_SCHEMA_VERSION = 9
 MAX_CACHE_DB_SIZE_MB = 2048
 CACHE_DATABASE_CLEANUP_TASK_ID = "cache_database_cleanup"
+# stale-while-revalidate fallback rows are kept past their expiration so they can still be
+# served while a refresh runs; the cleanup task removes those not refreshed within this window
+# (their key is no longer requested) to keep the cache from growing without bound.
+SWR_FALLBACK_MAX_AGE = 86400 * 90  # 90 days
 
 BYPASS_CACHE: ContextVar[bool] = ContextVar("BYPASS_CACHE", default=False)
 

--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -27,6 +27,7 @@ from music_assistant.controllers.cache.constants import (
     DEFAULT_CACHE_EXPIRATION,
     LOGGER,
     MAX_CACHE_DB_SIZE_MB,
+    SWR_FALLBACK_MAX_AGE,
     SerializableType,
 )
 from music_assistant.controllers.tasks.context import (
@@ -205,7 +206,9 @@ class CacheController(CoreController):
         # always serialize to JSON to ensure data is serializable
         # this raises if the data contains non-serializable objects
         data = await asyncio.to_thread(json_dumps, data)
-        await self.database.insert_or_replace(
+        # upsert (update in place on the UNIQUE(category, key, provider) conflict) instead of
+        # INSERT OR REPLACE, which deletes and re-inserts the row and so rewrites every index
+        await self.database.upsert(
             DB_TABLE_CACHE,
             {
                 "category": category,
@@ -262,11 +265,15 @@ class CacheController(CoreController):
         self.logger.debug("Running automatic cleanup...")
         update_current_task_progress_text("Removing expired cache records")
         cur_timestamp = int(time.time())
-        # clean up db cache object only if expired; entries marked with
-        # allow_expired_cache are kept as fallback for stale-while-revalidate
+        # remove expired entries; allow_expired_cache entries are kept as stale-while-revalidate
+        # fallback, but only until they are expired beyond SWR_FALLBACK_MAX_AGE - past that their
+        # key is clearly no longer requested and the row would otherwise live forever
+        swr_cutoff = cur_timestamp - SWR_FALLBACK_MAX_AGE
         cursor = await self.database.execute(
-            f"DELETE FROM {DB_TABLE_CACHE} WHERE expires < :timestamp AND allow_expired_cache = 0",
-            {"timestamp": cur_timestamp},
+            f"DELETE FROM {DB_TABLE_CACHE} WHERE "
+            "(expires < :timestamp AND allow_expired_cache = 0) "
+            "OR (expires < :swr_cutoff AND allow_expired_cache = 1)",
+            {"timestamp": cur_timestamp, "swr_cutoff": swr_cutoff},
         )
         await self.database.commit()
         cleaned_records = cursor.rowcount
@@ -388,29 +395,11 @@ class CacheController(CoreController):
     async def __create_database_indexes(self) -> None:
         """Create database indexes."""
         assert self.database is not None
-        await self.database.execute(
-            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_CACHE}_category_idx "
-            f"ON {DB_TABLE_CACHE}(category);"
-        )
-        await self.database.execute(
-            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_CACHE}_key_idx ON {DB_TABLE_CACHE}(key);"
-        )
-        await self.database.execute(
-            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_CACHE}_provider_idx "
-            f"ON {DB_TABLE_CACHE}(provider);"
-        )
-        await self.database.execute(
-            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_CACHE}_category_key_idx "
-            f"ON {DB_TABLE_CACHE}(category,key);"
-        )
-        await self.database.execute(
-            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_CACHE}_category_provider_idx "
-            f"ON {DB_TABLE_CACHE}(category,provider);"
-        )
-        await self.database.execute(
-            f"CREATE INDEX IF NOT EXISTS {DB_TABLE_CACHE}_category_key_provider_idx "
-            f"ON {DB_TABLE_CACHE}(category,key,provider);"
-        )
+        # The UNIQUE(category, key, provider) constraint already provides an index that serves
+        # every point lookup (get() matches exactly those three columns) and any delete that
+        # includes the category. The only access pattern its column order cannot serve is a
+        # delete that filters by (key, provider) without a category, so that is the single
+        # secondary index kept here.
         await self.database.execute(
             f"CREATE INDEX IF NOT EXISTS {DB_TABLE_CACHE}_key_provider_idx "
             f"ON {DB_TABLE_CACHE}(key,provider);"
@@ -428,6 +417,20 @@ class CacheController(CoreController):
                 f"ALTER TABLE {DB_TABLE_CACHE} "
                 "ADD COLUMN allow_expired_cache INTEGER NOT NULL DEFAULT 0"
             )
+        if prev_version <= 8:
+            # drop the redundant secondary indexes: they either duplicate the
+            # UNIQUE(category, key, provider) autoindex or are a left-prefix of it, so the
+            # autoindex already serves their lookups. The (key, provider) index is (re)created
+            # by __create_database_indexes and intentionally kept.
+            for index_name in (
+                "category_idx",
+                "key_idx",
+                "provider_idx",
+                "category_key_idx",
+                "category_provider_idx",
+                "category_key_provider_idx",
+            ):
+                await self.database.execute(f"DROP INDEX IF EXISTS {DB_TABLE_CACHE}_{index_name}")
         await self.database.commit()
 
     def _register_cleanup_task(self) -> None:

--- a/tests/controllers/cache/test_cache_controller.py
+++ b/tests/controllers/cache/test_cache_controller.py
@@ -9,8 +9,9 @@ from unittest.mock import AsyncMock, patch
 import aiofiles
 import pytest
 
-from music_assistant.constants import DB_TABLE_CACHE, VACUUM_MIN_RECLAIM_RATIO
+from music_assistant.constants import DB_TABLE_CACHE, DB_TABLE_SETTINGS, VACUUM_MIN_RECLAIM_RATIO
 from music_assistant.controllers.cache import MAX_CACHE_DB_SIZE_MB, CacheController
+from music_assistant.controllers.cache.constants import DB_SCHEMA_VERSION, SWR_FALLBACK_MAX_AGE
 from music_assistant.helpers.database import DatabaseConnection
 from music_assistant.mass import MusicAssistant
 
@@ -460,3 +461,146 @@ async def test_setup_runs_vacuum_when_reclaimable(
     ):
         await cache._setup_database()
     mock_vacuum.assert_awaited_once_with()
+
+
+# --- upsert (in-place write) ---
+
+
+async def test_set_upserts_in_place(cache: CacheController) -> None:
+    """Test that overwriting a key updates the row in place instead of replacing it."""
+    assert cache.database is not None
+    await cache.set("k", "v1", provider="test")
+    row = await cache.database.get_row(
+        DB_TABLE_CACHE, {"category": 0, "provider": "test", "key": "k"}
+    )
+    assert row is not None
+    row_id = row["id"]
+
+    await cache.set("k", "v2", provider="test")
+    assert await cache.get("k", provider="test") == "v2"
+    # a single row that kept its id — an INSERT OR REPLACE would delete it and assign a new id
+    assert await cache.database.get_count(DB_TABLE_CACHE) == 1
+    row = await cache.database.get_row(
+        DB_TABLE_CACHE, {"category": 0, "provider": "test", "key": "k"}
+    )
+    assert row is not None
+    assert row["id"] == row_id
+
+
+# --- secondary indexes ---
+
+
+async def _index_names(cache: CacheController) -> set[str]:
+    """Return the names of all indexes on the cache table."""
+    assert cache.database is not None
+    rows = await cache.database.get_rows_from_query(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = :table",
+        {"table": DB_TABLE_CACHE},
+    )
+    return {str(row["name"]) for row in rows}
+
+
+async def test_only_key_provider_index_is_created(cache: CacheController) -> None:
+    """Test that only the (key, provider) secondary index is created besides the autoindex."""
+    names = await _index_names(cache)
+    assert f"{DB_TABLE_CACHE}_key_provider_idx" in names
+    # the UNIQUE(category, key, provider) constraint provides an autoindex
+    assert any(name.startswith("sqlite_autoindex") for name in names)
+    # the redundant indexes are not (re)created
+    for removed in (
+        "category_idx",
+        "key_idx",
+        "provider_idx",
+        "category_key_idx",
+        "category_provider_idx",
+        "category_key_provider_idx",
+    ):
+        assert f"{DB_TABLE_CACHE}_{removed}" not in names
+
+
+async def test_migration_drops_redundant_indexes(mass_minimal: MusicAssistant) -> None:
+    """Test that opening a pre-v9 database migrates cleanly and drops the redundant indexes."""
+    db_path = os.path.join(mass_minimal.cache_path, "cache.db")
+    redundant = (
+        ("category_idx", "category"),
+        ("key_idx", "key"),
+        ("provider_idx", "provider"),
+        ("category_key_idx", "category,key"),
+        ("category_provider_idx", "category,provider"),
+        ("category_key_provider_idx", "category,key,provider"),
+        ("key_provider_idx", "key,provider"),
+    )
+    # build a v8 database with the old (full) index set and one row
+    old_db = DatabaseConnection(db_path)
+    await old_db.setup()
+    await old_db.execute(
+        f"CREATE TABLE {DB_TABLE_SETTINGS}(key TEXT PRIMARY KEY, value TEXT, type TEXT)"
+    )
+    await old_db.execute(
+        f"""CREATE TABLE {DB_TABLE_CACHE}(
+            [id] INTEGER PRIMARY KEY AUTOINCREMENT,
+            [category] INTEGER NOT NULL DEFAULT 0,
+            [key] TEXT NOT NULL,
+            [provider] TEXT NOT NULL,
+            [expires] INTEGER NOT NULL,
+            [data] TEXT NULL,
+            [checksum] TEXT NULL,
+            [persistent] INTEGER NOT NULL DEFAULT 0,
+            [allow_expired_cache] INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(category, key, provider)
+        )"""
+    )
+    for suffix, columns in redundant:
+        await old_db.execute(
+            f"CREATE INDEX {DB_TABLE_CACHE}_{suffix} ON {DB_TABLE_CACHE}({columns})"
+        )
+    await old_db.execute(
+        f"INSERT INTO {DB_TABLE_SETTINGS}(key, value, type) VALUES ('version', '8', 'str')"
+    )
+    await old_db.execute(
+        f"INSERT INTO {DB_TABLE_CACHE}(category, key, provider, expires, data) "
+        "VALUES (0, 'kept', 'test', 9999999999, '\"payload\"')"
+    )
+    await old_db.commit()
+    await old_db.close()
+
+    # opening the controller runs the migration
+    await mass_minimal.cache._setup_database()
+    cache = mass_minimal.cache
+    assert cache.database is not None
+
+    version_row = await cache.database.get_row(DB_TABLE_SETTINGS, {"key": "version"})
+    assert version_row is not None
+    assert version_row["value"] == str(DB_SCHEMA_VERSION)
+
+    names = await _index_names(cache)
+    assert f"{DB_TABLE_CACHE}_key_provider_idx" in names
+    for suffix, _ in redundant[:-1]:  # every index except key_provider is dropped
+        assert f"{DB_TABLE_CACHE}_{suffix}" not in names
+
+    # existing data survived the migration
+    assert await cache.get("kept", provider="test") == "payload"
+
+
+# --- stale-while-revalidate cleanup ---
+
+
+async def test_auto_cleanup_removes_stale_swr_rows(cache: CacheController) -> None:
+    """Test that auto_cleanup removes SWR fallback rows expired beyond the grace window."""
+    # expired but within the grace window -> kept as fallback
+    await cache.set("recent", "data", provider="test", expiration=-1, allow_expired_cache=True)
+    # expired well beyond the grace window -> removed
+    await cache.set(
+        "ancient",
+        "data",
+        provider="test",
+        expiration=-(SWR_FALLBACK_MAX_AGE + 86400),
+        allow_expired_cache=True,
+    )
+    await cache.auto_cleanup()
+
+    assert await cache.get("recent", provider="test", allow_expired_cache=True) == "data"
+    assert (
+        await cache.get("ancient", provider="test", default="gone", allow_expired_cache=True)
+        == "gone"
+    )


### PR DESCRIPTION
## Problem

Every `cache.set()` was an `INSERT OR REPLACE` (a delete + re-insert that rewrites every B-tree) fanning out to **seven** secondary indexes that are all redundant — the `UNIQUE(category, key, provider)` autoindex already serves every point lookup, and the others either duplicate it or are a left-prefix of it. So each cache write touched far more index pages than necessary.

Separately, the daily cleanup only removed non-fallback expired rows, so stale-while-revalidate fallback entries for keys that are never requested again (removed playlists, one-off pagination keys) lived forever and grew `cache.db` without bound (there's a 2 GB size warning for a reason).

## Changes

- Drop six redundant secondary indexes; keep only `(key, provider)`, which the autoindex's column order can't serve (used by `delete()` calls that omit the category). Schema bumped to v9 with a migration that drops the old indexes; existing databases open cleanly.
- `cache.set()` now upserts the row in place (`ON CONFLICT DO UPDATE`) instead of delete + re-insert.
- The daily cleanup now also removes stale-while-revalidate fallback rows once they've been expired for longer than 90 days.
