### PR TITLE
Sample smart playlist seeds evenly in discover mode

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1253,11 +1253,7 @@ class SmartPlaylistProvider(PluginProvider):
                 self.logger.warning("Could not resolve seed %s: %s", uri, exc)
         if not seeds:
             return []
-        # Build a separate pool per seed (its own base tracks plus tracks similar to them), then
-        # round-robin across those pools so every seed contributes evenly - a single large seed
-        # can no longer fill the whole pool before the others are reached. A shared `seen` set ties
-        # each track to the first seed that yields it. Downstream post-filtering, dedup, shuffle and
-        # limit shape this pool into the final playlist.
+        # round-robin each seed's own pool so seeds contribute evenly; `seen` dedupes across them
         pool_cap = target_size * 3
         per_seed_cap = -(-pool_cap // len(seeds))  # ceil, so the pools can still fill the cap
         seen: set[Track] = set()

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -19,6 +19,7 @@ import uuid as _uuid
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import replace as dc_replace
+from itertools import zip_longest
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -1250,30 +1251,40 @@ class SmartPlaylistProvider(PluginProvider):
                 seeds.append(await ctrl.get(item_id, provider))
             except Exception as exc:
                 self.logger.warning("Could not resolve seed %s: %s", uri, exc)
-        # each seed contributes its own (base) tracks plus tracks similar to them; downstream
-        # post-filtering, dedup, shuffle and limit shape this pool into the final playlist
-        pool: list[Track] = []
+        if not seeds:
+            return []
+        # Build a separate pool per seed (its own base tracks plus tracks similar to them), then
+        # round-robin across those pools so every seed contributes evenly - a single large seed
+        # can no longer fill the whole pool before the others are reached. A shared `seen` set ties
+        # each track to the first seed that yields it. Downstream post-filtering, dedup, shuffle and
+        # limit shape this pool into the final playlist.
+        pool_cap = target_size * 3
+        per_seed_cap = -(-pool_cap // len(seeds))  # ceil, so the pools can still fill the cap
         seen: set[Track] = set()
+        per_seed_pools: list[list[Track]] = []
         for seed in seeds:
-            if len(pool) >= target_size * 3:
-                break
+            seed_pool: list[Track] = []
             with suppress(MusicAssistantError):
                 for base in await self.mass.player_queues.get_tracks_for_playback(seed):
-                    if len(pool) >= target_size * 3:
+                    if len(seed_pool) >= per_seed_cap:
                         break
                     if base not in seen:
                         seen.add(base)
-                        pool.append(base)
+                        seed_pool.append(base)
                     with suppress(MusicAssistantError):
                         for track in await self.mass.music.tracks.similar_tracks(
                             base.item_id, base.provider
                         ):
-                            if len(pool) >= target_size * 3:
+                            if len(seed_pool) >= per_seed_cap:
                                 break
                             if track not in seen:
                                 seen.add(track)
-                                pool.append(track)
-        return pool
+                                seed_pool.append(track)
+            per_seed_pools.append(seed_pool)
+        pool: list[Track] = []
+        for round_tracks in zip_longest(*per_seed_pools):
+            pool.extend(track for track in round_tracks if track is not None)
+        return pool[:pool_cap]
 
     async def _update_playlist_description(
         self, library_item_id: int | str, description: str

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -899,6 +899,49 @@ async def test_tracks_from_seeds_pools_base_and_similar() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tracks_from_seeds_samples_evenly_across_seeds() -> None:
+    """A large seed must not crowd the pool: each seed contributes evenly (round-robin)."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    seed_a = _make_mock_track("seed_a", "library://track/seed_a")
+    seed_b = _make_mock_track("seed_b", "library://track/seed_b")
+    base_a = _make_mock_track("base_a", "library://track/base_a")
+    base_b = _make_mock_track("base_b", "library://track/base_b")
+    # Seed A yields far more similar tracks than seed B; the old sequential fill let A alone
+    # reach the pool cap so B never contributed a single track.
+    a_similar = [_make_mock_track(f"a_sim_{i}", f"library://track/a_sim_{i}") for i in range(30)]
+    b_similar = [_make_mock_track("b_sim_0", "library://track/b_sim_0")]
+
+    ctrl = MagicMock()
+    ctrl.get = AsyncMock(side_effect=[seed_a, seed_b])
+    mass.music.get_controller = MagicMock(return_value=ctrl)
+    mass.player_queues.get_tracks_for_playback = AsyncMock(
+        side_effect=lambda seed: {seed_a: [base_a], seed_b: [base_b]}[seed]
+    )
+    mass.music.tracks.similar_tracks = AsyncMock(
+        side_effect=lambda item_id, _provider: {"base_a": a_similar, "base_b": b_similar}[item_id]
+    )
+
+    result = await plugin._tracks_from_seeds(
+        ["library://track/seed_a", "library://track/seed_b"], target_size=4
+    )
+
+    ids = {track.item_id for track in result}
+    # seed B's tracks must survive even though seed A dwarfs it
+    assert "base_b" in ids
+    assert "b_sim_0" in ids
+    assert "base_a" in ids
+    # round-robin, not concatenation: A and B alternate at the head of the pool
+    head = [track.item_id for track in result[:2]]
+    assert head == ["base_a", "base_b"]
+
+
+@pytest.mark.asyncio
 async def test_exclusion_filters_out_excluded_artist() -> None:
     """Tracks from excluded artists are removed from the result."""
     mass = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

In discover mode, a smart playlist seeded from multiple items (e.g. playlist A **and** B) did not sample evenly across the seeds. All seeds fed a single shared pool capped at `limit * 3`, filled sequentially, so a large first seed could reach the cap on its own — leaving later seeds underrepresented or missing entirely. The final shuffle then hid the skew in the ordering.

This makes every seed contribute evenly:

- Each seed now builds its **own** pool (its base tracks + their similar tracks), capped at a fair share (`ceil(pool_cap / num_seeds)`).
- The per-seed pools are merged **round-robin** so seeds alternate in the pool regardless of size; a shared `seen` set still dedupes across seeds.
- Smaller seeds degrade gracefully — if one runs dry, the remaining rounds keep drawing from the others.
- Added a regression test that fails on the old sequential-fill behaviour.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
