### PR TITLE
Remove periodic garbage collection

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -1076,6 +1076,8 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             await self._play_announcement(player, announcement, volume_level)
         finally:
             player.extra_data[ATTR_ANNOUNCEMENT_IN_PROGRESS] = False
+            # release the announcement data registered by get_announcement_url
+            self.mass.streams.announcements.pop(player_id, None)
 
     @handle_player_command
     async def play_media(self, player_id: str, media: PlayerMedia) -> None:

--- a/music_assistant/controllers/streams/audio.py
+++ b/music_assistant/controllers/streams/audio.py
@@ -837,6 +837,9 @@ class StreamsAudio:
                 async for chunk in self.get_icy_radio_stream(current_url, streamdetails):
                     delivered_audio = True
                     failed_rotations = 0
+                    # release the previous failure while healthy: it pins the full
+                    # exception traceback (with frames) for the lifetime of the stream
+                    last_err = None
                     yield chunk
                 return
             except RADIO_MIRROR_FAILOVER_ERRORS as err:

--- a/music_assistant/controllers/streams/audio_buffer.py
+++ b/music_assistant/controllers/streams/audio_buffer.py
@@ -15,7 +15,7 @@ import logging
 import time
 from collections import deque
 from collections.abc import AsyncGenerator, Callable
-from contextlib import suppress
+from contextlib import aclosing, suppress
 from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import (
@@ -276,10 +276,14 @@ class AudioBuffer:
             chunk_count = 0
             status = "running"
             try:
-                async for chunk in audio_source:
-                    chunk_count += 1
-                    await self._put(chunk)
-                    await asyncio.sleep(0)
+                # aclosing guarantees the source generator (and any ffmpeg chain
+                # behind it) is finalized immediately when this task is cancelled,
+                # instead of lingering until garbage collection.
+                async with aclosing(audio_source):
+                    async for chunk in audio_source:
+                        chunk_count += 1
+                        await self._put(chunk)
+                        await asyncio.sleep(0)
                 await self._set_eof()
             except asyncio.CancelledError:
                 status = "cancelled"

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -8,12 +8,12 @@ purely to stream audio packets to players.
 from __future__ import annotations
 
 import asyncio
-import gc
 import logging
 import os
 import struct
 import time
 from collections.abc import AsyncGenerator
+from contextlib import aclosing
 from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
@@ -383,9 +383,6 @@ class StreamsController(CoreController):
                 ("*", "/announcement/{player_id}.{fmt}", self.serve_announcement_stream),
             ],
         )
-        # Start periodic garbage collection task
-        # This ensures memory from audio buffers and streams is cleaned up regularly
-        self.mass.call_later(900, self._periodic_garbage_collection)  # 15 minutes
 
     async def close(self) -> None:
         """Cleanup on exit."""
@@ -769,37 +766,42 @@ class StreamsController(CoreController):
             # for the duration of the transfer (see audio_analysis.playback_active).
             self._active_output_streams += 1
             try:
-                async for chunk in audio_bytes:
-                    try:
-                        await resp.write(chunk)
-                        bytes_sent += len(chunk)
-                        if not first_chunk_received:
-                            first_chunk_received = True
-                            # inform the queue that the track is now loaded in the buffer
-                            # so for example the next track can be enqueued
-                            self.mass.player_queues.track_loaded_in_buffer(
-                                queue_item.queue_id, queue_item.queue_item_id
-                            )
-                    except (BrokenPipeError, ConnectionResetError, ConnectionError) as err:
-                        if (
-                            first_chunk_received
-                            and not player.stop_called
-                            and queue_item.streamdetails.duration  # ignore for radio streams
-                        ):
-                            # Player disconnected (unexpected) after receiving at least some data
-                            # This could indicate buffering issues, network problems,
-                            # or player-specific issues.
-                            self.logger.warning(
-                                "Player %s disconnected prematurely from stream for %s (%s) - "
-                                "error: %s, sent %d bytes, content_length=%s",
-                                queue.display_name,
-                                queue_item.name,
-                                queue_item.uri,
-                                err.__class__.__name__,
-                                bytes_sent,
-                                resp.content_length,
-                            )
-                        break
+                # aclosing guarantees the generator (and thus the ffmpeg process chain
+                # behind it) is torn down immediately when the player disconnects
+                # mid-stream, instead of lingering until garbage collection finalizes
+                # the abandoned generator.
+                async with aclosing(audio_bytes):
+                    async for chunk in audio_bytes:
+                        try:
+                            await resp.write(chunk)
+                            bytes_sent += len(chunk)
+                            if not first_chunk_received:
+                                first_chunk_received = True
+                                # inform the queue that the track is now loaded in the buffer
+                                # so for example the next track can be enqueued
+                                self.mass.player_queues.track_loaded_in_buffer(
+                                    queue_item.queue_id, queue_item.queue_item_id
+                                )
+                        except (BrokenPipeError, ConnectionResetError, ConnectionError) as err:
+                            if (
+                                first_chunk_received
+                                and not player.stop_called
+                                and queue_item.streamdetails.duration  # ignore for radio streams
+                            ):
+                                # Player disconnected (unexpected) after receiving at least
+                                # some data. This could indicate buffering issues, network
+                                # problems, or player-specific issues.
+                                self.logger.warning(
+                                    "Player %s disconnected prematurely from stream for %s (%s) - "
+                                    "error: %s, sent %d bytes, content_length=%s",
+                                    queue.display_name,
+                                    queue_item.name,
+                                    queue_item.uri,
+                                    err.__class__.__name__,
+                                    bytes_sent,
+                                    resp.content_length,
+                                )
+                            break
             finally:
                 self._active_output_streams -= 1
             if queue_item.streamdetails.stream_error:
@@ -934,56 +936,60 @@ class StreamsController(CoreController):
         # Mark this player as actively streaming so audio analysis yields CPU to playback
         # for the duration of the flow stream (see audio_analysis.playback_active).
         self._active_output_streams += 1
+        audio_bytes = get_ffmpeg_stream(
+            audio_input=self.audio.get_queue_flow_stream(
+                queue=queue, start_queue_item=start_queue_item, pcm_format=flow_pcm_format
+            ),
+            input_format=flow_pcm_format,
+            output_format=output_format,
+            filter_params=self.audio.get_player_filter_params(
+                player.player_id, flow_pcm_format, output_format
+            ),
+            # we need to slowly feed the music to avoid the player stopping and later
+            # restarting (or completely failing) the audio stream by keeping the buffer short.
+            # this is reported to be an issue especially with Chromecast players.
+            # see for example: https://github.com/music-assistant/support/issues/3717
+            # allow buffer ahead of a few seconds and read rest in (near) realtime
+            extra_input_args=["-readrate", "1.1", "-readrate_initial_burst", "5"],
+            chunk_size=icy_meta_interval if enable_icy else calculate_content_length(output_format),
+        )
         try:
-            async for chunk in get_ffmpeg_stream(
-                audio_input=self.audio.get_queue_flow_stream(
-                    queue=queue, start_queue_item=start_queue_item, pcm_format=flow_pcm_format
-                ),
-                input_format=flow_pcm_format,
-                output_format=output_format,
-                filter_params=self.audio.get_player_filter_params(
-                    player.player_id, flow_pcm_format, output_format
-                ),
-                # we need to slowly feed the music to avoid the player stopping and later
-                # restarting (or completely failing) the audio stream by keeping the buffer short.
-                # this is reported to be an issue especially with Chromecast players.
-                # see for example: https://github.com/music-assistant/support/issues/3717
-                # allow buffer ahead of a few seconds and read rest in (near) realtime
-                extra_input_args=["-readrate", "1.1", "-readrate_initial_burst", "5"],
-                chunk_size=icy_meta_interval
-                if enable_icy
-                else calculate_content_length(output_format),
-            ):
-                try:
-                    await resp.write(chunk)
-                except BrokenPipeError, ConnectionResetError, ConnectionError:
-                    # race condition
-                    break
+            # aclosing guarantees the flow stream (and thus the ffmpeg process chain
+            # behind it) is torn down immediately when the player disconnects
+            # mid-stream, instead of lingering until garbage collection finalizes
+            # the abandoned generator.
+            async with aclosing(audio_bytes):
+                async for chunk in audio_bytes:
+                    try:
+                        await resp.write(chunk)
+                    except BrokenPipeError, ConnectionResetError, ConnectionError:
+                        # race condition
+                        break
 
-                if not enable_icy:
-                    continue
+                    if not enable_icy:
+                        continue
 
-                # if icy metadata is enabled, send the icy metadata after the chunk
-                if (
-                    # use current item here and not buffered item, otherwise
-                    # the icy metadata will be too much ahead
-                    (current_item := queue.current_item)
-                    and current_item.streamdetails
-                    and current_item.streamdetails.stream_title
-                ):
-                    title = current_item.streamdetails.stream_title
-                elif queue and current_item and current_item.name:
-                    title = current_item.name
-                else:
-                    title = "Music Assistant"
-                metadata = f"StreamTitle='{title}';".encode()
-                if icy_preference == "full" and current_item and current_item.image:
-                    metadata += f"StreamURL='{current_item.image.path}'".encode()
-                while len(metadata) % 16 != 0:
-                    metadata += b"\x00"
-                length = len(metadata)
-                length_b = chr(int(length / 16)).encode()
-                await resp.write(length_b + metadata)
+                    # if icy metadata is enabled, send the icy metadata after the chunk
+                    if (
+                        # use current item here and not buffered item, otherwise
+                        # the icy metadata will be too much ahead
+                        (current_item := queue.current_item)
+                        and current_item.streamdetails
+                        and current_item.streamdetails.stream_title
+                    ):
+                        title = current_item.streamdetails.stream_title
+                    elif queue and current_item and current_item.name:
+                        title = current_item.name
+                    else:
+                        title = "Music Assistant"
+                    metadata = f"StreamTitle='{title}';".encode()
+                    if icy_preference == "full" and current_item and current_item.image:
+                        metadata += f"StreamURL='{current_item.image.path}'".encode()
+                    while len(metadata) % 16 != 0:
+                        metadata += b"\x00"
+                    length = len(metadata)
+                    length_b = chr(int(length / 16)).encode()
+                    await resp.write(length_b + metadata)
         finally:
             self._active_output_streams -= 1
 
@@ -1020,13 +1026,18 @@ class StreamsController(CoreController):
             # given the fact that an announcement is just a short audio clip,
             # just send it over completely at once so we have a fixed content length
             data = b""
-            async for chunk in self.get_announcement_stream(
+            announcement_stream = self.get_announcement_stream(
                 announcement_url=announce_data["announcement_url"],
                 output_format=audio_format,
                 pre_announce=announce_data["pre_announce"],
                 pre_announce_url=announce_data["pre_announce_url"],
-            ):
-                data += chunk
+            )
+            # aclosing guarantees the stream (and thus the ffmpeg process chain behind
+            # it) is torn down immediately when the request is cancelled, instead of
+            # lingering until garbage collection finalizes the abandoned generator.
+            async with aclosing(announcement_stream):
+                async for chunk in announcement_stream:
+                    data += chunk
             return web.Response(
                 body=data,
                 content_type=get_mime_type(audio_format.output_format_str),
@@ -1050,16 +1061,22 @@ class StreamsController(CoreController):
             announce_data["announcement_url"],
             player.state.name,
         )
-        async for chunk in self.get_announcement_stream(
+        announcement_stream = self.get_announcement_stream(
             announcement_url=announce_data["announcement_url"],
             output_format=audio_format,
             pre_announce=announce_data["pre_announce"],
             pre_announce_url=announce_data["pre_announce_url"],
-        ):
-            try:
-                await resp.write(chunk)
-            except BrokenPipeError, ConnectionResetError:
-                break
+        )
+        # aclosing guarantees the stream (and thus the ffmpeg process chain behind
+        # it) is torn down immediately when the player disconnects mid-stream,
+        # instead of lingering until garbage collection finalizes the abandoned
+        # generator.
+        async with aclosing(announcement_stream):
+            async for chunk in announcement_stream:
+                try:
+                    await resp.write(chunk)
+                except BrokenPipeError, ConnectionResetError:
+                    break
 
         self.logger.debug(
             "Finished serving audio stream for Announcement %s to %s",
@@ -1273,22 +1290,33 @@ class StreamsController(CoreController):
 
         async def fetch_announcement() -> None:
             fmt = announcement_url.rsplit(".", maxsplit=1)[-1]
+            eof_pending = True
+            stream = get_ffmpeg_stream(
+                audio_input=announcement_url,
+                input_format=AudioFormat(content_type=ContentType.try_parse(fmt)),
+                output_format=pcm_format,
+                chunk_size=calculate_content_length(pcm_format, 1),
+            )
             try:
-                async for chunk in get_ffmpeg_stream(
-                    audio_input=announcement_url,
-                    input_format=AudioFormat(content_type=ContentType.try_parse(fmt)),
-                    output_format=pcm_format,
-                    chunk_size=calculate_content_length(pcm_format, 1),
-                ):
-                    await announcement_data.put(chunk)
+                # aclosing guarantees the ffmpeg stream is torn down immediately
+                # when this task gets cancelled while blocked on the queue put.
+                async with aclosing(stream):
+                    async for chunk in stream:
+                        await announcement_data.put(chunk)
+            except asyncio.CancelledError:
+                # consumer is gone: skip the end-of-stream sentinel because the
+                # queue may be full and nobody will drain it anymore
+                eof_pending = False
+                raise
             except AudioError as err:
                 self.logger.warning(
                     "Failed to fetch announcement audio from %s: %s", announcement_url, err
                 )
             finally:
-                await announcement_data.put(None)  # always signal end of stream
+                if eof_pending:
+                    await announcement_data.put(None)  # always signal end of stream
 
-        self.mass.create_task(fetch_announcement())
+        fetch_task = self.mass.create_task(fetch_announcement())
 
         async def _announcement_stream() -> AsyncGenerator[bytes]:
             """Generate the PCM audio stream for the announcement + optional pre-announce."""
@@ -1313,17 +1341,28 @@ class StreamsController(CoreController):
                     break
                 yield announcement_chunk
 
-        if output_format == pcm_format:
-            # no need to re-encode, just yield the raw PCM stream
-            async for chunk in _announcement_stream():
-                yield chunk
-            return
+        try:
+            if output_format == pcm_format:
+                # no need to re-encode, just yield the raw PCM stream
+                raw_stream = _announcement_stream()
+                async with aclosing(raw_stream):
+                    async for chunk in raw_stream:
+                        yield chunk
+                return
 
-        # stream final announcement in requested output format
-        async for chunk in get_ffmpeg_stream(
-            audio_input=_announcement_stream(), input_format=pcm_format, output_format=output_format
-        ):
-            yield chunk
+            # stream final announcement in requested output format
+            encoded_stream = get_ffmpeg_stream(
+                audio_input=_announcement_stream(),
+                input_format=pcm_format,
+                output_format=output_format,
+            )
+            async with aclosing(encoded_stream):
+                async for chunk in encoded_stream:
+                    yield chunk
+        finally:
+            # stop fetching when the consumer goes away early (e.g. player
+            # disconnected); no-op when the fetch already completed normally
+            fetch_task.cancel()
 
     async def _wrap_with_audio_source_lifecycle(
         self,
@@ -1393,18 +1432,6 @@ class StreamsController(CoreController):
             self.logger.debug(
                 "Got %s request to %s from %s", request.method, request.path, request.remote
             )
-
-    async def _periodic_garbage_collection(self) -> None:
-        """Periodic garbage collection to free up memory from audio buffers and streams."""
-        self.logger.log(VERBOSE_LOG_LEVEL, "Running periodic garbage collection...")
-        # Run gc.collect on the event loop thread to avoid thread-safety issues
-        # with StreamWriter.__del__ calling close() which requires the event loop thread
-        collected = gc.collect()
-        self.logger.log(
-            VERBOSE_LOG_LEVEL, "Garbage collection completed, collected %d objects", collected
-        )
-        # Schedule next run in 15 minutes
-        self.mass.call_later(900, self._periodic_garbage_collection)
 
     def _setup_smart_fades_logger(self, config: CoreConfig) -> None:
         """Set up smart fades logger level."""

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -15,6 +15,7 @@ import os
 import urllib.parse
 from collections.abc import Awaitable, Callable
 from concurrent import futures
+from contextlib import aclosing
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import quote
@@ -462,10 +463,15 @@ class WebserverController(CoreController):
         item_id = urllib.parse.unquote(request.query["item_id"])
         resp = web.StreamResponse(status=200, reason="OK", headers={"Content-Type": "audio/aac"})
         await resp.prepare(request)
-        async for chunk in self.mass.streams.get_preview_stream(
+        preview_stream = self.mass.streams.get_preview_stream(
             provider_instance_id_or_domain, item_id
-        ):
-            await resp.write(chunk)
+        )
+        # aclosing guarantees the preview stream (and the ffmpeg process behind it)
+        # is torn down immediately when the client disconnects, instead of lingering
+        # until garbage collection finalizes the abandoned generator.
+        async with aclosing(preview_stream):
+            async for chunk in preview_stream:
+                await resp.write(chunk)
         return resp
 
     async def _handle_cors_preflight(self, request: web.Request) -> web.Response:

--- a/tests/controllers/players/test_player_controller.py
+++ b/tests/controllers/players/test_player_controller.py
@@ -20,7 +20,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from music_assistant_models.constants import PLAYER_CONTROL_NATIVE, PLAYER_CONTROL_NONE
 from music_assistant_models.enums import EventType, PlaybackState, PlayerFeature, PlayerType
-from music_assistant_models.errors import InvalidDataError, UnsupportedFeaturedException
+from music_assistant_models.errors import (
+    InvalidDataError,
+    PlayerCommandFailed,
+    UnsupportedFeaturedException,
+)
 from music_assistant_models.player import PlayerSource
 
 from music_assistant.controllers.players import PlayerController
@@ -1167,6 +1171,59 @@ class TestCurrentMediaTimeUpdates:
         # (current_media already holds the fresh position in the same pass)
         mock_mass.player_queues.on_player_elapsed_time_corrected.assert_called_once_with(player)
         assert self._player_updated_signalled(mock_mass)
+
+
+class TestPlayAnnouncementCleanup:
+    """Test announcement data cleanup after play_announcement."""
+
+    def _make_player(
+        self, mock_mass: MagicMock, announcements: dict[str, object]
+    ) -> tuple[PlayerController, MockPlayer]:
+        """Create a controller and a player with native announcement support."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("test_provider", instance_id="test", mass=mock_mass)
+        player = MockPlayer(provider, "player_1", "Player 1")
+        player._attr_supported_features.add(PlayerFeature.PLAY_ANNOUNCEMENT)
+        player._cache.clear()
+        controller._players = {"player_1": player}
+        mock_mass.players = controller
+
+        # mimic the real streams controller: register announce data on url request
+        def _get_announcement_url(player_id: str, announce_data: object, **_kwargs: object) -> str:
+            announcements[player_id] = announce_data
+            return f"http://ma/announcement/{player_id}.mp3"
+
+        mock_mass.streams.announcements = announcements
+        mock_mass.streams.get_announcement_url = MagicMock(side_effect=_get_announcement_url)
+        player.update_state(signal_event=False)
+        return controller, player
+
+    async def test_announcement_data_removed_after_playback(self, mock_mass: MagicMock) -> None:
+        """The registered announcement data is released once playback finished."""
+        announcements: dict[str, object] = {}
+        controller, player = self._make_player(mock_mass, announcements)
+
+        async def _play_announcement(*_args: object, **_kwargs: object) -> None:
+            # entry must exist while the announcement is being played/served
+            assert "player_1" in announcements
+
+        player.play_announcement = AsyncMock(side_effect=_play_announcement)  # type: ignore[method-assign]
+
+        await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        player.play_announcement.assert_awaited_once()
+        assert announcements == {}
+
+    async def test_announcement_data_removed_on_error(self, mock_mass: MagicMock) -> None:
+        """The registered announcement data is released even when playback fails."""
+        announcements: dict[str, object] = {}
+        controller, player = self._make_player(mock_mass, announcements)
+        player.play_announcement = AsyncMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
+
+        with pytest.raises(PlayerCommandFailed):
+            await controller.play_announcement("player_1", "http://test/announcement.mp3")
+
+        assert announcements == {}
 
 
 if __name__ == "__main__":

--- a/tests/controllers/streams/test_announcement_stream.py
+++ b/tests/controllers/streams/test_announcement_stream.py
@@ -1,0 +1,71 @@
+"""Tests for the announcement stream lifecycle in the streams controller."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import aclosing
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from music_assistant_models.enums import ContentType
+from music_assistant_models.media_items import AudioFormat
+
+from music_assistant.controllers.streams.controller import StreamsController
+
+PCM_FORMAT = AudioFormat(
+    content_type=ContentType.PCM_S16LE,
+    sample_rate=44100,
+    bit_depth=16,
+    channels=2,
+)
+
+
+@pytest.mark.asyncio
+async def test_fetch_task_cancelled_when_consumer_abandons() -> None:
+    """The background fetch task and its ffmpeg stream stop when the consumer goes away."""
+    ffmpeg_stream_closed = asyncio.Event()
+    fetch_tasks: list[asyncio.Task[None]] = []
+
+    def _fake_ffmpeg_stream(*_args: Any, **_kwargs: Any) -> AsyncGenerator[bytes]:
+        async def _stream() -> AsyncGenerator[bytes]:
+            try:
+                while True:
+                    yield b"\x00" * 1024
+            finally:
+                ffmpeg_stream_closed.set()
+
+        return _stream()
+
+    def _create_task(coro: Any) -> asyncio.Task[None]:
+        task = asyncio.get_running_loop().create_task(coro)
+        fetch_tasks.append(task)
+        return task
+
+    fake_self = MagicMock()
+    fake_self.mass.create_task = MagicMock(side_effect=_create_task)
+
+    with patch(
+        "music_assistant.controllers.streams.controller.get_ffmpeg_stream",
+        side_effect=_fake_ffmpeg_stream,
+    ):
+        stream = StreamsController.get_announcement_stream(
+            cast("StreamsController", fake_self),
+            announcement_url="http://test/announcement.mp3",
+            output_format=PCM_FORMAT,
+            pre_announce=False,
+        )
+        # consume a few chunks, then abandon the stream (player disconnected)
+        async with aclosing(stream):
+            chunk_count = 0
+            async for _chunk in stream:
+                chunk_count += 1
+                if chunk_count == 3:
+                    break
+
+    assert len(fetch_tasks) == 1
+    # closing the consumer must cancel the fetch task and finalize the ffmpeg stream
+    await asyncio.wait_for(ffmpeg_stream_closed.wait(), timeout=1)
+    with pytest.raises(asyncio.CancelledError):
+        await fetch_tasks[0]

--- a/tests/controllers/streams/test_audio_buffer.py
+++ b/tests/controllers/streams/test_audio_buffer.py
@@ -231,6 +231,28 @@ async def test_fill_error_no_data() -> None:
         await _consume()
 
 
+@pytest.mark.asyncio
+async def test_fill_closes_source_on_cancel() -> None:
+    """The source generator is finalized immediately when the fill task is cancelled."""
+    source_closed = asyncio.Event()
+
+    async def _endless_source() -> AsyncGenerator[bytes]:
+        try:
+            while True:
+                yield ONE_SECOND_CHUNK
+        finally:
+            source_closed.set()
+
+    buf = AudioBuffer(TEST_PCM_FORMAT, buffer_size=BufferSize.MINIMAL)
+    buf.fill(_endless_source(), source_name="test")
+    # let the fill task run until it blocks on the full buffer
+    await asyncio.sleep(0.1)
+
+    # clear() cancels the fill task, which must close the source generator
+    await buf.clear()
+    await asyncio.wait_for(source_closed.wait(), timeout=1)
+
+
 # -- Seek and is_valid --
 
 


### PR DESCRIPTION
## Problem

The streams controller disables automatic gen-2 GC and runs a **full `gc.collect()` on the event-loop thread every 15 minutes**. A full collection walks the entire object graph and stalls all active streams (pipe pumping, pacing, HTTP writes) — measured 50-65 ms on M-series hardware, worse on Pi-class devices, and it can coincide with active playback.

Measurements with real HTTP streaming through real ffmpeg show the manual GC is no longer needed:

| Measurement | Result |
|---|---|
| RSS freed by manual full collect | **0.00 MB** (audio bytes are refcount-freed instantly) |
| Cyclic garbage after 9 streams | ~450 objects / 62 KB — purely CPython asyncio subprocess plumbing from ffmpeg spawns, zero MA objects |
| aiohttp 3.14 server write path | no `__del__` → the original loop-thread constraint is obsolete |
| Python 3.14 incremental GC | reclaims the small residue on its own under allocation pressure |

The one thing the periodic collect actually did was *non-deterministically* finalize abandoned async generators (deferred ffmpeg teardown after client disconnects). That is now fixed at the source.

## Changes

- Remove the periodic `gc.collect()` task and the `gc.set_threshold` override from the streams controller
- Deterministic stream teardown via `contextlib.aclosing()` so ffmpeg processes and buffers are torn down immediately on client disconnect: queue item stream, flow stream, announcement streams, preview stream, and `AudioBuffer.fill()`
- `get_announcement_stream`: cancel the background fetch task when the consumer abandons the stream (previously could leak a task blocked on a full queue + ffmpeg + ~1.7 MB PCM buffer)
- Clean up the `announcements` registry entry after `play_announcement` completes
- Drop the retained `last_err` traceback per successful chunk in the reconnecting ICY radio stream
- New tests covering source closure on cancel, fetch-task cancellation, and announcement cleanup