### PR TITLE
Prevent admin token leak to untrusted return_url during first-run setup

### DIFF
--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -18,7 +18,6 @@ from concurrent import futures
 from contextlib import aclosing
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final, cast
-from urllib.parse import quote
 
 import aiofiles
 from aiohttp import web
@@ -48,7 +47,10 @@ from music_assistant.controllers.webserver.helpers.ssl import (
 )
 from music_assistant.helpers.api import parse_arguments
 from music_assistant.helpers.json import json_dumps, json_loads
-from music_assistant.helpers.redirect_validation import is_allowed_redirect_url
+from music_assistant.helpers.redirect_validation import (
+    build_code_redirect_url,
+    is_allowed_redirect_url,
+)
 from music_assistant.helpers.util import format_ip_for_url, get_ip_addresses
 from music_assistant.helpers.webserver import Webserver
 from music_assistant.models.core_controller import CoreController
@@ -799,18 +801,7 @@ class WebserverController(CoreController):
                 if category != "trusted":
                     return web.Response(status=400, text="Invalid return_url")
 
-                # Insert code parameter before any hash fragment
-                code_param = f"code={quote(token, safe='')}"
-                if "#" in return_url:
-                    url_parts = return_url.split("#", 1)
-                    base_part = url_parts[0]
-                    hash_part = url_parts[1]
-                    separator = "&" if "?" in base_part else "?"
-                    redirect_url = f"{base_part}{separator}{code_param}#{hash_part}"
-                elif "?" in return_url:
-                    redirect_url = f"{return_url}&{code_param}"
-                else:
-                    redirect_url = f"{return_url}?{code_param}"
+                redirect_url = build_code_redirect_url(return_url, token)
 
                 response_data["redirect_to"] = redirect_url
                 self.logger.debug(
@@ -981,26 +972,7 @@ class WebserverController(CoreController):
                 elif category == "external":
                     # External domain - require user consent
                     requires_consent = True
-            # Add code parameter to redirect URL (the token URL-encoded)
-            # Important: Insert code BEFORE any hash fragment (e.g., #/) to ensure
-            # it's in query params, not inside the hash where Vue Router can't access it
-            code_param = f"code={quote(token, safe='')}"
-
-            # Split URL by hash to insert code in the right place
-            if "#" in final_redirect_url:
-                # URL has a hash fragment (e.g., http://example.com/#/ or http://example.com/path#section)
-                url_parts = final_redirect_url.split("#", 1)
-                base_url = url_parts[0]
-                hash_part = url_parts[1]
-
-                # Add code to base URL (before hash)
-                separator = "&" if "?" in base_url else "?"
-                final_redirect_url = f"{base_url}{separator}{code_param}#{hash_part}"
-            # No hash fragment, simple case
-            elif "?" in final_redirect_url:
-                final_redirect_url = f"{final_redirect_url}&{code_param}"
-            else:
-                final_redirect_url = f"{final_redirect_url}?{code_param}"
+            final_redirect_url = build_code_redirect_url(final_redirect_url, token)
 
             # Load OAuth callback success page template and inject token and redirect URL
             oauth_callback_html_path = str(RESOURCES_DIR.joinpath("oauth_callback.html"))
@@ -1030,14 +1002,12 @@ class WebserverController(CoreController):
 
     async def _handle_setup_page(self, request: web.Request) -> web.Response:
         """Handle request for first-time setup page."""
-        # Validate return_url if provided
+        # Setup forwards the admin token here with no consent step, so require a trusted destination.
         return_url = request.query.get("return_url")
         if return_url:
-            is_valid, _ = is_allowed_redirect_url(return_url, request, self.base_url)
-            if not is_valid:
+            _, category = is_allowed_redirect_url(return_url, request, self.base_url)
+            if category != "trusted":
                 return web.Response(status=400, text="Invalid return_url")
-        else:
-            return_url = "/"
 
         if self.auth.has_users:
             # this should not happen, but guard anyways
@@ -1102,13 +1072,24 @@ class WebserverController(CoreController):
             self.logger.info("First admin user created: %s", username)
 
             # Return token - frontend will complete onboarding via config/onboard_complete
-            return web.json_response(
-                {
-                    "success": True,
-                    "token": token,
-                    "user": user.to_dict(),
-                }
-            )
+            response_data: dict[str, Any] = {
+                "success": True,
+                "token": token,
+                "user": user.to_dict(),
+            }
+
+            # Only forward the token to a trusted destination (no consent step here).
+            return_url = body.get("return_url")
+            if return_url:
+                _, category = is_allowed_redirect_url(return_url, request, self.base_url)
+                if category == "trusted":
+                    response_data["redirect_to"] = build_code_redirect_url(
+                        return_url, token, {"onboard": "true"}
+                    )
+                else:
+                    self.logger.warning("Ignoring untrusted setup return_url: %s", return_url)
+
+            return web.json_response(response_data)
 
         except Exception as e:
             self.logger.exception("Error during setup")

--- a/music_assistant/controllers/webserver/controller.py
+++ b/music_assistant/controllers/webserver/controller.py
@@ -1080,7 +1080,7 @@ class WebserverController(CoreController):
 
             # Only forward the token to a trusted destination (no consent step here).
             return_url = body.get("return_url")
-            if return_url:
+            if return_url and isinstance(return_url, str):
                 _, category = is_allowed_redirect_url(return_url, request, self.base_url)
                 if category == "trusted":
                     response_data["redirect_to"] = build_code_redirect_url(

--- a/music_assistant/helpers/redirect_validation.py
+++ b/music_assistant/helpers/redirect_validation.py
@@ -124,15 +124,21 @@ def build_code_redirect_url(
     params = f"code={quote(token, safe='')}"
     if extra_params:
         for key, value in extra_params.items():
-            params += f"&{key}={quote(value, safe='')}"
+            params += f"&{quote(key, safe='')}={quote(value, safe='')}"
 
     if "#" in return_url:
         base_part, hash_part = return_url.split("#", 1)
-        separator = "&" if "?" in base_part else "?"
-        return f"{base_part}{separator}{params}#{hash_part}"
+        return f"{_append_query_params(base_part, params)}#{hash_part}"
 
-    separator = "&" if "?" in return_url else "?"
-    return f"{return_url}{separator}{params}"
+    return _append_query_params(return_url, params)
+
+
+def _append_query_params(base: str, params: str) -> str:
+    """Append query params to a URL part, reusing a trailing ? or & separator if present."""
+    if base.endswith(("?", "&")):
+        return f"{base}{params}"
+    separator = "&" if "?" in base else "?"
+    return f"{base}{separator}{params}"
 
 
 def _is_private_ip(hostname: str) -> bool:

--- a/music_assistant/helpers/redirect_validation.py
+++ b/music_assistant/helpers/redirect_validation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ipaddress
 import logging
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from music_assistant.constants import MASS_LOGGER_NAME
 
@@ -104,6 +104,35 @@ def is_allowed_redirect_url(
     except Exception as e:
         LOGGER.exception("Error validating redirect URL: %s", e)
         return False, "blocked"
+
+
+def build_code_redirect_url(
+    return_url: str,
+    token: str,
+    extra_params: dict[str, str] | None = None,
+) -> str:
+    """
+    Build a redirect URL with the auth code appended to the query string.
+
+    The code (and any extra params) are inserted before a possible hash fragment
+    so they end up in the query string rather than inside the fragment.
+
+    :param return_url: The validated destination URL to redirect to.
+    :param token: The auth token to pass along as the ``code`` query parameter.
+    :param extra_params: Optional additional query parameters to append.
+    """
+    params = f"code={quote(token, safe='')}"
+    if extra_params:
+        for key, value in extra_params.items():
+            params += f"&{key}={quote(value, safe='')}"
+
+    if "#" in return_url:
+        base_part, hash_part = return_url.split("#", 1)
+        separator = "&" if "?" in base_part else "?"
+        return f"{base_part}{separator}{params}#{hash_part}"
+
+    separator = "&" if "?" in return_url else "?"
+    return f"{return_url}{separator}{params}"
 
 
 def _is_private_ip(hostname: str) -> bool:

--- a/music_assistant/helpers/resources/setup.html
+++ b/music_assistant/helpers/resources/setup.html
@@ -191,17 +191,6 @@
         const deviceName = urlParams.get('device_name');
         const returnUrl = urlParams.get('return_url');
 
-        function isValidRedirectUrl(url) {
-            if (!url) return false;
-            try {
-                const parsed = new URL(url, window.location.origin);
-                const allowedProtocols = ['http:', 'https:', 'musicassistant:'];
-                return allowedProtocols.includes(parsed.protocol);
-            } catch {
-                return false;
-            }
-        }
-
         function showError(message) {
             const errorMessage = document.getElementById('errorMessage');
             errorMessage.textContent = message;
@@ -213,22 +202,10 @@
             errorMessage.classList.remove('show');
         }
 
-        function redirectWithToken(token) {
-            if (returnUrl && isValidRedirectUrl(returnUrl)) {
-                let finalUrl = returnUrl;
-
-                if (returnUrl.includes('#')) {
-                    const parts = returnUrl.split('#', 2);
-                    const basePart = parts[0];
-                    const hashPart = parts[1];
-                    const separator = basePart.includes('?') ? '&' : '?';
-                    finalUrl = `${basePart}${separator}code=${encodeURIComponent(token)}&onboard=true#${hashPart}`;
-                } else {
-                    const separator = returnUrl.includes('?') ? '&' : '?';
-                    finalUrl = `${returnUrl}${separator}code=${encodeURIComponent(token)}&onboard=true`;
-                }
-
-                window.location.href = finalUrl;
+        function redirectWithToken(token, redirectTo) {
+            // Follow the server-provided target; fall back to a local redirect otherwise.
+            if (redirectTo) {
+                window.location.href = redirectTo;
             } else {
                 window.location.href = `./?code=${encodeURIComponent(token)}&onboard=true`;
             }
@@ -271,6 +248,10 @@
                     requestBody.device_name = deviceName;
                 }
 
+                if (returnUrl) {
+                    requestBody.return_url = returnUrl;
+                }
+
                 const response = await fetch('setup', {
                     method: 'POST',
                     headers: {
@@ -282,7 +263,7 @@
                 const data = await response.json();
 
                 if (response.ok && data.success) {
-                    redirectWithToken(data.token);
+                    redirectWithToken(data.token, data.redirect_to);
                 } else {
                     submitBtn.disabled = false;
                     submitBtn.textContent = 'Create Account';

--- a/tests/helpers/test_redirect_validation.py
+++ b/tests/helpers/test_redirect_validation.py
@@ -1,0 +1,53 @@
+"""Tests for redirect URL validation and auth-code redirect building."""
+
+from __future__ import annotations
+
+from music_assistant.helpers.redirect_validation import build_code_redirect_url
+
+
+def test_build_code_redirect_url_plain() -> None:
+    """A code query param is appended to a URL without an existing query or fragment."""
+    assert (
+        build_code_redirect_url("https://example.com/cb", "tok")
+        == "https://example.com/cb?code=tok"
+    )
+
+
+def test_build_code_redirect_url_existing_query() -> None:
+    """The code param is joined with & when the URL already has a query string."""
+    assert (
+        build_code_redirect_url("https://example.com/cb?foo=bar", "tok")
+        == "https://example.com/cb?foo=bar&code=tok"
+    )
+
+
+def test_build_code_redirect_url_inserts_before_fragment() -> None:
+    """The code param lands in the query string, before any hash fragment."""
+    assert (
+        build_code_redirect_url("https://example.com/#/onboard", "tok")
+        == "https://example.com/?code=tok#/onboard"
+    )
+
+
+def test_build_code_redirect_url_fragment_with_existing_query() -> None:
+    """A URL with both query and fragment keeps the code param in the query part."""
+    assert (
+        build_code_redirect_url("https://example.com/?a=1#/x", "tok")
+        == "https://example.com/?a=1&code=tok#/x"
+    )
+
+
+def test_build_code_redirect_url_extra_params() -> None:
+    """Extra params are appended after the code param."""
+    assert (
+        build_code_redirect_url("https://example.com/cb", "tok", {"onboard": "true"})
+        == "https://example.com/cb?code=tok&onboard=true"
+    )
+
+
+def test_build_code_redirect_url_encodes_token() -> None:
+    """Reserved characters in the token are URL-encoded."""
+    assert (
+        build_code_redirect_url("https://example.com/cb", "a b/c")
+        == "https://example.com/cb?code=a%20b%2Fc"
+    )

--- a/tests/helpers/test_redirect_validation.py
+++ b/tests/helpers/test_redirect_validation.py
@@ -38,10 +38,26 @@ def test_build_code_redirect_url_fragment_with_existing_query() -> None:
 
 
 def test_build_code_redirect_url_extra_params() -> None:
-    """Extra params are appended after the code param."""
+    """Extra params are appended after the code param, with keys and values URL-encoded."""
     assert (
         build_code_redirect_url("https://example.com/cb", "tok", {"onboard": "true"})
         == "https://example.com/cb?code=tok&onboard=true"
+    )
+    assert (
+        build_code_redirect_url("https://example.com/cb", "tok", {"a key": "a value"})
+        == "https://example.com/cb?code=tok&a%20key=a%20value"
+    )
+
+
+def test_build_code_redirect_url_trailing_separator() -> None:
+    """A trailing ? or & in the URL is reused instead of adding another separator."""
+    assert (
+        build_code_redirect_url("https://example.com/cb?", "tok")
+        == "https://example.com/cb?code=tok"
+    )
+    assert (
+        build_code_redirect_url("https://example.com/cb?foo=bar&", "tok")
+        == "https://example.com/cb?foo=bar&code=tok"
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

Harden the first-run setup flow against leaking the admin access token to an untrusted `return_url`.

After creating the initial admin account, `setup.html` appended the token to whatever `return_url` was in the query string, validating only the URL *scheme* and not the host. A crafted setup link (`/setup?return_url=http://external-host/…`) could therefore redirect the browser to an external origin with `code=<admin token>` in the URL.

The setup flow did its token forwarding client-side, so the earlier login hardening (#4272) did not cover it. This makes the server authoritative over the redirect target — the same pattern as login — so the token is only ever forwarded to trusted destinations.

**Related issue (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

### Changes

- `setup.html`: drop the scheme-only client-side validation and client-built redirect; send `return_url` in the POST body and follow the server-provided `redirect_to` (local fallback otherwise).
- `_handle_setup` (POST): only build a `redirect_to` for `trusted` destinations; untrusted values are ignored.
- `_handle_setup_page` (GET): reject non-`trusted` `return_url` (was accepting `external`).
- Add `build_code_redirect_url` helper and reuse it in login and the OAuth callback (removes three copies of the code-insertion logic).
- Add unit tests for the helper.

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.