### PR TITLE
Snapcast fixes

### DIFF
--- a/music_assistant/providers/snapcast/control.py
+++ b/music_assistant/providers/snapcast/control.py
@@ -103,6 +103,7 @@ class MusicAssistantControl:
                     "id": id,
                 }
             )
+            return
 
         if cmd == "Control":
             command = request["params"]["command"]
@@ -386,14 +387,25 @@ if __name__ == "__main__":
             line = sys.stdin.readline()
             if not line:  # EOF
                 break
+            request: Any = None
             try:
-                ctrl.handle_snapcast_request(json.loads(line))
-            except Exception as e:
+                request = json.loads(line)
+                ctrl.handle_snapcast_request(request)
+            except json.JSONDecodeError as e:
                 send(
                     {
                         "jsonrpc": "2.0",
                         "error": {"code": -32700, "message": "Parse error", "data": str(e)},
-                        "id": id,
+                        "id": None,
+                    }
+                )
+            except (KeyError, TypeError, AttributeError, ValueError) as e:
+                # malformed request (e.g. missing params), reply instead of dying
+                send(
+                    {
+                        "jsonrpc": "2.0",
+                        "error": {"code": -32603, "message": "Internal error", "data": str(e)},
+                        "id": request.get("id") if isinstance(request, dict) else None,
                     }
                 )
     finally:

--- a/music_assistant/providers/snapcast/control.py
+++ b/music_assistant/providers/snapcast/control.py
@@ -9,6 +9,7 @@ and listens for player commands.
 
 import json
 import logging
+import os
 import socket
 import sys
 import threading
@@ -78,6 +79,9 @@ class MusicAssistantControl:
         logger.info("Shutdown requested by server")
         self.stop()
         self._shutdown_event.set()
+        # force exit; the main thread is blocked in sys.stdin.readline()
+        sys.stdout.flush()
+        os._exit(0)
 
     def handle_snapcast_request(self, request: dict[str, Any]) -> None:
         """Handle (JSON RPC) message from Snapcast."""
@@ -236,7 +240,7 @@ class MusicAssistantControl:
             logger.error(f"Invalid JSON: {e}")
             return
 
-        if data.get("command") == "shutdown":
+        if data.get("event") == "shutdown":
             self.shutdown()
             return
 

--- a/music_assistant/providers/snapcast/ma_stream.py
+++ b/music_assistant/providers/snapcast/ma_stream.py
@@ -182,7 +182,11 @@ class SnapcastMAStream:
             if self._streamer_task and not self._streamer_task.done():
                 if not allow_restart:
                     raise RuntimeError("streamer already running")
-                self._restart_if_running()
+                if self._stop_requested or self._stop_streamer_evt.is_set():
+                    # stop in flight; _on_streamer_done will start the fresh run
+                    self._restart_requested = True
+                else:
+                    self._restart_if_running()
                 return
 
             self._stop_requested = False

--- a/music_assistant/providers/snapcast/player.py
+++ b/music_assistant/providers/snapcast/player.py
@@ -399,10 +399,17 @@ class SnapCastPlayer(Player):
             self._poke_evt.clear()
             while True:
                 call_update: bool = False
-                async with self._state_update_lock:
-                    call_update = await self._process_snapcast_client_state()
-                if call_update:
-                    self.update_state()
+                try:
+                    async with self._state_update_lock:
+                        call_update = await self._process_snapcast_client_state()
+                    if call_update:
+                        self.update_state()
+                except KeyError, AttributeError, TypeError, ValueError:
+                    # a failed update must not kill this worker (state would freeze)
+                    self.logger.exception(
+                        "Error while processing state update for player %s", self.player_id
+                    )
+                    break
                 if self._poke_evt.is_set():
                     self._poke_evt.clear()
                     continue

--- a/music_assistant/providers/snapcast/provider.py
+++ b/music_assistant/providers/snapcast/provider.py
@@ -172,7 +172,8 @@ class SnapCastProvider(PlayerProvider):
         self._stop_called = True
 
         for snap_client in self._snapserver.clients:
-            player_id = self._get_ma_id(snap_client.identifier)
+            if not (player_id := self._get_ma_id(snap_client.identifier)):
+                continue
             if not (player := self.mass.players.get_player(player_id, raise_unavailable=False)):
                 continue
             if player.playback_state != PlaybackState.PLAYING:
@@ -362,11 +363,9 @@ class SnapCastProvider(PlayerProvider):
                     self._snapserver_started.clear()
                 self._controlscript_available = False
 
-    def _get_ma_id(self, snap_client_id: str) -> str:
-        search_dict = self._ids_map.inverse
-        ma_id = search_dict.get(snap_client_id)
-        assert ma_id is not None  # for type checking
-        return ma_id
+    def _get_ma_id(self, snap_client_id: str) -> str | None:
+        """Return the MA player id for the given snapclient id, or None if not registered."""
+        return self._ids_map.inverse.get(snap_client_id)
 
     def _get_snapclient_id(self, player_id: str) -> str:
         search_dict = self._ids_map
@@ -380,7 +379,7 @@ class SnapCastProvider(PlayerProvider):
             new_id = "ma_" + str(re.sub(r"\W+", "", snap_client_id))
             self._ids_map[new_id] = snap_client_id
             return new_id
-        return self._get_ma_id(snap_client_id)
+        return search_dict[snap_client_id]
 
     def _handle_player_init(self, snap_client: SnapclientProto) -> SnapCastPlayer | None:
         """Process Snapcast add to Player controller."""
@@ -560,7 +559,8 @@ class SnapCastProvider(PlayerProvider):
                 raise RuntimeError("Couldn't remove client from group")
             self._snapserver.synchronize(res)
             for client_id in group_members:
-                ma_player_id = self._get_ma_id(client_id)
+                if (ma_player_id := self._get_ma_id(client_id)) is None:
+                    continue
                 if ma_player := cast("SnapCastPlayer", self.mass.players.get_player(ma_player_id)):
                     client = self._snapserver.client(client_id)
                     if client is not None:
@@ -737,9 +737,11 @@ class SnapCastProvider(PlayerProvider):
     ) -> SnapCastPlayer | None:
         """Return the MA SnapCastPlayer for either given client_id or player_id."""
         if client_id is not None:
-            if player_id is not None and player_id != self._get_ma_id(client_id):
+            if (mapped_id := self._get_ma_id(client_id)) is None:
+                return None
+            if player_id is not None and player_id != mapped_id:
                 raise ValueError("provided client_id and player_id do not match")
-            player_id = self._get_ma_id(client_id)
+            player_id = mapped_id
 
         if player_id is None:
             return None


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

With Snapcast unmaintained I asked Claude to do a health check and it found three things.

**1. Orphaned control.py processes.** The shutdown message is sent with the key `event` but the control script checked for `command`, so it never saw it and retried the dead socket forever. Fixed the key and made shutdown exit the process properly.

**2. Player state could freeze until the provider reloads.** The per-player update worker had no error handling, so one exception killed it silently. The worker now logs and carries on, and `_get_ma_id` returns None instead of asserting.

**3. The control script could be killed by a single bad request.** Its error handler referenced the Python `id` builtin instead of the request id, so building the error reply crashed the script. It now sends a proper JSON-RPC error, and an unknown method no longer gets two replies for one request.

After the above I looked at the open issues and found:

**4. Resuming too quickly after pause left clients stuck on "Waiting for chunk" (#4261).** Pause stops the ffmpeg run, but its cleanup lingers for up to 10 seconds waiting for snapserver to report the stream idle. A play command inside that window was silently dropped and the group got pointed at a stream nothing was feeding. The restart is now queued and fires as soon as the old run finishes. I am waiting for a bit more info from the user on this one and I am hopeful this will fix it but I believe it is a valid fix regardless. edit: User no longer uses Snapcast so can't confirm.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/4261

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
