### PR TITLE
Add join code expiry lookup to auth controller

### DIFF
--- a/music_assistant/controllers/webserver/auth.py
+++ b/music_assistant/controllers/webserver/auth.py
@@ -1445,6 +1445,28 @@ class AuthenticationManager:
         row = await cursor.fetchone()
         return str(row["code"]) if row else None
 
+    async def get_join_code_expiry(self, code: str, user: User | None = None) -> datetime | None:
+        """
+        Get the expiry datetime for an active join code.
+
+        :param code: The join code to look up.
+        :param user: Optional user that must own the join code.
+        :return: The expiry datetime if the code is active, None otherwise.
+        """
+        query = """
+            SELECT expires_at FROM join_codes
+            WHERE code = :code
+            AND expires_at > :now
+            AND (max_uses = 0 OR use_count < max_uses)
+            """
+        params: dict[str, Any] = {"code": code.upper(), "now": utc().isoformat()}
+        if user is not None:
+            query += "AND user_id = :user_id "
+            params["user_id"] = user.user_id
+        cursor = await self.database.execute(query + "LIMIT 1", params)
+        row = await cursor.fetchone()
+        return datetime.fromisoformat(str(row["expires_at"])) if row else None
+
     @api_command("auth/join_code/exchange", authenticated=False)
     async def exchange_join_code(self, code: str) -> dict[str, Any]:
         """

--- a/tests/test_webserver_auth.py
+++ b/tests/test_webserver_auth.py
@@ -1218,6 +1218,73 @@ async def test_generate_join_code(auth_manager: AuthenticationManager) -> None:
     assert expires_at > utc()
 
 
+async def test_get_join_code_expiry(auth_manager: AuthenticationManager) -> None:
+    """
+    Test looking up the expiry for a specific active join code.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="joinexpiryuser", role=UserRole.GUEST)
+
+    code, expires_at = await auth_manager.generate_join_code(
+        user=user,
+        expires_in_hours=24,
+    )
+
+    assert await auth_manager.get_join_code_expiry(code, user) == expires_at
+    assert await auth_manager.get_join_code_expiry(code.lower(), user) == expires_at
+    assert await auth_manager.get_join_code_expiry("BADCODE", user) is None
+
+
+async def test_get_join_code_expiry_requires_matching_user(
+    auth_manager: AuthenticationManager,
+) -> None:
+    """
+    Test that join code expiry lookup can be scoped to a specific user.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="joinexpiryowner", role=UserRole.GUEST)
+    other_user = await auth_manager.create_user(
+        username="joinexpiryother",
+        role=UserRole.GUEST,
+    )
+
+    code, expires_at = await auth_manager.generate_join_code(
+        user=user,
+        expires_in_hours=24,
+    )
+
+    assert await auth_manager.get_join_code_expiry(code, user) == expires_at
+    assert await auth_manager.get_join_code_expiry(code) == expires_at
+    assert await auth_manager.get_join_code_expiry(code, other_user) is None
+
+
+async def test_get_join_code_expiry_expired(auth_manager: AuthenticationManager) -> None:
+    """
+    Test that expired join codes have no active expiry.
+
+    :param auth_manager: AuthenticationManager instance.
+    """
+    user = await auth_manager.create_user(username="joinexpiryexpired", role=UserRole.GUEST)
+
+    code, _ = await auth_manager.generate_join_code(
+        user=user,
+        expires_in_hours=24,
+    )
+    code_row = await auth_manager.database.get_row("join_codes", {"code": code})
+    assert code_row is not None
+
+    past_time = utc() - timedelta(hours=1)
+    await auth_manager.database.update(
+        "join_codes",
+        {"code_id": code_row["code_id"]},
+        {"expires_at": past_time.isoformat()},
+    )
+
+    assert await auth_manager.get_join_code_expiry(code, user) is None
+
+
 async def test_generate_join_code_non_guest_rejected(
     auth_manager: AuthenticationManager,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adds a `get_join_code_expiry` method to the webserver auth controller so clients can look up when a guest join code expires (optionally scoped to the owning user). This is groundwork extracted from #4572, needed to show guests when their join code expires.

- Add `get_join_code_expiry` to the auth controller
- Add tests covering active, user-scoped and expired codes

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.