### PR TITLE
Fix media position exceeding duration on squeezelite players

### DIFF
--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -527,10 +527,10 @@ class SqueezelitePlayer(Player):
             # Some players keep sending heartbeat with increasing elapsed time
             # even when paused (e.g. WiiM)
             return
-        # elapsed time change on the player will be auto picked up
-        # by the player manager.
         self._attr_elapsed_time = self.client.elapsed_seconds
         self._attr_elapsed_time_last_updated = time.time()
+        # update_state re-bases the position anchor if the elapsed time diverged (e.g. buffering)
+        self.update_state()
 
         # handle sync
         if self.synced_to:

--- a/music_assistant/providers/squeezelite/player.py
+++ b/music_assistant/providers/squeezelite/player.py
@@ -35,7 +35,12 @@ from music_assistant.constants import (
 )
 from music_assistant.helpers.audio import get_mime_type
 from music_assistant.helpers.util import TaskManager
-from music_assistant.models.player import DeviceInfo, Player, PlayerMedia
+from music_assistant.models.player import (
+    POSITION_JUMP_THRESHOLD,
+    DeviceInfo,
+    Player,
+    PlayerMedia,
+)
 
 from .constants import (
     CONF_ENTRY_DISPLAY,
@@ -529,8 +534,13 @@ class SqueezelitePlayer(Player):
             return
         self._attr_elapsed_time = self.client.elapsed_seconds
         self._attr_elapsed_time_last_updated = time.time()
-        # update_state re-bases the position anchor if the elapsed time diverged (e.g. buffering)
-        self.update_state()
+        # only involve the state machine when the reported position diverged (e.g. buffering/seek)
+        published_position = self.state.corrected_elapsed_time
+        if (
+            published_position is None
+            or abs(published_position - self.client.elapsed_seconds) > POSITION_JUMP_THRESHOLD
+        ):
+            self.update_state()
 
         # handle sync
         if self.synced_to:


### PR DESCRIPTION
## Problem

Home Assistant (and other clients) could show a `media_position` far beyond the track's `media_duration` for slimproto/squeezelite players (e.g. position 296 on a 151s track).

## Root cause

`_handle_player_heartbeat` updated the raw `_attr_elapsed_time` attributes but never called `update_state()` — the comment claimed the change would be "auto picked up by the player manager", which describes an outdated architecture. As a result:

1. The player's public state snapshot kept the position anchor from playback start.
2. Queue timing extrapolated from that stale anchor at wall-clock speed (`corrected_elapsed_time`).
3. Whenever the device played slower than real-time (e.g. a piCorePlayer/squeezeesp32 buffering a hi-res 192kHz FLAC), the reported position raced past the track duration.
4. The designed divergence-correction path (`__own_position_anchor_moved` → `on_player_position_jumped` → queue re-base) never fired because `update_state()` never ran.

The cast, sonos and airplay providers all call `update_state()` from their position callbacks; squeezelite was the outlier.

## Fix

Call `update_state()` from the heartbeat handler. During steady playback this is a cheap no-op (the anchor jump threshold keeps the previous anchor), and on divergence it re-bases the queue timing on the device's real position.

## Verification

Reproduced the stall scenario locally (hi-res ~4.2 Mbps FLAC on a squeezeesp32 via universal player, monitored queue + HA entity): before the fix, queue elapsed ticked at wall-clock speed to 162s+ on a 71s track; after the fix, elapsed advanced at the device's real (~0.5×) rate, peaked at 69.5/71s and the track ended cleanly.