### PR TITLE
Prevent universal player settings loss on startup restore

### DIFF
--- a/music_assistant/controllers/players/controller.py
+++ b/music_assistant/controllers/players/controller.py
@@ -251,7 +251,7 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
 
     async def setup(self, config: CoreConfig) -> None:
         """Async initialize of module."""
-        self._cleanup_stale_protocol_parent_ids()
+        self._repair_protocol_parent_links()
         self._poll_task = self.mass.create_task(self._poll_players())
         self.mass.tasks.register_scheduled_task(
             task_id="fix_group_member_configs",
@@ -2909,18 +2909,18 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
             # player was playing something before the announcement - try to resume that here
             await self._handle_cmd_resume(player.player_id, prev_source, prev_media)
 
-    def _cleanup_stale_protocol_parent_ids(self) -> None:
+    def _repair_protocol_parent_links(self) -> None:
         """
-        Clean up stale protocol_parent_id values in config on startup.
+        Repair protocol parent links in player configs on startup.
 
-        Scans protocol player configs and clears parent_ids that point to
-        player configs that no longer exist (e.g., deleted universal players).
+        Scans player configs with a protocol_parent_id set and clears parent_ids
+        that point to player configs that no longer exist (e.g., deleted universal
+        players). A valid parent link also proves the player is a protocol child,
+        so a stale player_type (left behind by an aborted registration) is healed.
         """
         all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
         for player_id, player_config in all_player_configs.items():
-            if player_config.get("player_type") != "protocol":
-                continue
-            values = player_config.get("values", {})
+            values = player_config.get("values") or {}
             parent_id = values.get(CONF_PROTOCOL_PARENT_ID)
             if not parent_id:
                 continue
@@ -2934,6 +2934,14 @@ class PlayerController(ProtocolLinkingMixin, CoreController):
                 )
                 conf_key = f"{CONF_PLAYERS}/{player_id}/values/{CONF_PROTOCOL_PARENT_ID}"
                 self.mass.config.set(conf_key, None)
+                continue
+            if player_config.get("player_type") != PlayerType.PROTOCOL.value:
+                self.logger.info(
+                    "Repairing player type of %s - linked as protocol child of %s",
+                    player_id,
+                    parent_id,
+                )
+                self.mass.config.set_player_type(player_id, PlayerType.PROTOCOL)
 
     async def _fix_group_member_configs(self) -> None:
         """

--- a/music_assistant/controllers/players/protocol_linking.py
+++ b/music_assistant/controllers/players/protocol_linking.py
@@ -114,6 +114,12 @@ class ProtocolLinkingMixin:
         elif player.state.type == PlayerType.GROUP:
             return
         else:
+            # A player that registers with a non-protocol type can no longer be a
+            # protocol child: drop a leftover persisted parent link (e.g. from a
+            # bridge client that turned web player) so the startup repair pass
+            # doesn't heal its player type back to protocol.
+            if self._get_cached_protocol_parent_id(player.player_id):
+                self._clear_protocol_parent_id(player.player_id)
             # Native player (including STEREO_PAIR): try to find protocol players to link
             self._try_link_protocols_to_native(player)
 

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -285,7 +285,7 @@ class UniversalPlayerProvider(PlayerProvider):
             return
 
         # Get stored values
-        values = config.get("values", {})
+        values = config.get("values") or {}
         stored_identifiers = values.get(CONF_DEVICE_IDENTIFIERS, {})
         stored_device_info = values.get(CONF_DEVICE_INFO, {})
 

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -12,7 +12,7 @@ interface while delegating actual playback to the underlying protocol player(s).
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from music_assistant_models.enums import IdentifierType, PlayerType
 
@@ -271,7 +271,7 @@ class UniversalPlayerProvider(PlayerProvider):
                     self.mass.players.delete_player_config(protocol_id)
         await self.remove_universal_player(player_id)
 
-    async def _restore_player(self, player_id: str) -> None:  # noqa: PLR0915
+    async def _restore_player(self, player_id: str) -> None:
         """
         Restore a universal player from config.
 
@@ -286,108 +286,52 @@ class UniversalPlayerProvider(PlayerProvider):
 
         # Get stored values
         values = config.get("values", {})
-        stored_protocol_ids = list(values.get(CONF_LINKED_PROTOCOL_IDS, []))
         stored_identifiers = values.get(CONF_DEVICE_IDENTIFIERS, {})
         stored_device_info = values.get(CONF_DEVICE_INFO, {})
 
-        # Filter out protocol IDs that are no longer valid for this universal
-        valid_protocol_ids = []
-        for protocol_id in stored_protocol_ids:
-            protocol_config = self.mass.config.get(f"{CONF_PLAYERS}/{protocol_id}")
-            if not protocol_config:
-                # Config doesn't exist, keep it for now (player may register later)
-                valid_protocol_ids.append(protocol_id)
-                continue
-            protocol_player_type = protocol_config.get("player_type")
-            protocol_values = protocol_config.get("values") or {}
-            if protocol_values.get(CONF_PROTOCOL_PARENT_ID) == player_id:
-                # the persisted parent link proves this child still belongs to us,
-                # even if its player_type was left stale by an aborted registration
-                valid_protocol_ids.append(protocol_id)
-                continue
-            if protocol_player_type != "protocol":
-                self.logger.info(
-                    "Removing %s from universal player %s - player type changed to %s",
-                    protocol_id,
-                    player_id,
-                    protocol_player_type,
-                )
-                continue
-            if not protocol_values.get(CONF_PROTOCOL_PARENT_ID):
-                self.logger.info(
-                    "Deleting orphaned protocol player config %s (was linked to %s)",
-                    protocol_id,
-                    player_id,
-                )
-                if self.mass.players.get_player(protocol_id):
-                    await self.mass.players.unregister(protocol_id, permanent=True)
-                else:
-                    self.mass.players.delete_player_config(protocol_id)
-                continue
-            valid_protocol_ids.append(protocol_id)
+        all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
+        valid_protocol_ids = self._resolve_stored_protocol_ids(player_id, all_player_configs)
 
-        # If no valid protocol IDs remain, delete this stale universal player
+        # Never delete the stored config of a universal player from the restore
+        # path - it holds user customizations. If nothing links to it (anymore),
+        # simply skip restoring it: the config is picked up again when protocol
+        # players return, as universal player ids are derived from the device.
         if not valid_protocol_ids:
-            self.logger.info(
-                "Deleting stale universal player %s - no valid protocol players remain",
+            self.logger.debug(
+                "Not restoring universal player %s - no linked protocol players remain",
                 player_id,
             )
-            await self.mass.config.remove_player_config(player_id)
             return
 
-        stored_protocol_ids = valid_protocol_ids
-
-        # Persist the filtered protocol IDs to config if they changed
-        if len(valid_protocol_ids) != len(values.get(CONF_LINKED_PROTOCOL_IDS, [])):
-            self.mass.config.set(
-                f"{CONF_PLAYERS}/{player_id}/values/{CONF_LINKED_PROTOCOL_IDS}",
-                valid_protocol_ids,
-            )
-
-        # Check if protocols have been linked to a native player (stale universal player)
-        for protocol_id in stored_protocol_ids:
-            protocol_config = self.mass.config.get(f"{CONF_PLAYERS}/{protocol_id}")
-            if protocol_config:
-                protocol_values = protocol_config.get("values", {})
-                protocol_parent_id = protocol_values.get("protocol_parent_id")
-                if protocol_parent_id and protocol_parent_id != player_id:
-                    self.logger.info(
-                        "Deleting stale universal player %s - protocol %s has moved to parent %s",
-                        player_id,
-                        protocol_id,
-                        protocol_parent_id,
-                    )
-                    await self.mass.config.remove_player_config(player_id)
-                    return
-
-            # Check if native player has this protocol in linked_protocol_ids
-            all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
+        # Protocols that (also) belong to a native player mean this universal
+        # player is a leftover wrapper: repair the protocol links to point at
+        # the rightful native parent and skip restoring the wrapper.
+        for protocol_id in valid_protocol_ids:
             for other_player_id, other_config in all_player_configs.items():
                 if other_player_id == player_id:
                     continue
                 if other_config.get("provider") == "universal_player":
                     continue
-                other_values = other_config.get("values", {})
-                linked_protocols = other_values.get(CONF_LINKED_PROTOCOL_IDS, [])
-                if protocol_id in linked_protocols:
-                    self.logger.info(
-                        "Deleting stale universal player %s - "
-                        "protocol %s is linked to native player %s",
-                        player_id,
-                        protocol_id,
-                        other_player_id,
-                    )
-                    # When the rightful parent is disabled, the universal player
-                    # was created because the parent's disable left its protocols
-                    # orphaned. Repair the protocol configs (restore parent link,
-                    # cascade-disable) so they don't immediately wrap into a fresh
-                    # universal player on the next registration cycle.
-                    if not other_config.get("enabled", True):
-                        await self._reparent_disabled_protocols(
-                            other_player_id, stored_protocol_ids
-                        )
-                    await self.mass.config.remove_player_config(player_id)
-                    return
+                other_values = other_config.get("values") or {}
+                if protocol_id not in other_values.get(CONF_LINKED_PROTOCOL_IDS, []):
+                    continue
+                self.logger.info(
+                    "Not restoring universal player %s - protocol %s is linked to native player %s",
+                    player_id,
+                    protocol_id,
+                    other_player_id,
+                )
+                await self._reparent_protocols_to_native(other_player_id, valid_protocol_ids)
+                return
+
+        stored_protocol_ids = valid_protocol_ids
+
+        # Persist the updated protocol IDs to config if they changed
+        if valid_protocol_ids != list(values.get(CONF_LINKED_PROTOCOL_IDS) or []):
+            self.mass.config.set(
+                f"{CONF_PLAYERS}/{player_id}/values/{CONF_LINKED_PROTOCOL_IDS}",
+                valid_protocol_ids,
+            )
 
         # Restore device info with stored values or defaults
         device_info = DeviceInfo(
@@ -423,17 +367,83 @@ class UniversalPlayerProvider(PlayerProvider):
         )
         await self.mass.players.register_or_update(player)
 
-    async def _reparent_disabled_protocols(
+    def _resolve_stored_protocol_ids(
+        self, player_id: str, all_player_configs: dict[str, dict[str, Any]]
+    ) -> list[str]:
+        """
+        Resolve the current protocol player membership of a stored universal player.
+
+        Reconciles the universal player's stored member list with the parent links
+        persisted on the protocol players themselves, dropping members that moved
+        away or unlinked. Configs are never deleted here.
+        """
+        config = all_player_configs.get(player_id) or {}
+        values = config.get("values") or {}
+        stored_protocol_ids = list(values.get(CONF_LINKED_PROTOCOL_IDS) or [])
+
+        # The child's persisted parent link is the canonical side of the relation:
+        # also pick up children that point at us but are missing from our stored
+        # list (e.g. only one side of the link survived an interrupted shutdown).
+        for child_id, child_config in all_player_configs.items():
+            child_values = child_config.get("values") or {}
+            if child_values.get(CONF_PROTOCOL_PARENT_ID) != player_id:
+                continue
+            if child_id not in stored_protocol_ids:
+                stored_protocol_ids.append(child_id)
+
+        valid_protocol_ids = []
+        for protocol_id in stored_protocol_ids:
+            protocol_config = all_player_configs.get(protocol_id)
+            if not protocol_config:
+                # Config doesn't exist, keep it for now (player may register later)
+                valid_protocol_ids.append(protocol_id)
+                continue
+            protocol_values = protocol_config.get("values") or {}
+            parent_id = protocol_values.get(CONF_PROTOCOL_PARENT_ID)
+            if parent_id == player_id:
+                # the persisted parent link proves this child still belongs to us,
+                # even if its player_type was left stale by an aborted registration
+                valid_protocol_ids.append(protocol_id)
+                continue
+            if parent_id:
+                self.logger.info(
+                    "Removing %s from universal player %s - moved to parent %s",
+                    protocol_id,
+                    player_id,
+                    parent_id,
+                )
+                continue
+            if protocol_config.get("player_type") != "protocol":
+                self.logger.info(
+                    "Removing %s from universal player %s - player type changed to %s",
+                    protocol_id,
+                    player_id,
+                    protocol_config.get("player_type"),
+                )
+                continue
+            # unlinked protocol player: no longer ours, but keep its config -
+            # it may relink (or be adopted by another player) once it registers
+            self.logger.info(
+                "Removing %s from universal player %s - no longer linked",
+                protocol_id,
+                player_id,
+            )
+        return valid_protocol_ids
+
+    async def _reparent_protocols_to_native(
         self, native_parent_id: str, protocol_ids: list[str]
     ) -> None:
         """
-        Restore protocol players' parent link to a disabled native parent and disable them.
+        Restore protocol players' parent link to their rightful native parent.
 
-        Used to repair configs after a stale universal player is removed: the protocols'
-        cached parent_id was overwritten to point at the universal player when it was
-        created. Resetting it to the rightful (disabled) native parent lets the regular
-        cascade-enable flow restore everything cleanly if the user re-enables that parent.
+        Used to repair configs when a stale universal player wrapped protocols that
+        belong to a native player: the protocols' cached parent_id was overwritten to
+        point at the universal player when it was created. Protocols of a disabled
+        native parent are cascade-disabled as well, so they don't immediately wrap
+        into a fresh universal player on the next registration cycle.
         """
+        parent_config = self.mass.config.get(f"{CONF_PLAYERS}/{native_parent_id}") or {}
+        parent_enabled = parent_config.get("enabled", True)
         for protocol_id in protocol_ids:
             protocol_raw = self.mass.config.get(f"{CONF_PLAYERS}/{protocol_id}")
             if not protocol_raw:
@@ -442,7 +452,7 @@ class UniversalPlayerProvider(PlayerProvider):
                 f"{CONF_PLAYERS}/{protocol_id}/values/{CONF_PROTOCOL_PARENT_ID}",
                 native_parent_id,
             )
-            if not protocol_raw.get("enabled", True):
+            if parent_enabled or not protocol_raw.get("enabled", True):
                 continue
             self.logger.info(
                 "Disabling orphaned protocol player %s to match its disabled parent %s",

--- a/music_assistant/providers/universal_player/provider.py
+++ b/music_assistant/providers/universal_player/provider.py
@@ -306,6 +306,7 @@ class UniversalPlayerProvider(PlayerProvider):
         # Protocols that (also) belong to a native player mean this universal
         # player is a leftover wrapper: repair the protocol links to point at
         # the rightful native parent and skip restoring the wrapper.
+        native_claims: dict[str, str] = {}
         for protocol_id in valid_protocol_ids:
             for other_player_id, other_config in all_player_configs.items():
                 if other_player_id == player_id:
@@ -313,16 +314,28 @@ class UniversalPlayerProvider(PlayerProvider):
                 if other_config.get("provider") == "universal_player":
                     continue
                 other_values = other_config.get("values") or {}
-                if protocol_id not in other_values.get(CONF_LINKED_PROTOCOL_IDS, []):
-                    continue
+                if protocol_id in (other_values.get(CONF_LINKED_PROTOCOL_IDS) or []):
+                    native_claims[protocol_id] = other_player_id
+                    break
+        if native_claims:
+            # Members are same-device by construction, so members not claimed by
+            # any native follow the first claimer (keeps the cascade-disable
+            # repair intact for protocols that appeared after the parent left).
+            default_parent = next(iter(native_claims.values()))
+            by_parent: dict[str, list[str]] = {}
+            for protocol_id in valid_protocol_ids:
+                parent_id = native_claims.get(protocol_id, default_parent)
+                by_parent.setdefault(parent_id, []).append(protocol_id)
+            for native_id, protocol_ids in by_parent.items():
                 self.logger.info(
-                    "Not restoring universal player %s - protocol %s is linked to native player %s",
+                    "Not restoring universal player %s - protocols %s are linked "
+                    "to native player %s",
                     player_id,
-                    protocol_id,
-                    other_player_id,
+                    protocol_ids,
+                    native_id,
                 )
-                await self._reparent_protocols_to_native(other_player_id, valid_protocol_ids)
-                return
+                await self._reparent_protocols_to_native(native_id, protocol_ids)
+            return
 
         stored_protocol_ids = valid_protocol_ids
 

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7101,6 +7101,28 @@ class TestStaleConfigMigration:
             "squeezelite_child", PlayerType.PROTOCOL
         )
 
+    def test_native_registration_clears_stale_parent_link(self, mock_mass: MagicMock) -> None:
+        """A player registering with a non-protocol type drops its leftover parent link."""
+        controller = PlayerController(mock_mass)
+        provider = MockProvider("sendspin", mass=mock_mass)
+        player = MockPlayer(provider, "web_player", "Web Player", player_type=PlayerType.PLAYER)
+
+        config_values = {
+            f"{CONF_PLAYERS}/web_player": {"player_type": "player"},
+            f"{CONF_PLAYERS}/web_player/values/protocol_parent_id": "up_old_parent",
+        }
+        mock_mass.config.get = MagicMock(
+            side_effect=lambda key, default=None: config_values.get(key, default)
+        )
+
+        with patch.object(controller, "_try_link_protocols_to_native"):
+            controller._evaluate_protocol_links(player)
+
+        mock_mass.config.set.assert_any_call(
+            f"{CONF_PLAYERS}/web_player/values/protocol_parent_id",
+            None,
+        )
+
 
 class TestUniversalPlayerRestoreOrphanCleanup:
     """Tests for UniversalPlayerProvider._restore_player membership repair behavior."""

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7438,6 +7438,72 @@ class TestUniversalPlayerRestoreOrphanCleanup:
             call.args[0] for call in mock_mass.config.save_player_config.await_args_list
         }
         assert disabled_ids == {ap_id, dlna_id}
+
+    @pytest.mark.asyncio
+    async def test_protocols_reparented_to_their_own_native_claimer(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """Each protocol is reparented to the native player that claims it, not the first found."""
+        provider = create_mock_universal_provider(mock_mass)
+        universal_id = "up_test"
+        ap_id = "airplay_1"
+        slimproto_id = "slimproto_1"
+
+        all_configs = {
+            universal_id: {
+                "values": {
+                    "linked_protocol_ids": [ap_id, slimproto_id],
+                    "device_identifiers": {},
+                    "device_info": {},
+                },
+                "name": "Test UP",
+            },
+            "native_a": {
+                "provider": "dlna",
+                "values": {"linked_protocol_ids": [ap_id]},
+            },
+            "native_b": {
+                "provider": "squeezelite",
+                "values": {"linked_protocol_ids": [slimproto_id]},
+            },
+            ap_id: {
+                "player_type": "protocol",
+                "values": {"protocol_parent_id": universal_id},
+            },
+            slimproto_id: {
+                "player_type": "protocol",
+                "values": {"protocol_parent_id": universal_id},
+            },
+        }
+
+        def _config_get(key: str, default: object = None) -> object:
+            if key == CONF_PLAYERS:
+                return all_configs
+            if key.startswith(f"{CONF_PLAYERS}/"):
+                pid = key.split("/", 1)[1]
+                return all_configs.get(pid, default)
+            return default
+
+        mock_mass.config.get.side_effect = _config_get
+        mock_mass.config.set = MagicMock()
+        mock_mass.config.save_player_config = AsyncMock()
+        mock_mass.config.remove_player_config = AsyncMock()
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(return_value=None)
+        mock_mass.players.register_or_update = AsyncMock()
+
+        await provider._restore_player(universal_id)
+
+        mock_mass.players.register_or_update.assert_not_called()
+        parent_restorations = {
+            call.args[0]: call.args[1]
+            for call in mock_mass.config.set.call_args_list
+            if "protocol_parent_id" in call.args[0]
+        }
+        assert parent_restorations == {
+            f"{CONF_PLAYERS}/{ap_id}/values/protocol_parent_id": "native_a",
+            f"{CONF_PLAYERS}/{slimproto_id}/values/protocol_parent_id": "native_b",
+        }
         for call in mock_mass.config.save_player_config.await_args_list:
             assert call.args[1] == {ATTR_ENABLED: False}
 

--- a/tests/controllers/players/test_protocol_linking.py
+++ b/tests/controllers/players/test_protocol_linking.py
@@ -7017,7 +7017,7 @@ class TestCleanupProtocolLinks:
 
 
 class TestStaleConfigMigration:
-    """Tests for stale protocol_parent_id cleanup on startup."""
+    """Tests for protocol parent link repair on startup."""
 
     def test_clears_stale_parent_ids(self, mock_mass: MagicMock) -> None:
         """Stale parent_ids pointing to deleted players are cleared on startup."""
@@ -7039,13 +7039,14 @@ class TestStaleConfigMigration:
             }
         )
 
-        controller._cleanup_stale_protocol_parent_ids()
+        controller._repair_protocol_parent_links()
 
         # Verify the stale parent_id was cleared
         mock_mass.config.set.assert_any_call(
             "players/airplay_test/values/protocol_parent_id",
             None,
         )
+        mock_mass.config.set_player_type.assert_not_called()
 
     def test_keeps_valid_parent_ids(self, mock_mass: MagicMock) -> None:
         """Valid parent_ids pointing to existing players are preserved."""
@@ -7067,15 +7068,42 @@ class TestStaleConfigMigration:
             }
         )
 
-        controller._cleanup_stale_protocol_parent_ids()
+        controller._repair_protocol_parent_links()
 
         # Verify no set calls were made to clear the parent_id
         for call in mock_mass.config.set.call_args_list:
             assert "protocol_parent_id" not in str(call), "Valid parent_id should not be cleared"
+        mock_mass.config.set_player_type.assert_not_called()
+
+    def test_heals_stale_player_type_of_linked_child(self, mock_mass: MagicMock) -> None:
+        """A parented child whose player_type was corrupted is healed back to protocol."""
+        controller = PlayerController(mock_mass)
+
+        mock_mass.config.get = MagicMock(
+            return_value={
+                "squeezelite_child": {
+                    "player_type": "player",
+                    "values": {
+                        "protocol_parent_id": "up_valid_player",
+                    },
+                },
+                "up_valid_player": {
+                    "player_type": "group",
+                    "provider": "universal_player",
+                    "values": {},
+                },
+            }
+        )
+
+        controller._repair_protocol_parent_links()
+
+        mock_mass.config.set_player_type.assert_called_once_with(
+            "squeezelite_child", PlayerType.PROTOCOL
+        )
 
 
 class TestUniversalPlayerRestoreOrphanCleanup:
-    """Tests for UniversalPlayerProvider._restore_player orphan cleanup behavior."""
+    """Tests for UniversalPlayerProvider._restore_player membership repair behavior."""
 
     @staticmethod
     def _setup_config_get(
@@ -7093,20 +7121,21 @@ class TestUniversalPlayerRestoreOrphanCleanup:
             },
             "name": "Test Universal",
         }
+        all_configs: dict[str, object] = {universal_id: universal_conf, **protocol_configs}
 
         def _get(key: str, default: object = None) -> object:
-            if key == f"players/{universal_id}":
-                return universal_conf
-            for pid, conf in protocol_configs.items():
-                if key == f"players/{pid}":
-                    return conf
+            if key == CONF_PLAYERS:
+                return all_configs
+            if key.startswith(f"{CONF_PLAYERS}/"):
+                pid = key.split("/", 1)[1]
+                return all_configs.get(pid, default)
             return default
 
         mock_mass.config.get.side_effect = _get
 
     @pytest.mark.asyncio
-    async def test_orphan_protocol_deleted_when_not_registered(self, mock_mass: MagicMock) -> None:
-        """Orphan protocol with no live registration → delete_player_config path."""
+    async def test_orphan_protocol_dropped_but_configs_kept(self, mock_mass: MagicMock) -> None:
+        """Orphan protocol is dropped from membership without deleting any config."""
         provider = create_mock_universal_provider(mock_mass)
         universal_id = "up_test"
         orphan_id = "spb_orphan"
@@ -7126,44 +7155,17 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         mock_mass.players.get_player = MagicMock(return_value=None)
         mock_mass.players.delete_player_config = MagicMock()
         mock_mass.players.unregister = AsyncMock()
+        mock_mass.players.register_or_update = AsyncMock()
         mock_mass.config.remove_player_config = AsyncMock()
 
         await provider._restore_player(universal_id)
 
-        mock_mass.players.delete_player_config.assert_called_once_with(orphan_id)
-        mock_mass.players.unregister.assert_not_called()
-        # With no valid protocols left, the universal is also removed
-        mock_mass.config.remove_player_config.assert_called_once_with(universal_id)
-
-    @pytest.mark.asyncio
-    async def test_orphan_protocol_unregistered_when_active(self, mock_mass: MagicMock) -> None:
-        """Orphan protocol that is currently registered → unregister(permanent=True) path."""
-        provider = create_mock_universal_provider(mock_mass)
-        universal_id = "up_test"
-        orphan_id = "spb_orphan"
-
-        self._setup_config_get(
-            mock_mass,
-            universal_id,
-            [orphan_id],
-            {
-                orphan_id: {
-                    "player_type": "protocol",
-                    "values": {"protocol_parent_id": None},
-                },
-            },
-        )
-        mock_mass.players = MagicMock()
-        mock_mass.players.get_player = MagicMock(return_value=MagicMock())
-        mock_mass.players.delete_player_config = MagicMock()
-        mock_mass.players.unregister = AsyncMock()
-        mock_mass.config.remove_player_config = AsyncMock()
-
-        await provider._restore_player(universal_id)
-
-        mock_mass.players.unregister.assert_awaited_once_with(orphan_id, permanent=True)
+        # Neither the orphan's config nor the universal's config is deleted
         mock_mass.players.delete_player_config.assert_not_called()
-        mock_mass.config.remove_player_config.assert_called_once_with(universal_id)
+        mock_mass.players.unregister.assert_not_called()
+        mock_mass.config.remove_player_config.assert_not_called()
+        # With no valid protocols left, the universal is simply not restored
+        mock_mass.players.register_or_update.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_valid_protocol_kept_and_no_cleanup(self, mock_mass: MagicMock) -> None:
@@ -7266,15 +7268,85 @@ class TestUniversalPlayerRestoreOrphanCleanup:
         assert configs[universal_id]["values"]["announce_volume_min"] == 55
 
     @pytest.mark.asyncio
+    async def test_membership_augmented_from_child_parent_link(self, mock_mass: MagicMock) -> None:
+        """A child whose parent link points at the universal is re-added to membership."""
+        provider = create_mock_universal_provider(mock_mass)
+        universal_id = "up_test"
+        stored_id = "spb_stored"
+        missing_id = "spb_missing"
+
+        self._setup_config_get(
+            mock_mass,
+            universal_id,
+            [stored_id],
+            {
+                stored_id: {
+                    "player_type": "protocol",
+                    "values": {"protocol_parent_id": universal_id},
+                },
+                missing_id: {
+                    "player_type": "protocol",
+                    "values": {"protocol_parent_id": universal_id},
+                },
+            },
+        )
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(return_value=None)
+        mock_mass.players.register_or_update = AsyncMock()
+        mock_mass.config.remove_player_config = AsyncMock()
+        mock_mass.config.get_base_player_config.return_value = create_mock_config("Test Universal")
+
+        await provider._restore_player(universal_id)
+
+        # The missing child is restored to membership and persisted
+        mock_mass.config.set.assert_any_call(
+            f"{CONF_PLAYERS}/{universal_id}/values/linked_protocol_ids",
+            [stored_id, missing_id],
+        )
+        registered = mock_mass.players.register_or_update.call_args.args[0]
+        assert registered._protocol_player_ids == [stored_id, missing_id]
+
+    @pytest.mark.asyncio
+    async def test_universal_config_kept_when_protocol_moved_to_other_parent(
+        self, mock_mass: MagicMock
+    ) -> None:
+        """A protocol that moved to another parent is dropped, universal config is kept."""
+        provider = create_mock_universal_provider(mock_mass)
+        universal_id = "up_test"
+        protocol_id = "spb_moved"
+
+        self._setup_config_get(
+            mock_mass,
+            universal_id,
+            [protocol_id],
+            {
+                protocol_id: {
+                    "player_type": "protocol",
+                    "values": {"protocol_parent_id": "up_other"},
+                },
+            },
+        )
+        mock_mass.players = MagicMock()
+        mock_mass.players.get_player = MagicMock(return_value=None)
+        mock_mass.players.register_or_update = AsyncMock()
+        mock_mass.config.remove_player_config = AsyncMock()
+
+        await provider._restore_player(universal_id)
+
+        mock_mass.config.remove_player_config.assert_not_called()
+        mock_mass.players.register_or_update.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_disabled_parent_reparents_and_disables_orphaned_protocols(
         self, mock_mass: MagicMock
     ) -> None:
         """
         Self-heal: stale UP whose protocols belong to a disabled native parent.
 
-        Restoring such a UP should delete the wrapper, restore each protocol's
-        parent_id back to the rightful (disabled) native parent, and cascade-disable
-        each protocol so the next registration cycle doesn't rebuild the wrapper.
+        Restoring such a UP should skip the wrapper (keeping its config), restore
+        each protocol's parent_id back to the rightful (disabled) native parent, and
+        cascade-disable each protocol so the next registration cycle doesn't rebuild
+        the wrapper.
         """
         provider = create_mock_universal_provider(mock_mass)
         universal_id = "up_test"
@@ -7325,8 +7397,8 @@ class TestUniversalPlayerRestoreOrphanCleanup:
 
         await provider._restore_player(universal_id)
 
-        # Stale UP is removed
-        mock_mass.config.remove_player_config.assert_awaited_once_with(universal_id)
+        # The wrapper is skipped but its config is kept
+        mock_mass.config.remove_player_config.assert_not_awaited()
 
         # Each protocol's parent_id is restored to the disabled native parent
         parent_restorations = {


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #4634. When a player's stored settings ended up in a corrupted state (for example after an interrupted shutdown), the startup restore logic could permanently delete universal player configurations — taking all user customizations with them. Startup restore and repair are now fully non-destructive:

- Restoring universal players no longer deletes any player configuration; players that are no longer linked are simply left out until they reconnect.
- A universal player without any linked players is skipped instead of deleted, so its settings are picked up again once its players return.
- Linked players missing from the stored member list are recovered from the link stored on the player itself.
- The startup repair pass now also heals a corrupted player type on linked players (previously it skipped exactly those).

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/5745

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.