### PR TITLE
Advertise both IP families via mDNS and respect a specific bind IP when publishing

### DIFF
--- a/music_assistant/constants.py
+++ b/music_assistant/constants.py
@@ -113,6 +113,7 @@ CONF_CROSSFADE_DURATION: Final[str] = "crossfade_duration"
 CONF_BIND_IP: Final[str] = "bind_ip"
 CONF_BIND_PORT: Final[str] = "bind_port"
 CONF_PUBLISH_IP: Final[str] = "publish_ip"
+WILDCARD_BIND_IPS: Final[tuple[str, ...]] = ("0.0.0.0", "::")
 CONF_AUTO_PLAY: Final[str] = "auto_play"
 CONF_PLAY_MEDIA_OVERRIDES_GROUP: Final[str] = "play_media_overrides_group"
 CONF_GROUP_MEMBERS: Final[str] = "group_members"

--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -27,9 +27,8 @@ from music_assistant.constants import (
     CONF_ZEROCONF_INTERFACES,
     INGRESS_SERVER_PORT,
     VERBOSE_LOG_LEVEL,
-    WILDCARD_BIND_IPS,
 )
-from music_assistant.helpers.util import get_ip_addresses, get_ip_pton, get_zeroconf_args
+from music_assistant.helpers.util import get_ip_pton, get_zeroconf_args
 from music_assistant.models.core_controller import CoreController
 
 if TYPE_CHECKING:
@@ -263,7 +262,7 @@ class DiscoveryController(CoreController):
             zeroconf_type,
             name=f"{server_id}.{zeroconf_type}",
             addresses=[
-                await get_ip_pton(address) for address in await self._get_publish_addresses()
+                await get_ip_pton(address) for address in self.mass.webserver.publish_addresses
             ],
             port=self.mass.webserver.publish_port,
             properties=self.mass.get_server_info().to_dict(),
@@ -279,21 +278,6 @@ class DiscoveryController(CoreController):
             self.logger.error(
                 "Music Assistant instance with identical name present in the local network!"
             )
-
-    async def _get_publish_addresses(self) -> list[str]:
-        """Return the IP addresses to include in the Music Assistant mDNS advertisement."""
-        webserver = self.mass.webserver
-        addresses = [webserver.publish_ip]
-        if webserver.bind_ip and webserver.bind_ip not in WILDCARD_BIND_IPS:
-            return addresses
-        # bound to all interfaces: also advertise the primary address of the other
-        # IP family (if any) so both IPv4-only and IPv6-only clients can connect
-        publish_is_ipv6 = ":" in webserver.publish_ip
-        for ip in await get_ip_addresses(include_ipv6=True):
-            if (":" in ip) != publish_is_ipv6:
-                addresses.append(ip)
-                break
-        return addresses
 
     def _on_mdns_service_state_change(
         self,

--- a/music_assistant/controllers/discovery/controller.py
+++ b/music_assistant/controllers/discovery/controller.py
@@ -27,8 +27,9 @@ from music_assistant.constants import (
     CONF_ZEROCONF_INTERFACES,
     INGRESS_SERVER_PORT,
     VERBOSE_LOG_LEVEL,
+    WILDCARD_BIND_IPS,
 )
-from music_assistant.helpers.util import get_ip_pton, get_zeroconf_args
+from music_assistant.helpers.util import get_ip_addresses, get_ip_pton, get_zeroconf_args
 from music_assistant.models.core_controller import CoreController
 
 if TYPE_CHECKING:
@@ -261,7 +262,9 @@ class DiscoveryController(CoreController):
         info = AsyncServiceInfo(
             zeroconf_type,
             name=f"{server_id}.{zeroconf_type}",
-            addresses=[await get_ip_pton(self.mass.webserver.publish_ip)],
+            addresses=[
+                await get_ip_pton(address) for address in await self._get_publish_addresses()
+            ],
             port=self.mass.webserver.publish_port,
             properties=self.mass.get_server_info().to_dict(),
             server="mass.local.",
@@ -276,6 +279,21 @@ class DiscoveryController(CoreController):
             self.logger.error(
                 "Music Assistant instance with identical name present in the local network!"
             )
+
+    async def _get_publish_addresses(self) -> list[str]:
+        """Return the IP addresses to include in the Music Assistant mDNS advertisement."""
+        webserver = self.mass.webserver
+        addresses = [webserver.publish_ip]
+        if webserver.bind_ip and webserver.bind_ip not in WILDCARD_BIND_IPS:
+            return addresses
+        # bound to all interfaces: also advertise the primary address of the other
+        # IP family (if any) so both IPv4-only and IPv6-only clients can connect
+        publish_is_ipv6 = ":" in webserver.publish_ip
+        for ip in await get_ip_addresses(include_ipv6=True):
+            if (":" in ip) != publish_is_ipv6:
+                addresses.append(ip)
+                break
+        return addresses
 
     def _on_mdns_service_state_change(
         self,

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -63,7 +63,6 @@ from music_assistant.constants import (
     ICY_HEADERS,
     SILENCE_FILE,
     VERBOSE_LOG_LEVEL,
-    WILDCARD_BIND_IPS,
 )
 from music_assistant.controllers.players.helpers import AnnounceData
 from music_assistant.controllers.streams.audio import StreamsAudio
@@ -345,15 +344,12 @@ class StreamsController(CoreController):
         await check_ffmpeg_version()
         # start the webserver
         self.publish_port = config.get_value(CONF_BIND_PORT, DEFAULT_PORT)
-        self._bind_ip = bind_ip = str(config.get_value(CONF_BIND_IP))
         publish_ip = str(config.get_value(CONF_PUBLISH_IP) or CONF_VALUE_AUTO)
         if publish_ip == CONF_VALUE_AUTO:
-            if bind_ip not in WILDCARD_BIND_IPS:
-                publish_ip = bind_ip
-            else:
-                # resolve the "auto" default (or an unset value) to this server's primary IP
-                publish_ip = (await get_ip_addresses(include_ipv6=True))[0]
+            # resolve the "auto" default (or an unset value) to this server's primary IP
+            publish_ip = (await get_ip_addresses(include_ipv6=True))[0]
         self.publish_ip = publish_ip
+        self._bind_ip = bind_ip = str(config.get_value(CONF_BIND_IP))
         # print a big fat message in the log where the streamserver is running
         # because this is a common source of issues for people with more complex setups
         self.logger.log(

--- a/music_assistant/controllers/streams/controller.py
+++ b/music_assistant/controllers/streams/controller.py
@@ -63,6 +63,7 @@ from music_assistant.constants import (
     ICY_HEADERS,
     SILENCE_FILE,
     VERBOSE_LOG_LEVEL,
+    WILDCARD_BIND_IPS,
 )
 from music_assistant.controllers.players.helpers import AnnounceData
 from music_assistant.controllers.streams.audio import StreamsAudio
@@ -344,12 +345,15 @@ class StreamsController(CoreController):
         await check_ffmpeg_version()
         # start the webserver
         self.publish_port = config.get_value(CONF_BIND_PORT, DEFAULT_PORT)
+        self._bind_ip = bind_ip = str(config.get_value(CONF_BIND_IP))
         publish_ip = str(config.get_value(CONF_PUBLISH_IP) or CONF_VALUE_AUTO)
         if publish_ip == CONF_VALUE_AUTO:
-            # resolve the "auto" default (or an unset value) to this server's primary IP
-            publish_ip = (await get_ip_addresses(include_ipv6=True))[0]
+            if bind_ip not in WILDCARD_BIND_IPS:
+                publish_ip = bind_ip
+            else:
+                # resolve the "auto" default (or an unset value) to this server's primary IP
+                publish_ip = (await get_ip_addresses(include_ipv6=True))[0]
         self.publish_ip = publish_ip
-        self._bind_ip = bind_ip = str(config.get_value(CONF_BIND_IP))
         # print a big fat message in the log where the streamserver is running
         # because this is a common source of issues for people with more complex setups
         self.logger.log(

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -40,6 +40,7 @@ from music_assistant.constants import (
     INGRESS_SERVER_PORT,
     RESOURCES_DIR,
     VERBOSE_LOG_LEVEL,
+    WILDCARD_BIND_IPS,
 )
 from music_assistant.controllers.webserver.helpers.ssl import (
     create_server_ssl_context,
@@ -115,6 +116,7 @@ class WebserverController(CoreController):
         self.clients: set[WebsocketClientHandler] = set()
         # the URL that the "auto" base_url setting resolves to, detected at setup
         self._auto_base_url: str = ""
+        self.bind_ip: str | None = None
         self.manifest.name = "Web Server (frontend and api)"
         self.manifest.description = (
             "The built-in webserver that hosts the Music Assistant Websockets API and frontend"
@@ -305,13 +307,17 @@ class WebserverController(CoreController):
         port_value = config.get_value(CONF_BIND_PORT)
         assert isinstance(port_value, int)
         self.publish_port = port_value
-        self.publish_ip = default_publish_ip
         bind_ip = cast("str | None", config.get_value(CONF_BIND_IP))
+        self.bind_ip = bind_ip
+        if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
+            self.publish_ip = bind_ip
+        else:
+            self.publish_ip = default_publish_ip
         ssl_enabled = config.get_value(CONF_ENABLE_SSL, False)
         # resolve the URL that the "auto" base_url default (or an unset value) translates to
         protocol = "https" if ssl_enabled else "http"
         self._auto_base_url = (
-            f"{protocol}://{format_ip_for_url(default_publish_ip)}:{self.publish_port}"
+            f"{protocol}://{format_ip_for_url(self.publish_ip)}:{self.publish_port}"
         )
         base_url = self.base_url
         # print a big fat message in the log where the webserver is running

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -86,6 +86,29 @@ MAX_PENDING_MSG = 512
 CANCELLATION_ERRORS: Final = (asyncio.CancelledError, futures.CancelledError)
 
 
+def _get_publish_addresses(
+    bind_ip: str | None, publish_ip: str, all_ip_addresses: tuple[str, ...]
+) -> list[str]:
+    """
+    Return the IP addresses the webserver should publish/advertise.
+
+    :param bind_ip: The configured bind IP (None or a wildcard means all interfaces).
+    :param publish_ip: The resolved primary publish IP.
+    :param all_ip_addresses: All detected host IP addresses, in ranked order.
+    """
+    addresses = [publish_ip]
+    if bind_ip and bind_ip not in WILDCARD_BIND_IPS:
+        return addresses
+    # bound to all interfaces: also publish the primary address of the other
+    # IP family (if any) so both IPv4-only and IPv6-only clients can connect
+    publish_is_ipv6 = ":" in publish_ip
+    for ip in all_ip_addresses:
+        if (":" in ip) != publish_is_ipv6:
+            addresses.append(ip)
+            break
+    return addresses
+
+
 def _locale_from_request(request: web.Request) -> str | None:
     """
     Determine the UI locale for an HTTP request from the standard ``Accept-Language`` header.
@@ -117,6 +140,7 @@ class WebserverController(CoreController):
         # the URL that the "auto" base_url setting resolves to, detected at setup
         self._auto_base_url: str = ""
         self.bind_ip: str | None = None
+        self.publish_addresses: list[str] = []
         self.manifest.name = "Web Server (frontend and api)"
         self.manifest.description = (
             "The built-in webserver that hosts the Music Assistant Websockets API and frontend"
@@ -313,6 +337,7 @@ class WebserverController(CoreController):
             self.publish_ip = bind_ip
         else:
             self.publish_ip = default_publish_ip
+        self.publish_addresses = _get_publish_addresses(bind_ip, self.publish_ip, all_ip_addresses)
         ssl_enabled = config.get_value(CONF_ENABLE_SSL, False)
         # resolve the URL that the "auto" base_url default (or an unset value) translates to
         protocol = "https" if ssl_enabled else "http"

--- a/tests/controllers/discovery/test_discovery.py
+++ b/tests/controllers/discovery/test_discovery.py
@@ -60,7 +60,7 @@ async def test_discovery_controller_owns_async_zeroconf(mass_minimal: MusicAssis
     )
     mass_minimal.webserver = MagicMock(
         publish_ip="127.0.0.1",
-        bind_ip="127.0.0.1",
+        publish_addresses=["127.0.0.1"],
         publish_port=8095,
         base_url="http://127.0.0.1:8095",
     )
@@ -106,32 +106,25 @@ async def test_discovery_controller_owns_async_zeroconf(mass_minimal: MusicAssis
     )
 
 
-def _create_mock_aiozc() -> MagicMock:
-    """Create a mocked AsyncZeroconf instance for service registration tests."""
-    mock_zc = MagicMock(spec=AsyncZeroconf)
-    mock_zc.async_register_service = AsyncMock()
-    mock_zc.async_update_service = AsyncMock()
-    return mock_zc
-
-
-async def test_mass_service_advertises_both_ip_families(mass_minimal: MusicAssistant) -> None:
-    """When bound to all interfaces, the advertisement holds an IPv4 and an IPv6 address."""
+async def test_mass_service_advertises_webserver_publish_addresses(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """The advertisement must contain exactly the webserver's publish addresses."""
     mass_minimal.webserver = MagicMock(
         publish_ip="192.168.1.10",
-        bind_ip="0.0.0.0",
+        publish_addresses=["192.168.1.10", "fd00::10"],
         publish_port=8095,
         base_url="http://192.168.1.10:8095",
     )
-    mass_minimal.discovery._aiozc = _create_mock_aiozc()
+    mock_zc = MagicMock(spec=AsyncZeroconf)
+    mock_zc.async_register_service = AsyncMock()
+    mock_zc.async_update_service = AsyncMock()
+    mass_minimal.discovery._aiozc = mock_zc
 
     with (
         patch(
             "music_assistant.controllers.discovery.controller.AsyncServiceInfo"
         ) as mock_service_info,
-        patch(
-            "music_assistant.controllers.discovery.controller.get_ip_addresses",
-            new=AsyncMock(return_value=("192.168.1.10", "10.0.0.5", "fd00::10", "fd00::20")),
-        ),
         patch(
             "music_assistant.controllers.discovery.controller.get_ip_pton",
             new=AsyncMock(side_effect=lambda ip: ip.encode()),
@@ -140,37 +133,6 @@ async def test_mass_service_advertises_both_ip_families(mass_minimal: MusicAssis
         await mass_minimal.discovery._register_mass_service()
 
     assert mock_service_info.call_args.kwargs["addresses"] == [b"192.168.1.10", b"fd00::10"]
-
-
-async def test_mass_service_advertises_only_specific_bind_ip(
-    mass_minimal: MusicAssistant,
-) -> None:
-    """When bound to one specific address, only that address may be advertised."""
-    mass_minimal.webserver = MagicMock(
-        publish_ip="fd00::10",
-        bind_ip="fd00::10",
-        publish_port=8095,
-        base_url="http://[fd00::10]:8095",
-    )
-    mass_minimal.discovery._aiozc = _create_mock_aiozc()
-
-    with (
-        patch(
-            "music_assistant.controllers.discovery.controller.AsyncServiceInfo"
-        ) as mock_service_info,
-        patch(
-            "music_assistant.controllers.discovery.controller.get_ip_addresses",
-            new=AsyncMock(return_value=("192.168.1.10", "fd00::10")),
-        ) as mock_get_ip_addresses,
-        patch(
-            "music_assistant.controllers.discovery.controller.get_ip_pton",
-            new=AsyncMock(side_effect=lambda ip: ip.encode()),
-        ),
-    ):
-        await mass_minimal.discovery._register_mass_service()
-
-    assert mock_service_info.call_args.kwargs["addresses"] == [b"fd00::10"]
-    mock_get_ip_addresses.assert_not_awaited()
 
 
 async def test_async_find_mdns_service_matches_exact_device_name(mass: MusicAssistant) -> None:

--- a/tests/controllers/discovery/test_discovery.py
+++ b/tests/controllers/discovery/test_discovery.py
@@ -60,6 +60,7 @@ async def test_discovery_controller_owns_async_zeroconf(mass_minimal: MusicAssis
     )
     mass_minimal.webserver = MagicMock(
         publish_ip="127.0.0.1",
+        bind_ip="127.0.0.1",
         publish_port=8095,
         base_url="http://127.0.0.1:8095",
     )
@@ -103,6 +104,73 @@ async def test_discovery_controller_owns_async_zeroconf(mass_minimal: MusicAssis
         ip_version=IPVersion.All,
         interfaces=["192.168.1.10", "fd00::1%2"],
     )
+
+
+def _create_mock_aiozc() -> MagicMock:
+    """Create a mocked AsyncZeroconf instance for service registration tests."""
+    mock_zc = MagicMock(spec=AsyncZeroconf)
+    mock_zc.async_register_service = AsyncMock()
+    mock_zc.async_update_service = AsyncMock()
+    return mock_zc
+
+
+async def test_mass_service_advertises_both_ip_families(mass_minimal: MusicAssistant) -> None:
+    """When bound to all interfaces, the advertisement holds an IPv4 and an IPv6 address."""
+    mass_minimal.webserver = MagicMock(
+        publish_ip="192.168.1.10",
+        bind_ip="0.0.0.0",
+        publish_port=8095,
+        base_url="http://192.168.1.10:8095",
+    )
+    mass_minimal.discovery._aiozc = _create_mock_aiozc()
+
+    with (
+        patch(
+            "music_assistant.controllers.discovery.controller.AsyncServiceInfo"
+        ) as mock_service_info,
+        patch(
+            "music_assistant.controllers.discovery.controller.get_ip_addresses",
+            new=AsyncMock(return_value=("192.168.1.10", "10.0.0.5", "fd00::10", "fd00::20")),
+        ),
+        patch(
+            "music_assistant.controllers.discovery.controller.get_ip_pton",
+            new=AsyncMock(side_effect=lambda ip: ip.encode()),
+        ),
+    ):
+        await mass_minimal.discovery._register_mass_service()
+
+    assert mock_service_info.call_args.kwargs["addresses"] == [b"192.168.1.10", b"fd00::10"]
+
+
+async def test_mass_service_advertises_only_specific_bind_ip(
+    mass_minimal: MusicAssistant,
+) -> None:
+    """When bound to one specific address, only that address may be advertised."""
+    mass_minimal.webserver = MagicMock(
+        publish_ip="fd00::10",
+        bind_ip="fd00::10",
+        publish_port=8095,
+        base_url="http://[fd00::10]:8095",
+    )
+    mass_minimal.discovery._aiozc = _create_mock_aiozc()
+
+    with (
+        patch(
+            "music_assistant.controllers.discovery.controller.AsyncServiceInfo"
+        ) as mock_service_info,
+        patch(
+            "music_assistant.controllers.discovery.controller.get_ip_addresses",
+            new=AsyncMock(return_value=("192.168.1.10", "fd00::10")),
+        ) as mock_get_ip_addresses,
+        patch(
+            "music_assistant.controllers.discovery.controller.get_ip_pton",
+            new=AsyncMock(side_effect=lambda ip: ip.encode()),
+        ),
+    ):
+        await mass_minimal.discovery._register_mass_service()
+
+    assert mock_service_info.call_args.kwargs["addresses"] == [b"fd00::10"]
+    mock_get_ip_addresses.assert_not_awaited()
 
 
 async def test_async_find_mdns_service_matches_exact_device_name(mass: MusicAssistant) -> None:

--- a/tests/controllers/webserver/test_publish_addresses.py
+++ b/tests/controllers/webserver/test_publish_addresses.py
@@ -1,0 +1,33 @@
+"""Tests for the webserver publish address selection."""
+
+from music_assistant.controllers.webserver.controller import _get_publish_addresses
+
+ALL_ADDRESSES = ("192.168.1.10", "10.0.0.5", "fd00::10", "fd00::20")
+
+
+def test_wildcard_bind_adds_other_ip_family() -> None:
+    """A wildcard bind publishes the publish IP plus the first address of the other family."""
+    assert _get_publish_addresses("0.0.0.0", "192.168.1.10", ALL_ADDRESSES) == [
+        "192.168.1.10",
+        "fd00::10",
+    ]
+    assert _get_publish_addresses(None, "192.168.1.10", ALL_ADDRESSES) == [
+        "192.168.1.10",
+        "fd00::10",
+    ]
+    assert _get_publish_addresses("::", "fd00::10", ALL_ADDRESSES) == [
+        "fd00::10",
+        "192.168.1.10",
+    ]
+
+
+def test_specific_bind_publishes_only_that_address() -> None:
+    """Binding to one specific address publishes only that address."""
+    assert _get_publish_addresses("fd00::10", "fd00::10", ALL_ADDRESSES) == ["fd00::10"]
+    assert _get_publish_addresses("192.168.1.10", "192.168.1.10", ALL_ADDRESSES) == ["192.168.1.10"]
+
+
+def test_single_family_host_publishes_single_address() -> None:
+    """A host with only one IP family publishes just the publish IP on a wildcard bind."""
+    assert _get_publish_addresses("0.0.0.0", "192.168.1.10", ("192.168.1.10",)) == ["192.168.1.10"]
+    assert _get_publish_addresses("::", "fd00::10", ("fd00::10", "fd00::20")) == ["fd00::10"]

--- a/tests/controllers/webserver/test_publish_addresses.py
+++ b/tests/controllers/webserver/test_publish_addresses.py
@@ -1,6 +1,7 @@
 """Tests for the webserver publish address selection."""
 
 from music_assistant.controllers.webserver.controller import _get_publish_addresses
+from music_assistant.helpers.util import format_ip_for_url
 
 ALL_ADDRESSES = ("192.168.1.10", "10.0.0.5", "fd00::10", "fd00::20")
 
@@ -27,7 +28,22 @@ def test_specific_bind_publishes_only_that_address() -> None:
     assert _get_publish_addresses("192.168.1.10", "192.168.1.10", ALL_ADDRESSES) == ["192.168.1.10"]
 
 
-def test_single_family_host_publishes_single_address() -> None:
-    """A host with only one IP family publishes just the publish IP on a wildcard bind."""
-    assert _get_publish_addresses("0.0.0.0", "192.168.1.10", ("192.168.1.10",)) == ["192.168.1.10"]
-    assert _get_publish_addresses("::", "fd00::10", ("fd00::10", "fd00::20")) == ["fd00::10"]
+def test_ipv4_only_host() -> None:
+    """An IPv4-only host publishes just its IPv4 address on a wildcard bind."""
+    v4_addresses = ("192.168.1.10", "10.0.0.5")
+    assert _get_publish_addresses("0.0.0.0", "192.168.1.10", v4_addresses) == ["192.168.1.10"]
+    assert _get_publish_addresses(None, "192.168.1.10", v4_addresses) == ["192.168.1.10"]
+
+
+def test_ipv6_only_host() -> None:
+    """An IPv6-only host publishes its IPv6 address, for both wildcard and specific binds."""
+    v6_addresses = ("fd00::10", "fd00::20")
+    assert _get_publish_addresses("::", "fd00::10", v6_addresses) == ["fd00::10"]
+    assert _get_publish_addresses(None, "fd00::10", v6_addresses) == ["fd00::10"]
+    assert _get_publish_addresses("fd00::10", "fd00::10", v6_addresses) == ["fd00::10"]
+
+
+def test_ipv6_publish_ip_yields_bracketed_base_url() -> None:
+    """An IPv6 publish IP must produce a bracketed host in the (auto) base URL."""
+    publish_ip = _get_publish_addresses("::", "fd00::10", ("fd00::10",))[0]
+    assert f"http://{format_ip_for_url(publish_ip)}:8095" == "http://[fd00::10]:8095"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The `_mass._tcp` zeroconf advertisement only ever contained the single auto-detected (usually IPv4) publish address, even when the host also has routable IPv6 addresses or when the webserver was explicitly bound to one specific (IPv6) address. IPv6-capable clients were therefore always pointed at the IPv4 address, and binding the server to a specific address advertised an address the server does not even listen on.

- discovery: advertise the primary address of both IP formats when bound to all interfaces, and only the bound address when bound to one specific address
- webserver: when bound to one specific address, use that address as the publish address (and for the auto base_url) instead of the auto-detected primary IP

I don't think this will break any existing behaviour. Testing was limited to confirming no regression in an IPv4 network as I dont have exclusively IPv6

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/4977

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
