### PR TITLE
Improve Sendspin proxy error handling and quieter websocket command logging

### DIFF
--- a/music_assistant/controllers/webserver/sendspin_proxy.py
+++ b/music_assistant/controllers/webserver/sendspin_proxy.py
@@ -14,6 +14,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
+import aiohttp
 from aiohttp import ClientConnectorError, WSMsgType, web
 
 from music_assistant.constants import MASS_LOGGER_NAME
@@ -24,7 +25,6 @@ from music_assistant.controllers.webserver.helpers.auth_middleware import (
 from music_assistant.helpers.util import format_ip_for_url
 
 if TYPE_CHECKING:
-    import aiohttp
     from music_assistant_models.auth import User
 
     from music_assistant.controllers.webserver import WebserverController
@@ -202,15 +202,48 @@ class SendspinProxyHandler:
             self._forward_internal_to_client(client_ws, internal_ws)
         )
 
-        _done, pending = await asyncio.wait(
+        done, pending = await asyncio.wait(
             [client_to_internal, internal_to_client],
             return_when=asyncio.FIRST_COMPLETED,
         )
 
         for task in pending:
             task.cancel()
+        peer_results = await asyncio.gather(*pending, return_exceptions=True)
+
+        # collect everything first so cleanup failures cannot mask the primary error
+        unexpected: list[BaseException] = []
+        for task in done:
             with contextlib.suppress(asyncio.CancelledError):
-                await task
+                if exc := task.exception():
+                    self._collect_proxy_exception(exc, unexpected)
+        for result in peer_results:
+            if isinstance(result, BaseException):
+                self._collect_proxy_exception(result, unexpected)
+        if not unexpected:
+            return
+        for extra in unexpected[1:]:
+            self.logger.warning(
+                "Additional Sendspin proxy error while forwarding: %s",
+                extra,
+            )
+        raise unexpected[0]
+
+    def _collect_proxy_exception(
+        self,
+        exc: BaseException,
+        unexpected: list[BaseException],
+    ) -> None:
+        """Log expected transport disconnects; collect anything else."""
+        if isinstance(exc, asyncio.CancelledError):
+            return
+        if isinstance(
+            exc,
+            (ConnectionError, aiohttp.ClientError, asyncio.IncompleteReadError, EOFError),
+        ):
+            self.logger.debug("Sendspin proxy connection closed while forwarding: %s", exc)
+            return
+        unexpected.append(exc)
 
     async def _forward_client_to_internal(
         self,
@@ -229,6 +262,8 @@ class SendspinProxyHandler:
             elif msg.type == WSMsgType.BINARY:
                 await internal_ws.send_bytes(msg.data)
             elif msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.ERROR):
+                if msg.type == WSMsgType.ERROR:
+                    self.logger.debug("Sendspin proxy client transport error: %s", msg.data)
                 break
 
     async def _forward_internal_to_client(
@@ -248,4 +283,6 @@ class SendspinProxyHandler:
             elif msg.type == WSMsgType.BINARY:
                 await client_ws.send_bytes(msg.data)
             elif msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.ERROR):
+                if msg.type == WSMsgType.ERROR:
+                    self.logger.debug("Sendspin proxy internal transport error: %s", msg.data)
                 break

--- a/music_assistant/controllers/webserver/websocket_client.py
+++ b/music_assistant/controllers/webserver/websocket_client.py
@@ -180,7 +180,7 @@ class WebsocketClientHandler:
 
     async def _handle_command(self, msg: CommandMessage) -> None:
         """Handle an incoming command from the client."""
-        self._logger.debug("Handling command %s", msg.command)
+        self._logger.log(VERBOSE_LOG_LEVEL, "Handling command %s", msg.command)
 
         # Handle special "auth" command
         if msg.command == "auth":

--- a/tests/test_sendspin_proxy.py
+++ b/tests/test_sendspin_proxy.py
@@ -1,7 +1,9 @@
 """Tests for the Sendspin WebSocket proxy handler."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 from aiohttp import ClientConnectorError, web
 from aiohttp.test_utils import make_mocked_request
@@ -123,3 +125,85 @@ class TestSendspinProxyRetry:
         assert mock_ws_connect.call_count == 1
         mock_ws_response.close.assert_called_once_with(code=1011, message=b"Internal server error")
         assert result is mock_ws_response
+
+
+class TestSendspinProxyMessages:
+    """Tests for bidirectional proxy task handling."""
+
+    async def test_expected_disconnect_is_consumed(self, handler: SendspinProxyHandler) -> None:
+        """Verify normal client disconnects do not leak as unretrieved task exceptions."""
+
+        async def raise_disconnect(*_: object) -> None:
+            raise ConnectionError("Connection lost")
+
+        async def wait_forever(*_: object) -> None:
+            await asyncio.Event().wait()
+
+        with (
+            patch.object(handler, "_forward_internal_to_client", new=raise_disconnect),
+            patch.object(handler, "_forward_client_to_internal", new=wait_forever),
+        ):
+            await handler._proxy_messages(MagicMock(), MagicMock())
+
+    async def test_unexpected_forwarding_error_is_raised(
+        self, handler: SendspinProxyHandler
+    ) -> None:
+        """Verify unexpected proxy task errors are still surfaced."""
+
+        async def raise_unexpected(*_: object) -> None:
+            raise RuntimeError("boom")
+
+        async def wait_forever(*_: object) -> None:
+            await asyncio.Event().wait()
+
+        with (
+            patch.object(handler, "_forward_internal_to_client", new=raise_unexpected),
+            patch.object(handler, "_forward_client_to_internal", new=wait_forever),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            await handler._proxy_messages(MagicMock(), MagicMock())
+
+    async def test_primary_error_is_not_masked_by_peer_cleanup_failure(
+        self, handler: SendspinProxyHandler
+    ) -> None:
+        """The first real failure must survive even if the peer task also errors."""
+
+        async def raise_primary(*_: object) -> None:
+            raise RuntimeError("primary failure")
+
+        async def raise_on_cancel(*_: object) -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                raise RuntimeError("secondary cleanup failure") from None
+
+        with (
+            patch.object(handler, "_forward_internal_to_client", new=raise_primary),
+            patch.object(handler, "_forward_client_to_internal", new=raise_on_cancel),
+            pytest.raises(RuntimeError, match="primary failure"),
+        ):
+            await handler._proxy_messages(MagicMock(), MagicMock())
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            aiohttp.ClientError("handshake failed"),
+            asyncio.IncompleteReadError(b"", 1),
+        ],
+    )
+    async def test_expected_transport_errors_are_consumed(
+        self, handler: SendspinProxyHandler, exc: BaseException
+    ) -> None:
+        """Normal aiohttp/stream disconnects must not bubble up as 500s."""
+
+        async def raise_disconnect(*_: object) -> None:
+            raise exc
+
+        async def wait_forever(*_: object) -> None:
+            await asyncio.Event().wait()
+
+        with (
+            patch.object(handler, "_forward_internal_to_client", new=raise_disconnect),
+            patch.object(handler, "_forward_client_to_internal", new=wait_forever),
+        ):
+            await handler._proxy_messages(MagicMock(), MagicMock())

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -1,0 +1,115 @@
+"""Tests for websocket API command authorization."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from music_assistant_models.api import CommandMessage, ErrorResultMessage
+from music_assistant_models.auth import Scope, User, UserRole
+from music_assistant_models.errors import InsufficientPermissions
+
+from music_assistant.controllers.webserver.websocket_client import WebsocketClientHandler
+from music_assistant.helpers.api import APICommandHandler
+
+
+async def _noop_command() -> None:
+    """Test command target."""
+
+
+def _create_client(user_role: UserRole | None, handler: APICommandHandler) -> Any:
+    """Create a minimally wired websocket client handler for dispatch tests."""
+    client: Any = WebsocketClientHandler.__new__(WebsocketClientHandler)
+    client._logger = MagicMock()
+    client.mass = MagicMock()
+    client.mass.command_handlers = {handler.command: handler}
+    client._authenticated_user = (
+        User(user_id="user_1", username="tester", role=user_role) if user_role else None
+    )
+    client._current_token = "token" if user_role else None
+    client._sendspin_player_id = None
+    client._send_message = AsyncMock()
+    return client
+
+
+def _command_handler(
+    required_scope: Scope | None = None,
+    authenticated: bool = True,
+) -> APICommandHandler:
+    """Create an API command handler with the given auth requirements."""
+    return APICommandHandler.parse(
+        "test/protected",
+        _noop_command,
+        authenticated=authenticated,
+        required_scope=required_scope,
+    )
+
+
+def _sent_error_code(client: Any) -> str | None:
+    """Return the error code of the last sent error message, if any."""
+    for call in client._send_message.await_args_list:
+        message = call.args[0]
+        if isinstance(message, ErrorResultMessage):
+            return str(message.error_code)
+    return None
+
+
+PERMISSION_DENIED = str(InsufficientPermissions.error_code)
+
+
+@pytest.mark.asyncio
+async def test_user_scoped_command_rejects_guest() -> None:
+    """A guest must not be able to invoke commands gated on a user-only scope."""
+    client = _create_client(UserRole.GUEST, _command_handler(required_scope=Scope.USERS_INVITE))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) == PERMISSION_DENIED
+    client.mass.create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", [UserRole.USER, UserRole.ADMIN])
+async def test_user_scoped_command_allows_user_and_admin(role: UserRole) -> None:
+    """Users and admins hold the USERS_INVITE scope used by host commands."""
+    client = _create_client(role, _command_handler(required_scope=Scope.USERS_INVITE))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) is None
+    client.mass.create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", [UserRole.USER, UserRole.GUEST])
+async def test_admin_scoped_command_rejects_non_admin(role: UserRole) -> None:
+    """Only admins hold admin-only scopes such as USERS_MANAGE."""
+    client = _create_client(role, _command_handler(required_scope=Scope.USERS_MANAGE))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) == PERMISSION_DENIED
+    client.mass.create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_authenticated_command_without_scope_allows_guest() -> None:
+    """Guests may invoke authenticated commands that require no specific scope."""
+    client = _create_client(UserRole.GUEST, _command_handler(required_scope=None))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) is None
+    client.mass.create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_scoped_command_rejects_unauthenticated_socket() -> None:
+    """Without authentication a scoped command must not run at all."""
+    client = _create_client(None, _command_handler(required_scope=Scope.USERS_INVITE))
+
+    await client._handle_command(CommandMessage(message_id="1", command="test/protected"))
+
+    assert _sent_error_code(client) is not None
+    client.mass.create_task.assert_not_called()

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -24,6 +24,8 @@ def _create_client(user_role: UserRole | None, handler: APICommandHandler) -> An
     client._logger = MagicMock()
     client.mass = MagicMock()
     client.mass.command_handlers = {handler.command: handler}
+    # close the coroutine passed to create_task to avoid "never awaited" warnings
+    client.mass.create_task = MagicMock(side_effect=lambda coro, *_: coro.close())
     client._authenticated_user = (
         User(user_id="user_1", username="tester", role=user_role) if user_role else None
     )


### PR DESCRIPTION
# What does this implement/fix?

When one side of the Sendspin websocket proxy failed, teardown of the other forwarding task could mask the real error, and normal client disconnects surfaced as noisy errors. Also, every incoming websocket command was logged at debug level, cluttering debug logs.

Extracted from #4572 as a standalone foundation PR.

- Collect exceptions from both proxy forwarding tasks so cleanup failures can no longer hide the primary error
- Log expected transport disconnects (connection reset, aiohttp client errors, EOF) at debug level instead of raising
- Log websocket transport error payloads at debug level in both forwarding directions
- Log "Handling command" at verbose level instead of debug
- Add tests covering the proxy teardown behavior and websocket command authorization scopes

**Related issue (if applicable):**

- related issue N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.