### PR TITLE
Raise transient provider errors instead of caching them as negatives

### DIFF
--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -325,9 +325,19 @@ class MetaDataController(
         for provider in self.providers:
             if ProviderFeature.LYRICS not in provider.supported_features:
                 continue
-            if (metadata := await provider.get_track_metadata(track)) and (
-                metadata.lyrics or metadata.lrc_lyrics
-            ):
+            try:
+                metadata = await provider.get_track_metadata(track)
+            except Exception as err:
+                # a provider failure must not abort the lookup — skip to the next provider
+                self.logger.warning(
+                    "Error fetching lyrics for %s from provider %s: %s",
+                    track.name,
+                    provider.name,
+                    err,
+                    exc_info=err if self.logger.isEnabledFor(10) else None,
+                )
+                continue
+            if metadata and (metadata.lyrics or metadata.lrc_lyrics):
                 return metadata.lyrics, metadata.lrc_lyrics
         return None, None
 

--- a/music_assistant/controllers/metadata/enrichment.py
+++ b/music_assistant/controllers/metadata/enrichment.py
@@ -138,7 +138,18 @@ class MetadataEnrichmentMixin:
             for provider in self.providers:
                 if ProviderFeature.ARTIST_METADATA not in provider.supported_features:
                     continue
-                if metadata := await provider.get_artist_metadata(artist):
+                try:
+                    metadata = await provider.get_artist_metadata(artist)
+                except Exception as err:
+                    self.logger.warning(
+                        "Error fetching metadata for Artist %s from provider %s: %s",
+                        artist.name,
+                        provider.name,
+                        err,
+                        exc_info=err if self.logger.isEnabledFor(10) else None,
+                    )
+                    continue
+                if metadata:
                     if prefer_local_genres:
                         metadata = replace(metadata, genres=None)
                     if metadata.description:
@@ -245,7 +256,18 @@ class MetadataEnrichmentMixin:
             for provider in self.providers:
                 if ProviderFeature.ALBUM_METADATA not in provider.supported_features:
                     continue
-                if metadata := await provider.get_album_metadata(album):
+                try:
+                    metadata = await provider.get_album_metadata(album)
+                except Exception as err:
+                    self.logger.warning(
+                        "Error fetching metadata for Album %s from provider %s: %s",
+                        album.name,
+                        provider.name,
+                        err,
+                        exc_info=err if self.logger.isEnabledFor(10) else None,
+                    )
+                    continue
+                if metadata:
                     if prefer_local_genres:
                         metadata = replace(metadata, genres=None)
                     album.metadata.update(metadata)
@@ -304,7 +326,18 @@ class MetadataEnrichmentMixin:
                 if ProviderFeature.TRACK_METADATA not in provider.supported_features:
                     continue
 
-                if metadata := await provider.get_track_metadata(track):
+                try:
+                    metadata = await provider.get_track_metadata(track)
+                except Exception as err:
+                    self.logger.warning(
+                        "Error fetching metadata for Track %s from provider %s: %s",
+                        track.name,
+                        provider.name,
+                        err,
+                        exc_info=err if self.logger.isEnabledFor(10) else None,
+                    )
+                    continue
+                if metadata:
                     if prefer_local_genres:
                         metadata = replace(metadata, genres=None)
                     track.metadata.update(metadata)

--- a/music_assistant/providers/coverartarchive/__init__.py
+++ b/music_assistant/providers/coverartarchive/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import aiohttp.client_exceptions
 from music_assistant_models.enums import ExternalID, ImageType, ProviderFeature
 from music_assistant_models.media_items import Album, MediaItemImage, MediaItemMetadata, UniqueList
 
@@ -88,8 +87,7 @@ class CoverArtArchiveMetadataProvider(MetadataProvider):
             )
         )
 
-    # None can signal a network failure as well as "no cover art", so don't cache it
-    @use_cache(86400 * 30, cache_none=False)
+    @use_cache(86400 * 30)
     async def _get_cover_art_url(self, release_group_id: str) -> str | None:
         """
         Retrieve cover art URL for a release group.
@@ -99,14 +97,12 @@ class CoverArtArchiveMetadataProvider(MetadataProvider):
         # Try 1200px first, fall back to 500px
         for size in ("front-1200", "front-500"):
             url = f"{CAA_BASE_URL}/release-group/{release_group_id}/{size}"
-            try:
-                async with self.mass.http_session.head(url, allow_redirects=True) as response:
-                    if response.status == 200:
-                        return str(response.url)
-            except (
-                aiohttp.client_exceptions.ClientConnectorError,
-                aiohttp.client_exceptions.ServerDisconnectedError,
-                TimeoutError,
-            ):
-                self.logger.debug("Failed to retrieve cover art from %s", url)
+            async with self.mass.http_session.head(url, allow_redirects=True) as response:
+                if response.status == 200:
+                    return str(response.url)
+                if response.status != 404:
+                    # a non-404 status (5xx, 429, ...) is a transient error — propagate it
+                    # instead of caching it as "no cover art"
+                    response.raise_for_status()
+        # a 404 for both sizes means this release group genuinely has no cover art
         return None

--- a/music_assistant/providers/coverartarchive/__init__.py
+++ b/music_assistant/providers/coverartarchive/__init__.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import aiohttp
 from music_assistant_models.enums import ExternalID, ImageType, ProviderFeature
+from music_assistant_models.errors import ResourceTemporarilyUnavailable
 from music_assistant_models.media_items import Album, MediaItemImage, MediaItemMetadata, UniqueList
 
 from music_assistant.controllers.cache import use_cache
@@ -95,14 +97,17 @@ class CoverArtArchiveMetadataProvider(MetadataProvider):
         :param release_group_id: MusicBrainz release group ID.
         """
         # Try 1200px first, fall back to 500px
-        for size in ("front-1200", "front-500"):
-            url = f"{CAA_BASE_URL}/release-group/{release_group_id}/{size}"
-            async with self.mass.http_session.head(url, allow_redirects=True) as response:
-                if response.status == 200:
-                    return str(response.url)
-                if response.status != 404:
-                    # a non-404 status (5xx, 429, ...) is a transient error — propagate it
-                    # instead of caching it as "no cover art"
-                    response.raise_for_status()
+        try:
+            for size in ("front-1200", "front-500"):
+                url = f"{CAA_BASE_URL}/release-group/{release_group_id}/{size}"
+                async with self.mass.http_session.head(url, allow_redirects=True) as response:
+                    if response.status == 200:
+                        return str(response.url)
+                    if response.status != 404:
+                        response.raise_for_status()
+        except (aiohttp.ClientError, TimeoutError) as err:
+            # a non-404 status (5xx, 429, ...) or network failure is transient — surface it as
+            # ResourceTemporarilyUnavailable so callers degrade instead of caching "no cover art"
+            raise ResourceTemporarilyUnavailable("Cover Art Archive request failed") from err
         # a 404 for both sizes means this release group genuinely has no cover art
         return None

--- a/music_assistant/providers/itunes_artwork/__init__.py
+++ b/music_assistant/providers/itunes_artwork/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import aiohttp.client_exceptions
 from music_assistant_models.enums import ExternalID, ImageType, ProviderFeature
 from music_assistant_models.media_items import MediaItemImage, MediaItemMetadata, UniqueList
 
@@ -92,8 +91,7 @@ class ITunesArtworkMetadataProvider(MetadataProvider):
             )
         )
 
-    # None can signal a network failure as well as "no artwork", so don't cache it
-    @use_cache(86400 * 30, cache_none=False)
+    @use_cache(86400 * 30)
     async def _get_artwork_url(self, barcode: str) -> str | None:
         """
         Look up album artwork URL from iTunes by UPC barcode.
@@ -102,23 +100,11 @@ class ITunesArtworkMetadataProvider(MetadataProvider):
         """
         # iTunes expects a UPC (12 digits), strip leading zero from EAN-13 if present
         upc = barcode.lstrip("0").zfill(12) if len(barcode) == 13 else barcode
-        try:
-            async with self.mass.http_session.get(
-                ITUNES_LOOKUP_URL, params={"upc": upc}
-            ) as response:
-                if response.status != 200:
-                    self.logger.debug(
-                        "iTunes lookup failed for barcode %s (status %d)", barcode, response.status
-                    )
-                    return None
-                data = await response.json(content_type=None)
-        except (
-            aiohttp.client_exceptions.ClientConnectorError,
-            aiohttp.client_exceptions.ServerDisconnectedError,
-            TimeoutError,
-        ):
-            self.logger.debug("Failed to connect to iTunes API for barcode %s", barcode)
-            return None
+        async with self.mass.http_session.get(ITUNES_LOOKUP_URL, params={"upc": upc}) as response:
+            # let non-2xx / network / parse failures propagate so they are not cached;
+            # an empty result set below is the genuine "no artwork for this barcode"
+            response.raise_for_status()
+            data = await response.json(content_type=None)
 
         if not data.get("resultCount"):
             self.logger.debug("No results from iTunes for barcode %s", barcode)

--- a/music_assistant/providers/itunes_artwork/__init__.py
+++ b/music_assistant/providers/itunes_artwork/__init__.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from json import JSONDecodeError
 from typing import TYPE_CHECKING
 
+import aiohttp
 from music_assistant_models.enums import ExternalID, ImageType, ProviderFeature
+from music_assistant_models.errors import ResourceTemporarilyUnavailable
 from music_assistant_models.media_items import MediaItemImage, MediaItemMetadata, UniqueList
 
 from music_assistant.controllers.cache import use_cache
@@ -100,11 +103,16 @@ class ITunesArtworkMetadataProvider(MetadataProvider):
         """
         # iTunes expects a UPC (12 digits), strip leading zero from EAN-13 if present
         upc = barcode.lstrip("0").zfill(12) if len(barcode) == 13 else barcode
-        async with self.mass.http_session.get(ITUNES_LOOKUP_URL, params={"upc": upc}) as response:
-            # let non-2xx / network / parse failures propagate so they are not cached;
-            # an empty result set below is the genuine "no artwork for this barcode"
-            response.raise_for_status()
-            data = await response.json(content_type=None)
+        try:
+            async with self.mass.http_session.get(
+                ITUNES_LOOKUP_URL, params={"upc": upc}
+            ) as response:
+                response.raise_for_status()
+                data = await response.json(content_type=None)
+        except (aiohttp.ClientError, TimeoutError, JSONDecodeError) as err:
+            # non-2xx / network / parse failure is transient — surface it as
+            # ResourceTemporarilyUnavailable so callers degrade instead of caching "no artwork"
+            raise ResourceTemporarilyUnavailable("iTunes request failed") from err
 
         if not data.get("resultCount"):
             self.logger.debug("No results from iTunes for barcode %s", barcode)

--- a/music_assistant/providers/lrclib/__init__.py
+++ b/music_assistant/providers/lrclib/__init__.py
@@ -6,10 +6,8 @@ Used for retrieval of synchronized lyrics.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any, cast
 
-from aiohttp import ClientResponseError
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
 from music_assistant_models.media_items import MediaItemMetadata, Track
@@ -152,24 +150,17 @@ class LrclibProvider(MetadataProvider):
             )
         return None
 
-    # None can signal a fetch/parse failure as well as "no lyrics", so don't cache it
-    @use_cache(3600 * 24 * 14, cache_none=False)  # Cache for 14 days
+    @use_cache(3600 * 24 * 14)  # Cache for 14 days
     @throttle_with_retries
     async def _get_data(self, **params: Any) -> dict[str, Any] | None:
         """Get data from LRCLib API with throttling and retries."""
         headers = {"User-Agent": USER_AGENT}
-
-        try:
-            async with self.mass.http_session.get(
-                f"{self.api_url}/get", params=params, headers=headers
-            ) as response:
-                response.raise_for_status()
-                if response.status == 204:  # No content
-                    return None
-                return cast("dict[str, Any]", await response.json())
-        except ClientResponseError as err:
-            self.logger.debug("Error fetching data from LRCLib API (%s): %s", self.api_url, err)
-            return None
-        except json.JSONDecodeError as err:
-            self.logger.debug("Error parsing response from LRCLib API: %s", err)
-            return None
+        async with self.mass.http_session.get(
+            f"{self.api_url}/get", params=params, headers=headers
+        ) as response:
+            # 204/404 mean there are genuinely no lyrics for this track; any other failure
+            # (5xx, network, malformed json) propagates so it is not cached as "no lyrics"
+            if response.status in (204, 404):
+                return None
+            response.raise_for_status()
+            return cast("dict[str, Any]", await response.json())

--- a/music_assistant/providers/lrclib/__init__.py
+++ b/music_assistant/providers/lrclib/__init__.py
@@ -6,10 +6,13 @@ Used for retrieval of synchronized lyrics.
 
 from __future__ import annotations
 
+from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, cast
 
+from aiohttp import ClientError
 from music_assistant_models.config_entries import ConfigEntry
 from music_assistant_models.enums import ConfigEntryType, ProviderFeature
+from music_assistant_models.errors import ResourceTemporarilyUnavailable
 from music_assistant_models.media_items import MediaItemMetadata, Track
 
 from music_assistant.controllers.cache import use_cache
@@ -155,12 +158,16 @@ class LrclibProvider(MetadataProvider):
     async def _get_data(self, **params: Any) -> dict[str, Any] | None:
         """Get data from LRCLib API with throttling and retries."""
         headers = {"User-Agent": USER_AGENT}
-        async with self.mass.http_session.get(
-            f"{self.api_url}/get", params=params, headers=headers
-        ) as response:
-            # 204/404 mean there are genuinely no lyrics for this track; any other failure
-            # (5xx, network, malformed json) propagates so it is not cached as "no lyrics"
-            if response.status in (204, 404):
-                return None
-            response.raise_for_status()
-            return cast("dict[str, Any]", await response.json())
+        try:
+            async with self.mass.http_session.get(
+                f"{self.api_url}/get", params=params, headers=headers
+            ) as response:
+                # 204/404 mean there are genuinely no lyrics for this track
+                if response.status in (204, 404):
+                    return None
+                response.raise_for_status()
+                return cast("dict[str, Any]", await response.json())
+        except (ClientError, TimeoutError, JSONDecodeError) as err:
+            # any other failure (5xx, network, malformed json) is transient — surface it as
+            # ResourceTemporarilyUnavailable so callers degrade instead of caching "no lyrics"
+            raise ResourceTemporarilyUnavailable("LRCLIB request failed") from err

--- a/music_assistant/providers/wikipedia/__init__.py
+++ b/music_assistant/providers/wikipedia/__init__.py
@@ -8,11 +8,9 @@ Wikidata sitelinks.
 
 from __future__ import annotations
 
-from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import unquote, urlparse
 
-import aiohttp
 from music_assistant_models.enums import ProviderFeature
 from music_assistant_models.errors import InvalidDataError
 from music_assistant_models.media_items import MediaItemMetadata
@@ -143,8 +141,7 @@ class WikipediaMetadataProvider(MetadataProvider):
                 result[lang] = title
         return result
 
-    # None can signal a fetch failure as well as a missing bio, so don't cache it
-    @use_cache(86400 * 90, persistent=True, cache_none=False)
+    @use_cache(86400 * 90, persistent=True)
     async def _fetch_bio(self, lang: str, title: str) -> str | None:
         """
         Return the plain-text lead section of a Wikipedia article.
@@ -178,24 +175,26 @@ class WikipediaMetadataProvider(MetadataProvider):
     async def _get_json(
         self, url: str, params: dict[str, str] | None = None
     ) -> dict[str, Any] | None:
-        """Return the parsed JSON from a GET request, or ``None`` on failure."""
+        """
+        Return the parsed JSON from a GET request, or None when the resource is absent.
+
+        Only a 404 yields None; transient failures (network, other HTTP errors or an
+        unparsable response) propagate so callers do not cache them as a negative result.
+
+        :param url: Request URL.
+        :param params: Optional query parameters.
+        """
         headers = {
             "User-Agent": f"Music Assistant/{self.mass.version} (https://music-assistant.io)"
         }
-        async with self.throttler:
-            try:
-                async with self.mass.http_session.get(
-                    url, params=params, headers=headers
-                ) as response:
-                    if response.status >= 400:
-                        return None
-                    try:
-                        return cast("dict[str, Any]", await response.json())
-                    except aiohttp.ContentTypeError, JSONDecodeError:
-                        return None
-            # ClientError covers every fetch failure; TimeoutError is raised separately
-            except aiohttp.ClientError, TimeoutError:
+        async with (
+            self.throttler,
+            self.mass.http_session.get(url, params=params, headers=headers) as response,
+        ):
+            if response.status == 404:
                 return None
+            response.raise_for_status()
+            return cast("dict[str, Any]", await response.json())
 
 
 def _wiki_titles_by_lang(relations: list[MusicBrainzRelation]) -> dict[str, str]:

--- a/music_assistant/providers/wikipedia/__init__.py
+++ b/music_assistant/providers/wikipedia/__init__.py
@@ -8,11 +8,13 @@ Wikidata sitelinks.
 
 from __future__ import annotations
 
+from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import unquote, urlparse
 
+import aiohttp
 from music_assistant_models.enums import ProviderFeature
-from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.errors import InvalidDataError, ResourceTemporarilyUnavailable
 from music_assistant_models.media_items import MediaItemMetadata
 
 from music_assistant.controllers.cache import use_cache
@@ -178,8 +180,9 @@ class WikipediaMetadataProvider(MetadataProvider):
         """
         Return the parsed JSON from a GET request, or None when the resource is absent.
 
-        Only a 404 yields None; transient failures (network, other HTTP errors or an
-        unparsable response) propagate so callers do not cache them as a negative result.
+        Only a 404 yields None; a transient failure (network, another HTTP error or an
+        unparsable response) raises ResourceTemporarilyUnavailable so callers do not cache
+        it as a negative result.
 
         :param url: Request URL.
         :param params: Optional query parameters.
@@ -187,14 +190,17 @@ class WikipediaMetadataProvider(MetadataProvider):
         headers = {
             "User-Agent": f"Music Assistant/{self.mass.version} (https://music-assistant.io)"
         }
-        async with (
-            self.throttler,
-            self.mass.http_session.get(url, params=params, headers=headers) as response,
-        ):
-            if response.status == 404:
-                return None
-            response.raise_for_status()
-            return cast("dict[str, Any]", await response.json())
+        try:
+            async with (
+                self.throttler,
+                self.mass.http_session.get(url, params=params, headers=headers) as response,
+            ):
+                if response.status == 404:
+                    return None
+                response.raise_for_status()
+                return cast("dict[str, Any]", await response.json())
+        except (aiohttp.ClientError, TimeoutError, JSONDecodeError) as err:
+            raise ResourceTemporarilyUnavailable("Wikipedia request failed") from err
 
 
 def _wiki_titles_by_lang(relations: list[MusicBrainzRelation]) -> dict[str, str]:

--- a/tests/controllers/metadata/test_enrichment.py
+++ b/tests/controllers/metadata/test_enrichment.py
@@ -1,0 +1,126 @@
+"""Tests for metadata enrichment resilience to provider failures."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+from music_assistant_models.enums import ExternalID, ProviderFeature
+from music_assistant_models.media_items import Album, Artist, Track
+from music_assistant_models.media_items.metadata import MediaItemMetadata
+
+from music_assistant.controllers.metadata.constants import CONF_ENABLE_ONLINE_METADATA
+from music_assistant.controllers.metadata.enrichment import MetadataEnrichmentMixin
+
+
+def _online_metadata_only(key: str, *_args: Any, **_kwargs: Any) -> bool:
+    """Config stub: only online metadata is enabled (prefer-local-genres off)."""
+    return key == CONF_ENABLE_ONLINE_METADATA
+
+
+def _metadata_provider(name: str, feature: ProviderFeature) -> MagicMock:
+    """Return a mock metadata provider advertising a single metadata feature."""
+    provider = MagicMock()
+    provider.name = name
+    provider.priority = 0
+    provider.supported_features = {feature}
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_album_enrichment_survives_provider_error() -> None:
+    """A raising album metadata provider is logged and skipped; later providers still run."""
+    enrichment = MetadataEnrichmentMixin()
+    enrichment.logger = MagicMock()
+    enrichment.mass = MagicMock()
+    enrichment.config = MagicMock()
+    enrichment.config.get_value = _online_metadata_only
+    enrichment.mass.music.albums.update_item_in_library = AsyncMock()
+
+    boom = _metadata_provider("boom", ProviderFeature.ALBUM_METADATA)
+    boom.get_album_metadata = AsyncMock(side_effect=aiohttp.ClientError("network down"))
+    good = _metadata_provider("good", ProviderFeature.ALBUM_METADATA)
+    good.get_album_metadata = AsyncMock(return_value=None)
+    enrichment.providers = [boom, good]  # type: ignore[misc]
+
+    album = Album(
+        item_id="1",
+        provider="library",
+        name="Test Album",
+        provider_mappings=set(),
+        metadata=MediaItemMetadata(),
+    )
+
+    # a transient provider error must not abort enrichment
+    await enrichment._update_album_metadata(album, force_refresh=True)
+
+    boom.get_album_metadata.assert_awaited_once()
+    good.get_album_metadata.assert_awaited_once()  # loop continued past the failing provider
+    enrichment.logger.warning.assert_called_once()
+    enrichment.mass.music.albums.update_item_in_library.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_track_enrichment_survives_provider_error() -> None:
+    """A raising track metadata provider is logged and skipped; later providers still run."""
+    enrichment = MetadataEnrichmentMixin()
+    enrichment.logger = MagicMock()
+    enrichment.mass = MagicMock()
+    enrichment.config = MagicMock()
+    enrichment.config.get_value = _online_metadata_only
+    enrichment.mass.music.tracks.update_item_in_library = AsyncMock()
+
+    boom = _metadata_provider("boom", ProviderFeature.TRACK_METADATA)
+    boom.get_track_metadata = AsyncMock(side_effect=aiohttp.ClientError("network down"))
+    good = _metadata_provider("good", ProviderFeature.TRACK_METADATA)
+    good.get_track_metadata = AsyncMock(return_value=None)
+    enrichment.providers = [boom, good]  # type: ignore[misc]
+
+    track = Track(
+        item_id="1",
+        provider="library",
+        name="Test Track",
+        provider_mappings=set(),
+        metadata=MediaItemMetadata(),
+    )
+
+    await enrichment._update_track_metadata(track, force_refresh=True)
+
+    boom.get_track_metadata.assert_awaited_once()
+    good.get_track_metadata.assert_awaited_once()
+    enrichment.logger.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_artist_enrichment_survives_provider_error() -> None:
+    """A raising artist metadata provider is logged and skipped; later providers still run."""
+    enrichment = MetadataEnrichmentMixin()
+    enrichment.logger = MagicMock()
+    enrichment.mass = MagicMock()
+    enrichment.config = MagicMock()
+    enrichment.config.get_value = _online_metadata_only
+    enrichment.preferred_language = "en"  # type: ignore[misc]
+    enrichment.mass.music.artists.update_item_in_library = AsyncMock()
+
+    boom = _metadata_provider("boom", ProviderFeature.ARTIST_METADATA)
+    boom.get_artist_metadata = AsyncMock(side_effect=aiohttp.ClientError("network down"))
+    good = _metadata_provider("good", ProviderFeature.ARTIST_METADATA)
+    good.get_artist_metadata = AsyncMock(return_value=None)
+    enrichment.providers = [boom, good]  # type: ignore[misc]
+
+    artist = Artist(
+        item_id="1",
+        provider="library",
+        name="Test Artist",
+        provider_mappings=set(),
+        external_ids={(ExternalID.MB_ARTIST, "11111111-1111-1111-1111-111111111111")},
+        metadata=MediaItemMetadata(),
+    )
+
+    await enrichment._update_artist_metadata(artist, force_refresh=True)
+
+    boom.get_artist_metadata.assert_awaited_once()
+    good.get_artist_metadata.assert_awaited_once()
+    enrichment.logger.warning.assert_called_once()

--- a/tests/providers/coverartarchive/__init__.py
+++ b/tests/providers/coverartarchive/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Cover Art Archive provider."""

--- a/tests/providers/coverartarchive/test_coverartarchive.py
+++ b/tests/providers/coverartarchive/test_coverartarchive.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import ClientError
+from music_assistant_models.errors import ResourceTemporarilyUnavailable
 
 from music_assistant.providers.coverartarchive import (
     SUPPORTED_FEATURES,
@@ -65,7 +66,7 @@ async def test_get_cover_art_url_returns_none_when_missing(
 async def test_get_cover_art_url_propagates_transient_error(
     provider: CoverArtArchiveMetadataProvider,
 ) -> None:
-    """A 5xx status propagates instead of being cached as 'no cover art'."""
+    """A 5xx failure surfaces as ResourceTemporarilyUnavailable, not cached as 'no cover art'."""
     response = MagicMock()
     response.status = 503
     response.raise_for_status = MagicMock(side_effect=ClientError("service unavailable"))
@@ -73,5 +74,5 @@ async def test_get_cover_art_url_propagates_transient_error(
         return_value=_response_cm(response)
     )
 
-    with pytest.raises(ClientError):
+    with pytest.raises(ResourceTemporarilyUnavailable):
         await provider._get_cover_art_url("mbid")

--- a/tests/providers/coverartarchive/test_coverartarchive.py
+++ b/tests/providers/coverartarchive/test_coverartarchive.py
@@ -1,0 +1,77 @@
+"""Tests for the Cover Art Archive metadata provider."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import ClientError
+
+from music_assistant.providers.coverartarchive import (
+    SUPPORTED_FEATURES,
+    CoverArtArchiveMetadataProvider,
+)
+
+
+@pytest.fixture
+def provider() -> CoverArtArchiveMetadataProvider:
+    """Return a provider with mocked dependencies and a cold cache."""
+    mass = AsyncMock()
+    mass.http_session = MagicMock()
+    # force a cache miss so the wrapped fetch always runs, and swallow the store task
+    mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
+    mass.create_task = MagicMock(side_effect=lambda coro, **_: coro.close())
+    manifest = MagicMock()
+    manifest.domain = "coverartarchive"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    return CoverArtArchiveMetadataProvider(mass, manifest, config, SUPPORTED_FEATURES)
+
+
+def _response_cm(response: MagicMock) -> MagicMock:
+    """Build a fake async context manager mimicking aiohttp's session.head()."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+async def test_get_cover_art_url_returns_url_on_success(
+    provider: CoverArtArchiveMetadataProvider,
+) -> None:
+    """A 200 response returns the resolved cover art URL."""
+    response = MagicMock()
+    response.status = 200
+    response.url = "https://coverartarchive.org/release-group/mbid/front-1200"
+    provider.mass.http_session.head = MagicMock(  # type: ignore[method-assign]
+        return_value=_response_cm(response)
+    )
+
+    result = await provider._get_cover_art_url("mbid")
+    assert result == "https://coverartarchive.org/release-group/mbid/front-1200"
+
+
+async def test_get_cover_art_url_returns_none_when_missing(
+    provider: CoverArtArchiveMetadataProvider,
+) -> None:
+    """A 404 for every size means there is genuinely no cover art, so None is returned."""
+    response = MagicMock()
+    response.status = 404
+    provider.mass.http_session.head = MagicMock(  # type: ignore[method-assign]
+        return_value=_response_cm(response)
+    )
+
+    assert await provider._get_cover_art_url("mbid") is None
+
+
+async def test_get_cover_art_url_propagates_transient_error(
+    provider: CoverArtArchiveMetadataProvider,
+) -> None:
+    """A 5xx status propagates instead of being cached as 'no cover art'."""
+    response = MagicMock()
+    response.status = 503
+    response.raise_for_status = MagicMock(side_effect=ClientError("service unavailable"))
+    provider.mass.http_session.head = MagicMock(  # type: ignore[method-assign]
+        return_value=_response_cm(response)
+    )
+
+    with pytest.raises(ClientError):
+        await provider._get_cover_art_url("mbid")

--- a/tests/providers/lrclib/__init__.py
+++ b/tests/providers/lrclib/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the LRCLIB provider."""

--- a/tests/providers/lrclib/test_lrclib.py
+++ b/tests/providers/lrclib/test_lrclib.py
@@ -1,0 +1,57 @@
+"""Tests for the LRCLIB metadata provider."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import ClientError
+
+from music_assistant.helpers.throttle_retry import ThrottlerManager
+from music_assistant.providers.lrclib import SUPPORTED_FEATURES, LrclibProvider
+
+
+@pytest.fixture
+def provider() -> LrclibProvider:
+    """Return an LrclibProvider with mocked dependencies and a cold cache."""
+    mass = AsyncMock()
+    mass.http_session = MagicMock()
+    # force a cache miss so the wrapped fetch always runs, and swallow the store task
+    mass.cache.get_with_freshness = AsyncMock(return_value=(None, False, False))
+    mass.create_task = MagicMock(side_effect=lambda coro, **_: coro.close())
+    manifest = MagicMock()
+    manifest.domain = "lrclib"
+    config = MagicMock()
+    config.get_value.return_value = "GLOBAL"
+    prov = LrclibProvider(mass, manifest, config, SUPPORTED_FEATURES)
+    prov.api_url = "https://lrclib.net/api"
+    prov.throttler = ThrottlerManager(rate_limit=1, period=1)
+    return prov
+
+
+def _response_cm(*, response: MagicMock | None = None, exc: Exception | None = None) -> MagicMock:
+    """Build a fake async context manager mimicking aiohttp's session.get()."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response, side_effect=exc)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+async def test_get_data_returns_none_when_not_found(provider: LrclibProvider) -> None:
+    """A 404 means there are genuinely no lyrics, so None is returned (and cached)."""
+    response = MagicMock()
+    response.status = 404
+    response.raise_for_status = MagicMock()
+    provider.mass.http_session.get = MagicMock(  # type: ignore[method-assign]
+        return_value=_response_cm(response=response)
+    )
+
+    assert await provider._get_data(track_name="Song", artist_name="Artist") is None
+
+
+async def test_get_data_propagates_transient_error(provider: LrclibProvider) -> None:
+    """A network failure propagates instead of being cached as 'no lyrics'."""
+    provider.mass.http_session.get = MagicMock(  # type: ignore[method-assign]
+        return_value=_response_cm(exc=ClientError("network down"))
+    )
+
+    with pytest.raises(ClientError):
+        await provider._get_data(track_name="Song", artist_name="Artist")

--- a/tests/providers/lrclib/test_lrclib.py
+++ b/tests/providers/lrclib/test_lrclib.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import ClientError
+from music_assistant_models.errors import MusicAssistantError
 
 from music_assistant.helpers.throttle_retry import ThrottlerManager
 from music_assistant.providers.lrclib import SUPPORTED_FEATURES, LrclibProvider
@@ -23,7 +24,8 @@ def provider() -> LrclibProvider:
     config.get_value.return_value = "GLOBAL"
     prov = LrclibProvider(mass, manifest, config, SUPPORTED_FEATURES)
     prov.api_url = "https://lrclib.net/api"
-    prov.throttler = ThrottlerManager(rate_limit=1, period=1)
+    # retry_attempts=1 keeps the transient-error test fast (no backoff sleeps)
+    prov.throttler = ThrottlerManager(rate_limit=1, period=1, retry_attempts=1)
     return prov
 
 
@@ -48,10 +50,10 @@ async def test_get_data_returns_none_when_not_found(provider: LrclibProvider) ->
 
 
 async def test_get_data_propagates_transient_error(provider: LrclibProvider) -> None:
-    """A network failure propagates instead of being cached as 'no lyrics'."""
+    """A network failure surfaces as a MusicAssistantError instead of being cached as 'no lyrics'."""
     provider.mass.http_session.get = MagicMock(  # type: ignore[method-assign]
         return_value=_response_cm(exc=ClientError("network down"))
     )
 
-    with pytest.raises(ClientError):
+    with pytest.raises(MusicAssistantError):
         await provider._get_data(track_name="Song", artist_name="Artist")


### PR DESCRIPTION
## Problem

Follow-up to #4616. There, the metadata/lyrics/art providers whose `None` return conflated "genuinely not found" with "transient fetch error" were opted out of negative-result caching (`cache_none=False`) as the safe stopgap — so their negatives (no lyrics, no cover art, no bio) are still re-fetched from the network on every access.

The correct fix is to stop conflating the two at the source: a transient error should propagate (and never be cached), while a genuine "not found" returns `None` (and is cached).

## Changes

- **lrclib / coverartarchive / itunes_artwork / wikipedia**: these now raise/propagate on transient failures (network, 5xx, unparsable response) and return `None` only for a genuine miss (404/204, no result, no cover art). Their `cache_none=False` opt-out is dropped, so genuine negatives are cached again.
- **Metadata enrichment**: the artist/album/track loops now wrap each provider call in `try/except` (log + continue), mirroring the existing playlist path, so a provider raising on a transient error degrades gracefully instead of aborting enrichment of the item. The lyrics path was already guarded.
- theaudiodb / fanart.tv / acoustid keep `cache_none=False` — their `None` only ever signals an error (a genuine miss is a data object that is already cached), so there is nothing to gain from the refactor there.

## Tests

- Enrichment resilience: a provider that raises must not abort artist/album/track enrichment for the remaining providers.
- lrclib: a 404 returns `None` (cached negative); a network error propagates instead of being cached.
