### PR TITLE
Block long-lived token creation for guest accounts

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1023,6 +1023,8 @@ class AuthenticationManager:
         Short-lived tokens (for regular user sessions) are only created during login
         and auto-renew on each use (sliding 30-day expiration window).
 
+        Long-lived tokens cannot be created for guest accounts.
+
         :param name: The name/description for the token (e.g., "Home Assistant", "Mobile App").
         :param user_id: Optional user ID to create token for (admin only).
         :return: The created token string.
@@ -1043,6 +1045,10 @@ class AuthenticationManager:
                 raise InvalidDataError("User not found")
         else:
             target_user = current_user
+
+        # Guest access is temporary by design, deny tokens that would outlive it
+        if target_user.role == UserRole.GUEST:
+            raise InsufficientPermissions("Long-lived tokens cannot be created for guest accounts")
 
         # Create a long-lived token (only long-lived tokens can be created via this command)
         token = await self.create_token(target_user, name, is_long_lived=True)

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -993,6 +993,33 @@ async def test_guest_token_fixed_short_lifetime(auth_manager: AuthenticationMana
     assert updated_row["expires_at"] == token_row["expires_at"]
 
 
+async def test_guest_cannot_create_long_lived_token(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that a guest cannot create a long-lived token for their own account.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    guest = await auth_manager.create_user(username="guesttoken", role=UserRole.GUEST)
+    set_current_user(guest)
+
+    with pytest.raises(InsufficientPermissions):
+        await auth_manager.create_long_lived_token("Guest Escalation")
+
+
+async def test_no_long_lived_token_for_guest_account(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that a long-lived token cannot be created for a guest account, even by an admin.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    admin = await auth_manager.create_user(username="tokenadmin", role=UserRole.ADMIN)
+    guest = await auth_manager.create_user(username="guesttarget", role=UserRole.GUEST)
+    set_current_user(admin)
+
+    with pytest.raises(InsufficientPermissions):
+        await auth_manager.create_long_lived_token("Guest Token", user_id=guest.user_id)
+
+
 async def test_username_case_insensitive_creation(auth_manager: AuthenticationManager) -> None:
     """
     Test that usernames are normalized to lowercase on creation.


### PR DESCRIPTION
# What does this implement/fix?

Guest access is temporary by design: a join code yields a short-lived guest token with a fixed 1-day lifetime and no renewal. However, `auth/token/create` had no role/scope restriction, so a guest could use that short-lived token to mint a 1-year long-lived token for their own account, defeating the temporary nature of guest access (remaining gap from security finding 3.1, follow-up to #4613).

- `auth/token/create` now rejects long-lived token creation when the target account has the guest role (covers both a guest creating one for themselves and an admin creating one for a guest account)
- added tests for both cases

**Related issue (if applicable):**

- related issue N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.