### PR TITLE
Fix several bugs in the Jellyfin provider

### DIFF
--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -24,7 +24,7 @@ from music_assistant_models.media_items import (
 )
 from music_assistant_models.streamdetails import StreamDetails
 
-from music_assistant.constants import UNKNOWN_ARTIST_ID_MBID
+from music_assistant.constants import UNKNOWN_ARTIST, UNKNOWN_ARTIST_ID_MBID
 from music_assistant.controllers.cache import use_cache
 from music_assistant.mass import MusicAssistant
 from music_assistant.models import ProviderInstanceType
@@ -40,14 +40,17 @@ from music_assistant.providers.jellyfin.parsers import (
 from .const import (
     ALBUM_FIELDS,
     ARTIST_FIELDS,
+    COLLECTION_TYPE_MUSIC,
+    COLLECTION_TYPE_PLAYLISTS,
     ITEM_KEY_COLLECTION_TYPE,
     ITEM_KEY_ID,
     ITEM_KEY_MEDIA_STREAMS,
+    ITEM_KEY_MEDIA_TYPE,
     ITEM_KEY_NAME,
     ITEM_KEY_RUNTIME_TICKS,
+    MEDIA_TYPE_AUDIO,
     SUPPORTED_CONTAINER_FORMATS,
     TRACK_FIELDS,
-    UNKNOWN_ARTIST_MAPPING,
     USER_APP_NAME,
 )
 
@@ -157,7 +160,7 @@ class JellyfinProvider(MusicProvider):
             self._client = await authenticate_by_name(
                 session_config,
                 username,
-                str(self.config.get_value(CONF_PASSWORD)),
+                str(self.config.get_value(CONF_PASSWORD) or ""),
             )
         except Exception as err:
             raise LoginFailed(f"Authentication failed: {err}") from err
@@ -181,11 +184,8 @@ class JellyfinProvider(MusicProvider):
         return tracks
 
     async def _search_album(self, search_query: str, limit: int) -> list[Album]:
-        if "-" in search_query:
-            searchterms = search_query.split(" - ")
-            albumname = searchterms[1]
-        else:
-            albumname = search_query
+        # an "Artist - Album" style query: search on the album part only
+        albumname = search_query.split(" - ", 1)[1] if " - " in search_query else search_query
         resultset = (
             await self._client.albums.search_term(albumname)
             .limit(limit)
@@ -319,8 +319,8 @@ class JellyfinProvider(MusicProvider):
                 .stream(100)
             )
             async for playlist in stream:
-                if "MediaType" in playlist:  # Only jellyfin has this property
-                    if playlist["MediaType"] == "Audio":
+                if ITEM_KEY_MEDIA_TYPE in playlist:  # Only jellyfin has this property
+                    if playlist[ITEM_KEY_MEDIA_TYPE] == MEDIA_TYPE_AUDIO:
                         yield parse_playlist(self.instance_id, self._client, playlist)
                 else:  # emby playlists are only audio type
                     yield parse_playlist(self.instance_id, self._client, playlist)
@@ -350,14 +350,14 @@ class JellyfinProvider(MusicProvider):
     @use_cache(60 * 15)  # Cache for 15 minutes
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """Get full artist details by id."""
-        if prov_artist_id == UNKNOWN_ARTIST_MAPPING.item_id:
+        if prov_artist_id == UNKNOWN_ARTIST:
             artist = Artist(
-                item_id=UNKNOWN_ARTIST_MAPPING.item_id,
-                name=UNKNOWN_ARTIST_MAPPING.name,
+                item_id=UNKNOWN_ARTIST,
+                name=UNKNOWN_ARTIST,
                 provider=self.instance_id,
                 provider_mappings={
                     ProviderMapping(
-                        item_id=UNKNOWN_ARTIST_MAPPING.item_id,
+                        item_id=UNKNOWN_ARTIST,
                         provider_domain=self.domain,
                         provider_instance=self.instance_id,
                     )
@@ -432,18 +432,22 @@ class JellyfinProvider(MusicProvider):
 
     async def get_stream_details(self, item_id: str, media_type: MediaType) -> StreamDetails:
         """Return the content details for the given track when it will be streamed."""
-        jellyfin_track = await self._client.get_track(item_id)
+        try:
+            jellyfin_track = await self._client.get_track(item_id)
+        except NotFound:
+            raise MediaNotFoundError(f"Item {item_id} not found")
         url = self._client.audio_url(
             jellyfin_track[ITEM_KEY_ID], container=SUPPORTED_CONTAINER_FORMATS
         )
+        runtime_ticks = jellyfin_track.get(ITEM_KEY_RUNTIME_TICKS)
         return StreamDetails(
             item_id=jellyfin_track[ITEM_KEY_ID],
             provider=self.instance_id,
             audio_format=audio_format(jellyfin_track),
             stream_type=StreamType.HTTP,
-            duration=int(
-                jellyfin_track[ITEM_KEY_RUNTIME_TICKS] / 10000000
-            ),  # 10000000 ticks per millisecond)
+            duration=int(runtime_ticks / 10000000)  # 10000000 ticks per second
+            if runtime_ticks
+            else None,
             path=url,
             can_seek=True,
             allow_seek=True,
@@ -466,7 +470,7 @@ class JellyfinProvider(MusicProvider):
         libraries = response["Items"]
         result = []
         for library in libraries:
-            if ITEM_KEY_COLLECTION_TYPE in library and library[ITEM_KEY_COLLECTION_TYPE] in "music":
+            if library.get(ITEM_KEY_COLLECTION_TYPE) == COLLECTION_TYPE_MUSIC:
                 result.append(library)
         return result
 
@@ -476,9 +480,6 @@ class JellyfinProvider(MusicProvider):
         libraries = response["Items"]
         result = []
         for library in libraries:
-            if (
-                ITEM_KEY_COLLECTION_TYPE in library
-                and library[ITEM_KEY_COLLECTION_TYPE] in "playlists"
-            ):
+            if library.get(ITEM_KEY_COLLECTION_TYPE) == COLLECTION_TYPE_PLAYLISTS:
                 result.append(library)
         return result

--- a/music_assistant/providers/jellyfin/__init__.py
+++ b/music_assistant/providers/jellyfin/__init__.py
@@ -445,9 +445,11 @@ class JellyfinProvider(MusicProvider):
             provider=self.instance_id,
             audio_format=audio_format(jellyfin_track),
             stream_type=StreamType.HTTP,
-            duration=int(runtime_ticks / 10000000)  # 10000000 ticks per second
-            if runtime_ticks
-            else None,
+            duration=(
+                int(runtime_ticks / 10000000)  # 10000000 ticks per second
+                if runtime_ticks is not None
+                else None
+            ),
             path=url,
             can_seek=True,
             allow_seek=True,

--- a/music_assistant/providers/jellyfin/const.py
+++ b/music_assistant/providers/jellyfin/const.py
@@ -4,20 +4,12 @@ from typing import Final
 
 from aiojellyfin import ImageType as JellyImageType
 from aiojellyfin import ItemFields
-from music_assistant_models.enums import ImageType, MediaType
-from music_assistant_models.media_items import ItemMapping
-
-from music_assistant.constants import UNKNOWN_ARTIST
+from music_assistant_models.enums import ImageType
 
 DOMAIN: Final = "jellyfin"
 
-COLLECTION_TYPE_MOVIES: Final = "movies"
 COLLECTION_TYPE_MUSIC: Final = "music"
-COLLECTION_TYPE_TVSHOWS: Final = "tvshows"
-
-CONF_CLIENT_DEVICE_ID: Final = "client_device_id"
-
-DEFAULT_NAME: Final = "Jellyfin"
+COLLECTION_TYPE_PLAYLISTS: Final = "playlists"
 
 ITEM_KEY_COLLECTION_TYPE: Final = "CollectionType"
 ITEM_KEY_ID: Final = "Id"
@@ -49,24 +41,11 @@ ITEM_KEY_PARENT_INDEX_NUM: Final = "ParentIndexNumber"
 ITEM_KEY_RUNTIME_TICKS: Final = "RunTimeTicks"
 ITEM_KEY_USER_DATA: Final = "UserData"
 
-ITEM_TYPE_AUDIO: Final = "Audio"
-ITEM_TYPE_LIBRARY: Final = "CollectionFolder"
-
 USER_DATA_KEY_IS_FAVORITE: Final = "IsFavorite"
 
-MAX_IMAGE_WIDTH: Final = 500
-MAX_STREAMING_BITRATE: Final = "140000000"
-
-MEDIA_SOURCE_KEY_PATH: Final = "Path"
-
 MEDIA_TYPE_AUDIO: Final = "Audio"
-MEDIA_TYPE_NONE: Final = ""
-
-SUPPORTED_COLLECTION_TYPES: Final = [COLLECTION_TYPE_MUSIC]
 
 SUPPORTED_CONTAINER_FORMATS: Final = "ogg,flac,mp3,aac,mpeg,alac,wav,aiff,wma,m4a,m4b,dsf,opus,wv"
-
-PLAYABLE_ITEM_TYPES: Final = [ITEM_TYPE_AUDIO]
 
 ARTIST_FIELDS: Final = [
     ItemFields.Overview,
@@ -87,11 +66,6 @@ TRACK_FIELDS: Final = [
 ]
 
 USER_APP_NAME: Final = "Music Assistant"
-USER_AGENT: Final = "Music-Assistant-1.0"
-
-UNKNOWN_ARTIST_MAPPING: Final = ItemMapping(
-    media_type=MediaType.ARTIST, item_id=UNKNOWN_ARTIST, provider=DOMAIN, name=UNKNOWN_ARTIST
-)
 
 MEDIA_IMAGE_TYPES: Final = {
     JellyImageType.Primary: ImageType.THUMB,

--- a/music_assistant/providers/jellyfin/parsers.py
+++ b/music_assistant/providers/jellyfin/parsers.py
@@ -21,6 +21,7 @@ from music_assistant_models.media_items import (
     UniqueList,
 )
 
+from music_assistant.constants import UNKNOWN_ARTIST
 from music_assistant.helpers.util import parse_title_and_version
 
 from .const import (
@@ -34,6 +35,7 @@ from .const import (
     ITEM_KEY_CONTAINER,
     ITEM_KEY_ID,
     ITEM_KEY_IMAGE_TAGS,
+    ITEM_KEY_INDEX_NUMBER,
     ITEM_KEY_MEDIA_CHANNELS,
     ITEM_KEY_MEDIA_CODEC,
     ITEM_KEY_MEDIA_SOURCES,
@@ -52,7 +54,6 @@ from .const import (
     ITEM_KEY_SORT_NAME,
     ITEM_KEY_USER_DATA,
     MEDIA_IMAGE_TYPES,
-    UNKNOWN_ARTIST_MAPPING,
     USER_DATA_KEY_IS_FAVORITE,
 )
 
@@ -73,7 +74,7 @@ def parse_album(
     name, version = parse_title_and_version(jellyfin_album[ITEM_KEY_NAME])
     album = Album(
         item_id=album_id,
-        provider=DOMAIN,
+        provider=instance_id,
         name=name,
         version=version,
         provider_mappings={
@@ -136,7 +137,7 @@ def parse_album(
                 )
             )
     else:
-        album.artists.append(UNKNOWN_ARTIST_MAPPING)
+        album.artists.append(_unknown_artist_mapping(instance_id))
 
     user_data = jellyfin_album.get(ITEM_KEY_USER_DATA, {})
     album.favorite = user_data.get(USER_DATA_KEY_IS_FAVORITE, False)
@@ -151,7 +152,7 @@ def parse_artist(
     artist = Artist(
         item_id=artist_id,
         name=jellyfin_artist[ITEM_KEY_NAME],
-        provider=DOMAIN,
+        provider=instance_id,
         provider_mappings={
             ProviderMapping(
                 item_id=str(artist_id),
@@ -227,7 +228,7 @@ def parse_track(
     )
 
     track.disc_number = jellyfin_track.get(ITEM_KEY_PARENT_INDEX_NUM, 0)
-    track.track_number = jellyfin_track.get("IndexNumber", 0)
+    track.track_number = jellyfin_track.get(ITEM_KEY_INDEX_NUMBER, 0)
     if track.track_number is not None and track.track_number >= 0:
         track.position = track.track_number
 
@@ -244,7 +245,7 @@ def parse_track(
                 )
             )
     else:
-        track.artists.append(UNKNOWN_ARTIST_MAPPING)
+        track.artists.append(_unknown_artist_mapping(instance_id))
 
     if ITEM_KEY_ALBUM_ID in jellyfin_track:
         if not (album_name := jellyfin_track.get(ITEM_KEY_ALBUM)):
@@ -260,7 +261,7 @@ def parse_track(
     if ITEM_KEY_RUNTIME_TICKS in jellyfin_track:
         track.duration = int(
             jellyfin_track[ITEM_KEY_RUNTIME_TICKS] / 10000000
-        )  # 10000000 ticks per millisecond
+        )  # 10000000 ticks per second
     if ITEM_KEY_MUSICBRAINZ_TRACK in jellyfin_track[ITEM_KEY_PROVIDER_IDS]:
         track_mbid = jellyfin_track[ITEM_KEY_PROVIDER_IDS][ITEM_KEY_MUSICBRAINZ_TRACK]
         try:
@@ -283,7 +284,7 @@ def parse_playlist(
     playlistid = jellyfin_playlist[ITEM_KEY_ID]
     playlist = Playlist(
         item_id=playlistid,
-        provider=DOMAIN,
+        provider=instance_id,
         name=jellyfin_playlist[ITEM_KEY_NAME],
         provider_mappings={
             ProviderMapping(
@@ -300,6 +301,15 @@ def parse_playlist(
     playlist.favorite = user_data.get(USER_DATA_KEY_IS_FAVORITE, False)
     playlist.is_editable = False
     return playlist
+
+
+def _unknown_artist_mapping(instance_id: str) -> ItemMapping:
+    return ItemMapping(
+        media_type=MediaType.ARTIST,
+        item_id=UNKNOWN_ARTIST,
+        provider=instance_id,
+        name=UNKNOWN_ARTIST,
+    )
 
 
 def _get_artwork(

--- a/tests/providers/jellyfin/__snapshots__/test_parsers.ambr
+++ b/tests/providers/jellyfin/__snapshots__/test_parsers.ambr
@@ -69,7 +69,7 @@
     }),
     'name': 'Infest',
     'position': None,
-    'provider': 'jellyfin',
+    'provider': 'xx-instance-id-xx',
     'provider_mappings': list([
       dict({
         'audio_format': dict({
@@ -92,7 +92,7 @@
       }),
     ]),
     'sort_name': 'infest',
-    'uri': 'jellyfin://album/70b7288088b42d318f75dbcc41fd0091',
+    'uri': 'xx-instance-id-xx://album/70b7288088b42d318f75dbcc41fd0091',
     'version': '',
     'year': 2000,
   })
@@ -167,7 +167,7 @@
     }),
     'name': 'Nu-Clear Sounds',
     'position': None,
-    'provider': 'jellyfin',
+    'provider': 'xx-instance-id-xx',
     'provider_mappings': list([
       dict({
         'audio_format': dict({
@@ -190,7 +190,7 @@
       }),
     ]),
     'sort_name': 'nu-clear sounds',
-    'uri': 'jellyfin://album/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+    'uri': 'xx-instance-id-xx://album/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
     'version': '',
     'year': 1998,
   })
@@ -265,7 +265,7 @@
     }),
     'name': 'This Is Christmas',
     'position': None,
-    'provider': 'jellyfin',
+    'provider': 'xx-instance-id-xx',
     'provider_mappings': list([
       dict({
         'audio_format': dict({
@@ -288,7 +288,7 @@
       }),
     ]),
     'sort_name': 'this is christmas',
-    'uri': 'jellyfin://album/32ed6a0091733dcff57eae67010f3d4b',
+    'uri': 'xx-instance-id-xx://album/32ed6a0091733dcff57eae67010f3d4b',
     'version': '',
     'year': 2011,
   })
@@ -306,10 +306,10 @@
         'item_id': '[unknown]',
         'media_type': 'artist',
         'name': '[unknown]',
-        'provider': 'jellyfin',
+        'provider': 'xx-instance-id-xx',
         'sort_name': 'unknown]',
         'translation_key': None,
-        'uri': 'jellyfin://artist/[unknown]',
+        'uri': 'xx-instance-id-xx://artist/[unknown]',
         'version': '',
         'year': None,
       }),
@@ -348,7 +348,7 @@
     }),
     'name': 'Yesterday, When I Was Mad [Disc 2]',
     'position': None,
-    'provider': 'jellyfin',
+    'provider': 'xx-instance-id-xx',
     'provider_mappings': list([
       dict({
         'audio_format': dict({
@@ -371,7 +371,7 @@
       }),
     ]),
     'sort_name': 'yesterday when i was mad [disc 0000000002]',
-    'uri': 'jellyfin://album/7c8d0bd55291c7fc0451d17ebef30017',
+    'uri': 'xx-instance-id-xx://album/7c8d0bd55291c7fc0451d17ebef30017',
     'version': '',
     'year': None,
   })
@@ -438,7 +438,7 @@
     }),
     'name': 'Ash',
     'position': None,
-    'provider': 'jellyfin',
+    'provider': 'xx-instance-id-xx',
     'provider_mappings': list([
       dict({
         'audio_format': dict({
@@ -461,7 +461,7 @@
       }),
     ]),
     'sort_name': 'ash',
-    'uri': 'jellyfin://artist/dd954bbf54398e247d803186d3585b79',
+    'uri': 'xx-instance-id-xx://artist/dd954bbf54398e247d803186d3585b79',
     'version': '',
   })
 # ---
@@ -602,10 +602,10 @@
         'item_id': '[unknown]',
         'media_type': 'artist',
         'name': '[unknown]',
-        'provider': 'jellyfin',
+        'provider': 'xx-instance-id-xx',
         'sort_name': 'unknown]',
         'translation_key': None,
-        'uri': 'jellyfin://artist/[unknown]',
+        'uri': 'xx-instance-id-xx://artist/[unknown]',
         'version': '',
         'year': None,
       }),


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Had Claude do a health check on the Jellyfin provider since it is unmaintained.

This is a batch of small fixes:

- Searching for anything with a hyphen in it (like "AC-DC") crashed the album search, which took the whole Jellyfin search down with it.
- Starting playback of a track that was deleted from the server, or that has no duration metadata, crashed instead of failing gracefully.
- Logging in with a passwordless Jellyfin account never worked, because the literal text "None" was sent as the password. An empty password is now sent correctly.
- With two Jellyfin servers configured, albums, artists and playlists could resolve to the wrong server (tracks were already correct). All item types are now tied to the specific server instance they came from.
- The checks that pick which Jellyfin libraries to sync used accidental substring matching instead of exact comparison. Fixed.
- Cleaned up a pile of unused constants and corrected two misleading comments.

No database changes, no config changes, existing installs keep working as-is. All provider tests pass (snapshots updated for the instance-id change).

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [ ] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
