### PR TITLE
Add queue-level media-details redaction for plugin-owned queues

### DIFF
--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -349,9 +349,9 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
         Enable or disable redaction of media details for the given queue.
 
         Intended for the plugin owning the queue: while enabled, all PlayerMedia sent to
-        players carries neutral metadata (no track title/artist/album/image), so media
-        details do not leak to player displays or connected integrations.
-        The flag is not persisted and resets when the queue is (re)created.
+        players carries neutral metadata (generic title, no artist/album and a generic
+        logo image), so media details do not leak to player displays or connected
+        integrations. The flag is not persisted and resets when the queue is (re)created.
 
         :param queue_id: The queue to configure.
         :param redact: True to redact media details, False to restore normal metadata.

--- a/music_assistant/controllers/player_queues/controller.py
+++ b/music_assistant/controllers/player_queues/controller.py
@@ -344,6 +344,20 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
             if next_item := self.get_next_item(queue_id, queue.index_in_buffer):
                 self._enqueue_next_item(queue_id, next_item)
 
+    def set_redact_media_details(self, queue_id: str, redact: bool) -> None:
+        """
+        Enable or disable redaction of media details for the given queue.
+
+        Intended for the plugin owning the queue: while enabled, all PlayerMedia sent to
+        players carries neutral metadata (no track title/artist/album/image), so media
+        details do not leak to player displays or connected integrations.
+        The flag is not persisted and resets when the queue is (re)created.
+
+        :param queue_id: The queue to configure.
+        :param redact: True to redact media details, False to restore normal metadata.
+        """
+        self._queue_data[queue_id].redact_media_details = redact
+
     # Two timebases are used in this controller when variable playback speed is in
     # effect (atempo applied server-side):
     #   "stream-time"  — seconds of audio the player has played (post-atempo).
@@ -1460,7 +1474,13 @@ class PlayerQueuesController(QueueLoaderMixin, PlaybackTrackerMixin, StreamFeede
                 "original_uri": queue_item.uri,
             },
         )
-        if queue_item.media_item:
+        if queue_data.redact_media_details:
+            # the queue-owning plugin requested neutral metadata; a real (logo) image is used
+            # because some player displays render empty image fields as broken placeholders
+            media.title = "Music Assistant"
+            media.artist = ""
+            media.album = ""
+        elif queue_item.media_item:
             media.title = queue_item.media_item.name
             media.artist = getattr(queue_item.media_item, "artist_str", "")
             media.album = (

--- a/music_assistant/controllers/player_queues/state.py
+++ b/music_assistant/controllers/player_queues/state.py
@@ -64,6 +64,9 @@ class PlayerQueueData:
     flow_mode_stream_log: list[PlayLogEntry] = field(default_factory=list)
     # queue_item_id most recently handed to the player as the next item
     next_item_id_enqueued: str | None = None
+    # when set (by the plugin owning the queue), all PlayerMedia handed to players carries
+    # neutral metadata so track details never reach player displays or connected integrations
+    redact_media_details: bool = False
     # set when the queue items changed since the last cache write; the debounced saver writes the
     # (heavier) items payload only when this is set
     items_cache_dirty: bool = False

--- a/tests/controllers/player_queues/test_player_media.py
+++ b/tests/controllers/player_queues/test_player_media.py
@@ -1,0 +1,117 @@
+"""Tests for PlayerMedia creation from queue items."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track, UniqueList
+from music_assistant_models.player_queue import PlayerQueue
+from music_assistant_models.queue_item import QueueItem
+
+from music_assistant.constants import MASS_LOGO_ONLINE
+from music_assistant.controllers.player_queues import PlayerQueuesController
+from music_assistant.controllers.player_queues.state import PlayerQueueData
+
+QUEUE_ID = "test_queue"
+
+
+def _track() -> Track:
+    """Return a track with real metadata."""
+    return Track(
+        item_id="track_1",
+        provider="library",
+        name="One More Time",
+        provider_mappings={
+            ProviderMapping(
+                item_id="track_1",
+                provider_domain="library",
+                provider_instance="library",
+            )
+        },
+        artists=UniqueList(
+            [
+                ItemMapping(
+                    item_id="artist_1",
+                    provider="library",
+                    media_type=MediaType.ARTIST,
+                    name="Daft Punk",
+                )
+            ]
+        ),
+    )
+
+
+def _controller() -> PlayerQueuesController:
+    """Return a minimal controller with one queue."""
+    ctrl = PlayerQueuesController.__new__(PlayerQueuesController)
+    ctrl.mass = MagicMock()
+    ctrl._queue_data = {
+        QUEUE_ID: PlayerQueueData(
+            queue=PlayerQueue(
+                queue_id=QUEUE_ID,
+                active=True,
+                display_name="Queue",
+                available=True,
+                items=1,
+            ),
+            session_id="session",
+        )
+    }
+    return ctrl
+
+
+def _queue_item() -> QueueItem:
+    """Return a queue item backed by a real track."""
+    return QueueItem(
+        queue_id=QUEUE_ID,
+        queue_item_id="item_1",
+        name="Daft Punk - One More Time",
+        duration=320,
+        media_item=_track(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_player_media_keeps_metadata_by_default() -> None:
+    """Without redaction, PlayerMedia carries the full track metadata."""
+    ctrl = _controller()
+
+    media = await ctrl.player_media_from_queue_item(_queue_item())
+
+    assert media.title == "One More Time"
+    assert media.artist == "Daft Punk"
+    assert media.uri == _queue_item().uri
+    assert media.duration == 320
+
+
+@pytest.mark.asyncio
+async def test_player_media_redacted_when_flag_set() -> None:
+    """With redaction enabled, PlayerMedia carries only neutral metadata."""
+    ctrl = _controller()
+    ctrl.set_redact_media_details(QUEUE_ID, True)
+
+    media = await ctrl.player_media_from_queue_item(_queue_item())
+
+    assert media.title == "Music Assistant"
+    assert media.artist == ""
+    assert media.album == ""
+    assert media.image_url == MASS_LOGO_ONLINE
+    # the fields needed for playback must remain intact
+    assert media.uri == _queue_item().uri
+    assert media.duration == 320
+    assert media.queue_item_id == "item_1"
+
+
+@pytest.mark.asyncio
+async def test_player_media_metadata_restored_after_disabling_redaction() -> None:
+    """Disabling redaction restores the full track metadata."""
+    ctrl = _controller()
+    ctrl.set_redact_media_details(QUEUE_ID, True)
+    ctrl.set_redact_media_details(QUEUE_ID, False)
+
+    media = await ctrl.player_media_from_queue_item(_queue_item())
+
+    assert media.title == "One More Time"
+    assert media.artist == "Daft Punk"

--- a/tests/controllers/player_queues/test_player_media.py
+++ b/tests/controllers/player_queues/test_player_media.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
-from music_assistant_models.enums import MediaType
-from music_assistant_models.media_items import ItemMapping, ProviderMapping, Track, UniqueList
+from music_assistant_models.enums import ImageType, MediaType
+from music_assistant_models.media_items import (
+    ItemMapping,
+    MediaItemImage,
+    ProviderMapping,
+    Track,
+    UniqueList,
+)
 from music_assistant_models.player_queue import PlayerQueue
 from music_assistant_models.queue_item import QueueItem
 
@@ -63,13 +70,18 @@ def _controller() -> PlayerQueuesController:
 
 
 def _queue_item() -> QueueItem:
-    """Return a queue item backed by a real track."""
+    """Return a queue item backed by a real track with artwork."""
     return QueueItem(
         queue_id=QUEUE_ID,
         queue_item_id="item_1",
         name="Daft Punk - One More Time",
         duration=320,
         media_item=_track(),
+        image=MediaItemImage(
+            type=ImageType.THUMB,
+            path="https://example.com/cover.jpg",
+            provider="library",
+        ),
     )
 
 
@@ -82,6 +94,7 @@ async def test_player_media_keeps_metadata_by_default() -> None:
 
     assert media.title == "One More Time"
     assert media.artist == "Daft Punk"
+    assert media.image_url == cast("MagicMock", ctrl.mass.metadata.get_image_url).return_value
     assert media.uri == _queue_item().uri
     assert media.duration == 320
 
@@ -98,6 +111,8 @@ async def test_player_media_redacted_when_flag_set() -> None:
     assert media.artist == ""
     assert media.album == ""
     assert media.image_url == MASS_LOGO_ONLINE
+    # the track's own artwork must never be resolved while redaction is active
+    cast("MagicMock", ctrl.mass.metadata.get_image_url).assert_not_called()
     # the fields needed for playback must remain intact
     assert media.uri == _queue_item().uri
     assert media.duration == 320


### PR DESCRIPTION
# What does this implement/fix?

Plugins that own a queue (such as an upcoming music quiz game) need to hide what is playing, so the answer doesn't leak to speaker displays, Home Assistant entities or phone lock screens. This adds a generic server-side redaction flag on the queue that the owning plugin can set.

- New runtime-only `redact_media_details` flag on the queue's server-side state (not persisted, so it can never outlive the owning plugin)
- New `set_redact_media_details(queue_id, redact)` method on the player queues controller for plugins (not exposed as a frontend command)
- When enabled, all outgoing player metadata is neutralized: generic "Music Assistant" title, no artist/album, MA logo as image — while playback fields (uri, duration) stay intact
- Tests covering normal, redacted and toggle-off behavior

**Related issue (if applicable):**

- related to #4572

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically; the
release-notes generator uses that same label to slot this change
into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] New music/player/metadata/plugin provider — `new-provider`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `documentation`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
- [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked.
- [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked.
- [x] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions.
- [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate.