### PR TITLE
Speed up library listings by streaming from the sort index

### DIFF
--- a/music_assistant/controllers/music/media/albums.py
+++ b/music_assistant/controllers/music/media/albums.py
@@ -413,9 +413,15 @@ class AlbumsController(MediaControllerBase[Album]):
     ) -> list[Track]:
         """Return in-database album tracks for the given database album."""
         db_id = int(item_id)  # ensure integer
+        # pass the album id as preferred album so the track_album subquery in the
+        # base query returns this album's disc/track numbers for tracks that
+        # appear on multiple albums
         return await self.mass.music.tracks.get_library_items_by_query(
-            extra_query_parts=["WHERE album_tracks.album_id = :album_id"],
-            extra_query_params={"album_id": db_id},
+            extra_query_parts=[
+                f"tracks.item_id IN (SELECT track_id FROM {DB_TABLE_ALBUM_TRACKS} "
+                "WHERE album_id = :album_id)"
+            ],
+            extra_query_params={"album_id": db_id, "preferred_album_id": db_id},
         )
 
     async def add_item_mapping_as_album_to_library(self, item: ItemMapping) -> Album:

--- a/music_assistant/controllers/music/media/audiobooks.py
+++ b/music_assistant/controllers/music/media/audiobooks.py
@@ -71,7 +71,14 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
         resume_position_ms). When a session user is present the join is scoped to that
         user, so multi-user installs don't surface each other's resume state.
         """
-        query = """
+        params: dict[str, Any] = {}
+        # scope the playlog lookup to the session user (if any) and pick at most one
+        # row (the most recent) so the join can never fan out the result set
+        playlog_user_clause = ""
+        if session_user := get_current_user():
+            playlog_user_clause = "AND p2.userid = :playlog_userid "
+            params["playlog_userid"] = session_user.user_id
+        query = f"""
         SELECT
             audiobooks.*,
             (SELECT JSON_GROUP_ARRAY(
@@ -100,12 +107,11 @@ class AudiobooksController(MediaControllerBase[Audiobook]):
             playlog.seconds_played AS seconds_played,
             playlog.seconds_played * 1000 as resume_position_ms
             FROM audiobooks
-            LEFT JOIN playlog ON playlog.item_id = audiobooks.item_id AND playlog.media_type = 'audiobook'
+            LEFT JOIN playlog ON playlog.id = (
+                SELECT p2.id FROM playlog p2
+                WHERE p2.item_id = audiobooks.item_id AND p2.media_type = 'audiobook'
+                {playlog_user_clause}ORDER BY p2.timestamp DESC LIMIT 1)
             """
-        params: dict[str, Any] = {}
-        if session_user := get_current_user():
-            query += " AND playlog.userid = :playlog_userid"
-            params["playlog_userid"] = session_user.user_id
         return query, params
 
     async def library_items(

--- a/music_assistant/controllers/music/media/base.py
+++ b/music_assistant/controllers/music/media/base.py
@@ -997,7 +997,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             self._apply_filters(
                 query_parts=query_parts,
                 query_params=query_params,
-                join_parts=join_parts,
                 favorite=favorite,
                 search=search,
                 genre_ids=genre_ids,
@@ -1007,7 +1006,9 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             )
         # build and execute final query
         sql_query, base_query_params = self._build_final_query(query_parts, join_parts, order_by)
-        query_params.update(base_query_params)
+        # base query params act as defaults: callers may override them via extra_query_params
+        for key, value in base_query_params.items():
+            query_params.setdefault(key, value)
 
         return [
             cast("ItemCls", self.item_cls.from_dict(self._parse_db_row(db_row)))
@@ -1141,7 +1142,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         self._apply_filters(
             query_parts=sub_query_parts,
             query_params=query_params,
-            join_parts=sub_join_parts,
             favorite=favorite,
             search=search,
             genre_ids=genre_ids,
@@ -1172,7 +1172,6 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
         self,
         query_parts: list[str],
         query_params: dict[str, Any],
-        join_parts: list[str],
         favorite: bool | None,
         search: str | None,
         genre_ids: list[int] | None,
@@ -1203,6 +1202,9 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 "AND gm.genre_id IN :genre_ids)"
             )
         # Apply the provider filter
+        # NOTE: provider mapping filters are applied as a correlated EXISTS subquery
+        # instead of a JOIN + GROUP BY, so SQLite can stream results straight from the
+        # sort index instead of materializing/sorting the whole (deduped) result set.
         if provider_filter:
             provider_conditions = []
             for idx, prov in enumerate(provider_filter):
@@ -1211,18 +1213,20 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
                 query_params[param_name] = prov
             query_params["provider_media_type"] = self.media_type.value
             in_library_clause = "AND provider_mappings.in_library = 1 " if in_library_only else ""
-            join_parts.append(
-                f"JOIN provider_mappings ON provider_mappings.item_id = {self.db_table}.item_id "
+            query_parts.append(
+                "EXISTS(SELECT 1 FROM provider_mappings "
+                f"WHERE provider_mappings.item_id = {self.db_table}.item_id "
                 "AND provider_mappings.media_type = :provider_media_type "
                 f"{in_library_clause}"
-                f"AND ({' OR '.join(provider_conditions)})"
+                f"AND ({' OR '.join(provider_conditions)}))"
             )
         elif in_library_only:
             query_params["provider_media_type"] = self.media_type.value
-            join_parts.append(
-                f"JOIN provider_mappings ON provider_mappings.item_id = {self.db_table}.item_id "
+            query_parts.append(
+                "EXISTS(SELECT 1 FROM provider_mappings "
+                f"WHERE provider_mappings.item_id = {self.db_table}.item_id "
                 "AND provider_mappings.media_type = :provider_media_type "
-                "AND provider_mappings.in_library = 1"
+                "AND provider_mappings.in_library = 1)"
             )
 
     @final
@@ -1244,8 +1248,11 @@ class MediaControllerBase[ItemCls: "MediaItemType"](metaclass=ABCMeta):
             # prevent duplicate where statement
             sql_query += " WHERE " + " AND ".join(self._clean_query_parts(query_parts))
 
-        # Add grouping and ordering
-        sql_query += f" GROUP BY {self.db_table}.item_id"
+        # Add grouping (only needed when caller-provided joins can fan out rows)
+        # and ordering. Without a GROUP BY, SQLite can stream results directly
+        # from the sort index instead of sorting the whole result set.
+        if join_parts:
+            sql_query += f" GROUP BY {self.db_table}.item_id"
 
         if order_by:
             if sort_key := SORT_KEYS.get(order_by):

--- a/music_assistant/controllers/music/media/tracks.py
+++ b/music_assistant/controllers/music/media/tracks.py
@@ -77,6 +77,11 @@ class TracksController(MediaControllerBase[Track]):
     @property
     def base_query(self) -> tuple[str, dict[str, Any]]:
         """Return the base SELECT query for tracks and its bound query params."""
+        # NOTE: the track_album subquery is fully self-contained (correlated) so the
+        # outer query needs no join with album_tracks (which would fan out rows for
+        # tracks that appear on multiple albums and force a GROUP BY). For tracks on
+        # multiple albums it prefers :preferred_album_id (used for album track
+        # listings) and otherwise deterministically picks the lowest album id.
         query = """
         SELECT
             tracks.*,
@@ -113,11 +118,14 @@ class TracksController(MediaControllerBase[Track]):
                     'disc_number', album_tracks.disc_number,
                     'track_number', album_tracks.track_number,
                     'images', json_extract(albums.metadata, '$.images')
-                ) FROM albums WHERE albums.item_id = album_tracks.album_id) AS track_album
+                ) FROM album_tracks
+                JOIN albums ON albums.item_id = album_tracks.album_id
+                WHERE album_tracks.track_id = tracks.item_id
+                ORDER BY (album_tracks.album_id IS :preferred_album_id) DESC, album_tracks.album_id
+                LIMIT 1) AS track_album
             FROM tracks
-            LEFT JOIN album_tracks on album_tracks.track_id = tracks.item_id
             """
-        return query, {}
+        return query, {"preferred_album_id": None}
 
     async def get(
         self,

--- a/tests/controllers/music/test_library_listing_queries.py
+++ b/tests/controllers/music/test_library_listing_queries.py
@@ -1,0 +1,596 @@
+"""
+Tests for the library listing query builder (EXISTS-based provider filtering).
+
+The provider/in-library filters in ``get_library_items_by_query`` are applied as
+correlated EXISTS subqueries (instead of a JOIN + GROUP BY) so SQLite can stream
+results straight from the sort index. These tests verify that:
+
+* the new queries return the exact same items (and order) as the legacy
+  JOIN + GROUP BY queries for a matrix of filter combinations
+* the generated listing queries stream from the sort index without a
+  temporary b-tree for sorting
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, NonCallableMagicMock, patch
+from uuid import uuid4
+
+import pytest
+from music_assistant_models.enums import AlbumType, MediaType
+from music_assistant_models.media_items import (
+    Album,
+    Artist,
+    Audiobook,
+    ProviderMapping,
+    Track,
+)
+from music_assistant_models.unique_list import UniqueList
+
+from music_assistant.constants import (
+    DB_TABLE_ALBUM_TRACKS,
+    DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+    DB_TABLE_PLAYLOG,
+    DB_TABLE_PROVIDER_MAPPINGS,
+)
+from music_assistant.controllers.music.media.base import MediaControllerBase
+from music_assistant.helpers.compare import create_safe_string
+from music_assistant.mass import MusicAssistant
+from tests.common import suppress_auto_loaded_providers
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(scope="module")
+async def seeded_mass(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncGenerator[MusicAssistant]:
+    """Module-scoped hermetic MusicAssistant instance with a seeded library."""
+    tmp_path = tmp_path_factory.mktemp("listing_query_tests")
+    storage_path = tmp_path / "data"
+    cache_path = tmp_path / "cache"
+    storage_path.mkdir(parents=True)
+    cache_path.mkdir(parents=True)
+    logging.getLogger("aiosqlite").level = logging.INFO
+    mass_instance = MusicAssistant(str(storage_path), str(cache_path))
+    with (
+        patch(
+            "music_assistant.controllers.discovery.controller.AsyncZeroconf",
+            return_value=NonCallableMagicMock(
+                async_register_service=AsyncMock(),
+                async_update_service=AsyncMock(),
+                async_unregister_service=AsyncMock(),
+                async_close=AsyncMock(),
+            ),
+        ),
+        patch(
+            "music_assistant.controllers.discovery.controller.AsyncServiceBrowser",
+            return_value=NonCallableMagicMock(),
+        ),
+        patch(
+            "music_assistant.controllers.streams.controller.check_ffmpeg_version",
+            new=AsyncMock(),
+        ),
+        # hermetic: no real SSDP search
+        patch(
+            "music_assistant.controllers.discovery.controller.async_upnp_search",
+            new=AsyncMock(),
+        ),
+        suppress_auto_loaded_providers(),
+    ):
+        await mass_instance.start()
+        try:
+            await _seed_library(mass_instance)
+            yield mass_instance
+        finally:
+            await mass_instance.stop()
+
+
+def _mapping(provider_instance: str = "prov_a_inst") -> ProviderMapping:
+    """Create a provider mapping with a unique provider_item_id."""
+    return ProviderMapping(
+        item_id=uuid4().hex,
+        provider_domain=provider_instance.removesuffix("_inst"),
+        provider_instance=provider_instance,
+        in_library=True,
+    )
+
+
+async def _seed_library(mass: MusicAssistant) -> None:
+    """Seed artists, albums and tracks covering all listing edge cases."""
+    artists: list[Artist] = []
+    for idx in range(1, 5):
+        artist = Artist(
+            item_id="0",
+            provider="library",
+            name=f"Artist {idx:02d}",
+            provider_mappings={_mapping()},
+            favorite=idx % 2 == 0,
+        )
+        artists.append(await mass.music.artists.add_item_to_library(artist))
+
+    albums: list[Album] = []
+    for idx in range(1, 6):
+        album = Album(
+            item_id="0",
+            provider="library",
+            name=f"Album {idx:02d}",
+            album_type=AlbumType.ALBUM,
+            provider_mappings={
+                # some albums have multiple provider mappings (fanout in legacy JOIN)
+                _mapping(),
+                *([_mapping("prov_b_inst")] if idx % 2 == 0 else []),
+            },
+            artists=UniqueList([artists[idx % len(artists)]]),
+            favorite=idx % 3 == 0,
+        )
+        albums.append(await mass.music.albums.add_item_to_library(album))
+
+    for idx in range(1, 21):
+        track = Track(
+            item_id="0",
+            provider="library",
+            name=f"Track {idx:02d}",
+            provider_mappings={
+                _mapping(),
+                *([_mapping("prov_b_inst")] if idx % 4 == 0 else []),
+            },
+            artists=UniqueList([artists[idx % len(artists)]]),
+            album=albums[idx % len(albums)],
+            disc_number=1,
+            track_number=idx,
+            favorite=idx % 5 == 0,
+        )
+        db_track = await mass.music.tracks.add_item_to_library(track)
+        # track 3 appears on two albums (fanout in legacy album_tracks JOIN)
+        if idx == 3:
+            await mass.music.tracks._set_track_album(
+                db_id=int(db_track.item_id),
+                album=albums[4],
+                disc_number=2,
+                track_number=99,
+            )
+
+    # one track only has a mapping with in_library=0 (hidden from library listings)
+    hidden = Track(
+        item_id="0",
+        provider="library",
+        name="Track hidden",
+        provider_mappings={_mapping()},
+        artists=UniqueList([artists[0]]),
+        favorite=True,
+    )
+    db_hidden = await mass.music.tracks.add_item_to_library(hidden)
+    await mass.music.database.execute(
+        f"UPDATE {DB_TABLE_PROVIDER_MAPPINGS} SET in_library = 0 "
+        "WHERE item_id = :item_id AND media_type = 'track'",
+        {"item_id": int(db_hidden.item_id)},
+    )
+
+    # genre mapping for some tracks
+    for track_db_id in (1, 2, 3):
+        await mass.music.database.insert(
+            DB_TABLE_GENRE_MEDIA_ITEM_MAPPING,
+            {"genre_id": 1, "media_id": track_db_id, "media_type": "track"},
+        )
+    # mark some items as played
+    await mass.music.database.execute(
+        "UPDATE tracks SET last_played = item_id WHERE item_id IN (2, 4, 6)"
+    )
+    await mass.music.database.commit()
+
+
+def _legacy_tracks_base_query() -> str:
+    """Return the legacy tracks base query (with the album_tracks JOIN)."""
+    return """
+        SELECT
+            tracks.*,
+            (SELECT JSON_GROUP_ARRAY(
+                json_object(
+                'item_id', track_pm.provider_item_id,
+                    'provider_domain', track_pm.provider_domain,
+                        'provider_instance', track_pm.provider_instance,
+                        'available', track_pm.available,
+                        'audio_format', json(track_pm.audio_format),
+                        'url', track_pm.url,
+                        'details', track_pm.details,
+                        'in_library', track_pm.in_library,
+                        'is_unique', track_pm.is_unique
+                )) FROM provider_mappings track_pm WHERE track_pm.item_id = tracks.item_id AND track_pm.media_type = 'track') AS provider_mappings,
+            (SELECT JSON_GROUP_ARRAY(
+                json_object(
+                'item_id', artists.item_id,
+                'provider', 'library',
+                    'name', artists.name,
+                    'sort_name', artists.sort_name,
+                    'media_type', 'artist',
+                    'external_ids', json(artists.external_ids)
+                )) FROM artists JOIN track_artists on track_artists.track_id = tracks.item_id  WHERE artists.item_id = track_artists.artist_id) AS artists,
+            (SELECT
+                json_object(
+                'item_id', albums.item_id,
+                'provider', 'library',
+                    'name', albums.name,
+                    'sort_name', albums.sort_name,
+                    'media_type', 'album',
+                    'year', albums.year,
+                    'disc_number', album_tracks.disc_number,
+                    'track_number', album_tracks.track_number,
+                    'images', json_extract(albums.metadata, '$.images')
+                ) FROM albums WHERE albums.item_id = album_tracks.album_id) AS track_album
+            FROM tracks
+            LEFT JOIN album_tracks on album_tracks.track_id = tracks.item_id
+            """
+
+
+def _legacy_query(  # noqa: PLR0913
+    controller: MediaControllerBase[Any],
+    *,
+    base_query: str | None = None,
+    favorite: bool | None = None,
+    search: str | None = None,
+    provider_filter: list[str] | None = None,
+    in_library_only: bool = False,
+    played_only: bool = False,
+    genre_ids: list[int] | None = None,
+    extra_query_parts: list[str] | None = None,
+    extra_join_parts: list[str] | None = None,
+    order_by: str | None = "sort_name",
+) -> tuple[str, dict[str, Any]]:
+    """Build a listing query the way the legacy (JOIN + GROUP BY) builder did."""
+    table = controller.db_table
+    query_parts: list[str] = list(extra_query_parts or [])
+    join_parts: list[str] = list(extra_join_parts or [])
+    params: dict[str, Any] = {}
+    if search:
+        query_parts.append(f"{table}.search_name LIKE :search")
+        params["search"] = f"%{create_safe_string(search, True, True)}%"
+    if favorite is not None:
+        query_parts.append(f"{table}.favorite = :favorite")
+        params["favorite"] = favorite
+    if played_only:
+        query_parts.append(f"{table}.last_played > 0")
+    if genre_ids:
+        params["genre_ids"] = genre_ids
+        params["genre_media_type"] = controller.media_type.value
+        query_parts.append(
+            f"EXISTS(SELECT 1 FROM {DB_TABLE_GENRE_MEDIA_ITEM_MAPPING} gm "
+            f"WHERE gm.media_id = {table}.item_id "
+            "AND gm.media_type = :genre_media_type AND gm.genre_id IN :genre_ids)"
+        )
+    if provider_filter:
+        provider_conditions = []
+        for idx, prov in enumerate(provider_filter):
+            provider_conditions.append(f"provider_mappings.provider_instance = :prov_{idx}")
+            params[f"prov_{idx}"] = prov
+        params["provider_media_type"] = controller.media_type.value
+        in_library_clause = "AND provider_mappings.in_library = 1 " if in_library_only else ""
+        join_parts.append(
+            f"JOIN provider_mappings ON provider_mappings.item_id = {table}.item_id "
+            "AND provider_mappings.media_type = :provider_media_type "
+            f"{in_library_clause}"
+            f"AND ({' OR '.join(provider_conditions)})"
+        )
+    elif in_library_only:
+        params["provider_media_type"] = controller.media_type.value
+        join_parts.append(
+            f"JOIN provider_mappings ON provider_mappings.item_id = {table}.item_id "
+            "AND provider_mappings.media_type = :provider_media_type "
+            "AND provider_mappings.in_library = 1"
+        )
+    sql_query = base_query if base_query is not None else controller.base_query[0]
+    if join_parts:
+        sql_query += f" {' '.join(join_parts)} "
+    if query_parts:
+        sql_query += " WHERE " + " AND ".join(
+            x[5:] if x.lower().startswith("where ") else x for x in query_parts
+        )
+    sql_query += f" GROUP BY {table}.item_id"
+    if order_by:
+        sort_key = {
+            "sort_name": "search_sort_name ASC",
+            "sort_name_desc": "search_sort_name DESC",
+            "timestamp_added": "timestamp_added ASC",
+            "timestamp_added_desc": "timestamp_added DESC",
+            "last_played": "last_played ASC",
+            "last_played_desc": "last_played DESC",
+        }[order_by]
+        sql_query += f" ORDER BY {sort_key}"
+    return sql_query, params
+
+
+async def _compare(
+    mass: MusicAssistant,
+    controller: MediaControllerBase[Any],
+    *,
+    legacy_base_query: str | None = None,
+    limit: int = 500,
+    offset: int = 0,
+    **filter_kwargs: Any,
+) -> list[Any]:
+    """Run the new and legacy listing queries and assert identical items/order."""
+    legacy_sql, legacy_params = _legacy_query(
+        controller, base_query=legacy_base_query, **filter_kwargs
+    )
+    legacy_rows = await mass.music.database.get_rows_from_query(
+        legacy_sql, legacy_params, limit=limit, offset=offset
+    )
+    order_by = filter_kwargs.pop("order_by", "sort_name")
+    new_items = await controller.get_library_items_by_query(
+        order_by=order_by, limit=limit, offset=offset, **filter_kwargs
+    )
+    assert [str(row["item_id"]) for row in legacy_rows] == [x.item_id for x in new_items]
+    # provider mappings must be hydrated identically
+    for row, item in zip(legacy_rows, new_items, strict=True):
+        legacy_mappings = {
+            (m["provider_instance"], m["item_id"]) for m in json.loads(row["provider_mappings"])
+        }
+        new_mappings = {(m.provider_instance, m.item_id) for m in item.provider_mappings}
+        assert legacy_mappings == new_mappings
+    return new_items
+
+
+FILTER_MATRIX: list[dict[str, Any]] = [
+    {"in_library_only": True},
+    {"in_library_only": True, "favorite": True},
+    {"in_library_only": True, "search": "02"},
+    {"in_library_only": True, "provider_filter": ["prov_b_inst"]},
+    {"in_library_only": True, "provider_filter": ["prov_a_inst", "prov_b_inst"]},
+    {"provider_filter": ["prov_b_inst"]},
+    {"in_library_only": True, "favorite": False, "search": "0", "order_by": "timestamp_added"},
+    {
+        "in_library_only": True,
+        "favorite": True,
+        "provider_filter": ["prov_a_inst"],
+        "search": "1",
+    },
+    {"in_library_only": True, "order_by": "sort_name_desc"},
+    {"in_library_only": True, "order_by": "timestamp_added_desc"},
+]
+
+
+@pytest.mark.parametrize("filter_kwargs", FILTER_MATRIX)
+async def test_artist_listing_matches_legacy(
+    seeded_mass: MusicAssistant, filter_kwargs: dict[str, Any]
+) -> None:
+    """Artist listings return the same items/order as the legacy JOIN queries."""
+    await _compare(seeded_mass, seeded_mass.music.artists, **dict(filter_kwargs))
+
+
+@pytest.mark.parametrize("filter_kwargs", FILTER_MATRIX)
+async def test_album_listing_matches_legacy(
+    seeded_mass: MusicAssistant, filter_kwargs: dict[str, Any]
+) -> None:
+    """Album listings return the same items/order as the legacy JOIN queries."""
+    await _compare(seeded_mass, seeded_mass.music.albums, **dict(filter_kwargs))
+
+
+@pytest.mark.parametrize("filter_kwargs", FILTER_MATRIX)
+async def test_track_listing_matches_legacy(
+    seeded_mass: MusicAssistant, filter_kwargs: dict[str, Any]
+) -> None:
+    """Track listings return the same items/order as the legacy JOIN queries."""
+    await _compare(
+        seeded_mass,
+        seeded_mass.music.tracks,
+        legacy_base_query=_legacy_tracks_base_query(),
+        **dict(filter_kwargs),
+    )
+
+
+async def test_track_listing_with_pagination_matches_legacy(seeded_mass: MusicAssistant) -> None:
+    """Paged track listings return the same items/order as the legacy queries."""
+    for offset in (0, 5, 15):
+        await _compare(
+            seeded_mass,
+            seeded_mass.music.tracks,
+            legacy_base_query=_legacy_tracks_base_query(),
+            limit=5,
+            offset=offset,
+            in_library_only=True,
+        )
+
+
+async def test_track_listing_played_only_matches_legacy(seeded_mass: MusicAssistant) -> None:
+    """played_only track listings return the same items as the legacy queries."""
+    items = await _compare(
+        seeded_mass,
+        seeded_mass.music.tracks,
+        legacy_base_query=_legacy_tracks_base_query(),
+        in_library_only=True,
+        played_only=True,
+    )
+    assert len(items) == 3
+
+
+async def test_track_listing_genre_filter_matches_legacy(seeded_mass: MusicAssistant) -> None:
+    """Genre-filtered track listings return the same items as the legacy queries."""
+    items = await _compare(
+        seeded_mass,
+        seeded_mass.music.tracks,
+        legacy_base_query=_legacy_tracks_base_query(),
+        in_library_only=True,
+        genre_ids=[1],
+    )
+    assert len(items) == 3
+
+
+async def test_track_listing_artist_join_matches_legacy(seeded_mass: MusicAssistant) -> None:
+    """Artist-name search (with join fanout) still dedupes via GROUP BY."""
+    join = (
+        "JOIN track_artists ON track_artists.track_id = tracks.item_id "
+        "JOIN artists ON artists.item_id = track_artists.artist_id "
+        "AND artists.search_name LIKE :search_artist"
+    )
+    legacy_sql, legacy_params = _legacy_query(
+        seeded_mass.music.tracks,
+        base_query=_legacy_tracks_base_query(),
+        in_library_only=True,
+        extra_join_parts=[join],
+    )
+    legacy_params["search_artist"] = "%artist02%"
+    legacy_rows = await seeded_mass.music.database.get_rows_from_query(legacy_sql, legacy_params)
+    new_items = await seeded_mass.music.tracks.get_library_items_by_query(
+        order_by="sort_name",
+        in_library_only=True,
+        extra_join_parts=[join],
+        extra_query_params={"search_artist": "%artist02%"},
+    )
+    assert [str(row["item_id"]) for row in legacy_rows] == [x.item_id for x in new_items]
+    assert len(new_items) > 0
+
+
+async def test_hidden_track_excluded_from_library_listing(seeded_mass: MusicAssistant) -> None:
+    """A track whose only mapping has in_library=0 is hidden from library listings."""
+    items = await seeded_mass.music.tracks.get_library_items_by_query(in_library_only=True)
+    assert "Track hidden" not in {x.name for x in items}
+    # ...but still returned when not filtering on library membership
+    items = await seeded_mass.music.tracks.get_library_items_by_query()
+    assert "Track hidden" in {x.name for x in items}
+
+
+async def test_random_order_applies_filters(seeded_mass: MusicAssistant) -> None:
+    """The random-order subquery applies the provider/in-library filters."""
+    items = await seeded_mass.music.tracks.get_library_items_by_query(
+        order_by="random", in_library_only=True, provider_filter=["prov_b_inst"]
+    )
+    expected = await seeded_mass.music.tracks.get_library_items_by_query(
+        in_library_only=True, provider_filter=["prov_b_inst"]
+    )
+    assert {x.item_id for x in items} == {x.item_id for x in expected}
+
+
+async def test_album_tracks_returns_album_scoped_disc_and_track_numbers(
+    seeded_mass: MusicAssistant,
+) -> None:
+    """get_library_album_tracks returns the requested album's disc/track numbers."""
+    # track 3 is on two albums with different disc/track numbers
+    row = await seeded_mass.music.database.get_row("tracks", {"name": "Track 03"})
+    assert row is not None
+    track_db_id = int(row["item_id"])
+    album_track_rows = await seeded_mass.music.database.get_rows(
+        DB_TABLE_ALBUM_TRACKS, {"track_id": track_db_id}
+    )
+    assert len(album_track_rows) == 2
+    for album_track_row in album_track_rows:
+        album_tracks = await seeded_mass.music.albums.get_library_album_tracks(
+            album_track_row["album_id"]
+        )
+        track = next(x for x in album_tracks if int(x.item_id) == track_db_id)
+        assert track.album is not None
+        assert int(track.album.item_id) == album_track_row["album_id"]
+        assert track.disc_number == album_track_row["disc_number"]
+        assert track.track_number == album_track_row["track_number"]
+
+
+async def test_album_tracks_matches_legacy(seeded_mass: MusicAssistant) -> None:
+    """get_library_album_tracks returns the same tracks as the legacy album JOIN query."""
+    albums = await seeded_mass.music.albums.get_library_items_by_query(in_library_only=True)
+    for album in albums:
+        legacy_sql, legacy_params = _legacy_query(
+            seeded_mass.music.tracks,
+            base_query=_legacy_tracks_base_query(),
+            extra_query_parts=["WHERE album_tracks.album_id = :album_id"],
+            order_by=None,
+        )
+        legacy_params["album_id"] = int(album.item_id)
+        legacy_rows = await seeded_mass.music.database.get_rows_from_query(
+            legacy_sql, legacy_params
+        )
+        new_items = await seeded_mass.music.albums.get_library_album_tracks(album.item_id)
+        assert sorted(str(row["item_id"]) for row in legacy_rows) == sorted(
+            x.item_id for x in new_items
+        )
+
+
+async def test_audiobook_listing_resume_info(seeded_mass: MusicAssistant) -> None:
+    """Audiobook listings dedupe playlog rows and surface the most recent resume info."""
+    audiobook = Audiobook(
+        item_id="0",
+        provider="library",
+        name="Book 01",
+        provider_mappings={_mapping()},
+    )
+    db_book = await seeded_mass.music.audiobooks.add_item_to_library(audiobook)
+    # two playlog rows for the same book (e.g. two users/providers)
+    for userid, timestamp, seconds_played in (("user-a", 100, 60), ("user-b", 200, 120)):
+        await seeded_mass.music.database.insert(
+            DB_TABLE_PLAYLOG,
+            {
+                "item_id": db_book.item_id,
+                "provider": "library",
+                "media_type": MediaType.AUDIOBOOK.value,
+                "name": db_book.name,
+                "timestamp": timestamp,
+                "fully_played": False,
+                "seconds_played": seconds_played,
+                "userid": userid,
+                "user_initiated": True,
+            },
+        )
+    await seeded_mass.music.database.commit()
+    items = await seeded_mass.music.audiobooks.get_library_items_by_query(in_library_only=True)
+    books = [x for x in items if x.item_id == db_book.item_id]
+    # the playlog join may not fan out the result set
+    assert len(books) == 1
+    # the most recent playlog entry wins
+    assert books[0].resume_position_ms == 120 * 1000
+
+
+async def test_listing_queries_stream_from_sort_index(seeded_mass: MusicAssistant) -> None:
+    """Default library listings stream from the sort index without a temp b-tree."""
+    database = seeded_mass.music.database
+    # drop the planner statistics so SQLite falls back to its default (large) table
+    # size estimates: with only a handful of seeded rows it would (rightfully) just
+    # scan the table, while the streaming-from-sort-index behaviour is what matters
+    # for large libraries
+    await database.execute("ANALYZE")
+    await database.execute("DELETE FROM sqlite_stat1")
+    await database.execute("ANALYZE sqlite_master")
+    try:
+        for controller in (
+            seeded_mass.music.artists,
+            seeded_mass.music.albums,
+            seeded_mass.music.tracks,
+        ):
+            captured: dict[str, Any] = {}
+            orig = database.get_rows_from_query
+
+            async def spy(
+                query: str,
+                params: dict[str, Any] | None = None,
+                limit: int = 500,
+                offset: int = 0,
+                _captured: dict[str, Any] = captured,
+                _orig: Any = orig,
+            ) -> list[Any]:
+                _captured["query"], _captured["params"] = query, params
+                result: list[Any] = await _orig(query, params, limit=limit, offset=offset)
+                return result
+
+            with patch.object(database, "get_rows_from_query", spy):
+                await controller.get_library_items_by_query(
+                    order_by="sort_name", in_library_only=True
+                )
+            plan_rows = await database.get_rows_from_query(
+                f"EXPLAIN QUERY PLAN {captured['query']} LIMIT 500 OFFSET 0",
+                captured["params"],
+                limit=0,
+            )
+            details = [row["detail"] for row in plan_rows]
+            table = controller.db_table
+            assert any(
+                f"SCAN {table} USING INDEX {table}_search_sort_name_idx" in detail
+                for detail in details
+            ), details
+            # no temp b-tree may be used to sort the (potentially huge) main result;
+            # correlated subqueries only sort the few rows of a single item
+            top_level = [row["detail"] for row in plan_rows if row["parent"] == 0]
+            assert not any("TEMP B-TREE" in detail.upper() for detail in top_level), details
+    finally:
+        # restore the real statistics for any tests running after this one
+        await database.execute("ANALYZE")

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -682,20 +682,18 @@ def _create_controller_for_filter_tests() -> Mock:
 
 async def test_apply_filters_in_library_only_without_provider_filter() -> None:
     """
-    Test that in_library_only adds a JOIN on provider_mappings with in_library=1.
+    Test that in_library_only adds an EXISTS filter on provider_mappings with in_library=1.
 
-    When no provider_filter is set but in_library_only=True, a JOIN on
+    When no provider_filter is set but in_library_only=True, an EXISTS subquery on
     provider_mappings should be added with the in_library=1 condition.
     """
     ctrl = _create_controller_for_filter_tests()
     query_parts: list[str] = []
     query_params: dict[str, object] = {}
-    join_parts: list[str] = []
 
     ctrl._apply_filters(
         query_parts=query_parts,
         query_params=query_params,
-        join_parts=join_parts,
         favorite=None,
         search=None,
         genre_ids=None,
@@ -703,27 +701,26 @@ async def test_apply_filters_in_library_only_without_provider_filter() -> None:
         in_library_only=True,
     )
 
-    assert len(join_parts) == 1
-    assert "provider_mappings.in_library = 1" in join_parts[0]
+    assert len(query_parts) == 1
+    assert query_parts[0].startswith("EXISTS(")
+    assert "provider_mappings.in_library = 1" in query_parts[0]
     assert "provider_media_type" in query_params
 
 
 async def test_apply_filters_in_library_only_with_provider_filter() -> None:
     """
-    Test that in_library_only with provider_filter adds both conditions to the JOIN.
+    Test that in_library_only with provider_filter adds both conditions to the EXISTS.
 
-    When both in_library_only=True and a provider_filter are set, the JOIN should
-    include both the provider condition and the in_library=1 condition.
+    When both in_library_only=True and a provider_filter are set, the EXISTS subquery
+    should include both the provider condition and the in_library=1 condition.
     """
     ctrl = _create_controller_for_filter_tests()
     query_parts: list[str] = []
     query_params: dict[str, object] = {}
-    join_parts: list[str] = []
 
     ctrl._apply_filters(
         query_parts=query_parts,
         query_params=query_params,
-        join_parts=join_parts,
         favorite=None,
         search=None,
         genre_ids=None,
@@ -731,28 +728,27 @@ async def test_apply_filters_in_library_only_with_provider_filter() -> None:
         in_library_only=True,
     )
 
-    assert len(join_parts) == 1
-    assert "provider_mappings.in_library = 1" in join_parts[0]
+    assert len(query_parts) == 1
+    assert query_parts[0].startswith("EXISTS(")
+    assert "provider_mappings.in_library = 1" in query_parts[0]
     assert "provider_filter_0" in query_params
     assert query_params["provider_filter_0"] == "spotify_1"
 
 
 async def test_apply_filters_no_in_library_filter_by_default() -> None:
     """
-    Test that no provider_mappings JOIN is added when in_library_only is False.
+    Test that no provider_mappings filter is added when in_library_only is False.
 
-    Without a provider_filter or in_library_only flag, no JOIN on
+    Without a provider_filter or in_library_only flag, no filter on
     provider_mappings should be added.
     """
     ctrl = _create_controller_for_filter_tests()
     query_parts: list[str] = []
     query_params: dict[str, object] = {}
-    join_parts: list[str] = []
 
     ctrl._apply_filters(
         query_parts=query_parts,
         query_params=query_params,
-        join_parts=join_parts,
         favorite=None,
         search=None,
         genre_ids=None,
@@ -760,25 +756,23 @@ async def test_apply_filters_no_in_library_filter_by_default() -> None:
         in_library_only=False,
     )
 
-    assert len(join_parts) == 0
+    assert len(query_parts) == 0
 
 
 async def test_apply_filters_provider_filter_without_in_library() -> None:
     """
     Test that provider_filter without in_library_only omits the in_library clause.
 
-    When a provider_filter is set but in_library_only is False, the JOIN should
-    filter by provider but NOT include the in_library=1 condition.
+    When a provider_filter is set but in_library_only is False, the EXISTS subquery
+    should filter by provider but NOT include the in_library=1 condition.
     """
     ctrl = _create_controller_for_filter_tests()
     query_parts: list[str] = []
     query_params: dict[str, object] = {}
-    join_parts: list[str] = []
 
     ctrl._apply_filters(
         query_parts=query_parts,
         query_params=query_params,
-        join_parts=join_parts,
         favorite=None,
         search=None,
         genre_ids=None,
@@ -786,8 +780,9 @@ async def test_apply_filters_provider_filter_without_in_library() -> None:
         in_library_only=False,
     )
 
-    assert len(join_parts) == 1
-    assert "in_library" not in join_parts[0]
+    assert len(query_parts) == 1
+    assert query_parts[0].startswith("EXISTS(")
+    assert "in_library" not in query_parts[0]
     assert "provider_filter_0" in query_params
 
 


### PR DESCRIPTION
## Problem

Every `library_items()` call adds a `JOIN provider_mappings ... GROUP BY item_id` to dedupe items with multiple provider mappings. That JOIN + GROUP BY forces SQLite to drive the query from `provider_mappings`, materialize and sort the **entire** table with temp b-trees for every page, and evaluate the correlated JSON subqueries (provider_mappings/artists/album) for **all** rows instead of just the requested page. This runs behind every artists/albums/tracks page in the UI, on the DB thread.

## Changes

- Provider filter and `in_library_only` filters are now correlated `EXISTS` subqueries instead of a JOIN + GROUP BY (provider conditions live inside the EXISTS)
- `GROUP BY` is only emitted when actual join fanout remains (e.g. artist search/sort joins)
- Tracks: album/disc/track resolved via a self-contained correlated subquery with a deterministic album pick instead of `LEFT JOIN album_tracks` (`get_library_album_tracks` passes the album as preferred so album-scoped disc/track numbers are unchanged)
- Audiobooks: playlog resume data joined 1:1 via a most-recent-entry scalar subquery
- New tests compare new vs legacy query results for a matrix of filter combinations (favorite, search, provider filter, genre, played_only, pagination, artist joins, multi-provider/multi-album items) and assert via `EXPLAIN QUERY PLAN` that listings scan the sort index without a top-level temp b-tree

With this, default listings plan as `SCAN tracks USING INDEX tracks_search_sort_name_idx` and the per-row JSON subqueries only run for the emitted LIMIT rows.

## Benchmarks

Synthetic 100k-track DB with matching schema/indexes, 500-row pages, default sort:

| Query | Before | After |
|---|---|---|
| tracks page, offset 0 | 124.6 ms | 4.7 ms |
| tracks page, offset 5,000 | 311.8 ms | 11.1 ms |
| tracks page, offset 50,000 | 1083.5 ms | 58.8 ms |
| tracks page, provider filter | 42.8 ms | 12.7 ms |

Result sets verified identical (all 97k rows, including JSON columns) between old and new queries.