### PR TITLE
Fix Home Assistant integration losing authentication after restart or over time

### DIFF
--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -448,7 +448,6 @@ class DiscoveryController(CoreController):
 
     async def _announce_to_homeassistant(self) -> None:
         """Announce Music Assistant Ingress server to Home Assistant via Supervisor API."""
-        # Safe to repeat: Supervisor dedupes identical payloads and HA only reloads on change
         supervisor_token = os.environ["SUPERVISOR_TOKEN"]
         addon_hostname = os.environ["HOSTNAME"]
         ha_integration_token = await self.mass.webserver.auth.get_homeassistant_system_user_token()

--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -47,8 +47,7 @@ UPNP_DISCOVERY_BROADCAST_TARGET = (str(IPv4Address("255.255.255.255")), 1900)
 UPNP_DISCOVERY_TASK_ID = "discovery_upnp_cycle"
 UPNP_DISCOVERY_TIMER_ID = "discovery_upnp_timer"
 
-# Re-announce daily so the HA integration token is rotated (and pushed to HA via
-# Supervisor discovery) before it expires, also on long uptimes without restarts.
+# Re-announce daily so the HA integration token rotates before expiry, also on long uptimes
 HA_ANNOUNCE_INTERVAL = 86400
 HA_ANNOUNCE_TIMER_ID = "discovery_ha_announce_timer"
 
@@ -448,13 +447,8 @@ class DiscoveryController(CoreController):
                 )
 
     async def _announce_to_homeassistant(self) -> None:
-        """
-        Announce Music Assistant Ingress server to Home Assistant via Supervisor API.
-
-        Safe to repeat: the announced token only changes when it is due for rotation,
-        the Supervisor dedupes identical payloads and the HA integration only reloads
-        when the payload actually changed.
-        """
+        """Announce Music Assistant Ingress server to Home Assistant via Supervisor API."""
+        # Safe to repeat: Supervisor dedupes identical payloads and HA only reloads on change
         supervisor_token = os.environ["SUPERVISOR_TOKEN"]
         addon_hostname = os.environ["HOSTNAME"]
         ha_integration_token = await self.mass.webserver.auth.get_homeassistant_system_user_token()

--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -47,6 +47,11 @@ UPNP_DISCOVERY_BROADCAST_TARGET = (str(IPv4Address("255.255.255.255")), 1900)
 UPNP_DISCOVERY_TASK_ID = "discovery_upnp_cycle"
 UPNP_DISCOVERY_TIMER_ID = "discovery_upnp_timer"
 
+# Re-announce daily so the HA integration token is rotated (and pushed to HA via
+# Supervisor discovery) before it expires, also on long uptimes without restarts.
+HA_ANNOUNCE_INTERVAL = 86400
+HA_ANNOUNCE_TIMER_ID = "discovery_ha_announce_timer"
+
 
 async def async_upnp_search(*args: Any, **kwargs: Any) -> None:
     """Run async_upnp_client SSDP search with lazy import."""
@@ -93,6 +98,7 @@ class DiscoveryController(CoreController):
         if self.mass.running_as_hass_addon:
             # (re)announce to HA supervisor to make sure that HA picks it up
             await self._announce_to_homeassistant()
+            self._schedule_periodic_ha_announce()
         self._schedule_periodic_upnp_discovery()
 
     async def get_config_entries(
@@ -116,6 +122,7 @@ class DiscoveryController(CoreController):
         """Handle logic on server stop."""
         self.mass.cancel_timer(UPNP_DISCOVERY_TIMER_ID)
         self.mass.cancel_task(UPNP_DISCOVERY_TASK_ID)
+        self.mass.cancel_timer(HA_ANNOUNCE_TIMER_ID)
 
         await self._cancel_mdns_browser()
 
@@ -441,7 +448,13 @@ class DiscoveryController(CoreController):
                 )
 
     async def _announce_to_homeassistant(self) -> None:
-        """Announce Music Assistant Ingress server to Home Assistant via Supervisor API."""
+        """
+        Announce Music Assistant Ingress server to Home Assistant via Supervisor API.
+
+        Safe to repeat: the announced token only changes when it is due for rotation,
+        the Supervisor dedupes identical payloads and the HA integration only reloads
+        when the payload actually changed.
+        """
         supervisor_token = os.environ["SUPERVISOR_TOKEN"]
         addon_hostname = os.environ["HOSTNAME"]
         ha_integration_token = await self.mass.webserver.auth.get_homeassistant_system_user_token()
@@ -468,3 +481,16 @@ class DiscoveryController(CoreController):
                 )
         except Exception as err:
             self.logger.warning("Failed to announce to Home Assistant: %s", err)
+
+    def _schedule_periodic_ha_announce(self) -> None:
+        """Schedule the periodic (re)announce to Home Assistant."""
+
+        def run_announce() -> None:
+            self.mass.create_task(self._announce_to_homeassistant())
+            self._schedule_periodic_ha_announce()
+
+        self.mass.call_later(
+            HA_ANNOUNCE_INTERVAL,
+            run_announce,
+            task_id=HA_ANNOUNCE_TIMER_ID,
+        )

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -63,8 +63,7 @@ TOKEN_LONG_LIVED_EXPIRATION = 365  # Long-lived tokens (1 year, no auto-renewal)
 # Max days a sliding short-lived session may live from creation before re-auth.
 TOKEN_ABSOLUTE_MAX_EXPIRATION = 90
 TOKEN_GUEST_EXPIRATION = 1  # Guest sessions: short fixed lifetime, no renewal
-# Days before the absolute cap at which the HA integration token is rotated, so the
-# replacement is announced (and picked up by HA) before the current one stops working.
+# Days before the absolute cap at which the HA integration token is rotated
 HA_TOKEN_ROTATION_MARGIN = 7
 
 HA_TOKEN_SETTING_KEY = "ha_integration_token"
@@ -436,15 +435,13 @@ class AuthenticationManager:
         """
         system_user = await self.get_homeassistant_system_user()
 
-        # The plain token is kept in the settings table so it can be re-announced as-is.
-        # This adds no attack surface: the jwt_secret in the same table can mint any token.
+        # Keep the plain token in settings for re-announcing; the jwt_secret next to it can mint any token anyway
         if token_row := await self.database.get_row("settings", {"key": HA_TOKEN_SETTING_KEY}):
             token = str(token_row["value"])
             if await self._can_reuse_ha_integration_token(token, system_user):
                 return token
 
-        # A superseded token stays valid until it expires on its own, so the integration
-        # keeps working until it has reloaded with the newly announced token.
+        # A superseded token stays valid until expiry, so HA keeps working until it reloads
         token = await self.create_token(
             user=system_user,
             name=HA_TOKEN_NAME,
@@ -1965,13 +1962,7 @@ class AuthenticationManager:
         return updates
 
     async def _can_reuse_ha_integration_token(self, token: str, system_user: User) -> bool:
-        """
-        Check whether the stored Home Assistant integration token can still be announced.
-
-        :param token: The previously announced token.
-        :param system_user: The Home Assistant system user.
-        :return: True when the token is valid and not yet due for rotation.
-        """
+        """Check whether the stored HA integration token is valid and not yet due for rotation."""
         token_id = self.jwt_helper.get_token_id(token)
         if not token_id:
             return False

--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -63,6 +63,12 @@ TOKEN_LONG_LIVED_EXPIRATION = 365  # Long-lived tokens (1 year, no auto-renewal)
 # Max days a sliding short-lived session may live from creation before re-auth.
 TOKEN_ABSOLUTE_MAX_EXPIRATION = 90
 TOKEN_GUEST_EXPIRATION = 1  # Guest sessions: short fixed lifetime, no renewal
+# Days before the absolute cap at which the HA integration token is rotated, so the
+# replacement is announced (and picked up by HA) before the current one stops working.
+HA_TOKEN_ROTATION_MARGIN = 7
+
+HA_TOKEN_SETTING_KEY = "ha_integration_token"
+HA_TOKEN_NAME = "Home Assistant Integration"
 
 # Join code constants (short codes for QR/link-based login)
 JOIN_CODE_LENGTH = 12
@@ -418,34 +424,44 @@ class AuthenticationManager:
 
     async def get_homeassistant_system_user_token(self) -> str:
         """
-        Get or create an auth token for the Home Assistant system user.
+        Get the auth token to announce to the Home Assistant integration.
 
-        This method ensures only one active token exists for the HA integration.
-        If an old token exists, it is deleted and a new one is created.
-        The token auto-renews on use (expires after 30 days of inactivity).
+        Returns the same (still valid) token on repeated calls so re-announcing it via
+        Supervisor discovery is idempotent for the HA integration. A replacement is only
+        minted when the current token is missing, expired or revoked, or shortly before
+        it reaches its absolute lifetime cap - allowing seamless rotation as HA reloads
+        with the newly announced token while the old one is still accepted.
 
         :return: Authentication token for the Home Assistant system user.
         """
-        token_name = "Home Assistant Integration"
-
-        # Get the system user
         system_user = await self.get_homeassistant_system_user()
 
-        # Delete any existing tokens with this name to avoid accumulation
-        # We can't retrieve the plain token from the hash, so we always create a new one
-        existing_tokens = await self.database.get_rows(
-            "auth_tokens",
-            {"user_id": system_user.user_id, "name": token_name},
-        )
-        for token_row in existing_tokens:
-            await self.database.delete("auth_tokens", {"token_id": token_row["token_id"]})
+        # The plain token is kept in the settings table so it can be re-announced as-is.
+        # This adds no attack surface: the jwt_secret in the same table can mint any token.
+        if token_row := await self.database.get_row("settings", {"key": HA_TOKEN_SETTING_KEY}):
+            token = str(token_row["value"])
+            if await self._can_reuse_ha_integration_token(token, system_user):
+                return token
 
-        # Create a new token for the system user
-        return await self.create_token(
+        # A superseded token stays valid until it expires on its own, so the integration
+        # keeps working until it has reloaded with the newly announced token.
+        token = await self.create_token(
             user=system_user,
-            name=token_name,
+            name=HA_TOKEN_NAME,
             is_long_lived=False,
         )
+        await self.database.insert_or_replace(
+            "settings",
+            {"key": HA_TOKEN_SETTING_KEY, "value": token, "type": "string"},
+        )
+        now = utc()
+        for old_row in await self.database.get_rows(
+            "auth_tokens", {"user_id": system_user.user_id, "name": HA_TOKEN_NAME}
+        ):
+            if old_row["expires_at"] and datetime.fromisoformat(old_row["expires_at"]) <= now:
+                await self.database.delete("auth_tokens", {"token_id": old_row["token_id"]})
+        await self.database.commit()
+        return token
 
     async def link_user_to_provider(
         self,
@@ -1947,3 +1963,26 @@ class AuthenticationManager:
                 updates["expires_at"] = new_expires_at.isoformat()
 
         return updates
+
+    async def _can_reuse_ha_integration_token(self, token: str, system_user: User) -> bool:
+        """
+        Check whether the stored Home Assistant integration token can still be announced.
+
+        :param token: The previously announced token.
+        :param system_user: The Home Assistant system user.
+        :return: True when the token is valid and not yet due for rotation.
+        """
+        token_id = self.jwt_helper.get_token_id(token)
+        if not token_id:
+            return False
+        token_row = await self.database.get_row("auth_tokens", {"token_id": token_id})
+        if not token_row or token_row["user_id"] != system_user.user_id:
+            return False
+        now = utc()
+        if token_row["expires_at"] and datetime.fromisoformat(token_row["expires_at"]) <= now:
+            return False
+        created_at = datetime.fromisoformat(token_row["created_at"])
+        rotate_after = created_at + timedelta(
+            days=TOKEN_ABSOLUTE_MAX_EXPIRATION - HA_TOKEN_ROTATION_MARGIN
+        )
+        return now < rotate_after

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -508,28 +508,111 @@ async def test_homeassistant_system_user(auth_manager: AuthenticationManager) ->
     assert system_user2.user_id == system_user.user_id
 
 
-async def test_homeassistant_system_user_token(auth_manager: AuthenticationManager) -> None:
+async def test_homeassistant_system_user_token_stable_across_restarts(
+    auth_manager: AuthenticationManager,
+) -> None:
     """
-    Test Home Assistant system user token creation.
+    Test that a valid Home Assistant integration token is reused on repeated announces.
+
+    The addon announces on every startup; re-minting each time would invalidate the
+    token the HA integration still holds (issue #158174). Repeated calls must return
+    the exact same token so the re-announce is idempotent.
 
     :param auth_manager: AuthenticationManager instance.
     """
-    # Get or create token
     token1 = await auth_manager.get_homeassistant_system_user_token()
     assert token1 is not None
 
-    # Getting it again should create a new token (old one is replaced)
+    # A later startup (restart) returns the same token unchanged.
     token2 = await auth_manager.get_homeassistant_system_user_token()
-    assert token2 is not None
+    assert token2 == token1
+
+    user = await auth_manager.authenticate_with_token(token1)
+    assert user is not None
+    assert user.username == HOMEASSISTANT_SYSTEM_USER
+
+
+async def test_homeassistant_system_user_token_reissued_when_invalid(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Test that a fresh token is minted once the existing one is revoked or gone.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    token1 = await auth_manager.get_homeassistant_system_user_token()
+
+    # Drop the token row, as would happen if it expired or was revoked.
+    token_id = auth_manager.jwt_helper.get_token_id(token1)
+    await auth_manager.database.delete("auth_tokens", {"token_id": token_id})
+
+    token2 = await auth_manager.get_homeassistant_system_user_token()
+    assert token2 != token1
+    assert await auth_manager.authenticate_with_token(token2) is not None
+    assert await auth_manager.authenticate_with_token(token1) is None
+
+
+async def test_homeassistant_system_user_token_rotated_before_absolute_max(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Test that the Home Assistant integration token is rotated before its absolute cap.
+
+    The integration cannot reauth while running as an addon, so the token must be
+    replaced (and re-announced) before the absolute lifetime cap silently strands
+    the integration (issue #171938). The superseded token must remain valid so the
+    integration keeps working until it reloads with the new one.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    token1 = await auth_manager.get_homeassistant_system_user_token()
+    token_id = auth_manager.jwt_helper.get_token_id(token1)
+
+    # Age the token into the rotation window (close to the absolute cap, still valid).
+    now = utc()
+    created_at = now - timedelta(days=TOKEN_ABSOLUTE_MAX_EXPIRATION - 1)
+    await auth_manager.database.update(
+        "auth_tokens",
+        {"token_id": token_id},
+        {
+            "created_at": created_at.isoformat(),
+            "expires_at": (now + timedelta(days=1)).isoformat(),
+        },
+    )
+
+    # The next (periodic) announce must mint a replacement.
+    token2 = await auth_manager.get_homeassistant_system_user_token()
     assert token2 != token1
 
-    # Old token should not work
-    user1 = await auth_manager.authenticate_with_token(token1)
-    assert user1 is None
+    # Both tokens work: the old one until it expires, the new one going forward.
+    assert await auth_manager.authenticate_with_token(token1) is not None
+    assert await auth_manager.authenticate_with_token(token2) is not None
 
-    # New token should work
-    user2 = await auth_manager.authenticate_with_token(token2)
-    assert user2 is not None
+    # The new token is stable again on subsequent announces.
+    assert await auth_manager.get_homeassistant_system_user_token() == token2
+
+
+async def test_homeassistant_system_user_token_cleans_up_expired_rows(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Test that expired Home Assistant integration token rows are removed on rotation.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    token1 = await auth_manager.get_homeassistant_system_user_token()
+    token_id = auth_manager.jwt_helper.get_token_id(token1)
+
+    # Expire the token entirely so the next announce mints a replacement.
+    await auth_manager.database.update(
+        "auth_tokens",
+        {"token_id": token_id},
+        {"expires_at": (utc() - timedelta(days=1)).isoformat()},
+    )
+
+    token2 = await auth_manager.get_homeassistant_system_user_token()
+    assert token2 != token1
+    assert await auth_manager.database.get_row("auth_tokens", {"token_id": token_id}) is None
 
 
 async def test_update_user_role(auth_manager: AuthenticationManager) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The Home Assistant integration repeatedly loses authentication to the Music Assistant server when running as the HAOS add-on, failing setup with `Authentication failed, addon discovery not completed yet` (or a reauth prompt). Two variants are reported: it breaks **on every restart** of the MA container (a reload fixes it) and it breaks **over time** (after ~90 days).

Root cause is in `get_homeassistant_system_user_token()`: it deleted and re-minted the token on every announce (so each MA restart invalidated the token the integration still held), and the token silently died at the 90-day absolute lifetime cap with no rotation path (the integration cannot reauth while running as an add-on).

This keeps the short-lived, expiring token but makes the announce idempotent and rotates the token proactively:

- The announced token is persisted (in the auth DB, next to the `jwt_secret` that can mint any token, so no added attack surface) and reused as-is on subsequent announces. Re-announcing the same payload is a no-op: the Supervisor dedupes it and HA only reloads the entry when the token actually changed.
- A replacement token is only minted when the current one is missing, expired or revoked, or within 7 days of its 90-day absolute cap. The superseded token stays valid until it expires on its own, so HA keeps working until it reloads with the new one.
- The add-on now re-announces daily, so rotation also happens on long uptimes and a missed announce (e.g. HA-side discovery flow aborted during startup) self-heals.
- Expired token rows for the HA system user are cleaned up on rotation.

**Related issue (if applicable):**

- Fixes https://github.com/home-assistant/core/issues/171938
- Fixes https://github.com/home-assistant/core/issues/158174

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
