### PR TITLE
Reduce image proxy-id overhead when serializing media items

### DIFF
--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -205,6 +205,28 @@ class CacheController(CoreController):
                 return data, is_fresh, True
         return None, False, False
 
+    async def get_expiration(
+        self,
+        key: str,
+        provider: str = "default",
+        category: int = 0,
+    ) -> int | None:
+        """
+        Return the expiration timestamp (epoch seconds) of a cache entry, if any.
+
+        Cheap existence/freshness probe: the stored data is not deserialized.
+        Returns None when no entry exists for the given key.
+
+        :param key: The (unique) lookup key of the cache object.
+        :param provider: Provider id to group cache objects.
+        :param category: Category to group cache objects.
+        """
+        assert self.database is not None
+        db_row = await self.database.get_row(
+            DB_TABLE_CACHE, {"category": category, "provider": provider, "key": key}
+        )
+        return int(db_row["expires"]) if db_row else None
+
     async def set(
         self,
         key: str,

--- a/music_assistant/controllers/cache/controller.py
+++ b/music_assistant/controllers/cache/controller.py
@@ -214,18 +214,22 @@ class CacheController(CoreController):
         """
         Return the expiration timestamp (epoch seconds) of a cache entry, if any.
 
-        Cheap existence/freshness probe: the stored data is not deserialized.
-        Returns None when no entry exists for the given key.
+        Cheap existence/freshness probe: only the expiration column is read, the
+        stored data is not. Returns None when no entry exists for the given key.
 
         :param key: The (unique) lookup key of the cache object.
         :param provider: Provider id to group cache objects.
         :param category: Category to group cache objects.
         """
         assert self.database is not None
-        db_row = await self.database.get_row(
-            DB_TABLE_CACHE, {"category": category, "provider": provider, "key": key}
+        assert key, "No key provided"
+        rows = await self.database.get_rows_from_query(
+            f"SELECT expires FROM {DB_TABLE_CACHE} "
+            "WHERE category = :category AND provider = :provider AND key = :key",
+            {"category": category, "provider": provider, "key": key},
+            limit=1,
         )
-        return int(db_row["expires"]) if db_row else None
+        return int(rows[0]["expires"]) if rows else None
 
     async def set(
         self,

--- a/music_assistant/controllers/metadata/constants.py
+++ b/music_assistant/controllers/metadata/constants.py
@@ -93,9 +93,15 @@ DEFAULT_THUMB_CACHE_MAX_SIZE_MB = 500
 # cache namespace.
 CACHE_CATEGORY_IMAGE_IDS = 102
 
+# Bounds each of the in-memory image-id maps (forward memo, reverse LRU and
+# persisted markers). The maps share their key/id string objects, so the
+# combined worst-case footprint stays in the single-digit MB range. Overflow is
+# harmless: an evicted entry merely costs one re-hash and/or one cache-db probe
+# on the next encounter.
 _IMAGE_ID_LRU_MAX = 10000
 
-_IMAGE_ID_CACHE_TTL = 86400 * 365  # 1 year, refreshed on each write
+# 1 year; a stored mapping is refreshed once the row burns through half its TTL
+_IMAGE_ID_CACHE_TTL = 86400 * 365
 
 # Sizes accepted by the imageproxy. 0 means "no resize". The set is small enough
 # to bound PIL memory + thumbnail cache cardinality; expand if a real use case appears.

--- a/music_assistant/controllers/metadata/controller.py
+++ b/music_assistant/controllers/metadata/controller.py
@@ -91,12 +91,21 @@ class MetaDataController(
         )
         self.manifest.icon = "book-information-variant"
         self._throttler = Throttler(1, 30)
-        # image-id LRU: image_id -> (provider, path). Acts as a write-through
-        # hot cache in front of the cache controller so that resolving an image
-        # by id never blocks on sqlite if the URL was generated recently.
+        # image-id bookkeeping, all bounded by _IMAGE_ID_LRU_MAX and sharing the
+        # same key/id string objects so the combined footprint stays small:
+        # - _image_id_forward: (provider, path) -> image_id memo so serializing a
+        #   known image skips the sha256 and the lock entirely. Read lock-free
+        #   (single dict lookup is atomic), mutated only while holding the lock.
+        # - _image_id_lru: image_id -> (provider, path). Write-through hot cache
+        #   in front of the cache controller so that resolving an image by id
+        #   never blocks on sqlite if the URL was generated recently.
+        # - _image_id_persisted: image_id -> epoch of the last persist to the
+        #   cache db, so repeat encounters skip the sqlite write.
         # The lock is needed because compute_image_id() runs from the executor
         # thread during outbound websocket serialization.
+        self._image_id_forward: dict[tuple[str, str], str] = {}
         self._image_id_lru: OrderedDict[str, tuple[str, str]] = OrderedDict()
+        self._image_id_persisted: dict[str, float] = {}
         self._image_id_lock = threading.Lock()
 
     async def get_config_entries(

--- a/music_assistant/controllers/metadata/images.py
+++ b/music_assistant/controllers/metadata/images.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import random
 import threading
+import time
 from base64 import b64encode
 from typing import TYPE_CHECKING, cast
 
@@ -78,7 +79,9 @@ class ImageProxyMixin:
         logger: logging.Logger
         domain: str
         _collage_images_dir: str
+        _image_id_forward: dict[tuple[str, str], str]
         _image_id_lru: OrderedDict[str, tuple[str, str]]
+        _image_id_persisted: dict[str, float]
         _image_id_lock: threading.Lock
 
     def compute_image_id(self, provider: str, path: str) -> str:
@@ -95,14 +98,33 @@ class ImageProxyMixin:
         :param provider: Provider id that owns / can resolve the image.
         :param path: Image path or URL as the provider knows it.
         """
+        # fast path: a bare dict read is atomic, so no hashing or locking is
+        # needed for an image that was serialized before. This runs for every
+        # image occurrence in every outbound message, so it must stay cheap.
+        image_key = (provider, path)
+        if (image_id := self._image_id_forward.get(image_key)) is not None:
+            return image_id
         image_id = create_thumb_hash(provider, path)
+        now = time.time()
         with self._image_id_lock:
-            if image_id in self._image_id_lru:
-                self._image_id_lru.move_to_end(image_id)
-                return image_id
-            self._image_id_lru[image_id] = (provider, path)
+            self._image_id_forward[image_key] = image_id
+            while len(self._image_id_forward) > _IMAGE_ID_LRU_MAX:
+                del self._image_id_forward[next(iter(self._image_id_forward))]
+            self._image_id_lru[image_id] = image_key
+            self._image_id_lru.move_to_end(image_id)
             while len(self._image_id_lru) > _IMAGE_ID_LRU_MAX:
                 self._image_id_lru.popitem(last=False)
+            # skip the persist when this process already stored the mapping
+            # recently; re-persist once the stored row has burned through half
+            # its TTL so long-lived ids remain resolvable across restarts
+            persisted_at = self._image_id_persisted.get(image_id)
+            if persisted_at is not None and now - persisted_at < _IMAGE_ID_CACHE_TTL / 2:
+                return image_id
+            # mark optimistically at schedule time to dedupe concurrent bursts;
+            # _persist_image_id drops the marker again if storing fails
+            self._image_id_persisted[image_id] = now
+            while len(self._image_id_persisted) > _IMAGE_ID_LRU_MAX:
+                del self._image_id_persisted[next(iter(self._image_id_persisted))]
         # the to_dict hook calls us from the executor when running under
         # _send_message; only call create_task directly when we know we are
         # on the loop thread, otherwise hop across via call_soon_threadsafe
@@ -137,6 +159,9 @@ class ImageProxyMixin:
                     self._image_id_lru[image_id] = result
                     while len(self._image_id_lru) > _IMAGE_ID_LRU_MAX:
                         self._image_id_lru.popitem(last=False)
+                    self._image_id_forward[result] = image_id
+                    while len(self._image_id_forward) > _IMAGE_ID_LRU_MAX:
+                        del self._image_id_forward[next(iter(self._image_id_forward))]
                 return result
         return None
 
@@ -434,11 +459,28 @@ class ImageProxyMixin:
 
     async def _persist_image_id(self, image_id: str, provider: str, path: str) -> None:
         """Store an image-id mapping so a later imageproxy request can resolve it."""
-        await self.cache.set(
-            key=image_id,
-            data={"provider": provider, "path": path},
-            category=CACHE_CATEGORY_IMAGE_IDS,
-            provider=self.domain,
-            expiration=_IMAGE_ID_CACHE_TTL,
-            persistent=True,
-        )
+        try:
+            # the mapping is usually already stored by a previous process run;
+            # probing the expiration first turns the write storm while browsing
+            # after a restart into (much cheaper) reads. Only rewrite when the
+            # stored row is absent or has burned through half its TTL.
+            expires = await self.cache.get_expiration(
+                key=image_id,
+                category=CACHE_CATEGORY_IMAGE_IDS,
+                provider=self.domain,
+            )
+            if expires is not None and expires - time.time() > _IMAGE_ID_CACHE_TTL / 2:
+                return
+            await self.cache.set(
+                key=image_id,
+                data={"provider": provider, "path": path},
+                category=CACHE_CATEGORY_IMAGE_IDS,
+                provider=self.domain,
+                expiration=_IMAGE_ID_CACHE_TTL,
+                persistent=True,
+            )
+        except Exception:
+            # drop the optimistic marker so a later encounter retries the persist
+            with self._image_id_lock:
+                self._image_id_persisted.pop(image_id, None)
+            raise

--- a/tests/controllers/cache/test_cache_controller.py
+++ b/tests/controllers/cache/test_cache_controller.py
@@ -1,6 +1,7 @@
 """Tests for cache controller."""
 
 import os
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -58,6 +59,22 @@ async def test_set_and_get_string(cache: CacheController) -> None:
     await cache.set("test_key", "hello", provider="test")
     result = await cache.get("test_key", provider="test")
     assert result == "hello"
+
+
+async def test_get_expiration(cache: CacheController) -> None:
+    """get_expiration returns the stored expiry epoch, also for expired rows."""
+    before = int(time.time())
+    await cache.set("exp_key", {"a": 1}, provider="test", expiration=500)
+    expires = await cache.get_expiration("exp_key", provider="test")
+    assert expires is not None
+    assert abs(expires - (before + 500)) <= 5
+    # a missing key yields None
+    assert await cache.get_expiration("missing_key", provider="test") is None
+    # an expired-but-present row still reports its (past) expiration
+    await cache.set("expired_key", "x", provider="test", expiration=-100)
+    expired = await cache.get_expiration("expired_key", provider="test")
+    assert expired is not None
+    assert expired < int(time.time())
 
 
 async def test_set_and_get_int(cache: CacheController) -> None:

--- a/tests/controllers/metadata/test_image_proxy.py
+++ b/tests/controllers/metadata/test_image_proxy.py
@@ -2,13 +2,25 @@
 
 import asyncio
 import hashlib
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from aiohttp import web
+from music_assistant_models.enums import ImageType
+from music_assistant_models.media_items import (
+    MediaItemImage,
+    MediaItemMetadata,
+    ProviderMapping,
+    Track,
+)
+from music_assistant_models.media_items.metadata import IMAGE_PROXY_ID_RESOLVER
+from music_assistant_models.unique_list import UniqueList
 from PIL import Image
 
 from music_assistant.controllers.metadata import MetaDataController
 from music_assistant.controllers.metadata.constants import (
+    _IMAGE_ID_CACHE_TTL,
     _IMAGEPROXY_CONTENT_TYPES,
     CACHE_CATEGORY_IMAGE_IDS,
 )
@@ -135,6 +147,233 @@ async def test_image_id_persists_with_persistent_flag(
     metadata_controller._image_id_lru.clear()
     resolved = await metadata_controller.resolve_image_id(image_id)
     assert resolved == ("filesystem", "/persistent.jpg")
+
+
+def _track_with_image(item_id: str, image: MediaItemImage) -> Track:
+    """Build a minimal serializable Track carrying the given image."""
+    return Track(
+        item_id=item_id,
+        provider="library",
+        name=f"Track {item_id}",
+        provider_mappings={
+            ProviderMapping(
+                item_id=item_id,
+                provider_domain="filesystem",
+                provider_instance="filesystem--test",
+            )
+        },
+        metadata=MediaItemMetadata(images=UniqueList([image])),
+    )
+
+
+async def _wait_for_expiration_refresh(
+    controller: MetaDataController, image_id: str, old_expires: int, timeout: float = 2.0
+) -> int:
+    """Wait until the stored row's expiration moved past `old_expires`, or fail."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        expires = await controller.cache.get_expiration(
+            key=image_id,
+            category=CACHE_CATEGORY_IMAGE_IDS,
+            provider=controller.domain,
+        )
+        if expires is not None and expires > old_expires:
+            return expires
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"expiration for {image_id!r} not refreshed within {timeout}s")
+
+
+async def test_serialize_twice_hashes_once_and_persists_once(
+    metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Serializing the same item list twice hashes and persists each unique image only once.
+
+    The proxy_id injection runs per image occurrence per outbound message, so
+    repeat serializations must be served from the forward memo: no hashing at
+    all on the second pass and exactly one cache write per unique image.
+    """
+    hash_calls: list[tuple[str, str]] = []
+
+    def counting_thumb_hash(provider: str, path: str) -> str:
+        hash_calls.append((provider, path))
+        return create_thumb_hash(provider, path)
+
+    monkeypatch.setattr(
+        "music_assistant.controllers.metadata.images.create_thumb_hash", counting_thumb_hash
+    )
+    persist_calls: list[str] = []
+    real_cache_set = metadata_controller.cache.set
+
+    async def counting_cache_set(*args: Any, **kwargs: Any) -> None:
+        if kwargs.get("category") == CACHE_CATEGORY_IMAGE_IDS:
+            persist_calls.append(kwargs["key"])
+        await real_cache_set(*args, **kwargs)
+
+    monkeypatch.setattr(metadata_controller.cache, "set", counting_cache_set)
+
+    # three image occurrences per pass, but only two unique images
+    image_a = MediaItemImage(type=ImageType.THUMB, path="/album_a.jpg", provider="filesystem")
+    image_b = MediaItemImage(type=ImageType.THUMB, path="/album_b.jpg", provider="filesystem")
+    tracks = [
+        _track_with_image("1", image_a),
+        _track_with_image("2", image_a),
+        _track_with_image("3", image_b),
+    ]
+    token = IMAGE_PROXY_ID_RESOLVER.set(metadata_controller.compute_image_id)
+    try:
+        first_pass = [track.to_dict() for track in tracks]
+        assert len(hash_calls) == 2
+        second_pass = [track.to_dict() for track in tracks]
+    finally:
+        IMAGE_PROXY_ID_RESOLVER.reset(token)
+    # zero hashing on the second pass: everything came from the forward memo
+    assert len(hash_calls) == 2
+    assert first_pass == second_pass
+    expected_ids = sorted(
+        create_thumb_hash("filesystem", path) for path in ("/album_a.jpg", "/album_b.jpg")
+    )
+    for track_dict in first_pass:
+        assert track_dict["metadata"]["images"][0]["proxy_id"] in expected_ids
+    # exactly one persist per unique image across both passes
+    for image_id in expected_ids:
+        await _wait_for_persisted_image_id(metadata_controller, image_id)
+    assert sorted(persist_calls) == expected_ids
+
+
+async def test_persist_skipped_when_row_already_fresh(
+    metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mapping already stored with plenty of TTL left must not be rewritten."""
+    provider, path = "filesystem", "/prestored.jpg"
+    image_id = create_thumb_hash(provider, path)
+    # simulate a previous process run that already stored the mapping
+    await metadata_controller.cache.set(
+        key=image_id,
+        data={"provider": provider, "path": path},
+        category=CACHE_CATEGORY_IMAGE_IDS,
+        provider=metadata_controller.domain,
+        expiration=_IMAGE_ID_CACHE_TTL,
+        persistent=True,
+    )
+    probes: list[str] = []
+    real_get_expiration = metadata_controller.cache.get_expiration
+
+    async def recording_get_expiration(*args: Any, **kwargs: Any) -> int | None:
+        result = await real_get_expiration(*args, **kwargs)
+        probes.append(kwargs.get("key") or args[0])
+        return result
+
+    writes: list[str] = []
+    real_cache_set = metadata_controller.cache.set
+
+    async def recording_cache_set(*args: Any, **kwargs: Any) -> None:
+        writes.append(kwargs.get("key") or args[0])
+        await real_cache_set(*args, **kwargs)
+
+    monkeypatch.setattr(metadata_controller.cache, "get_expiration", recording_get_expiration)
+    monkeypatch.setattr(metadata_controller.cache, "set", recording_cache_set)
+
+    assert metadata_controller.compute_image_id(provider, path) == image_id
+    # wait for the freshness probe, then give the persist task time to (not) write
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 2.0
+    while not probes and loop.time() < deadline:
+        await asyncio.sleep(0.01)
+    assert probes == [image_id]
+    await asyncio.sleep(0.05)
+    assert writes == []
+    # the pre-stored row keeps the id resolvable, also without the in-memory layer
+    metadata_controller._image_id_lru.clear()
+    assert await metadata_controller.resolve_image_id(image_id) == (provider, path)
+
+
+async def test_persist_refreshes_stale_row(metadata_controller: MetaDataController) -> None:
+    """A stored row past half its TTL is rewritten so the id stays resolvable."""
+    provider, path = "filesystem", "/stale.jpg"
+    image_id = create_thumb_hash(provider, path)
+    # a row whose remaining TTL is way below half of _IMAGE_ID_CACHE_TTL
+    await metadata_controller.cache.set(
+        key=image_id,
+        data={"provider": provider, "path": path},
+        category=CACHE_CATEGORY_IMAGE_IDS,
+        provider=metadata_controller.domain,
+        expiration=1000,
+        persistent=True,
+    )
+    old_expires = await metadata_controller.cache.get_expiration(
+        key=image_id,
+        category=CACHE_CATEGORY_IMAGE_IDS,
+        provider=metadata_controller.domain,
+    )
+    assert old_expires is not None
+    assert metadata_controller.compute_image_id(provider, path) == image_id
+    await _wait_for_expiration_refresh(metadata_controller, image_id, old_expires)
+
+
+async def test_imageproxy_resolves_after_restart(
+    metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    An id persisted by one process run must resolve on the imageproxy of the next.
+
+    Simulates a restart with a second controller instance on the same cache
+    database: cold in-memory maps, so resolution can only come from the
+    persisted row.
+    """
+    provider, path = "filesystem", "/restart/cover.jpg"
+    image_id = metadata_controller.compute_image_id(provider, path)
+    await _wait_for_persisted_image_id(metadata_controller, image_id)
+
+    restarted = MetaDataController(metadata_controller.mass)
+    assert not restarted._image_id_forward
+    assert not restarted._image_id_lru
+    served: list[tuple[str, str]] = []
+
+    async def fake_serve_thumbnail(
+        path_arg: str, provider_arg: str, _size: int, _image_format: str
+    ) -> web.Response:
+        served.append((provider_arg, path_arg))
+        return web.Response(status=200)
+
+    monkeypatch.setattr(restarted, "_serve_thumbnail", fake_serve_thumbnail)
+    request = MagicMock()
+    request.path = f"/imageproxy/{image_id}"
+    request.query = {}
+    response = await restarted.handle_imageproxy(request)
+    assert response.status == 200
+    assert served == [(provider, path)]
+
+
+async def test_no_repersist_after_in_memory_eviction(
+    metadata_controller: MetaDataController, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-encountering an image after memo/LRU eviction must not hit the cache db again."""
+    provider, path = "filesystem", "/evicted.jpg"
+    image_id = metadata_controller.compute_image_id(provider, path)
+    await _wait_for_persisted_image_id(metadata_controller, image_id)
+    # simulate LRU pressure evicting the in-memory maps (markers survive)
+    metadata_controller._image_id_forward.clear()
+    metadata_controller._image_id_lru.clear()
+
+    calls: list[str] = []
+
+    async def recording_get_expiration(*_args: object, **_kwargs: object) -> int | None:
+        calls.append("probe")
+        return None
+
+    async def recording_cache_set(*_args: object, **_kwargs: object) -> None:
+        calls.append("write")
+
+    monkeypatch.setattr(metadata_controller.cache, "get_expiration", recording_get_expiration)
+    monkeypatch.setattr(metadata_controller.cache, "set", recording_cache_set)
+
+    # re-encounter re-hashes (memo was evicted) but the persist marker is fresh,
+    # so no persist work is scheduled at all
+    assert metadata_controller.compute_image_id(provider, path) == image_id
+    await asyncio.sleep(0.05)
+    assert calls == []
 
 
 def test_normalize_imageproxy_format() -> None:


### PR DESCRIPTION
Serializing media items injects a `proxy_id` for every image occurrence in every outbound message: a single 500-track listing performs ~1,500 `compute_image_id` calls, each doing a fresh SHA-256 + lock + LRU shuffle. On top of that, every LRU miss unconditionally rewrote the id mapping to the cache db — so after each restart, browsing replayed one sqlite write per unique image, and libraries larger than the 10k LRU cap kept repeating those writes forever.

Changes:
- Add a forward `(provider, path) → id` memo so repeat serializations are a single lock-free dict read (~7.5x faster warm path and no more lock contention between the event loop and executor threads).
- Skip re-persisting mappings that are already stored: an in-process marker plus a cheap expiration probe (new `CacheController.get_expiration` helper) turn the post-restart write storm into reads. A stored row is only rewritten once it has burned through half its 1-year TTL, so long-lived ids stay resolvable across restarts.
