### PR TITLE
Update aiodns to 4.0.4 and remove pycares pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "aiodns>=3.2.0", # Pin pycares to 4.11.0 until aiodns is updated to support pycares 5.0 API changes  # pycares 5.0.0 (released 2025-12-10) has breaking changes incompatible with current aiodns
-  "pycares==4.11.0",
+  "aiodns>=4.0.4",
   "aiohttp_asyncmdnsresolver==0.2.0",
   "Brotli>=1.0.9",
   "aiohttp==3.14.1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,7 +4,7 @@
 
 Brotli>=1.0.9
 aioaudiobookshelf==0.1.22
-aiodns>=3.2.0
+aiodns>=4.0.4
 aiofiles==24.1.0
 aiohttp==3.14.1
 aiohttp_asyncmdnsresolver==0.2.0
@@ -65,7 +65,6 @@ py-opensonic==10.1.0
 pyacoustid==1.3.0
 pyamplipi==0.4.12
 pyblu==2.0.8
-pycares==4.11.0
 PyChromecast==14.0.10
 pycryptodome==3.23.0
 pyheos==1.0.6


### PR DESCRIPTION
# What does this implement/fix?

aiodns was held back at `>=3.2.0` with pycares pinned to `4.11.0`, because pycares 5.0 introduced breaking API changes that aiodns didn't support yet. aiodns 4.0.4 now supports pycares 5.x, so the workaround is no longer needed.

- Bump `aiodns` to `>=4.0.4` (requires pycares `>=5.0.0,<6`)
- Remove the `pycares==4.11.0` pin
- Regenerate `requirements_all.txt`

Verified locally with a fresh server start (aiodns 4.0.4 + pycares 5.0.1): clean startup, DNS resolution working.

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.