### PR TITLE
Add fixed genres to Phish.in tracks

### DIFF
--- a/music_assistant/providers/phishin/constants.py
+++ b/music_assistant/providers/phishin/constants.py
@@ -18,6 +18,8 @@ PHISH_ARTIST_ID: Final[str] = "phish"
 PHISH_MUSICBRAINZ_ID: Final[str] = "e01646f2-2a04-450d-8bf2-0d993082e058"
 PHISH_DISCOGS_ID: Final[str] = "252354"
 PHISH_TADB_ID: Final[str] = "112677"
+# The API serves a single artist and exposes no genre info, so use fixed genres
+PHISH_GENRES: Final[frozenset[str]] = frozenset({"Jam Band", "Progressive Rock", "Funk Rock"})
 
 # Fallback image for albums without artwork
 FALLBACK_ALBUM_IMAGE: Final[str] = (

--- a/music_assistant/providers/phishin/helpers.py
+++ b/music_assistant/providers/phishin/helpers.py
@@ -28,6 +28,7 @@ from .constants import (
     PHISH_ARTIST_ID,
     PHISH_ARTIST_NAME,
     PHISH_DISCOGS_ID,
+    PHISH_GENRES,
     PHISH_MUSICBRAINZ_ID,
     PHISH_TADB_ID,
     REQUEST_TIMEOUT,
@@ -286,23 +287,19 @@ def track_to_ma_track(
     # Build details string
     details = _build_track_details(track_data, song_data, show_date, set_name, venue_name)
 
-    # Create metadata with image
-    metadata = MediaItemMetadata()
-    if show_data:
-        image_url = show_data.get("album_cover_url")
-        if image_url:
-            metadata = MediaItemMetadata(
-                images=UniqueList(
-                    [
-                        MediaItemImage(
-                            type=ImageType.THUMB,
-                            path=image_url,
-                            provider=provider.instance_id,
-                            remotely_accessible=True,
-                        )
-                    ]
+    # Create metadata with genres and image
+    metadata = MediaItemMetadata(genres=set(PHISH_GENRES))
+    if show_data and (image_url := show_data.get("album_cover_url")):
+        metadata.images = UniqueList(
+            [
+                MediaItemImage(
+                    type=ImageType.THUMB,
+                    path=image_url,
+                    provider=provider.instance_id,
+                    remotely_accessible=True,
                 )
-            )
+            ]
+        )
 
     return Track(
         item_id=track_id,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The Phish.in API exposes no genre information, so tracks from the provider end up without any genres in the library. Attach a fixed set of genres (Jam Band, Progressive Rock, Funk Rock) to all tracks, as the catalog is a single artist.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [X] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [X] The code change is tested and works locally.
- [X] `pre-commit run --all-files` passes.
- [X] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [X] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.
