### PR TITLE
Add virtual player support to the Sendspin provider

### DIFF
--- a/music_assistant/providers/sendspin/README.md
+++ b/music_assistant/providers/sendspin/README.md
@@ -265,6 +265,10 @@ default, expose no volume controls (member volumes apply instead), and are
 removed automatically when the owning provider unloads. Stale configurations
 of virtual players whose owner no longer exists are swept on provider startup.
 
+Virtual player registrations are in-memory only: when the Sendspin provider
+itself reloads (or the server restarts), they are gone and the owning provider
+must call `create_virtual_player` again to restore its session anchor.
+
 ## Related Documentation
 
 - [Sendspin Protocol Specification](https://github.com/Sendspin/spec)

--- a/music_assistant/providers/sendspin/README.md
+++ b/music_assistant/providers/sendspin/README.md
@@ -265,9 +265,12 @@ default, expose no volume controls (member volumes apply instead), and are
 removed automatically when the owning provider unloads. Stale configurations
 of virtual players whose owner no longer exists are swept on provider startup.
 
-Virtual player registrations are in-memory only: when the Sendspin provider
-itself reloads (or the server restarts), they are gone and the owning provider
-must call `create_virtual_player` again to restore its session anchor.
+Virtual players are never auto-restored: when the Sendspin provider reloads
+(or the server restarts), the owning provider must call `create_virtual_player`
+again to restore its session anchor. The player's configuration (including the
+owner marker) may persist across restarts and is reused when the same owner
+recreates the same player id; it is deleted on `remove_virtual_player` or swept
+at startup once the owner provider no longer exists.
 
 ## Related Documentation
 

--- a/music_assistant/providers/sendspin/README.md
+++ b/music_assistant/providers/sendspin/README.md
@@ -238,6 +238,33 @@ To bridge another protocol to Sendspin:
 
 See the [AirPlay Sendspin Bridge](../airplay/sendspin_bridge.py) for a complete implementation example.
 
+## Virtual Players
+
+Other providers (typically plugins) can host a shared listening session on a
+hidden, server-side "anchor" player via the public virtual player API:
+
+```python
+sendspin = mass.get_provider("sendspin")
+player_id = await sendspin.create_virtual_player(
+    owner_instance_id=self.instance_id,
+    display_name="My Session",
+)
+...
+await sendspin.remove_virtual_player(player_id)
+```
+
+A virtual player owns its own PlayerQueue and leads a native Sendspin group,
+but never renders audio itself. Guest players (e.g. web players) are attached
+and detached through standard grouping (`mass.players.cmd_set_members`) and
+receive the audio stream, with join-catchup for late joiners. Because the
+anchor is server-side and permanent for the session's lifetime, guests coming
+and going never cause a group leader transfer.
+
+Virtual players are hidden from the UI and not exposed to Home Assistant by
+default, expose no volume controls (member volumes apply instead), and are
+removed automatically when the owning provider unloads. Stale configurations
+of virtual players whose owner no longer exists are swept on provider startup.
+
 ## Related Documentation
 
 - [Sendspin Protocol Specification](https://github.com/Sendspin/spec)

--- a/music_assistant/providers/sendspin/constants.py
+++ b/music_assistant/providers/sendspin/constants.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 BRIDGE_PREFIX = "spb_"
+VIRTUAL_PLAYER_ID_PREFIX = "sendspin_virtual_"
 
 CONF_CAST_AUDIO_UNSUPPORTED = "cast_audio_unsupported"
 CONF_SENDSPIN_STATIC_DELAY = "sendspin_static_delay"
+CONF_VIRTUAL_PLAYER_OWNER = "virtual_player_owner"
 DEFAULT_SENDSPIN_STATIC_DELAY = 0

--- a/music_assistant/providers/sendspin/player.py
+++ b/music_assistant/providers/sendspin/player.py
@@ -551,11 +551,17 @@ class SendspinPlayer(SendspinBasePlayer):
                     self._attr_volume_muted = muted
                 if volume is not None or muted is not None:
                     break
-        self._attr_expose_to_ha_by_default = not self.is_web_player
-        self._attr_hidden_by_default = self.is_web_player
+        # virtual players are server-owned anchors that follow the same
+        # hidden/standalone semantics as web players, without relying on the
+        # device-info heuristics above
+        is_standalone = self.is_web_player or cast(
+            "SendspinProvider", self.provider
+        ).is_virtual_player(self.player_id)
+        self._attr_expose_to_ha_by_default = not is_standalone
+        self._attr_hidden_by_default = is_standalone
         # register web/app player as native player type because it doesn't need to be linked
         # every web/app player is just a standalone player.
-        self._attr_type = PlayerType.PLAYER if self.is_web_player else PlayerType.PROTOCOL
+        self._attr_type = PlayerType.PLAYER if is_standalone else PlayerType.PROTOCOL
 
     def event_cb(self, client: SendspinClient, event: ClientEvent) -> None:
         """Event callback registered to the sendspin client."""

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -309,6 +309,12 @@ class SendspinProvider(PlayerProvider):
         """
         if (owner := self.mass.get_provider(owner_instance_id)) is None:
             raise SetupFailedError(f"Owner provider {owner_instance_id} is not loaded")
+        if owner.instance_id != owner_instance_id and (
+            len(self.mass.get_provider_instances(owner.domain)) > 1
+        ):
+            raise SetupFailedError(
+                f"Multiple instances exist for {owner_instance_id}: pass an exact instance id"
+            )
         # normalize a provider domain to the actual instance id
         owner_instance_id = owner.instance_id
         if player_id is None:
@@ -751,11 +757,6 @@ class SendspinProvider(PlayerProvider):
                 values = {}
             owner_instance_id = values.get(CONF_VIRTUAL_PLAYER_OWNER)
             if owner_instance_id is None:
-                if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX):
-                    continue
-                # a prefixed config without owner marker is a leftover of an
-                # interrupted creation and can never be claimed again
-                self.mass.players.delete_player_config(player_id)
                 continue
             if self.mass.config.get(f"{CONF_PROVIDERS}/{owner_instance_id}") is not None:
                 # owner still configured; it will recreate its virtual players

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -338,7 +338,10 @@ class SendspinProvider(PlayerProvider):
         Remove a virtual Sendspin player and permanently delete its configuration.
 
         :param player_id: The player_id returned by create_virtual_player.
+        :raises ValueError: If the given player_id is not a virtual player id.
         """
+        if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX):
+            raise ValueError(f"{player_id} is not a virtual player")
         self._virtual_players.pop(player_id, None)
         if self.server_api.get_client(player_id) is not None:
             await self.server_api.remove_client(player_id)

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -305,6 +305,7 @@ class SendspinProvider(PlayerProvider):
             is generated when omitted. The id is always prefixed with
             ``VIRTUAL_PLAYER_ID_PREFIX``.
         :return: The player_id of the registered virtual player.
+        :raises SetupFailedError: If the virtual player can not be created.
         """
         if self.mass.get_provider(owner_instance_id) is None:
             raise SetupFailedError(f"Owner provider {owner_instance_id} is not loaded")
@@ -313,16 +314,18 @@ class SendspinProvider(PlayerProvider):
         if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX):
             player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}{player_id}"
         if player_id in self._virtual_players or self.server_api.get_client(player_id) is not None:
-            raise AlreadyRegisteredError(f"Virtual player {player_id} already exists")
+            raise SetupFailedError(f"Virtual player {player_id} already exists")
         self._virtual_players[player_id] = owner_instance_id
         try:
             self._register_virtual_player_client(player_id, display_name)
             await self._wait_for_virtual_player(player_id)
-        except Exception:
+        except Exception as err:
             self._virtual_players.pop(player_id, None)
             if self.server_api.get_client(player_id) is not None:
                 await self.server_api.remove_client(player_id)
-            raise
+            if isinstance(err, SetupFailedError):
+                raise
+            raise SetupFailedError(f"Failed to create virtual player {player_id}") from err
         # persist the owner so orphaned configs can be swept after a restart
         self.mass.config.set_raw_player_config_value(
             player_id, CONF_VIRTUAL_PLAYER_OWNER, owner_instance_id

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import Callable
 from copy import deepcopy
 from ipaddress import ip_address
@@ -319,6 +320,10 @@ class SendspinProvider(PlayerProvider):
         owner_instance_id = owner.instance_id
         if player_id is None:
             player_id = uuid4().hex
+        elif not re.fullmatch(r"[a-zA-Z0-9_-]+", player_id):
+            raise SetupFailedError(
+                f"Invalid player_id {player_id}: only alphanumerics, '_' and '-' are allowed"
+            )
         if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX):
             player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}{player_id}"
         if player_id in self._virtual_players or self.server_api.get_client(player_id) is not None:
@@ -355,7 +360,7 @@ class SendspinProvider(PlayerProvider):
         :param player_id: The player_id returned by create_virtual_player.
         :raises ValueError: If the given player_id is not a (known) virtual player.
         """
-        if (
+        if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX) or (
             player_id not in self._virtual_players
             and self._get_virtual_player_config_owner(player_id) is None
         ):

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -307,8 +307,10 @@ class SendspinProvider(PlayerProvider):
         :return: The player_id of the registered virtual player.
         :raises SetupFailedError: If the virtual player can not be created.
         """
-        if self.mass.get_provider(owner_instance_id) is None:
+        if (owner := self.mass.get_provider(owner_instance_id)) is None:
             raise SetupFailedError(f"Owner provider {owner_instance_id} is not loaded")
+        # normalize a provider domain to the actual instance id
+        owner_instance_id = owner.instance_id
         if player_id is None:
             player_id = uuid4().hex
         if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX):

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -317,6 +317,10 @@ class SendspinProvider(PlayerProvider):
             player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}{player_id}"
         if player_id in self._virtual_players or self.server_api.get_client(player_id) is not None:
             raise SetupFailedError(f"Virtual player {player_id} already exists")
+        # a persisted config may only be reclaimed by the same owner
+        stored_owner = self._get_virtual_player_config_owner(player_id)
+        if stored_owner is not None and stored_owner != owner_instance_id:
+            raise SetupFailedError(f"Virtual player {player_id} is owned by {stored_owner}")
         self._virtual_players[player_id] = owner_instance_id
         try:
             self._register_virtual_player_client(player_id, display_name)
@@ -345,8 +349,9 @@ class SendspinProvider(PlayerProvider):
         :param player_id: The player_id returned by create_virtual_player.
         :raises ValueError: If the given player_id is not a (known) virtual player.
         """
-        if player_id not in self._virtual_players and not self._has_virtual_player_config(
-            player_id
+        if (
+            player_id not in self._virtual_players
+            and self._get_virtual_player_config_owner(player_id) is None
         ):
             raise ValueError(f"{player_id} is not a virtual player")
         self._virtual_players.pop(player_id, None)
@@ -653,13 +658,15 @@ class SendspinProvider(PlayerProvider):
         finally:
             self._finish_client_event(client_id)
 
-    def _has_virtual_player_config(self, player_id: str) -> bool:
-        """Return whether a stored player config marks the given id as a virtual player."""
+    def _get_virtual_player_config_owner(self, player_id: str) -> str | None:
+        """Return the owner instance id from a stored virtual player config, if any."""
         raw_conf = self.mass.config.get(f"{CONF_PLAYERS}/{player_id}")
         if not isinstance(raw_conf, dict) or raw_conf.get("provider") != self.instance_id:
-            return False
+            return None
         values = raw_conf.get("values")
-        return isinstance(values, dict) and values.get(CONF_VIRTUAL_PLAYER_OWNER) is not None
+        if not isinstance(values, dict):
+            return None
+        return cast("str | None", values.get(CONF_VIRTUAL_PLAYER_OWNER))
 
     def _register_virtual_player_client(self, player_id: str, display_name: str) -> None:
         """Register the silent external Sendspin client backing a virtual player."""

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -338,10 +338,10 @@ class SendspinProvider(PlayerProvider):
             await self._wait_for_virtual_player(player_id)
         except Exception as err:
             self._virtual_players.pop(player_id, None)
-            if self.server_api.get_client(player_id) is not None:
-                await self.server_api.remove_client(player_id)
             # purge any partially registered player and its config
             await self.mass.players.unregister(player_id, permanent=True)
+            if self.server_api.get_client(player_id) is not None:
+                await self.server_api.remove_client(player_id)
             self.mass.players.delete_player_config(player_id)
             if isinstance(err, SetupFailedError):
                 raise
@@ -366,10 +366,12 @@ class SendspinProvider(PlayerProvider):
         ):
             raise ValueError(f"{player_id} is not a virtual player")
         self._virtual_players.pop(player_id, None)
+        # unregister the player first so the client removed event handler
+        # can not race us with a non-permanent unregister
+        await self.mass.players.unregister(player_id, permanent=True)
         if self.server_api.get_client(player_id) is not None:
             await self.server_api.remove_client(player_id)
-        await self.mass.players.unregister(player_id, permanent=True)
-        # the config may linger when the player was already unregistered
+        # the config may linger when the player was never registered
         self.mass.players.delete_player_config(player_id)
         self.logger.info("Virtual player %s removed", player_id)
 

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -8,8 +8,12 @@ from copy import deepcopy
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, cast
 from urllib.parse import urlsplit
+from uuid import uuid4
 
-from aiosendspin.models.types import PlayerCommand
+from aiosendspin.models.core import ClientHelloPayload
+from aiosendspin.models.core import DeviceInfo as SendspinDeviceInfo
+from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
+from aiosendspin.models.types import AudioCodec, PlayerCommand
 from aiosendspin.server import (
     ClientAddedEvent,
     ClientRemovedEvent,
@@ -18,22 +22,36 @@ from aiosendspin.server import (
     SendspinServer,
 )
 from music_assistant_models.enums import (
+    EventType,
     IdentifierType,
     PlayerFeature,
     PlayerType,
     ProviderFeature,
 )
-from music_assistant_models.errors import AlreadyRegisteredError
+from music_assistant_models.errors import AlreadyRegisteredError, SetupFailedError
 
 from music_assistant.constants import (
     CONF_ENABLED,
     CONF_ENTRY_MANUAL_DISCOVERY_IPS,
+    CONF_PLAYERS,
+    CONF_PROVIDERS,
 )
 from music_assistant.helpers.util import format_ip_for_url
 from music_assistant.mass import MusicAssistant
 from music_assistant.models.player import Player
 from music_assistant.models.player_provider import PlayerProvider
-from music_assistant.providers.sendspin.constants import CONF_SENDSPIN_STATIC_DELAY
+from music_assistant.providers.sendspin.bridge_role import (
+    BRIDGE_BIT_DEPTH,
+    BRIDGE_CHANNELS,
+    BRIDGE_ROLE_ID,
+    BRIDGE_SAMPLE_RATE,
+    BridgePlayerRole,
+)
+from music_assistant.providers.sendspin.constants import (
+    CONF_SENDSPIN_STATIC_DELAY,
+    CONF_VIRTUAL_PLAYER_OWNER,
+    VIRTUAL_PLAYER_ID_PREFIX,
+)
 from music_assistant.providers.sendspin.player import (
     SendspinBasePlayer,
     SendspinPlayer,
@@ -41,9 +59,10 @@ from music_assistant.providers.sendspin.player import (
 )
 
 if TYPE_CHECKING:
-    from aiosendspin.models.core import ClientHelloPayload
     from aiosendspin.server.client import SendspinClient
+    from aiosendspin.server.server import ExternalStreamStartRequest
     from music_assistant_models.config_entries import ProviderConfig
+    from music_assistant_models.event import MassEvent
     from music_assistant_models.provider import ProviderManifest
 
     from music_assistant.providers.hass import HomeAssistantProvider
@@ -51,6 +70,7 @@ if TYPE_CHECKING:
 
 DEFAULT_SENDSPIN_CLIENT_PORT = 8928
 DEFAULT_SENDSPIN_CLIENT_PATH = "/sendspin"
+VIRTUAL_PLAYER_REGISTER_TIMEOUT = 10.0
 
 
 def _manual_client_url(address: str) -> str:
@@ -95,6 +115,7 @@ class SendspinProvider(PlayerProvider):
     _client_event_versions: dict[str, int]
     _client_event_task_counts: dict[str, int]
     _manual_ip_config: tuple[str, ...]
+    _virtual_players: dict[str, str]
     _unloading: bool
 
     def __init__(
@@ -119,9 +140,11 @@ class SendspinProvider(PlayerProvider):
         self._bridge_player_types: dict[str, PlayerType] = {}
         self._client_event_versions = {}
         self._client_event_task_counts = {}
+        self._virtual_players = {}
         self._unloading = False
         self.unregister_cbs = [
             self.server_api.add_event_listener(self.event_cb),
+            self.mass.subscribe(self._on_providers_updated, EventType.PROVIDERS_UPDATED),
         ]
 
     def event_cb(self, server: SendspinServer, event: SendspinEvent) -> None:
@@ -260,6 +283,71 @@ class SendspinProvider(PlayerProvider):
         await self.mass.players.register_or_update(player)
         return True
 
+    async def create_virtual_player(
+        self,
+        owner_instance_id: str,
+        display_name: str,
+        player_id: str | None = None,
+    ) -> str:
+        """
+        Create a hidden, server-side virtual Sendspin player.
+
+        A virtual player owns its own PlayerQueue and leads a native Sendspin
+        group, but never renders audio itself: the audio stream is delivered to
+        the guest players that are attached to it through standard grouping.
+        It is hidden from the UI and not exposed to Home Assistant by default,
+        and is automatically removed when the owning provider unloads.
+
+        :param owner_instance_id: Instance id of the (loaded) provider that owns
+            the virtual player and controls its lifecycle.
+        :param display_name: Human readable name for the virtual player.
+        :param player_id: Optional stable id for the virtual player; a random id
+            is generated when omitted. The id is always prefixed with
+            ``VIRTUAL_PLAYER_ID_PREFIX``.
+        :return: The player_id of the registered virtual player.
+        """
+        if self.mass.get_provider(owner_instance_id) is None:
+            raise SetupFailedError(f"Owner provider {owner_instance_id} is not loaded")
+        if player_id is None:
+            player_id = uuid4().hex
+        if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX):
+            player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}{player_id}"
+        if player_id in self._virtual_players or self.server_api.get_client(player_id) is not None:
+            raise AlreadyRegisteredError(f"Virtual player {player_id} already exists")
+        self._virtual_players[player_id] = owner_instance_id
+        try:
+            self._register_virtual_player_client(player_id, display_name)
+            await self._wait_for_virtual_player(player_id)
+        except Exception:
+            self._virtual_players.pop(player_id, None)
+            if self.server_api.get_client(player_id) is not None:
+                await self.server_api.remove_client(player_id)
+            raise
+        # persist the owner so orphaned configs can be swept after a restart
+        self.mass.config.set_raw_player_config_value(
+            player_id, CONF_VIRTUAL_PLAYER_OWNER, owner_instance_id
+        )
+        self.logger.info("Virtual player %s created for %s", player_id, owner_instance_id)
+        return player_id
+
+    async def remove_virtual_player(self, player_id: str) -> None:
+        """
+        Remove a virtual Sendspin player and permanently delete its configuration.
+
+        :param player_id: The player_id returned by create_virtual_player.
+        """
+        self._virtual_players.pop(player_id, None)
+        if self.server_api.get_client(player_id) is not None:
+            await self.server_api.remove_client(player_id)
+        await self.mass.players.unregister(player_id, permanent=True)
+        # the config may linger when the player was already unregistered
+        self.mass.players.delete_player_config(player_id)
+        self.logger.info("Virtual player %s removed", player_id)
+
+    def is_virtual_player(self, player_id: str) -> bool:
+        """Return whether the given player_id belongs to a registered virtual player."""
+        return player_id in self._virtual_players
+
     @property
     def supported_features(self) -> set[ProviderFeature]:
         """Return the features supported by this Provider."""
@@ -270,6 +358,7 @@ class SendspinProvider(PlayerProvider):
     async def loaded_in_mass(self) -> None:
         """Call after the provider has been loaded."""
         await super().loaded_in_mass()
+        self._remove_orphan_virtual_player_configs()
         # Start server for handling incoming Sendspin connections from clients
         # and mDNS discovery of new clients
         await self.server_api.start_server(
@@ -327,6 +416,7 @@ class SendspinProvider(PlayerProvider):
         self.unregister_cbs = []
         self._client_event_task_counts.clear()
         self._client_event_versions.clear()
+        self._virtual_players.clear()
         await asyncio.gather(
             *(
                 self.mass.players.unregister(player_id, permanent=is_removed)
@@ -549,3 +639,98 @@ class SendspinProvider(PlayerProvider):
             await self.mass.players.register_or_update(existing_player)
         finally:
             self._finish_client_event(client_id)
+
+    def _register_virtual_player_client(self, player_id: str, display_name: str) -> None:
+        """Register the silent external Sendspin client backing a virtual player."""
+        hello = ClientHelloPayload(
+            client_id=player_id,
+            name=display_name,
+            version=1,
+            supported_roles=[BRIDGE_ROLE_ID],
+            device_info=SendspinDeviceInfo(
+                product_name="Virtual Player",
+                manufacturer="Music Assistant",
+            ),
+            player_support=ClientHelloPlayerSupport(
+                supported_formats=[
+                    SupportedAudioFormat(
+                        codec=AudioCodec.PCM,
+                        channels=BRIDGE_CHANNELS,
+                        sample_rate=BRIDGE_SAMPLE_RATE,
+                        bit_depth=BRIDGE_BIT_DEPTH,
+                    )
+                ],
+                buffer_capacity=1_000,
+                supported_commands=[],
+            ),
+        )
+        sendspin_client = self.server_api.register_external_player(
+            hello, on_stream_start=self._on_virtual_player_stream_start
+        )
+        for role in sendspin_client.roles_by_family("player"):
+            if not isinstance(role, BridgePlayerRole):
+                continue
+            # audio delivered to the role is simply discarded: the virtual player
+            # only anchors the group, the members receive the actual stream
+            role.set_callbacks(
+                on_audio_chunk=_virtual_player_noop,
+                on_volume_change=_virtual_player_noop,
+                on_mute_change=_virtual_player_noop,
+                on_stream_start=_virtual_player_noop,
+                on_stream_end=_virtual_player_noop,
+            )
+            role.setup_audio_requirements()
+            role.set_timing(required_lead_time_ms=0, min_buffer_ms=0)
+            break
+
+    async def _wait_for_virtual_player(self, player_id: str) -> None:
+        """Wait until the virtual player is registered in MA with its queue."""
+        deadline = self.mass.loop.time() + VIRTUAL_PLAYER_REGISTER_TIMEOUT
+        while self.mass.loop.time() < deadline:
+            if (
+                self.mass.players.get_player(player_id) is not None
+                and self.mass.player_queues.get(player_id) is not None
+            ):
+                return
+            await asyncio.sleep(0.1)
+        raise SetupFailedError(f"Virtual player {player_id} was not registered in time")
+
+    def _on_virtual_player_stream_start(self, _request: ExternalStreamStartRequest) -> None:
+        """Accept stream start requests for virtual players (nothing to connect)."""
+
+    async def _on_providers_updated(self, event: MassEvent) -> None:
+        """Remove virtual players whose owning provider is no longer loaded."""
+        if self._unloading:
+            return
+        for player_id, owner_instance_id in list(self._virtual_players.items()):
+            if self.mass.get_provider(owner_instance_id) is not None:
+                continue
+            self.logger.debug(
+                "Removing virtual player %s: owner %s unloaded", player_id, owner_instance_id
+            )
+            await self.remove_virtual_player(player_id)
+
+    def _remove_orphan_virtual_player_configs(self) -> None:
+        """Delete stored configs of virtual players whose owner provider is gone."""
+        all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
+        for player_id, raw_conf in list(all_player_configs.items()):
+            if not isinstance(raw_conf, dict):
+                continue
+            values = raw_conf.get("values") or {}
+            owner_instance_id = values.get(CONF_VIRTUAL_PLAYER_OWNER)
+            if owner_instance_id is None:
+                if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX):
+                    continue
+                # a prefixed config without owner marker is a leftover of an
+                # interrupted creation and can never be claimed again
+                self.mass.players.delete_player_config(player_id)
+                continue
+            if self.mass.config.get(f"{CONF_PROVIDERS}/{owner_instance_id}") is not None:
+                # owner still configured; it will recreate its virtual players
+                continue
+            self.logger.debug("Removing orphan virtual player config %s", player_id)
+            self.mass.players.delete_player_config(player_id)
+
+
+def _virtual_player_noop(*_args: object) -> None:
+    """No-op callback for virtual players, which never render audio locally."""

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -323,6 +323,9 @@ class SendspinProvider(PlayerProvider):
             self._virtual_players.pop(player_id, None)
             if self.server_api.get_client(player_id) is not None:
                 await self.server_api.remove_client(player_id)
+            # purge any partially registered player and its config
+            await self.mass.players.unregister(player_id, permanent=True)
+            self.mass.players.delete_player_config(player_id)
             if isinstance(err, SetupFailedError):
                 raise
             raise SetupFailedError(f"Failed to create virtual player {player_id}") from err

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -700,7 +700,9 @@ class SendspinProvider(PlayerProvider):
 
     async def _on_providers_updated(self, event: MassEvent) -> None:
         """Remove virtual players whose owning provider is no longer loaded."""
-        if self._unloading:
+        # during (server) shutdown all providers unload; the startup sweep
+        # takes care of configs whose owner is really gone
+        if self._unloading or self.mass.closing:
             return
         for player_id, owner_instance_id in list(self._virtual_players.items()):
             if self.mass.get_provider(owner_instance_id) is not None:
@@ -714,9 +716,11 @@ class SendspinProvider(PlayerProvider):
         """Delete stored configs of virtual players whose owner provider is gone."""
         all_player_configs = self.mass.config.get(CONF_PLAYERS, {})
         for player_id, raw_conf in list(all_player_configs.items()):
-            if not isinstance(raw_conf, dict):
+            if not isinstance(raw_conf, dict) or raw_conf.get("provider") != self.instance_id:
                 continue
-            values = raw_conf.get("values") or {}
+            values = raw_conf.get("values")
+            if not isinstance(values, dict):
+                values = {}
             owner_instance_id = values.get(CONF_VIRTUAL_PLAYER_OWNER)
             if owner_instance_id is None:
                 if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX):

--- a/music_assistant/providers/sendspin/provider.py
+++ b/music_assistant/providers/sendspin/provider.py
@@ -341,9 +341,11 @@ class SendspinProvider(PlayerProvider):
         Remove a virtual Sendspin player and permanently delete its configuration.
 
         :param player_id: The player_id returned by create_virtual_player.
-        :raises ValueError: If the given player_id is not a virtual player id.
+        :raises ValueError: If the given player_id is not a (known) virtual player.
         """
-        if not player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX):
+        if player_id not in self._virtual_players and not self._has_virtual_player_config(
+            player_id
+        ):
             raise ValueError(f"{player_id} is not a virtual player")
         self._virtual_players.pop(player_id, None)
         if self.server_api.get_client(player_id) is not None:
@@ -648,6 +650,14 @@ class SendspinProvider(PlayerProvider):
             await self.mass.players.register_or_update(existing_player)
         finally:
             self._finish_client_event(client_id)
+
+    def _has_virtual_player_config(self, player_id: str) -> bool:
+        """Return whether a stored player config marks the given id as a virtual player."""
+        raw_conf = self.mass.config.get(f"{CONF_PLAYERS}/{player_id}")
+        if not isinstance(raw_conf, dict) or raw_conf.get("provider") != self.instance_id:
+            return False
+        values = raw_conf.get("values")
+        return isinstance(values, dict) and values.get(CONF_VIRTUAL_PLAYER_OWNER) is not None
 
     def _register_virtual_player_client(self, player_id: str, display_name: str) -> None:
         """Register the silent external Sendspin client backing a virtual player."""

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -78,6 +78,17 @@ async def test_create_virtual_player_custom_id(mass: MusicAssistant) -> None:
     assert mass.players.get_player(player_id) is not None
 
 
+async def test_create_virtual_player_invalid_id(mass: MusicAssistant) -> None:
+    """Test that a player_id with unsafe characters is rejected."""
+    sendspin = _get_sendspin_provider(mass)
+    with pytest.raises(SetupFailedError, match="Invalid player_id"):
+        await sendspin.create_virtual_player(
+            owner_instance_id=sendspin.instance_id,
+            display_name="Test Session",
+            player_id="my/session",
+        )
+
+
 async def test_create_virtual_player_duplicate(mass: MusicAssistant) -> None:
     """Test that creating a duplicate virtual player raises."""
     sendspin = _get_sendspin_provider(mass)

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -1,0 +1,169 @@
+"""Tests for the Sendspin virtual player API."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from music_assistant_models.enums import PlayerFeature, PlayerType
+from music_assistant_models.errors import AlreadyRegisteredError, SetupFailedError
+
+from music_assistant.constants import CONF_PLAYERS
+from music_assistant.providers.sendspin.constants import (
+    CONF_VIRTUAL_PLAYER_OWNER,
+    VIRTUAL_PLAYER_ID_PREFIX,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from music_assistant.mass import MusicAssistant
+    from music_assistant.providers.sendspin.provider import SendspinProvider
+
+
+def _get_sendspin_provider(mass: MusicAssistant) -> SendspinProvider:
+    """Return the loaded Sendspin provider instance."""
+    provider = mass.get_provider("sendspin")
+    assert provider is not None
+    return cast("SendspinProvider", provider)
+
+
+async def _wait_for(condition: Callable[[], bool], timeout: float = 5.0) -> None:
+    """Wait until the given condition callable returns True."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if condition():
+            return
+        await asyncio.sleep(0.05)
+    raise TimeoutError("Condition not met within timeout")
+
+
+async def test_create_virtual_player(mass: MusicAssistant) -> None:
+    """Test creating a virtual player registers a hidden queue-owning player."""
+    sendspin = _get_sendspin_provider(mass)
+    player_id = await sendspin.create_virtual_player(
+        owner_instance_id=sendspin.instance_id,
+        display_name="Test Session",
+    )
+    assert player_id.startswith(VIRTUAL_PLAYER_ID_PREFIX)
+    assert sendspin.is_virtual_player(player_id)
+
+    player = mass.players.get_player(player_id)
+    assert player is not None
+    assert player.type == PlayerType.PLAYER
+    assert player.hidden_by_default is True
+    assert player.expose_to_ha_by_default is False
+    assert PlayerFeature.VOLUME_SET not in player.supported_features
+    assert PlayerFeature.VOLUME_MUTE not in player.supported_features
+    assert PlayerFeature.SET_MEMBERS in player.supported_features
+    assert mass.player_queues.get(player_id) is not None
+    # the owner marker must be persisted for orphan sweeps
+    assert (
+        mass.config.get_raw_player_config_value(player_id, CONF_VIRTUAL_PLAYER_OWNER)
+        == sendspin.instance_id
+    )
+
+
+async def test_create_virtual_player_custom_id(mass: MusicAssistant) -> None:
+    """Test creating a virtual player with a caller-supplied id."""
+    sendspin = _get_sendspin_provider(mass)
+    player_id = await sendspin.create_virtual_player(
+        owner_instance_id=sendspin.instance_id,
+        display_name="Test Session",
+        player_id="my_session",
+    )
+    assert player_id == f"{VIRTUAL_PLAYER_ID_PREFIX}my_session"
+    assert mass.players.get_player(player_id) is not None
+
+
+async def test_create_virtual_player_duplicate(mass: MusicAssistant) -> None:
+    """Test that creating a duplicate virtual player raises."""
+    sendspin = _get_sendspin_provider(mass)
+    player_id = await sendspin.create_virtual_player(
+        owner_instance_id=sendspin.instance_id,
+        display_name="Test Session",
+        player_id="my_session",
+    )
+    with pytest.raises(AlreadyRegisteredError):
+        await sendspin.create_virtual_player(
+            owner_instance_id=sendspin.instance_id,
+            display_name="Test Session",
+            player_id=player_id,
+        )
+
+
+async def test_create_virtual_player_owner_not_loaded(mass: MusicAssistant) -> None:
+    """Test that creating a virtual player for an unknown owner raises."""
+    sendspin = _get_sendspin_provider(mass)
+    with pytest.raises(SetupFailedError):
+        await sendspin.create_virtual_player(
+            owner_instance_id="nonexistent_provider",
+            display_name="Test Session",
+        )
+
+
+async def test_remove_virtual_player(mass: MusicAssistant) -> None:
+    """Test removing a virtual player cleans up player, client and config."""
+    sendspin = _get_sendspin_provider(mass)
+    player_id = await sendspin.create_virtual_player(
+        owner_instance_id=sendspin.instance_id,
+        display_name="Test Session",
+    )
+    await sendspin.remove_virtual_player(player_id)
+    assert not sendspin.is_virtual_player(player_id)
+    assert mass.players.get_player(player_id) is None
+    assert sendspin.server_api.get_client(player_id) is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{player_id}") is None
+
+
+async def test_virtual_player_removed_on_owner_unload(mass: MusicAssistant) -> None:
+    """Test that unloading the owner provider removes its virtual players."""
+    await mass.config.save_provider_config("profiler", {})
+    owner = mass.get_provider("profiler")
+    assert owner is not None
+    await owner.initialized.wait()
+
+    sendspin = _get_sendspin_provider(mass)
+    player_id = await sendspin.create_virtual_player(
+        owner_instance_id=owner.instance_id,
+        display_name="Test Session",
+    )
+    assert mass.players.get_player(player_id) is not None
+
+    await mass.unload_provider(owner.instance_id)
+    await _wait_for(lambda: mass.players.get_player(player_id) is None)
+    assert not sendspin.is_virtual_player(player_id)
+    assert sendspin.server_api.get_client(player_id) is None
+
+
+async def test_orphan_virtual_player_config_sweep(mass: MusicAssistant) -> None:
+    """Test that stale virtual player configs are swept at provider startup."""
+    sendspin = _get_sendspin_provider(mass)
+    orphan_id = f"{VIRTUAL_PLAYER_ID_PREFIX}orphan"
+    kept_id = f"{VIRTUAL_PLAYER_ID_PREFIX}kept"
+    leftover_id = f"{VIRTUAL_PLAYER_ID_PREFIX}leftover"
+    for player_id, owner in (
+        (orphan_id, "removed_provider"),
+        (kept_id, sendspin.instance_id),
+    ):
+        mass.config.set(
+            f"{CONF_PLAYERS}/{player_id}",
+            {
+                "player_id": player_id,
+                "provider": sendspin.instance_id,
+                "values": {CONF_VIRTUAL_PLAYER_OWNER: owner},
+            },
+        )
+    # a prefixed config without owner marker (interrupted creation)
+    mass.config.set(
+        f"{CONF_PLAYERS}/{leftover_id}",
+        {"player_id": leftover_id, "provider": sendspin.instance_id, "values": {}},
+    )
+
+    sendspin._remove_orphan_virtual_player_configs()
+
+    assert mass.config.get(f"{CONF_PLAYERS}/{orphan_id}") is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{leftover_id}") is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{kept_id}") is not None

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -119,10 +119,13 @@ async def test_remove_virtual_player(mass: MusicAssistant) -> None:
 
 
 async def test_remove_virtual_player_rejects_regular_player(mass: MusicAssistant) -> None:
-    """Test that removal is refused for non-virtual player ids."""
+    """Test that removal is refused for players that are not virtual players."""
     sendspin = _get_sendspin_provider(mass)
     with pytest.raises(ValueError, match="not a virtual player"):
         await sendspin.remove_virtual_player("some_regular_player")
+    # even a prefixed id is refused when it was never created as virtual player
+    with pytest.raises(ValueError, match="not a virtual player"):
+        await sendspin.remove_virtual_player(f"{VIRTUAL_PLAYER_ID_PREFIX}unknown")
 
 
 async def test_virtual_player_removed_on_owner_unload(mass: MusicAssistant) -> None:

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -186,7 +186,7 @@ async def test_orphan_virtual_player_config_sweep(mass: MusicAssistant) -> None:
                 "values": {CONF_VIRTUAL_PLAYER_OWNER: owner},
             },
         )
-    # a prefixed config without owner marker (interrupted creation)
+    # a prefixed config without owner marker must be left alone
     mass.config.set(
         f"{CONF_PLAYERS}/{leftover_id}",
         {"player_id": leftover_id, "provider": sendspin.instance_id, "values": {}},
@@ -201,6 +201,6 @@ async def test_orphan_virtual_player_config_sweep(mass: MusicAssistant) -> None:
     sendspin._remove_orphan_virtual_player_configs()
 
     assert mass.config.get(f"{CONF_PLAYERS}/{orphan_id}") is None
-    assert mass.config.get(f"{CONF_PLAYERS}/{leftover_id}") is None
+    assert mass.config.get(f"{CONF_PLAYERS}/{leftover_id}") is not None
     assert mass.config.get(f"{CONF_PLAYERS}/{kept_id}") is not None
     assert mass.config.get(f"{CONF_PLAYERS}/{foreign_id}") is not None

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -118,6 +118,13 @@ async def test_remove_virtual_player(mass: MusicAssistant) -> None:
     assert mass.config.get(f"{CONF_PLAYERS}/{player_id}") is None
 
 
+async def test_remove_virtual_player_rejects_regular_player(mass: MusicAssistant) -> None:
+    """Test that removal is refused for non-virtual player ids."""
+    sendspin = _get_sendspin_provider(mass)
+    with pytest.raises(ValueError, match="not a virtual player"):
+        await sendspin.remove_virtual_player("some_regular_player")
+
+
 async def test_virtual_player_removed_on_owner_unload(mass: MusicAssistant) -> None:
     """Test that unloading the owner provider removes its virtual players."""
     await mass.config.save_provider_config("profiler", {})

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -161,9 +161,16 @@ async def test_orphan_virtual_player_config_sweep(mass: MusicAssistant) -> None:
         f"{CONF_PLAYERS}/{leftover_id}",
         {"player_id": leftover_id, "provider": sendspin.instance_id, "values": {}},
     )
+    # a config of another provider must never be touched by the sweep
+    foreign_id = f"{VIRTUAL_PLAYER_ID_PREFIX}foreign"
+    mass.config.set(
+        f"{CONF_PLAYERS}/{foreign_id}",
+        {"player_id": foreign_id, "provider": "other_provider", "values": {}},
+    )
 
     sendspin._remove_orphan_virtual_player_configs()
 
     assert mass.config.get(f"{CONF_PLAYERS}/{orphan_id}") is None
     assert mass.config.get(f"{CONF_PLAYERS}/{leftover_id}") is None
     assert mass.config.get(f"{CONF_PLAYERS}/{kept_id}") is not None
+    assert mass.config.get(f"{CONF_PLAYERS}/{foreign_id}") is not None

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -104,6 +104,26 @@ async def test_create_virtual_player_owner_not_loaded(mass: MusicAssistant) -> N
         )
 
 
+async def test_create_virtual_player_owned_by_other_provider(mass: MusicAssistant) -> None:
+    """Test that a persisted virtual player id can not be claimed by another owner."""
+    sendspin = _get_sendspin_provider(mass)
+    player_id = f"{VIRTUAL_PLAYER_ID_PREFIX}claimed"
+    mass.config.set(
+        f"{CONF_PLAYERS}/{player_id}",
+        {
+            "player_id": player_id,
+            "provider": sendspin.instance_id,
+            "values": {CONF_VIRTUAL_PLAYER_OWNER: "some_other_provider"},
+        },
+    )
+    with pytest.raises(SetupFailedError, match="owned by"):
+        await sendspin.create_virtual_player(
+            owner_instance_id=sendspin.instance_id,
+            display_name="Test Session",
+            player_id=player_id,
+        )
+
+
 async def test_remove_virtual_player(mass: MusicAssistant) -> None:
     """Test removing a virtual player cleans up player, client and config."""
     sendspin = _get_sendspin_provider(mass)

--- a/tests/providers/sendspin/test_virtual_player.py
+++ b/tests/providers/sendspin/test_virtual_player.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 from music_assistant_models.enums import PlayerFeature, PlayerType
-from music_assistant_models.errors import AlreadyRegisteredError, SetupFailedError
+from music_assistant_models.errors import SetupFailedError
 
 from music_assistant.constants import CONF_PLAYERS
 from music_assistant.providers.sendspin.constants import (
@@ -86,7 +86,7 @@ async def test_create_virtual_player_duplicate(mass: MusicAssistant) -> None:
         display_name="Test Session",
         player_id="my_session",
     )
-    with pytest.raises(AlreadyRegisteredError):
+    with pytest.raises(SetupFailedError):
         await sendspin.create_virtual_player(
             owner_instance_id=sendspin.instance_id,
             display_name="Test Session",


### PR DESCRIPTION
# What does this implement/fix?

Plugins that want to host a shared listening session (e.g. a party or music quiz) need a stable, server-side playback target whose audio all guest players receive. Until now that required reaching into the Sendspin provider's internals. This adds a small public API to the Sendspin provider to create and remove "virtual players": hidden, server-owned players that own their own queue and lead a native Sendspin group, while guests simply join and leave through standard grouping — without ever causing a group leader change.

- New public methods on the Sendspin provider: `create_virtual_player`, `remove_virtual_player` and `is_virtual_player`.
- Virtual players are hidden from the UI and not exposed to Home Assistant by default; they never render audio themselves and have no volume controls (group volume operates on the members).
- Lifecycle handling: virtual players are automatically removed when their owning provider unloads, and stale configs are swept at startup so a restart never leaves ghost players behind.
- Documented the feature in the provider README and added tests covering create/remove, classification, owner-unload cleanup and the orphan sweep.

**Related issue (if applicable):**

- related issue <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.