### PR TITLE
Run dependency security checks without an untrusted privileged checkout

### DIFF
--- a/.github/workflows/dependency-approval-command.yml
+++ b/.github/workflows/dependency-approval-command.yml
@@ -58,31 +58,26 @@ jobs:
               return;
             }
 
-            // Check if already approved
+            // Check if already approved (label add is skipped below, but the
+            // status flip still runs so the command can repair a stuck status)
             const labels = context.payload.issue.labels.map(l => l.name);
             const alreadyApproved = labels.includes('dependencies-reviewed');
 
-            if (alreadyApproved) {
-              await github.rest.issues.createComment({
+            if (!alreadyApproved) {
+              // Add the dependencies-reviewed label
+              await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: `ℹ️  Dependencies already approved - \`dependencies-reviewed\` label is present.`
+                labels: ['dependencies-reviewed']
               });
-              return;
             }
-
-            // Add the dependencies-reviewed label
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['dependencies-reviewed']
-            });
 
             // Flip the "Dependency Security Review" commit status. The label add
             // above uses GITHUB_TOKEN and therefore cannot re-trigger the
-            // dependency-security workflows, so the status is updated here.
+            // dependency-security workflows, so the status is updated here. This
+            // runs even when the label was already present, so the command can
+            // repair a stuck failing status (e.g. after a transient API error).
             // Only a 'failure' (awaiting review) status may be flipped; 'error'
             // (failed analysis / high risk / vulnerabilities) must be resolved
             // by a re-run or a fix and cannot be approved away.
@@ -122,11 +117,14 @@ jobs:
             }
 
             // Add a confirmation comment
+            const labelNote = alreadyApproved
+              ? 'The `dependencies-reviewed` label was already present.'
+              : 'The `dependencies-reviewed` label has been added.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `✅ **Dependencies approved** by @${comment.user.login}\n\nThe \`dependencies-reviewed\` label has been added. ${statusNote}`
+              body: `✅ **Dependencies approved** by @${comment.user.login}\n\n${labelNote} ${statusNote}`
             });
 
             // Add a reaction to the command comment

--- a/.github/workflows/dependency-approval-command.yml
+++ b/.github/workflows/dependency-approval-command.yml
@@ -77,16 +77,35 @@ jobs:
             // above uses GITHUB_TOKEN and therefore cannot re-trigger the
             // dependency-security workflows, so the status is updated here. This
             // runs even when the label was already present, so the command can
-            // repair a stuck failing status (e.g. after a transient API error).
-            // Only a 'failure' (awaiting review) status may be flipped; 'error'
-            // (failed analysis / high risk / vulnerabilities) must be resolved
-            // by a re-run or a fix and cannot be approved away.
+            // repair a stuck failing (or missing) status.
+            // Only 'failure' (awaiting review) or missing statuses may be
+            // flipped; 'error' (failed analysis / high risk / vulnerabilities)
+            // must be resolved by a re-run or a fix and cannot be approved away.
             const statusContext = 'Dependency Security Review';
             const pr = (await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
             })).data;
+
+            // The commit status is per-SHA: if other open PRs share this head
+            // commit, flipping it here would greenlight them too. Only flip when
+            // every such PR carries the review label.
+            const assoc = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: pr.head.sha,
+                per_page: 100,
+              },
+            );
+            const unapprovedSibling = assoc.find(p =>
+              p.number !== pr.number &&
+              p.state === 'open' &&
+              p.head.sha === pr.head.sha &&
+              !p.labels.map(l => l.name).includes('dependencies-reviewed')
+            );
 
             const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
               owner: context.repo.owner,
@@ -98,7 +117,16 @@ jobs:
             const current = statuses.find(s => s.context === statusContext);
 
             let statusNote = '';
-            if (current && current.state === 'failure') {
+            if (current && current.state === 'error') {
+              statusNote = `⚠️ The security check reported an error ("${current.description}") which cannot be overridden by this command. Resolve it or re-run the Dependency Security Check workflow.`;
+            } else if (current && current.state === 'pending') {
+              statusNote = 'The dependency security analysis is still running; the status will reflect the approval once it completes.';
+            } else if (current && current.state === 'success') {
+              statusNote = 'The security check is already passing.';
+            } else if (unapprovedSibling) {
+              statusNote = `⚠️ The commit status was not updated: PR #${unapprovedSibling.number} shares the same head commit and has not been approved yet. Approve it as well, or re-run the Dependency Security Check workflow.`;
+            } else {
+              // 'failure' (awaiting review) or no status yet: publish approval
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -107,12 +135,6 @@ jobs:
                 context: statusContext,
                 description: `Dependency changes reviewed (approved by @${comment.user.login})`,
               });
-              statusNote = 'Security checks will now pass and this PR can be merged.';
-            } else if (current && current.state === 'error') {
-              statusNote = `⚠️ The security check reported an error ("${current.description}") which cannot be overridden by this command. Resolve it or re-run the Dependency Security Check workflow.`;
-            } else if (current && current.state === 'pending') {
-              statusNote = 'The dependency security analysis is still running; the status will reflect the approval once it completes.';
-            } else {
               statusNote = 'Security checks will now pass and this PR can be merged.';
             }
 

--- a/.github/workflows/dependency-approval-command.yml
+++ b/.github/workflows/dependency-approval-command.yml
@@ -1,5 +1,13 @@
 # Dependency Approval via Comment Command
 # Allows maintainers to approve dependency changes by commenting /approve-dependencies
+#
+# Besides adding the `dependencies-reviewed` label, this workflow also flips the
+# "Dependency Security Review" commit status to success. Events created with the
+# default GITHUB_TOKEN (like this label add) cannot trigger other workflows, so
+# the dependency-security workflows will NOT re-run — the status must be updated
+# here directly. Only a 'failure' (awaiting review) status is flipped; 'error'
+# states (failed analysis, high-risk packages, known vulnerabilities) cannot be
+# overridden by this command.
 
 name: Dependency Approval Command
 
@@ -10,6 +18,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  statuses: write
 
 jobs:
   approve-via-command:
@@ -71,12 +80,53 @@ jobs:
               labels: ['dependencies-reviewed']
             });
 
+            // Flip the "Dependency Security Review" commit status. The label add
+            // above uses GITHUB_TOKEN and therefore cannot re-trigger the
+            // dependency-security workflows, so the status is updated here.
+            // Only a 'failure' (awaiting review) status may be flipped; 'error'
+            // (failed analysis / high risk / vulnerabilities) must be resolved
+            // by a re-run or a fix and cannot be approved away.
+            const statusContext = 'Dependency Security Review';
+            const pr = (await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            })).data;
+
+            const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: pr.head.sha,
+              per_page: 100,
+            });
+            // Statuses are newest-first; the first match is the current state.
+            const current = statuses.find(s => s.context === statusContext);
+
+            let statusNote = '';
+            if (current && current.state === 'failure') {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: pr.head.sha,
+                state: 'success',
+                context: statusContext,
+                description: `Dependency changes reviewed (approved by @${comment.user.login})`,
+              });
+              statusNote = 'Security checks will now pass and this PR can be merged.';
+            } else if (current && current.state === 'error') {
+              statusNote = `⚠️ The security check reported an error ("${current.description}") which cannot be overridden by this command. Resolve it or re-run the Dependency Security Check workflow.`;
+            } else if (current && current.state === 'pending') {
+              statusNote = 'The dependency security analysis is still running; the status will reflect the approval once it completes.';
+            } else {
+              statusNote = 'Security checks will now pass and this PR can be merged.';
+            }
+
             // Add a confirmation comment
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `✅ **Dependencies approved** by @${comment.user.login}\n\nThe \`dependencies-reviewed\` label has been added. Security checks will now pass and this PR can be merged.`
+              body: `✅ **Dependencies approved** by @${comment.user.login}\n\nThe \`dependencies-reviewed\` label has been added. ${statusNote}`
             });
 
             // Add a reaction to the command comment

--- a/.github/workflows/dependency-security-report.yml
+++ b/.github/workflows/dependency-security-report.yml
@@ -17,6 +17,18 @@
 # Because a workflow_run job is not itself a PR status check, the merge gate is
 # re-established by posting a commit status ("Dependency Security Review") to the
 # PR head commit. Configure that context as a required check in branch protection.
+#
+# Status semantics:
+#   success — no dependency changes, or changes reviewed/auto-approved
+#   pending — dependency changes detected, analysis in progress (set by init job)
+#   failure — awaiting maintainer review (overridable via /approve-dependencies)
+#   error   — analysis failed, high-risk packages or known vulnerabilities
+#             (NOT overridable via /approve-dependencies; requires a re-run or fix)
+#
+# The `init` job runs on `pull_request_target` for EVERY PR (the analysis
+# workflow is path-filtered, so without it non-dependency PRs would never
+# receive the required status). It is safe despite the privileged trigger
+# because it never checks out or executes PR code — it only calls the API.
 
 name: Dependency Security Report
 
@@ -24,14 +36,57 @@ on:
   workflow_run:
     workflows: ["Dependency Security Check"]
     types: [completed]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - stable
+      - dev
 
 permissions:
   contents: read
 
 jobs:
+  # Seed the commit status for every PR so the required check never hangs in
+  # "Expected": success for PRs without dependency changes, pending for PRs
+  # that will be analysed. The report job later posts the final state.
+  # SECURITY: privileged trigger, but no checkout — API calls only.
+  init:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Post initial commit status
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const isDepFile = (f) =>
+              f === 'requirements_all.txt' ||
+              f === 'pyproject.toml' ||
+              f === 'manifest.json' ||
+              f.endsWith('/manifest.json');
+            const depsChanged = files.some(f => isDepFile(f.filename));
+
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha: pr.head.sha,
+              state: depsChanged ? 'pending' : 'success',
+              context: 'Dependency Security Review',
+              description: depsChanged
+                ? 'Dependency security analysis in progress'
+                : 'No dependency changes to review',
+            });
+
   report:
     # Only report for runs triggered by pull requests
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,13 +95,6 @@ jobs:
       issues: write
       statuses: write
     steps:
-      - name: Download security reports
-        uses: actions/download-artifact@v8
-        with:
-          name: security-reports
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       # Resolve the PR and all trusted facts from the head commit. head_sha is
       # set by GitHub from the workflow_run event and cannot be forged by the PR.
       - name: Resolve pull request (trusted)
@@ -57,10 +105,11 @@ jobs:
             const { owner, repo } = context.repo;
             const headSha = context.payload.workflow_run.head_sha;
 
-            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner, repo, commit_sha: headSha,
-            });
-            const pr = prs.data.find(p =>
+            const prs = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              { owner, repo, commit_sha: headSha, per_page: 100 },
+            );
+            const pr = prs.find(p =>
               p.state === 'open' &&
               p.head.sha === headSha &&
               ['dev', 'stable'].includes(p.base.ref)
@@ -93,13 +142,24 @@ jobs:
             core.setOutput('deps_changed', depsChanged ? 'true' : 'false');
             core.setOutput('is_automated', isAutomated ? 'true' : 'false');
 
+      # Download the analysis artifact. Only meaningful when the analysis run
+      # succeeded; a failed run may have partial or missing results, which the
+      # status step reports as an error instead.
+      - name: Download security reports
+        if: steps.resolve.outputs.found == 'true' && github.event.workflow_run.conclusion == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: security-reports
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       # Parse the UNTRUSTED status.env against a strict allowlist. Only known keys
       # with lowercase-letter/underscore values are accepted, and results are
       # written to step outputs (data), never sourced into $GITHUB_ENV. This
       # neutralises env-injection via crafted step outputs from the analysis job.
       - name: Parse analysis results
         id: results
-        if: steps.resolve.outputs.found == 'true'
+        if: steps.resolve.outputs.found == 'true' && github.event.workflow_run.conclusion == 'success'
         run: |
           if [ ! -f status.env ]; then
             echo "status.env not found; treating results as empty"
@@ -119,7 +179,7 @@ jobs:
       # Combine report fragments into a single security report. The .md fragments
       # are untrusted but only ever posted as comment text (never executed).
       - name: Create combined security report
-        if: steps.resolve.outputs.found == 'true'
+        if: steps.resolve.outputs.found == 'true' && github.event.workflow_run.conclusion == 'success'
         env:
           DEPS_CHANGED: ${{ steps.resolve.outputs.deps_changed }}
           IS_AUTOMATED: ${{ steps.resolve.outputs.is_automated }}
@@ -238,7 +298,7 @@ jobs:
 
       # Post the combined report as a PR comment (targeting the trusted PR number)
       - name: Post security report to PR
-        if: steps.resolve.outputs.found == 'true'
+        if: steps.resolve.outputs.found == 'true' && github.event.workflow_run.conclusion == 'success'
         uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
@@ -270,7 +330,9 @@ jobs:
       # Gate the merge via a commit status on the PR head, and auto-approve
       # automated PRs. All gate-relevant inputs are trusted (API-derived); the
       # scan results (high risk / vulnerabilities) are advisory and can only make
-      # the gate stricter, never bypass the review requirement.
+      # the gate stricter, never bypass the review requirement. A failed analysis
+      # run is reported as an 'error' status: scan results are then unavailable,
+      # so nothing may be approved (fail closed).
       - name: Report security status
         if: steps.resolve.outputs.found == 'true'
         uses: actions/github-script@v9
@@ -280,6 +342,7 @@ jobs:
           LABELS: ${{ steps.resolve.outputs.labels }}
           DEPS_CHANGED: ${{ steps.resolve.outputs.deps_changed }}
           IS_AUTOMATED: ${{ steps.resolve.outputs.is_automated }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           SAFETY_STATUS: ${{ steps.results.outputs.SAFETY_STATUS }}
           PIP_AUDIT: ${{ steps.results.outputs.PIP_AUDIT }}
         with:
@@ -291,17 +354,21 @@ jobs:
             const depsChanged = process.env.DEPS_CHANGED === 'true';
             const isAutomated = process.env.IS_AUTOMATED === 'true';
             const hasReviewLabel = labels.includes('dependencies-reviewed');
+            const analysisOk = process.env.RUN_CONCLUSION === 'success';
             const isHighRisk = process.env.SAFETY_STATUS === 'high_risk';
             const hasVulns = process.env.PIP_AUDIT === 'fail';
 
             let state = 'success';
             let description = 'No dependency changes to review';
 
-            if (isHighRisk) {
-              state = 'failure';
+            if (!analysisOk) {
+              state = 'error';
+              description = 'Dependency security analysis failed - re-run the Dependency Security Check workflow';
+            } else if (isHighRisk) {
+              state = 'error';
               description = 'High-risk packages detected - security review required';
             } else if (hasVulns) {
-              state = 'failure';
+              state = 'error';
               description = 'Known vulnerabilities detected';
             } else if (depsChanged) {
               if (isAutomated || hasReviewLabel) {
@@ -320,12 +387,12 @@ jobs:
               context: 'Dependency Security Review', description,
             });
 
-            if (depsChanged && isAutomated && !hasReviewLabel && !isHighRisk && !hasVulns) {
+            if (analysisOk && depsChanged && isAutomated && !hasReviewLabel && !isHighRisk && !hasVulns) {
               await github.rest.issues.addLabels({
                 owner, repo, issue_number: prNumber, labels: ['dependencies-reviewed'],
               });
             }
 
-            if (state === 'failure') {
+            if (state !== 'success') {
               core.setFailed(description);
             }

--- a/.github/workflows/dependency-security-report.yml
+++ b/.github/workflows/dependency-security-report.yml
@@ -1,0 +1,277 @@
+# Dependency Security Report Workflow
+#
+# Companion to `dependency-security.yml`. That workflow analyses (possibly
+# untrusted) PR code in an unprivileged `pull_request` context and uploads its
+# findings as an artifact. This workflow runs afterwards via `workflow_run` with
+# write permissions to comment on the PR and gate merging, WITHOUT ever checking
+# out untrusted code — it only consumes the pre-computed report artifact.
+#
+# Because a workflow_run job is not itself a PR status check, the merge gate is
+# re-established by posting a commit status ("Dependency Security Review") to the
+# PR head commit. Configure that context as a required check in branch protection.
+
+name: Dependency Security Report
+
+on:
+  workflow_run:
+    workflows: ["Dependency Security Check"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    # Only report for runs triggered by pull requests
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+      issues: write
+      statuses: write
+    steps:
+      - name: Download security reports
+        uses: actions/download-artifact@v8
+        with:
+          name: security-reports
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load analysis status
+        run: cat status.env >> "$GITHUB_ENV"
+
+      - name: Detect automated dependency PRs
+        id: pr_type
+        run: |
+          PR_AUTHOR=$(jq -r '.author' pr_meta.json)
+          PR_LABELS=$(jq -r '.labels | join(",")' pr_meta.json)
+
+          if [[ "$PR_AUTHOR" == "dependabot[bot]" ]] || \
+             [[ "$PR_AUTHOR" == "renovate[bot]" ]] || \
+             echo "$PR_LABELS" | grep -q "auto-merge"; then
+            echo "is_automated=true" >> $GITHUB_OUTPUT
+            echo "✅ Detected automated dependency update PR"
+          else
+            echo "is_automated=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Combine all report fragments into a single security report
+      - name: Create combined security report
+        env:
+          IS_AUTOMATED: ${{ steps.pr_type.outputs.is_automated }}
+        run: |
+          echo "# 🔒 Dependency Security Report" > security_report.md
+          echo "" >> security_report.md
+
+          if [ "$DEPS_CHANGES" == "true" ] || [ "$MANIFEST_CHANGES" == "true" ]; then
+            # 1. Show sync status if out of sync
+            if [ "$REQ_SYNC" == "out_of_sync" ] && [ -f sync_report.md ]; then
+              cat sync_report.md >> security_report.md
+              echo "" >> security_report.md
+              echo "---" >> security_report.md
+              echo "" >> security_report.md
+            fi
+
+            # 2. Modified Dependencies Section (consolidated)
+            echo "## 📦 Modified Dependencies" >> security_report.md
+            echo "" >> security_report.md
+
+            # Combine requirements_all.txt and manifest changes
+            HAS_DEPS=false
+
+            if [ "$MANIFEST_CHANGES" == "true" ] && [ -f manifest_report.md ]; then
+              cat manifest_report.md | grep -v "^## " >> security_report.md
+              HAS_DEPS=true
+            fi
+
+            if [ "$DEPS_CHANGES" == "true" ] && [ -f deps_report.md ]; then
+              if [ "$HAS_DEPS" = "true" ]; then
+                echo "" >> security_report.md
+              fi
+              cat deps_report.md | grep -v "^## " >> security_report.md
+            fi
+
+            echo "" >> security_report.md
+            echo "---" >> security_report.md
+            echo "" >> security_report.md
+
+            # 3. Vulnerability Scan Results
+            if [ -f audit_report.md ]; then
+              cat audit_report.md >> security_report.md
+            fi
+            echo "" >> security_report.md
+            echo "---" >> security_report.md
+            echo "" >> security_report.md
+
+            # 4. Automated Security Checks
+            echo "### Automated Security Checks" >> security_report.md
+            echo "" >> security_report.md
+
+            # Vulnerability scan check
+            if [ "$PIP_AUDIT" == "fail" ]; then
+              echo "- ❌ **Vulnerability Scan**: Failed - Known vulnerabilities detected" >> security_report.md
+            else
+              echo "- ✅ **Vulnerability Scan**: Passed - No known vulnerabilities" >> security_report.md
+            fi
+
+            # Trusted sources check
+            if [ "$TRUSTED_SOURCES" == "fail" ]; then
+              echo "- ❌ **Trusted Sources**: Some packages missing source repository" >> security_report.md
+            else
+              echo "- ✅ **Trusted Sources**: All packages have verified source repositories" >> security_report.md
+            fi
+
+            # Typosquatting check
+            if [ "$TYPOSQUATTING" == "fail" ]; then
+              echo "- ❌ **Typosquatting Check**: Suspicious package names detected!" >> security_report.md
+            else
+              echo "- ✅ **Typosquatting Check**: No suspicious package names detected" >> security_report.md
+            fi
+
+            # License compatibility check
+            if [ "$LICENSE" == "fail" ]; then
+              echo "- ⚠️  **License Compatibility**: Some licenses may not be compatible" >> security_report.md
+            else
+              echo "- ✅ **License Compatibility**: All licenses are OSI-approved and compatible" >> security_report.md
+            fi
+
+            # Supply chain risk check
+            if [ "$SAFETY_STATUS" == "high_risk" ]; then
+              echo "- ❌ **Supply Chain Risk**: High risk packages detected" >> security_report.md
+            elif [ "$SAFETY_STATUS" == "medium_risk" ]; then
+              echo "- ⚠️  **Supply Chain Risk**: Medium risk - review recommended" >> security_report.md
+            else
+              echo "- ✅ **Supply Chain Risk**: Passed - packages appear mature and maintained" >> security_report.md
+            fi
+
+            echo "" >> security_report.md
+
+            # Check if automated PR
+            if [ "$IS_AUTOMATED" == "true" ]; then
+              echo "> 🤖 **Automated dependency update** - This PR is from a trusted source (dependabot/renovate) and will be auto-approved if all checks pass." >> security_report.md
+              echo "" >> security_report.md
+            fi
+
+            echo "### Manual Review" >> security_report.md
+            echo "" >> security_report.md
+            echo "**Maintainer approval required:**" >> security_report.md
+            echo "" >> security_report.md
+            echo "- [ ] **I have reviewed the changes above and approve these dependency updates**" >> security_report.md
+            echo "" >> security_report.md
+
+            if [ "$IS_AUTOMATED" == "true" ]; then
+              echo "_Automated PRs with all checks passing will be auto-approved._" >> security_report.md
+            else
+              echo "**To approve:** Comment \`/approve-dependencies\` or manually add the \`dependencies-reviewed\` label." >> security_report.md
+            fi
+          else
+            echo "✅ No dependency changes detected in this PR." >> security_report.md
+          fi
+
+          cat security_report.md
+
+          # Add to GitHub job summary
+          cat security_report.md >> $GITHUB_STEP_SUMMARY
+
+      # Post the combined report as a PR comment
+      - name: Post security report to PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('security_report.md', 'utf8');
+            const meta = JSON.parse(fs.readFileSync('pr_meta.json', 'utf8'));
+
+            // Find existing bot comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: meta.number,
+            });
+
+            const botComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('🔒 Dependency Security Report')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: report
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: meta.number,
+                body: report
+              });
+            }
+
+      # Gate the merge via a commit status on the PR head, and auto-approve
+      # automated PRs by adding the review label.
+      - name: Report security status
+        uses: actions/github-script@v9
+        env:
+          IS_AUTOMATED: ${{ steps.pr_type.outputs.is_automated }}
+        with:
+          script: |
+            const fs = require('fs');
+            const meta = JSON.parse(fs.readFileSync('pr_meta.json', 'utf8'));
+
+            const headSha = context.payload.workflow_run.head_sha;
+            const isAutomated = process.env.IS_AUTOMATED === 'true';
+            const isHighRisk = process.env.SAFETY_STATUS === 'high_risk';
+            const hasVulns = process.env.PIP_AUDIT === 'fail';
+            const depsChanged =
+              process.env.DEPS_CHANGES === 'true' ||
+              process.env.MANIFEST_CHANGES === 'true';
+            const hasReviewLabel = (meta.labels || []).includes('dependencies-reviewed');
+
+            let state = 'success';
+            let description = 'No dependency changes to review';
+
+            if (isHighRisk) {
+              state = 'failure';
+              description = 'High-risk packages detected - security review required';
+            } else if (hasVulns) {
+              state = 'failure';
+              description = 'Known vulnerabilities detected';
+            } else if (depsChanged) {
+              if (isAutomated || hasReviewLabel) {
+                state = 'success';
+                description = isAutomated
+                  ? 'Automated dependency update - approved'
+                  : 'Dependency changes reviewed';
+              } else {
+                state = 'failure';
+                description = 'Awaiting maintainer review (add "dependencies-reviewed" label)';
+              }
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: headSha,
+              state,
+              context: 'Dependency Security Review',
+              description,
+            });
+
+            // Auto-approve automated PRs by applying the review label
+            if (depsChanged && isAutomated && !hasReviewLabel && !isHighRisk && !hasVulns) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: meta.number,
+                labels: ['dependencies-reviewed'],
+              });
+            }
+
+            if (state === 'failure') {
+              core.setFailed(description);
+            }

--- a/.github/workflows/dependency-security-report.yml
+++ b/.github/workflows/dependency-security-report.yml
@@ -123,8 +123,10 @@ jobs:
       issues: write
       statuses: write
     steps:
-      # Resolve the PR and all trusted facts from the head commit. head_sha is
+      # Resolve the PR(s) and all trusted facts from the head commit. head_sha is
       # set by GitHub from the workflow_run event and cannot be forged by the PR.
+      # Commit statuses are per-SHA, so if several open PRs share this head
+      # commit the gate must consider ALL of them (strictest result wins).
       - name: Resolve pull request (trusted)
         id: resolve
         uses: actions/github-script@v9
@@ -133,28 +135,20 @@ jobs:
             const { owner, repo } = context.repo;
             const headSha = context.payload.workflow_run.head_sha;
 
-            const prs = await github.paginate(
+            const assoc = await github.paginate(
               github.rest.repos.listPullRequestsAssociatedWithCommit,
               { owner, repo, commit_sha: headSha, per_page: 100 },
             );
-            const pr = prs.find(p =>
+            const openPrs = assoc.filter(p =>
               p.state === 'open' &&
               p.head.sha === headSha &&
               ['dev', 'stable'].includes(p.base.ref)
             );
-            if (!pr) {
+            if (openPrs.length === 0) {
               core.info(`No open PR found for head ${headSha}; nothing to report.`);
               core.setOutput('found', 'false');
               return;
             }
-
-            // Trusted deps-changed check, mirroring the analysis workflow's
-            // semantics: added/modified lines in requirements_all.txt, or a
-            // changed `requirements` array in a provider manifest. Filename-only
-            // matching would wrongly gate metadata-only manifest edits.
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner, repo, pull_number: pr.number, per_page: 100,
-            });
 
             const getRequirements = async (path, ref) => {
               try {
@@ -166,37 +160,53 @@ jobs:
               }
             };
 
-            let depsChanged = false;
-            const reqFile = files.find(f => f.filename === 'requirements_all.txt');
-            if (reqFile && reqFile.additions > 0) depsChanged = true;
+            // Trusted deps-changed check per PR, mirroring the analysis
+            // workflow's semantics: added/modified lines in requirements_all.txt,
+            // or a changed `requirements` array in a provider manifest.
+            // Filename-only matching would wrongly gate metadata-only edits.
+            const results = [];
+            for (const pr of openPrs) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number: pr.number, per_page: 100,
+              });
 
-            if (!depsChanged) {
-              const manifests = files.filter(f =>
-                f.filename === 'manifest.json' || f.filename.endsWith('/manifest.json'));
-              for (const m of manifests) {
-                const oldReqs = await getRequirements(m.previous_filename ?? m.filename, pr.base.sha) ?? '[]';
-                const newReqs = m.status === 'removed'
-                  ? '[]'
-                  : await getRequirements(m.filename, headSha);
-                // Unreadable/unparsable new manifest: treat as changed (fail closed)
-                if (newReqs === null || oldReqs !== newReqs) {
-                  depsChanged = true;
-                  break;
+              let depsChanged = false;
+              const reqFile = files.find(f => f.filename === 'requirements_all.txt');
+              if (reqFile && reqFile.additions > 0) depsChanged = true;
+
+              if (!depsChanged) {
+                const manifests = files.filter(f =>
+                  f.filename === 'manifest.json' || f.filename.endsWith('/manifest.json'));
+                for (const m of manifests) {
+                  const oldReqs = await getRequirements(m.previous_filename ?? m.filename, pr.base.sha) ?? '[]';
+                  const newReqs = m.status === 'removed'
+                    ? '[]'
+                    : await getRequirements(m.filename, headSha);
+                  // Unreadable/unparsable new manifest: treat as changed (fail closed)
+                  if (newReqs === null || oldReqs !== newReqs) {
+                    depsChanged = true;
+                    break;
+                  }
                 }
               }
+
+              const labels = pr.labels.map(l => l.name);
+              results.push({
+                number: pr.number,
+                deps_changed: depsChanged,
+                has_review_label: labels.includes('dependencies-reviewed'),
+                is_automated:
+                  ['dependabot[bot]', 'renovate[bot]'].includes(pr.user.login) ||
+                  labels.includes('auto-merge'),
+              });
             }
 
-            const labels = pr.labels.map(l => l.name);
-            const isAutomated =
-              ['dependabot[bot]', 'renovate[bot]'].includes(pr.user.login) ||
-              labels.includes('auto-merge');
-
             core.setOutput('found', 'true');
-            core.setOutput('pr_number', String(pr.number));
             core.setOutput('head_sha', headSha);
-            core.setOutput('labels', JSON.stringify(labels));
-            core.setOutput('deps_changed', depsChanged ? 'true' : 'false');
-            core.setOutput('is_automated', isAutomated ? 'true' : 'false');
+            core.setOutput('prs', JSON.stringify(results));
+            // Aggregated values for the human-readable report body
+            core.setOutput('deps_changed', results.some(r => r.deps_changed) ? 'true' : 'false');
+            core.setOutput('is_automated', results.every(r => r.is_automated) ? 'true' : 'false');
 
       # Download the analysis artifact. Only meaningful when the analysis run
       # succeeded; a failed run may have partial or missing results, which the
@@ -213,14 +223,18 @@ jobs:
       # with lowercase-letter/underscore values are accepted, and results are
       # written to step outputs (data), never sourced into $GITHUB_ENV. This
       # neutralises env-injection via crafted step outputs from the analysis job.
+      # A missing status.env in a successful run is anomalous and reported as
+      # such, so the gate can fail closed instead of treating it as "no findings".
       - name: Parse analysis results
         id: results
         if: steps.resolve.outputs.found == 'true' && github.event.workflow_run.conclusion == 'success'
         run: |
           if [ ! -f status.env ]; then
-            echo "status.env not found; treating results as empty"
+            echo "status.env not found; scan results unavailable"
+            echo "present=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "present=true" >> "$GITHUB_OUTPUT"
           while IFS='=' read -r key val; do
             case "$key" in
               REQ_SYNC|PIP_AUDIT|DEPS_CHANGES|MANIFEST_CHANGES|SAFETY_STATUS|TRUSTED_SOURCES|TYPOSQUATTING|LICENSE) ;;
@@ -352,65 +366,65 @@ jobs:
           cat security_report.md
           cat security_report.md >> "$GITHUB_STEP_SUMMARY"
 
-      # Post the combined report as a PR comment (targeting the trusted PR number)
+      # Post the combined report as a PR comment (targeting the trusted PR numbers)
       - name: Post security report to PR
         if: steps.resolve.outputs.found == 'true' && github.event.workflow_run.conclusion == 'success'
         uses: actions/github-script@v9
         env:
-          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          PRS: ${{ steps.resolve.outputs.prs }}
         with:
           script: |
             const fs = require('fs');
             const { owner, repo } = context.repo;
-            const prNumber = Number(process.env.PR_NUMBER);
+            const prs = JSON.parse(process.env.PRS);
             const report = fs.readFileSync('security_report.md', 'utf8');
             const marker = '🔒 Dependency Security Report';
 
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number: prNumber, per_page: 100,
-            });
-            const existing = comments.find(c =>
-              c.user.login === 'github-actions[bot]' && c.body.includes(marker)
-            );
+            for (const pr of prs) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              const existing = comments.find(c =>
+                c.user.login === 'github-actions[bot]' && c.body.includes(marker)
+              );
 
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner, repo, comment_id: existing.id, body: report,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: prNumber, body: report,
-              });
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id, body: report,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: pr.number, body: report,
+                });
+              }
             }
 
       # Gate the merge via a commit status on the PR head, and auto-approve
       # automated PRs. All gate-relevant inputs are trusted (API-derived); the
       # scan results (high risk / vulnerabilities) are advisory and can only make
-      # the gate stricter, never bypass the review requirement. A failed analysis
-      # run is reported as an 'error' status: scan results are then unavailable,
-      # so nothing may be approved (fail closed).
+      # the gate stricter, never bypass the review requirement. Fail-closed cases
+      # reported as 'error': failed analysis run, failed artifact download, or a
+      # successful run without scan results.
+      # The commit status is per-SHA: when several open PRs share this head
+      # commit, every PR must independently pass the gate (strictest wins), so
+      # approval of one PR cannot greenlight another.
       - name: Report security status
-        if: steps.resolve.outputs.found == 'true'
+        if: always() && steps.resolve.outputs.found == 'true'
         uses: actions/github-script@v9
         env:
-          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          PRS: ${{ steps.resolve.outputs.prs }}
           HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
-          LABELS: ${{ steps.resolve.outputs.labels }}
-          DEPS_CHANGED: ${{ steps.resolve.outputs.deps_changed }}
-          IS_AUTOMATED: ${{ steps.resolve.outputs.is_automated }}
           RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RESULTS_PRESENT: ${{ steps.results.outputs.present }}
           SAFETY_STATUS: ${{ steps.results.outputs.SAFETY_STATUS }}
           PIP_AUDIT: ${{ steps.results.outputs.PIP_AUDIT }}
         with:
           script: |
             const { owner, repo } = context.repo;
-            const prNumber = Number(process.env.PR_NUMBER);
+            const prs = JSON.parse(process.env.PRS);
             const headSha = process.env.HEAD_SHA;
-            const labels = JSON.parse(process.env.LABELS || '[]');
-            const depsChanged = process.env.DEPS_CHANGED === 'true';
-            const isAutomated = process.env.IS_AUTOMATED === 'true';
-            const hasReviewLabel = labels.includes('dependencies-reviewed');
             const analysisOk = process.env.RUN_CONCLUSION === 'success';
+            const resultsPresent = process.env.RESULTS_PRESENT === 'true';
             const isHighRisk = process.env.SAFETY_STATUS === 'high_risk';
             const hasVulns = process.env.PIP_AUDIT === 'fail';
 
@@ -420,21 +434,29 @@ jobs:
             if (!analysisOk) {
               state = 'error';
               description = 'Dependency security analysis failed - re-run the Dependency Security Check workflow';
+            } else if (!resultsPresent) {
+              state = 'error';
+              description = 'Dependency security scan results missing - re-run the Dependency Security Check workflow';
             } else if (isHighRisk) {
               state = 'error';
               description = 'High-risk packages detected - security review required';
             } else if (hasVulns) {
               state = 'error';
               description = 'Known vulnerabilities detected';
-            } else if (depsChanged) {
-              if (isAutomated || hasReviewLabel) {
+            } else {
+              // Every open PR sharing this head commit must pass the gate
+              const blocked = prs.find(p =>
+                p.deps_changed && !p.is_automated && !p.has_review_label);
+              if (blocked) {
+                state = 'failure';
+                description = prs.length > 1
+                  ? `Awaiting maintainer review on PR #${blocked.number} (add "dependencies-reviewed" label)`
+                  : 'Awaiting maintainer review (add "dependencies-reviewed" label)';
+              } else if (prs.some(p => p.deps_changed)) {
                 state = 'success';
-                description = isAutomated
+                description = prs.every(p => !p.deps_changed || p.is_automated)
                   ? 'Automated dependency update - approved'
                   : 'Dependency changes reviewed';
-              } else {
-                state = 'failure';
-                description = 'Awaiting maintainer review (add "dependencies-reviewed" label)';
               }
             }
 
@@ -443,10 +465,14 @@ jobs:
               context: 'Dependency Security Review', description,
             });
 
-            if (analysisOk && depsChanged && isAutomated && !hasReviewLabel && !isHighRisk && !hasVulns) {
-              await github.rest.issues.addLabels({
-                owner, repo, issue_number: prNumber, labels: ['dependencies-reviewed'],
-              });
+            if (analysisOk && resultsPresent && !isHighRisk && !hasVulns) {
+              for (const pr of prs) {
+                if (pr.deps_changed && pr.is_automated && !pr.has_review_label) {
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: pr.number, labels: ['dependencies-reviewed'],
+                  });
+                }
+              }
             }
 
             if (state !== 'success') {

--- a/.github/workflows/dependency-security-report.yml
+++ b/.github/workflows/dependency-security-report.yml
@@ -4,7 +4,15 @@
 # untrusted) PR code in an unprivileged `pull_request` context and uploads its
 # findings as an artifact. This workflow runs afterwards via `workflow_run` with
 # write permissions to comment on the PR and gate merging, WITHOUT ever checking
-# out untrusted code — it only consumes the pre-computed report artifact.
+# out untrusted code.
+#
+# SECURITY: the downloaded artifact is UNTRUSTED (produced by fork code). It is
+# used ONLY for the human-readable report body and as advisory scan results that
+# can make the gate stricter, never looser. All security-relevant facts — which
+# PR this is, its author, its labels, and whether dependency files changed — are
+# derived from the GitHub API keyed on the trusted `workflow_run.head_sha`.
+# `status.env` is parsed against a strict allowlist and never sourced into the
+# environment.
 #
 # Because a workflow_run job is not itself a PR status check, the merge gate is
 # re-established by posting a commit status ("Dependency Security Review") to the
@@ -39,33 +47,95 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Load analysis status
-        run: cat status.env >> "$GITHUB_ENV"
+      # Resolve the PR and all trusted facts from the head commit. head_sha is
+      # set by GitHub from the workflow_run event and cannot be forged by the PR.
+      - name: Resolve pull request (trusted)
+        id: resolve
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const headSha = context.payload.workflow_run.head_sha;
 
-      - name: Detect automated dependency PRs
-        id: pr_type
+            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: headSha,
+            });
+            const pr = prs.data.find(p =>
+              p.state === 'open' &&
+              p.head.sha === headSha &&
+              ['dev', 'stable'].includes(p.base.ref)
+            );
+            if (!pr) {
+              core.info(`No open PR found for head ${headSha}; nothing to report.`);
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const isDepFile = (f) =>
+              f === 'requirements_all.txt' ||
+              f === 'pyproject.toml' ||
+              f === 'manifest.json' ||
+              f.endsWith('/manifest.json');
+            const depsChanged = files.some(f => isDepFile(f.filename));
+
+            const labels = pr.labels.map(l => l.name);
+            const isAutomated =
+              ['dependabot[bot]', 'renovate[bot]'].includes(pr.user.login) ||
+              labels.includes('auto-merge');
+
+            core.setOutput('found', 'true');
+            core.setOutput('pr_number', String(pr.number));
+            core.setOutput('head_sha', headSha);
+            core.setOutput('labels', JSON.stringify(labels));
+            core.setOutput('deps_changed', depsChanged ? 'true' : 'false');
+            core.setOutput('is_automated', isAutomated ? 'true' : 'false');
+
+      # Parse the UNTRUSTED status.env against a strict allowlist. Only known keys
+      # with lowercase-letter/underscore values are accepted, and results are
+      # written to step outputs (data), never sourced into $GITHUB_ENV. This
+      # neutralises env-injection via crafted step outputs from the analysis job.
+      - name: Parse analysis results
+        id: results
+        if: steps.resolve.outputs.found == 'true'
         run: |
-          PR_AUTHOR=$(jq -r '.author' pr_meta.json)
-          PR_LABELS=$(jq -r '.labels | join(",")' pr_meta.json)
-
-          if [[ "$PR_AUTHOR" == "dependabot[bot]" ]] || \
-             [[ "$PR_AUTHOR" == "renovate[bot]" ]] || \
-             echo "$PR_LABELS" | grep -q "auto-merge"; then
-            echo "is_automated=true" >> $GITHUB_OUTPUT
-            echo "✅ Detected automated dependency update PR"
-          else
-            echo "is_automated=false" >> $GITHUB_OUTPUT
+          if [ ! -f status.env ]; then
+            echo "status.env not found; treating results as empty"
+            exit 0
           fi
+          while IFS='=' read -r key val; do
+            case "$key" in
+              REQ_SYNC|PIP_AUDIT|DEPS_CHANGES|MANIFEST_CHANGES|SAFETY_STATUS|TRUSTED_SOURCES|TYPOSQUATTING|LICENSE) ;;
+              *) continue ;;
+            esac
+            case "$val" in
+              ''|*[!a-z_]*) continue ;;
+            esac
+            echo "$key=$val" >> "$GITHUB_OUTPUT"
+          done < status.env
 
-      # Combine all report fragments into a single security report
+      # Combine report fragments into a single security report. The .md fragments
+      # are untrusted but only ever posted as comment text (never executed).
       - name: Create combined security report
+        if: steps.resolve.outputs.found == 'true'
         env:
-          IS_AUTOMATED: ${{ steps.pr_type.outputs.is_automated }}
+          DEPS_CHANGED: ${{ steps.resolve.outputs.deps_changed }}
+          IS_AUTOMATED: ${{ steps.resolve.outputs.is_automated }}
+          REQ_SYNC: ${{ steps.results.outputs.REQ_SYNC }}
+          PIP_AUDIT: ${{ steps.results.outputs.PIP_AUDIT }}
+          DEPS_CHANGES: ${{ steps.results.outputs.DEPS_CHANGES }}
+          MANIFEST_CHANGES: ${{ steps.results.outputs.MANIFEST_CHANGES }}
+          SAFETY_STATUS: ${{ steps.results.outputs.SAFETY_STATUS }}
+          TRUSTED_SOURCES: ${{ steps.results.outputs.TRUSTED_SOURCES }}
+          TYPOSQUATTING: ${{ steps.results.outputs.TYPOSQUATTING }}
+          LICENSE: ${{ steps.results.outputs.LICENSE }}
         run: |
           echo "# 🔒 Dependency Security Report" > security_report.md
           echo "" >> security_report.md
 
-          if [ "$DEPS_CHANGES" == "true" ] || [ "$MANIFEST_CHANGES" == "true" ]; then
+          if [ "$DEPS_CHANGED" == "true" ]; then
             # 1. Show sync status if out of sync
             if [ "$REQ_SYNC" == "out_of_sync" ] && [ -f sync_report.md ]; then
               cat sync_report.md >> security_report.md
@@ -78,11 +148,10 @@ jobs:
             echo "## 📦 Modified Dependencies" >> security_report.md
             echo "" >> security_report.md
 
-            # Combine requirements_all.txt and manifest changes
             HAS_DEPS=false
 
             if [ "$MANIFEST_CHANGES" == "true" ] && [ -f manifest_report.md ]; then
-              cat manifest_report.md | grep -v "^## " >> security_report.md
+              grep -v "^## " manifest_report.md >> security_report.md
               HAS_DEPS=true
             fi
 
@@ -90,7 +159,7 @@ jobs:
               if [ "$HAS_DEPS" = "true" ]; then
                 echo "" >> security_report.md
               fi
-              cat deps_report.md | grep -v "^## " >> security_report.md
+              grep -v "^## " deps_report.md >> security_report.md
             fi
 
             echo "" >> security_report.md
@@ -109,35 +178,30 @@ jobs:
             echo "### Automated Security Checks" >> security_report.md
             echo "" >> security_report.md
 
-            # Vulnerability scan check
             if [ "$PIP_AUDIT" == "fail" ]; then
               echo "- ❌ **Vulnerability Scan**: Failed - Known vulnerabilities detected" >> security_report.md
             else
               echo "- ✅ **Vulnerability Scan**: Passed - No known vulnerabilities" >> security_report.md
             fi
 
-            # Trusted sources check
             if [ "$TRUSTED_SOURCES" == "fail" ]; then
               echo "- ❌ **Trusted Sources**: Some packages missing source repository" >> security_report.md
             else
               echo "- ✅ **Trusted Sources**: All packages have verified source repositories" >> security_report.md
             fi
 
-            # Typosquatting check
             if [ "$TYPOSQUATTING" == "fail" ]; then
               echo "- ❌ **Typosquatting Check**: Suspicious package names detected!" >> security_report.md
             else
               echo "- ✅ **Typosquatting Check**: No suspicious package names detected" >> security_report.md
             fi
 
-            # License compatibility check
             if [ "$LICENSE" == "fail" ]; then
               echo "- ⚠️  **License Compatibility**: Some licenses may not be compatible" >> security_report.md
             else
               echo "- ✅ **License Compatibility**: All licenses are OSI-approved and compatible" >> security_report.md
             fi
 
-            # Supply chain risk check
             if [ "$SAFETY_STATUS" == "high_risk" ]; then
               echo "- ❌ **Supply Chain Risk**: High risk packages detected" >> security_report.md
             elif [ "$SAFETY_STATUS" == "medium_risk" ]; then
@@ -148,7 +212,6 @@ jobs:
 
             echo "" >> security_report.md
 
-            # Check if automated PR
             if [ "$IS_AUTOMATED" == "true" ]; then
               echo "> 🤖 **Automated dependency update** - This PR is from a trusted source (dependabot/renovate) and will be auto-approved if all checks pass." >> security_report.md
               echo "" >> security_report.md
@@ -171,66 +234,65 @@ jobs:
           fi
 
           cat security_report.md
+          cat security_report.md >> "$GITHUB_STEP_SUMMARY"
 
-          # Add to GitHub job summary
-          cat security_report.md >> $GITHUB_STEP_SUMMARY
-
-      # Post the combined report as a PR comment
+      # Post the combined report as a PR comment (targeting the trusted PR number)
       - name: Post security report to PR
+        if: steps.resolve.outputs.found == 'true'
         uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
         with:
           script: |
             const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const prNumber = Number(process.env.PR_NUMBER);
             const report = fs.readFileSync('security_report.md', 'utf8');
-            const meta = JSON.parse(fs.readFileSync('pr_meta.json', 'utf8'));
+            const marker = '🔒 Dependency Security Report';
 
-            // Find existing bot comment
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: meta.number,
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
             });
-
-            const botComment = comments.data.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('🔒 Dependency Security Report')
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' && c.body.includes(marker)
             );
 
-            if (botComment) {
+            if (existing) {
               await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: report
+                owner, repo, comment_id: existing.id, body: report,
               });
             } else {
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: meta.number,
-                body: report
+                owner, repo, issue_number: prNumber, body: report,
               });
             }
 
       # Gate the merge via a commit status on the PR head, and auto-approve
-      # automated PRs by adding the review label.
+      # automated PRs. All gate-relevant inputs are trusted (API-derived); the
+      # scan results (high risk / vulnerabilities) are advisory and can only make
+      # the gate stricter, never bypass the review requirement.
       - name: Report security status
+        if: steps.resolve.outputs.found == 'true'
         uses: actions/github-script@v9
         env:
-          IS_AUTOMATED: ${{ steps.pr_type.outputs.is_automated }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+          LABELS: ${{ steps.resolve.outputs.labels }}
+          DEPS_CHANGED: ${{ steps.resolve.outputs.deps_changed }}
+          IS_AUTOMATED: ${{ steps.resolve.outputs.is_automated }}
+          SAFETY_STATUS: ${{ steps.results.outputs.SAFETY_STATUS }}
+          PIP_AUDIT: ${{ steps.results.outputs.PIP_AUDIT }}
         with:
           script: |
-            const fs = require('fs');
-            const meta = JSON.parse(fs.readFileSync('pr_meta.json', 'utf8'));
-
-            const headSha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const headSha = process.env.HEAD_SHA;
+            const labels = JSON.parse(process.env.LABELS || '[]');
+            const depsChanged = process.env.DEPS_CHANGED === 'true';
             const isAutomated = process.env.IS_AUTOMATED === 'true';
+            const hasReviewLabel = labels.includes('dependencies-reviewed');
             const isHighRisk = process.env.SAFETY_STATUS === 'high_risk';
             const hasVulns = process.env.PIP_AUDIT === 'fail';
-            const depsChanged =
-              process.env.DEPS_CHANGES === 'true' ||
-              process.env.MANIFEST_CHANGES === 'true';
-            const hasReviewLabel = (meta.labels || []).includes('dependencies-reviewed');
 
             let state = 'success';
             let description = 'No dependency changes to review';
@@ -254,21 +316,13 @@ jobs:
             }
 
             await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: headSha,
-              state,
-              context: 'Dependency Security Review',
-              description,
+              owner, repo, sha: headSha, state,
+              context: 'Dependency Security Review', description,
             });
 
-            // Auto-approve automated PRs by applying the review label
             if (depsChanged && isAutomated && !hasReviewLabel && !isHighRisk && !hasVulns) {
               await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: meta.number,
-                labels: ['dependencies-reviewed'],
+                owner, repo, issue_number: prNumber, labels: ['dependencies-reviewed'],
               });
             }
 

--- a/.github/workflows/dependency-security-report.yml
+++ b/.github/workflows/dependency-security-report.yml
@@ -65,15 +65,43 @@ jobs:
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
 
+            // Gate only on actual dependency changes, mirroring the analysis
+            // workflow: added/modified lines in requirements_all.txt, or a
+            // changed `requirements` array in a provider manifest. Metadata-only
+            // manifest edits must not require review.
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number: pr.number, per_page: 100,
             });
-            const isDepFile = (f) =>
-              f === 'requirements_all.txt' ||
-              f === 'pyproject.toml' ||
-              f === 'manifest.json' ||
-              f.endsWith('/manifest.json');
-            const depsChanged = files.some(f => isDepFile(f.filename));
+
+            const getRequirements = async (path, ref) => {
+              try {
+                const res = await github.rest.repos.getContent({ owner, repo, path, ref });
+                const manifest = JSON.parse(Buffer.from(res.data.content, 'base64').toString('utf8'));
+                return JSON.stringify(manifest.requirements ?? []);
+              } catch (e) {
+                return null;
+              }
+            };
+
+            let depsChanged = false;
+            const reqFile = files.find(f => f.filename === 'requirements_all.txt');
+            if (reqFile && reqFile.additions > 0) depsChanged = true;
+
+            if (!depsChanged) {
+              const manifests = files.filter(f =>
+                f.filename === 'manifest.json' || f.filename.endsWith('/manifest.json'));
+              for (const m of manifests) {
+                const oldReqs = await getRequirements(m.previous_filename ?? m.filename, pr.base.sha) ?? '[]';
+                const newReqs = m.status === 'removed'
+                  ? '[]'
+                  : await getRequirements(m.filename, pr.head.sha);
+                // Unreadable/unparsable new manifest: treat as changed (fail closed)
+                if (newReqs === null || oldReqs !== newReqs) {
+                  depsChanged = true;
+                  break;
+                }
+              }
+            }
 
             await github.rest.repos.createCommitStatus({
               owner, repo, sha: pr.head.sha,
@@ -120,15 +148,43 @@ jobs:
               return;
             }
 
+            // Trusted deps-changed check, mirroring the analysis workflow's
+            // semantics: added/modified lines in requirements_all.txt, or a
+            // changed `requirements` array in a provider manifest. Filename-only
+            // matching would wrongly gate metadata-only manifest edits.
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number: pr.number, per_page: 100,
             });
-            const isDepFile = (f) =>
-              f === 'requirements_all.txt' ||
-              f === 'pyproject.toml' ||
-              f === 'manifest.json' ||
-              f.endsWith('/manifest.json');
-            const depsChanged = files.some(f => isDepFile(f.filename));
+
+            const getRequirements = async (path, ref) => {
+              try {
+                const res = await github.rest.repos.getContent({ owner, repo, path, ref });
+                const manifest = JSON.parse(Buffer.from(res.data.content, 'base64').toString('utf8'));
+                return JSON.stringify(manifest.requirements ?? []);
+              } catch (e) {
+                return null;
+              }
+            };
+
+            let depsChanged = false;
+            const reqFile = files.find(f => f.filename === 'requirements_all.txt');
+            if (reqFile && reqFile.additions > 0) depsChanged = true;
+
+            if (!depsChanged) {
+              const manifests = files.filter(f =>
+                f.filename === 'manifest.json' || f.filename.endsWith('/manifest.json'));
+              for (const m of manifests) {
+                const oldReqs = await getRequirements(m.previous_filename ?? m.filename, pr.base.sha) ?? '[]';
+                const newReqs = m.status === 'removed'
+                  ? '[]'
+                  : await getRequirements(m.filename, headSha);
+                // Unreadable/unparsable new manifest: treat as changed (fail closed)
+                if (newReqs === null || oldReqs !== newReqs) {
+                  depsChanged = true;
+                  break;
+                }
+              }
+            }
 
             const labels = pr.labels.map(l => l.name);
             const isAutomated =

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -1,10 +1,17 @@
 # Dependency Security Check Workflow
-# Checks Python dependencies for security vulnerabilities and supply chain risks
+# Checks Python dependencies for security vulnerabilities and supply chain risks.
+#
+# SECURITY: This workflow runs on `pull_request` (NOT `pull_request_target`), so
+# for PRs from forks it gets a read-only GITHUB_TOKEN and no access to repository
+# secrets. That makes it safe to check out and execute untrusted PR code here.
+# It cannot comment on the PR or change labels; that is handled by the companion
+# `dependency-security-report.yml` workflow, which runs with write permissions
+# but never checks out untrusted code.
 
 name: Dependency Security Check
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, labeled]
     paths:
       - "requirements_all.txt"
@@ -26,15 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    outputs:
-      req_sync: ${{ steps.req_sync.outputs.status }}
-      pip_audit: ${{ steps.pip_audit.outputs.status }}
-      deps_has_changes: ${{ steps.deps_check.outputs.has_changes }}
-      manifest_has_changes: ${{ steps.manifest_check.outputs.has_changes }}
-      safety_status: ${{ steps.safety_check.outputs.status }}
-      trusted_sources: ${{ steps.safety_check.outputs.trusted_sources }}
-      typosquatting: ${{ steps.safety_check.outputs.typosquatting }}
-      license: ${{ steps.safety_check.outputs.license }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v7
@@ -257,7 +255,30 @@ jobs:
 
           cat safety_report.md
 
-      # Step 5: Hand off report fragments to the trusted reporting job
+      # Step 5: Persist status and PR metadata for the reporting workflow.
+      # The report runs via workflow_run and cannot see the pull_request event
+      # or this job's outputs, so everything it needs is passed via the artifact.
+      - name: Persist status and PR metadata
+        if: always()
+        run: |
+          {
+            echo "REQ_SYNC=${{ steps.req_sync.outputs.status }}"
+            echo "PIP_AUDIT=${{ steps.pip_audit.outputs.status }}"
+            echo "DEPS_CHANGES=${{ steps.deps_check.outputs.has_changes }}"
+            echo "MANIFEST_CHANGES=${{ steps.manifest_check.outputs.has_changes }}"
+            echo "SAFETY_STATUS=${{ steps.safety_check.outputs.status }}"
+            echo "TRUSTED_SOURCES=${{ steps.safety_check.outputs.trusted_sources }}"
+            echo "TYPOSQUATTING=${{ steps.safety_check.outputs.typosquatting }}"
+            echo "LICENSE=${{ steps.safety_check.outputs.license }}"
+          } > status.env
+
+          jq -n \
+            --argjson number '${{ github.event.pull_request.number }}' \
+            --arg author '${{ github.event.pull_request.user.login }}' \
+            --argjson labels '${{ toJson(github.event.pull_request.labels.*.name) }}' \
+            '{number: $number, author: $author, labels: $labels}' > pr_meta.json
+
+      # Step 6: Hand off report fragments and metadata to the reporting workflow
       - name: Upload security reports
         if: always()
         uses: actions/upload-artifact@v7
@@ -269,263 +290,7 @@ jobs:
             deps_report.md
             manifest_report.md
             safety_report.md
+            status.env
+            pr_meta.json
           if-no-files-found: ignore
           retention-days: 1
-
-  report:
-    needs: audit
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Detect automated dependency PRs
-        id: pr_type
-        run: |
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-          PR_LABELS="${{ toJson(github.event.pull_request.labels.*.name) }}"
-
-          # Check if PR is from dependabot, renovate, or has auto-merge label
-          if [[ "$PR_AUTHOR" == "dependabot[bot]" ]] || \
-             [[ "$PR_AUTHOR" == "renovate[bot]" ]] || \
-             echo "$PR_LABELS" | grep -q "auto-merge"; then
-            echo "is_automated=true" >> $GITHUB_OUTPUT
-            echo "✅ Detected automated dependency update PR - will auto-approve security checks"
-          else
-            echo "is_automated=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Download security reports
-        uses: actions/download-artifact@v8
-        with:
-          name: security-reports
-
-      # Step 6: Combine all reports and post as PR comment
-      - name: Create combined security report
-        id: report
-        env:
-          REQ_SYNC: ${{ needs.audit.outputs.req_sync }}
-          PIP_AUDIT: ${{ needs.audit.outputs.pip_audit }}
-          DEPS_CHANGES: ${{ needs.audit.outputs.deps_has_changes }}
-          MANIFEST_CHANGES: ${{ needs.audit.outputs.manifest_has_changes }}
-          SAFETY_STATUS: ${{ needs.audit.outputs.safety_status }}
-          TRUSTED_SOURCES: ${{ needs.audit.outputs.trusted_sources }}
-          TYPOSQUATTING: ${{ needs.audit.outputs.typosquatting }}
-          LICENSE: ${{ needs.audit.outputs.license }}
-          IS_AUTOMATED: ${{ steps.pr_type.outputs.is_automated }}
-        run: |
-          echo "# 🔒 Dependency Security Report" > security_report.md
-          echo "" >> security_report.md
-
-          if [ "$DEPS_CHANGES" == "true" ] || [ "$MANIFEST_CHANGES" == "true" ]; then
-            # 1. Show sync status if out of sync
-            if [ "$REQ_SYNC" == "out_of_sync" ] && [ -f sync_report.md ]; then
-              cat sync_report.md >> security_report.md
-              echo "" >> security_report.md
-              echo "---" >> security_report.md
-              echo "" >> security_report.md
-            fi
-
-            # 2. Modified Dependencies Section (consolidated)
-            echo "## 📦 Modified Dependencies" >> security_report.md
-            echo "" >> security_report.md
-
-            # Combine requirements_all.txt and manifest changes
-            HAS_DEPS=false
-
-            if [ "$MANIFEST_CHANGES" == "true" ] && [ -f manifest_report.md ]; then
-              cat manifest_report.md | grep -v "^## " >> security_report.md
-              HAS_DEPS=true
-            fi
-
-            if [ "$DEPS_CHANGES" == "true" ] && [ -f deps_report.md ]; then
-              if [ "$HAS_DEPS" = "true" ]; then
-                echo "" >> security_report.md
-              fi
-              cat deps_report.md | grep -v "^## " >> security_report.md
-            fi
-
-            echo "" >> security_report.md
-            echo "---" >> security_report.md
-            echo "" >> security_report.md
-
-            # 3. Vulnerability Scan Results
-            if [ -f audit_report.md ]; then
-              cat audit_report.md >> security_report.md
-            fi
-            echo "" >> security_report.md
-            echo "---" >> security_report.md
-            echo "" >> security_report.md
-
-            # 4. Automated Security Checks
-            echo "### Automated Security Checks" >> security_report.md
-            echo "" >> security_report.md
-
-            # Vulnerability scan check
-            if [ "$PIP_AUDIT" == "fail" ]; then
-              echo "- ❌ **Vulnerability Scan**: Failed - Known vulnerabilities detected" >> security_report.md
-            else
-              echo "- ✅ **Vulnerability Scan**: Passed - No known vulnerabilities" >> security_report.md
-            fi
-
-            # Trusted sources check
-            if [ "$TRUSTED_SOURCES" == "fail" ]; then
-              echo "- ❌ **Trusted Sources**: Some packages missing source repository" >> security_report.md
-            else
-              echo "- ✅ **Trusted Sources**: All packages have verified source repositories" >> security_report.md
-            fi
-
-            # Typosquatting check
-            if [ "$TYPOSQUATTING" == "fail" ]; then
-              echo "- ❌ **Typosquatting Check**: Suspicious package names detected!" >> security_report.md
-            else
-              echo "- ✅ **Typosquatting Check**: No suspicious package names detected" >> security_report.md
-            fi
-
-            # License compatibility check
-            if [ "$LICENSE" == "fail" ]; then
-              echo "- ⚠️  **License Compatibility**: Some licenses may not be compatible" >> security_report.md
-            else
-              echo "- ✅ **License Compatibility**: All licenses are OSI-approved and compatible" >> security_report.md
-            fi
-
-            # Supply chain risk check
-            if [ "$SAFETY_STATUS" == "high_risk" ]; then
-              echo "- ❌ **Supply Chain Risk**: High risk packages detected" >> security_report.md
-            elif [ "$SAFETY_STATUS" == "medium_risk" ]; then
-              echo "- ⚠️  **Supply Chain Risk**: Medium risk - review recommended" >> security_report.md
-            else
-              echo "- ✅ **Supply Chain Risk**: Passed - packages appear mature and maintained" >> security_report.md
-            fi
-
-            echo "" >> security_report.md
-
-            # Check if automated PR
-            if [ "$IS_AUTOMATED" == "true" ]; then
-              echo "> 🤖 **Automated dependency update** - This PR is from a trusted source (dependabot/renovate) and will be auto-approved if all checks pass." >> security_report.md
-              echo "" >> security_report.md
-            fi
-
-            echo "### Manual Review" >> security_report.md
-            echo "" >> security_report.md
-            echo "**Maintainer approval required:**" >> security_report.md
-            echo "" >> security_report.md
-            echo "- [ ] **I have reviewed the changes above and approve these dependency updates**" >> security_report.md
-            echo "" >> security_report.md
-
-            if [ "$IS_AUTOMATED" == "true" ]; then
-              echo "_Automated PRs with all checks passing will be auto-approved._" >> security_report.md
-            else
-              echo "**To approve:** Comment \`/approve-dependencies\` or manually add the \`dependencies-reviewed\` label." >> security_report.md
-            fi
-          else
-            echo "✅ No dependency changes detected in this PR." >> security_report.md
-          fi
-
-          cat security_report.md
-
-          # Add to GitHub job summary (always available, even for forks)
-          cat security_report.md >> $GITHUB_STEP_SUMMARY
-
-      # Step 7: Post comment to PR
-      - name: Post security report to PR
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const report = fs.readFileSync('security_report.md', 'utf8');
-
-            // Find existing bot comment
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.data.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('🔒 Dependency Security Report')
-            );
-
-            if (botComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: report
-              });
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: report
-              });
-            }
-
-      # Step 8: Check for approval label (if dependencies changed)
-      - name: Check for security review approval
-        if: needs.audit.outputs.deps_has_changes == 'true' || needs.audit.outputs.manifest_has_changes == 'true'
-        uses: actions/github-script@v9
-        env:
-          IS_AUTOMATED: ${{ steps.pr_type.outputs.is_automated }}
-          SAFETY_STATUS: ${{ needs.audit.outputs.safety_status }}
-          PIP_AUDIT: ${{ needs.audit.outputs.pip_audit }}
-        with:
-          script: |
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            const hasReviewLabel = labels.includes('dependencies-reviewed');
-            const isAutomated = process.env.IS_AUTOMATED === 'true';
-            const isHighRisk = process.env.SAFETY_STATUS === 'high_risk';
-            const hasFailed = process.env.PIP_AUDIT === 'fail';
-
-            if (isHighRisk) {
-              core.setFailed('🔴 HIGH RISK dependencies detected! This PR requires thorough security review before merging.');
-            } else if (hasFailed) {
-              core.setFailed('🔴 Known vulnerabilities detected! Please address the security issues above.');
-            } else if (isAutomated) {
-              // Auto-approve automated PRs if security checks passed
-              core.info('✅ Automated dependency update with passing security checks - auto-approved');
-
-              // Optionally add the label automatically
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels: ['dependencies-reviewed']
-              });
-            } else if (!hasReviewLabel) {
-              core.setFailed('⚠️  Dependency changes detected. A maintainer must add the "dependencies-reviewed" label after security review.');
-            } else {
-              core.info('✅ Security review approved via "dependencies-reviewed" label');
-            }
-
-      # Step 9: Fail the check if high-risk or vulnerabilities found
-      - name: Final security status
-        if: always()
-        env:
-          PIP_AUDIT: ${{ needs.audit.outputs.pip_audit }}
-          SAFETY_STATUS: ${{ needs.audit.outputs.safety_status }}
-          DEPS_CHANGES: ${{ needs.audit.outputs.deps_has_changes }}
-          MANIFEST_CHANGES: ${{ needs.audit.outputs.manifest_has_changes }}
-        run: |
-          if [ "$PIP_AUDIT" == "fail" ]; then
-            echo "❌ Known vulnerabilities found!"
-            exit 1
-          fi
-
-          if [ "$SAFETY_STATUS" == "high_risk" ]; then
-            echo "❌ High-risk packages detected!"
-            exit 1
-          fi
-
-          if [ "$DEPS_CHANGES" == "true" ] || [ "$MANIFEST_CHANGES" == "true" ]; then
-            echo "⚠️  Dependency changes require review"
-            # Don't fail here - the label check above will handle it
-          fi
-
-          echo "✅ Security checks completed"

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -255,10 +255,12 @@ jobs:
 
           cat safety_report.md
 
-      # Step 5: Persist status and PR metadata for the reporting workflow.
-      # The report runs via workflow_run and cannot see the pull_request event
-      # or this job's outputs, so everything it needs is passed via the artifact.
-      - name: Persist status and PR metadata
+      # Step 5: Persist analysis results for the reporting workflow.
+      # The report runs via workflow_run and cannot see this job's outputs, so
+      # the result strings are passed via the artifact. This data is UNTRUSTED
+      # (produced by fork code); the reporting workflow validates it and derives
+      # all PR identity/labels from the GitHub API, never from this artifact.
+      - name: Persist analysis results
         if: always()
         run: |
           {
@@ -272,13 +274,7 @@ jobs:
             echo "LICENSE=${{ steps.safety_check.outputs.license }}"
           } > status.env
 
-          jq -n \
-            --argjson number '${{ github.event.pull_request.number }}' \
-            --arg author '${{ github.event.pull_request.user.login }}' \
-            --argjson labels '${{ toJson(github.event.pull_request.labels.*.name) }}' \
-            '{number: $number, author: $author, labels: $labels}' > pr_meta.json
-
-      # Step 6: Hand off report fragments and metadata to the reporting workflow
+      # Step 6: Hand off report fragments and results to the reporting workflow
       - name: Upload security reports
         if: always()
         uses: actions/upload-artifact@v7
@@ -291,6 +287,5 @@ jobs:
             manifest_report.md
             safety_report.md
             status.env
-            pr_meta.json
           if-no-files-found: ignore
           retention-days: 1


### PR DESCRIPTION
# What does this implement/fix?

The `Dependency Security Check` workflow ran on `pull_request_target` and checked out the PR head (`actions/checkout@v7`) before installing dependencies and running the analysis scripts. That executed untrusted fork code in a privileged context with the base repo's `GITHUB_TOKEN` — a classic "pwn request". `actions/checkout@v7` now hard-refuses this pattern, so the job fails on every fork PR that touches a dependency file (e.g. #4571).

This splits the workflow into the GitHub-recommended safe pattern:

- **`dependency-security.yml`** now runs on `pull_request` (unprivileged). Fork PRs get a read-only token and no secrets, so checking out and running their code is safe — and `checkout@v7` no longer refuses it. It only analyses and uploads its findings + PR metadata as an artifact; it can no longer comment or label.
- **`dependency-security-report.yml`** is a new `workflow_run` workflow that has write access but **never checks out fork code**. It consumes the artifact, posts the PR comment, and manages the review label. It also contains an `init` job (`pull_request_target`, no checkout — API calls only) that seeds the commit status for *every* PR, so the required check never hangs in "Expected" for PRs that don't touch dependency files.

Because a `workflow_run` job is not itself a PR status check, the merge gate is re-established as a commit status (`Dependency Security Review`) posted to the PR head. Status semantics:

- `success` — no dependency changes, or changes reviewed/auto-approved
- `pending` — dependency changes detected, analysis in progress
- `failure` — awaiting maintainer review (overridable)
- `error` — analysis run failed, high-risk packages, or known vulnerabilities (**not** overridable; fail closed)

Behaviour (auto-approve for dependabot/renovate, block on high-risk/vulnerabilities, require the `dependencies-reviewed` label otherwise) is unchanged, with one hardening: a failed analysis run now posts an `error` status and never auto-approves, instead of being silently treated as passing.

`/approve-dependencies` still works: since a label added with the default `GITHUB_TOKEN` cannot re-trigger workflows, the command workflow now flips the awaiting-review (`failure`) status to `success` directly. It cannot override `error` states.

> [!IMPORTANT]
> Branch protection must be updated: the required check moves from the old `Dependency Security Check` report job to the `Dependency Security Review` commit-status context. Thanks to the `init` job this status is posted on every PR targeting `dev`/`stable`, so non-dependency PRs are not blocked.

Note: the analysis still runs the fork's own copy of the safety scripts (a pre-existing limitation, unchanged here). Running the base-repo scripts against fork data is a larger follow-up.

**Related issue (if applicable):**

- Fixes the `actions/checkout@v7` untrusted-checkout failure seen on #4571

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
