### PR TITLE
Shuffle smart playlist seed tracks before sampling

### DIFF
--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1277,8 +1277,7 @@ class SmartPlaylistProvider(PluginProvider):
             seed_pool: list[Track] = []
             with suppress(MusicAssistantError):
                 seed_tracks = await self.mass.player_queues.get_tracks_for_playback(seed)
-                # draw base tracks from across the whole seed, not just its first few items
-                # (playlists resolve in stored order), so re-generations vary the seeds used
+                # shuffle so seeds are drawn from across the whole playlist, not just its top
                 random.shuffle(seed_tracks)
                 for base in seed_tracks:
                     if len(seed_pool) >= per_seed_cap:

--- a/music_assistant/providers/smart_playlist/__init__.py
+++ b/music_assistant/providers/smart_playlist/__init__.py
@@ -1276,7 +1276,11 @@ class SmartPlaylistProvider(PluginProvider):
         for seed in seeds:
             seed_pool: list[Track] = []
             with suppress(MusicAssistantError):
-                for base in await self.mass.player_queues.get_tracks_for_playback(seed):
+                seed_tracks = await self.mass.player_queues.get_tracks_for_playback(seed)
+                # draw base tracks from across the whole seed, not just its first few items
+                # (playlists resolve in stored order), so re-generations vary the seeds used
+                random.shuffle(seed_tracks)
+                for base in seed_tracks:
                     if len(seed_pool) >= per_seed_cap:
                         break
                     if base not in seen:

--- a/tests/providers/smart_playlist/test_smart_playlist.py
+++ b/tests/providers/smart_playlist/test_smart_playlist.py
@@ -942,6 +942,36 @@ async def test_tracks_from_seeds_samples_evenly_across_seeds() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tracks_from_seeds_shuffles_seed_tracks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Base tracks are drawn from across the seed, not just its first few (stored-order) items."""
+    mass = MagicMock()
+    manifest = MagicMock()
+    manifest.domain = "smart_playlist"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    plugin = SmartPlaylistProvider(mass, manifest, config, set())
+
+    # a large seed whose tracks resolve in stored order; without shuffling only t0.. would be used
+    seed_tracks = [_make_mock_track(f"t{i}", f"library://track/t{i}") for i in range(20)]
+
+    ctrl = MagicMock()
+    ctrl.get = AsyncMock(return_value=_make_mock_track("seed", "library://track/seed"))
+    mass.music.get_controller = MagicMock(return_value=ctrl)
+    mass.player_queues.get_tracks_for_playback = AsyncMock(return_value=seed_tracks)
+    mass.music.tracks.similar_tracks = AsyncMock(return_value=[])
+    # deterministic "shuffle": reverse in place, so tail tracks land at the head
+    monkeypatch.setattr(
+        "music_assistant.providers.smart_playlist.random.shuffle", lambda seq: seq.reverse()
+    )
+
+    result = await plugin._tracks_from_seeds(["library://track/seed"], target_size=2)
+
+    ids = {track.item_id for track in result}
+    assert "t19" in ids
+    assert "t0" not in ids
+
+
+@pytest.mark.asyncio
 async def test_exclusion_filters_out_excluded_artist() -> None:
     """Tracks from excluded artists are removed from the result."""
     mass = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the even-seed-sampling fix. In discover mode the base seed tracks were taken from the **top** of each seed in resolved order — playlists resolve in their stored order and are not shuffled — so a playlist seed always drew its seeds from its first few tracks. Because each base track also pulls in its similar tracks (both count toward the per-seed cap), only the first handful of a playlist's tracks were ever used as seeds, and re-generating produced the same seeds every time.

- Shuffle each seed's resolved tracks in `_tracks_from_seeds` before sampling, so base seeds are drawn from across the whole playlist and vary between generations.
- Stays local to the smart-playlist provider — does not touch the shared queue resolver, so normal playlist playback order is unaffected.
- Added a regression test asserting seeds are drawn from beyond the first few tracks.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
