### PR TITLE
Allow the Home Assistant system user to filter listings by user and remove players

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -54,6 +54,8 @@ from .auth import AuthenticationManager
 from .helpers.auth_middleware import (
     get_authenticated_user,
     is_request_from_ingress,
+    is_system_user_allowed_admin_command,
+    resolve_username_workaround,
     set_current_user,
 )
 from .helpers.auth_providers import BuiltinLoginProvider, get_ha_user_role
@@ -571,13 +573,20 @@ class WebserverController(CoreController):
 
             # Set user in context and check role
             set_current_user(user)
-            if handler.required_role == "admin" and user.role != UserRole.ADMIN:
+            if (
+                handler.required_role == "admin"
+                and user.role != UserRole.ADMIN
+                and not is_system_user_allowed_admin_command(user, handler.command)
+            ):
                 return web.Response(
                     status=403,
                     text="Admin access required",
                 )
 
         try:
+            # TEMPORARY workaround for the 2.9 stable branch: handle the optional
+            # username argument on library listing and search commands
+            await resolve_username_workaround(self.mass, handler.command, command_msg.args)
             args = parse_arguments(handler.signature, handler.type_hints, command_msg.args)
             result: Any = handler.target(**args)
             if hasattr(result, "__anext__"):

--- a/music_assistant/controllers/webserver/helpers/auth_middleware.py
+++ b/music_assistant/controllers/webserver/helpers/auth_middleware.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp import web
 from music_assistant_models.auth import AuthProviderType, User, UserRole
+from music_assistant_models.errors import InsufficientPermissions, InvalidDataError
 
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER, MASS_LOGGER_NAME, VERBOSE_LOG_LEVEL
 
@@ -21,11 +22,67 @@ if TYPE_CHECKING:
 # Context key for storing authenticated user in request
 USER_CONTEXT_KEY = "authenticated_user"
 
+# TEMPORARY workaround for the 2.9 stable branch until the scope based authorization
+# from 2.10 lands: admin-only commands the Home Assistant system user may execute,
+# so add-on users are not blocked by the insufficient rights error.
+SYSTEM_USER_ALLOWED_ADMIN_COMMANDS = ("players/remove", "config/players/remove")
+
 # ContextVar for tracking current user and token across async calls
 current_user: ContextVar[User | None] = ContextVar("current_user", default=None)
 current_token: ContextVar[str | None] = ContextVar("current_token", default=None)
 # ContextVar for tracking the sendspin player associated with the current connection
 sendspin_player_id: ContextVar[str | None] = ContextVar("sendspin_player_id", default=None)
+
+
+def is_system_user_allowed_admin_command(user: User, command: str) -> bool:
+    """
+    Check if the user may execute the given admin-only command despite not being admin.
+
+    TEMPORARY workaround for the 2.9 stable branch until the scope based
+    authorization from 2.10 lands.
+
+    :param user: The authenticated user.
+    :param command: The API command being executed.
+    """
+    return (
+        user.username == HOMEASSISTANT_SYSTEM_USER and command in SYSTEM_USER_ALLOWED_ADMIN_COMMANDS
+    )
+
+
+async def resolve_username_workaround(
+    mass: MusicAssistant, command: str, args: dict[str, Any] | None
+) -> None:
+    """
+    Handle the optional username argument on library listing and search commands.
+
+    TEMPORARY workaround for the 2.9 stable branch until the centralized
+    impersonation from 2.10 lands: the given user's library filters are applied
+    by executing the (read-only) command as that user. Only allowed for admin
+    users and the Home Assistant system user.
+
+    :param mass: The MusicAssistant instance.
+    :param command: The API command being executed.
+    :param args: The (mutable) arguments dict of the incoming command.
+    """
+    if not args:
+        return
+    if command != "music/search" and not (
+        command.startswith("music/") and command.endswith("/library_items")
+    ):
+        return
+    # deliberately treat None and empty string as "no user context requested"
+    if not (username := args.pop("username", None)):
+        return
+    caller = current_user.get()
+    if caller is None:
+        raise InsufficientPermissions("Authentication is necessary to impersonate another user.")
+    if caller.username == username:
+        return
+    if caller.role != UserRole.ADMIN and caller.username != HOMEASSISTANT_SYSTEM_USER:
+        raise InsufficientPermissions("Insufficient permissions to impersonate another user.")
+    if not (target_user := await mass.webserver.auth.get_user_by_username(str(username))):
+        raise InvalidDataError(f"A user with username {username} is not available.")
+    set_current_user(target_user)
 
 
 async def get_authenticated_user(request: web.Request) -> User | None:

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -34,6 +34,8 @@ from music_assistant.helpers.api import APICommandHandler, parse_arguments
 
 from .helpers.auth_middleware import (
     is_request_from_ingress,
+    is_system_user_allowed_admin_command,
+    resolve_username_workaround,
     set_current_token,
     set_current_user,
     set_sendspin_player_id,
@@ -212,7 +214,11 @@ class WebsocketClientHandler:
 
             # Check role if required
             if handler.required_role == "admin":
-                if self._authenticated_user.role != UserRole.ADMIN:
+                if self._authenticated_user.role != UserRole.ADMIN and (
+                    not is_system_user_allowed_admin_command(
+                        self._authenticated_user, handler.command
+                    )
+                ):
                     await self._send_message(
                         ErrorResultMessage(
                             msg.message_id,
@@ -228,6 +234,9 @@ class WebsocketClientHandler:
     async def _run_handler(self, handler: APICommandHandler, msg: CommandMessage) -> None:
         """Run command handler and send response."""
         try:
+            # TEMPORARY workaround for the 2.9 stable branch: handle the optional
+            # username argument on library listing and search commands
+            await resolve_username_workaround(self.mass, handler.command, msg.args)
             args = parse_arguments(handler.signature, handler.type_hints, msg.args)
             result: Any = handler.target(**args)
             if hasattr(result, "__anext__"):

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -10,13 +10,16 @@ from sqlite3 import IntegrityError
 
 import pytest
 from music_assistant_models.auth import AuthProviderType, UserRole
-from music_assistant_models.errors import InvalidDataError
+from music_assistant_models.errors import InsufficientPermissions, InvalidDataError
 
 from music_assistant.constants import HOMEASSISTANT_SYSTEM_USER
 from music_assistant.controllers.config import ConfigController
 from music_assistant.controllers.webserver.auth import AuthenticationManager
 from music_assistant.controllers.webserver.controller import WebserverController
 from music_assistant.controllers.webserver.helpers.auth_middleware import (
+    get_current_user,
+    is_system_user_allowed_admin_command,
+    resolve_username_workaround,
     set_current_token,
     set_current_user,
 )
@@ -1207,3 +1210,69 @@ async def test_revoke_join_code_api_not_found(auth_manager: AuthenticationManage
 
     with pytest.raises(InvalidDataError, match="Join code not found"):
         await auth_manager.revoke_join_code("nonexistent-code-id")
+
+
+async def test_system_user_allowed_admin_commands(auth_manager: AuthenticationManager) -> None:
+    """
+    Test the temporary stable-branch exemption for the Home Assistant system user.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    system_user = await auth_manager.get_homeassistant_system_user()
+    standard_user = await auth_manager.create_user(username="user_a", role=UserRole.USER)
+
+    assert is_system_user_allowed_admin_command(system_user, "players/remove")
+    assert is_system_user_allowed_admin_command(system_user, "config/players/remove")
+    # other admin commands remain off limits for the system user
+    assert not is_system_user_allowed_admin_command(system_user, "config/core/save")
+    # regular users are not exempt
+    assert not is_system_user_allowed_admin_command(standard_user, "players/remove")
+
+
+async def test_username_workaround(auth_manager: AuthenticationManager) -> None:
+    """
+    Test the temporary stable-branch username argument on listing commands.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    mass = auth_manager.mass
+    system_user = await auth_manager.get_homeassistant_system_user()
+    admin_user = await auth_manager.create_user(username="admin", role=UserRole.ADMIN)
+    standard_user = await auth_manager.create_user(username="user_a", role=UserRole.USER)
+
+    # no username argument present is a no-op and leaves other args untouched
+    set_current_user(system_user)
+    args: dict[str, str | int] = {"limit": 10}
+    await resolve_username_workaround(mass, "music/tracks/library_items", args)
+    assert args == {"limit": 10}
+    assert get_current_user() == system_user
+
+    # the system user may execute listing commands as another user
+    args = {"limit": 10, "username": "user_a"}
+    await resolve_username_workaround(mass, "music/tracks/library_items", args)
+    assert args == {"limit": 10}
+    assert get_current_user() == standard_user
+
+    # admin users may do the same (also on music/search)
+    set_current_user(admin_user)
+    await resolve_username_workaround(mass, "music/search", {"username": "user_a"})
+    assert get_current_user() == standard_user
+
+    # the username argument is ignored on other commands
+    set_current_user(system_user)
+    args = {"username": "user_a"}
+    await resolve_username_workaround(mass, "player_queues/items", args)
+    assert args == {"username": "user_a"}
+    assert get_current_user() == system_user
+
+    # an unknown username must raise
+    with pytest.raises(InvalidDataError):
+        await resolve_username_workaround(mass, "music/search", {"username": "nobody"})
+
+    # a regular user may not execute listing commands as another user
+    set_current_user(standard_user)
+    with pytest.raises(InsufficientPermissions):
+        await resolve_username_workaround(mass, "music/search", {"username": "admin"})
+    # but passing their own username is a no-op
+    await resolve_username_workaround(mass, "music/search", {"username": "user_a"})
+    assert get_current_user() == standard_user


### PR DESCRIPTION
# What does this implement/fix?

Temporary, stable-branch-only workaround so Home Assistant add-on users are not stuck until the 2.10 release (which brings the full scope based authorization, see #4613):

- the Home Assistant system user may now execute `players/remove` and `config/players/remove`, fixing the "insufficient rights" error when removing players from HA
- `music/search` and `music/*/library_items` accept an optional `username` argument (admin and system user only) which applies the library filters of that user, so the HA integration can offer per-user library and search
- playback attribution via `username` on `play_media` already works on stable and is unchanged

Deliberately minimal (a small dispatch-level exception, no signatures or permission model touched) - this is fully replaced by the scope based authorization in 2.10 and must NOT be forward-ported to dev.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
