### PR TITLE
Prevent syncgroup self-dissolve when recovering a stuck member

### DIFF
--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -1106,6 +1106,8 @@ class SyncGroupPlayer(Player):
                     await self.mass.players._handle_set_members(
                         stale_parent, player_ids_to_remove=[member_id]
                     )
+            except asyncio.CancelledError:
+                raise
             except Exception as err:
                 self.logger.debug(
                     "stale-parent removal recovery for %s raised: %s", member.display_name, err

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -620,28 +620,29 @@ class SyncGroupPlayer(Player):
         if not self.sync_leader:
             self.sync_leader = self._select_sync_leader()
 
-        if not self.sync_leader:
+        # pin the leader ref: a concurrent command (e.g. a dissolve) may clear
+        # or replace self.sync_leader while we await below
+        leader = self.sync_leader
+        if not leader:
             # we have no members in the group, so we can't form a syncgroup
             return
 
         # ensure the sync leader is first in the list
         self._attr_group_members = [
-            self.sync_leader.player_id,
-            *[x for x in self._attr_group_members if x != self.sync_leader.player_id],
+            leader.player_id,
+            *[x for x in self._attr_group_members if x != leader.player_id],
         ]
         # If the leader still believes it's synced to a previous leader (e.g. we
         # just picked a new leader after dissolving the old session and the
         # protocol-level state hasn't propagated yet), wait for it to settle.
         # Without this, the subsequent play_media call hits the provider's
         # "I'm synced to another player" guard and gets rejected.
-        if self.sync_leader.state.synced_to is not None:
+        if leader.state.synced_to is not None:
             self.logger.debug(
                 "Waiting for new leader %s to report synced_to=None before forming",
-                self.sync_leader.display_name,
+                leader.display_name,
             )
-            # pin the leader ref: a concurrent command may clear self.sync_leader mid-wait
-            stuck_leader = self.sync_leader
-            if not await self._wait_member_unsynced(stuck_leader.player_id):
+            if not await self._wait_member_unsynced(leader.player_id):
                 # Leader is genuinely stuck — bail out before issuing play_media
                 # so we don't trigger the provider's "synced to another player"
                 # rejection. The caller (play / play_media) will surface this as
@@ -650,17 +651,19 @@ class SyncGroupPlayer(Player):
                 self.logger.error(
                     "Aborting syncgroup form for %s: leader %s is stuck synced",
                     self.display_name,
-                    stuck_leader.display_name,
+                    leader.display_name,
                 )
                 self.sync_leader = None
                 return
+            if self.sync_leader is not leader:
+                # the group was dissolved or re-led while we waited —
+                # this form attempt is stale, abort
+                return
         # Translate the leader's group_members (may be protocol IDs) to parent IDs
         # so we can compare against our _attr_group_members (always parent IDs)
-        already_synced = set(self._translate_to_parent_ids(self.sync_leader.state.group_members))
+        already_synced = set(self._translate_to_parent_ids(leader.state.group_members))
         members_to_sync = [
-            x
-            for x in self._attr_group_members
-            if x != self.sync_leader.player_id and x not in already_synced
+            x for x in self._attr_group_members if x != leader.player_id and x not in already_synced
         ]
         if members_to_sync:
             # If the sync leader is playing something independently, stop it first
@@ -668,21 +671,25 @@ class SyncGroupPlayer(Player):
             # (we're about to start new playback on the syncgroup).
             # Wait for the leader to actually reach IDLE before adding members,
             # since some providers reject set_members while still playing.
-            if self.sync_leader.state.playback_state == PlaybackState.PLAYING:
+            if leader.state.playback_state == PlaybackState.PLAYING:
                 async with self.mass.players.wait_for_player_update(
-                    self.sync_leader.player_id,
+                    leader.player_id,
                     attribute_name="playback_state",
                     attribute_value=PlaybackState.IDLE,
                     timeout=5,
                 ):
-                    await self.mass.players._handle_cmd_stop(self.sync_leader.player_id)
+                    await self.mass.players._handle_cmd_stop(leader.player_id)
+                if self.sync_leader is not leader:
+                    # the group was dissolved or re-led while we waited —
+                    # this form attempt is stale, abort
+                    return
             # use _handle_set_members directly to avoid the redirect loop
             # (cmd_set_members redirects sync-leader targets back to this syncgroup)
             async with self.mass.players.get_player_lock(
-                self.sync_leader.player_id, PlayerLockPurpose.PLAYBACK
+                leader.player_id, PlayerLockPurpose.PLAYBACK
             ):
                 await self.mass.players._handle_set_members(
-                    self.sync_leader, player_ids_to_add=members_to_sync
+                    leader, player_ids_to_add=members_to_sync
                 )
 
     @asynccontextmanager
@@ -1085,11 +1092,16 @@ class SyncGroupPlayer(Player):
                 timeout,
             )
             try:
-                async with self.mass.players.wait_for_player_update(
-                    member_id,
-                    attribute_name="synced_to",
-                    attribute_value=None,
-                    timeout=2.0,
+                async with (
+                    self.mass.players.wait_for_player_update(
+                        member_id,
+                        attribute_name="synced_to",
+                        attribute_value=None,
+                        timeout=2.0,
+                    ),
+                    self.mass.players.get_player_lock(
+                        stale_parent.player_id, PlayerLockPurpose.PLAYBACK
+                    ),
                 ):
                     await self.mass.players._handle_set_members(
                         stale_parent, player_ids_to_remove=[member_id]

--- a/music_assistant/providers/sync_group/player.py
+++ b/music_assistant/providers/sync_group/player.py
@@ -639,7 +639,9 @@ class SyncGroupPlayer(Player):
                 "Waiting for new leader %s to report synced_to=None before forming",
                 self.sync_leader.display_name,
             )
-            if not await self._wait_member_unsynced(self.sync_leader.player_id):
+            # pin the leader ref: a concurrent command may clear self.sync_leader mid-wait
+            stuck_leader = self.sync_leader
+            if not await self._wait_member_unsynced(stuck_leader.player_id):
                 # Leader is genuinely stuck — bail out before issuing play_media
                 # so we don't trigger the provider's "synced to another player"
                 # rejection. The caller (play / play_media) will surface this as
@@ -648,7 +650,7 @@ class SyncGroupPlayer(Player):
                 self.logger.error(
                     "Aborting syncgroup form for %s: leader %s is stuck synced",
                     self.display_name,
-                    self.sync_leader.display_name,
+                    stuck_leader.display_name,
                 )
                 self.sync_leader = None
                 return
@@ -1020,14 +1022,14 @@ class SyncGroupPlayer(Player):
             # re-forming. Providers like Sonos propagate group state
             # asynchronously — the children can still report synced_to for
             # a few seconds after the leader's ungroup command returns.
+            # snapshot: concurrent (un)group commands may mutate the list while we await
+            members = list(self._attr_group_members)
             unsync_results = await asyncio.gather(
-                *(self._wait_member_unsynced(m) for m in self._attr_group_members),
+                *(self._wait_member_unsynced(m) for m in members),
                 return_exceptions=True,
             )
             stuck_members = [
-                self._attr_group_members[i]
-                for i, result in enumerate(unsync_results)
-                if result is False
+                members[i] for i, result in enumerate(unsync_results) if result is False
             ]
             if stuck_members:
                 self.logger.error(
@@ -1069,27 +1071,33 @@ class SyncGroupPlayer(Player):
         member = self.mass.players.get_player(member_id)
         if member is None or member.synced_to is None:
             return True
-        # The provider didn't propagate within the timeout. Try an explicit
-        # ungroup to push the protocol layer, then wait again with a tighter
-        # budget. This rescues the common "Sonos UPnP event lag" case.
-        self.logger.warning(
-            "Player %s still reports synced_to=%s after %ss; "
-            "issuing explicit ungroup and re-waiting",
-            member.display_name,
-            member.synced_to,
-            timeout,
-        )
-        try:
-            await self.mass.players.cmd_ungroup(member_id)
-        except Exception as err:
-            self.logger.debug("ungroup recovery for %s raised: %s", member.display_name, err)
-        async with self.mass.players.wait_for_player_update(
-            member_id,
-            attribute_name="synced_to",
-            attribute_value=None,
-            timeout=2.0,
-        ):
-            pass
+        # The provider didn't propagate within the timeout. Kick the member
+        # from its stale parent, then wait again with a tighter budget.
+        # This rescues the common "Sonos UPnP event lag" case.
+        # NOTE: not the public cmd_ungroup - it re-enters this syncgroup's set_members.
+        # if the stale parent is gone, no kick is possible - fall through to the final check
+        if stale_parent := self.mass.players.get_player(member.synced_to):
+            self.logger.warning(
+                "Player %s still reports synced_to=%s after %ss; "
+                "removing it from its stale parent and re-waiting",
+                member.display_name,
+                member.synced_to,
+                timeout,
+            )
+            try:
+                async with self.mass.players.wait_for_player_update(
+                    member_id,
+                    attribute_name="synced_to",
+                    attribute_value=None,
+                    timeout=2.0,
+                ):
+                    await self.mass.players._handle_set_members(
+                        stale_parent, player_ids_to_remove=[member_id]
+                    )
+            except Exception as err:
+                self.logger.debug(
+                    "stale-parent removal recovery for %s raised: %s", member.display_name, err
+                )
         member = self.mass.players.get_player(member_id)
         if member is None or member.synced_to is None:
             return True

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -1145,6 +1145,32 @@ class TestFormWaitsForLeaderUnsynced:
         # won't be issued against a stuck player (the original Poolhouse race).
         assert sgp.sync_leader is None
 
+    @pytest.mark.asyncio
+    async def test_form_aborts_when_leader_cleared_during_wait(self) -> None:
+        """If a concurrent dissolve clears sync_leader during the wait, abort the stale form."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        leader = _make_mock_player("leader", provider_domain="sonos")
+        leader.state.synced_to = "old_leader"
+        member = _make_mock_player("m2", provider_domain="sonos")
+        mass.players.get_player = _player_lookup({"leader": leader, "m2": member})
+        sgp._attr_group_members = ["leader", "m2"]
+
+        async def fake_wait(_member_id: str, _timeout: float = 5.0) -> bool:
+            leader.state.synced_to = None
+            sgp.sync_leader = None  # simulate a concurrent dissolve while waiting
+            return True
+
+        with (
+            patch.object(sgp, "update_state"),
+            patch.object(sgp, "_wait_member_unsynced", side_effect=fake_wait),
+        ):
+            await sgp._form_syncgroup()
+
+        # the stale form attempt must not (re)sync any members
+        mass.players._handle_set_members.assert_not_awaited()
+        assert sgp.sync_leader is None
+
 
 class TestWaitMemberUnsynced:
     """The helper that waits for a member's synced_to to clear (with recovery)."""
@@ -1208,6 +1234,20 @@ class TestWaitMemberUnsynced:
         mass.players._handle_set_members.assert_awaited_once_with(
             old_leader, player_ids_to_remove=["m1"]
         )
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_stale_parent_gone(self) -> None:
+        """If the stale parent no longer exists, skip the kick and report stuck."""
+        mass = _make_mock_mass()
+        sgp = _make_sync_group(mass)
+        member = _make_mock_player("m1")
+        member.synced_to = "old_leader"  # parent is no longer registered
+        mass.players.get_player = _player_lookup({"m1": member})
+
+        ok = await sgp._wait_member_unsynced("m1")
+
+        assert ok is False
+        mass.players._handle_set_members.assert_not_awaited()
 
 
 class TestSupportedFeaturesPower:

--- a/tests/providers/sync_group/test_sync_group.py
+++ b/tests/providers/sync_group/test_sync_group.py
@@ -1166,24 +1166,30 @@ class TestWaitMemberUnsynced:
 
     @pytest.mark.asyncio
     async def test_attempts_recovery_when_stuck(self) -> None:
-        """If the first wait doesn't clear it, issue a recovery ungroup and wait again."""
+        """If the first wait doesn't clear it, kick the member from its stale parent directly."""
         mass = _make_mock_mass()
         sgp = _make_sync_group(mass)
         member = _make_mock_player("m1")
         member.synced_to = "old_leader"  # still stale after first wait
-        mass.players.get_player = _player_lookup({"m1": member})
+        old_leader = _make_mock_player("old_leader")
+        mass.players.get_player = _player_lookup({"m1": member, "old_leader": old_leader})
 
-        # cmd_ungroup is what should be called as the recovery action.
+        # _handle_set_members on the stale parent is the expected recovery action.
         # We make it succeed by side-effect-clearing synced_to.
-        async def _ungroup(_player_id: str) -> None:
+        async def _kick(_parent: Any, player_ids_to_remove: list[str]) -> None:
+            assert player_ids_to_remove == ["m1"]
             member.synced_to = None
 
-        mass.players.cmd_ungroup = AsyncMock(side_effect=_ungroup)
+        mass.players._handle_set_members = AsyncMock(side_effect=_kick)
+        mass.players.cmd_ungroup = AsyncMock()
 
         ok = await sgp._wait_member_unsynced("m1")
 
         assert ok is True
-        mass.players.cmd_ungroup.assert_awaited_once_with("m1")
+        mass.players._handle_set_members.assert_awaited_once_with(
+            old_leader, player_ids_to_remove=["m1"]
+        )
+        mass.players.cmd_ungroup.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_returns_false_when_genuinely_stuck(self) -> None:
@@ -1192,13 +1198,16 @@ class TestWaitMemberUnsynced:
         sgp = _make_sync_group(mass)
         member = _make_mock_player("m1")
         member.synced_to = "old_leader"  # stays stuck even after recovery
-        mass.players.get_player = _player_lookup({"m1": member})
-        mass.players.cmd_ungroup = AsyncMock()  # no-op: state stays stale
+        old_leader = _make_mock_player("old_leader")
+        mass.players.get_player = _player_lookup({"m1": member, "old_leader": old_leader})
+        mass.players._handle_set_members = AsyncMock()  # no-op: state stays stale
 
         ok = await sgp._wait_member_unsynced("m1")
 
         assert ok is False
-        mass.players.cmd_ungroup.assert_awaited_once_with("m1")
+        mass.players._handle_set_members.assert_awaited_once_with(
+            old_leader, player_ids_to_remove=["m1"]
+        )
 
 
 class TestSupportedFeaturesPower:


### PR DESCRIPTION
# What does this implement/fix?

Rapid ungroup commands on a syncgroup can leave a member stuck `synced_to` a stale leader. The recovery in `_wait_member_unsynced` called the public `cmd_ungroup`, which re-enters the syncgroup's own `set_members`. When the stuck member was the freshly picked leader, this dissolved the group being re-formed: playback stopped ("An empty group cannot play media") and `_form_syncgroup` crashed with `'NoneType' object has no attribute 'display_name'`. Diagnosed from production logs with WiiM players.

- kick the stuck member from its stale sync parent directly via `_handle_set_members` instead of the re-entrant `cmd_ungroup`
- use a local leader reference in `_form_syncgroup`'s abort branch (fixes the crash)
- snapshot `_attr_group_members` before the `asyncio.gather`, as the list may mutate while awaiting
- updated `TestWaitMemberUnsynced` accordingly

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.