### PR TITLE
Harden MSX bridge against host-header XSS and cross-origin fetches

### DIFF
--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -279,8 +279,7 @@ class MSXHTTPServer:
         sendspin_port = "8927"
         sendspin_url = f"http://{hostname}:{sendspin_port}"
         kiosk_html5_url = f"{base}/web?kiosk=1"
-        # compose from the raw prefix and escape the full URL so the host-derived
-        # value is HTML-escaped as a whole (including the & separators)
+        # escape the composed URL as a whole: host-derived prefix plus & separators
         sendspin_query = f"sendspin=1&sendspin_url={quote(sendspin_url, safe='')}"
         sendspin_web_url = html_escape(f"{prefix}/web?{sendspin_query}")
         sendspin_kiosk_url = html_escape(f"{prefix}/web?kiosk=1&{sendspin_query}")

--- a/music_assistant/providers/msx_bridge/http_server.py
+++ b/music_assistant/providers/msx_bridge/http_server.py
@@ -257,7 +257,8 @@ class MSXHTTPServer:
         """Serve status dashboard."""
         players = self.provider.players
         # base is derived from the Host header, so escape it before embedding in HTML
-        base = html_escape(self._get_prefix(request))
+        prefix = self._get_prefix(request)
+        base = html_escape(prefix)
         player_rows = []
         for p in players:
             row = (
@@ -278,10 +279,11 @@ class MSXHTTPServer:
         sendspin_port = "8927"
         sendspin_url = f"http://{hostname}:{sendspin_port}"
         kiosk_html5_url = f"{base}/web?kiosk=1"
-        sendspin_web_url = f"{base}/web?sendspin=1&sendspin_url={quote(sendspin_url, safe='')}"
-        sendspin_kiosk_url = (
-            f"{base}/web?kiosk=1&sendspin=1&sendspin_url={quote(sendspin_url, safe='')}"
-        )
+        # compose from the raw prefix and escape the full URL so the host-derived
+        # value is HTML-escaped as a whole (including the & separators)
+        sendspin_query = f"sendspin=1&sendspin_url={quote(sendspin_url, safe='')}"
+        sendspin_web_url = html_escape(f"{prefix}/web?{sendspin_query}")
+        sendspin_kiosk_url = html_escape(f"{prefix}/web?kiosk=1&{sendspin_query}")
 
         html = f"""<!DOCTYPE html>
 <html>

--- a/music_assistant/providers/msx_bridge/static/web/web.js
+++ b/music_assistant/providers/msx_bridge/static/web/web.js
@@ -131,8 +131,7 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
             try {
                 var parsed = new URL(url);
                 if (parsed.host !== location.host) return '';
-                // Rebuild from parsed parts so the request host is always ours,
-                // even for tricky inputs like a "//evil.com/x" pathname.
+                // rebuild from parsed parts so a "//evil.com/x" pathname can't change the host
                 return BASE + parsed.pathname + parsed.search;
             } catch (e) {
                 return '';

--- a/music_assistant/providers/msx_bridge/static/web/web.js
+++ b/music_assistant/providers/msx_bridge/static/web/web.js
@@ -129,7 +129,11 @@ const SENDSPIN_URL_PARAM = urlParams.get('sendspin_url') || '';
         if (!url) return '';
         if (isHttpUrl(url)) {
             try {
-                return new URL(url).host === location.host ? url : '';
+                var parsed = new URL(url);
+                if (parsed.host !== location.host) return '';
+                // Rebuild from parsed parts so the request host is always ours,
+                // even for tricky inputs like a "//evil.com/x" pathname.
+                return BASE + parsed.pathname + parsed.search;
             } catch (e) {
                 return '';
             }

--- a/tests/providers/msx_bridge/test_http_server.py
+++ b/tests/providers/msx_bridge/test_http_server.py
@@ -47,6 +47,17 @@ async def test_root_html_escapes_host_header(http_client: TestClient[Any, Any]) 
     assert resp.status == 200
     body = await resp.text()
     assert "<script>alert(1)</script>" not in body
+    # the quote must be escaped so the host can't break out of href attributes
+    assert 'evil">' not in body
+
+
+async def test_root_html_sendspin_urls_escaped(http_client: TestClient[Any, Any]) -> None:
+    """Generated sendspin hrefs must be HTML-escaped as a whole, including & separators."""
+    resp = await http_client.get("/")
+    assert resp.status == 200
+    body = await resp.text()
+    assert "&amp;sendspin_url=http%3A%2F%2F" in body
+    assert "&sendspin_url=http%3A%2F%2F" not in body
 
 
 async def test_start_json(http_client: TestClient[Any, Any]) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Resolves CodeQL code scanning alerts #97 (reflected XSS) and #88 (request forgery) in the MSX bridge provider.

- Dashboard sendspin URLs are now composed from the raw host prefix and HTML-escaped as a whole, so the Host-header-derived value can never inject markup (and `&` query separators are correctly escaped in HTML attributes).
- `resolveUrl()` in the web player now rebuilds validated URLs as `BASE + pathname + search` after the same-host check, so the request host can never be attacker-controlled — this also closes a real edge case where a pathname like `//evil.com/x` could pass through and cause a cross-origin fetch.

**Related issue (if applicable):**

- related issue https://github.com/music-assistant/server/security/code-scanning/97 and https://github.com/music-assistant/server/security/code-scanning/88

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.