### PR TITLE
Fix broken album artists filtering

### DIFF
--- a/music_assistant/controllers/music/media/artists.py
+++ b/music_assistant/controllers/music/media/artists.py
@@ -144,7 +144,7 @@ class ArtistsController(MediaControllerBase[Artist]):
         extra_query_parts: list[str] = []
         if artist_type:
             extra_query_parts = [f"artist_type = '{artist_type}'"]
-        if album_artists_only and artist_type == ArtistType.SINGER:
+        if album_artists_only and artist_type in (None, ArtistType.SINGER):
             extra_query_parts.append(
                 f"artists.item_id in (select {DB_TABLE_ALBUM_ARTISTS}.artist_id "
                 f"from {DB_TABLE_ALBUM_ARTISTS})"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

https://github.com/music-assistant/server/pull/3570 changed the condition for album artist filtering to add artist_type as a condition. The frontend doesn't send an artist_type when the filter is on thus the filter silently stopped working. This allows for None as a valid artist_type. 

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
