### PR TITLE
Fix Plex artist albums not loading on servers without filter metadata

### DIFF
--- a/music_assistant/providers/plex/__init__.py
+++ b/music_assistant/providers/plex/__init__.py
@@ -1156,7 +1156,18 @@ class PlexProvider(MusicProvider):
         """Get a list of albums for the given artist."""
         if not prov_artist_id.startswith(FAKE_ARTIST_PREFIX):
             plex_artist = await self._get_data(prov_artist_id, PlexArtist)
-            plex_albums = cast("list[PlexAlbum]", await self._run_async(plex_artist.albums))
+            try:
+                plex_albums = cast("list[PlexAlbum]", await self._run_async(plex_artist.albums))
+            except plexapi.exceptions.NotFound:
+                # PlexArtist.albums() relies on Plex's advanced filters API.
+                # Some Plex servers return no filtering metadata, making plexapi
+                # raise 'Unknown libtype "artist"'. Fall back to the artist's
+                # /children endpoint, which does not depend on the filters API.
+                albums_key = f"{plex_artist.key}/children"
+                plex_albums = cast(
+                    "list[PlexAlbum]",
+                    await self._run_async(plex_artist.fetchItems, albums_key, PlexAlbum),
+                )
             if plex_albums:
                 albums = []
                 for album_obj in plex_albums:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

`PlexArtist.albums()` searches albums filtered by `artist.id`, which relies on Plex's advanced filters API. Some Plex servers return no filtering metadata, causing plexapi to raise `Unknown libtype "artist" for this library. Available libtypes: []`, so an artist's album list never loads in the UI (and artist metadata refreshes fail too). The trigger for the empty filter metadata is unconfirmed (seen across different Plex server versions), but any empty filter-metadata response breaks the whole artist→albums path.

Keep `PlexArtist.albums()` as the primary path and fall back to the artist's `/children` endpoint, which does not depend on the filters API, when that error occurs. Servers with healthy filter metadata are unaffected.

Testing was done by the affected user and reported successful in the issue conversation.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/support/issues/4669

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [X] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
