### PR TITLE
Preserve player config when replacing registered players

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1593,24 +1593,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             # We use the 'initialized' attribute to indicate that the player
             # is still in the process of being registered so we can filter it out where needed.
             self._players[player_id] = player
-            # update state to ensure player.state reflects the final attributes
-            # (e.g. player type) set after super().__init__() in the player subclass,
-            # before we fetch config (which relies on state.type for entry resolution)
-            player.update_state(signal_event=False)
-            # ensure we fetch and set the latest/full config for the player
-            player_config = await self.mass.config.get_player_config(player_id)
-            player.set_config(player_config)
-            # update state again now that config is loaded
-            player.update_state(signal_event=False)
-            self._save_underlying_player_id(player)
-            # call hook after the player is registered and config is set
-            await player.on_config_updated()
-
-            # Handle protocol linking
-            self._evaluate_protocol_links(player)
-
-            # now we're ready to signal the player is added and available
-            player.set_initialized()
+            await self._setup_registered_player(player, signal_state_event=False)
             self.logger.info(
                 "Player (type %s) registered: %s/%s",
                 player.state.type.value,
@@ -1635,15 +1618,29 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
         if self.mass.closing:
             return
 
-        if player.player_id in self._players:
-            self._players[player.player_id] = player
-            player.update_state()
-            # the derived-transport edge may have been set/revoked after the
-            # initial registration (e.g. via a bridge claim)
-            self._save_underlying_player_id(player)
-            # Also schedule update when replacing existing player
-            self._schedule_update_all_players()
-            return
+        if previous_player := self._players.get(player.player_id):
+            if previous_player is player:
+                player.update_state()
+                # the derived-transport edge may have been set/revoked after the
+                # initial registration (e.g. via a bridge claim)
+                self._save_underlying_player_id(player)
+                # Also schedule update when updating existing player
+                self._schedule_update_all_players()
+                return
+
+            async with self._register_lock:
+                if current_player := self._players.get(player.player_id):
+                    if current_player is player:
+                        player.update_state()
+                        # the derived-transport edge may have been set/revoked after the
+                        # initial registration (e.g. via a bridge claim)
+                        self._save_underlying_player_id(player)
+                    else:
+                        self._players[player.player_id] = player
+                        await self._setup_registered_player(player, signal_state_event=True)
+                    # Also schedule update when updating existing player
+                    self._schedule_update_all_players()
+                    return
 
         await self.register(player)
 
@@ -2350,6 +2347,27 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
     def __iter__(self) -> Iterator[Player]:
         """Iterate over all players."""
         return iter(self._players.values())
+
+    async def _setup_registered_player(self, player: Player, *, signal_state_event: bool) -> None:
+        """Load config and run common setup for a player present in the registry."""
+        # update state to ensure player.state reflects the final attributes
+        # (e.g. player type) set after super().__init__() in the player subclass,
+        # before we fetch config (which relies on state.type for entry resolution)
+        player.update_state(signal_event=False)
+        # ensure we fetch and set the latest/full config for the player
+        player_config = await self.mass.config.get_player_config(player.player_id)
+        player.set_config(player_config)
+        # update state again now that config is loaded
+        player.update_state(signal_event=signal_state_event)
+        self._save_underlying_player_id(player)
+        # call hook after the player is registered and config is set
+        await player.on_config_updated()
+
+        # Handle protocol linking
+        self._evaluate_protocol_links(player)
+
+        # now we're ready to signal the player is added and available
+        player.set_initialized()
 
     async def _release_player_for_play_media(self, player: Player) -> None:
         """

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -18,7 +18,7 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
-from music_assistant_models.config_entries import ConfigEntry, PlayerConfig
+from music_assistant_models.config_entries import ConfigEntry, ConfigValueType, PlayerConfig
 from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
 from music_assistant_models.enums import (
     ConfigEntryType,
@@ -30,7 +30,12 @@ from music_assistant_models.enums import (
 from music_assistant_models.errors import InvalidDataError, UnsupportedFeaturedException
 from music_assistant_models.player import PlayerSource
 
-from music_assistant.constants import CONF_HIDE_IN_UI
+from music_assistant.constants import (
+    CONF_ENTRY_ANNOUNCE_VOLUME_MAX,
+    CONF_ENTRY_ANNOUNCE_VOLUME_MIN,
+    CONF_ENTRY_PLAY_MEDIA_OVERRIDES_GROUP,
+    CONF_HIDE_IN_UI,
+)
 from music_assistant.controllers.players import PlayerController
 from tests.common import MockPlayer, MockProvider
 
@@ -246,14 +251,15 @@ class TestRegisterOrUpdate:
         player_id: str,
         provider: MockProvider,
         *,
+        default_name: str = "Default Player",
         name: str | None = None,
-        values: dict[str, bool] | None = None,
+        values: dict[str, ConfigValueType] | None = None,
     ) -> PlayerConfig:
         """Build a player config with the settings relevant to replacement tests."""
         raw_config: dict[str, object] = {
             "player_id": player_id,
             "provider": provider.instance_id,
-            "default_name": "Default Player",
+            "default_name": default_name,
             "player_type": PlayerType.PLAYER,
             "enabled": True,
             "values": values or {},
@@ -269,7 +275,10 @@ class TestRegisterOrUpdate:
                         type=ConfigEntryType.BOOLEAN,
                         default_value=False,
                         required=False,
-                    )
+                    ),
+                    CONF_ENTRY_ANNOUNCE_VOLUME_MIN,
+                    CONF_ENTRY_ANNOUNCE_VOLUME_MAX,
+                    CONF_ENTRY_PLAY_MEDIA_OVERRIDES_GROUP,
                 ],
                 raw_config,
             ),
@@ -299,6 +308,47 @@ class TestRegisterOrUpdate:
         assert replacement.state.name == "Custom Player"
         assert replacement.state.hide_in_ui is True
         assert replacement.initialized.is_set()
+        mock_mass.config.get_player_config.assert_awaited_once_with(player_id)
+        controller._evaluate_protocol_links.assert_called_once_with(replacement)
+
+    async def test_squeezelite_universal_player_replacement_preserves_reported_settings(
+        self, mock_mass: MagicMock, controller: PlayerController
+    ) -> None:
+        """Regression for support#5745's Squeezelite universal-player config shape."""
+        provider = MockProvider("universal_player", instance_id="universal_player", mass=mock_mass)
+        player_id = "up_issue_5745_squeezelite"
+        default_name = "default-squeezelite-player"
+        custom_values: dict[str, ConfigValueType] = {
+            CONF_HIDE_IN_UI: True,
+            CONF_ENTRY_ANNOUNCE_VOLUME_MIN.key: 55,
+            CONF_ENTRY_ANNOUNCE_VOLUME_MAX.key: 98,
+            CONF_ENTRY_PLAY_MEDIA_OVERRIDES_GROUP.key: False,
+        }
+        original = MockPlayer(provider, player_id, "Existing Universal Player")
+        controller._players = {player_id: original}
+        mock_mass.players = controller
+
+        replacement = MockPlayer(provider, player_id, default_name)
+        replacement.set_config(self._player_config(player_id, provider, default_name=default_name))
+        full_config = self._player_config(
+            player_id,
+            provider,
+            default_name=default_name,
+            name="Custom Squeezelite Player",
+            values=custom_values,
+        )
+        mock_mass.config.get_player_config = AsyncMock(return_value=full_config)
+        controller._evaluate_protocol_links = MagicMock()  # type: ignore[method-assign]
+
+        await controller.register_or_update(replacement)
+
+        assert controller.get_player(player_id) is replacement
+        assert replacement.config is full_config
+        assert replacement.state.name == "Custom Squeezelite Player"
+        assert replacement.state.hide_in_ui is True
+        assert replacement.config.get_value(CONF_ENTRY_ANNOUNCE_VOLUME_MIN.key) == 55
+        assert replacement.config.get_value(CONF_ENTRY_ANNOUNCE_VOLUME_MAX.key) == 98
+        assert replacement.config.get_value(CONF_ENTRY_PLAY_MEDIA_OVERRIDES_GROUP.key) is False
         mock_mass.config.get_player_config.assert_awaited_once_with(player_id)
         controller._evaluate_protocol_links.assert_called_once_with(replacement)
 

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -15,14 +15,22 @@ import contextlib
 import time
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from music_assistant_models.config_entries import ConfigEntry, PlayerConfig
 from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
-from music_assistant_models.enums import EventType, PlaybackState, PlayerFeature, PlayerType
+from music_assistant_models.enums import (
+    ConfigEntryType,
+    EventType,
+    PlaybackState,
+    PlayerFeature,
+    PlayerType,
+)
 from music_assistant_models.errors import InvalidDataError, UnsupportedFeaturedException
 from music_assistant_models.player import PlayerSource
 
+from music_assistant.constants import CONF_HIDE_IN_UI
 from music_assistant.controllers.players import PlayerController
 from tests.common import MockPlayer, MockProvider
 
@@ -228,6 +236,140 @@ class TestPlayerAvailability:
         # This should either skip the unavailable player or raise an exception
         with contextlib.suppress(Exception):
             asyncio.run(controller.cmd_set_members("leader", player_ids_to_add=["member"]))
+
+
+class TestRegisterOrUpdate:
+    """Test player replacement registration behavior."""
+
+    @staticmethod
+    def _player_config(
+        player_id: str,
+        provider: MockProvider,
+        *,
+        name: str | None = None,
+        values: dict[str, bool] | None = None,
+    ) -> PlayerConfig:
+        """Build a player config with the settings relevant to replacement tests."""
+        raw_config: dict[str, object] = {
+            "player_id": player_id,
+            "provider": provider.instance_id,
+            "default_name": "Default Player",
+            "player_type": PlayerType.PLAYER,
+            "enabled": True,
+            "values": values or {},
+        }
+        if name is not None:
+            raw_config["name"] = name
+        return cast(
+            "PlayerConfig",
+            PlayerConfig.parse(
+                [
+                    ConfigEntry(
+                        key=CONF_HIDE_IN_UI,
+                        type=ConfigEntryType.BOOLEAN,
+                        default_value=False,
+                        required=False,
+                    )
+                ],
+                raw_config,
+            ),
+        )
+
+    async def test_existing_player_replacement_keeps_full_config(
+        self, mock_mass: MagicMock, controller: PlayerController, provider: MockProvider
+    ) -> None:
+        """Replacing an existing player applies persisted config before state is published."""
+        player_id = "player_1"
+        original = MockPlayer(provider, player_id, "Original Player")
+        controller._players = {player_id: original}
+        mock_mass.players = controller
+
+        replacement = MockPlayer(provider, player_id, "Default Player")
+        replacement.set_config(self._player_config(player_id, provider))
+        full_config = self._player_config(
+            player_id, provider, name="Custom Player", values={CONF_HIDE_IN_UI: True}
+        )
+        mock_mass.config.get_player_config = AsyncMock(return_value=full_config)
+        controller._evaluate_protocol_links = MagicMock()  # type: ignore[method-assign]
+
+        await controller.register_or_update(replacement)
+
+        assert controller.get_player(player_id) is replacement
+        assert replacement.config is full_config
+        assert replacement.state.name == "Custom Player"
+        assert replacement.state.hide_in_ui is True
+        assert replacement.initialized.is_set()
+        mock_mass.config.get_player_config.assert_awaited_once_with(player_id)
+        controller._evaluate_protocol_links.assert_called_once_with(replacement)
+
+    async def test_overlapping_replacements_are_serialized(
+        self, mock_mass: MagicMock, controller: PlayerController, provider: MockProvider
+    ) -> None:
+        """Replacement setup cannot overlap and run hooks on stale players."""
+        player_id = "player_1"
+        controller._players = {player_id: MockPlayer(provider, player_id, "Original Player")}
+        mock_mass.players = controller
+        first_replacement = MockPlayer(provider, player_id, "First Player")
+        second_replacement = MockPlayer(provider, player_id, "Second Player")
+        first_config = self._player_config(player_id, provider, name="First Player")
+        second_config = self._player_config(player_id, provider, name="Second Player")
+        first_config_hook_started = asyncio.Event()
+        release_first_config_hook = asyncio.Event()
+        config_call_count = 0
+
+        async def get_player_config(_player_id: str) -> PlayerConfig:
+            nonlocal config_call_count
+            config_call_count += 1
+            if config_call_count == 1:
+                return first_config
+            return second_config
+
+        async def first_on_config_updated() -> None:
+            first_config_hook_started.set()
+            await release_first_config_hook.wait()
+
+        mock_mass.config.get_player_config = AsyncMock(side_effect=get_player_config)
+        first_replacement.on_config_updated = first_on_config_updated  # type: ignore[method-assign]
+        controller._evaluate_protocol_links = MagicMock()  # type: ignore[method-assign]
+
+        first_task = asyncio.create_task(controller.register_or_update(first_replacement))
+        await first_config_hook_started.wait()
+        second_task = asyncio.create_task(controller.register_or_update(second_replacement))
+        await asyncio.sleep(0)
+
+        assert not second_task.done()
+        assert controller.get_player(player_id) is first_replacement
+
+        release_first_config_hook.set()
+        await first_task
+        await second_task
+
+        assert controller.get_player(player_id) is second_replacement
+        assert first_replacement.config is first_config
+        assert first_replacement.initialized.is_set()
+        assert second_replacement.config is second_config
+        assert second_replacement.initialized.is_set()
+        assert controller._evaluate_protocol_links.call_args_list == [
+            call(first_replacement),
+            call(second_replacement),
+        ]
+
+    async def test_existing_player_same_instance_update_stays_lightweight(
+        self, mock_mass: MagicMock, controller: PlayerController, provider: MockProvider
+    ) -> None:
+        """Updating the already-registered object avoids a redundant config reload."""
+        player_id = "player_1"
+        player = MockPlayer(provider, player_id, "Existing Player")
+        controller._players = {player_id: player}
+        mock_mass.players = controller
+        mock_mass.config.get_player_config = AsyncMock()
+        controller._evaluate_protocol_links = MagicMock()  # type: ignore[method-assign]
+
+        await controller.register_or_update(player)
+
+        assert controller.get_player(player_id) is player
+        mock_mass.config.get_player_config.assert_not_awaited()
+        controller._evaluate_protocol_links.assert_not_called()
 
 
 class TestStateForwarding:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Load the persisted full player config when `register_or_update()` replaces an existing player object.

This reuses the normal registered-player setup path so replacement state is published after config load and protocol links are refreshed consistently. Same-instance updates stay on the lightweight path, while true replacements are serialized to avoid overlapping setup hooks.

This PR also adds regression coverage for replacement config preservation, overlapping replacements, same-instance updates, and a Squeezelite/universal-player replacement shape found while investigating support#5745.

This should be treated as a related in-memory replacement lifecycle fix only. It does not change the code path that writes ordinary player settings to `settings.json`; those writes go through `save_player_config()` / `ConfigController.set()` and are not modified here. It should not be treated as proven closure for the on-disk settings rewrite reported in support#5745.

Validation:

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -p no:cacheprovider --no-cov tests/controllers/players/test_player_controller.py::TestRegisterOrUpdate -q` -> 4 passed.
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -p no:cacheprovider --no-cov tests/controllers/players/test_player_controller.py tests/controllers/players/test_player_protocol_state.py tests/controllers/players/test_protocol_linking.py -q` -> 209 passed.
- `.venv/bin/pre-commit run --all-files` -> passed.

Scope / non-goals:

- No provider discovery, Squeezelite protocol, playback, queue, frontend, migration behavior, or `settings.json` write path changed.
- No hardware/container recreation smoke test was run; proof is controller-level regression coverage plus adjacent player/protocol tests.
- No claim that this closes the on-disk settings rewrite mechanism reported in support#5745.
- No real music-service account, media library, playback device, Home Assistant state, LAN discovery, or user credentials were used.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5745

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
