### PR TITLE
Expose bpm, musical key and RMS waveform to the frontend

### DIFF
--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -141,6 +141,9 @@ class TracksController(MediaControllerBase[Track]):
             provider_instance_id_or_domain,
             allow_update_metadata=allow_update_metadata,
         )
+        track.audio_metadata = await self.mass.streams.audio_analysis.get_track_audio_metadata(
+            track
+        )
         if not recursive and album_uri is None:
             # return early if we do not want recursive full details and no album uri is provided
             return track

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -19,6 +19,7 @@ from music_assistant_models.auth import Scope
 from music_assistant_models.background_task import TaskSchedule
 from music_assistant_models.enums import ContentType, MediaType, ProviderType, StreamType
 from music_assistant_models.errors import ProviderUnavailableError
+from music_assistant_models.media_items import AudioMetadata
 
 from music_assistant.constants import (
     CONF_BACKGROUND_SCAN_CONCURRENCY,
@@ -79,7 +80,7 @@ LOGGER = logging.getLogger(f"{MASS_LOGGER_NAME}.audio_analysis")
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from music_assistant_models.media_items import AudioFormat
+    from music_assistant_models.media_items import AudioFormat, Track
     from music_assistant_models.streamdetails import StreamDetails
 
     from music_assistant.controllers.streams.audio_buffer import AudioBuffer
@@ -516,6 +517,53 @@ class AudioAnalysisController:
             p.domain for p in self.mass.get_providers(ProviderType.AUDIO_ANALYSIS) if p.available
         }
         return _merged_from_rows(rows, available_aa_domains, priority)
+
+    async def get_track_audio_metadata(self, track: Track) -> AudioMetadata | None:
+        """
+        Return AudioMetadata (bpm, musical key) for a track, or None when no analysis exists.
+
+        Provider mappings are tried best-quality first; per field the Smart Fades AA
+        provider is preferred over other AA providers.
+
+        :param track: The track to look up stored analysis data for.
+        """
+        priority = self._aa_domains_preferring(SMART_FADES_ANALYSIS_DOMAIN)
+        for mapping in sorted(track.provider_mappings, key=lambda m: m.quality, reverse=True):
+            analysis = await self.get_audio_analysis(
+                mapping.item_id, mapping.provider_instance, priority=priority
+            )
+            if analysis is None or (analysis.bpm is None and analysis.key is None):
+                continue
+            musical_key: str | None = None
+            if analysis.key is not None:
+                musical_key = f"{analysis.key} {analysis.mode}" if analysis.mode else analysis.key
+            return AudioMetadata(bpm=analysis.bpm, musical_key=musical_key)
+        return None
+
+    @api_command("audio_analysis/wave_form")
+    async def get_wave_form(
+        self,
+        item_id: str,
+        provider_instance_id_or_domain: str,
+    ) -> list[float] | None:
+        """
+        Return the RMS energy waveform for a track, or None when no analysis exists.
+
+        The waveform is a fixed array of 1800 bins (normalized 0.0-1.0) evenly covering
+        the track duration. Values come from the Smart Fades AA provider when available,
+        falling back to any other AA provider that stored RMS energy.
+
+        :param item_id: Provider-native item ID.
+        :param provider_instance_id_or_domain: Music provider instance ID or domain.
+        """
+        analysis = await self.get_audio_analysis(
+            item_id,
+            provider_instance_id_or_domain,
+            priority=self._aa_domains_preferring(SMART_FADES_ANALYSIS_DOMAIN),
+        )
+        if analysis is None or analysis.rms_energy is None:
+            return None
+        return [float(value) for value in analysis.rms_energy]
 
     async def set_track_loudness(
         self,
@@ -1373,6 +1421,15 @@ class AudioAnalysisController:
                 self._finalize_providers(session_key)
             else:
                 self._cancel_providers(session_key)
+
+    def _aa_domains_preferring(self, preferred: str) -> tuple[str, ...]:
+        """Return all AA provider domains ordered with the preferred domain first."""
+        others = sorted(
+            p.domain
+            for p in self.mass.get_providers(ProviderType.AUDIO_ANALYSIS)
+            if p.domain != preferred
+        )
+        return (preferred, *others)
 
     def _cpu_count(self) -> int:
         """Return the CPU core count available to this process (fallback 4 when unknown)."""

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -45,6 +45,9 @@ from music_assistant.models.music_provider import MusicProvider
 LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
 SMART_FADES_ANALYSIS_DOMAIN = "smart_fades"
 SONIC_ANALYSIS_DOMAIN = "sonic_analysis"
+# AA domains trusted for frontend-facing track data (bpm/key/waveform), authoritative first.
+# Extend deliberately when a new AA provider should feed the frontend.
+TRACK_EXPORT_AA_PRIORITY = (SMART_FADES_ANALYSIS_DOMAIN, SONIC_ANALYSIS_DOMAIN)
 BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300
 BACKGROUND_PER_TRACK_TIMEOUT_DURATION_MULTIPLIER = 1.5
@@ -527,7 +530,7 @@ class AudioAnalysisController:
 
         :param track: The track to look up stored analysis data for.
         """
-        priority = self._aa_domains_preferring(SMART_FADES_ANALYSIS_DOMAIN)
+        priority = TRACK_EXPORT_AA_PRIORITY
         for mapping in sorted(track.provider_mappings, key=lambda m: m.quality, reverse=True):
             analysis = await self.get_audio_analysis(
                 mapping.item_id, mapping.provider_instance, priority=priority
@@ -559,7 +562,7 @@ class AudioAnalysisController:
         analysis = await self.get_audio_analysis(
             item_id,
             provider_instance_id_or_domain,
-            priority=self._aa_domains_preferring(SMART_FADES_ANALYSIS_DOMAIN),
+            priority=TRACK_EXPORT_AA_PRIORITY,
         )
         if analysis is None or analysis.rms_energy is None:
             return None
@@ -1421,15 +1424,6 @@ class AudioAnalysisController:
                 self._finalize_providers(session_key)
             else:
                 self._cancel_providers(session_key)
-
-    def _aa_domains_preferring(self, preferred: str) -> tuple[str, ...]:
-        """Return all AA provider domains ordered with the preferred domain first."""
-        others = sorted(
-            p.domain
-            for p in self.mass.get_providers(ProviderType.AUDIO_ANALYSIS)
-            if p.domain != preferred
-        )
-        return (preferred, *others)
 
     def _cpu_count(self) -> int:
         """Return the CPU core count available to this process (fallback 4 when unknown)."""

--- a/music_assistant/controllers/streams/audio_analysis.py
+++ b/music_assistant/controllers/streams/audio_analysis.py
@@ -46,7 +46,6 @@ LOUDNESS_ANALYSIS_DOMAIN = "loudness_analysis"
 SMART_FADES_ANALYSIS_DOMAIN = "smart_fades"
 SONIC_ANALYSIS_DOMAIN = "sonic_analysis"
 # AA domains trusted for frontend-facing track data (bpm/key/waveform), authoritative first.
-# Extend deliberately when a new AA provider should feed the frontend.
 TRACK_EXPORT_AA_PRIORITY = (SMART_FADES_ANALYSIS_DOMAIN, SONIC_ANALYSIS_DOMAIN)
 BACKGROUND_SCAN_TASK_ID = "audio_analysis_background_scan"
 BACKGROUND_PER_TRACK_TIMEOUT_SECONDS = 300

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -1350,20 +1350,3 @@ async def test_get_wave_form_none_without_rms() -> None:
     """wave_form returns None when no AA provider stored RMS energy."""
     c = _analysis_controller_with_rows([_aa_row(SMART_FADES_ANALYSIS_DOMAIN, 1, bpm=120.0)])
     assert await c.get_wave_form("track-1", "test-provider") is None
-
-
-def test_aa_domains_preferring_orders_preferred_first() -> None:
-    """The preferred AA domain is listed first, remaining domains follow sorted."""
-    c, _ = _stub_controller()
-    c.mass.get_providers = MagicMock(  # type: ignore[method-assign]
-        return_value=[
-            _aa_provider_stub(SONIC_ANALYSIS_DOMAIN),
-            _aa_provider_stub(SMART_FADES_ANALYSIS_DOMAIN),
-            _aa_provider_stub(LOUDNESS_ANALYSIS_DOMAIN),
-        ]
-    )
-    assert c._aa_domains_preferring(SMART_FADES_ANALYSIS_DOMAIN) == (
-        SMART_FADES_ANALYSIS_DOMAIN,
-        LOUDNESS_ANALYSIS_DOMAIN,
-        SONIC_ANALYSIS_DOMAIN,
-    )

--- a/tests/controllers/streams/test_audio_analysis.py
+++ b/tests/controllers/streams/test_audio_analysis.py
@@ -9,11 +9,12 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 from music_assistant_models.audio_analysis import AudioAnalysisCoverage
 from music_assistant_models.enums import ContentType, MediaType, StreamType
 from music_assistant_models.errors import ProviderUnavailableError
-from music_assistant_models.media_items import AudioFormat
+from music_assistant_models.media_items import AudioFormat, ProviderMapping, Track
 
 import music_assistant.controllers.streams.audio_analysis as audio_analysis_mod
 from music_assistant.constants import (
@@ -1259,3 +1260,110 @@ def test_controller_has_no_provider_specific_extra_data_keys() -> None:
     # do not weaken this to an import/attribute check.
     assert "_EXPORT_STRIP_EXTRA_DATA_KEYS" not in source
     assert "clap_embedding" not in source
+
+
+# --- track audio metadata & waveform export ---
+
+
+def _track_with_mapping(item_id: str = "track-1", provider: str = "test-provider") -> Track:
+    """Build a Track with a single provider mapping."""
+    return Track(
+        item_id=item_id,
+        provider="library",
+        name="Test Track",
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain=provider,
+                provider_instance=provider,
+            )
+        },
+    )
+
+
+def _analysis_controller_with_rows(rows: list[dict[str, Any]]) -> AudioAnalysisController:
+    """Build a stub controller whose DB returns the given analysis rows for any track."""
+    c, db = _stub_controller()
+    db.get_rows = AsyncMock(return_value=rows)
+    music_prov = MagicMock(spec=MusicProvider)
+    music_prov.is_streaming_provider = True
+    music_prov.domain = "test-provider"
+    c.mass.get_provider = MagicMock(return_value=music_prov)  # type: ignore[method-assign]
+    c.mass.get_providers = MagicMock(  # type: ignore[method-assign]
+        return_value=[
+            _aa_provider_stub(SMART_FADES_ANALYSIS_DOMAIN),
+            _aa_provider_stub(SONIC_ANALYSIS_DOMAIN),
+        ]
+    )
+    return c
+
+
+@pytest.mark.asyncio
+async def test_get_track_audio_metadata_prefers_smart_fades() -> None:
+    """bpm/key come from smart_fades even when another AA provider wrote them later."""
+    c = _analysis_controller_with_rows(
+        [
+            _aa_row(SMART_FADES_ANALYSIS_DOMAIN, 1, bpm=128.0, key="F#", mode="minor"),
+            _aa_row(SONIC_ANALYSIS_DOMAIN, 2, bpm=100.0),
+        ]
+    )
+    result = await c.get_track_audio_metadata(_track_with_mapping())
+    assert result is not None
+    assert result.bpm == 128.0
+    assert result.musical_key == "F# minor"
+
+
+@pytest.mark.asyncio
+async def test_get_track_audio_metadata_key_without_mode() -> None:
+    """musical_key falls back to the bare pitch class when no mode was detected."""
+    c = _analysis_controller_with_rows([_aa_row(SMART_FADES_ANALYSIS_DOMAIN, 1, key="C")])
+    result = await c.get_track_audio_metadata(_track_with_mapping())
+    assert result is not None
+    assert result.bpm is None
+    assert result.musical_key == "C"
+
+
+@pytest.mark.asyncio
+async def test_get_track_audio_metadata_none_without_relevant_analysis() -> None:
+    """No AudioMetadata when stored analysis has neither bpm nor key."""
+    c = _analysis_controller_with_rows(
+        [_aa_row(SONIC_ANALYSIS_DOMAIN, 1, loudness_integrated=-7.5)]
+    )
+    assert await c.get_track_audio_metadata(_track_with_mapping()) is None
+
+
+@pytest.mark.asyncio
+async def test_get_wave_form_returns_rms_bins() -> None:
+    """wave_form returns the stored RMS energy bins as a plain list of floats."""
+    rms = np.linspace(0.0, 1.0, 1800, dtype=np.float32)
+    c = _analysis_controller_with_rows([_aa_row(SMART_FADES_ANALYSIS_DOMAIN, 1, rms_energy=rms)])
+    result = await c.get_wave_form("track-1", "test-provider")
+    assert result is not None
+    assert len(result) == 1800
+    assert result[0] == pytest.approx(0.0)
+    assert result[-1] == pytest.approx(1.0)
+    assert all(isinstance(v, float) for v in result)
+
+
+@pytest.mark.asyncio
+async def test_get_wave_form_none_without_rms() -> None:
+    """wave_form returns None when no AA provider stored RMS energy."""
+    c = _analysis_controller_with_rows([_aa_row(SMART_FADES_ANALYSIS_DOMAIN, 1, bpm=120.0)])
+    assert await c.get_wave_form("track-1", "test-provider") is None
+
+
+def test_aa_domains_preferring_orders_preferred_first() -> None:
+    """The preferred AA domain is listed first, remaining domains follow sorted."""
+    c, _ = _stub_controller()
+    c.mass.get_providers = MagicMock(  # type: ignore[method-assign]
+        return_value=[
+            _aa_provider_stub(SONIC_ANALYSIS_DOMAIN),
+            _aa_provider_stub(SMART_FADES_ANALYSIS_DOMAIN),
+            _aa_provider_stub(LOUDNESS_ANALYSIS_DOMAIN),
+        ]
+    )
+    assert c._aa_domains_preferring(SMART_FADES_ANALYSIS_DOMAIN) == (
+        SMART_FADES_ANALYSIS_DOMAIN,
+        LOUDNESS_ANALYSIS_DOMAIN,
+        SONIC_ANALYSIS_DOMAIN,
+    )


### PR DESCRIPTION
# What does this implement/fix?

Exposes audio-analysis results to the frontend: bpm and musical key for the track overview page, and the RMS energy waveform (1800 bins) for a future waveform progress bar in the now playing screen.

- Populate the new `Track.audio_metadata` (bpm + musical_key) on full track get, trying provider mappings best-quality first with the Smart Fades AA provider preferred per field
- Add `audio_analysis/wave_form` API command (params: `item_id`, `provider_instance_id_or_domain`) returning the 1800 normalized RMS bins, Smart Fades preferred
- Add tests for the new controller methods

Depends on music-assistant/models#290 (`AudioMetadata` model); needs a models release + version bump before CI passes.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [x] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.