### PR TITLE
Fix frozen now-playing on WiiM players when UPnP events are blocked

### DIFF
--- a/music_assistant/providers/wiim/player.py
+++ b/music_assistant/providers/wiim/player.py
@@ -481,6 +481,11 @@ class WiimPlayer(Player):
         if (media := self.device.current_media) is not None and media.position is not None:
             self._attr_elapsed_time = media.position
             self._attr_elapsed_time_last_updated = time.time()
+        elif (position := self.device._state_source_device()._current_position) is not None:
+            # No media info from UPnP events (e.g. NOTIFY callbacks blocked by
+            # a firewall) - fall back to the position we just polled.
+            self._attr_elapsed_time = position
+            self._attr_elapsed_time_last_updated = time.time()
         self._update_ma_state_from_sdk_cache()
 
     async def _refresh_multiroom(self) -> None:


### PR DESCRIPTION
# What does this implement/fix?

On WiiM players, now-playing info (Pandora/Deezer radio) froze on the first track and the position never updated when the device's UPnP NOTIFY callbacks can't reach the MA server (e.g. player and server on different subnets/VLANs with a firewall in between).

`WiimPlayer._sync_position()` successfully polls the position via GetPositionInfo every 5s, but discarded it whenever `device.current_media` was None — and `current_media` is only ever populated from UPnP event data. So without events, elapsed time stayed at 0 forever, which also blocked the queue's stream metadata updates (frozen Pandora now-playing).

- Fall back to the freshly polled SDK position when no media info from UPnP events is available

Verified against an emulated WiiM device that accepts event subscriptions but never delivers NOTIFYs: before the fix elapsed time stayed None/0 while the device position advanced; after the fix player and queue elapsed time track the polled position.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5634

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
