### PR TITLE
Preserve universal player settings during startup restore

### DIFF
--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -501,9 +501,14 @@ class PlayerConfigMixin:
             # update default name if needed
             if name and name != existing_conf.get("default_name"):
                 self.set(f"{CONF_PLAYERS}/{player_id}/default_name", name)
-            # update player_type if needed
-            if existing_conf.get("player_type") != player_type:
-                self.set(f"{CONF_PLAYERS}/{player_id}/player_type", player_type.value)
+            # NOTE: player_type is deliberately NOT updated here. This is called from
+            # Player.__init__ where the type can still be a transient class default
+            # (the real type is often only determined during provider setup).
+            # Overwriting the persisted type here corrupts the stored config if
+            # registration is interrupted (e.g. shutdown while clients reconnect),
+            # which in turn caused universal player configs to be deleted on the
+            # next startup. Genuine player type changes are persisted by
+            # update_state once the player is fully registered.
             return
         # config does not yet exist, create a default one
         conf_key = f"{CONF_PLAYERS}/{player_id}"

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -501,14 +501,9 @@ class PlayerConfigMixin:
             # update default name if needed
             if name and name != existing_conf.get("default_name"):
                 self.set(f"{CONF_PLAYERS}/{player_id}/default_name", name)
-            # NOTE: player_type is deliberately NOT updated here. This is called from
-            # Player.__init__ where the type can still be a transient class default
-            # (the real type is often only determined during provider setup).
-            # Overwriting the persisted type here corrupts the stored config if
-            # registration is interrupted (e.g. shutdown while clients reconnect),
-            # which in turn caused universal player configs to be deleted on the
-            # next startup. Genuine player type changes are persisted by
-            # update_state once the player is fully registered.
+            # deliberately do NOT update player_type here: this is called from
+            # Player.__init__ where the type can still be a transient class default.
+            # Genuine type changes are persisted by update_state after registration.
             return
         # config does not yet exist, create a default one
         conf_key = f"{CONF_PLAYERS}/{player_id}"

--- a/music_assistant/controllers/config/players.py
+++ b/music_assistant/controllers/config/players.py
@@ -155,11 +155,12 @@ class PlayerConfigMixin:
             if include_values:
                 result.append(await self.get_player_config(raw_conf["player_id"]))
             else:
-                raw_conf["default_name"] = (
-                    player.state.name if player else raw_conf.get("default_name")
+                summary_conf = deepcopy(raw_conf)
+                summary_conf["default_name"] = (
+                    player.state.name if player else summary_conf.get("default_name")
                 )
-                raw_conf["available"] = player.state.available if player else False
-                result.append(cast("PlayerConfig", PlayerConfig.parse([], raw_conf)))
+                summary_conf["available"] = player.state.available if player else False
+                result.append(cast("PlayerConfig", PlayerConfig.parse([], summary_conf)))
         return result
 
     @api_command("config/players/get", required_scope=Scope.CONFIG_PLAYERS_READ)

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -299,6 +299,13 @@ class UniversalPlayerProvider(PlayerProvider):
                 valid_protocol_ids.append(protocol_id)
                 continue
             protocol_player_type = protocol_config.get("player_type")
+            protocol_values = protocol_config.get("values") or {}
+            if protocol_values.get(CONF_PROTOCOL_PARENT_ID) == player_id:
+                # During startup, the underlying provider can briefly rewrite
+                # this row's type before its protocol attributes are refreshed.
+                # The persisted parent link still proves it belongs to this UP.
+                valid_protocol_ids.append(protocol_id)
+                continue
             if protocol_player_type != "protocol":
                 self.logger.info(
                     "Removing %s from universal player %s - player type changed to %s",
@@ -307,8 +314,7 @@ class UniversalPlayerProvider(PlayerProvider):
                     protocol_player_type,
                 )
                 continue
-            protocol_values = protocol_config.get("values") or {}
-            if not protocol_values.get("protocol_parent_id"):
+            if not protocol_values.get(CONF_PROTOCOL_PARENT_ID):
                 self.logger.info(
                     "Deleting orphaned protocol player config %s (was linked to %s)",
                     protocol_id,

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -301,9 +301,8 @@ class UniversalPlayerProvider(PlayerProvider):
             protocol_player_type = protocol_config.get("player_type")
             protocol_values = protocol_config.get("values") or {}
             if protocol_values.get(CONF_PROTOCOL_PARENT_ID) == player_id:
-                # During startup, the underlying provider can briefly rewrite
-                # this row's type before its protocol attributes are refreshed.
-                # The persisted parent link still proves it belongs to this UP.
+                # the persisted parent link proves this child still belongs to us,
+                # even if its player_type was left stale by an aborted registration
                 valid_protocol_ids.append(protocol_id)
                 continue
             if protocol_player_type != "protocol":

--- a/tests/controllers/config/test_default_player_config.py
+++ b/tests/controllers/config/test_default_player_config.py
@@ -1,0 +1,44 @@
+"""
+Regression tests for create_default_player_config not corrupting existing configs.
+
+Reproduces music-assistant/support#5745: Player.__init__ calls
+create_default_player_config before provider setup has determined the real
+player type, so the passed type can be a transient class default. For
+squeezelite protocol players this rewrote the persisted player_type from
+"protocol" to "player" on every client (re)connect. Normally healed right
+after registration, but when registration was interrupted (e.g. shutdown
+while clients reconnect) the corrupted row hit disk and the universal player
+restore logic deleted the wrapping universal player config on next startup,
+wiping all user customizations.
+"""
+
+from music_assistant_models.enums import PlayerType
+
+from music_assistant.constants import CONF_PLAYERS
+from music_assistant.mass import MusicAssistant
+
+PLAYER_ID = "e4:5f:01:70:ef:67"
+
+
+async def test_existing_player_type_not_rewritten(mass_minimal: MusicAssistant) -> None:
+    """A repeated call with a transient type must not touch the persisted player_type."""
+    mass_minimal.config.create_default_player_config(
+        PLAYER_ID, "squeezelite", PlayerType.PROTOCOL, "solarium-bath-sl"
+    )
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/player_type") == "protocol"
+
+    # simulate reconnect: Player.__init__ runs with the class default type (player)
+    mass_minimal.config.create_default_player_config(PLAYER_ID, "squeezelite", PlayerType.PLAYER)
+
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/player_type") == "protocol"
+
+
+async def test_existing_default_name_still_updated(mass_minimal: MusicAssistant) -> None:
+    """The default_name update for existing configs keeps working."""
+    mass_minimal.config.create_default_player_config(
+        PLAYER_ID, "squeezelite", PlayerType.PROTOCOL, "old-name"
+    )
+    mass_minimal.config.create_default_player_config(
+        PLAYER_ID, "squeezelite", PlayerType.PROTOCOL, "new-name"
+    )
+    assert mass_minimal.config.get(f"{CONF_PLAYERS}/{PLAYER_ID}/default_name") == "new-name"

--- a/tests/controllers/config/test_persistent_storage_save.py
+++ b/tests/controllers/config/test_persistent_storage_save.py
@@ -17,12 +17,15 @@ from __future__ import annotations
 
 import json
 import os
+from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from music_assistant_models.enums import PlayerType
 
+from music_assistant.constants import CONF_PLAYERS
 from music_assistant.controllers.config.controller import ConfigController
 
 
@@ -113,3 +116,45 @@ async def test_save_succeeds_when_directory_fsync_unsupported(tmp_path: Path) ->
         await controller._async_save()
 
     assert json.loads(Path(controller.filename).read_text()) == {"generation": 1}
+
+
+async def test_player_config_summary_read_does_not_rewrite_settings(
+    tmp_path: Path,
+) -> None:
+    """A config/players read must not dirty raw player config that is later saved."""
+    mass = SimpleNamespace(storage_path=str(tmp_path), players=MagicMock())
+    controller = ConfigController(mass)  # type: ignore[arg-type]
+    controller.initialized = True
+    player_id = "upe45f0170ef67"
+    raw_config = {
+        "player_id": player_id,
+        "provider": "universal_player",
+        "player_type": "player",
+        "enabled": True,
+        "name": "WC-Player",
+        "default_name": "solarium-bath-sl",
+        "values": {
+            "hide_in_ui": True,
+            "announce_volume_min": 55,
+            "announce_volume_max": 98,
+            "play_media_overrides_group": False,
+            "linked_protocol_ids": ["e4:5f:01:70:ef:67"],
+        },
+    }
+    controller._data = {CONF_PLAYERS: {player_id: deepcopy(raw_config)}}
+    live_player = SimpleNamespace(
+        state=SimpleNamespace(
+            name="solarium-bath-sl",
+            available=False,
+            type=PlayerType.PLAYER,
+        )
+    )
+    mass.players.get_player.return_value = live_player
+
+    configs = await controller.get_player_configs(include_values=False)
+    await controller._async_save()
+
+    assert configs[0].default_name == "solarium-bath-sl"
+    assert controller._data[CONF_PLAYERS][player_id] == raw_config
+    saved = json.loads(Path(controller.filename).read_text())
+    assert saved[CONF_PLAYERS][player_id] == raw_config

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7202,6 +7202,70 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         assert protocol_id in registered._protocol_player_ids
 
     @pytest.mark.asyncio
+    async def test_restore_keeps_linked_protocol_after_startup_type_rewrite(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A linked protocol whose type was rewritten must not delete its universal config."""
+        provider = create_mock_universal_provider(mock_mass)
+        universal_id = "upe45f0170ef67"
+        protocol_id = "e4:5f:01:70:ef:67"
+        universal_config: dict[str, Any] = {
+            "player_id": universal_id,
+            "provider": "universal_player",
+            "player_type": "player",
+            "enabled": True,
+            "name": "WC-Player",
+            "default_name": "solarium-bath-sl",
+            "values": {
+                "hide_in_ui": True,
+                "announce_volume_min": 55,
+                "announce_volume_max": 98,
+                "play_media_overrides_group": False,
+                "linked_protocol_ids": [protocol_id],
+                "device_identifiers": {},
+                "device_info": {},
+            },
+        }
+        configs: dict[str, dict[str, Any]] = {
+            universal_id: universal_config,
+            protocol_id: {
+                "player_id": protocol_id,
+                "provider": "squeezelite",
+                "player_type": "player",
+                "enabled": True,
+                "values": {"protocol_parent_id": universal_id},
+            },
+        }
+
+        def _config_get(key: str, default: object = None) -> object:
+            if key == CONF_PLAYERS:
+                return configs
+            if key.startswith(f"{CONF_PLAYERS}/"):
+                pid = key.split("/", 1)[1]
+                return configs.get(pid, default)
+            return default
+
+        mock_mass.config.get.side_effect = _config_get
+        mock_mass.config.remove_player_config = AsyncMock()
+        mock_mass.config.get_base_player_config.return_value = create_mock_config("WC-Player")
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(return_value=None)
+        mock_mass.players.delete_player_config = MagicMock()
+        mock_mass.players.unregister = AsyncMock()
+        mock_mass.players.register_or_update = AsyncMock()
+
+        await provider._restore_player(universal_id)
+
+        mock_mass.config.remove_player_config.assert_not_called()
+        mock_mass.players.delete_player_config.assert_not_called()
+        mock_mass.players.unregister.assert_not_called()
+        mock_mass.players.register_or_update.assert_awaited_once()
+        registered = mock_mass.players.register_or_update.call_args.args[0]
+        assert protocol_id in registered._protocol_player_ids
+        assert configs[universal_id]["values"]["hide_in_ui"] is True
+        assert configs[universal_id]["values"]["announce_volume_min"] == 55
+
+    @pytest.mark.asyncio
     async def test_disabled_parent_reparents_and_disables_orphaned_protocols(
         self, mock_mass: MagicMock
     ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Preserve restored Universal Player configs when a linked protocol child was temporarily rewritten as a regular player during startup.

The issue's startup log shows restored Universal Players being deleted because their linked Squeezelite child rows briefly had `player_type: player`, followed by the same Universal Player IDs being recreated with default names/settings. The restore path now treats a persisted `protocol_parent_id` pointing at the Universal Player as the stronger signal that the child still belongs to that wrapper, so the existing Universal Player config is kept instead of deleted and recreated.

This also keeps `config/players` summary reads from mutating raw player config data that can later be saved to `settings.json`.

Fixes music-assistant/support#5745.

Validation:

- Added a regression that reproduces the destructive restore decision for `upe45f0170ef67` / `e4:5f:01:70:ef:67` and verifies the Universal Player config is not removed.
- Added a persistence regression proving a `config/players` summary read followed by a save leaves the raw `settings.json` player row unchanged.
- Replayed the issue attachment shape locally by taking the reported `settings-before.json`, changing the four affected Squeezelite child rows to the transient `player_type: player` state shown in the startup log, then running restore + save; the four affected Universal Player rows remained unchanged.
- `.venv/bin/pytest --no-cov -q tests/controllers/players/test_protocol_linking.py::TestUniversalPlayerRestoreOrphanCleanup tests/controllers/config/test_persistent_storage_save.py` -> passed.
- `.venv/bin/pytest --no-cov -q tests/controllers/players/test_protocol_linking.py` -> passed.
- `.venv/bin/pre-commit run --all-files` -> passed.

Scope:

- Does not change protocol child registration or type detection.
- Does not change stale Universal Player cleanup when a child has no parent link or has moved to another parent.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5745

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
