### PR TITLE
Use shared port helpers in Plex Connect port allocation

### DIFF
--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1128,7 +1128,7 @@ async def select_free_port(range_start: int, range_end: int, host: str | None = 
             if not await is_port_in_use(port, host=host):
                 _reserved_ports[port] = now + _PORT_RESERVATION_TTL
                 return port
-    msg = f"No free port available in range {range_start}-{range_end}"
+    msg = f"No free port available in range {range_start}-{range_end - 1}"
     raise OSError(msg)
 
 

--- a/music_assistant/helpers/util.py
+++ b/music_assistant/helpers/util.py
@@ -1128,7 +1128,7 @@ async def select_free_port(range_start: int, range_end: int, host: str | None = 
             if not await is_port_in_use(port, host=host):
                 _reserved_ports[port] = now + _PORT_RESERVATION_TTL
                 return port
-    msg = "No free port available"
+    msg = f"No free port available in range {range_start}-{range_end}"
     raise OSError(msg)
 
 

--- a/music_assistant/providers/plex_connect/__init__.py
+++ b/music_assistant/providers/plex_connect/__init__.py
@@ -182,10 +182,15 @@ class PlexConnectProvider(PluginProvider):
         :return: The port to bind this instance's remote control server to.
         """
         configured_port = self.config.get_value(CONF_PORT)
-        if isinstance(configured_port, int) and not await is_port_in_use(configured_port):
+        # Probe on IPv4 all-interfaces, matching how the remote control server binds
+        if isinstance(configured_port, int) and not await is_port_in_use(
+            configured_port, host="0.0.0.0"
+        ):
             return configured_port
 
-        port = await select_free_port(PORT_RANGE_START, PORT_RANGE_START + PORT_RANGE_ATTEMPTS)
+        port = await select_free_port(
+            PORT_RANGE_START, PORT_RANGE_START + PORT_RANGE_ATTEMPTS, host="0.0.0.0"
+        )
         if port != configured_port:
             try:
                 self.mass.config.set_raw_provider_config_value(self.instance_id, CONF_PORT, port)

--- a/music_assistant/providers/plex_connect/__init__.py
+++ b/music_assistant/providers/plex_connect/__init__.py
@@ -11,13 +11,13 @@ Multiple instances can be created to expose multiple MA players to Plex.
 from __future__ import annotations
 
 import asyncio
-import socket
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
 from music_assistant_models.config_entries import ConfigEntry, ConfigValueOption
 from music_assistant_models.enums import ConfigEntryType, EventType, ProviderFeature
 
+from music_assistant.helpers.util import is_port_in_use, select_free_port
 from music_assistant.models.plugin import PluginProvider
 
 from .server import PlayerRemoteInstance
@@ -171,40 +171,7 @@ class PlexConnectProvider(PluginProvider):
             callback()
         self._on_unload_callbacks.clear()
 
-    def _is_port_available(self, port: int) -> bool:
-        """
-        Check if a port is available by attempting to bind to it.
-
-        :param port: Port number to check.
-        :return: True if port is available, False otherwise.
-        """
-        try:
-            # Try to bind to the port on all interfaces
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                sock.bind(("", port))
-                return True
-        except OSError:
-            return False
-
-    def _find_available_port(self) -> int:
-        """
-        Find the first available port in the configured range.
-
-        :return: First available port number.
-        """
-        for port in range(PORT_RANGE_START, PORT_RANGE_START + PORT_RANGE_ATTEMPTS):
-            if self._is_port_available(port):
-                return port
-
-        # Fallback - should rarely happen
-        msg = (
-            f"Could not find available port in range "
-            f"{PORT_RANGE_START}-{PORT_RANGE_START + PORT_RANGE_ATTEMPTS}"
-        )
-        raise RuntimeError(msg)
-
-    def _resolve_port(self) -> int:
+    async def _resolve_port(self) -> int:
         """
         Return the long-term port for this instance, allocating one if needed.
 
@@ -215,10 +182,10 @@ class PlexConnectProvider(PluginProvider):
         :return: The port to bind this instance's remote control server to.
         """
         configured_port = self.config.get_value(CONF_PORT)
-        if isinstance(configured_port, int) and self._is_port_available(configured_port):
+        if isinstance(configured_port, int) and not await is_port_in_use(configured_port):
             return configured_port
 
-        port = self._find_available_port()
+        port = await select_free_port(PORT_RANGE_START, PORT_RANGE_START + PORT_RANGE_ATTEMPTS)
         if port != configured_port:
             try:
                 self.mass.config.set_raw_provider_config_value(self.instance_id, CONF_PORT, port)
@@ -244,7 +211,7 @@ class PlexConnectProvider(PluginProvider):
 
         # Resolve the long-term port for this instance (persisted across restarts)
         if not self._allocated_port:
-            self._allocated_port = self._resolve_port()
+            self._allocated_port = await self._resolve_port()
 
         # Use custom name if provided, otherwise use player's display name
         player_name = self.custom_player_name or player.display_name

--- a/tests/helpers/test_util.py
+++ b/tests/helpers/test_util.py
@@ -85,6 +85,15 @@ class TestSelectFreePort:
             port = await select_free_port(38800, 38900, host="127.0.0.1")
         probe.assert_awaited_once_with(port, host="127.0.0.1")
 
+    @pytest.mark.asyncio
+    async def test_exhausted_range_error_mentions_inclusive_range(self) -> None:
+        """The exhausted-range error names the searched range with an inclusive end."""
+        with (
+            patch("music_assistant.helpers.util.is_port_in_use", return_value=True),
+            pytest.raises(OSError, match=r"38800-38809$"),
+        ):
+            await select_free_port(38800, 38810)
+
 
 class TestIsPortInUse:
     """is_port_in_use can probe the exact address a server will bind."""
@@ -96,6 +105,14 @@ class TestIsPortInUse:
             sock.bind(("127.0.0.1", 0))
             sock.listen(1)
             assert await is_port_in_use(sock.getsockname()[1], host="127.0.0.1")
+
+    @pytest.mark.asyncio
+    async def test_released_loopback_port_is_free(self) -> None:
+        """A port without a listener on the probed address is reported free."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        assert not await is_port_in_use(port, host="127.0.0.1")
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

CodeQL flagged Plex Connect's port probing for binding a socket to all network interfaces (alert #125). The provider reimplemented port availability checks with its own blocking socket code, duplicating existing helpers and doing blocking IO in the async setup path.

- Replace `_is_port_available`/`_find_available_port` with the shared `is_port_in_use` and `select_free_port` helpers from `music_assistant.helpers.util`
- Make `_resolve_port` async, removing blocking socket IO from the async setup path
- Port selection now also benefits from the helper's race-safe port reservations

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/server/security/code-scanning/125

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.