### PR TITLE
Auto-approve automated frontend/models bump PRs in dependency security gate

### DIFF
--- a/.github/workflows/dependency-security-report.yml
+++ b/.github/workflows/dependency-security-report.yml
@@ -191,13 +191,20 @@ jobs:
               }
 
               const labels = pr.labels.map(l => l.name);
+              // Same-repo check is required: fork branch names are
+              // attacker-controlled, same-repo branches need write access.
+              const isSameRepoBumpBranch =
+                pr.head.repo &&
+                pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}` &&
+                /^auto-update-(frontend|models)-/.test(pr.head.ref);
               results.push({
                 number: pr.number,
                 deps_changed: depsChanged,
                 has_review_label: labels.includes('dependencies-reviewed'),
                 is_automated:
                   ['dependabot[bot]', 'renovate[bot]'].includes(pr.user.login) ||
-                  labels.includes('auto-merge'),
+                  labels.includes('auto-merge') ||
+                  isSameRepoBumpBranch,
               });
             }
 


### PR DESCRIPTION
# What does this implement/fix?

Since #4618, automated frontend/models bump PRs (e.g. #4635, author `music-assistant-machine`) get a failing 'Dependency Security Review' status because the gate's `is_automated` check only recognizes dependabot/renovate or the `auto-merge` label — so GitHub auto-merge stays blocked on the required check.

- Treat a PR as automated when its head branch is a **same-repo** branch matching `auto-update-(frontend|models)-*`
- The same-repo check is enforced (`pr.head.repo.full_name === base repo`) so fork branch names, which are attacker-controlled, can't spoof the gate
- Existing dependabot/renovate/`auto-merge`-label rules unchanged

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [ ] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.